### PR TITLE
feat: git status and CI status indicators on workspace cards

### DIFF
--- a/apps/dashboard/src-tauri/src/commands/branch_status.rs
+++ b/apps/dashboard/src-tauri/src/commands/branch_status.rs
@@ -1,0 +1,291 @@
+use crate::git;
+use crate::state;
+use serde::Serialize;
+use std::collections::HashMap;
+use std::process::Command;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
+use tauri::{AppHandle, Emitter, Manager};
+
+#[derive(Debug, Clone, Serialize)]
+pub struct GitStatus {
+    pub dirty: bool,
+    pub conflict: bool,
+    pub ahead: u32,
+    pub behind: u32,
+    /// "synced" | "ahead" | "behind" | "diverged" | "untracked" (no upstream)
+    pub sync_state: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct CIStatus {
+    /// "none" | "pending" | "running" | "success" | "failure" | "cancelled"
+    pub state: String,
+    pub url: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct WorkspaceBranchStatus {
+    pub git: GitStatus,
+    pub ci: CIStatus,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct BranchStatusEvent {
+    pub statuses: HashMap<String, WorkspaceBranchStatus>,
+}
+
+pub struct BranchStatusPollerState(pub Arc<Mutex<Option<Arc<AtomicBool>>>>);
+
+fn gh_cmd() -> Command {
+    let mut cmd = Command::new("gh");
+    if let Ok(path) = std::env::var("PATH") {
+        cmd.env("PATH", format!("/opt/homebrew/bin:/usr/local/bin:{}", path));
+    }
+    cmd
+}
+
+fn get_git_status(worktree_path: &str) -> GitStatus {
+    // git status --porcelain
+    let porcelain = git::git_cmd()
+        .args(["status", "--porcelain"])
+        .current_dir(worktree_path)
+        .output();
+
+    let (dirty, conflict) = match porcelain {
+        Ok(output) if output.status.success() => {
+            let text = String::from_utf8_lossy(&output.stdout);
+            let has_changes = !text.trim().is_empty();
+            let has_conflict = text.lines().any(|line| {
+                line.starts_with("UU ")
+                    || line.starts_with("AA ")
+                    || line.starts_with("DD ")
+                    || line.starts_with("AU ")
+                    || line.starts_with("UA ")
+                    || line.starts_with("DU ")
+                    || line.starts_with("UD ")
+            });
+            (has_changes, has_conflict)
+        }
+        _ => (false, false),
+    };
+
+    // Check if there's an upstream tracking branch
+    let has_upstream = git::git_cmd()
+        .args(["rev-parse", "--abbrev-ref", "@{upstream}"])
+        .current_dir(worktree_path)
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false);
+
+    if !has_upstream {
+        return GitStatus {
+            dirty,
+            conflict,
+            ahead: 0,
+            behind: 0,
+            sync_state: "untracked".to_string(),
+        };
+    }
+
+    // git rev-list --left-right --count HEAD...@{upstream}
+    let rev_list = git::git_cmd()
+        .args(["rev-list", "--left-right", "--count", "HEAD...@{upstream}"])
+        .current_dir(worktree_path)
+        .output();
+
+    let (ahead, behind) = match rev_list {
+        Ok(output) if output.status.success() => {
+            let text = String::from_utf8_lossy(&output.stdout);
+            let parts: Vec<&str> = text.trim().split_whitespace().collect();
+            if parts.len() == 2 {
+                let a = parts[0].parse::<u32>().unwrap_or(0);
+                let b = parts[1].parse::<u32>().unwrap_or(0);
+                (a, b)
+            } else {
+                (0, 0)
+            }
+        }
+        _ => (0, 0),
+    };
+
+    let sync_state = match (ahead, behind) {
+        (0, 0) => "synced",
+        (_, 0) => "ahead",
+        (0, _) => "behind",
+        (_, _) => "diverged",
+    };
+
+    GitStatus {
+        dirty,
+        conflict,
+        ahead,
+        behind,
+        sync_state: sync_state.to_string(),
+    }
+}
+
+fn get_ci_status(worktree_path: &str, branch: &str) -> CIStatus {
+    let none = CIStatus {
+        state: "none".to_string(),
+        url: None,
+    };
+
+    let output = match gh_cmd()
+        .args([
+            "run",
+            "list",
+            "--branch",
+            branch,
+            "--limit",
+            "1",
+            "--json",
+            "status,conclusion,url,updatedAt",
+        ])
+        .current_dir(worktree_path)
+        .output()
+    {
+        Ok(o) => o,
+        Err(_) => return none,
+    };
+
+    if !output.status.success() {
+        return none;
+    }
+
+    let text = String::from_utf8_lossy(&output.stdout);
+    let runs: Vec<serde_json::Value> = match serde_json::from_str(&text) {
+        Ok(v) => v,
+        Err(_) => return none,
+    };
+
+    let run = match runs.first() {
+        Some(r) => r,
+        None => return none,
+    };
+
+    let status = run["status"].as_str().unwrap_or("");
+    let conclusion = run["conclusion"].as_str().unwrap_or("");
+    let url = run["url"].as_str().map(|s| s.to_string());
+
+    let state = match status {
+        "completed" => match conclusion {
+            "success" => "success",
+            "failure" | "timed_out" => "failure",
+            "cancelled" | "skipped" => "cancelled",
+            _ => "failure",
+        },
+        "in_progress" => "running",
+        "queued" | "waiting" | "pending" | "requested" => "pending",
+        _ => "none",
+    };
+
+    CIStatus {
+        state: state.to_string(),
+        url,
+    }
+}
+
+#[tauri::command]
+pub fn branch_status_watch_start(app: AppHandle) -> Result<(), String> {
+    let state = app.state::<BranchStatusPollerState>();
+    let mut guard = state.0.lock().unwrap();
+
+    // If already running, stop the old one
+    if let Some(old_stop) = guard.take() {
+        old_stop.store(true, Ordering::Relaxed);
+    }
+
+    let stop_flag = Arc::new(AtomicBool::new(false));
+    *guard = Some(stop_flag.clone());
+    drop(guard);
+
+    let app_handle = app.clone();
+
+    std::thread::spawn(move || {
+        let mut ci_cache: HashMap<String, CIStatus> = HashMap::new();
+        let mut tick_count: u64 = 0;
+
+        loop {
+            if stop_flag.load(Ordering::Relaxed) {
+                break;
+            }
+
+            let app_state = match state::load_state() {
+                Ok(s) => s,
+                Err(_) => {
+                    std::thread::sleep(std::time::Duration::from_secs(5));
+                    tick_count += 1;
+                    continue;
+                }
+            };
+
+            // CI poll every 30s (6 ticks of 5s), git fetch at same cadence
+            let do_ci = tick_count % 6 == 0;
+
+            // git fetch at CI cadence — per unique project path
+            if do_ci {
+                let mut fetched_paths = std::collections::HashSet::new();
+                for proj in &app_state.projects {
+                    if fetched_paths.insert(proj.path.clone()) {
+                        let _ = git::git_cmd()
+                            .args(["fetch", "--quiet", "--all"])
+                            .current_dir(&proj.path)
+                            .output();
+                    }
+                }
+            }
+
+            let mut statuses: HashMap<String, WorkspaceBranchStatus> = HashMap::new();
+
+            for proj in &app_state.projects {
+                for wt in &proj.worktrees {
+                    let ws_id = format!("{}-{}", proj.name, wt.branch);
+                    let git_status = get_git_status(&wt.path);
+
+                    let ci_status = if do_ci {
+                        let ci = get_ci_status(&wt.path, &wt.branch);
+                        ci_cache.insert(ws_id.clone(), ci.clone());
+                        ci
+                    } else {
+                        ci_cache.get(&ws_id).cloned().unwrap_or(CIStatus {
+                            state: "none".to_string(),
+                            url: None,
+                        })
+                    };
+
+                    statuses.insert(
+                        ws_id,
+                        WorkspaceBranchStatus {
+                            git: git_status,
+                            ci: ci_status,
+                        },
+                    );
+                }
+            }
+
+            let _ = app_handle.emit("branch-status", BranchStatusEvent { statuses });
+
+            tick_count += 1;
+            // Sleep in 1s increments to allow stop_flag checking
+            for _ in 0..5 {
+                if stop_flag.load(Ordering::Relaxed) {
+                    return;
+                }
+                std::thread::sleep(std::time::Duration::from_secs(1));
+            }
+        }
+    });
+
+    Ok(())
+}
+
+#[tauri::command]
+pub fn branch_status_watch_stop(app: AppHandle) -> Result<(), String> {
+    let state = app.state::<BranchStatusPollerState>();
+    let mut guard = state.0.lock().unwrap();
+    if let Some(stop_flag) = guard.take() {
+        stop_flag.store(true, Ordering::Relaxed);
+    }
+    Ok(())
+}

--- a/apps/dashboard/src-tauri/src/commands/branch_status.rs
+++ b/apps/dashboard/src-tauri/src/commands/branch_status.rs
@@ -79,12 +79,22 @@ fn get_git_status(worktree_path: &str) -> GitStatus {
         .unwrap_or(false);
 
     if !has_upstream {
+        // Count commits on this branch not on any remote-tracking branch
+        let commit_count = git::git_cmd()
+            .args(["rev-list", "--count", "HEAD", "--not", "--remotes"])
+            .current_dir(worktree_path)
+            .output()
+            .ok()
+            .filter(|o| o.status.success())
+            .and_then(|o| String::from_utf8_lossy(&o.stdout).trim().parse::<u32>().ok())
+            .unwrap_or(0);
+
         return GitStatus {
             dirty,
             conflict,
-            ahead: 0,
+            ahead: commit_count,
             behind: 0,
-            sync_state: "untracked".to_string(),
+            sync_state: if commit_count > 0 { "ahead".to_string() } else { "synced".to_string() },
         };
     }
 

--- a/apps/dashboard/src-tauri/src/commands/mod.rs
+++ b/apps/dashboard/src-tauri/src/commands/mod.rs
@@ -1,3 +1,4 @@
+pub mod branch_status;
 pub mod hooks;
 pub mod ide;
 pub mod project;

--- a/apps/dashboard/src-tauri/src/git.rs
+++ b/apps/dashboard/src-tauri/src/git.rs
@@ -1,7 +1,7 @@
 use std::path::Path;
 use std::process::Command;
 
-fn git_cmd() -> Command {
+pub fn git_cmd() -> Command {
     let mut cmd = Command::new("git");
     // Ensure git is found via Homebrew on macOS
     if let Ok(path) = std::env::var("PATH") {

--- a/apps/dashboard/src-tauri/src/lib.rs
+++ b/apps/dashboard/src-tauri/src/lib.rs
@@ -2,6 +2,7 @@ mod commands;
 mod git;
 mod state;
 
+use commands::branch_status::BranchStatusPollerState;
 use commands::status::WatcherState;
 use std::sync::{Arc, Mutex};
 use tauri::Manager;
@@ -15,6 +16,7 @@ pub fn run() {
         .plugin(tauri_plugin_shell::init())
         .plugin(tauri_plugin_dialog::init())
         .manage(WatcherState(Arc::new(Mutex::new(None))))
+        .manage(BranchStatusPollerState(Arc::new(Mutex::new(None))))
         .invoke_handler(tauri::generate_handler![
             commands::project::project_init,
             commands::project::project_list,
@@ -34,6 +36,8 @@ pub fn run() {
             commands::hooks::hooks_install,
             commands::settings::settings_get,
             commands::settings::settings_update,
+            commands::branch_status::branch_status_watch_start,
+            commands::branch_status::branch_status_watch_stop,
         ])
         .setup(|app| {
             let window = app.get_webview_window("main").unwrap();

--- a/apps/dashboard/src/App.tsx
+++ b/apps/dashboard/src/App.tsx
@@ -4,7 +4,7 @@ import { AddProjectDialog } from "@/components/AddProjectDialog";
 import { SettingsPage } from "@/components/SettingsPage";
 import { useDashboardStore } from "@/stores/dashboard-store";
 import { useSettingsStore } from "@/stores/settings-store";
-import { useStatusWatcher, useActiveWorkspaceWatcher } from "@/hooks/use-status";
+import { useStatusWatcher, useActiveWorkspaceWatcher, useBranchStatusWatcher } from "@/hooks/use-status";
 import { useHooksSetup } from "@/hooks/use-hooks-setup";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { Separator } from "@/components/ui/separator";
@@ -27,6 +27,7 @@ export default function App() {
 
   useStatusWatcher();
   useActiveWorkspaceWatcher();
+  useBranchStatusWatcher();
 
   useEffect(() => {
     loadProjects();

--- a/apps/dashboard/src/components/CIStatusIndicator.tsx
+++ b/apps/dashboard/src/components/CIStatusIndicator.tsx
@@ -1,0 +1,34 @@
+import { CIStatus } from "@/stores/dashboard-store";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+
+interface Props {
+  ci: CIStatus;
+}
+
+const config: Record<string, { color: string; animate?: boolean; label: string }> = {
+  pending: { color: "bg-yellow-400", label: "CI pending" },
+  running: { color: "bg-yellow-400", animate: true, label: "CI running" },
+  success: { color: "bg-green-400", label: "CI passed" },
+  failure: { color: "bg-red-400", label: "CI failed" },
+  cancelled: { color: "bg-gray-400", label: "CI cancelled" },
+};
+
+export function CIStatusIndicator({ ci }: Props) {
+  const cfg = config[ci.state];
+  if (!cfg) return null;
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <span
+          className={`inline-block size-2 rounded-full shrink-0 ${cfg.color} ${cfg.animate ? "animate-pulse" : ""}`}
+        />
+      </TooltipTrigger>
+      <TooltipContent>{cfg.label}</TooltipContent>
+    </Tooltip>
+  );
+}

--- a/apps/dashboard/src/components/CIStatusIndicator.tsx
+++ b/apps/dashboard/src/components/CIStatusIndicator.tsx
@@ -4,31 +4,45 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
+import { CircleCheck, CircleAlert, Loader } from "lucide-react";
 
 interface Props {
   ci: CIStatus;
 }
 
-const config: Record<string, { color: string; animate?: boolean; label: string }> = {
-  pending: { color: "bg-yellow-400", label: "CI pending" },
-  running: { color: "bg-yellow-400", animate: true, label: "CI running" },
-  success: { color: "bg-green-400", label: "CI passed" },
-  failure: { color: "bg-red-400", label: "CI failed" },
-  cancelled: { color: "bg-gray-400", label: "CI cancelled" },
-};
-
 export function CIStatusIndicator({ ci }: Props) {
-  const cfg = config[ci.state];
-  if (!cfg) return null;
+  if (ci.state === "success") {
+    return (
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <CircleCheck className="size-3 shrink-0 text-green-400" />
+        </TooltipTrigger>
+        <TooltipContent>CI passed</TooltipContent>
+      </Tooltip>
+    );
+  }
 
-  return (
-    <Tooltip>
-      <TooltipTrigger asChild>
-        <span
-          className={`inline-block size-2 rounded-full shrink-0 ${cfg.color} ${cfg.animate ? "animate-pulse" : ""}`}
-        />
-      </TooltipTrigger>
-      <TooltipContent>{cfg.label}</TooltipContent>
-    </Tooltip>
-  );
+  if (ci.state === "failure") {
+    return (
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <CircleAlert className="size-3 shrink-0 text-red-400" />
+        </TooltipTrigger>
+        <TooltipContent>CI failed</TooltipContent>
+      </Tooltip>
+    );
+  }
+
+  if (ci.state === "running" || ci.state === "pending") {
+    return (
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Loader className="size-3 shrink-0 text-yellow-400 animate-spin" />
+        </TooltipTrigger>
+        <TooltipContent>{ci.state === "running" ? "CI running" : "CI pending"}</TooltipContent>
+      </Tooltip>
+    );
+  }
+
+  return null;
 }

--- a/apps/dashboard/src/components/GitStatusIndicator.tsx
+++ b/apps/dashboard/src/components/GitStatusIndicator.tsx
@@ -24,8 +24,6 @@ export function GitStatusIndicator({ git }: Props) {
     parts.push({ text: `\u2193${git.behind}`, color: "text-yellow-400", tooltip: `${git.behind} commit${git.behind > 1 ? "s" : ""} behind` });
   } else if (git.sync_state === "diverged") {
     parts.push({ text: `\u2191${git.ahead}\u2193${git.behind}`, color: "text-orange-400", tooltip: `Diverged: ${git.ahead} ahead, ${git.behind} behind` });
-  } else if (git.sync_state === "untracked") {
-    parts.push({ text: "\u2298", color: "text-muted-foreground", tooltip: "No upstream branch" });
   }
 
   if (parts.length === 0) return null;

--- a/apps/dashboard/src/components/GitStatusIndicator.tsx
+++ b/apps/dashboard/src/components/GitStatusIndicator.tsx
@@ -1,0 +1,47 @@
+import { GitStatus } from "@/stores/dashboard-store";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+
+interface Props {
+  git: GitStatus;
+}
+
+export function GitStatusIndicator({ git }: Props) {
+  const parts: { text: string; color: string; tooltip: string }[] = [];
+
+  if (git.conflict) {
+    parts.push({ text: "!", color: "text-red-400", tooltip: "Merge conflict" });
+  } else if (git.dirty) {
+    parts.push({ text: "M", color: "text-yellow-400", tooltip: "Uncommitted changes" });
+  }
+
+  if (git.sync_state === "ahead") {
+    parts.push({ text: `\u2191${git.ahead}`, color: "text-blue-400", tooltip: `${git.ahead} commit${git.ahead > 1 ? "s" : ""} ahead` });
+  } else if (git.sync_state === "behind") {
+    parts.push({ text: `\u2193${git.behind}`, color: "text-yellow-400", tooltip: `${git.behind} commit${git.behind > 1 ? "s" : ""} behind` });
+  } else if (git.sync_state === "diverged") {
+    parts.push({ text: `\u2191${git.ahead}\u2193${git.behind}`, color: "text-orange-400", tooltip: `Diverged: ${git.ahead} ahead, ${git.behind} behind` });
+  } else if (git.sync_state === "untracked") {
+    parts.push({ text: "\u2298", color: "text-muted-foreground", tooltip: "No upstream branch" });
+  }
+
+  if (parts.length === 0) return null;
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <span className="inline-flex items-center gap-0.5 font-mono text-[10px] leading-none shrink-0">
+          {parts.map((p, i) => (
+            <span key={i} className={p.color}>{p.text}</span>
+          ))}
+        </span>
+      </TooltipTrigger>
+      <TooltipContent>
+        {parts.map((p) => p.tooltip).join(", ")}
+      </TooltipContent>
+    </Tooltip>
+  );
+}

--- a/apps/dashboard/src/components/ProjectList.tsx
+++ b/apps/dashboard/src/components/ProjectList.tsx
@@ -19,6 +19,7 @@ import { Clipboard, Ellipsis, FolderOpen, ListMinus, Plus } from "lucide-react";
 export function ProjectList() {
   const projects = useDashboardStore((s) => s.projects);
   const statuses = useDashboardStore((s) => s.statuses);
+  const branchStatuses = useDashboardStore((s) => s.branchStatuses);
   const removeProject = useDashboardStore((s) => s.removeProject);
   const openWorkspace = useDashboardStore((s) => s.openWorkspace);
   const [workspaceDialog, setWorkspaceDialog] = useState<string | null>(null);
@@ -164,6 +165,7 @@ export function ProjectList() {
                     projectName={project.name}
                     defaultBranch={project.defaultBranch}
                     status={statuses.get(wsId)}
+                    branchStatus={branchStatuses.get(wsId)}
                     isFocused={currentIndex === focusedIndex}
                   />
                 );

--- a/apps/dashboard/src/components/WorkspaceCard.tsx
+++ b/apps/dashboard/src/components/WorkspaceCard.tsx
@@ -1,9 +1,12 @@
 import { useEffect, useRef } from "react";
 import { AgentStatusBadge } from "@/components/AgentStatusBadge";
+import { GitStatusIndicator } from "@/components/GitStatusIndicator";
+import { CIStatusIndicator } from "@/components/CIStatusIndicator";
 import {
   useDashboardStore,
   WorktreeInfo,
   WorkspaceStatus,
+  WorkspaceBranchStatus,
 } from "@/stores/dashboard-store";
 import { Button } from "@/components/ui/button";
 import {
@@ -19,10 +22,11 @@ interface Props {
   projectName: string;
   defaultBranch: string;
   status?: WorkspaceStatus;
+  branchStatus?: WorkspaceBranchStatus;
   isFocused?: boolean;
 }
 
-export function WorkspaceCard({ worktree, projectName, defaultBranch, status, isFocused }: Props) {
+export function WorkspaceCard({ worktree, projectName, defaultBranch, status, branchStatus, isFocused }: Props) {
   const cardRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
@@ -46,6 +50,8 @@ export function WorkspaceCard({ worktree, projectName, defaultBranch, status, is
       <div className="flex items-center gap-3 min-w-0 overflow-hidden">
         <GitBranch className={`size-3 shrink-0 ${isActive ? "text-primary" : "text-muted-foreground"}`} />
         <span className={`text-xs truncate ${isActive ? "font-semibold text-foreground" : "font-medium"}`} style={isActive ? undefined : { color: "oklch(0.7 0 0)" }}>{worktree.branch}</span>
+        {branchStatus && <GitStatusIndicator git={branchStatus.git} />}
+        {branchStatus && <CIStatusIndicator ci={branchStatus.ci} />}
         <AgentStatusBadge agent={status?.agent} />
       </div>
       <DropdownMenu>

--- a/apps/dashboard/src/components/WorkspaceCard.tsx
+++ b/apps/dashboard/src/components/WorkspaceCard.tsx
@@ -50,10 +50,11 @@ export function WorkspaceCard({ worktree, projectName, defaultBranch, status, br
       <div className="flex items-center gap-3 min-w-0 overflow-hidden">
         <GitBranch className={`size-3 shrink-0 ${isActive ? "text-primary" : "text-muted-foreground"}`} />
         <span className={`text-xs truncate ${isActive ? "font-semibold text-foreground" : "font-medium"}`} style={isActive ? undefined : { color: "oklch(0.7 0 0)" }}>{worktree.branch}</span>
-        {branchStatus && <GitStatusIndicator git={branchStatus.git} />}
-        {branchStatus && <CIStatusIndicator ci={branchStatus.ci} />}
         <AgentStatusBadge agent={status?.agent} />
       </div>
+      <div className="flex items-center gap-2 shrink-0">
+        {branchStatus && <GitStatusIndicator git={branchStatus.git} />}
+        {branchStatus && <CIStatusIndicator ci={branchStatus.ci} />}
       <DropdownMenu>
         <DropdownMenuTrigger asChild onClick={(e) => e.stopPropagation()}>
           <Button
@@ -90,6 +91,7 @@ export function WorkspaceCard({ worktree, projectName, defaultBranch, status, br
           )}
         </DropdownMenuContent>
       </DropdownMenu>
+      </div>
     </div>
   );
 }

--- a/apps/dashboard/src/hooks/use-status.ts
+++ b/apps/dashboard/src/hooks/use-status.ts
@@ -1,5 +1,5 @@
 import { useEffect } from "react";
-import { useDashboardStore, WorkspaceStatus } from "@/stores/dashboard-store";
+import { useDashboardStore, WorkspaceStatus, WorkspaceBranchStatus } from "@/stores/dashboard-store";
 
 function isTauri(): boolean {
   return typeof window !== "undefined" && "__TAURI_INTERNALS__" in window;
@@ -76,4 +76,36 @@ export function useActiveWorkspaceWatcher() {
 
     return () => cleanup?.();
   }, [setActiveWorkspace]);
+}
+
+interface BranchStatusEvent {
+  statuses: Record<string, WorkspaceBranchStatus>;
+}
+
+export function useBranchStatusWatcher() {
+  const updateBranchStatuses = useDashboardStore((s) => s.updateBranchStatuses);
+
+  useEffect(() => {
+    if (!isTauri()) return;
+
+    let cleanup: (() => void) | undefined;
+
+    (async () => {
+      const { invoke } = await import("@tauri-apps/api/core");
+      const { listen } = await import("@tauri-apps/api/event");
+
+      invoke("branch_status_watch_start").catch(console.error);
+
+      const unlisten = await listen<BranchStatusEvent>("branch-status", (event) => {
+        updateBranchStatuses(event.payload.statuses);
+      });
+
+      cleanup = () => {
+        unlisten();
+        invoke("branch_status_watch_stop").catch(console.error);
+      };
+    })();
+
+    return () => cleanup?.();
+  }, [updateBranchStatuses]);
 }

--- a/apps/dashboard/src/stores/dashboard-store.ts
+++ b/apps/dashboard/src/stores/dashboard-store.ts
@@ -45,7 +45,7 @@ export interface WorktreeInfo {
   head?: string;
 }
 
-export type GitSyncState = "synced" | "ahead" | "behind" | "diverged" | "untracked";
+export type GitSyncState = "synced" | "ahead" | "behind" | "diverged";
 
 export interface GitStatus {
   dirty: boolean;

--- a/apps/dashboard/src/stores/dashboard-store.ts
+++ b/apps/dashboard/src/stores/dashboard-store.ts
@@ -45,6 +45,28 @@ export interface WorktreeInfo {
   head?: string;
 }
 
+export type GitSyncState = "synced" | "ahead" | "behind" | "diverged" | "untracked";
+
+export interface GitStatus {
+  dirty: boolean;
+  conflict: boolean;
+  ahead: number;
+  behind: number;
+  sync_state: GitSyncState;
+}
+
+export type CIState = "none" | "pending" | "running" | "success" | "failure" | "cancelled";
+
+export interface CIStatus {
+  state: CIState;
+  url?: string;
+}
+
+export interface WorkspaceBranchStatus {
+  git: GitStatus;
+  ci: CIStatus;
+}
+
 interface DashboardState {
   projects: ProjectInfo[];
   statuses: Map<string, WorkspaceStatus>;
@@ -66,11 +88,14 @@ interface DashboardState {
   updateStatus: (status: WorkspaceStatus) => void;
   removeStatus: (workspaceId: string) => void;
   setActiveWorkspace: (workspaceId: string | null) => void;
+  branchStatuses: Map<string, WorkspaceBranchStatus>;
+  updateBranchStatuses: (statuses: Record<string, WorkspaceBranchStatus>) => void;
 }
 
 export const useDashboardStore = create<DashboardState>((set, get) => ({
   projects: [],
   statuses: new Map(),
+  branchStatuses: new Map(),
   activeWorkspaceId: null,
   loading: false,
   error: null,
@@ -162,5 +187,9 @@ export const useDashboardStore = create<DashboardState>((set, get) => ({
     console.log("[dashboard] setActiveWorkspace:", workspaceId, "(current:", get().activeWorkspaceId + ")");
     if (get().activeWorkspaceId === workspaceId) return;
     set({ activeWorkspaceId: workspaceId });
+  },
+
+  updateBranchStatuses: (statuses: Record<string, WorkspaceBranchStatus>) => {
+    set({ branchStatuses: new Map(Object.entries(statuses)) });
   },
 }));


### PR DESCRIPTION
## Summary
- Poll git working directory state (dirty/conflict/ahead/behind) every 5s and GitHub Actions CI status every 30s via a Rust background thread
- Display compact inline indicators on each workspace card: modified marker, ahead/behind counts, CI pass/fail icons
- Graceful degradation when `gh` CLI is not installed or authenticated

## Test plan
- [ ] Create a workspace, make uncommitted changes → see yellow `M` indicator
- [ ] Push a commit → see `↑1` indicator until `git push`
- [ ] If `gh` CLI is authenticated → see green check or red alert after CI runs
- [ ] If `gh` not installed → no CI indicator shown

🤖 Generated with [Claude Code](https://claude.com/claude-code)