### PR TITLE
feat: bundle web server into dashboard DMG

### DIFF
--- a/apps/dashboard/src-tauri/src/commands/webserver.rs
+++ b/apps/dashboard/src-tauri/src/commands/webserver.rs
@@ -12,6 +12,35 @@ const DEFAULT_WEB_SERVER_PORT: u16 = 3456;
 // Helpers
 // ---------------------------------------------------------------------------
 
+/// Resolve the user's full PATH by asking their login shell.
+/// macOS GUI apps get a minimal PATH that doesn't include version managers
+/// (nvm, fnm, volta) or Homebrew, so we need the shell's PATH.
+fn resolve_shell_path() -> String {
+    let shell = std::env::var("SHELL").unwrap_or_else(|_| "/bin/zsh".to_string());
+    let fallback = std::env::var("PATH").unwrap_or_default();
+
+    Command::new(&shell)
+        .args(["-l", "-c", "echo $PATH"])
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .output()
+        .ok()
+        .and_then(|o| {
+            if o.status.success() {
+                String::from_utf8(o.stdout)
+                    .ok()
+                    .map(|s| s.trim().to_string())
+                    .filter(|s| !s.is_empty())
+            } else {
+                None
+            }
+        })
+        .unwrap_or_else(|| {
+            format!("/opt/homebrew/bin:/usr/local/bin:{fallback}")
+        })
+}
+// ---------------------------------------------------------------------------
+
 fn resolve_web_dir() -> Result<std::path::PathBuf, String> {
     // 1. Dev: CARGO_MANIFEST_DIR (compile-time)
     let compile_time =
@@ -157,15 +186,20 @@ pub fn webserver_start(
     let mut cmd = Command::new("node");
     cmd.arg(&start_script)
         .current_dir(&web_dir)
+        .env("PATH", resolve_shell_path())
         .env("PORT", port.to_string())
         .env("BAND_TOKEN_SECRET", &secret)
         .stdout(Stdio::null())
         .stderr(Stdio::null());
     set_process_group(&mut cmd);
 
-    let child = cmd
-        .spawn()
-        .map_err(|e| format!("Failed to start web server: {e}"))?;
+    let child = cmd.spawn().map_err(|e| {
+        if e.kind() == std::io::ErrorKind::NotFound {
+            "Node.js is required but not installed. Install it from https://nodejs.org".to_string()
+        } else {
+            format!("Failed to start web server: {e}")
+        }
+    })?;
 
     state.0.set(child);
     Ok(())
@@ -254,6 +288,7 @@ pub async fn webserver_get_token(
 pub fn tunnel_check() -> Result<bool, String> {
     let output = Command::new("which")
         .arg("cloudflared")
+        .env("PATH", resolve_shell_path())
         .output()
         .map_err(|e| format!("Failed to check cloudflared: {e}"))?;
     Ok(output.status.success())
@@ -261,8 +296,10 @@ pub fn tunnel_check() -> Result<bool, String> {
 
 #[tauri::command]
 pub async fn tunnel_install() -> Result<(), String> {
+    let path = resolve_shell_path();
     let output = tokio::process::Command::new("brew")
         .args(["install", "cloudflared"])
+        .env("PATH", path)
         .output()
         .await
         .map_err(|e| format!("Failed to run brew: {e}"))?;
@@ -293,6 +330,7 @@ pub fn tunnel_start(
     let port = get_configured_port();
     let mut cmd = Command::new("cloudflared");
     cmd.args(["tunnel", "--url", &format!("http://127.0.0.1:{port}")])
+        .env("PATH", resolve_shell_path())
         .stderr(Stdio::piped())
         .stdout(Stdio::null());
     set_process_group(&mut cmd);

--- a/apps/dashboard/src-tauri/tauri.conf.json
+++ b/apps/dashboard/src-tauri/tauri.conf.json
@@ -7,7 +7,7 @@
     "frontendDist": "../dist",
     "devUrl": "http://localhost:1420",
     "beforeDevCommand": "pnpm dev",
-    "beforeBuildCommand": "pnpm build"
+    "beforeBuildCommand": "pnpm -F @band/web build && pnpm -F @band/web bundle:server && pnpm build"
   },
   "app": {
     "windows": [
@@ -26,6 +26,21 @@
     ],
     "security": {
       "csp": null
+    }
+  },
+  "bundle": {
+    "active": true,
+    "targets": ["dmg"],
+    "icon": [
+      "icons/32x32.png",
+      "icons/128x128.png",
+      "icons/128x128@2x.png",
+      "icons/icon.icns",
+      "icons/icon.ico"
+    ],
+    "resources": {
+      "../../web/dist/": "web/dist/",
+      "../../web/dist/start-server.mjs": "web/start-server.mjs"
     }
   },
   "plugins": {}

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -7,6 +7,7 @@
     "dev": "vite dev --port 3456 --host 0.0.0.0",
     "build": "vite build",
     "start": "node start-server.mjs",
+    "bundle:server": "esbuild start-server.mjs --bundle --platform=node --format=esm --outfile=dist/start-server.mjs --external:./dist/server/server.js",
     "test": "node --test auth.test.mjs"
   },
   "dependencies": {
@@ -48,6 +49,7 @@
     "@types/react-dom": "^19.0.0",
     "@vitejs/plugin-react": "^4.3.0",
     "tailwindcss": "^4.0.0",
+    "esbuild": "^0.25.0",
     "typescript": "^5.7.0",
     "vite": "^7.0.0"
   }

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -18,6 +18,11 @@
     "radix-ui": "^1.4.3",
     "tailwind-merge": "^3.5.0"
   },
+  "devDependencies": {
+    "@types/react": "^19.0.0",
+    "@types/react-dom": "^19.0.0",
+    "typescript": "^5.7.0"
+  },
   "peerDependencies": {
     "react": "^19.0.0",
     "react-dom": "^19.0.0"

--- a/packages/ui/tsconfig.json
+++ b/packages/ui/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "useDefineForClassFields": true,
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "isolatedModules": true,
+    "moduleDetection": "force",
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedSideEffectImports": true
+  },
+  "include": ["src"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -202,6 +202,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^4.3.0
         version: 4.7.0(vite@7.3.1(@types/node@22.19.13)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+      esbuild:
+        specifier: ^0.25.0
+        version: 0.25.12
       tailwindcss:
         specifier: ^4.0.0
         version: 4.2.1
@@ -276,6 +279,16 @@ importers:
       tailwind-merge:
         specifier: ^3.5.0
         version: 3.5.0
+    devDependencies:
+      '@types/react':
+        specifier: ^19.0.0
+        version: 19.2.14
+      '@types/react-dom':
+        specifier: ^19.0.0
+        version: 19.2.3(@types/react@19.2.14)
+      typescript:
+        specifier: ^5.7.0
+        version: 5.9.3
 
 packages:
 


### PR DESCRIPTION
## Summary
- Bundle `start-server.mjs` + `sirv` + `auth.mjs` into a single file with esbuild so the DMG doesn't need `node_modules` for the entry point
- Configure Tauri `bundle.resources` to copy the built web server into `.app/Contents/Resources/web/`
- Resolve user's login shell PATH via `$SHELL -l -c "echo $PATH"` for all spawned processes (node, brew, cloudflared, which) so they're found when the app is launched from Finder
- Show user-friendly error when Node.js is not installed

## Test plan
- [ ] Build DMG with `pnpm tauri build`
- [ ] Mount DMG and verify `Band.app/Contents/Resources/web/` contains `start-server.mjs` and `dist/`
- [ ] Launch from Finder — web server starts successfully
- [ ] Tunnel install/start works from Finder-launched app

🤖 Generated with [Claude Code](https://claude.com/claude-code)