### PR TITLE
feat: user default settings for VS Code layout

### DIFF
--- a/.band/config.yaml
+++ b/.band/config.yaml
@@ -1,9 +1,0 @@
-project: "band"
-
-terminals:
-  - name: "claude"
-    command: "claude-epic --dangerously-skip-permissions"
-    agentType: "claude-code"
-  - name: "shell"
-    command: ""
-    split: "vertical"

--- a/apps/dashboard/src-tauri/src/state.rs
+++ b/apps/dashboard/src-tauri/src/state.rs
@@ -35,6 +35,8 @@ impl Default for AppState {
 pub struct Settings {
     #[serde(rename = "worktreesDir", skip_serializing_if = "Option::is_none")]
     pub worktrees_dir: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub defaults: Option<serde_json::Value>,
 }
 
 pub fn band_home() -> PathBuf {

--- a/apps/dashboard/src/components/SettingsPage.tsx
+++ b/apps/dashboard/src/components/SettingsPage.tsx
@@ -11,6 +11,20 @@ import { Button } from "@/components/ui/button";
 import { Label } from "@/components/ui/label";
 import { FolderOpen, X } from "lucide-react";
 
+const DEFAULT_DEFAULTS = {
+  layout: {
+    orientation: "horizontal" as const,
+    groups: [
+      { size: 0.6 },
+      { size: 0.4, browser: { url: "http://localhost:3000" } },
+    ],
+  },
+  terminals: [
+    { name: "claude", command: "claude", agentType: "claude-code" as const },
+    { name: "shell", command: "", split: "vertical" as const },
+  ],
+};
+
 interface Props {
   onClose: () => void;
 }
@@ -20,6 +34,8 @@ export function SettingsPage({ onClose }: Props) {
   const [worktreesDir, setWorktreesDir] = useState(
     settings.worktreesDir ?? "",
   );
+  const [defaultsJson, setDefaultsJson] = useState("");
+  const [defaultsError, setDefaultsError] = useState<string | null>(null);
 
   useEffect(() => {
     loadSettings();
@@ -27,7 +43,12 @@ export function SettingsPage({ onClose }: Props) {
 
   useEffect(() => {
     setWorktreesDir(settings.worktreesDir ?? "");
-  }, [settings.worktreesDir]);
+    setDefaultsJson(
+      settings.defaults
+        ? JSON.stringify(settings.defaults, null, 2)
+        : "",
+    );
+  }, [settings.worktreesDir, settings.defaults]);
 
   const handleBrowse = async () => {
     try {
@@ -39,9 +60,38 @@ export function SettingsPage({ onClose }: Props) {
     }
   };
 
+  const handleDefaultsChange = (value: string) => {
+    setDefaultsJson(value);
+    if (value.trim() === "") {
+      setDefaultsError(null);
+      return;
+    }
+    try {
+      JSON.parse(value);
+      setDefaultsError(null);
+    } catch (e) {
+      setDefaultsError(e instanceof Error ? e.message : "Invalid JSON");
+    }
+  };
+
+  const handleInsertTemplate = () => {
+    const json = JSON.stringify(DEFAULT_DEFAULTS, null, 2);
+    setDefaultsJson(json);
+    setDefaultsError(null);
+  };
+
   const handleSave = async () => {
+    let defaults = undefined;
+    if (defaultsJson.trim()) {
+      try {
+        defaults = JSON.parse(defaultsJson);
+      } catch {
+        return;
+      }
+    }
     await updateSettings({
       worktreesDir: worktreesDir.trim() || null,
+      defaults,
     });
   };
 
@@ -53,7 +103,7 @@ export function SettingsPage({ onClose }: Props) {
           <X />
         </Button>
       </div>
-      <Accordion type="single" collapsible defaultValue="general">
+      <Accordion type="multiple" defaultValue={["general", "defaults"]}>
         <AccordionItem value="general">
           <AccordionTrigger>General</AccordionTrigger>
           <AccordionContent>
@@ -81,13 +131,57 @@ export function SettingsPage({ onClose }: Props) {
                   default location.
                 </p>
               </div>
-              <Button onClick={handleSave} size="sm">
-                Save
-              </Button>
+            </div>
+          </AccordionContent>
+        </AccordionItem>
+        <AccordionItem value="defaults">
+          <AccordionTrigger>Default Workspace</AccordionTrigger>
+          <AccordionContent>
+            <div className="space-y-4 pt-1">
+              <div className="space-y-2">
+                <div className="flex items-center justify-between">
+                  <Label htmlFor="defaults-json">
+                    Default layout &amp; terminals
+                  </Label>
+                  {!defaultsJson.trim() && (
+                    <Button
+                      type="button"
+                      variant="link"
+                      size="sm"
+                      className="h-auto p-0 text-xs"
+                      onClick={handleInsertTemplate}
+                    >
+                      Insert template
+                    </Button>
+                  )}
+                </div>
+                <textarea
+                  id="defaults-json"
+                  className="w-full min-h-[200px] rounded-md border border-input bg-background px-3 py-2 text-sm font-mono ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+                  placeholder='{"layout": {...}, "terminals": [...]}'
+                  value={defaultsJson}
+                  onChange={(e) => handleDefaultsChange(e.target.value)}
+                  spellCheck={false}
+                />
+                {defaultsError && (
+                  <p className="text-xs text-destructive">{defaultsError}</p>
+                )}
+                <p className="text-xs text-muted-foreground">
+                  Default VS Code layout and terminal configuration applied to
+                  Band worktrees that don't have a project-level{" "}
+                  <code className="text-xs">.band/config.json</code>. Leave
+                  empty to disable.
+                </p>
+              </div>
             </div>
           </AccordionContent>
         </AccordionItem>
       </Accordion>
+      <div className="mt-4 px-1">
+        <Button onClick={handleSave} size="sm" disabled={!!defaultsError}>
+          Save
+        </Button>
+      </div>
     </div>
   );
 }

--- a/apps/dashboard/src/stores/settings-store.ts
+++ b/apps/dashboard/src/stores/settings-store.ts
@@ -15,8 +15,25 @@ async function invoke<T>(
   return tauriInvoke<T>(cmd, args);
 }
 
+export interface BandConfig {
+  layout?: {
+    orientation: "horizontal" | "vertical";
+    groups: {
+      size: number;
+      browser?: { url: string; pinned?: boolean };
+    }[];
+  };
+  terminals?: {
+    name: string;
+    command: string;
+    split?: "horizontal" | "vertical";
+    agentType?: "claude-code";
+  }[];
+}
+
 export interface Settings {
   worktreesDir: string | null;
+  defaults?: BandConfig;
 }
 
 interface SettingsState {
@@ -30,7 +47,7 @@ interface SettingsState {
 }
 
 export const useSettingsStore = create<SettingsState>((set) => ({
-  settings: { worktreesDir: null },
+  settings: { worktreesDir: null, defaults: undefined },
   loading: false,
   error: null,
 

--- a/extensions/vscode/package-lock.json
+++ b/extensions/vscode/package-lock.json
@@ -7,9 +7,6 @@
     "": {
       "name": "band-vscode",
       "version": "0.1.0",
-      "dependencies": {
-        "yaml": "^2.6.1"
-      },
       "devDependencies": {
         "@types/node": "^22.10.0",
         "@types/vscode": "^1.109.0",
@@ -127,6 +124,7 @@
     },
     "../../node_modules/.pnpm/yaml@2.8.2/node_modules/yaml": {
       "version": "2.8.2",
+      "extraneous": true,
       "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"
@@ -178,10 +176,6 @@
     },
     "node_modules/typescript": {
       "resolved": "../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript",
-      "link": true
-    },
-    "node_modules/yaml": {
-      "resolved": "../../node_modules/.pnpm/yaml@2.8.2/node_modules/yaml",
       "link": true
     }
   }

--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -11,7 +11,8 @@
     "Other"
   ],
   "activationEvents": [
-    "workspaceContains:**/.band/config.yaml"
+    "workspaceContains:**/.band/config.json",
+    "onStartupFinished"
   ],
   "main": "./dist/extension.js",
   "contributes": {
@@ -25,7 +26,7 @@
   "scripts": {
     "build": "esbuild src/extension.ts --bundle --outfile=dist/extension.js --external:vscode --format=cjs --platform=node && npm run deploy",
     "watch": "esbuild src/extension.ts --bundle --outfile=dist/extension.js --external:vscode --format=cjs --platform=node --watch",
-    "deploy": "cp dist/extension.js ~/.vscode/extensions/band.band-vscode-0.1.0/dist/extension.js",
+    "deploy": "cp dist/extension.js ~/.vscode/extensions/band.band-vscode-0.1.0/dist/extension.js && cp package.json ~/.vscode/extensions/band.band-vscode-0.1.0/package.json",
     "package": "vsce package"
   },
   "devDependencies": {
@@ -33,8 +34,5 @@
     "@types/vscode": "^1.109.0",
     "esbuild": "^0.24.0",
     "typescript": "^5.7.0"
-  },
-  "dependencies": {
-    "yaml": "^2.6.1"
   }
 }

--- a/extensions/vscode/src/config.ts
+++ b/extensions/vscode/src/config.ts
@@ -1,6 +1,6 @@
 import * as fs from "fs";
 import * as path from "path";
-import { parse } from "yaml";
+import * as os from "os";
 
 export interface BrowserConfig {
   url: string;
@@ -32,7 +32,7 @@ export interface BandConfig {
 }
 
 export function getConfigPath(workspacePath: string): string {
-  return path.join(workspacePath, ".band", "config.yaml");
+  return path.join(workspacePath, ".band", "config.json");
 }
 
 export async function loadConfig(
@@ -43,11 +43,57 @@ export async function loadConfig(
   try {
     await fs.promises.access(configPath, fs.constants.R_OK);
     const content = await fs.promises.readFile(configPath, "utf-8");
-    const config = parse(content) as BandConfig;
+    const config = JSON.parse(content) as BandConfig;
 
     return config;
   } catch (err) {
     console.log(`[Band] Failed to load config at ${configPath}:`, err);
     return null;
+  }
+}
+
+export async function loadUserDefaults(): Promise<BandConfig | null> {
+  const settingsPath = path.join(os.homedir(), ".band", "settings.json");
+
+  try {
+    await fs.promises.access(settingsPath, fs.constants.R_OK);
+    const content = await fs.promises.readFile(settingsPath, "utf-8");
+    const settings = JSON.parse(content);
+
+    if (settings && settings.defaults) {
+      return settings.defaults as BandConfig;
+    }
+
+    return null;
+  } catch (err) {
+    console.log(`[Band] Failed to load user defaults:`, err);
+    return null;
+  }
+}
+
+export async function isBandWorktree(workspacePath: string): Promise<boolean> {
+  const statePath = path.join(os.homedir(), ".band", "state.json");
+
+  try {
+    await fs.promises.access(statePath, fs.constants.R_OK);
+    const content = await fs.promises.readFile(statePath, "utf-8");
+    const state = JSON.parse(content);
+
+    if (state && Array.isArray(state.projects)) {
+      for (const project of state.projects) {
+        if (Array.isArray(project.worktrees)) {
+          for (const wt of project.worktrees) {
+            if (wt.path === workspacePath) {
+              return true;
+            }
+          }
+        }
+      }
+    }
+
+    return false;
+  } catch (err) {
+    console.log(`[Band] Failed to read state.json:`, err);
+    return false;
   }
 }

--- a/extensions/vscode/src/extension.ts
+++ b/extensions/vscode/src/extension.ts
@@ -1,5 +1,5 @@
 import * as vscode from "vscode";
-import { loadConfig } from "./config";
+import { loadConfig, loadUserDefaults, isBandWorktree } from "./config";
 import { setupWorkspace } from "./workspace-setup";
 
 let log: vscode.OutputChannel;
@@ -18,13 +18,28 @@ export async function activate(context: vscode.ExtensionContext) {
   // Auto-setup if config exists
   const workspaceFolders = vscode.workspace.workspaceFolders;
   if (workspaceFolders && workspaceFolders.length > 0) {
-    const config = await loadConfig(workspaceFolders[0].uri.fsPath);
+    const workspacePath = workspaceFolders[0].uri.fsPath;
+    const config = await loadConfig(workspacePath);
     if (config) {
-      log.appendLine("Config loaded, setting up workspace...");
+      log.appendLine("Project config loaded, setting up workspace...");
       await setupWorkspace(config);
       vscode.window.showInformationMessage("Band workspace setup complete");
+    } else if (await isBandWorktree(workspacePath)) {
+      log.appendLine(
+        "No project config, but workspace is a Band worktree. Checking user defaults..."
+      );
+      const defaults = await loadUserDefaults();
+      if (defaults) {
+        log.appendLine("User defaults loaded, setting up workspace...");
+        await setupWorkspace(defaults);
+        vscode.window.showInformationMessage(
+          "Band workspace setup complete (using defaults)"
+        );
+      } else {
+        log.appendLine("No user defaults found");
+      }
     } else {
-      log.appendLine("No config found");
+      log.appendLine("No config found and not a Band worktree");
     }
   } else {
     log.appendLine("No workspace folders");
@@ -47,9 +62,21 @@ async function runSetup() {
     }
   }
 
-  const checkedPath = workspaceFolders[0].uri.fsPath;
+  // No project config found — try user defaults if it's a Band worktree
+  const workspacePath = workspaceFolders[0].uri.fsPath;
+  if (await isBandWorktree(workspacePath)) {
+    const defaults = await loadUserDefaults();
+    if (defaults) {
+      await setupWorkspace(defaults);
+      vscode.window.showInformationMessage(
+        "Band workspace setup complete (using defaults)"
+      );
+      return;
+    }
+  }
+
   vscode.window.showErrorMessage(
-    `No .band/config.yaml found. Checked: ${checkedPath}/.band/config.yaml`
+    `No .band/config.json found. Checked: ${workspacePath}/.band/config.json`
   );
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -76,10 +76,6 @@ importers:
         version: 6.4.1(@types/node@22.19.13)(jiti@2.6.1)(lightningcss@1.31.1)(yaml@2.8.2)
 
   extensions/vscode:
-    dependencies:
-      yaml:
-        specifier: ^2.6.1
-        version: 2.8.2
     devDependencies:
       '@types/node':
         specifier: ^22.10.0
@@ -3646,7 +3642,8 @@ snapshots:
 
   yallist@3.1.1: {}
 
-  yaml@2.8.2: {}
+  yaml@2.8.2:
+    optional: true
 
   zustand@5.0.11(@types/react@19.2.14)(react@19.2.4)(use-sync-external-store@1.6.0(react@19.2.4)):
     optionalDependencies:


### PR DESCRIPTION
## Summary
- Switch project config from `.band/config.yaml` to `.band/config.json` (removed yaml dependency)
- Add user-level defaults in `~/.band/settings.json` that apply to Band worktrees without a project config
- Add `onStartupFinished` activation event so the extension loads even without a config file
- Add "Default Workspace" JSON editor section to the dashboard settings page
- VS Code extension fallback: project config → Band worktree check → user defaults

## Test plan
- [ ] Open a Band worktree without `.band/config.json` but with defaults in `~/.band/settings.json` — layout should apply
- [ ] Open a worktree WITH `.band/config.json` — project config wins
- [ ] Open a non-Band workspace — nothing happens
- [ ] Dashboard settings: edit defaults JSON, save, reload — preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)