### PR TITLE
fix: suppress deprecated cocoa crate warnings in Rust build

### DIFF
--- a/apps/dashboard/src-tauri/src/lib.rs
+++ b/apps/dashboard/src-tauri/src/lib.rs
@@ -66,6 +66,7 @@ pub fn run() {
 
             // Set window background to black so the transparent title bar appears black
             #[cfg(target_os = "macos")]
+            #[allow(deprecated)] // cocoa crate deprecated in favor of objc2-app-kit
             {
                 use cocoa::appkit::NSWindow;
                 use cocoa::appkit::NSColor;


### PR DESCRIPTION
## Summary
- Adds `#[allow(deprecated)]` to the macOS-specific cocoa crate block in `lib.rs` to suppress 8 deprecation warnings during Rust builds
- The cocoa crate has deprecated its APIs in favor of `objc2-app-kit`, but migration is out of scope for this fix

## Test plan
- [x] Verified `cargo build` completes with zero warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)