### PR TITLE
feat: add keyboard navigation between workspaces

### DIFF
--- a/apps/dashboard/src/App.tsx
+++ b/apps/dashboard/src/App.tsx
@@ -67,7 +67,15 @@ export default function App() {
         </div>
       )}
 
-      <ScrollArea className="flex-1">
+      <ScrollArea
+        className="flex-1"
+        onClick={(e) => {
+          const target = e.target as HTMLElement;
+          if (target.closest("button, a, input, select, textarea")) return;
+          const list = (e.currentTarget as HTMLElement).querySelector<HTMLElement>('[tabindex="0"]');
+          list?.focus();
+        }}
+      >
         <main className="px-2 py-4">
           {view === "dashboard" ? <ProjectList /> : <SettingsPage onClose={() => setView("dashboard")} />}
         </main>

--- a/apps/dashboard/src/components/ProjectList.tsx
+++ b/apps/dashboard/src/components/ProjectList.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useDashboardStore } from "@/stores/dashboard-store";
 import { WorkspaceCard } from "@/components/WorkspaceCard";
 import { NewWorkspaceDialog } from "@/components/NewWorkspaceForm";
@@ -20,7 +20,44 @@ export function ProjectList() {
   const projects = useDashboardStore((s) => s.projects);
   const statuses = useDashboardStore((s) => s.statuses);
   const removeProject = useDashboardStore((s) => s.removeProject);
+  const openWorkspace = useDashboardStore((s) => s.openWorkspace);
   const [workspaceDialog, setWorkspaceDialog] = useState<string | null>(null);
+  const [focusedIndex, setFocusedIndex] = useState(-1);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  const allWorkspaceIds = useMemo(
+    () =>
+      projects.flatMap((project) =>
+        project.worktrees.map((wt) => `${project.name}-${wt.branch}`)
+      ),
+    [projects]
+  );
+
+  useEffect(() => {
+    setFocusedIndex(-1);
+  }, [projects]);
+
+  useEffect(() => {
+    containerRef.current?.focus();
+  }, []);
+
+  function handleKeyDown(e: React.KeyboardEvent) {
+    if (allWorkspaceIds.length === 0) return;
+
+    if (e.key === "ArrowDown") {
+      e.preventDefault();
+      setFocusedIndex((prev) =>
+        prev < allWorkspaceIds.length - 1 ? prev + 1 : prev
+      );
+    } else if (e.key === "ArrowUp") {
+      e.preventDefault();
+      setFocusedIndex((prev) => (prev > 0 ? prev - 1 : prev));
+    } else if (e.key === "Enter") {
+      if (focusedIndex >= 0 && focusedIndex < allWorkspaceIds.length) {
+        openWorkspace(allWorkspaceIds[focusedIndex]);
+      }
+    }
+  }
 
   if (projects.length === 0) {
     return (
@@ -33,8 +70,15 @@ export function ProjectList() {
     );
   }
 
+  let workspaceIndex = 0;
+
   return (
-    <div className="flex flex-col gap-6">
+    <div
+      ref={containerRef}
+      tabIndex={0}
+      onKeyDown={handleKeyDown}
+      className="flex flex-col gap-6 outline-none"
+    >
       {projects.map((project) => (
         <div key={project.name}>
           <div className="flex items-center justify-between mb-2 px-1">
@@ -106,12 +150,14 @@ export function ProjectList() {
             ) : (
               project.worktrees.map((wt) => {
                 const wsId = `${project.name}-${wt.branch}`;
+                const currentIndex = workspaceIndex++;
                 return (
                   <WorkspaceCard
                     key={wt.branch}
                     worktree={wt}
                     projectName={project.name}
                     status={statuses.get(wsId)}
+                    isFocused={currentIndex === focusedIndex}
                   />
                 );
               })

--- a/apps/dashboard/src/components/WorkspaceCard.tsx
+++ b/apps/dashboard/src/components/WorkspaceCard.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useRef } from "react";
 import { AgentStatusBadge } from "@/components/AgentStatusBadge";
 import {
   useDashboardStore,
@@ -18,9 +19,17 @@ interface Props {
   worktree: WorktreeInfo;
   projectName: string;
   status?: WorkspaceStatus;
+  isFocused?: boolean;
 }
 
-export function WorkspaceCard({ worktree, projectName, status }: Props) {
+export function WorkspaceCard({ worktree, projectName, status, isFocused }: Props) {
+  const cardRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (isFocused) {
+      cardRef.current?.scrollIntoView({ block: "nearest" });
+    }
+  }, [isFocused]);
   const openWorkspace = useDashboardStore((s) => s.openWorkspace);
   const removeWorkspace = useDashboardStore((s) => s.removeWorkspace);
   const activeWorkspaceId = useDashboardStore((s) => s.activeWorkspaceId);
@@ -30,7 +39,8 @@ export function WorkspaceCard({ worktree, projectName, status }: Props) {
 
   return (
     <Card
-      className={`flex-row items-center justify-between px-4 py-2.5 gap-0 rounded-none border-0 shadow-none cursor-pointer transition-colors hover:bg-accent/50 ${isActive ? "bg-accent/50 border-l-2 border-l-primary" : ""}`}
+      ref={cardRef}
+      className={`flex-row items-center justify-between px-4 py-2.5 gap-0 rounded-none border-0 shadow-none cursor-pointer transition-colors hover:bg-accent/50 ${isActive ? "bg-accent/50 border-l-2 border-l-primary" : ""} ${isFocused ? "ring-2 ring-ring" : ""}`}
       onClick={() => openWorkspace(workspaceId)}
     >
       <div className="flex items-center gap-3 min-w-0">


### PR DESCRIPTION
## Summary
- ArrowUp/ArrowDown moves focus between workspace cards, Enter opens the focused one
- Clicking anywhere in the scroll area acquires focus for keyboard navigation
- Navigation naturally disables when dialogs, dropdowns, or settings view are open (focus moves away)

## Test plan
- [ ] Arrow keys move focus highlight between workspace cards
- [ ] Enter opens the focused workspace
- [ ] Opening a dropdown or dialog stops arrow key navigation
- [ ] Switching to settings view stops arrow key navigation
- [ ] Focus ring is visually distinct from active workspace highlight

🤖 Generated with [Claude Code](https://claude.com/claude-code)