### PR TITLE
feat: custom black title bar

### DIFF
--- a/apps/dashboard/src-tauri/Cargo.lock
+++ b/apps/dashboard/src-tauri/Cargo.lock
@@ -86,6 +86,7 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 name = "band-dashboard"
 version = "0.1.0"
 dependencies = [
+ "cocoa",
  "dirs",
  "notify",
  "serde",
@@ -123,6 +124,12 @@ checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 dependencies = [
  "serde_core",
 ]
+
+[[package]]
+name = "block"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d8c1fef690941d3e7788d328517591fecc684c084084702d6ff1641e993699a"
 
 [[package]]
 name = "block-buffer"
@@ -310,6 +317,35 @@ dependencies = [
  "num-traits",
  "serde",
  "windows-link 0.2.1",
+]
+
+[[package]]
+name = "cocoa"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad36507aeb7e16159dfe68db81ccc27571c3ccd4b76fb2fb72fc59e7a4b1b64c"
+dependencies = [
+ "bitflags 2.11.0",
+ "block",
+ "cocoa-foundation",
+ "core-foundation",
+ "core-graphics",
+ "foreign-types",
+ "libc",
+ "objc",
+]
+
+[[package]]
+name = "cocoa-foundation"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81411967c50ee9a1fc11365f8c585f863a22a9697c89239c452292c40ba79b0d"
+dependencies = [
+ "bitflags 2.11.0",
+ "block",
+ "core-foundation",
+ "core-graphics-types",
+ "objc",
 ]
 
 [[package]]
@@ -1784,6 +1820,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c41e0c4fef86961ac6d6f8a82609f55f31b05e4fce149ac5710e439df7619ba4"
 
 [[package]]
+name = "malloc_buf"
+version = "0.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62bb907fe88d54d8d9ce32a3cceab4218ed2f6b7d35617cafe9adf84e43919cb"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "markup5ever"
 version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1983,6 +2028,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "objc"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "915b1b472bc21c53464d6c8461c9d3af805ba1ef837e1cac254428f4a77177b1"
+dependencies = [
+ "malloc_buf",
 ]
 
 [[package]]

--- a/apps/dashboard/src-tauri/Cargo.toml
+++ b/apps/dashboard/src-tauri/Cargo.toml
@@ -23,3 +23,6 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 notify = "7"
 dirs = "6"
+
+[target.'cfg(target_os = "macos")'.dependencies]
+cocoa = "0.26"

--- a/apps/dashboard/src-tauri/src/lib.rs
+++ b/apps/dashboard/src-tauri/src/lib.rs
@@ -40,6 +40,19 @@ pub fn run() {
             };
             let _ = window.set_title(&title);
 
+            // Set window background to black so the transparent title bar appears black
+            #[cfg(target_os = "macos")]
+            {
+                use cocoa::appkit::NSWindow;
+                use cocoa::appkit::NSColor;
+                use cocoa::base::{id, nil};
+                let ns_window = window.ns_window().unwrap() as id;
+                unsafe {
+                    let color = NSColor::colorWithSRGBRed_green_blue_alpha_(nil, 0.0, 0.0, 0.0, 1.0);
+                    ns_window.setBackgroundColor_(color);
+                }
+            }
+
             // Position dashboard at left edge, full screen height
             if let Ok(monitor) = window.current_monitor() {
                 if let Some(monitor) = monitor {

--- a/apps/dashboard/src-tauri/tauri.conf.json
+++ b/apps/dashboard/src-tauri/tauri.conf.json
@@ -20,7 +20,8 @@
         "resizable": true,
         "fullscreen": false,
         "decorations": true,
-        "transparent": false
+        "transparent": false,
+        "titleBarStyle": "Transparent"
       }
     ],
     "security": {

--- a/apps/dashboard/src/App.tsx
+++ b/apps/dashboard/src/App.tsx
@@ -27,7 +27,9 @@ export default function App() {
   }, [loadProjects]);
 
   return (
-    <div className="min-h-screen flex flex-col bg-background text-foreground">
+    <div className="min-h-screen flex flex-col bg-background text-foreground p-0">
+      <Separator />
+
       {error && (
         <div className="mx-4 mt-2 px-4 py-2 bg-destructive/10 border border-destructive/30 rounded-lg text-sm text-destructive flex items-center justify-between gap-2">
           <span className="truncate">{error}</span>
@@ -43,7 +45,7 @@ export default function App() {
       )}
 
       <ScrollArea className="flex-1">
-        <main className="px-2 py-2">
+        <main className="px-2 py-4">
           <ProjectList />
         </main>
       </ScrollArea>


### PR DESCRIPTION
## Summary
- Use macOS transparent title bar style (`titleBarStyle: "Transparent"`) to replace the default OS title bar appearance
- Set window background to black via `cocoa` crate so the transparent title bar appears fully black with native traffic lights and drag support
- Add separator between title bar and project list, adjust content padding

## Test plan
- [ ] Verify title bar appears black with "Band - {branch}" title text
- [ ] Verify traffic light buttons (close/minimize/expand) work correctly
- [ ] Verify window dragging works when focused and unfocused
- [ ] Verify project list spacing looks correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)