### PR TITLE
fix: dashboard UI improvements

### DIFF
--- a/apps/dashboard/src-tauri/tauri.conf.json
+++ b/apps/dashboard/src-tauri/tauri.conf.json
@@ -7,7 +7,7 @@
     "frontendDist": "../dist",
     "devUrl": "http://localhost:1420",
     "beforeDevCommand": "pnpm dev",
-    "beforeBuildCommand": "pnpm -F @band/web build && pnpm -F @band/web bundle:server && pnpm build"
+    "beforeBuildCommand": "pnpm -F @band/web build && pnpm build"
   },
   "app": {
     "windows": [

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -5,9 +5,8 @@
   "type": "module",
   "scripts": {
     "dev": "vite dev --port 3456 --host 0.0.0.0",
-    "build": "vite build",
+    "build": "vite build && esbuild start-server.mjs --bundle --platform=node --format=esm --outfile=dist/start-server.mjs --external:./dist/server/server.js",
     "start": "node start-server.mjs",
-    "bundle:server": "esbuild start-server.mjs --bundle --platform=node --format=esm --outfile=dist/start-server.mjs --external:./dist/server/server.js",
     "test": "node --test auth.test.mjs"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "description": "IDE-agnostic agent orchestrator — dashboard + VS Code extension",
   "type": "module",
   "scripts": {
-    "dev:dashboard": "pnpm build:web & pnpm --filter @band/dashboard tauri:dev",
+    "dev:dashboard": "pnpm build:web && pnpm --filter @band/dashboard tauri:dev",
     "dev:web": "pnpm --filter @band/web dev",
     "build:dashboard": "pnpm --filter @band/dashboard tauri build",
     "build:web": "pnpm --filter @band/web build",

--- a/packages/dashboard-core/src/components/DashboardShell.tsx
+++ b/packages/dashboard-core/src/components/DashboardShell.tsx
@@ -1,7 +1,11 @@
-import { Check, FolderPlus, Plus, Settings, Tag, X } from "lucide-react";
-import { type ReactNode, useEffect, useState } from "react";
 import {
   Button,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
@@ -13,13 +17,15 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@band/ui";
-import { useDashboardStore, useSettingsStore } from "../stores/index";
+import { Check, FolderPlus, Plus, Settings, Tag, X } from "lucide-react";
+import { type ReactNode, useEffect, useState } from "react";
+import { useHooksSetup } from "../hooks/use-hooks-setup";
 import {
-  useStatusWatcher,
   useActiveWorkspaceWatcher,
   useBranchStatusWatcher,
+  useStatusWatcher,
 } from "../hooks/use-status";
-import { useHooksSetup } from "../hooks/use-hooks-setup";
+import { useDashboardStore, useSettingsStore } from "../stores/index";
 import { AddProjectDialog } from "./AddProjectDialog";
 import { ProjectList } from "./ProjectList";
 import { SettingsPage } from "./SettingsPage";
@@ -37,6 +43,7 @@ export function DashboardShell({ toolbarExtra }: DashboardShellProps) {
   const loadSettings = useSettingsStore((s) => s.loadSettings);
   const labels = useSettingsStore((s) => s.settings.labels) ?? [];
   const [showAddDialog, setShowAddDialog] = useState(false);
+  const [showErrorDialog, setShowErrorDialog] = useState(false);
   const [view, setView] = useState<"dashboard" | "settings">("dashboard");
   const [labelFilter, setLabelFilter] = useState<string | null>(null);
   const { state: hooksState, install: installHooks } = useHooksSetup();
@@ -54,138 +61,194 @@ export function DashboardShell({ toolbarExtra }: DashboardShellProps) {
     <div className="h-screen w-screen overflow-hidden flex flex-col bg-background text-foreground p-0">
       <Separator />
 
-      {error && (
-        <div className="mx-4 mt-2 px-4 py-2 bg-destructive/10 border border-destructive/30 rounded-lg text-sm text-destructive flex items-center justify-between gap-2">
-          <span className="truncate">{error}</span>
-          <Button
-            variant="ghost"
-            size="icon-xs"
-            className="text-destructive shrink-0"
-            onClick={clearError}
-          >
-            <X />
-          </Button>
-        </div>
-      )}
-
-      {hooksState.status === "needs_install" && (
-        <div className="mx-4 mt-2 px-4 py-2 bg-blue-500/10 border border-blue-500/30 rounded-lg text-sm flex items-center justify-between gap-2">
-          <span className="text-blue-200">
-            Install Claude Code hooks for agent status detection
-          </span>
-          <Button variant="outline" size="sm" className="shrink-0 text-xs" onClick={installHooks}>
-            Install
-          </Button>
-        </div>
-      )}
-
-      <div className="flex items-center justify-between px-4">
-        <div className="flex items-center gap-1">
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <Button
-                size="icon-xs"
-                variant="ghost"
-                onClick={() => setView(view === "settings" ? "dashboard" : "settings")}
-              >
-                <Settings className="size-4" />
-              </Button>
-            </TooltipTrigger>
-            <TooltipContent>Settings</TooltipContent>
-          </Tooltip>
-          {toolbarExtra}
-          {labels.length > 0 && (
-            <DropdownMenu>
-              <DropdownMenuTrigger asChild>
-                <Button
-                  size="sm"
-                  variant="ghost"
-                  className={`text-sm h-8 px-2 gap-1.5 ${labelFilter ? "bg-accent text-accent-foreground" : ""}`}
-                >
-                  {labelFilter ? (
-                    <>
-                      <span
-                        className="size-2.5 rounded-full shrink-0"
-                        style={{ backgroundColor: labels.find((l) => l.id === labelFilter)?.color }}
-                      />
-                      {labels.find((l) => l.id === labelFilter)?.name}
-                    </>
-                  ) : (
-                    <>
-                      <Tag className="size-4" />
-                      All
-                    </>
-                  )}
-                </Button>
-              </DropdownMenuTrigger>
-              <DropdownMenuContent align="start">
-                <DropdownMenuItem onClick={() => setLabelFilter(null)}>
-                  <span className="flex-1">All</span>
-                  {!labelFilter && <Check className="size-3 ml-2" />}
-                </DropdownMenuItem>
-                {labels.map((lbl) => (
-                  <DropdownMenuItem key={lbl.id} onClick={() => setLabelFilter(lbl.id)}>
-                    <span
-                      className="size-2.5 rounded-full shrink-0 mr-2"
-                      style={{ backgroundColor: lbl.color }}
-                    />
-                    <span className="flex-1">{lbl.name}</span>
-                    {labelFilter === lbl.id && <Check className="size-3 ml-2" />}
-                  </DropdownMenuItem>
-                ))}
-              </DropdownMenuContent>
-            </DropdownMenu>
-          )}
-        </div>
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <Button size="icon-xs" variant="ghost" onClick={() => setShowAddDialog(true)}>
-              <Plus className="size-4" />
-            </Button>
-          </TooltipTrigger>
-          <TooltipContent>Add project</TooltipContent>
-        </Tooltip>
-      </div>
-
-      <Separator />
-
-      <ScrollArea
-        className="flex-1 overflow-hidden"
-        onClick={(e: React.MouseEvent<HTMLDivElement>) => {
-          const target = e.target as HTMLElement;
-          if (target.closest("button, a, input, select, textarea")) return;
-          const list = (e.currentTarget as HTMLElement).querySelector<HTMLElement>(
-            '[tabindex="0"]',
-          );
-          list?.focus();
-        }}
-      >
-        <main className="px-2 py-2 overflow-hidden">
-          {view === "settings" ? (
+      {view === "settings" ? (
+        <ScrollArea className="flex-1 overflow-hidden">
+          <div className="px-2 py-2">
             <SettingsPage onClose={() => setView("dashboard")} />
-          ) : loading ? (
-            <div className="flex items-center justify-center py-12">
-              <Spinner className="size-5 text-muted-foreground" />
-            </div>
-          ) : projects.length === 0 ? (
-            <div className="flex flex-col items-center justify-center gap-3 py-12 text-center">
-              <FolderPlus className="size-8 text-muted-foreground/50" />
-              <div>
-                <p className="text-sm font-medium text-muted-foreground">No projects yet</p>
-                <p className="text-xs text-muted-foreground/70 mt-1">Add a project to get started</p>
-              </div>
-              <Button variant="outline" size="sm" onClick={() => setShowAddDialog(true)}>
-                <Plus className="size-3 mr-1" />
-                Add project
+          </div>
+        </ScrollArea>
+      ) : (
+        <>
+          {error && (
+            <div className="mx-4 mt-2 px-4 py-2 bg-destructive/10 border border-destructive/30 rounded-lg text-sm text-destructive flex items-center justify-between gap-2">
+              <button
+                type="button"
+                className="truncate text-left cursor-pointer hover:underline"
+                onClick={() => setShowErrorDialog(true)}
+              >
+                {error}
+              </button>
+              <Button
+                variant="ghost"
+                size="icon-xs"
+                className="text-destructive shrink-0"
+                onClick={clearError}
+              >
+                <X />
               </Button>
             </div>
-          ) : (
-            <ProjectList labelFilter={labelFilter} />
           )}
-        </main>
-      </ScrollArea>
 
-      <AddProjectDialog open={showAddDialog} onOpenChange={setShowAddDialog} defaultLabel={labelFilter} />
+          <Dialog open={showErrorDialog} onOpenChange={setShowErrorDialog}>
+            <DialogContent>
+              <DialogHeader>
+                <DialogTitle className="text-destructive">Error</DialogTitle>
+                <DialogDescription>Click the error text to select it.</DialogDescription>
+              </DialogHeader>
+              <pre className="whitespace-pre-wrap break-words text-sm bg-muted/50 rounded-md p-3 max-h-64 overflow-auto select-all cursor-text">
+                {error}
+              </pre>
+              <DialogFooter>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => {
+                    if (error) navigator.clipboard.writeText(error);
+                  }}
+                >
+                  Copy
+                </Button>
+                <Button
+                  variant="default"
+                  size="sm"
+                  onClick={() => {
+                    setShowErrorDialog(false);
+                    clearError();
+                  }}
+                >
+                  Dismiss
+                </Button>
+              </DialogFooter>
+            </DialogContent>
+          </Dialog>
+
+          {hooksState.status === "needs_install" && (
+            <div className="mx-4 mt-2 px-4 py-2 bg-blue-500/10 border border-blue-500/30 rounded-lg text-sm flex items-center justify-between gap-2">
+              <span className="text-blue-200">
+                Install Claude Code hooks for agent status detection
+              </span>
+              <Button
+                variant="outline"
+                size="sm"
+                className="shrink-0 text-xs"
+                onClick={installHooks}
+              >
+                Install
+              </Button>
+            </div>
+          )}
+
+          <div className="flex items-center justify-between px-4">
+            <div className="flex items-center gap-1">
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button size="icon-xs" variant="ghost" onClick={() => setView("settings")}>
+                    <Settings className="size-4" />
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent>Settings</TooltipContent>
+              </Tooltip>
+              {toolbarExtra}
+              {labels.length > 0 && (
+                <DropdownMenu>
+                  <DropdownMenuTrigger asChild>
+                    <Button
+                      size="sm"
+                      variant="ghost"
+                      className={`text-sm h-8 px-2 gap-1.5 ${labelFilter ? "bg-accent text-accent-foreground" : ""}`}
+                    >
+                      {labelFilter ? (
+                        <>
+                          <span
+                            className="size-2.5 rounded-full shrink-0"
+                            style={{
+                              backgroundColor: labels.find((l) => l.id === labelFilter)?.color,
+                            }}
+                          />
+                          {labels.find((l) => l.id === labelFilter)?.name}
+                        </>
+                      ) : (
+                        <>
+                          <Tag className="size-4" />
+                          All
+                        </>
+                      )}
+                    </Button>
+                  </DropdownMenuTrigger>
+                  <DropdownMenuContent align="start">
+                    <DropdownMenuItem onClick={() => setLabelFilter(null)}>
+                      <span className="flex-1">All</span>
+                      {!labelFilter && <Check className="size-3 ml-2" />}
+                    </DropdownMenuItem>
+                    {labels.map((lbl) => (
+                      <DropdownMenuItem key={lbl.id} onClick={() => setLabelFilter(lbl.id)}>
+                        <span
+                          className="size-2.5 rounded-full shrink-0 mr-2"
+                          style={{ backgroundColor: lbl.color }}
+                        />
+                        <span className="flex-1">{lbl.name}</span>
+                        {labelFilter === lbl.id && <Check className="size-3 ml-2" />}
+                      </DropdownMenuItem>
+                    ))}
+                  </DropdownMenuContent>
+                </DropdownMenu>
+              )}
+            </div>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button size="icon-xs" variant="ghost" onClick={() => setShowAddDialog(true)}>
+                  <Plus className="size-4" />
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent>Add project</TooltipContent>
+            </Tooltip>
+          </div>
+
+          <Separator />
+
+          <ScrollArea
+            className="flex-1 overflow-hidden"
+            onClick={(e: React.MouseEvent<HTMLDivElement>) => {
+              const target = e.target as HTMLElement;
+              if (target.closest("button, a, input, select, textarea")) return;
+              const list = (e.currentTarget as HTMLElement).querySelector<HTMLElement>(
+                '[tabindex="0"]',
+              );
+              list?.focus();
+            }}
+          >
+            <main className="px-2 py-2 overflow-hidden">
+              {loading ? (
+                <div className="flex items-center justify-center py-12">
+                  <Spinner className="size-5 text-muted-foreground" />
+                </div>
+              ) : projects.length === 0 ? (
+                <div className="flex flex-col items-center justify-center gap-3 py-12 text-center">
+                  <FolderPlus className="size-8 text-muted-foreground/50" />
+                  <div>
+                    <p className="text-sm font-medium text-muted-foreground">No projects yet</p>
+                    <p className="text-xs text-muted-foreground/70 mt-1">
+                      Add a project to get started
+                    </p>
+                  </div>
+                  <Button variant="outline" size="sm" onClick={() => setShowAddDialog(true)}>
+                    <Plus className="size-3 mr-1" />
+                    Add project
+                  </Button>
+                </div>
+              ) : (
+                <ProjectList labelFilter={labelFilter} />
+              )}
+            </main>
+          </ScrollArea>
+
+          <AddProjectDialog
+            open={showAddDialog}
+            onOpenChange={setShowAddDialog}
+            defaultLabel={labelFilter}
+          />
+        </>
+      )}
     </div>
   );
 }

--- a/packages/dashboard-core/src/components/ProjectList.tsx
+++ b/packages/dashboard-core/src/components/ProjectList.tsx
@@ -1,32 +1,37 @@
 import {
-  DndContext,
-  DragOverlay,
-  closestCenter,
-  PointerSensor,
-  useSensor,
-  useSensors,
-  useDroppable,
-  type DragEndEvent,
-  type DragStartEvent,
-} from "@dnd-kit/core";
-import { SortableContext, useSortable, verticalListSortingStrategy, arrayMove } from "@dnd-kit/sortable";
-import { CSS } from "@dnd-kit/utilities";
-import { Check, Clipboard, Ellipsis, FolderOpen, ListMinus, Plus, Tag } from "lucide-react";
-import { useEffect, useMemo, useRef, useState } from "react";
-import {
   Button,
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuPortal,
-  DropdownMenuSub,
-  DropdownMenuSubContent,
-  DropdownMenuSubTrigger,
-  DropdownMenuTrigger,
+  ContextMenu,
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuPortal,
+  ContextMenuSub,
+  ContextMenuSubContent,
+  ContextMenuSubTrigger,
+  ContextMenuTrigger,
   Tooltip,
   TooltipContent,
   TooltipTrigger,
 } from "@band/ui";
+import {
+  closestCenter,
+  DndContext,
+  type DragEndEvent,
+  DragOverlay,
+  type DragStartEvent,
+  PointerSensor,
+  useDroppable,
+  useSensor,
+  useSensors,
+} from "@dnd-kit/core";
+import {
+  arrayMove,
+  SortableContext,
+  useSortable,
+  verticalListSortingStrategy,
+} from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
+import { Check, Clipboard, FolderOpen, ListMinus, Plus, Tag } from "lucide-react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useCapabilities } from "../context";
 import { useDashboardStore, useSettingsStore } from "../stores/index";
 import type {
@@ -78,86 +83,79 @@ function SortableProject({
 
   return (
     <div ref={setNodeRef} style={style} className="min-w-0 px-2">
-      <div className="flex items-center justify-between mb-1 px-1">
-        <div
-          className="flex items-center gap-2 min-w-0 cursor-grab touch-none"
-          {...attributes}
-          {...listeners}
-        >
-          <FolderOpen className="size-3.5 shrink-0 text-muted-foreground" />
-          <h2 className="text-sm font-semibold text-foreground truncate">{project.name}</h2>
-        </div>
-        <div className="flex items-center gap-1">
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <Button
-                variant="ghost"
-                size="icon-xs"
-                onClick={() => setWorkspaceDialog(project.name)}
-              >
-                <Plus />
-              </Button>
-            </TooltipTrigger>
-            <TooltipContent>Add workspace</TooltipContent>
-          </Tooltip>
-          <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-              <Button variant="ghost" size="icon-xs" className="text-muted-foreground">
-                <Ellipsis />
-              </Button>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent align="end">
-              {labels.length > 0 && (
-                <DropdownMenuSub>
-                  <DropdownMenuSubTrigger>
-                    <Tag className="size-4 mr-2" />
-                    Set label
-                  </DropdownMenuSubTrigger>
-                  <DropdownMenuPortal>
-                    <DropdownMenuSubContent>
-                      <DropdownMenuItem onClick={() => updateProjectLabel(project.name, null)}>
-                        <span className="flex-1">None</span>
-                        {!project.label && <Check className="size-3 ml-2" />}
-                      </DropdownMenuItem>
-                      {labels.map((lbl) => (
-                        <DropdownMenuItem
-                          key={lbl.id}
-                          onClick={() => updateProjectLabel(project.name, lbl.id)}
-                        >
-                          <span
-                            className="size-2.5 rounded-full shrink-0 mr-2"
-                            style={{ backgroundColor: lbl.color }}
-                          />
-                          <span className="flex-1">{lbl.name}</span>
-                          {project.label === lbl.id && <Check className="size-3 ml-2" />}
-                        </DropdownMenuItem>
-                      ))}
-                    </DropdownMenuSubContent>
-                  </DropdownMenuPortal>
-                </DropdownMenuSub>
-              )}
-              {capabilities.copyPath && (
-                <DropdownMenuItem onClick={() => navigator.clipboard.writeText(project.path)}>
-                  <Clipboard />
-                  Copy path
-                </DropdownMenuItem>
-              )}
-              {capabilities.revealInFinder && (
-                <DropdownMenuItem
-                  onClick={() => capabilities.revealInFinder!(project.path)}
+      <ContextMenu>
+        <ContextMenuTrigger asChild>
+          <div className="flex items-center justify-between mb-1 px-1">
+            <div
+              className="flex items-center gap-2 min-w-0 cursor-grab touch-none"
+              {...attributes}
+              {...listeners}
+            >
+              <FolderOpen className="size-3.5 shrink-0 text-muted-foreground" />
+              <h2 className="text-sm font-semibold text-foreground truncate">{project.name}</h2>
+            </div>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  variant="ghost"
+                  size="icon-xs"
+                  onClick={() => setWorkspaceDialog(project.name)}
                 >
-                  <FolderOpen />
-                  Open in Finder
-                </DropdownMenuItem>
-              )}
-              <DropdownMenuItem onClick={() => removeProject(project.name)}>
-                <ListMinus />
-                Remove from list
-              </DropdownMenuItem>
-            </DropdownMenuContent>
-          </DropdownMenu>
-        </div>
-      </div>
+                  <Plus />
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent>Add workspace</TooltipContent>
+            </Tooltip>
+          </div>
+        </ContextMenuTrigger>
+        <ContextMenuContent>
+          {labels.length > 0 && (
+            <ContextMenuSub>
+              <ContextMenuSubTrigger>
+                <Tag className="size-4 mr-2" />
+                Set label
+              </ContextMenuSubTrigger>
+              <ContextMenuPortal>
+                <ContextMenuSubContent>
+                  <ContextMenuItem onClick={() => updateProjectLabel(project.name, null)}>
+                    <span className="flex-1">None</span>
+                    {!project.label && <Check className="size-3 ml-2" />}
+                  </ContextMenuItem>
+                  {labels.map((lbl) => (
+                    <ContextMenuItem
+                      key={lbl.id}
+                      onClick={() => updateProjectLabel(project.name, lbl.id)}
+                    >
+                      <span
+                        className="size-2.5 rounded-full shrink-0 mr-2"
+                        style={{ backgroundColor: lbl.color }}
+                      />
+                      <span className="flex-1">{lbl.name}</span>
+                      {project.label === lbl.id && <Check className="size-3 ml-2" />}
+                    </ContextMenuItem>
+                  ))}
+                </ContextMenuSubContent>
+              </ContextMenuPortal>
+            </ContextMenuSub>
+          )}
+          {capabilities.copyPath && (
+            <ContextMenuItem onClick={() => navigator.clipboard.writeText(project.path)}>
+              <Clipboard />
+              Copy path
+            </ContextMenuItem>
+          )}
+          {capabilities.revealInFinder && (
+            <ContextMenuItem onClick={() => capabilities.revealInFinder!(project.path)}>
+              <FolderOpen />
+              Open in Finder
+            </ContextMenuItem>
+          )}
+          <ContextMenuItem onClick={() => removeProject(project.name)}>
+            <ListMinus />
+            Remove from list
+          </ContextMenuItem>
+        </ContextMenuContent>
+      </ContextMenu>
 
       <NewWorkspaceDialog
         projectName={project.name}
@@ -197,10 +195,7 @@ function DroppableLabelHeader({ labelId, label }: { labelId: string; label: Labe
       ref={setNodeRef}
       className={`flex items-center gap-2 px-3 py-2.5 mb-1 transition-colors ${isOver ? "bg-primary/20" : "bg-accent"}`}
     >
-      <span
-        className="size-2.5 rounded-full shrink-0"
-        style={{ backgroundColor: label.color }}
-      />
+      <span className="size-2.5 rounded-full shrink-0" style={{ backgroundColor: label.color }} />
       <span className="text-sm font-semibold text-foreground/80">{label.name}</span>
     </div>
   );
@@ -240,7 +235,8 @@ export function ProjectList({ labelFilter }: ProjectListProps) {
   const sensors = useSensors(useSensor(PointerSensor, { activationConstraint: { distance: 8 } }));
 
   const groups = useMemo(() => {
-    if (labels.length === 0) return [{ labelId: null as string | null, label: null as LabelDefinition | null, projects }];
+    if (labels.length === 0)
+      return [{ labelId: null as string | null, label: null as LabelDefinition | null, projects }];
 
     const byLabel = new Map<string | null, ProjectInfo[]>();
     for (const p of projects) {
@@ -249,7 +245,11 @@ export function ProjectList({ labelFilter }: ProjectListProps) {
       byLabel.get(key)!.push(p);
     }
 
-    const result: { labelId: string | null; label: LabelDefinition | null; projects: ProjectInfo[] }[] = [];
+    const result: {
+      labelId: string | null;
+      label: LabelDefinition | null;
+      projects: ProjectInfo[];
+    }[] = [];
     for (const lbl of labels) {
       const grouped = byLabel.get(lbl.id);
       if (grouped) {
@@ -381,13 +381,13 @@ export function ProjectList({ labelFilter }: ProjectListProps) {
           {visibleGroups.map((group, groupIndex) => (
             <div key={group.labelId ?? "__unlabeled"}>
               {groupIndex > 0 && !labels.length && <hr className="border-border my-1 mx-2" />}
-              {labels.length > 0 && !labelFilter && (
-                group.label ? (
+              {labels.length > 0 &&
+                !labelFilter &&
+                (group.label ? (
                   <DroppableLabelHeader labelId={group.labelId!} label={group.label} />
                 ) : (
                   <DroppableUnlabeledHeader />
-                )
-              )}
+                ))}
               {group.projects.map((project, index) => (
                 <div key={project.name}>
                   {index > 0 && <hr className="border-border mb-1 mx-2" />}

--- a/packages/dashboard-core/src/components/WorkspaceCard.tsx
+++ b/packages/dashboard-core/src/components/WorkspaceCard.tsx
@@ -50,7 +50,7 @@ export function WorkspaceCard({
     if (!href) openWorkspace(workspaceId);
   };
 
-  const className = `flex flex-row items-center justify-between px-3 py-1.5 min-w-0 overflow-hidden cursor-pointer transition-colors hover:bg-accent/50 ${isActive ? "bg-accent/50 border-l-2 border-l-primary" : ""} ${isFocused ? "ring-2 ring-inset ring-ring" : ""} ${href ? "no-underline text-inherit" : ""}`;
+  const className = `flex flex-row items-center justify-between px-3 py-2.5 min-w-0 overflow-hidden cursor-pointer transition-colors hover:bg-accent/50 ${isActive ? "bg-accent/50 border-l-2 border-l-primary" : ""} ${isFocused ? "ring-2 ring-inset ring-ring" : ""} ${href ? "no-underline text-inherit" : ""}`;
 
   const Container = href ? "a" : "div";
   const containerProps = href

--- a/packages/dashboard-core/src/components/WorkspaceCard.tsx
+++ b/packages/dashboard-core/src/components/WorkspaceCard.tsx
@@ -1,12 +1,6 @@
-import { Clipboard, Ellipsis, FolderOpen, GitBranch, Play, Square, Trash2 } from "lucide-react";
+import { ContextMenu, ContextMenuContent, ContextMenuItem, ContextMenuTrigger } from "@band/ui";
+import { Clipboard, FolderOpen, GitBranch, Play, Square, Trash2 } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
-import {
-  Button,
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-} from "@band/ui";
 import { useCapabilities } from "../context";
 import { useDashboardStore } from "../stores/index";
 import type { WorkspaceBranchStatus, WorkspaceStatus, WorktreeInfo } from "../types";
@@ -61,7 +55,15 @@ export function WorkspaceCard({
   const Container = href ? "a" : "div";
   const containerProps = href
     ? { href, ref: cardRef as React.Ref<HTMLAnchorElement>, className, tabIndex: 0 }
-    : { ref: cardRef, className, tabIndex: 0, onClick: handleClick, onKeyDown: (e: React.KeyboardEvent) => { if (e.key === "Enter" || e.key === " ") handleClick(); } };
+    : {
+        ref: cardRef,
+        className,
+        tabIndex: 0,
+        onClick: handleClick,
+        onKeyDown: (e: React.KeyboardEvent) => {
+          if (e.key === "Enter" || e.key === " ") handleClick();
+        },
+      };
 
   const ciState = branchStatus?.ci.state;
   const hasUnmergedPR = ciState !== undefined && ciState !== "none" && ciState !== "merged";
@@ -82,65 +84,59 @@ export function WorkspaceCard({
   };
 
   return (
-    <Container {...(containerProps as React.HTMLAttributes<HTMLElement>)}>
-
-      <div className="flex flex-1 items-center gap-3 min-w-0 overflow-hidden">
-        <GitBranch
-          className={`size-3 shrink-0 ${isActive ? "text-primary" : "text-muted-foreground"}`}
-        />
-        <span
-          className={`text-xs truncate ${isActive ? "font-semibold text-foreground" : "font-medium"}`}
-          style={isActive ? undefined : { color: "oklch(0.7 0 0)" }}
-        >
-          {worktree.branch}
-        </span>
-        <AgentStatusBadge agent={status?.agent} />
-      </div>
-      <div className="flex items-center gap-2 shrink-0">
-        {branchStatus && <GitStatusIndicator git={branchStatus.git} />}
-        {branchStatus && <CIStatusIndicator ci={branchStatus.ci} />}
-        <DropdownMenu>
-          <DropdownMenuTrigger asChild onClick={(e: React.MouseEvent) => e.stopPropagation()}>
-            <Button variant="ghost" size="icon-xs" className="text-muted-foreground shrink-0">
-              <Ellipsis />
-            </Button>
-          </DropdownMenuTrigger>
-          <DropdownMenuContent align="end" onClick={(e: React.MouseEvent) => e.stopPropagation()}>
-            {capabilities.copyPath && (
-              <DropdownMenuItem onClick={() => navigator.clipboard.writeText(worktree.path)}>
-                <Clipboard />
-                Copy path
-              </DropdownMenuItem>
-            )}
-            {capabilities.revealInFinder && (
-              <DropdownMenuItem
-                onClick={() => capabilities.revealInFinder!(worktree.path)}
-              >
-                <FolderOpen />
-                Open in Finder
-              </DropdownMenuItem>
-            )}
-            {worktree.hasSetup && (
-              <DropdownMenuItem onClick={() => runScript(worktree.path, "setup")}>
-                <Play />
-                Run setup
-              </DropdownMenuItem>
-            )}
-            {worktree.hasTeardown && (
-              <DropdownMenuItem onClick={() => runScript(worktree.path, "teardown")}>
-                <Square />
-                Run teardown
-              </DropdownMenuItem>
-            )}
-            {worktree.branch !== defaultBranch && (
-              <DropdownMenuItem variant="destructive" onClick={handleDelete}>
-                <Trash2 />
-                Delete workspace
-              </DropdownMenuItem>
-            )}
-          </DropdownMenuContent>
-        </DropdownMenu>
-      </div>
+    <ContextMenu>
+      <ContextMenuTrigger asChild>
+        <Container {...(containerProps as React.HTMLAttributes<HTMLElement>)}>
+          <div className="flex flex-1 items-center gap-3 min-w-0 overflow-hidden">
+            <GitBranch
+              className={`size-3 shrink-0 ${isActive ? "text-primary" : "text-muted-foreground"}`}
+            />
+            <span
+              className={`text-xs truncate ${isActive ? "font-semibold text-foreground" : "font-medium"}`}
+              style={isActive ? undefined : { color: "oklch(0.7 0 0)" }}
+            >
+              {worktree.branch}
+            </span>
+            <AgentStatusBadge agent={status?.agent} />
+          </div>
+          <div className="flex items-center gap-2 shrink-0">
+            {branchStatus && <GitStatusIndicator git={branchStatus.git} />}
+            {branchStatus && <CIStatusIndicator ci={branchStatus.ci} />}
+          </div>
+        </Container>
+      </ContextMenuTrigger>
+      <ContextMenuContent>
+        {capabilities.copyPath && (
+          <ContextMenuItem onClick={() => navigator.clipboard.writeText(worktree.path)}>
+            <Clipboard />
+            Copy path
+          </ContextMenuItem>
+        )}
+        {capabilities.revealInFinder && (
+          <ContextMenuItem onClick={() => capabilities.revealInFinder!(worktree.path)}>
+            <FolderOpen />
+            Open in Finder
+          </ContextMenuItem>
+        )}
+        {worktree.hasSetup && (
+          <ContextMenuItem onClick={() => runScript(worktree.path, "setup")}>
+            <Play />
+            Run setup
+          </ContextMenuItem>
+        )}
+        {worktree.hasTeardown && (
+          <ContextMenuItem onClick={() => runScript(worktree.path, "teardown")}>
+            <Square />
+            Run teardown
+          </ContextMenuItem>
+        )}
+        {worktree.branch !== defaultBranch && (
+          <ContextMenuItem variant="destructive" onClick={handleDelete}>
+            <Trash2 />
+            Delete workspace
+          </ContextMenuItem>
+        )}
+      </ContextMenuContent>
       <DeleteWorkspaceDialog
         open={showDeleteDialog}
         onOpenChange={setShowDeleteDialog}
@@ -150,6 +146,6 @@ export function WorkspaceCard({
         isDirty={isDirty}
         hasUnpushedCommits={hasUnpushedCommits}
       />
-    </Container>
+    </ContextMenu>
   );
 }

--- a/packages/ui/src/components/context-menu.tsx
+++ b/packages/ui/src/components/context-menu.tsx
@@ -1,0 +1,129 @@
+import { ChevronRightIcon } from "lucide-react";
+import { ContextMenu as ContextMenuPrimitive } from "radix-ui";
+import type * as React from "react";
+
+import { cn } from "../utils";
+
+function ContextMenu({ ...props }: React.ComponentProps<typeof ContextMenuPrimitive.Root>) {
+  return <ContextMenuPrimitive.Root data-slot="context-menu" {...props} />;
+}
+
+function ContextMenuTrigger({
+  ...props
+}: React.ComponentProps<typeof ContextMenuPrimitive.Trigger>) {
+  return <ContextMenuPrimitive.Trigger data-slot="context-menu-trigger" {...props} />;
+}
+
+function ContextMenuPortal({ ...props }: React.ComponentProps<typeof ContextMenuPrimitive.Portal>) {
+  return <ContextMenuPrimitive.Portal data-slot="context-menu-portal" {...props} />;
+}
+
+function ContextMenuContent({
+  className,
+  ...props
+}: React.ComponentProps<typeof ContextMenuPrimitive.Content>) {
+  return (
+    <ContextMenuPrimitive.Portal>
+      <ContextMenuPrimitive.Content
+        data-slot="context-menu-content"
+        className={cn(
+          "z-50 max-h-(--radix-context-menu-content-available-height) min-w-[8rem] origin-(--radix-context-menu-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border bg-popover p-1 text-popover-foreground shadow-md data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95",
+          className,
+        )}
+        {...props}
+      />
+    </ContextMenuPrimitive.Portal>
+  );
+}
+
+function ContextMenuItem({
+  className,
+  inset,
+  variant = "default",
+  ...props
+}: React.ComponentProps<typeof ContextMenuPrimitive.Item> & {
+  inset?: boolean;
+  variant?: "default" | "destructive";
+}) {
+  return (
+    <ContextMenuPrimitive.Item
+      data-slot="context-menu-item"
+      data-inset={inset}
+      data-variant={variant}
+      className={cn(
+        "relative flex cursor-pointer items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 data-[inset]:pl-8 data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 data-[variant=destructive]:focus:text-destructive dark:data-[variant=destructive]:focus:bg-destructive/20 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 [&_svg:not([class*='text-'])]:text-muted-foreground data-[variant=destructive]:*:[svg]:text-destructive!",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function ContextMenuSub({ ...props }: React.ComponentProps<typeof ContextMenuPrimitive.Sub>) {
+  return <ContextMenuPrimitive.Sub data-slot="context-menu-sub" {...props} />;
+}
+
+function ContextMenuSubTrigger({
+  className,
+  inset,
+  children,
+  ...props
+}: React.ComponentProps<typeof ContextMenuPrimitive.SubTrigger> & {
+  inset?: boolean;
+}) {
+  return (
+    <ContextMenuPrimitive.SubTrigger
+      data-slot="context-menu-sub-trigger"
+      data-inset={inset}
+      className={cn(
+        "flex cursor-pointer items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground data-[inset]:pl-8 data-[state=open]:bg-accent data-[state=open]:text-accent-foreground [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 [&_svg:not([class*='text-'])]:text-muted-foreground",
+        className,
+      )}
+      {...props}
+    >
+      {children}
+      <ChevronRightIcon className="ml-auto size-4" />
+    </ContextMenuPrimitive.SubTrigger>
+  );
+}
+
+function ContextMenuSubContent({
+  className,
+  ...props
+}: React.ComponentProps<typeof ContextMenuPrimitive.SubContent>) {
+  return (
+    <ContextMenuPrimitive.SubContent
+      data-slot="context-menu-sub-content"
+      className={cn(
+        "z-50 min-w-[8rem] origin-(--radix-context-menu-content-transform-origin) overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-lg data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function ContextMenuSeparator({
+  className,
+  ...props
+}: React.ComponentProps<typeof ContextMenuPrimitive.Separator>) {
+  return (
+    <ContextMenuPrimitive.Separator
+      data-slot="context-menu-separator"
+      className={cn("-mx-1 my-1 h-px bg-border", className)}
+      {...props}
+    />
+  );
+}
+
+export {
+  ContextMenu,
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuPortal,
+  ContextMenuSeparator,
+  ContextMenuSub,
+  ContextMenuSubContent,
+  ContextMenuSubTrigger,
+  ContextMenuTrigger,
+};

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -7,6 +7,7 @@ export * from "./components/card";
 export * from "./components/collapsible";
 export * from "./components/color-picker";
 export * from "./components/command";
+export * from "./components/context-menu";
 export * from "./components/dialog";
 export * from "./components/dropdown-menu";
 export * from "./components/hover-card";


### PR DESCRIPTION
## Summary
- Error messages are now clickable — opens a dialog with full selectable/copyable error text
- Settings view renders as a full page instead of inside the project list area
- Replace 3-dot dropdown menus on projects and workspaces with right-click / long-press context menus
- Consolidate web build scripts (vite build + esbuild bundle in single `build` command)
- Increase workspace card padding for better touch targets

## Test plan
- [ ] Trigger an error and verify clicking it opens the error detail dialog with Copy/Dismiss buttons
- [ ] Open settings and verify it takes the full page
- [ ] Right-click a project header to see the context menu (labels, copy path, remove)
- [ ] Right-click a workspace card to see the context menu (copy path, open in finder, delete)
- [ ] Long-press on mobile to verify context menus work
- [ ] Run `pnpm build:web` and verify both vite + esbuild output is produced
- [ ] Verify Tauri build still works with `pnpm build:dashboard`

🤖 Generated with [Claude Code](https://claude.com/claude-code)