### PR TITLE
fix: co-raise dashboard and VS Code windows on focus

### DIFF
--- a/apps/dashboard/src-tauri/src/commands/ide.rs
+++ b/apps/dashboard/src-tauri/src/commands/ide.rs
@@ -52,6 +52,15 @@ extern "C" {
     ) -> i32;
 }
 
+// --- Objective-C runtime for NSWindow manipulation ---
+
+#[link(name = "objc", kind = "dylib")]
+extern "C" {
+    fn objc_getClass(name: *const i8) -> *const c_void;
+    fn objc_msgSend();
+    fn sel_registerName(name: *const i8) -> *const c_void;
+}
+
 // --- CoreFoundation string helpers ---
 
 unsafe fn cfstr(s: &str) -> *const c_void {
@@ -393,11 +402,63 @@ fn detect_frontmost_workspace() -> Option<String> {
     None
 }
 
+/// Bring all dashboard windows to front without activating the app.
+/// Uses NSWindow's orderFrontRegardless to raise without stealing focus.
+/// Must be called on the main thread.
+unsafe fn raise_dashboard_windows() {
+    // Use transmute to cast objc_msgSend to the correct function signatures.
+    // This is required on ARM64 where variadic and non-variadic calling conventions differ.
+    type MsgSend = unsafe extern "C" fn(*const c_void, *const c_void) -> *const c_void;
+    type MsgSendIdx = unsafe extern "C" fn(*const c_void, *const c_void, usize) -> *const c_void;
+    type MsgSendCount = unsafe extern "C" fn(*const c_void, *const c_void) -> usize;
+
+    let msg: MsgSend = std::mem::transmute(objc_msgSend as unsafe extern "C" fn());
+    let msg_idx: MsgSendIdx = std::mem::transmute(objc_msgSend as unsafe extern "C" fn());
+    let msg_count: MsgSendCount = std::mem::transmute(objc_msgSend as unsafe extern "C" fn());
+
+    let cls = objc_getClass(b"NSApplication\0".as_ptr() as *const i8);
+    if cls.is_null() {
+        return;
+    }
+
+    let app = msg(
+        cls,
+        sel_registerName(b"sharedApplication\0".as_ptr() as *const i8),
+    );
+    if app.is_null() {
+        return;
+    }
+
+    let windows = msg(
+        app,
+        sel_registerName(b"windows\0".as_ptr() as *const i8),
+    );
+    if windows.is_null() {
+        return;
+    }
+
+    let count = msg_count(
+        windows,
+        sel_registerName(b"count\0".as_ptr() as *const i8),
+    );
+    let obj_at = sel_registerName(b"objectAtIndex:\0".as_ptr() as *const i8);
+    let raise = sel_registerName(b"orderFrontRegardless\0".as_ptr() as *const i8);
+
+    for i in 0..count {
+        let win = msg_idx(windows, obj_at, i);
+        if !win.is_null() {
+            msg(win, raise);
+        }
+    }
+}
+
 /// Start a background thread that polls the frontmost window
 /// and updates active.json when the focused workspace changes.
-pub fn start_focus_polling() {
-    std::thread::spawn(|| {
+/// When a managed workspace is focused, also brings the dashboard to front.
+pub fn start_focus_polling(app_handle: tauri::AppHandle) {
+    std::thread::spawn(move || {
         let mut last_active: Option<String> = None;
+        let mut dashboard_raised = false;
         loop {
             std::thread::sleep(Duration::from_millis(500));
 
@@ -406,8 +467,44 @@ pub fn start_focus_polling() {
                     last_active = Some(ws_id.clone());
                     write_active_marker(&ws_id);
                 }
+                // Bring dashboard to front when a managed workspace gains focus
+                if !dashboard_raised {
+                    let _ = app_handle.run_on_main_thread(|| unsafe {
+                        raise_dashboard_windows();
+                    });
+                    dashboard_raised = true;
+                }
+            } else {
+                dashboard_raised = false;
             }
         }
+    });
+}
+
+/// Raise the VS Code window matching the branch to front without activating VS Code.
+/// Uses AXRaise via AppleScript so VS Code doesn't steal focus from the dashboard.
+pub fn raise_vscode_window(branch: &str) {
+    let branch = branch.to_string();
+    std::thread::spawn(move || {
+        let script = format!(
+            r#"tell application "System Events"
+    if exists (first process whose bundle identifier is "com.microsoft.VSCode") then
+        tell (first process whose bundle identifier is "com.microsoft.VSCode")
+            repeat with w in windows
+                if title of w contains "{branch}" then
+                    perform action "AXRaise" of w
+                    exit repeat
+                end if
+            end repeat
+        end tell
+    end if
+end tell"#,
+            branch = branch
+        );
+
+        let _ = std::process::Command::new("osascript")
+            .args(["-e", &script])
+            .output();
     });
 }
 

--- a/apps/dashboard/src-tauri/src/lib.rs
+++ b/apps/dashboard/src-tauri/src/lib.rs
@@ -58,9 +58,9 @@ pub fn run() {
 
             // Poll the frontmost VS Code window to track active workspace
             // (handles projects without the Band VS Code extension)
-            commands::ide::start_focus_polling();
+            commands::ide::start_focus_polling(app.handle().clone());
 
-            // Re-align the last workspace's VS Code window when dashboard gains focus
+            // Raise the active workspace's VS Code window when dashboard gains focus
             window.on_window_event(move |event| {
                 if let tauri::WindowEvent::Focused(true) = event {
                     // Read active workspace from marker file
@@ -77,7 +77,7 @@ pub fn run() {
                                     for wt in &proj.worktrees {
                                         let id = format!("{}-{}", proj.name, wt.branch);
                                         if id == marker.workspace_id {
-                                            commands::ide::align_vscode_window(&wt.branch);
+                                            commands::ide::raise_vscode_window(&wt.branch);
                                             return;
                                         }
                                     }


### PR DESCRIPTION
## Summary
- When a managed VS Code window gains focus, the dashboard window automatically raises to front using NSWindow `orderFrontRegardless` via Objective-C runtime FFI
- When the dashboard gains focus, the active workspace's VS Code window raises to front using `AXRaise` via AppleScript
- Neither operation steals keyboard focus from the other — both windows stay visible side-by-side

## Test plan
- [ ] Open a workspace from the dashboard
- [ ] Switch to another app (e.g. Safari), then click the VS Code window — dashboard should also appear
- [ ] Click the dashboard — VS Code window should also appear
- [ ] Switch to an unmanaged app — dashboard should not auto-raise

🤖 Generated with [Claude Code](https://claude.com/claude-code)