### PR TITLE
fix: workspace deletion UX and idempotent creation

### DIFF
--- a/apps/dashboard/src-tauri/src/commands/ide.rs
+++ b/apps/dashboard/src-tauri/src/commands/ide.rs
@@ -237,6 +237,69 @@ fn get_descendant_cwds(parent_pid: i32) -> Vec<PathBuf> {
     cwds
 }
 
+// --- Process cleanup ---
+
+const SIGTERM: i32 = 15;
+
+extern "C" {
+    fn kill(pid: i32, sig: i32) -> i32;
+}
+
+/// Close all processes associated with a worktree.
+/// 1. Close the VS Code window gracefully via AppleScript.
+/// 2. SIGTERM any remaining processes whose CWD is inside the worktree.
+pub fn close_workspace(worktree_path: &str) {
+    let wt_path = PathBuf::from(worktree_path);
+
+    // Close the VS Code window matching this worktree's folder name
+    if let Some(folder) = wt_path.file_name().and_then(|n| n.to_str()) {
+        let script = format!(
+            r#"tell application "System Events"
+    if exists (first process whose bundle identifier is "com.microsoft.VSCode") then
+        tell (first process whose bundle identifier is "com.microsoft.VSCode")
+            repeat with w in windows
+                if title of w contains "{folder}" then
+                    click (first button of w whose subrole is "AXCloseButton")
+                    exit repeat
+                end if
+            end repeat
+        end tell
+    end if
+end tell"#,
+            folder = folder
+        );
+        let _ = std::process::Command::new("osascript")
+            .args(["-e", &script])
+            .output();
+    }
+
+    // Kill remaining processes whose CWD is inside the worktree (dev servers, agents, etc.)
+    let my_pid = std::process::id() as i32;
+    let mut ancestors = std::collections::HashSet::new();
+    let mut pid = my_pid;
+    ancestors.insert(pid);
+    while let Some(ppid) = get_ppid(pid) {
+        if ppid <= 1 || ancestors.contains(&ppid) {
+            break;
+        }
+        ancestors.insert(ppid);
+        pid = ppid;
+    }
+
+    for pid in get_all_pids() {
+        if pid <= 1 || ancestors.contains(&pid) {
+            continue;
+        }
+        if let Some(cwd) = get_process_cwd(pid) {
+            if cwd == wt_path || cwd.starts_with(&wt_path) {
+                unsafe {
+                    kill(pid, SIGTERM);
+                }
+            }
+        }
+    }
+}
+
 // --- Workspace matching ---
 
 fn match_cwds_to_workspace(cwds: &[PathBuf]) -> Option<String> {

--- a/apps/dashboard/src-tauri/src/commands/status.rs
+++ b/apps/dashboard/src-tauri/src/commands/status.rs
@@ -23,7 +23,6 @@ pub struct WorkspaceStatus {
     #[serde(rename = "worktreePath")]
     pub worktree_path: String,
     pub ide: String,
-    pub pid: Option<u32>,
     pub agent: Option<AgentInfo>,
 }
 

--- a/apps/dashboard/src-tauri/src/commands/workspace.rs
+++ b/apps/dashboard/src-tauri/src/commands/workspace.rs
@@ -12,12 +12,9 @@ pub fn workspace_create(project: String, branch: String, base: Option<String>) -
         .find(|p| p.name == project)
         .ok_or_else(|| format!("Project '{}' not found", project))?;
 
-    // Check if worktree for this branch already exists
+    // Already tracked in state — nothing to do
     if proj.worktrees.iter().any(|wt| wt.branch == branch) {
-        return Err(format!(
-            "Worktree for branch '{}' already exists in project '{}'",
-            branch, project
-        ));
+        return Ok(());
     }
 
     let band_home = state::band_home();
@@ -27,11 +24,14 @@ pub fn workspace_create(project: String, branch: String, base: Option<String>) -
         .join(&branch);
     let target_path_str = target_path.to_string_lossy().to_string();
 
-    let base_branch = base
-        .as_deref()
-        .unwrap_or(&proj.default_branch);
+    // Only create the git worktree if it doesn't already exist on disk
+    if !target_path.exists() {
+        let base_branch = base
+            .as_deref()
+            .unwrap_or(&proj.default_branch);
 
-    git::create_worktree(&proj.path, &branch, &target_path_str, Some(base_branch))?;
+        git::create_worktree(&proj.path, &branch, &target_path_str, Some(base_branch))?;
+    }
 
     proj.worktrees.push(state::WorktreeState {
         branch: branch.clone(),
@@ -72,6 +72,9 @@ pub fn workspace_remove(project: String, branch: String) -> Result<(), String> {
         .ok_or_else(|| format!("Worktree '{}' not found", branch))?;
 
     let worktree_path = wt.path.clone();
+
+    // Close VS Code window and kill any processes running inside the worktree
+    ide::close_workspace(&worktree_path);
 
     // Remove git worktree (ignore errors if the path no longer exists on disk)
     if std::path::Path::new(&worktree_path).exists() {

--- a/apps/dashboard/src-tauri/src/git.rs
+++ b/apps/dashboard/src-tauri/src/git.rs
@@ -144,8 +144,8 @@ pub fn create_worktree(
     target_path: &str,
     base_branch: Option<&str>,
 ) -> Result<(), String> {
+    // Try creating a new branch with -b
     let mut args = vec!["worktree", "add"];
-
     if let Some(base) = base_branch {
         args.extend_from_slice(&["-b", branch, target_path, base]);
     } else {
@@ -154,6 +154,17 @@ pub fn create_worktree(
 
     let output = git_cmd()
         .args(&args)
+        .current_dir(repo_path)
+        .output()
+        .map_err(|e| format!("Failed to create worktree: {}", e))?;
+
+    if output.status.success() {
+        return Ok(());
+    }
+
+    // Branch may already exist — retry without -b to check out the existing branch
+    let output = git_cmd()
+        .args(["worktree", "add", target_path, branch])
         .current_dir(repo_path)
         .output()
         .map_err(|e| format!("Failed to create worktree: {}", e))?;

--- a/apps/dashboard/src/stores/dashboard-store.ts
+++ b/apps/dashboard/src/stores/dashboard-store.ts
@@ -29,7 +29,6 @@ export interface WorkspaceStatus {
   branch: string;
   worktreePath: string;
   ide: string;
-  pid?: number;
   agent?: AgentInfo;
 }
 
@@ -114,11 +113,22 @@ export const useDashboardStore = create<DashboardState>((set, get) => ({
   },
 
   removeWorkspace: async (project: string, branch: string) => {
+    // Optimistically remove from UI immediately so it doesn't feel blocked
+    const previousProjects = get().projects;
+    set({
+      projects: previousProjects.map((p) =>
+        p.name === project
+          ? { ...p, worktrees: p.worktrees.filter((wt) => wt.branch !== branch) }
+          : p,
+      ),
+    });
+
     try {
       await invoke("workspace_remove", { project, branch });
       await get().loadProjects();
     } catch (e) {
-      set({ error: String(e) });
+      // Restore previous state on failure
+      set({ projects: previousProjects, error: String(e) });
     }
   },
 

--- a/extensions/vscode/src/status-reporter.ts
+++ b/extensions/vscode/src/status-reporter.ts
@@ -35,7 +35,6 @@ export class StatusReporter {
       branch: branch || "",
       worktreePath: "",
       ide: "vscode",
-      pid: process.pid,
       agent: this.agentType
         ? {
             name: this.agentType,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -85,7 +85,7 @@ importers:
         specifier: ^22.10.0
         version: 22.19.13
       '@types/vscode':
-        specifier: ^1.85.0
+        specifier: ^1.109.0
         version: 1.109.0
       esbuild:
         specifier: ^0.24.0


### PR DESCRIPTION
## Summary
- Optimistically remove workspace from UI before backend completes so deletion feels instant
- Close VS Code window gracefully (AppleScript) and SIGTERM child processes (dev servers, agents) on workspace delete
- Make workspace creation idempotent: skip if already in state, reuse existing worktree/branch on disk
- Remove PID tracking from VS Code extension — dashboard handles cleanup via CWD matching

## Test plan
- [ ] Delete a workspace with VS Code open — window should close, UI should update instantly
- [ ] Delete a workspace with a dev server running — server process should be killed
- [ ] Create a workspace for an existing branch — should succeed without error
- [ ] Create a workspace that's already tracked in state — should no-op

🤖 Generated with [Claude Code](https://claude.com/claude-code)