### PR TITLE
feat: multi-worktree dev support, branch in window title, fix input autocapitalize

### DIFF
--- a/apps/dashboard/package.json
+++ b/apps/dashboard/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "preview": "vite preview",
-    "tauri": "tauri"
+    "tauri": "tauri",
+    "tauri:dev": "node scripts/tauri-dev.mjs"
   },
   "dependencies": {
     "@tauri-apps/api": "^2.0.0",

--- a/apps/dashboard/scripts/tauri-dev.mjs
+++ b/apps/dashboard/scripts/tauri-dev.mjs
@@ -1,0 +1,39 @@
+import net from "net";
+import { spawn } from "child_process";
+
+function isPortAvailable(port) {
+  return new Promise((resolve) => {
+    const socket = net.createConnection({ port, host: "localhost" });
+    socket.once("connect", () => {
+      socket.destroy();
+      resolve(false);
+    });
+    socket.once("error", () => {
+      resolve(true);
+    });
+  });
+}
+
+async function findAvailablePort(startPort) {
+  let port = startPort;
+  while (!(await isPortAvailable(port))) {
+    port++;
+  }
+  return port;
+}
+
+const port = await findAvailablePort(1420);
+console.log(`Using port ${port} for dev server`);
+
+const configOverride = JSON.stringify({
+  build: {
+    devUrl: `http://localhost:${port}`,
+  },
+});
+
+const child = spawn("npx", ["tauri", "dev", "--config", configOverride], {
+  stdio: "inherit",
+  env: { ...process.env, VITE_PORT: String(port) },
+});
+
+child.on("exit", (code) => process.exit(code ?? 1));

--- a/apps/dashboard/src-tauri/src/git.rs
+++ b/apps/dashboard/src-tauri/src/git.rs
@@ -19,6 +19,24 @@ pub fn is_git_repo(path: &str) -> bool {
         .unwrap_or(false)
 }
 
+pub fn get_current_branch() -> Option<String> {
+    let output = git_cmd()
+        .args(["rev-parse", "--abbrev-ref", "HEAD"])
+        .output()
+        .ok()?;
+
+    if !output.status.success() {
+        return None;
+    }
+
+    let branch = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if branch.is_empty() {
+        None
+    } else {
+        Some(branch)
+    }
+}
+
 pub fn get_repo_name(path: &str) -> String {
     Path::new(path)
         .file_name()

--- a/apps/dashboard/src-tauri/src/lib.rs
+++ b/apps/dashboard/src-tauri/src/lib.rs
@@ -33,6 +33,13 @@ pub fn run() {
         .setup(|app| {
             let window = app.get_webview_window("main").unwrap();
 
+            // Set window title with git branch if available
+            let title = match git::get_current_branch() {
+                Some(branch) => format!("Band - {}", branch),
+                None => "Band".to_string(),
+            };
+            let _ = window.set_title(&title);
+
             // Position dashboard at left edge, full screen height
             if let Ok(monitor) = window.current_monitor() {
                 if let Some(monitor) = monitor {

--- a/apps/dashboard/src/components/NewWorkspaceForm.tsx
+++ b/apps/dashboard/src/components/NewWorkspaceForm.tsx
@@ -49,6 +49,9 @@ export function NewWorkspaceDialog({ projectName, open, onOpenChange }: Props) {
               placeholder="feature/my-branch"
               value={branch}
               onChange={(e) => setBranch(e.target.value)}
+              autoCapitalize="off"
+              autoCorrect="off"
+              spellCheck={false}
               autoFocus
             />
             <Label htmlFor="base-branch">Base branch (optional)</Label>
@@ -57,6 +60,9 @@ export function NewWorkspaceDialog({ projectName, open, onOpenChange }: Props) {
               placeholder="main"
               value={base}
               onChange={(e) => setBase(e.target.value)}
+              autoCapitalize="off"
+              autoCorrect="off"
+              spellCheck={false}
             />
           </div>
           <DialogFooter>

--- a/apps/dashboard/vite.config.ts
+++ b/apps/dashboard/vite.config.ts
@@ -4,8 +4,9 @@ import react from "@vitejs/plugin-react";
 import tailwindcss from "@tailwindcss/vite";
 
 const host = process.env.TAURI_DEV_HOST;
+const port = Number(process.env.VITE_PORT) || 1420;
 
-export default defineConfig(async () => ({
+export default defineConfig({
   plugins: [react(), tailwindcss()],
   resolve: {
     alias: {
@@ -14,18 +15,18 @@ export default defineConfig(async () => ({
   },
   clearScreen: false,
   server: {
-    port: 1420,
+    port,
     strictPort: true,
     host: host || false,
     hmr: host
       ? {
           protocol: "ws",
           host,
-          port: 1421,
+          port: port + 1,
         }
       : undefined,
     watch: {
       ignored: ["**/src-tauri/**"],
     },
   },
-}));
+});

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "description": "IDE-agnostic agent orchestrator — dashboard + VS Code extension",
   "type": "module",
   "scripts": {
-    "dev:dashboard": "pnpm --filter @band/dashboard tauri dev",
+    "dev:dashboard": "pnpm --filter @band/dashboard tauri:dev",
     "build:dashboard": "pnpm --filter @band/dashboard tauri build",
     "build:extension": "pnpm --filter band-vscode build"
   }


### PR DESCRIPTION
## Summary
- Add `tauri-dev.mjs` wrapper script that auto-detects the first available port from 1420, enabling parallel dev servers across multiple git worktrees
- Show the current git branch in the window title (e.g. "Band - settings") to distinguish between running instances
- Disable autoCapitalize/autoCorrect/spellCheck on branch name inputs to prevent mangled branch names

## Test plan
- [ ] Run `pnpm dev:dashboard` in two worktrees simultaneously — each should get a different port
- [ ] Verify window title shows "Band - {branch}" when launched from a git repo
- [ ] Verify window title shows "Band" when launched outside a git repo
- [ ] Create a new workspace and confirm branch name input has no auto-capitalize

🤖 Generated with [Claude Code](https://claude.com/claude-code)