### PR TITLE
feat: add setup/teardown script support for worktrees

### DIFF
--- a/.band/config.json
+++ b/.band/config.json
@@ -1,0 +1,3 @@
+{
+  "setup": "pnpm install"
+}

--- a/.superset/config.json
+++ b/.superset/config.json
@@ -1,4 +1,0 @@
-{
-  "setup": [],
-  "teardown": []
-}

--- a/apps/dashboard/src-tauri/src/commands/workspace.rs
+++ b/apps/dashboard/src-tauri/src/commands/workspace.rs
@@ -33,11 +33,18 @@ pub fn workspace_create(project: String, branch: String, base: Option<String>) -
 
     proj.worktrees.push(state::WorktreeState {
         branch: branch.clone(),
-        path: target_path_str,
+        path: target_path_str.clone(),
         head: None,
     });
 
     state::save_state(&app_state)?;
+
+    // Run setup script if configured
+    let config = state::load_project_config(&target_path_str);
+    if let Some(setup) = &config.setup {
+        state::run_script(setup, &target_path_str)?;
+    }
+
     Ok(())
 }
 
@@ -82,6 +89,12 @@ pub fn workspace_remove(project: String, branch: String) -> Result<(), String> {
 
     // Do heavy cleanup (close IDE, remove worktree from disk) in a background thread
     std::thread::spawn(move || {
+        // Run teardown script if configured
+        let config = state::load_project_config(&worktree_path);
+        if let Some(teardown) = &config.teardown {
+            let _ = state::run_script(teardown, &worktree_path);
+        }
+
         ide::close_workspace(&worktree_path);
 
         if std::path::Path::new(&worktree_path).exists() {

--- a/apps/dashboard/src-tauri/src/state.rs
+++ b/apps/dashboard/src-tauri/src/state.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Serialize};
 use std::fs;
 use std::path::PathBuf;
+use std::process::Command;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ProjectState {
@@ -126,4 +127,43 @@ pub fn worktrees_dir() -> PathBuf {
         .and_then(|s| s.worktrees_dir)
         .map(PathBuf::from)
         .unwrap_or_else(|| band_home().join("worktrees"))
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct ProjectConfig {
+    pub setup: Option<String>,
+    pub teardown: Option<String>,
+}
+
+pub fn load_project_config(project_path: &str) -> ProjectConfig {
+    let config_path = PathBuf::from(project_path).join(".band").join("config.json");
+    if !config_path.exists() {
+        return ProjectConfig::default();
+    }
+    fs::read_to_string(&config_path)
+        .ok()
+        .and_then(|data| serde_json::from_str(&data).ok())
+        .unwrap_or_default()
+}
+
+pub fn run_script(command: &str, cwd: &str) -> Result<(), String> {
+    let output = Command::new("sh")
+        .args(["-c", command])
+        .current_dir(cwd)
+        .env(
+            "PATH",
+            format!(
+                "/opt/homebrew/bin:/usr/local/bin:{}",
+                std::env::var("PATH").unwrap_or_default()
+            ),
+        )
+        .output()
+        .map_err(|e| format!("Failed to run script: {}", e))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(format!("Script failed: {}", stderr));
+    }
+
+    Ok(())
 }


### PR DESCRIPTION
## Summary
- Add optional `setup` and `teardown` script support via `.band/config.json`
- Run `setup` command after worktree creation, `teardown` before worktree removal
- Replace `.superset/config.json` with `.band/config.json`

## Test plan
- [ ] Build with `cargo build` in `apps/dashboard/src-tauri/`
- [ ] Create a worktree and verify the setup script runs
- [ ] Remove a worktree and verify the teardown script runs
- [ ] Verify projects without `.band/config.json` still work normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)