### PR TITLE
fix: prevent text selection on dashboard drag

### DIFF
--- a/apps/dashboard/src/styles/globals.css
+++ b/apps/dashboard/src/styles/globals.css
@@ -94,4 +94,5 @@ body {
     "Helvetica Neue", Arial, sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+  user-select: none;
 }


### PR DESCRIPTION
## Summary
- Added `user-select: none` to the dashboard body to prevent accidental text selection when dragging the cursor

## Test plan
- [ ] Verify dragging cursor on the dashboard no longer selects text
- [ ] Verify buttons and interactive elements still work normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)