### PR TITLE
feat: add session history listing and loading on web

### DIFF
--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -1,7 +1,8 @@
 import { useChat } from "@ai-sdk/react";
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@band/ui";
 import { DefaultChatTransport, isToolUIPart } from "ai";
-import { Bot, Loader2 } from "lucide-react";
-import { useCallback, useMemo, useRef } from "react";
+import { Bot, ChevronDownIcon, Loader2, WrenchIcon } from "lucide-react";
+import { useCallback, useMemo, useRef, useState } from "react";
 import {
   Conversation,
   ConversationContent,
@@ -13,6 +14,7 @@ import { Message, MessageContent, MessageResponse } from "./ai-elements/message"
 import type { PromptInputMessage } from "./ai-elements/prompt-input";
 import { PromptInput, PromptInputSubmit, PromptInputTextarea } from "./ai-elements/prompt-input";
 import { ToolCallGroup } from "./ai-elements/tool-call-group";
+import { SessionList } from "./SessionList";
 
 function ThinkingIndicator() {
   return (
@@ -23,13 +25,43 @@ function ThinkingIndicator() {
   );
 }
 
+interface HistoryMessageContent {
+  type: "text" | "tool_use" | "tool_result";
+  text?: string;
+  toolCallId?: string;
+  toolName?: string;
+  input?: unknown;
+  output?: string;
+  isError?: boolean;
+}
+
+interface HistoryMessage {
+  role: "user" | "assistant";
+  id: string;
+  content: HistoryMessageContent[];
+}
+
 interface ChatViewProps {
   workspaceId: string;
   workspaceName: string;
+  supportsSessionListing: boolean;
+  showSessionList: boolean;
+  onShowSessionListChange: (show: boolean) => void;
 }
 
-export function ChatView({ workspaceId, workspaceName }: ChatViewProps) {
+export function ChatView({
+  workspaceId,
+  workspaceName,
+  supportsSessionListing,
+  showSessionList,
+  onShowSessionListChange,
+}: ChatViewProps) {
   const sessionIdRef = useRef<string | undefined>(undefined);
+  const [activeSessionId, setActiveSessionId] = useState<string | undefined>(undefined);
+  const [historicalMessages, setHistoricalMessages] = useState<HistoryMessage[]>([]);
+  const [loadingHistory, setLoadingHistory] = useState(false);
+  const [historyOffset, setHistoryOffset] = useState(0);
+  const [hasMoreHistory, setHasMoreHistory] = useState(false);
 
   const transport = useMemo(
     () =>
@@ -42,7 +74,7 @@ export function ChatView({ workspaceId, workspaceName }: ChatViewProps) {
     [workspaceId],
   );
 
-  const { messages, sendMessage, status } = useChat({
+  const { messages, sendMessage, status, setMessages } = useChat({
     transport,
     onData: (dataPart) => {
       if (
@@ -58,6 +90,61 @@ export function ChatView({ workspaceId, workspaceName }: ChatViewProps) {
 
   const isStreaming = status === "submitted" || status === "streaming";
 
+  const PAGE_SIZE = 50;
+
+  const loadMessages = useCallback(
+    async (sessionId: string, offset: number) => {
+      setLoadingHistory(true);
+      try {
+        const res = await fetch(
+          `/api/sessions/${encodeURIComponent(workspaceId)}/${encodeURIComponent(sessionId)}/messages?limit=${PAGE_SIZE}&offset=${offset}`,
+        );
+        if (!res.ok) throw new Error("Failed to load messages");
+        const data = (await res.json()) as { messages: HistoryMessage[] };
+        if (offset === 0) {
+          setHistoricalMessages(data.messages);
+        } else {
+          setHistoricalMessages((prev) => [...data.messages, ...prev]);
+        }
+        setHistoryOffset(offset + data.messages.length);
+        setHasMoreHistory(data.messages.length === PAGE_SIZE);
+      } finally {
+        setLoadingHistory(false);
+      }
+    },
+    [workspaceId],
+  );
+
+  const handleSelectSession = useCallback(
+    async (sessionId: string) => {
+      sessionIdRef.current = sessionId;
+      setActiveSessionId(sessionId);
+      setMessages([]);
+      setHistoricalMessages([]);
+      setHistoryOffset(0);
+      setHasMoreHistory(false);
+      onShowSessionListChange(false);
+      await loadMessages(sessionId, 0);
+    },
+    [loadMessages, setMessages, onShowSessionListChange],
+  );
+
+  const handleNewSession = useCallback(() => {
+    sessionIdRef.current = undefined;
+    setActiveSessionId(undefined);
+    setHistoricalMessages([]);
+    setHistoryOffset(0);
+    setHasMoreHistory(false);
+    setMessages([]);
+    onShowSessionListChange(false);
+  }, [setMessages, onShowSessionListChange]);
+
+  const handleLoadMore = useCallback(() => {
+    if (activeSessionId && !loadingHistory) {
+      loadMessages(activeSessionId, historyOffset);
+    }
+  }, [activeSessionId, loadingHistory, historyOffset, loadMessages]);
+
   const handleSubmit = useCallback(
     (message: PromptInputMessage) => {
       if (!message.text.trim()) return;
@@ -66,17 +153,65 @@ export function ChatView({ workspaceId, workspaceName }: ChatViewProps) {
     [sendMessage],
   );
 
+  if (supportsSessionListing && showSessionList) {
+    return (
+      <SessionList
+        workspaceId={workspaceId}
+        activeSessionId={activeSessionId ?? sessionIdRef.current}
+        onSelectSession={handleSelectSession}
+        onNewSession={handleNewSession}
+      />
+    );
+  }
+
+  const hasHistory = historicalMessages.length > 0;
+  const hasLiveMessages = messages.length > 0;
+  const isEmpty = !hasHistory && !hasLiveMessages;
+
   return (
     <div className="flex h-full flex-col">
       <Conversation className="min-h-0 flex-1">
         <ConversationContent>
-          {messages.length === 0 && (
+          {isEmpty && (
             <ConversationEmptyState
               icon={<Bot className="size-8" />}
               title={workspaceName}
               description="Send a message to start coding"
             />
           )}
+
+          {hasMoreHistory && (
+            <div className="flex justify-center py-3">
+              <button
+                type="button"
+                onClick={handleLoadMore}
+                disabled={loadingHistory}
+                className="inline-flex items-center gap-2 rounded-md bg-secondary px-3 py-1.5 text-xs text-muted-foreground transition-colors hover:bg-secondary/80 disabled:opacity-50"
+              >
+                {loadingHistory ? <Loader2 className="size-3 animate-spin" /> : null}
+                Load earlier messages
+              </button>
+            </div>
+          )}
+
+          {loadingHistory && historicalMessages.length === 0 && (
+            <div className="flex items-center justify-center py-8">
+              <Loader2 className="size-5 animate-spin text-muted-foreground" />
+            </div>
+          )}
+
+          {historicalMessages.map((msg) => (
+            <HistoryMessageView key={msg.id} message={msg} />
+          ))}
+
+          {hasHistory && hasLiveMessages && (
+            <div className="flex items-center gap-3 py-2">
+              <div className="h-px flex-1 bg-border/50" />
+              <span className="text-xs text-muted-foreground">new messages</span>
+              <div className="h-px flex-1 bg-border/50" />
+            </div>
+          )}
+
           {messages.map((message, messageIndex) => {
             const isLastMessage = messageIndex === messages.length - 1;
             const isLastAssistant = message.role === "assistant" && isLastMessage;
@@ -133,5 +268,87 @@ export function ChatView({ workspaceId, workspaceName }: ChatViewProps) {
         </PromptInput>
       </div>
     </div>
+  );
+}
+
+function HistoryMessageView({ message }: { message: HistoryMessage }) {
+  const textBlocks = message.content.filter((b) => b.type === "text" && b.text?.trim());
+  const toolUseBlocks = message.content.filter((b) => b.type === "tool_use");
+  const toolResultBlocks = message.content.filter((b) => b.type === "tool_result");
+
+  if (message.role === "user") {
+    const userText = textBlocks.map((b) => b.text).join("\n");
+    if (!userText && toolResultBlocks.length === 0) return null;
+    if (toolResultBlocks.length > 0 && !userText) return null;
+    return (
+      <Message from="user">
+        <MessageContent>{userText && <MessageResponse>{userText}</MessageResponse>}</MessageContent>
+      </Message>
+    );
+  }
+
+  if (textBlocks.length === 0 && toolUseBlocks.length === 0) return null;
+
+  return (
+    <Message from="assistant">
+      <MessageContent>{renderHistoryContent(message)}</MessageContent>
+    </Message>
+  );
+}
+
+function renderHistoryContent(message: HistoryMessage) {
+  const elements: React.ReactNode[] = [];
+  let toolGroup: HistoryMessageContent[] = [];
+
+  const flushToolGroup = () => {
+    if (toolGroup.length > 0) {
+      elements.push(<HistoryToolGroup key={`tools-${elements.length}`} tools={toolGroup} />);
+      toolGroup = [];
+    }
+  };
+
+  for (const block of message.content) {
+    if (block.type === "text" && block.text?.trim()) {
+      flushToolGroup();
+      elements.push(
+        <MessageResponse key={`text-${elements.length}`}>{block.text}</MessageResponse>,
+      );
+    } else if (block.type === "tool_use") {
+      toolGroup.push(block);
+    }
+  }
+  flushToolGroup();
+
+  return elements;
+}
+
+function HistoryToolGroup({ tools }: { tools: HistoryMessageContent[] }) {
+  return (
+    <Collapsible className="group/outer not-prose mb-4 w-full rounded border border-border/50">
+      <CollapsibleTrigger className="flex w-full items-center justify-between gap-4 p-3">
+        <div className="flex items-center gap-2">
+          <WrenchIcon className="size-4 shrink-0 text-muted-foreground" />
+          <span className="font-medium text-sm text-muted-foreground">
+            {tools.length} tool{tools.length !== 1 ? " calls" : " call"} completed
+          </span>
+        </div>
+        <ChevronDownIcon className="size-4 shrink-0 text-muted-foreground transition-transform group-data-[state=open]/outer:rotate-180" />
+      </CollapsibleTrigger>
+      <CollapsibleContent>
+        <div className="border-t border-border/50">
+          {tools.map((tool) => (
+            <div
+              key={tool.toolCallId}
+              className="border-b border-border/50 px-4 py-2 last:border-b-0"
+            >
+              <div className="flex items-center gap-2">
+                <span className="size-2 shrink-0 rounded-full bg-green-500" />
+                <span className="text-sm">{tool.toolName}</span>
+              </div>
+            </div>
+          ))}
+        </div>
+      </CollapsibleContent>
+    </Collapsible>
   );
 }

--- a/apps/web/src/components/SessionList.tsx
+++ b/apps/web/src/components/SessionList.tsx
@@ -1,0 +1,141 @@
+import { GitBranch, Loader2, MessageSquare, Plus, RefreshCw } from "lucide-react";
+import { useCallback, useEffect, useState } from "react";
+
+interface SessionItem {
+  sessionId: string;
+  summary: string;
+  lastModified: number;
+  firstPrompt?: string;
+  gitBranch?: string;
+}
+
+interface SessionListProps {
+  workspaceId: string;
+  activeSessionId?: string;
+  onSelectSession: (sessionId: string) => void;
+  onNewSession: () => void;
+}
+
+function relativeTime(ms: number): string {
+  const seconds = Math.floor((Date.now() - ms) / 1000);
+  if (seconds < 60) return "just now";
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  if (days < 30) return `${days}d ago`;
+  const months = Math.floor(days / 30);
+  return `${months}mo ago`;
+}
+
+export function SessionList({
+  workspaceId,
+  activeSessionId,
+  onSelectSession,
+  onNewSession,
+}: SessionListProps) {
+  const [sessions, setSessions] = useState<SessionItem[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchSessions = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch(`/api/sessions/${encodeURIComponent(workspaceId)}`);
+      if (!res.ok) throw new Error("Failed to fetch sessions");
+      const data = (await res.json()) as { sessions: SessionItem[]; supported: boolean };
+      setSessions(data.sessions);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to load sessions");
+    } finally {
+      setLoading(false);
+    }
+  }, [workspaceId]);
+
+  useEffect(() => {
+    fetchSessions();
+  }, [fetchSessions]);
+
+  if (loading) {
+    return (
+      <div className="flex h-full items-center justify-center">
+        <Loader2 className="size-6 animate-spin text-muted-foreground" />
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="flex h-full flex-col items-center justify-center gap-4 p-8 text-center">
+        <p className="text-sm text-destructive">{error}</p>
+        <button
+          type="button"
+          onClick={fetchSessions}
+          className="inline-flex items-center gap-2 rounded-md bg-secondary px-3 py-1.5 text-sm hover:bg-secondary/80"
+        >
+          <RefreshCw className="size-3.5" />
+          Retry
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex h-full flex-col">
+      <div className="shrink-0 p-3">
+        <button
+          type="button"
+          onClick={onNewSession}
+          className="flex w-full items-center justify-center gap-2 rounded-lg bg-primary px-4 py-2.5 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90 active:bg-primary/80"
+        >
+          <Plus className="size-4" />
+          New Session
+        </button>
+      </div>
+
+      {sessions.length === 0 ? (
+        <div className="flex flex-1 flex-col items-center justify-center gap-3 p-8 text-center">
+          <MessageSquare className="size-10 text-muted-foreground" />
+          <div>
+            <p className="font-medium">No sessions yet</p>
+            <p className="text-sm text-muted-foreground">Start a new session to begin coding</p>
+          </div>
+        </div>
+      ) : (
+        <div className="flex-1 overflow-y-auto">
+          <div className="flex flex-col gap-1 p-2 pt-0">
+            {sessions.map((session) => {
+              const isActive = session.sessionId === activeSessionId;
+              return (
+                <button
+                  key={session.sessionId}
+                  type="button"
+                  onClick={() => onSelectSession(session.sessionId)}
+                  className={`flex flex-col gap-1 rounded-lg px-3 py-2.5 text-left transition-colors hover:bg-accent/50 active:bg-accent/50 ${isActive ? "bg-accent/50 ring-1 ring-primary/30" : ""}`}
+                >
+                <span className="line-clamp-2 text-sm font-medium text-foreground">
+                  {session.summary}
+                </span>
+                <div className="flex items-center gap-2 text-xs text-muted-foreground">
+                  <span>{relativeTime(session.lastModified)}</span>
+                  {session.gitBranch && (
+                    <>
+                      <span className="text-border">·</span>
+                      <span className="inline-flex items-center gap-1">
+                        <GitBranch className="size-3" />
+                        {session.gitBranch}
+                      </span>
+                    </>
+                  )}
+                </div>
+                </button>
+              );
+            })}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/lib/workspace.ts
+++ b/apps/web/src/lib/workspace.ts
@@ -1,0 +1,18 @@
+import { loadState } from "./state";
+
+export function resolveWorkspace(workspaceId: string) {
+  const state = loadState();
+
+  for (const project of state.projects) {
+    const prefix = `${project.name}-`;
+    if (workspaceId.startsWith(prefix)) {
+      const branch = workspaceId.slice(prefix.length);
+      for (const wt of project.worktrees) {
+        if (wt.branch === branch) {
+          return { project, worktree: wt };
+        }
+      }
+    }
+  }
+  return null;
+}

--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -14,6 +14,8 @@ import { Route as ChatWorkspaceIdRouteImport } from './routes/chat.$workspaceId'
 import { Route as ApiProjectsRouteImport } from './routes/api/projects'
 import { Route as ApiChatRouteImport } from './routes/api/chat'
 import { Route as ApiStatusStreamRouteImport } from './routes/api/status.stream'
+import { Route as ApiSessionsWorkspaceIdRouteImport } from './routes/api/sessions.$workspaceId'
+import { Route as ApiSessionsWorkspaceIdSessionIdMessagesRouteImport } from './routes/api/sessions.$workspaceId.$sessionId.messages'
 
 const IndexRoute = IndexRouteImport.update({
   id: '/',
@@ -40,20 +42,35 @@ const ApiStatusStreamRoute = ApiStatusStreamRouteImport.update({
   path: '/api/status/stream',
   getParentRoute: () => rootRouteImport,
 } as any)
+const ApiSessionsWorkspaceIdRoute = ApiSessionsWorkspaceIdRouteImport.update({
+  id: '/api/sessions/$workspaceId',
+  path: '/api/sessions/$workspaceId',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ApiSessionsWorkspaceIdSessionIdMessagesRoute =
+  ApiSessionsWorkspaceIdSessionIdMessagesRouteImport.update({
+    id: '/$sessionId/messages',
+    path: '/$sessionId/messages',
+    getParentRoute: () => ApiSessionsWorkspaceIdRoute,
+  } as any)
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
   '/api/chat': typeof ApiChatRoute
   '/api/projects': typeof ApiProjectsRoute
   '/chat/$workspaceId': typeof ChatWorkspaceIdRoute
+  '/api/sessions/$workspaceId': typeof ApiSessionsWorkspaceIdRouteWithChildren
   '/api/status/stream': typeof ApiStatusStreamRoute
+  '/api/sessions/$workspaceId/$sessionId/messages': typeof ApiSessionsWorkspaceIdSessionIdMessagesRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
   '/api/chat': typeof ApiChatRoute
   '/api/projects': typeof ApiProjectsRoute
   '/chat/$workspaceId': typeof ChatWorkspaceIdRoute
+  '/api/sessions/$workspaceId': typeof ApiSessionsWorkspaceIdRouteWithChildren
   '/api/status/stream': typeof ApiStatusStreamRoute
+  '/api/sessions/$workspaceId/$sessionId/messages': typeof ApiSessionsWorkspaceIdSessionIdMessagesRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
@@ -61,7 +78,9 @@ export interface FileRoutesById {
   '/api/chat': typeof ApiChatRoute
   '/api/projects': typeof ApiProjectsRoute
   '/chat/$workspaceId': typeof ChatWorkspaceIdRoute
+  '/api/sessions/$workspaceId': typeof ApiSessionsWorkspaceIdRouteWithChildren
   '/api/status/stream': typeof ApiStatusStreamRoute
+  '/api/sessions/$workspaceId/$sessionId/messages': typeof ApiSessionsWorkspaceIdSessionIdMessagesRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
@@ -70,21 +89,27 @@ export interface FileRouteTypes {
     | '/api/chat'
     | '/api/projects'
     | '/chat/$workspaceId'
+    | '/api/sessions/$workspaceId'
     | '/api/status/stream'
+    | '/api/sessions/$workspaceId/$sessionId/messages'
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/'
     | '/api/chat'
     | '/api/projects'
     | '/chat/$workspaceId'
+    | '/api/sessions/$workspaceId'
     | '/api/status/stream'
+    | '/api/sessions/$workspaceId/$sessionId/messages'
   id:
     | '__root__'
     | '/'
     | '/api/chat'
     | '/api/projects'
     | '/chat/$workspaceId'
+    | '/api/sessions/$workspaceId'
     | '/api/status/stream'
+    | '/api/sessions/$workspaceId/$sessionId/messages'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
@@ -92,6 +117,7 @@ export interface RootRouteChildren {
   ApiChatRoute: typeof ApiChatRoute
   ApiProjectsRoute: typeof ApiProjectsRoute
   ChatWorkspaceIdRoute: typeof ChatWorkspaceIdRoute
+  ApiSessionsWorkspaceIdRoute: typeof ApiSessionsWorkspaceIdRouteWithChildren
   ApiStatusStreamRoute: typeof ApiStatusStreamRoute
 }
 
@@ -132,14 +158,44 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ApiStatusStreamRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/api/sessions/$workspaceId': {
+      id: '/api/sessions/$workspaceId'
+      path: '/api/sessions/$workspaceId'
+      fullPath: '/api/sessions/$workspaceId'
+      preLoaderRoute: typeof ApiSessionsWorkspaceIdRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/sessions/$workspaceId/$sessionId/messages': {
+      id: '/api/sessions/$workspaceId/$sessionId/messages'
+      path: '/$sessionId/messages'
+      fullPath: '/api/sessions/$workspaceId/$sessionId/messages'
+      preLoaderRoute: typeof ApiSessionsWorkspaceIdSessionIdMessagesRouteImport
+      parentRoute: typeof ApiSessionsWorkspaceIdRoute
+    }
   }
 }
+
+interface ApiSessionsWorkspaceIdRouteChildren {
+  ApiSessionsWorkspaceIdSessionIdMessagesRoute: typeof ApiSessionsWorkspaceIdSessionIdMessagesRoute
+}
+
+const ApiSessionsWorkspaceIdRouteChildren: ApiSessionsWorkspaceIdRouteChildren =
+  {
+    ApiSessionsWorkspaceIdSessionIdMessagesRoute:
+      ApiSessionsWorkspaceIdSessionIdMessagesRoute,
+  }
+
+const ApiSessionsWorkspaceIdRouteWithChildren =
+  ApiSessionsWorkspaceIdRoute._addFileChildren(
+    ApiSessionsWorkspaceIdRouteChildren,
+  )
 
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   ApiChatRoute: ApiChatRoute,
   ApiProjectsRoute: ApiProjectsRoute,
   ChatWorkspaceIdRoute: ChatWorkspaceIdRoute,
+  ApiSessionsWorkspaceIdRoute: ApiSessionsWorkspaceIdRouteWithChildren,
   ApiStatusStreamRoute: ApiStatusStreamRoute,
 }
 export const routeTree = rootRouteImport

--- a/apps/web/src/routes/api/chat.ts
+++ b/apps/web/src/routes/api/chat.ts
@@ -1,25 +1,8 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { createUIMessageStream, createUIMessageStreamResponse } from "ai";
 import { getOrCreateAgent } from "../../lib/agent-pool";
-import { loadState } from "../../lib/state";
 import { writeAgentStream } from "../../lib/stream-writer";
-
-function resolveWorkspace(workspaceId: string) {
-  const state = loadState();
-
-  for (const project of state.projects) {
-    const prefix = `${project.name}-`;
-    if (workspaceId.startsWith(prefix)) {
-      const branch = workspaceId.slice(prefix.length);
-      for (const wt of project.worktrees) {
-        if (wt.branch === branch) {
-          return { project, worktree: wt };
-        }
-      }
-    }
-  }
-  return null;
-}
+import { resolveWorkspace } from "../../lib/workspace";
 
 export const Route = createFileRoute("/api/chat")({
   server: {

--- a/apps/web/src/routes/api/sessions.$workspaceId.$sessionId.messages.ts
+++ b/apps/web/src/routes/api/sessions.$workspaceId.$sessionId.messages.ts
@@ -1,0 +1,36 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { getOrCreateAgent } from "../../lib/agent-pool";
+import { resolveWorkspace } from "../../lib/workspace";
+
+export const Route = createFileRoute("/api/sessions/$workspaceId/$sessionId/messages")({
+  server: {
+    handlers: {
+      GET: async ({ params, request }) => {
+        const workspaceId = decodeURIComponent(params.workspaceId);
+        const sessionId = decodeURIComponent(params.sessionId);
+
+        const workspace = resolveWorkspace(workspaceId);
+        if (!workspace) {
+          return Response.json({ error: "Workspace not found" }, { status: 404 });
+        }
+
+        const agent = await getOrCreateAgent(workspaceId, workspace.worktree.path);
+
+        if (!agent.supportedFeatures.sessionListing || !agent.getSessionMessages) {
+          return Response.json({ error: "Session listing not supported" }, { status: 400 });
+        }
+
+        const url = new URL(request.url);
+        const limit = Number(url.searchParams.get("limit")) || 50;
+        const offset = Number(url.searchParams.get("offset")) || 0;
+
+        const messages = await agent.getSessionMessages(sessionId, workspace.worktree.path, {
+          limit,
+          offset,
+        });
+
+        return Response.json({ messages });
+      },
+    },
+  },
+});

--- a/apps/web/src/routes/api/sessions.$workspaceId.ts
+++ b/apps/web/src/routes/api/sessions.$workspaceId.ts
@@ -1,0 +1,27 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { getOrCreateAgent } from "../../lib/agent-pool";
+import { resolveWorkspace } from "../../lib/workspace";
+
+export const Route = createFileRoute("/api/sessions/$workspaceId")({
+  server: {
+    handlers: {
+      GET: async ({ params }) => {
+        const workspaceId = decodeURIComponent(params.workspaceId);
+
+        const workspace = resolveWorkspace(workspaceId);
+        if (!workspace) {
+          return Response.json({ error: "Workspace not found" }, { status: 404 });
+        }
+
+        const agent = await getOrCreateAgent(workspaceId, workspace.worktree.path);
+
+        if (!agent.supportedFeatures.sessionListing || !agent.listSessions) {
+          return Response.json({ sessions: [], supported: false });
+        }
+
+        const sessions = await agent.listSessions(workspace.worktree.path);
+        return Response.json({ sessions, supported: true });
+      },
+    },
+  },
+});

--- a/apps/web/src/routes/chat.$workspaceId.tsx
+++ b/apps/web/src/routes/chat.$workspaceId.tsx
@@ -1,5 +1,6 @@
 import { createFileRoute, Link } from "@tanstack/react-router";
-import { ArrowLeft } from "lucide-react";
+import { ArrowLeft, Clock } from "lucide-react";
+import { useCallback, useEffect, useState } from "react";
 import { ChatView } from "../components/ChatView";
 
 export const Route = createFileRoute("/chat/$workspaceId")({
@@ -9,6 +10,36 @@ export const Route = createFileRoute("/chat/$workspaceId")({
 function ChatPage() {
   const { workspaceId } = Route.useParams();
   const decoded = decodeURIComponent(workspaceId);
+  const [supportsSessionListing, setSupportsSessionListing] = useState(false);
+  const [showSessionList, setShowSessionList] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    fetch(`/api/sessions/${encodeURIComponent(decoded)}`)
+      .then((res) => {
+        if (!res.ok) {
+          console.error("[sessions] fetch failed:", res.status, res.statusText);
+          return null;
+        }
+        return res.json();
+      })
+      .then((data: { supported?: boolean } | null) => {
+        console.log("[sessions] response:", data);
+        if (!cancelled && data?.supported) {
+          setSupportsSessionListing(true);
+        }
+      })
+      .catch((err) => {
+        console.error("[sessions] error:", err);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [decoded]);
+
+  const handleToggleSessionList = useCallback(() => {
+    setShowSessionList((prev) => !prev);
+  }, []);
 
   return (
     <div className="flex h-dvh flex-col">
@@ -22,9 +53,24 @@ function ChatPage() {
         <div className="min-w-0 flex-1">
           <h1 className="truncate text-sm font-semibold">{decoded}</h1>
         </div>
+        {supportsSessionListing && (
+          <button
+            type="button"
+            onClick={handleToggleSessionList}
+            className={`inline-flex size-8 items-center justify-center rounded-md transition-colors hover:bg-accent ${showSessionList ? "bg-accent text-foreground" : "text-muted-foreground"}`}
+          >
+            <Clock className="size-4" />
+          </button>
+        )}
       </header>
       <main className="min-h-0 flex-1">
-        <ChatView workspaceId={decoded} workspaceName={decoded} />
+        <ChatView
+          workspaceId={decoded}
+          workspaceName={decoded}
+          supportsSessionListing={supportsSessionListing}
+          showSessionList={showSessionList}
+          onShowSessionListChange={setShowSessionList}
+        />
       </main>
     </div>
   );

--- a/packages/coding-agent/src/adapters/claude-code.ts
+++ b/packages/coding-agent/src/adapters/claude-code.ts
@@ -1,8 +1,9 @@
-import { query } from "@anthropic-ai/claude-agent-sdk";
+import type { SDKSessionInfo, SessionMessage } from "@anthropic-ai/claude-agent-sdk";
+import { getSessionMessages, listSessions, query } from "@anthropic-ai/claude-agent-sdk";
 import { createLogger } from "@band/logger";
 import type { ClaudeCodeConfig } from "../config.js";
 import type { AgentEvent } from "../events.js";
-import type { CodingAgent } from "../types.js";
+import type { CodingAgent, SessionListItem, SessionMessageItem } from "../types.js";
 
 const log = createLogger("coding-agent:claude-code");
 
@@ -10,6 +11,7 @@ export class ClaudeCodeAdapter implements CodingAgent {
   readonly name = "Claude Code";
   readonly supportedFeatures = {
     costTracking: true,
+    sessionListing: true,
   } as const;
 
   private readonly workspaceDir: string;
@@ -83,6 +85,82 @@ export class ClaudeCodeAdapter implements CodingAgent {
       conversation.close();
     }
   }
+
+  async listSessions(dir: string): Promise<SessionListItem[]> {
+    log.info({ dir }, "listSessions");
+    const sessions = await listSessions({ dir, limit: 50 });
+    return sessions.filter((s) => s.cwd === dir).map(mapSessionInfo);
+  }
+
+  async getSessionMessages(
+    sessionId: string,
+    dir: string,
+    options?: { limit?: number; offset?: number },
+  ): Promise<SessionMessageItem[]> {
+    log.info({ sessionId, dir, ...options }, "getSessionMessages");
+    const messages = await getSessionMessages(sessionId, {
+      dir,
+      limit: options?.limit,
+      offset: options?.offset,
+    });
+    return messages.map(mapSessionMessage);
+  }
+}
+
+function mapSessionInfo(info: SDKSessionInfo): SessionListItem {
+  return {
+    sessionId: info.sessionId,
+    summary: info.customTitle ?? info.summary ?? info.firstPrompt ?? "Untitled session",
+    lastModified: info.lastModified,
+    firstPrompt: info.firstPrompt,
+    gitBranch: info.gitBranch,
+  };
+}
+
+function mapSessionMessage(msg: SessionMessage): SessionMessageItem {
+  const content: SessionMessageItem["content"] = [];
+  const raw = msg.message as {
+    content?: Array<{
+      type: string;
+      text?: string;
+      id?: string;
+      name?: string;
+      input?: unknown;
+      tool_use_id?: string;
+      content?: unknown;
+      is_error?: boolean;
+    }>;
+  } | null;
+
+  if (raw?.content && Array.isArray(raw.content)) {
+    for (const block of raw.content) {
+      if (block.type === "text" && block.text) {
+        content.push({ type: "text", text: block.text });
+      } else if (block.type === "tool_use") {
+        content.push({
+          type: "tool_use",
+          toolCallId: block.id ?? "",
+          toolName: block.name ?? "unknown",
+          input: block.input ?? {},
+        });
+      } else if (block.type === "tool_result" && block.tool_use_id) {
+        const output =
+          typeof block.content === "string" ? block.content : JSON.stringify(block.content ?? "");
+        content.push({
+          type: "tool_result",
+          toolCallId: block.tool_use_id,
+          output,
+          isError: block.is_error ?? false,
+        });
+      }
+    }
+  }
+
+  return {
+    role: msg.type,
+    id: msg.uuid,
+    content,
+  };
 }
 
 interface ProcessedState {

--- a/packages/coding-agent/src/adapters/cursor-cli.ts
+++ b/packages/coding-agent/src/adapters/cursor-cli.ts
@@ -52,6 +52,7 @@ export class CursorCliAdapter implements CodingAgent {
   readonly name = "Cursor CLI";
   readonly supportedFeatures = {
     costTracking: false,
+    sessionListing: false,
   } as const;
 
   private readonly maxTurns: number;

--- a/packages/coding-agent/src/adapters/gemini-cli.ts
+++ b/packages/coding-agent/src/adapters/gemini-cli.ts
@@ -11,6 +11,7 @@ export class GeminiCliAdapter implements CodingAgent {
   readonly name = "Gemini CLI";
   readonly supportedFeatures = {
     costTracking: false,
+    sessionListing: false,
   } as const;
 
   private readonly workspaceDir: string;

--- a/packages/coding-agent/src/adapters/openai-codex.ts
+++ b/packages/coding-agent/src/adapters/openai-codex.ts
@@ -9,6 +9,7 @@ export class OpenAICodexAdapter implements CodingAgent {
   readonly name = "OpenAI Codex";
   readonly supportedFeatures = {
     costTracking: true,
+    sessionListing: false,
   } as const;
 
   private readonly workspaceDir: string;

--- a/packages/coding-agent/src/index.ts
+++ b/packages/coding-agent/src/index.ts
@@ -16,4 +16,9 @@ export type {
   ToolUseEvent,
 } from "./events.js";
 export { createCodingAgent } from "./factory.js";
-export type { CodingAgent, CodingAgentFeatures } from "./types.js";
+export type {
+  CodingAgent,
+  CodingAgentFeatures,
+  SessionListItem,
+  SessionMessageItem,
+} from "./types.js";

--- a/packages/coding-agent/src/types.ts
+++ b/packages/coding-agent/src/types.ts
@@ -2,10 +2,35 @@ import type { AgentEvent } from "./events.js";
 
 export interface CodingAgentFeatures {
   costTracking: boolean;
+  sessionListing: boolean;
+}
+
+export interface SessionListItem {
+  sessionId: string;
+  summary: string;
+  lastModified: number;
+  firstPrompt?: string;
+  gitBranch?: string;
+}
+
+export interface SessionMessageItem {
+  role: "user" | "assistant";
+  id: string;
+  content: Array<
+    | { type: "text"; text: string }
+    | { type: "tool_use"; toolCallId: string; toolName: string; input: unknown }
+    | { type: "tool_result"; toolCallId: string; output: string; isError: boolean }
+  >;
 }
 
 export interface CodingAgent {
   readonly name: string;
   readonly supportedFeatures: CodingAgentFeatures;
   runSession(prompt: string, sessionId?: string): AsyncGenerator<AgentEvent>;
+  listSessions?(dir: string): Promise<SessionListItem[]>;
+  getSessionMessages?(
+    sessionId: string,
+    dir: string,
+    options?: { limit?: number; offset?: number },
+  ): Promise<SessionMessageItem[]>;
 }


### PR DESCRIPTION
## Summary
- Leverage Claude Agent SDK's `listSessions()` and `getSessionMessages()` to browse and resume previous agent sessions on the web UI
- Add session list with timestamps, git branch badges, and active session highlighting
- Support historical message loading with pagination and session resumption
- Only enabled for Claude Code workspaces via `sessionListing` feature flag

## Test plan
- [ ] Navigate to a Claude Code workspace — verify Clock button appears in header
- [ ] Tap Clock — verify session list shows previous sessions filtered to that worktree
- [ ] Select a session — verify messages load with text and tool call groups
- [ ] Scroll to top — verify "Load more" fetches older messages
- [ ] Send a new message — verify the agent resumes the session
- [ ] Tap "New Session" — verify a fresh session starts
- [ ] For a non-Claude-Code workspace — verify the Clock button is hidden

🤖 Generated with [Claude Code](https://claude.com/claude-code)