### PR TITLE
feat: notification sound on agent needs attention

### DIFF
--- a/apps/dashboard/src-tauri/src/state.rs
+++ b/apps/dashboard/src-tauri/src/state.rs
@@ -32,6 +32,18 @@ impl Default for AppState {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct NotificationSettings {
+    #[serde(
+        rename = "soundOnNeedsAttention",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub sound_on_needs_attention: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub sound: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct Settings {
     #[serde(rename = "worktreesDir", skip_serializing_if = "Option::is_none")]
     pub worktrees_dir: Option<String>,
@@ -39,6 +51,8 @@ pub struct Settings {
     pub defaults: Option<serde_json::Value>,
     #[serde(rename = "codingAgent", skip_serializing_if = "Option::is_none")]
     pub coding_agent: Option<serde_json::Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub notifications: Option<NotificationSettings>,
 }
 
 pub fn band_home() -> PathBuf {

--- a/apps/dashboard/src/components/SettingsPage.tsx
+++ b/apps/dashboard/src/components/SettingsPage.tsx
@@ -15,6 +15,7 @@ import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import { Label } from "@/components/ui/label";
 import { Separator } from "@/components/ui/separator";
+import { Switch } from "@/components/ui/switch";
 import {
   ChevronDown,
   ChevronLeft,
@@ -27,6 +28,7 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
+import { playSound, SOUNDS, type SoundId } from "@/lib/sounds";
 
 const AGENT_TYPES: { value: CodingAgentType; label: string }[] = [
   { value: "claude-code", label: "Claude Code" },
@@ -50,7 +52,7 @@ const DEFAULT_DEFAULTS = {
   ],
 };
 
-type Section = "menu" | "general" | "coding-agent" | "defaults";
+type Section = "menu" | "general" | "coding-agent" | "defaults" | "notifications";
 
 interface Props {
   onClose: () => void;
@@ -94,6 +96,12 @@ export function SettingsPage({ onClose }: Props) {
   const [agentCommand, setAgentCommand] = useState(
     settings.codingAgent?.command ?? "",
   );
+  const [soundOnNeedsAttention, setSoundOnNeedsAttention] = useState(
+    settings.notifications?.soundOnNeedsAttention ?? false,
+  );
+  const [selectedSound, setSelectedSound] = useState<SoundId>(
+    (settings.notifications?.sound as SoundId) ?? "chime",
+  );
 
   useEffect(() => {
     loadSettings();
@@ -106,7 +114,13 @@ export function SettingsPage({ onClose }: Props) {
     );
     setAgentType(settings.codingAgent?.type ?? "");
     setAgentCommand(settings.codingAgent?.command ?? "");
-  }, [settings.worktreesDir, settings.defaults, settings.codingAgent]);
+    setSoundOnNeedsAttention(
+      settings.notifications?.soundOnNeedsAttention ?? false,
+    );
+    setSelectedSound(
+      (settings.notifications?.sound as SoundId) ?? "chime",
+    );
+  }, [settings.worktreesDir, settings.defaults, settings.codingAgent, settings.notifications]);
 
   const handleBrowse = async () => {
     try {
@@ -158,12 +172,16 @@ export function SettingsPage({ onClose }: Props) {
       worktreesDir: worktreesDir.trim() || null,
       defaults,
       codingAgent,
+      notifications: { soundOnNeedsAttention, sound: selectedSound },
     });
   };
 
   const worktreesDirPreview = worktreesDir || "Default";
   const agentPreview = agentType ? AGENT_LABEL[agentType] : "None";
   const defaultsPreview = defaultsJson.trim() ? "Configured" : "None";
+  const notificationsPreview = soundOnNeedsAttention
+    ? SOUNDS.find((s) => s.id === selectedSound)?.label ?? "On"
+    : "Off";
 
   if (section !== "menu") {
     return (
@@ -180,6 +198,7 @@ export function SettingsPage({ onClose }: Props) {
             {section === "general" && "General"}
             {section === "coding-agent" && "Coding Agent"}
             {section === "defaults" && "Workspace Settings"}
+            {section === "notifications" && "Notifications"}
           </h2>
           <Tooltip>
             <TooltipTrigger asChild>
@@ -327,6 +346,65 @@ export function SettingsPage({ onClose }: Props) {
             </div>
           </div>
         )}
+
+        {section === "notifications" && (
+          <div className="space-y-4 px-1">
+            <div className="space-y-2">
+              <Label>Notification sound</Label>
+              <div className="flex items-center justify-between">
+                <span className="text-xs text-muted-foreground">
+                  Play when agent needs attention
+                </span>
+                <Switch
+                  id="sound-needs-attention"
+                  checked={soundOnNeedsAttention}
+                  onCheckedChange={(checked) => {
+                    setSoundOnNeedsAttention(checked);
+                    if (checked) {
+                      playSound(selectedSound);
+                    }
+                  }}
+                />
+              </div>
+            </div>
+            {soundOnNeedsAttention && (
+              <div className="space-y-2">
+                <Label>Sound</Label>
+                <DropdownMenu>
+                  <DropdownMenuTrigger asChild>
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      className="w-full justify-between font-normal h-7 text-xs px-2"
+                    >
+                      {SOUNDS.find((s) => s.id === selectedSound)?.label ?? "Chime"}
+                      <ChevronDown className="size-3 opacity-50" />
+                    </Button>
+                  </DropdownMenuTrigger>
+                  <DropdownMenuContent align="start" className="w-[--radix-dropdown-menu-trigger-width]">
+                    <DropdownMenuRadioGroup
+                      value={selectedSound}
+                      onValueChange={(v) => {
+                        setSelectedSound(v as SoundId);
+                        playSound(v as SoundId);
+                      }}
+                    >
+                      {SOUNDS.map((s) => (
+                        <DropdownMenuRadioItem key={s.id} value={s.id}>
+                          {s.label}
+                        </DropdownMenuRadioItem>
+                      ))}
+                    </DropdownMenuRadioGroup>
+                  </DropdownMenuContent>
+                </DropdownMenu>
+                <p className="text-xs text-muted-foreground">
+                  Choose a sound to play when an agent transitions from working
+                  to needs attention.
+                </p>
+              </div>
+            )}
+          </div>
+        )}
       </div>
     );
   }
@@ -356,6 +434,12 @@ export function SettingsPage({ onClose }: Props) {
           label="Workspace Settings"
           value={defaultsPreview}
           onClick={() => setSection("defaults")}
+        />
+        <Separator />
+        <SettingsRow
+          label="Notifications"
+          value={notificationsPreview}
+          onClick={() => setSection("notifications")}
         />
       </div>
     </div>

--- a/apps/dashboard/src/components/ui/switch.tsx
+++ b/apps/dashboard/src/components/ui/switch.tsx
@@ -1,0 +1,27 @@
+import * as React from "react"
+import { Switch as SwitchPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+
+function Switch({
+  className,
+  ...props
+}: React.ComponentProps<typeof SwitchPrimitive.Root>) {
+  return (
+    <SwitchPrimitive.Root
+      className={cn(
+        "peer inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent shadow-xs transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=unchecked]:bg-input",
+        className,
+      )}
+      {...props}
+    >
+      <SwitchPrimitive.Thumb
+        className={cn(
+          "pointer-events-none block h-4 w-4 rounded-full bg-background shadow-lg ring-0 transition-transform data-[state=checked]:translate-x-4 data-[state=unchecked]:translate-x-0",
+        )}
+      />
+    </SwitchPrimitive.Root>
+  )
+}
+
+export { Switch }

--- a/apps/dashboard/src/hooks/use-status.ts
+++ b/apps/dashboard/src/hooks/use-status.ts
@@ -1,5 +1,7 @@
-import { useEffect } from "react";
-import { useDashboardStore, WorkspaceStatus, GitStatus, CIStatus } from "@/stores/dashboard-store";
+import { useEffect, useRef } from "react";
+import { useDashboardStore, WorkspaceStatus, AgentStatusType, GitStatus, CIStatus } from "@/stores/dashboard-store";
+import { useSettingsStore } from "@/stores/settings-store";
+import { playSound, type SoundId } from "@/lib/sounds";
 
 function isTauri(): boolean {
   return typeof window !== "undefined" && "__TAURI_INTERNALS__" in window;
@@ -14,6 +16,7 @@ interface StatusEvent {
 export function useStatusWatcher() {
   const updateStatus = useDashboardStore((s) => s.updateStatus);
   const removeStatus = useDashboardStore((s) => s.removeStatus);
+  const previousStatuses = useRef<Map<string, AgentStatusType>>(new Map());
 
   useEffect(() => {
     if (!isTauri()) return;
@@ -29,8 +32,30 @@ export function useStatusWatcher() {
       const unlisten = await listen<StatusEvent>("agent-status", (event) => {
         const payload = event.payload;
         if (payload.kind === "update" && payload.status) {
+          const wsId = payload.status.workspaceId;
+          const newAgentStatus = payload.status.agent?.status;
+          const prevAgentStatus = previousStatuses.current.get(wsId);
+
+          if (newAgentStatus) {
+            previousStatuses.current.set(wsId, newAgentStatus);
+          } else {
+            previousStatuses.current.delete(wsId);
+          }
+
+          if (
+            prevAgentStatus === "working" &&
+            newAgentStatus === "needs_attention"
+          ) {
+            const notifications =
+              useSettingsStore.getState().settings.notifications;
+            if (notifications?.soundOnNeedsAttention) {
+              playSound((notifications.sound ?? "chime") as SoundId);
+            }
+          }
+
           updateStatus(payload.status);
         } else if (payload.kind === "remove" && payload.workspaceId) {
+          previousStatuses.current.delete(payload.workspaceId);
           removeStatus(payload.workspaceId);
         }
       });

--- a/apps/dashboard/src/lib/sounds.ts
+++ b/apps/dashboard/src/lib/sounds.ts
@@ -1,0 +1,165 @@
+let audioContext: AudioContext | null = null;
+
+function getAudioContext(): AudioContext {
+  if (!audioContext) {
+    audioContext = new AudioContext();
+  }
+  return audioContext;
+}
+
+export type SoundId =
+  | "chime"
+  | "bell"
+  | "ping"
+  | "drop"
+  | "ripple"
+  | "blip"
+  | "horn"
+  | "marimba"
+  | "chirp"
+  | "gong";
+
+export const SOUNDS: { id: SoundId; label: string }[] = [
+  { id: "chime", label: "Chime" },
+  { id: "bell", label: "Bell" },
+  { id: "ping", label: "Ping" },
+  { id: "drop", label: "Drop" },
+  { id: "ripple", label: "Ripple" },
+  { id: "blip", label: "Blip" },
+  { id: "horn", label: "Horn" },
+  { id: "marimba", label: "Marimba" },
+  { id: "chirp", label: "Chirp" },
+  { id: "gong", label: "Gong" },
+];
+
+function playTone(
+  ctx: AudioContext,
+  freq: number,
+  start: number,
+  duration: number,
+  volume: number,
+  type: OscillatorType = "sine",
+) {
+  const osc = ctx.createOscillator();
+  const gain = ctx.createGain();
+  osc.type = type;
+  osc.frequency.value = freq;
+  gain.gain.setValueAtTime(0, start);
+  gain.gain.linearRampToValueAtTime(volume, start + 0.01);
+  gain.gain.exponentialRampToValueAtTime(0.001, start + duration);
+  osc.connect(gain);
+  gain.connect(ctx.destination);
+  osc.start(start);
+  osc.stop(start + duration);
+}
+
+function playChime() {
+  const ctx = getAudioContext();
+  const now = ctx.currentTime;
+  playTone(ctx, 660, now, 0.12, 0.3);
+  playTone(ctx, 880, now + 0.2, 0.12, 0.3);
+}
+
+function playBell() {
+  const ctx = getAudioContext();
+  const now = ctx.currentTime;
+  playTone(ctx, 830, now, 0.6, 0.25);
+  playTone(ctx, 1245, now, 0.4, 0.1);
+  playTone(ctx, 1660, now, 0.2, 0.05);
+}
+
+function playPing() {
+  const ctx = getAudioContext();
+  const now = ctx.currentTime;
+  playTone(ctx, 1200, now, 0.15, 0.25);
+}
+
+function playDrop() {
+  const ctx = getAudioContext();
+  const now = ctx.currentTime;
+  const osc = ctx.createOscillator();
+  const gain = ctx.createGain();
+  osc.type = "sine";
+  osc.frequency.setValueAtTime(800, now);
+  osc.frequency.exponentialRampToValueAtTime(300, now + 0.3);
+  gain.gain.setValueAtTime(0.3, now);
+  gain.gain.exponentialRampToValueAtTime(0.001, now + 0.3);
+  osc.connect(gain);
+  gain.connect(ctx.destination);
+  osc.start(now);
+  osc.stop(now + 0.3);
+}
+
+function playRipple() {
+  const ctx = getAudioContext();
+  const now = ctx.currentTime;
+  const notes = [523, 659, 784, 1047];
+  notes.forEach((freq, i) => {
+    playTone(ctx, freq, now + i * 0.08, 0.15, 0.2);
+  });
+}
+
+function playBlip() {
+  const ctx = getAudioContext();
+  const now = ctx.currentTime;
+  playTone(ctx, 440, now, 0.06, 0.25, "square");
+  playTone(ctx, 660, now + 0.08, 0.06, 0.25, "square");
+}
+
+function playHorn() {
+  const ctx = getAudioContext();
+  const now = ctx.currentTime;
+  playTone(ctx, 440, now, 0.3, 0.2, "sawtooth");
+  playTone(ctx, 554, now + 0.05, 0.25, 0.15, "sawtooth");
+}
+
+function playMarimba() {
+  const ctx = getAudioContext();
+  const now = ctx.currentTime;
+  playTone(ctx, 523, now, 0.2, 0.3, "triangle");
+  playTone(ctx, 659, now + 0.15, 0.2, 0.25, "triangle");
+  playTone(ctx, 784, now + 0.3, 0.25, 0.2, "triangle");
+}
+
+function playChirp() {
+  const ctx = getAudioContext();
+  const now = ctx.currentTime;
+  const osc = ctx.createOscillator();
+  const gain = ctx.createGain();
+  osc.type = "sine";
+  osc.frequency.setValueAtTime(400, now);
+  osc.frequency.exponentialRampToValueAtTime(1600, now + 0.1);
+  osc.frequency.exponentialRampToValueAtTime(400, now + 0.2);
+  gain.gain.setValueAtTime(0, now);
+  gain.gain.linearRampToValueAtTime(0.25, now + 0.02);
+  gain.gain.exponentialRampToValueAtTime(0.001, now + 0.2);
+  osc.connect(gain);
+  gain.connect(ctx.destination);
+  osc.start(now);
+  osc.stop(now + 0.2);
+}
+
+function playGong() {
+  const ctx = getAudioContext();
+  const now = ctx.currentTime;
+  playTone(ctx, 220, now, 1.0, 0.25);
+  playTone(ctx, 330, now, 0.6, 0.1);
+  playTone(ctx, 440, now, 0.3, 0.05, "triangle");
+}
+
+const players: Record<SoundId, () => void> = {
+  chime: playChime,
+  bell: playBell,
+  ping: playPing,
+  drop: playDrop,
+  ripple: playRipple,
+  blip: playBlip,
+  horn: playHorn,
+  marimba: playMarimba,
+  chirp: playChirp,
+  gong: playGong,
+};
+
+export function playSound(id: SoundId) {
+  players[id]();
+}

--- a/apps/dashboard/src/stores/settings-store.ts
+++ b/apps/dashboard/src/stores/settings-store.ts
@@ -38,10 +38,16 @@ export interface CodingAgentConfig {
   command?: string;
 }
 
+export interface NotificationSettings {
+  soundOnNeedsAttention?: boolean;
+  sound?: string;
+}
+
 export interface Settings {
   worktreesDir: string | null;
   defaults?: BandConfig;
   codingAgent?: CodingAgentConfig;
+  notifications?: NotificationSettings;
 }
 
 interface SettingsState {


### PR DESCRIPTION
## Summary
- Add configurable notification sound when an agent transitions from working to needs_attention
- 10 built-in sounds generated via Web Audio API (Chime, Bell, Ping, Drop, Ripple, Blip, Horn, Marimba, Chirp, Gong)
- New Notifications section in settings with toggle and sound picker dropdown

## Test plan
- [ ] Enable notification sound in Settings > Notifications
- [ ] Verify sound preview plays when toggling on and when selecting a sound
- [ ] Verify sound plays when an agent transitions from working to needs_attention
- [ ] Verify no sound plays when the setting is off

🤖 Generated with [Claude Code](https://claude.com/claude-code)