### PR TITLE
feat: drag-and-drop reorder projects

### DIFF
--- a/apps/dashboard/package.json
+++ b/apps/dashboard/package.json
@@ -12,6 +12,9 @@
   },
   "dependencies": {
     "@band/ui": "workspace:^",
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^10.0.0",
+    "@dnd-kit/utilities": "^3.2.2",
     "@tauri-apps/api": "^2.0.0",
     "@tauri-apps/plugin-fs": "^2.0.0",
     "@tauri-apps/plugin-shell": "^2.0.0",

--- a/apps/dashboard/src-tauri/src/commands/project.rs
+++ b/apps/dashboard/src-tauri/src/commands/project.rs
@@ -110,6 +110,21 @@ pub fn project_list() -> Result<Vec<ProjectInfo>, String> {
 }
 
 #[tauri::command]
+pub fn project_reorder(names: Vec<String>) -> Result<(), String> {
+    let mut app_state = state::load_state()?;
+
+    app_state.projects.sort_by_key(|p| {
+        names
+            .iter()
+            .position(|n| n == &p.name)
+            .unwrap_or(usize::MAX)
+    });
+
+    state::save_state(&app_state)?;
+    Ok(())
+}
+
+#[tauri::command]
 pub fn project_remove(name: String) -> Result<(), String> {
     let mut app_state = state::load_state()?;
     let initial_len = app_state.projects.len();

--- a/apps/dashboard/src-tauri/src/lib.rs
+++ b/apps/dashboard/src-tauri/src/lib.rs
@@ -28,6 +28,7 @@ pub fn run() {
             commands::project::project_init,
             commands::project::project_list,
             commands::project::project_remove,
+            commands::project::project_reorder,
             commands::workspace::workspace_create,
             commands::workspace::workspace_list,
             commands::workspace::workspace_remove,

--- a/apps/dashboard/src/components/ProjectList.tsx
+++ b/apps/dashboard/src/components/ProjectList.tsx
@@ -1,3 +1,13 @@
+import {
+  DndContext,
+  closestCenter,
+  PointerSensor,
+  useSensor,
+  useSensors,
+  type DragEndEvent,
+} from "@dnd-kit/core";
+import { SortableContext, useSortable, verticalListSortingStrategy, arrayMove } from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
 import { Clipboard, Ellipsis, FolderOpen, ListMinus, Plus } from "lucide-react";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { NewWorkspaceDialog } from "@/components/NewWorkspaceForm";
@@ -10,18 +20,146 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { WorkspaceCard } from "@/components/WorkspaceCard";
-import { useDashboardStore } from "@/stores/dashboard-store";
+import {
+  useDashboardStore,
+  type ProjectInfo,
+  type WorkspaceStatus,
+  type WorkspaceBranchStatus,
+} from "@/stores/dashboard-store";
+
+interface SortableProjectProps {
+  project: ProjectInfo;
+  statuses: Map<string, WorkspaceStatus>;
+  branchStatuses: Map<string, WorkspaceBranchStatus>;
+  removeProject: (name: string) => void;
+  workspaceDialog: string | null;
+  setWorkspaceDialog: (name: string | null) => void;
+  focusedIndex: number;
+  workspaceIndexStart: number;
+}
+
+function SortableProject({
+  project,
+  statuses,
+  branchStatuses,
+  removeProject,
+  workspaceDialog,
+  setWorkspaceDialog,
+  focusedIndex,
+  workspaceIndexStart,
+}: SortableProjectProps) {
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
+    id: project.name,
+  });
+
+  const style = {
+    transform: CSS.Translate.toString(transform),
+    transition,
+    opacity: isDragging ? 0.5 : undefined,
+  };
+
+  let workspaceIndex = workspaceIndexStart;
+
+  return (
+    <div ref={setNodeRef} style={style} className="min-w-0">
+      <div className="flex items-center justify-between mb-1 px-1">
+        <div
+          className="flex items-center gap-2 min-w-0 cursor-grab touch-none"
+          {...attributes}
+          {...listeners}
+        >
+          <FolderOpen className="size-3.5 shrink-0 text-muted-foreground" />
+          <h2 className="text-sm font-semibold text-foreground truncate">{project.name}</h2>
+        </div>
+        <div className="flex items-center gap-1">
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                variant="ghost"
+                size="icon-xs"
+                onClick={() => setWorkspaceDialog(project.name)}
+              >
+                <Plus />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>Add workspace</TooltipContent>
+          </Tooltip>
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button variant="ghost" size="icon-xs" className="text-muted-foreground">
+                <Ellipsis />
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end">
+              <DropdownMenuItem onClick={() => navigator.clipboard.writeText(project.path)}>
+                <Clipboard />
+                Copy path
+              </DropdownMenuItem>
+              <DropdownMenuItem
+                onClick={() => {
+                  import("@tauri-apps/api/core").then(({ invoke }) =>
+                    invoke("reveal_in_finder", { path: project.path }),
+                  );
+                }}
+              >
+                <FolderOpen />
+                Open in Finder
+              </DropdownMenuItem>
+              <DropdownMenuItem onClick={() => removeProject(project.name)}>
+                <ListMinus />
+                Remove from list
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+        </div>
+      </div>
+
+      <NewWorkspaceDialog
+        projectName={project.name}
+        open={workspaceDialog === project.name}
+        onOpenChange={(open) => setWorkspaceDialog(open ? project.name : null)}
+      />
+
+      <div className="flex flex-col gap-0.5 overflow-hidden">
+        {project.worktrees.length === 0 ? (
+          <p className="text-sm text-muted-foreground px-4 py-2">No workspaces yet</p>
+        ) : (
+          project.worktrees.map((wt) => {
+            const wsId = `${project.name}-${wt.branch}`;
+            const currentIndex = workspaceIndex++;
+            return (
+              <WorkspaceCard
+                key={wt.branch}
+                worktree={wt}
+                projectName={project.name}
+                defaultBranch={project.defaultBranch}
+                status={statuses.get(wsId)}
+                branchStatus={branchStatuses.get(wsId)}
+                isFocused={currentIndex === focusedIndex}
+              />
+            );
+          })
+        )}
+      </div>
+    </div>
+  );
+}
 
 export function ProjectList() {
   const projects = useDashboardStore((s) => s.projects);
   const statuses = useDashboardStore((s) => s.statuses);
   const branchStatuses = useDashboardStore((s) => s.branchStatuses);
   const removeProject = useDashboardStore((s) => s.removeProject);
+  const reorderProjects = useDashboardStore((s) => s.reorderProjects);
   const openWorkspace = useDashboardStore((s) => s.openWorkspace);
   const [workspaceDialog, setWorkspaceDialog] = useState<string | null>(null);
   const [focusedIndex, setFocusedIndex] = useState(-1);
   const containerRef = useRef<HTMLDivElement>(null);
   const activeWorkspaceId = useDashboardStore((s) => s.activeWorkspaceId);
+
+  const sensors = useSensors(useSensor(PointerSensor, { activationConstraint: { distance: 8 } }));
+
+  const projectNames = useMemo(() => projects.map((p) => p.name), [projects]);
 
   const allWorkspaceIds = useMemo(
     () =>
@@ -58,6 +196,16 @@ export function ProjectList() {
     }
   }
 
+  function handleDragEnd(event: DragEndEvent) {
+    const { active, over } = event;
+    if (!over || active.id === over.id) return;
+
+    const oldIndex = projectNames.indexOf(active.id as string);
+    const newIndex = projectNames.indexOf(over.id as string);
+    const newOrder = arrayMove(projectNames, oldIndex, newIndex);
+    reorderProjects(newOrder);
+  }
+
   if (projects.length === 0) {
     return (
       <div className="flex flex-col items-center justify-center py-16 text-muted-foreground">
@@ -67,7 +215,13 @@ export function ProjectList() {
     );
   }
 
-  let workspaceIndex = 0;
+  // Pre-compute workspace index offsets for each project
+  const workspaceIndexStarts: number[] = [];
+  let runningIndex = 0;
+  for (const project of projects) {
+    workspaceIndexStarts.push(runningIndex);
+    runningIndex += project.worktrees.length;
+  }
 
   return (
     <div
@@ -76,86 +230,25 @@ export function ProjectList() {
       onKeyDown={handleKeyDown}
       className="flex flex-col gap-2 outline-none min-w-0"
     >
-      {projects.map((project, index) => (
-        <div key={project.name} className="min-w-0">
-          {index > 0 && <hr className="border-border mb-2" />}
-          <div className="flex items-center justify-between mb-1 px-1">
-            <div className="flex items-center gap-2 min-w-0">
-              <FolderOpen className="size-3.5 shrink-0 text-muted-foreground" />
-              <h2 className="text-sm font-semibold text-foreground truncate">{project.name}</h2>
+      <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
+        <SortableContext items={projectNames} strategy={verticalListSortingStrategy}>
+          {projects.map((project, index) => (
+            <div key={project.name}>
+              {index > 0 && <hr className="border-border mb-2" />}
+              <SortableProject
+                project={project}
+                statuses={statuses}
+                branchStatuses={branchStatuses}
+                removeProject={removeProject}
+                workspaceDialog={workspaceDialog}
+                setWorkspaceDialog={setWorkspaceDialog}
+                focusedIndex={focusedIndex}
+                workspaceIndexStart={workspaceIndexStarts[index]}
+              />
             </div>
-            <div className="flex items-center gap-1">
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <Button
-                    variant="ghost"
-                    size="icon-xs"
-                    onClick={() => setWorkspaceDialog(project.name)}
-                  >
-                    <Plus />
-                  </Button>
-                </TooltipTrigger>
-                <TooltipContent>Add workspace</TooltipContent>
-              </Tooltip>
-              <DropdownMenu>
-                <DropdownMenuTrigger asChild>
-                  <Button variant="ghost" size="icon-xs" className="text-muted-foreground">
-                    <Ellipsis />
-                  </Button>
-                </DropdownMenuTrigger>
-                <DropdownMenuContent align="end">
-                  <DropdownMenuItem onClick={() => navigator.clipboard.writeText(project.path)}>
-                    <Clipboard />
-                    Copy path
-                  </DropdownMenuItem>
-                  <DropdownMenuItem
-                    onClick={() => {
-                      import("@tauri-apps/api/core").then(({ invoke }) =>
-                        invoke("reveal_in_finder", { path: project.path }),
-                      );
-                    }}
-                  >
-                    <FolderOpen />
-                    Open in Finder
-                  </DropdownMenuItem>
-                  <DropdownMenuItem onClick={() => removeProject(project.name)}>
-                    <ListMinus />
-                    Remove from list
-                  </DropdownMenuItem>
-                </DropdownMenuContent>
-              </DropdownMenu>
-            </div>
-          </div>
-
-          <NewWorkspaceDialog
-            projectName={project.name}
-            open={workspaceDialog === project.name}
-            onOpenChange={(open) => setWorkspaceDialog(open ? project.name : null)}
-          />
-
-          <div className="flex flex-col gap-0.5 overflow-hidden">
-            {project.worktrees.length === 0 ? (
-              <p className="text-sm text-muted-foreground px-4 py-2">No workspaces yet</p>
-            ) : (
-              project.worktrees.map((wt) => {
-                const wsId = `${project.name}-${wt.branch}`;
-                const currentIndex = workspaceIndex++;
-                return (
-                  <WorkspaceCard
-                    key={wt.branch}
-                    worktree={wt}
-                    projectName={project.name}
-                    defaultBranch={project.defaultBranch}
-                    status={statuses.get(wsId)}
-                    branchStatus={branchStatuses.get(wsId)}
-                    isFocused={currentIndex === focusedIndex}
-                  />
-                );
-              })
-            )}
-          </div>
-        </div>
-      ))}
+          ))}
+        </SortableContext>
+      </DndContext>
     </div>
   );
 }

--- a/apps/dashboard/src/stores/dashboard-store.ts
+++ b/apps/dashboard/src/stores/dashboard-store.ts
@@ -76,6 +76,7 @@ interface DashboardState {
   loadProjects: () => Promise<void>;
   addProject: (path: string) => Promise<void>;
   removeProject: (name: string) => Promise<void>;
+  reorderProjects: (projectNames: string[]) => Promise<void>;
   createWorkspace: (project: string, branch: string, base?: string) => Promise<void>;
   removeWorkspace: (project: string, branch: string) => Promise<void>;
   openWorkspace: (workspaceId: string) => void;
@@ -122,6 +123,20 @@ export const useDashboardStore = create<DashboardState>((set, get) => ({
       await get().loadProjects();
     } catch (e) {
       set({ error: String(e) });
+    }
+  },
+
+  reorderProjects: async (projectNames: string[]) => {
+    const previousProjects = get().projects;
+    const reordered = [...previousProjects].sort(
+      (a, b) => projectNames.indexOf(a.name) - projectNames.indexOf(b.name),
+    );
+    set({ projects: reordered });
+
+    try {
+      await invoke("project_reorder", { names: projectNames });
+    } catch (e) {
+      set({ projects: previousProjects, error: String(e) });
     }
   },
 

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -14,6 +14,9 @@
     "@band/coding-agent": "workspace:^",
     "@band/logger": "workspace:^",
     "@band/ui": "workspace:^",
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^10.0.0",
+    "@dnd-kit/utilities": "^3.2.2",
     "@streamdown/cjk": "^1.0.2",
     "@streamdown/code": "^1.0.3",
     "@streamdown/math": "^1.0.2",
@@ -30,11 +33,11 @@
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "shiki": "^4.0.1",
+    "sirv": "^3.0.0",
     "streamdown": "^2.3.0",
     "tailwind-merge": "^3.5.0",
     "tw-animate-css": "^1.4.0",
     "use-stick-to-bottom": "^1.1.3",
-    "sirv": "^3.0.0",
     "zod": "^3.25.67"
   },
   "devDependencies": {

--- a/apps/web/src/components/DashboardView.tsx
+++ b/apps/web/src/components/DashboardView.tsx
@@ -1,5 +1,20 @@
+import {
+  DndContext,
+  closestCenter,
+  PointerSensor,
+  useSensor,
+  useSensors,
+  type DragEndEvent,
+} from "@dnd-kit/core";
+import {
+  SortableContext,
+  useSortable,
+  verticalListSortingStrategy,
+  arrayMove,
+} from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
 import { FolderOpen, Loader2, RefreshCw } from "lucide-react";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { WorkspaceCard } from "./WorkspaceCard";
 
 interface AgentInfo {
@@ -36,11 +51,49 @@ interface StatusEvent {
   workspaceId?: string;
 }
 
+function SortableProject({ project }: { project: ProjectWithWorktrees }) {
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
+    id: project.name,
+  });
+
+  const style = {
+    transform: CSS.Translate.toString(transform),
+    transition,
+    opacity: isDragging ? 0.5 : undefined,
+  };
+
+  return (
+    <div ref={setNodeRef} style={style} className="min-w-0">
+      <div
+        className="flex items-center gap-2 mb-1 px-1 cursor-grab touch-none"
+        {...attributes}
+        {...listeners}
+      >
+        <FolderOpen className="size-3.5 shrink-0 text-muted-foreground" />
+        <h2 className="text-sm font-semibold text-foreground truncate">{project.name}</h2>
+      </div>
+      <div className="flex flex-col gap-0.5 overflow-hidden">
+        {project.worktrees.map((wt) => (
+          <WorkspaceCard
+            key={wt.workspaceId}
+            workspaceId={wt.workspaceId}
+            branch={wt.branch}
+            agent={wt.agent}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+
 export function DashboardView() {
   const [projects, setProjects] = useState<ProjectWithWorktrees[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const eventSourceRef = useRef<EventSource | null>(null);
+
+  const sensors = useSensors(useSensor(PointerSensor, { activationConstraint: { distance: 8 } }));
+  const projectNames = useMemo(() => projects.map((p) => p.name), [projects]);
 
   const fetchProjects = useCallback(async () => {
     try {
@@ -116,6 +169,31 @@ export function DashboardView() {
     };
   }, []);
 
+  function handleDragEnd(event: DragEndEvent) {
+    const { active, over } = event;
+    if (!over || active.id === over.id) return;
+
+    const oldIndex = projectNames.indexOf(active.id as string);
+    const newIndex = projectNames.indexOf(over.id as string);
+    const newOrder = arrayMove(projectNames, oldIndex, newIndex);
+
+    // Optimistic reorder
+    setProjects((prev) => {
+      const map = new Map(prev.map((p) => [p.name, p]));
+      return newOrder.map((name) => map.get(name)!);
+    });
+
+    // Persist
+    fetch("/api/projects/reorder", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ names: newOrder }),
+    }).catch(() => {
+      // Revert on failure by re-fetching
+      fetchProjects();
+    });
+  }
+
   if (loading) {
     return (
       <div className="flex h-full items-center justify-center">
@@ -156,25 +234,16 @@ export function DashboardView() {
 
   return (
     <div className="flex flex-col gap-2 p-2">
-      {projects.map((project, index) => (
-        <div key={project.name} className="min-w-0">
-          {index > 0 && <hr className="border-border mb-2" />}
-          <div className="flex items-center gap-2 mb-1 px-1">
-            <FolderOpen className="size-3.5 shrink-0 text-muted-foreground" />
-            <h2 className="text-sm font-semibold text-foreground truncate">{project.name}</h2>
-          </div>
-          <div className="flex flex-col gap-0.5 overflow-hidden">
-            {project.worktrees.map((wt) => (
-              <WorkspaceCard
-                key={wt.workspaceId}
-                workspaceId={wt.workspaceId}
-                branch={wt.branch}
-                agent={wt.agent}
-              />
-            ))}
-          </div>
-        </div>
-      ))}
+      <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
+        <SortableContext items={projectNames} strategy={verticalListSortingStrategy}>
+          {projects.map((project, index) => (
+            <div key={project.name}>
+              {index > 0 && <hr className="border-border mb-2" />}
+              <SortableProject project={project} />
+            </div>
+          ))}
+        </SortableContext>
+      </DndContext>
     </div>
   );
 }

--- a/apps/web/src/lib/state.ts
+++ b/apps/web/src/lib/state.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, readdirSync, readFile, readFileSync } from "node:fs";
+import { mkdirSync, readdirSync, readFile, readFileSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
 
@@ -72,6 +72,11 @@ export function loadState(): AppState {
   } catch {
     return { projects: [] };
   }
+}
+
+export function saveState(state: AppState): void {
+  ensureDirs();
+  writeFileSync(stateFile(), JSON.stringify(state, null, 2), "utf-8");
 }
 
 export function loadSettings(): Settings {

--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -15,6 +15,7 @@ import { Route as ApiProjectsRouteImport } from './routes/api/projects'
 import { Route as ApiChatRouteImport } from './routes/api/chat'
 import { Route as ApiStatusStreamRouteImport } from './routes/api/status.stream'
 import { Route as ApiSessionsWorkspaceIdRouteImport } from './routes/api/sessions.$workspaceId'
+import { Route as ApiProjectsReorderRouteImport } from './routes/api/projects.reorder'
 import { Route as ApiSessionsWorkspaceIdSessionIdMessagesRouteImport } from './routes/api/sessions.$workspaceId.$sessionId.messages'
 
 const IndexRoute = IndexRouteImport.update({
@@ -47,6 +48,11 @@ const ApiSessionsWorkspaceIdRoute = ApiSessionsWorkspaceIdRouteImport.update({
   path: '/api/sessions/$workspaceId',
   getParentRoute: () => rootRouteImport,
 } as any)
+const ApiProjectsReorderRoute = ApiProjectsReorderRouteImport.update({
+  id: '/reorder',
+  path: '/reorder',
+  getParentRoute: () => ApiProjectsRoute,
+} as any)
 const ApiSessionsWorkspaceIdSessionIdMessagesRoute =
   ApiSessionsWorkspaceIdSessionIdMessagesRouteImport.update({
     id: '/$sessionId/messages',
@@ -57,8 +63,9 @@ const ApiSessionsWorkspaceIdSessionIdMessagesRoute =
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
   '/api/chat': typeof ApiChatRoute
-  '/api/projects': typeof ApiProjectsRoute
+  '/api/projects': typeof ApiProjectsRouteWithChildren
   '/chat/$workspaceId': typeof ChatWorkspaceIdRoute
+  '/api/projects/reorder': typeof ApiProjectsReorderRoute
   '/api/sessions/$workspaceId': typeof ApiSessionsWorkspaceIdRouteWithChildren
   '/api/status/stream': typeof ApiStatusStreamRoute
   '/api/sessions/$workspaceId/$sessionId/messages': typeof ApiSessionsWorkspaceIdSessionIdMessagesRoute
@@ -66,8 +73,9 @@ export interface FileRoutesByFullPath {
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
   '/api/chat': typeof ApiChatRoute
-  '/api/projects': typeof ApiProjectsRoute
+  '/api/projects': typeof ApiProjectsRouteWithChildren
   '/chat/$workspaceId': typeof ChatWorkspaceIdRoute
+  '/api/projects/reorder': typeof ApiProjectsReorderRoute
   '/api/sessions/$workspaceId': typeof ApiSessionsWorkspaceIdRouteWithChildren
   '/api/status/stream': typeof ApiStatusStreamRoute
   '/api/sessions/$workspaceId/$sessionId/messages': typeof ApiSessionsWorkspaceIdSessionIdMessagesRoute
@@ -76,8 +84,9 @@ export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
   '/api/chat': typeof ApiChatRoute
-  '/api/projects': typeof ApiProjectsRoute
+  '/api/projects': typeof ApiProjectsRouteWithChildren
   '/chat/$workspaceId': typeof ChatWorkspaceIdRoute
+  '/api/projects/reorder': typeof ApiProjectsReorderRoute
   '/api/sessions/$workspaceId': typeof ApiSessionsWorkspaceIdRouteWithChildren
   '/api/status/stream': typeof ApiStatusStreamRoute
   '/api/sessions/$workspaceId/$sessionId/messages': typeof ApiSessionsWorkspaceIdSessionIdMessagesRoute
@@ -89,6 +98,7 @@ export interface FileRouteTypes {
     | '/api/chat'
     | '/api/projects'
     | '/chat/$workspaceId'
+    | '/api/projects/reorder'
     | '/api/sessions/$workspaceId'
     | '/api/status/stream'
     | '/api/sessions/$workspaceId/$sessionId/messages'
@@ -98,6 +108,7 @@ export interface FileRouteTypes {
     | '/api/chat'
     | '/api/projects'
     | '/chat/$workspaceId'
+    | '/api/projects/reorder'
     | '/api/sessions/$workspaceId'
     | '/api/status/stream'
     | '/api/sessions/$workspaceId/$sessionId/messages'
@@ -107,6 +118,7 @@ export interface FileRouteTypes {
     | '/api/chat'
     | '/api/projects'
     | '/chat/$workspaceId'
+    | '/api/projects/reorder'
     | '/api/sessions/$workspaceId'
     | '/api/status/stream'
     | '/api/sessions/$workspaceId/$sessionId/messages'
@@ -115,7 +127,7 @@ export interface FileRouteTypes {
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
   ApiChatRoute: typeof ApiChatRoute
-  ApiProjectsRoute: typeof ApiProjectsRoute
+  ApiProjectsRoute: typeof ApiProjectsRouteWithChildren
   ChatWorkspaceIdRoute: typeof ChatWorkspaceIdRoute
   ApiSessionsWorkspaceIdRoute: typeof ApiSessionsWorkspaceIdRouteWithChildren
   ApiStatusStreamRoute: typeof ApiStatusStreamRoute
@@ -165,6 +177,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ApiSessionsWorkspaceIdRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/api/projects/reorder': {
+      id: '/api/projects/reorder'
+      path: '/reorder'
+      fullPath: '/api/projects/reorder'
+      preLoaderRoute: typeof ApiProjectsReorderRouteImport
+      parentRoute: typeof ApiProjectsRoute
+    }
     '/api/sessions/$workspaceId/$sessionId/messages': {
       id: '/api/sessions/$workspaceId/$sessionId/messages'
       path: '/$sessionId/messages'
@@ -174,6 +193,18 @@ declare module '@tanstack/react-router' {
     }
   }
 }
+
+interface ApiProjectsRouteChildren {
+  ApiProjectsReorderRoute: typeof ApiProjectsReorderRoute
+}
+
+const ApiProjectsRouteChildren: ApiProjectsRouteChildren = {
+  ApiProjectsReorderRoute: ApiProjectsReorderRoute,
+}
+
+const ApiProjectsRouteWithChildren = ApiProjectsRoute._addFileChildren(
+  ApiProjectsRouteChildren,
+)
 
 interface ApiSessionsWorkspaceIdRouteChildren {
   ApiSessionsWorkspaceIdSessionIdMessagesRoute: typeof ApiSessionsWorkspaceIdSessionIdMessagesRoute
@@ -193,7 +224,7 @@ const ApiSessionsWorkspaceIdRouteWithChildren =
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   ApiChatRoute: ApiChatRoute,
-  ApiProjectsRoute: ApiProjectsRoute,
+  ApiProjectsRoute: ApiProjectsRouteWithChildren,
   ChatWorkspaceIdRoute: ChatWorkspaceIdRoute,
   ApiSessionsWorkspaceIdRoute: ApiSessionsWorkspaceIdRouteWithChildren,
   ApiStatusStreamRoute: ApiStatusStreamRoute,

--- a/apps/web/src/routes/api/projects.reorder.ts
+++ b/apps/web/src/routes/api/projects.reorder.ts
@@ -1,0 +1,27 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { loadState, saveState } from "../../lib/state";
+
+export const Route = createFileRoute("/api/projects/reorder")({
+  server: {
+    handlers: {
+      POST: async ({ request }) => {
+        const body = (await request.json()) as { names: string[] };
+        if (!Array.isArray(body.names)) {
+          return new Response(JSON.stringify({ error: "names must be an array" }), {
+            status: 400,
+          });
+        }
+
+        const state = loadState();
+        state.projects.sort((a, b) => {
+          const ai = body.names.indexOf(a.name);
+          const bi = body.names.indexOf(b.name);
+          return (ai === -1 ? Infinity : ai) - (bi === -1 ? Infinity : bi);
+        });
+        saveState(state);
+
+        return Response.json({ ok: true });
+      },
+    },
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,15 @@ importers:
       '@band/ui':
         specifier: workspace:^
         version: link:../../packages/ui
+      '@dnd-kit/core':
+        specifier: ^6.3.1
+        version: 6.3.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@dnd-kit/sortable':
+        specifier: ^10.0.0
+        version: 10.0.0(@dnd-kit/core@6.3.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)
+      '@dnd-kit/utilities':
+        specifier: ^3.2.2
+        version: 3.2.2(react@19.2.4)
       '@tauri-apps/api':
         specifier: ^2.0.0
         version: 2.10.1
@@ -99,6 +108,15 @@ importers:
       '@band/ui':
         specifier: workspace:^
         version: link:../../packages/ui
+      '@dnd-kit/core':
+        specifier: ^6.3.1
+        version: 6.3.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@dnd-kit/sortable':
+        specifier: ^10.0.0
+        version: 10.0.0(@dnd-kit/core@6.3.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)
+      '@dnd-kit/utilities':
+        specifier: ^3.2.2
+        version: 3.2.2(react@19.2.4)
       '@streamdown/cjk':
         specifier: ^1.0.2
         version: 1.0.2(@types/mdast@4.0.4)(micromark-util-types@2.0.2)(micromark@4.0.2)(react@19.2.4)(unified@11.0.5)
@@ -461,6 +479,28 @@ packages:
 
   '@chevrotain/utils@11.1.2':
     resolution: {integrity: sha512-4mudFAQ6H+MqBTfqLmU7G1ZwRzCLfJEooL/fsF6rCX5eePMbGhoy5n4g+G4vlh2muDcsCTJtL+uKbOzWxs5LHA==}
+
+  '@dnd-kit/accessibility@3.1.1':
+    resolution: {integrity: sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==}
+    peerDependencies:
+      react: '>=16.8.0'
+
+  '@dnd-kit/core@6.3.1':
+    resolution: {integrity: sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+
+  '@dnd-kit/sortable@10.0.0':
+    resolution: {integrity: sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==}
+    peerDependencies:
+      '@dnd-kit/core': ^6.3.0
+      react: '>=16.8.0'
+
+  '@dnd-kit/utilities@3.2.2':
+    resolution: {integrity: sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==}
+    peerDependencies:
+      react: '>=16.8.0'
 
   '@esbuild/aix-ppc64@0.24.2':
     resolution: {integrity: sha512-thpVCb/rhxE/BnMLQ7GReQLLN8q9qbHmI55F4489/ByVg2aQaQ6kbcLb6FHkocZzQhxc4gx0sCk0tJkKBFzDhA==}
@@ -4207,6 +4247,31 @@ snapshots:
   '@chevrotain/types@11.1.2': {}
 
   '@chevrotain/utils@11.1.2': {}
+
+  '@dnd-kit/accessibility@3.1.1(react@19.2.4)':
+    dependencies:
+      react: 19.2.4
+      tslib: 2.8.1
+
+  '@dnd-kit/core@6.3.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@dnd-kit/accessibility': 3.1.1(react@19.2.4)
+      '@dnd-kit/utilities': 3.2.2(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+      tslib: 2.8.1
+
+  '@dnd-kit/sortable@10.0.0(@dnd-kit/core@6.3.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@dnd-kit/core': 6.3.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@dnd-kit/utilities': 3.2.2(react@19.2.4)
+      react: 19.2.4
+      tslib: 2.8.1
+
+  '@dnd-kit/utilities@3.2.2(react@19.2.4)':
+    dependencies:
+      react: 19.2.4
+      tslib: 2.8.1
 
   '@esbuild/aix-ppc64@0.24.2':
     optional: true


### PR DESCRIPTION
## Summary
- Add drag-and-drop reordering of projects in both desktop (Tauri) and web dashboard using `@dnd-kit`
- Project title row is the drag target; order persists to `~/.band/state.json`
- New `project_reorder` Tauri command and `/api/projects/reorder` web endpoint

## Test plan
- [ ] Drag projects to reorder in desktop app, verify order persists after reload
- [ ] Drag projects to reorder in web app, verify order persists
- [ ] Verify dropdown menus and buttons still work (not intercepted by drag)
- [ ] Verify single project and empty states don't break

🤖 Generated with [Claude Code](https://claude.com/claude-code)