### PR TITLE
feat: coding agent settings and iOS-style settings UI

### DIFF
--- a/apps/dashboard/src-tauri/src/state.rs
+++ b/apps/dashboard/src-tauri/src/state.rs
@@ -37,6 +37,8 @@ pub struct Settings {
     pub worktrees_dir: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub defaults: Option<serde_json::Value>,
+    #[serde(rename = "codingAgent", skip_serializing_if = "Option::is_none")]
+    pub coding_agent: Option<serde_json::Value>,
 }
 
 pub fn band_home() -> PathBuf {

--- a/apps/dashboard/src/components/AddProjectDialog.tsx
+++ b/apps/dashboard/src/components/AddProjectDialog.tsx
@@ -63,7 +63,7 @@ export function AddProjectDialog({ open, onOpenChange }: Props) {
               <Button
                 type="button"
                 variant="outline"
-                size="icon"
+                size="icon-xs"
                 onClick={handleBrowse}
               >
                 <FolderOpen />

--- a/apps/dashboard/src/components/SettingsPage.tsx
+++ b/apps/dashboard/src/components/SettingsPage.tsx
@@ -1,15 +1,35 @@
 import { useEffect, useState } from "react";
-import { useSettingsStore } from "@/stores/settings-store";
 import {
-  Accordion,
-  AccordionContent,
-  AccordionItem,
-  AccordionTrigger,
-} from "@/components/ui/accordion";
+  useSettingsStore,
+  type CodingAgentConfig,
+  type CodingAgentType,
+} from "@/stores/settings-store";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import { Label } from "@/components/ui/label";
-import { FolderOpen, X } from "lucide-react";
+import { Separator } from "@/components/ui/separator";
+import {
+  ChevronDown,
+  ChevronLeft,
+  ChevronRight,
+  FolderOpen,
+  X,
+} from "lucide-react";
+
+const AGENT_TYPES: { value: CodingAgentType; label: string }[] = [
+  { value: "claude-code", label: "Claude Code" },
+];
+
+const AGENT_LABEL: Record<string, string> = {
+  "claude-code": "Claude Code",
+};
 
 const DEFAULT_DEFAULTS = {
   layout: {
@@ -25,17 +45,50 @@ const DEFAULT_DEFAULTS = {
   ],
 };
 
+type Section = "menu" | "general" | "coding-agent" | "defaults";
+
 interface Props {
   onClose: () => void;
 }
 
+function SettingsRow({
+  label,
+  value,
+  onClick,
+}: {
+  label: string;
+  value?: string;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      className="flex w-full items-center justify-between px-3 py-2.5 text-sm hover:bg-accent/50 rounded-md transition-colors text-left"
+      onClick={onClick}
+    >
+      <span>{label}</span>
+      <span className="flex items-center gap-1 text-muted-foreground">
+        {value && <span className="text-xs truncate max-w-[140px]">{value}</span>}
+        <ChevronRight className="size-4 shrink-0" />
+      </span>
+    </button>
+  );
+}
+
 export function SettingsPage({ onClose }: Props) {
   const { settings, loadSettings, updateSettings } = useSettingsStore();
+  const [section, setSection] = useState<Section>("menu");
   const [worktreesDir, setWorktreesDir] = useState(
     settings.worktreesDir ?? "",
   );
   const [defaultsJson, setDefaultsJson] = useState("");
   const [defaultsError, setDefaultsError] = useState<string | null>(null);
+  const [agentType, setAgentType] = useState<CodingAgentType | "">(
+    settings.codingAgent?.type ?? "",
+  );
+  const [agentCommand, setAgentCommand] = useState(
+    settings.codingAgent?.command ?? "",
+  );
 
   useEffect(() => {
     loadSettings();
@@ -44,11 +97,11 @@ export function SettingsPage({ onClose }: Props) {
   useEffect(() => {
     setWorktreesDir(settings.worktreesDir ?? "");
     setDefaultsJson(
-      settings.defaults
-        ? JSON.stringify(settings.defaults, null, 2)
-        : "",
+      settings.defaults ? JSON.stringify(settings.defaults, null, 2) : "",
     );
-  }, [settings.worktreesDir, settings.defaults]);
+    setAgentType(settings.codingAgent?.type ?? "");
+    setAgentCommand(settings.codingAgent?.command ?? "");
+  }, [settings.worktreesDir, settings.defaults, settings.codingAgent]);
 
   const handleBrowse = async () => {
     try {
@@ -89,11 +142,188 @@ export function SettingsPage({ onClose }: Props) {
         return;
       }
     }
+    let codingAgent: CodingAgentConfig | undefined = undefined;
+    if (agentType) {
+      codingAgent = { type: agentType };
+      if (agentCommand.trim()) {
+        codingAgent.command = agentCommand.trim();
+      }
+    }
     await updateSettings({
       worktreesDir: worktreesDir.trim() || null,
       defaults,
+      codingAgent,
     });
   };
+
+  const worktreesDirPreview = worktreesDir || "Default";
+  const agentPreview = agentType ? AGENT_LABEL[agentType] : "None";
+  const defaultsPreview = defaultsJson.trim() ? "Configured" : "None";
+
+  if (section !== "menu") {
+    return (
+      <div>
+        <div className="flex items-center gap-1 mb-3 px-1">
+          <Button
+            variant="ghost"
+            size="icon-xs"
+            onClick={() => setSection("menu")}
+          >
+            <ChevronLeft />
+          </Button>
+          <h2 className="text-base font-semibold">
+            {section === "general" && "General"}
+            {section === "coding-agent" && "Coding Agent"}
+            {section === "defaults" && "Workspace Settings"}
+          </h2>
+        </div>
+
+        {section === "general" && (
+          <div className="space-y-4 px-1">
+            <div className="space-y-2">
+              <Label htmlFor="worktrees-dir">Worktrees folder</Label>
+              <div className="flex gap-2">
+                <Input
+                  id="worktrees-dir"
+                  placeholder="~/.band/worktrees (default)"
+                  value={worktreesDir}
+                  onChange={(e) => setWorktreesDir(e.target.value)}
+                />
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="icon-xs"
+                  onClick={handleBrowse}
+                >
+                  <FolderOpen />
+                </Button>
+              </div>
+              <p className="text-xs text-muted-foreground">
+                Directory where new worktrees are created. Leave empty for the
+                default location.
+              </p>
+            </div>
+            <Button onClick={handleSave} size="sm">
+              Save
+            </Button>
+          </div>
+        )}
+
+        {section === "coding-agent" && (
+          <div className="space-y-4 px-1">
+            <div className="space-y-2">
+              <Label>Agent type</Label>
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    className="w-full justify-between font-normal h-7 text-xs px-2"
+                  >
+                    {agentType ? AGENT_LABEL[agentType] : "None"}
+                    <ChevronDown className="size-3 opacity-50" />
+                  </Button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align="start" className="w-[--radix-dropdown-menu-trigger-width]">
+                  <DropdownMenuRadioGroup
+                    value={agentType}
+                    onValueChange={(v) =>
+                      setAgentType(v as CodingAgentType | "")
+                    }
+                  >
+                    <DropdownMenuRadioItem value="">
+                      None
+                    </DropdownMenuRadioItem>
+                    {AGENT_TYPES.map((t) => (
+                      <DropdownMenuRadioItem key={t.value} value={t.value}>
+                        {t.label}
+                      </DropdownMenuRadioItem>
+                    ))}
+                  </DropdownMenuRadioGroup>
+                </DropdownMenuContent>
+              </DropdownMenu>
+              <p className="text-xs text-muted-foreground">
+                The coding agent used for background jobs.
+              </p>
+            </div>
+            {agentType && (
+              <div className="space-y-2">
+                <Label htmlFor="agent-command">
+                  Command{" "}
+                  <span className="text-muted-foreground font-normal">
+                    (optional)
+                  </span>
+                </Label>
+                <Input
+                  id="agent-command"
+                  placeholder="claude --dangerously-skip-permissions"
+                  value={agentCommand}
+                  onChange={(e) => setAgentCommand(e.target.value)}
+                />
+                <p className="text-xs text-muted-foreground">
+                  Custom command with arguments to run the agent. Leave empty to
+                  use the default command for the selected agent type.
+                </p>
+              </div>
+            )}
+            <Button onClick={handleSave} size="sm">
+              Save
+            </Button>
+          </div>
+        )}
+
+        {section === "defaults" && (
+          <div className="space-y-4 px-1">
+            <div className="space-y-2">
+              <div className="flex items-center justify-between">
+                <Label htmlFor="defaults-json">
+                  Default layout &amp; terminals
+                </Label>
+                {!defaultsJson.trim() && (
+                  <Button
+                    type="button"
+                    variant="link"
+                    size="sm"
+                    className="h-auto p-0 text-xs"
+                    onClick={handleInsertTemplate}
+                  >
+                    Insert template
+                  </Button>
+                )}
+              </div>
+              <textarea
+                id="defaults-json"
+                className="w-full min-h-[160px] rounded-md border border-input bg-background px-2 py-1.5 text-xs font-mono ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 dark:bg-input/30"
+                placeholder='{"layout": {...}, "terminals": [...]}'
+                value={defaultsJson}
+                onChange={(e) => handleDefaultsChange(e.target.value)}
+                autoCapitalize="off"
+                autoCorrect="off"
+                autoComplete="off"
+                spellCheck={false}
+              />
+              {defaultsError && (
+                <p className="text-xs text-destructive">{defaultsError}</p>
+              )}
+              <p className="text-xs text-muted-foreground">
+                Default VS Code layout and terminal configuration applied to
+                Band worktrees that don't have a project-level{" "}
+                <code className="text-xs">.band/config.json</code>. Leave empty
+                to disable.
+              </p>
+            </div>
+            <Button
+              onClick={handleSave}
+              size="sm"
+              disabled={!!defaultsError}
+            >
+              Save
+            </Button>
+          </div>
+        )}
+      </div>
+    );
+  }
 
   return (
     <div>
@@ -103,87 +333,24 @@ export function SettingsPage({ onClose }: Props) {
           <X />
         </Button>
       </div>
-      <Accordion type="multiple" defaultValue={["general", "defaults"]}>
-        <AccordionItem value="general">
-          <AccordionTrigger>General</AccordionTrigger>
-          <AccordionContent>
-            <div className="space-y-4 pt-1">
-              <div className="space-y-2">
-                <Label htmlFor="worktrees-dir">Worktrees folder</Label>
-                <div className="flex gap-2">
-                  <Input
-                    id="worktrees-dir"
-                    placeholder="~/.band/worktrees (default)"
-                    value={worktreesDir}
-                    onChange={(e) => setWorktreesDir(e.target.value)}
-                  />
-                  <Button
-                    type="button"
-                    variant="outline"
-                    size="icon"
-                    onClick={handleBrowse}
-                  >
-                    <FolderOpen />
-                  </Button>
-                </div>
-                <p className="text-xs text-muted-foreground">
-                  Directory where new worktrees are created. Leave empty for the
-                  default location.
-                </p>
-              </div>
-            </div>
-          </AccordionContent>
-        </AccordionItem>
-        <AccordionItem value="defaults">
-          <AccordionTrigger>Default Workspace</AccordionTrigger>
-          <AccordionContent>
-            <div className="space-y-4 pt-1">
-              <div className="space-y-2">
-                <div className="flex items-center justify-between">
-                  <Label htmlFor="defaults-json">
-                    Default layout &amp; terminals
-                  </Label>
-                  {!defaultsJson.trim() && (
-                    <Button
-                      type="button"
-                      variant="link"
-                      size="sm"
-                      className="h-auto p-0 text-xs"
-                      onClick={handleInsertTemplate}
-                    >
-                      Insert template
-                    </Button>
-                  )}
-                </div>
-                <textarea
-                  id="defaults-json"
-                  className="w-full min-h-[200px] rounded-md border border-input bg-background px-3 py-2 text-sm font-mono ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
-                  placeholder='{"layout": {...}, "terminals": [...]}'
-                  value={defaultsJson}
-                  onChange={(e) => handleDefaultsChange(e.target.value)}
-                  autoCapitalize="off"
-                  autoCorrect="off"
-                  autoComplete="off"
-                  spellCheck={false}
-                />
-                {defaultsError && (
-                  <p className="text-xs text-destructive">{defaultsError}</p>
-                )}
-                <p className="text-xs text-muted-foreground">
-                  Default VS Code layout and terminal configuration applied to
-                  Band worktrees that don't have a project-level{" "}
-                  <code className="text-xs">.band/config.json</code>. Leave
-                  empty to disable.
-                </p>
-              </div>
-            </div>
-          </AccordionContent>
-        </AccordionItem>
-      </Accordion>
-      <div className="mt-4 px-1">
-        <Button onClick={handleSave} size="sm" disabled={!!defaultsError}>
-          Save
-        </Button>
+      <div className="flex flex-col gap-px">
+        <SettingsRow
+          label="General"
+          value={worktreesDirPreview}
+          onClick={() => setSection("general")}
+        />
+        <Separator />
+        <SettingsRow
+          label="Coding Agent"
+          value={agentPreview}
+          onClick={() => setSection("coding-agent")}
+        />
+        <Separator />
+        <SettingsRow
+          label="Workspace Settings"
+          value={defaultsPreview}
+          onClick={() => setSection("defaults")}
+        />
       </div>
     </div>
   );

--- a/apps/dashboard/src/components/ui/input.tsx
+++ b/apps/dashboard/src/components/ui/input.tsx
@@ -12,7 +12,7 @@ function Input({ className, type, ...props }: React.ComponentProps<"input">) {
       spellCheck={false}
       data-slot="input"
       className={cn(
-        "h-9 w-full min-w-0 rounded-md border border-input bg-transparent px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none selection:bg-primary selection:text-primary-foreground file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm dark:bg-input/30",
+        "h-7 w-full min-w-0 rounded-md border border-input bg-transparent px-2 py-1 text-xs shadow-xs transition-[color,box-shadow] outline-none selection:bg-primary selection:text-primary-foreground file:inline-flex file:h-5 file:border-0 file:bg-transparent file:text-xs file:font-medium file:text-foreground placeholder:text-muted-foreground disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 dark:bg-input/30",
         "focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50",
         "aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40",
         className

--- a/apps/dashboard/src/stores/settings-store.ts
+++ b/apps/dashboard/src/stores/settings-store.ts
@@ -31,9 +31,17 @@ export interface BandConfig {
   }[];
 }
 
+export type CodingAgentType = "claude-code";
+
+export interface CodingAgentConfig {
+  type: CodingAgentType;
+  command?: string;
+}
+
 export interface Settings {
   worktreesDir: string | null;
   defaults?: BandConfig;
+  codingAgent?: CodingAgentConfig;
 }
 
 interface SettingsState {


### PR DESCRIPTION
## Summary
- Add **Coding Agent** setting for configuring the default agent for background jobs (agent type + optional custom command)
- Redesign settings page with **iOS-style drill-down navigation** (menu → section → back)
- Replace native `<select>` with Radix dropdown menu for consistent dark theme styling
- Shrink all input sizes globally for a more compact UI

## Changes
- `settings-store.ts`: New `CodingAgentConfig` type and `codingAgent` field on `Settings`
- `state.rs`: Add `coding_agent` field to Rust `Settings` struct for persistence
- `SettingsPage.tsx`: Full rewrite — menu rows with chevrons, section views with back navigation, separators between rows
- `input.tsx`: Smaller default input size (h-7, text-xs)
- `AddProjectDialog.tsx`: Shrink browse button to match smaller inputs

## Test plan
- [ ] Open settings, verify three menu rows render with previews
- [ ] Tap each row, verify drill-down navigation and back button work
- [ ] Set coding agent to Claude Code with a custom command, save, reload — verify persistence
- [ ] Set coding agent to None, save — verify `codingAgent` is removed from settings.json
- [ ] Verify inputs in Add Project and New Workspace dialogs are also smaller

🤖 Generated with [Claude Code](https://claude.com/claude-code)