### PR TITLE
feat: add CI/CD workflows and version bump script

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,103 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: ci-${{ github.head_ref }}
+  cancel-in-progress: true
+
+jobs:
+  check:
+    name: Lint, Test & Build
+    runs-on: macos-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy, rustfmt
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Cache pnpm store
+        uses: actions/cache@v4
+        with:
+          path: ~/.pnpm-store
+          key: pnpm-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: pnpm-${{ runner.os }}-
+
+      - name: Cache Cargo registry
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+          key: cargo-registry-${{ runner.os }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: cargo-registry-${{ runner.os }}-
+
+      - name: Cache CLI target
+        uses: actions/cache@v4
+        with:
+          path: apps/cli/target
+          key: cargo-cli-${{ runner.os }}-${{ hashFiles('apps/cli/Cargo.lock') }}
+          restore-keys: cargo-cli-${{ runner.os }}-
+
+      - name: Cache Dashboard target
+        uses: actions/cache@v4
+        with:
+          path: apps/dashboard/src-tauri/target
+          key: cargo-dashboard-${{ runner.os }}-${{ hashFiles('apps/dashboard/src-tauri/Cargo.lock') }}
+          restore-keys: cargo-dashboard-${{ runner.os }}-
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Lint (Biome)
+        run: biome check .
+
+      - name: Lint (cargo fmt)
+        run: |
+          cargo fmt --manifest-path apps/cli/Cargo.toml -- --check
+          cargo fmt --manifest-path apps/dashboard/src-tauri/Cargo.toml -- --check
+
+      - name: Lint (cargo clippy)
+        run: |
+          cargo clippy --manifest-path apps/cli/Cargo.toml -- -D warnings
+          cargo clippy --manifest-path apps/dashboard/src-tauri/Cargo.toml -- -D warnings
+
+      - name: Test (web)
+        run: pnpm --filter @band/web test
+
+      - name: Test (CLI)
+        run: cargo test --manifest-path apps/cli/Cargo.toml
+
+      - name: Build CLI
+        run: pnpm build:cli
+
+      - name: Test (Dashboard)
+        run: |
+          mkdir -p apps/web/dist
+          touch apps/web/dist/start-server.mjs
+          cargo test --manifest-path apps/dashboard/src-tauri/Cargo.toml
+          rm -rf apps/web/dist
+
+      - name: Build DMG
+        run: pnpm build:dashboard
+
+      - name: Upload DMG
+        uses: actions/upload-artifact@v4
+        with:
+          name: band-dmg
+          path: apps/dashboard/src-tauri/target/release/bundle/dmg/*.dmg
+          retention-days: 7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,19 +73,20 @@ jobs:
           cargo fmt --manifest-path apps/cli/Cargo.toml -- --check
           cargo fmt --manifest-path apps/dashboard/src-tauri/Cargo.toml -- --check
 
-      - name: Lint (cargo clippy)
-        run: |
-          cargo clippy --manifest-path apps/cli/Cargo.toml -- -D warnings
-          cargo clippy --manifest-path apps/dashboard/src-tauri/Cargo.toml -- -D warnings
+      - name: Lint (cargo clippy — CLI)
+        run: cargo clippy --manifest-path apps/cli/Cargo.toml -- -D warnings
+
+      - name: Build CLI
+        run: pnpm build:cli
+
+      - name: Lint (cargo clippy — Dashboard)
+        run: cargo clippy --manifest-path apps/dashboard/src-tauri/Cargo.toml -- -D warnings
 
       - name: Test (web)
         run: pnpm --filter @band/web test
 
       - name: Test (CLI)
         run: cargo test --manifest-path apps/cli/Cargo.toml
-
-      - name: Build CLI
-        run: pnpm build:cli
 
       - name: Test (Dashboard)
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,7 +80,10 @@ jobs:
         run: pnpm build:cli
 
       - name: Lint (cargo clippy — Dashboard)
-        run: cargo clippy --manifest-path apps/dashboard/src-tauri/Cargo.toml -- -D warnings
+        run: |
+          mkdir -p apps/web/dist
+          touch apps/web/dist/start-server.mjs
+          cargo clippy --manifest-path apps/dashboard/src-tauri/Cargo.toml -- -D warnings
 
       - name: Test (web)
         run: pnpm --filter @band/web test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,7 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Lint (Biome)
-        run: biome check .
+        run: pnpm exec biome check .
 
       - name: Lint (cargo fmt)
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,8 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
+        with:
+          version: 10
 
       - name: Cache pnpm store
         uses: actions/cache@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,8 +98,10 @@ jobs:
           cargo test --manifest-path apps/dashboard/src-tauri/Cargo.toml
           rm -rf apps/web/dist
 
-      - name: Build web
-        run: pnpm build:web
+      - name: Build frontend
+        run: |
+          pnpm build:web
+          pnpm --filter @band/dashboard build
 
       - name: Build DMG
         run: pnpm --filter @band/dashboard tauri build --ci --config '{"build":{"beforeBuildCommand":""}}'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,8 +98,11 @@ jobs:
           cargo test --manifest-path apps/dashboard/src-tauri/Cargo.toml
           rm -rf apps/web/dist
 
+      - name: Build web
+        run: pnpm build:web
+
       - name: Build DMG
-        run: pnpm build:dashboard
+        run: pnpm --filter @band/dashboard tauri build --ci --config '{"build":{"beforeBuildCommand":""}}'
 
       - name: Upload DMG
         uses: actions/upload-artifact@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -116,7 +116,10 @@ jobs:
         run: pnpm build:cli
 
       - name: Lint (cargo clippy — Dashboard)
-        run: cargo clippy --manifest-path apps/dashboard/src-tauri/Cargo.toml -- -D warnings
+        run: |
+          mkdir -p apps/web/dist
+          touch apps/web/dist/start-server.mjs
+          cargo clippy --manifest-path apps/dashboard/src-tauri/Cargo.toml -- -D warnings
 
       - name: Test
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,158 @@
+name: Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Explicit version (e.g. 1.2.3). Leave empty to use bump or auto-detect."
+        required: false
+        type: string
+      bump:
+        description: "Bump type. Leave empty to auto-detect from commits."
+        required: false
+        type: choice
+        default: ""
+        options:
+          - ""
+          - patch
+          - minor
+          - major
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    name: Release
+    runs-on: macos-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy, rustfmt
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Cache pnpm store
+        uses: actions/cache@v4
+        with:
+          path: ~/.pnpm-store
+          key: pnpm-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: pnpm-${{ runner.os }}-
+
+      - name: Cache Cargo registry
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+          key: cargo-registry-${{ runner.os }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: cargo-registry-${{ runner.os }}-
+
+      - name: Cache CLI target
+        uses: actions/cache@v4
+        with:
+          path: apps/cli/target
+          key: cargo-cli-${{ runner.os }}-${{ hashFiles('apps/cli/Cargo.lock') }}
+          restore-keys: cargo-cli-${{ runner.os }}-
+
+      - name: Cache Dashboard target
+        uses: actions/cache@v4
+        with:
+          path: apps/dashboard/src-tauri/target
+          key: cargo-dashboard-${{ runner.os }}-${{ hashFiles('apps/dashboard/src-tauri/Cargo.lock') }}
+          restore-keys: cargo-dashboard-${{ runner.os }}-
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Determine version
+        id: version
+        run: |
+          if [ -n "${{ inputs.version }}" ]; then
+            BUMP_ARGS="--version ${{ inputs.version }}"
+          elif [ -n "${{ inputs.bump }}" ]; then
+            BUMP_ARGS="--bump ${{ inputs.bump }}"
+          else
+            BUMP_ARGS="--from-commits"
+          fi
+          NEW_VERSION=$(node scripts/bump-version.mjs $BUMP_ARGS --dry-run 2>&1 | grep "^Version:" | sed 's/Version: .* → //')
+          echo "new_version=$NEW_VERSION" >> "$GITHUB_OUTPUT"
+          echo "bump_args=$BUMP_ARGS" >> "$GITHUB_OUTPUT"
+          echo "Will release version: $NEW_VERSION"
+
+      - name: Verify tag does not exist
+        run: |
+          if git rev-parse "v${{ steps.version.outputs.new_version }}" >/dev/null 2>&1; then
+            echo "Error: Tag v${{ steps.version.outputs.new_version }} already exists"
+            exit 1
+          fi
+
+      - name: Bump versions
+        run: node scripts/bump-version.mjs ${{ steps.version.outputs.bump_args }}
+
+      - name: Lint
+        run: |
+          biome check .
+          cargo fmt --manifest-path apps/cli/Cargo.toml -- --check
+          cargo fmt --manifest-path apps/dashboard/src-tauri/Cargo.toml -- --check
+          cargo clippy --manifest-path apps/cli/Cargo.toml -- -D warnings
+          cargo clippy --manifest-path apps/dashboard/src-tauri/Cargo.toml -- -D warnings
+
+      - name: Test
+        run: |
+          pnpm --filter @band/web test
+          cargo test --manifest-path apps/cli/Cargo.toml
+          pnpm build:cli
+          mkdir -p apps/web/dist
+          touch apps/web/dist/start-server.mjs
+          cargo test --manifest-path apps/dashboard/src-tauri/Cargo.toml
+          rm -rf apps/web/dist
+
+      - name: Build DMG
+        run: pnpm build:dashboard
+
+      - name: Commit and tag
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add -A
+          git commit -m "chore: release v${{ steps.version.outputs.new_version }}"
+          git tag "v${{ steps.version.outputs.new_version }}"
+          git push origin main --follow-tags
+
+      - name: Generate changelog
+        id: changelog
+        run: |
+          LAST_TAG=$(git describe --tags --abbrev=0 HEAD^ 2>/dev/null || echo "")
+          if [ -n "$LAST_TAG" ]; then
+            RANGE="${LAST_TAG}..v${{ steps.version.outputs.new_version }}"
+          else
+            RANGE="v${{ steps.version.outputs.new_version }}"
+          fi
+          CHANGELOG=$(git log $RANGE --pretty=format:"- %s" --no-merges | grep -v "^- chore: release" || true)
+          {
+            echo "changelog<<EOF"
+            echo "$CHANGELOG"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: v${{ steps.version.outputs.new_version }}
+          name: v${{ steps.version.outputs.new_version }}
+          body: ${{ steps.changelog.outputs.changelog }}
+          files: apps/dashboard/src-tauri/target/release/bundle/dmg/*.dmg

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -111,13 +111,17 @@ jobs:
           cargo fmt --manifest-path apps/cli/Cargo.toml -- --check
           cargo fmt --manifest-path apps/dashboard/src-tauri/Cargo.toml -- --check
           cargo clippy --manifest-path apps/cli/Cargo.toml -- -D warnings
-          cargo clippy --manifest-path apps/dashboard/src-tauri/Cargo.toml -- -D warnings
+
+      - name: Build CLI
+        run: pnpm build:cli
+
+      - name: Lint (cargo clippy — Dashboard)
+        run: cargo clippy --manifest-path apps/dashboard/src-tauri/Cargo.toml -- -D warnings
 
       - name: Test
         run: |
           pnpm --filter @band/web test
           cargo test --manifest-path apps/cli/Cargo.toml
-          pnpm build:cli
           mkdir -p apps/web/dist
           touch apps/web/dist/start-server.mjs
           cargo test --manifest-path apps/dashboard/src-tauri/Cargo.toml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -107,7 +107,7 @@ jobs:
 
       - name: Lint
         run: |
-          biome check .
+          pnpm exec biome check .
           cargo fmt --manifest-path apps/cli/Cargo.toml -- --check
           cargo fmt --manifest-path apps/dashboard/src-tauri/Cargo.toml -- --check
           cargo clippy --manifest-path apps/cli/Cargo.toml -- -D warnings

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -130,8 +130,10 @@ jobs:
           cargo test --manifest-path apps/dashboard/src-tauri/Cargo.toml
           rm -rf apps/web/dist
 
-      - name: Build web
-        run: pnpm build:web
+      - name: Build frontend
+        run: |
+          pnpm build:web
+          pnpm --filter @band/dashboard build
 
       - name: Build DMG
         run: pnpm --filter @band/dashboard tauri build --ci --config '{"build":{"beforeBuildCommand":""}}'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,6 +44,8 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
+        with:
+          version: 10
 
       - name: Cache pnpm store
         uses: actions/cache@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -130,8 +130,11 @@ jobs:
           cargo test --manifest-path apps/dashboard/src-tauri/Cargo.toml
           rm -rf apps/web/dist
 
+      - name: Build web
+        run: pnpm build:web
+
       - name: Build DMG
-        run: pnpm build:dashboard
+        run: pnpm --filter @band/dashboard tauri build --ci --config '{"build":{"beforeBuildCommand":""}}'
 
       - name: Commit and tag
         run: |

--- a/apps/cli/src/state.rs
+++ b/apps/cli/src/state.rs
@@ -163,7 +163,9 @@ pub fn load_settings() -> Result<Settings, String> {
 }
 
 pub fn load_project_config(project_path: &str) -> ProjectConfig {
-    let config_path = PathBuf::from(project_path).join(".band").join("config.json");
+    let config_path = PathBuf::from(project_path)
+        .join(".band")
+        .join("config.json");
     if !config_path.exists() {
         return ProjectConfig::default();
     }

--- a/apps/cli/tests/integration.rs
+++ b/apps/cli/tests/integration.rs
@@ -316,11 +316,7 @@ fn setup_failure_is_non_fatal() {
 
     let band_dir = env.repo_path.join(".band");
     fs::create_dir_all(&band_dir).unwrap();
-    fs::write(
-        band_dir.join("config.json"),
-        r#"{ "setup": "exit 1" }"#,
-    )
-    .unwrap();
+    fs::write(band_dir.join("config.json"), r#"{ "setup": "exit 1" }"#).unwrap();
     git(&env.repo_path, &["add", ".band/config.json"]);
     git(&env.repo_path, &["commit", "-m", "add failing setup"]);
 

--- a/apps/dashboard/src-tauri/src/commands/cli.rs
+++ b/apps/dashboard/src-tauri/src/commands/cli.rs
@@ -79,12 +79,8 @@ pub fn install_cli(symlink_path: &Path, sidecar_path: &Path) -> Result<(), Strin
 
     // Remove existing symlink/file if it exists
     if symlink_path.symlink_metadata().is_ok() {
-        fs::remove_file(symlink_path).map_err(|e| {
-            format!(
-                "Failed to remove existing {}: {e}",
-                symlink_path.display()
-            )
-        })?;
+        fs::remove_file(symlink_path)
+            .map_err(|e| format!("Failed to remove existing {}: {e}", symlink_path.display()))?;
     }
 
     #[cfg(unix)]
@@ -255,7 +251,11 @@ mod tests {
 
         install_cli(&symlink_path, &sidecar).unwrap();
 
-        assert!(symlink_path.symlink_metadata().unwrap().file_type().is_symlink());
+        assert!(symlink_path
+            .symlink_metadata()
+            .unwrap()
+            .file_type()
+            .is_symlink());
         assert_eq!(fs::read_link(&symlink_path).unwrap(), sidecar);
     }
 
@@ -267,7 +267,11 @@ mod tests {
 
         install_cli(&symlink_path, &sidecar).unwrap();
 
-        assert!(symlink_path.symlink_metadata().unwrap().file_type().is_symlink());
+        assert!(symlink_path
+            .symlink_metadata()
+            .unwrap()
+            .file_type()
+            .is_symlink());
         assert_eq!(fs::read_link(&symlink_path).unwrap(), sidecar);
     }
 
@@ -300,7 +304,11 @@ mod tests {
         let sidecar = make_sidecar(tmp.path());
         install_cli(&symlink_path, &sidecar).unwrap();
 
-        assert!(symlink_path.symlink_metadata().unwrap().file_type().is_symlink());
+        assert!(symlink_path
+            .symlink_metadata()
+            .unwrap()
+            .file_type()
+            .is_symlink());
         assert_eq!(fs::read_link(&symlink_path).unwrap(), sidecar);
     }
 

--- a/apps/dashboard/src-tauri/src/commands/ide.rs
+++ b/apps/dashboard/src-tauri/src/commands/ide.rs
@@ -118,8 +118,8 @@ fn check_accessibility() -> bool {
                 keys.as_ptr(),
                 values.as_ptr(),
                 1,
-                &kCFTypeDictionaryKeyCallBacks as *const c_void,
-                &kCFTypeDictionaryValueCallBacks as *const c_void,
+                &raw const kCFTypeDictionaryKeyCallBacks,
+                &raw const kCFTypeDictionaryValueCallBacks,
             );
             let result = AXIsProcessTrustedWithOptions(opts);
             CFRelease(key);

--- a/apps/dashboard/src-tauri/src/commands/webserver.rs
+++ b/apps/dashboard/src-tauri/src/commands/webserver.rs
@@ -83,11 +83,15 @@ pub(crate) fn which_binary(name: &str) -> Result<String, String> {
 fn generate_secret() -> Result<String, String> {
     use std::io::Read;
     let mut f = std::fs::File::open("/dev/urandom")
-        .map_err(|e| format!("Failed to open /dev/urandom: {}", e))?;
+        .map_err(|e| format!("Failed to open /dev/urandom: {e}"))?;
     let mut buf = [0u8; 32];
     f.read_exact(&mut buf)
-        .map_err(|e| format!("Failed to read random bytes: {}", e))?;
-    Ok(buf.iter().map(|b| format!("{:02x}", b)).collect())
+        .map_err(|e| format!("Failed to read random bytes: {e}"))?;
+    Ok(buf.iter().fold(String::with_capacity(64), |mut acc, b| {
+        use std::fmt::Write;
+        write!(acc, "{b:02x}").unwrap();
+        acc
+    }))
 }
 
 /// Load or create a persistent token secret (saved in settings).
@@ -281,11 +285,11 @@ pub async fn webserver_get_token(
         .args([
             "-s",
             "-f",
-            &format!("http://127.0.0.1:{}/api/auth/token", port),
+            &format!("http://127.0.0.1:{port}/api/auth/token"),
         ])
         .output()
         .await
-        .map_err(|e| format!("Failed to fetch token: {}", e))?;
+        .map_err(|e| format!("Failed to fetch token: {e}"))?;
 
     if !output.status.success() {
         return Err("Failed to fetch auth token from web server".to_string());
@@ -293,7 +297,7 @@ pub async fn webserver_get_token(
 
     let body = String::from_utf8_lossy(&output.stdout);
     let parsed: serde_json::Value = serde_json::from_str(&body)
-        .map_err(|e| format!("Failed to parse token response: {}", e))?;
+        .map_err(|e| format!("Failed to parse token response: {e}"))?;
     let token = parsed["token"]
         .as_str()
         .ok_or_else(|| "Token not found in response".to_string())?
@@ -457,7 +461,7 @@ pub fn tunnel_start(
                         let token_guard = token_arc.lock().ok();
                         let token = token_guard.as_ref().and_then(|g| g.as_ref().cloned());
                         let url = match token {
-                            Some(t) => format!("{}?token={}", base_url, t),
+                            Some(t) => format!("{base_url}?token={t}"),
                             None => base_url,
                         };
                         let _ = app_handle.emit("tunnel-url", url);
@@ -500,7 +504,7 @@ pub fn tunnel_start(
                     } else {
                         meaningful.join("\n")
                     };
-                    format!("instatunnel failed:\n{}", display)
+                    format!("instatunnel failed:\n{display}")
                 };
                 let _ = app_handle.emit("tunnel-error", msg);
             }
@@ -530,7 +534,7 @@ pub async fn tunnel_stop(state: State<'_, TunnelState>) -> Result<(), String> {
         let sub = guard
             .url
             .as_ref()
-            .and_then(|url| extract_subdomain(url).map(|s| s.to_string()));
+            .and_then(|url| extract_subdomain(url).map(std::string::ToString::to_string));
         guard.url = None;
         sub
     };
@@ -570,7 +574,7 @@ pub fn tunnel_status(
 fn append_token(base_url: &str, token_state: &State<'_, AccessTokenState>) -> String {
     let guard = token_state.0.lock().unwrap();
     match *guard {
-        Some(ref token) => format!("{}?token={}", base_url, token),
+        Some(ref token) => format!("{base_url}?token={token}"),
         None => base_url.to_string(),
     }
 }

--- a/apps/dashboard/src-tauri/src/commands/webserver.rs
+++ b/apps/dashboard/src-tauri/src/commands/webserver.rs
@@ -296,8 +296,8 @@ pub async fn webserver_get_token(
     }
 
     let body = String::from_utf8_lossy(&output.stdout);
-    let parsed: serde_json::Value = serde_json::from_str(&body)
-        .map_err(|e| format!("Failed to parse token response: {e}"))?;
+    let parsed: serde_json::Value =
+        serde_json::from_str(&body).map_err(|e| format!("Failed to parse token response: {e}"))?;
     let token = parsed["token"]
         .as_str()
         .ok_or_else(|| "Token not found in response".to_string())?

--- a/apps/dashboard/src-tauri/src/commands/webserver.rs
+++ b/apps/dashboard/src-tauri/src/commands/webserver.rs
@@ -343,7 +343,6 @@ pub async fn node_install() -> Result<(), String> {
 // Tunnel commands
 // ---------------------------------------------------------------------------
 
-
 #[tauri::command]
 pub async fn tunnel_install() -> Result<(), String> {
     let path = shell_path().to_string();
@@ -442,10 +441,7 @@ pub fn tunnel_start(
                 if let Some(start) = line.find("https://") {
                     let rest = &line[start..];
                     // Extract URL: take chars valid in a URL, then trim trailing punctuation
-                    let raw_url: String = rest
-                        .chars()
-                        .take_while(|c| !c.is_whitespace())
-                        .collect();
+                    let raw_url: String = rest.chars().take_while(|c| !c.is_whitespace()).collect();
                     let base_url = raw_url.trim_end_matches(|c: char| {
                         matches!(c, '"' | '\'' | ')' | '(' | ']' | '[' | '>' | ',')
                     });
@@ -459,8 +455,7 @@ pub fn tunnel_start(
                             guard.url = Some(base_url.clone());
                         }
                         let token_guard = token_arc.lock().ok();
-                        let token =
-                            token_guard.as_ref().and_then(|g| g.as_ref().cloned());
+                        let token = token_guard.as_ref().and_then(|g| g.as_ref().cloned());
                         let url = match token {
                             Some(t) => format!("{}?token={}", base_url, t),
                             None => base_url,
@@ -532,7 +527,10 @@ pub async fn tunnel_auth_check() -> Result<bool, String> {
 pub async fn tunnel_stop(state: State<'_, TunnelState>) -> Result<(), String> {
     let subdomain = {
         let mut guard = state.0.lock().unwrap();
-        let sub = guard.url.as_ref().and_then(|url| extract_subdomain(url).map(|s| s.to_string()));
+        let sub = guard
+            .url
+            .as_ref()
+            .and_then(|url| extract_subdomain(url).map(|s| s.to_string()));
         guard.url = None;
         sub
     };
@@ -559,7 +557,10 @@ pub fn tunnel_status(
 ) -> Result<Option<String>, String> {
     let guard = state.0.lock().unwrap();
     if guard.process.is_running() {
-        Ok(guard.url.as_ref().map(|base_url| append_token(base_url, &token_state)))
+        Ok(guard
+            .url
+            .as_ref()
+            .map(|base_url| append_token(base_url, &token_state)))
     } else {
         Ok(None)
     }

--- a/apps/dashboard/src-tauri/src/state.rs
+++ b/apps/dashboard/src-tauri/src/state.rs
@@ -143,7 +143,9 @@ pub struct ProjectConfig {
 }
 
 pub fn load_project_config(project_path: &str) -> ProjectConfig {
-    let config_path = PathBuf::from(project_path).join(".band").join("config.json");
+    let config_path = PathBuf::from(project_path)
+        .join(".band")
+        .join("config.json");
     if !config_path.exists() {
         return ProjectConfig::default();
     }

--- a/apps/dashboard/src-tauri/src/state.rs
+++ b/apps/dashboard/src-tauri/src/state.rs
@@ -156,15 +156,14 @@ pub fn load_project_config(project_path: &str) -> ProjectConfig {
 }
 
 pub fn run_script_in_terminal(command: &str, cwd: &str) -> Result<(), String> {
-    let escaped_cwd = cwd.replace('\'', "'\\''");
+    let safe_cwd = cwd.replace('\'', "'\\''");
     let escaped_cmd = command.replace('\'', "'\\''");
 
     let apple_script = format!(
         "tell application \"Terminal\"\n\
              activate\n\
-             do script \"cd '{}' && {}\"\n\
-         end tell",
-        escaped_cwd, escaped_cmd
+             do script \"cd '{safe_cwd}' && {escaped_cmd}\"\n\
+         end tell"
     );
 
     Command::new("osascript")
@@ -181,11 +180,11 @@ pub fn run_script(command: &str, cwd: &str) -> Result<(), String> {
         .current_dir(cwd)
         .env("PATH", crate::commands::webserver::shell_path())
         .output()
-        .map_err(|e| format!("Failed to run script: {}", e))?;
+        .map_err(|e| format!("Failed to run script: {e}"))?;
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
-        return Err(format!("Script failed: {}", stderr));
+        return Err(format!("Script failed: {stderr}"));
     }
 
     Ok(())

--- a/apps/dashboard/src/App.tsx
+++ b/apps/dashboard/src/App.tsx
@@ -1,5 +1,5 @@
 import { DashboardProvider, DashboardShell } from "@band/dashboard-core";
-import { TauriDashboardAdapter, TauriCapabilities } from "@band/dashboard-core/adapters/tauri";
+import { TauriCapabilities, TauriDashboardAdapter } from "@band/dashboard-core/adapters/tauri";
 import { TunnelToolbarButton } from "@/components/TunnelToolbarButton";
 
 const adapter = new TauriDashboardAdapter();

--- a/apps/dashboard/src/components/PrereqDialog.tsx
+++ b/apps/dashboard/src/components/PrereqDialog.tsx
@@ -1,6 +1,3 @@
-import { invoke } from "@tauri-apps/api/core";
-import { Loader2 } from "lucide-react";
-import { useEffect, useState } from "react";
 import {
   Button,
   Dialog,
@@ -9,6 +6,9 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@band/ui";
+import { invoke } from "@tauri-apps/api/core";
+import { Loader2 } from "lucide-react";
+import { useEffect, useState } from "react";
 
 type PrereqStep = "checking" | "missing" | "installing" | "error";
 
@@ -71,11 +71,8 @@ export function PrereqDialog({ open, onOpenChange, onReady }: Props) {
     }
   };
 
-  const missingLabel = needNode && needInstatunnel
-    ? "Node.js & instatunnel"
-    : needNode
-      ? "Node.js"
-      : "instatunnel";
+  const missingLabel =
+    needNode && needInstatunnel ? "Node.js & instatunnel" : needNode ? "Node.js" : "instatunnel";
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>

--- a/apps/dashboard/src/components/TunnelDialog.tsx
+++ b/apps/dashboard/src/components/TunnelDialog.tsx
@@ -1,17 +1,10 @@
+import { useSettingsStore } from "@band/dashboard-core";
+import { Button, Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from "@band/ui";
 import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
 import { Loader2 } from "lucide-react";
 import { QRCodeSVG } from "qrcode.react";
 import { useCallback, useEffect, useState } from "react";
-import { useSettingsStore } from "@band/dashboard-core";
-import {
-  Button,
-  Dialog,
-  DialogContent,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from "@band/ui";
 
 type TunnelStep =
   | "starting"
@@ -186,9 +179,7 @@ export function TunnelDialog({ open, onOpenChange, onStopped, initialUrl, onTunn
                 You need to log in to instatunnel to use the subdomain{" "}
                 <strong>{settings.tunnelSubdomain}</strong>.
               </p>
-              <p className="text-xs text-muted-foreground text-center">
-                Run in your terminal:
-              </p>
+              <p className="text-xs text-muted-foreground text-center">Run in your terminal:</p>
               <code className="text-xs bg-muted px-2 py-1 rounded select-all">
                 instatunnel auth login
               </code>
@@ -203,7 +194,12 @@ export function TunnelDialog({ open, onOpenChange, onStopped, initialUrl, onTunn
 
           {step === "ready" && tunnelUrl && (
             <>
-              <a href={tunnelUrl} target="_blank" rel="noopener noreferrer" className="rounded-lg bg-white p-3 block cursor-pointer hover:opacity-80 transition-opacity">
+              <a
+                href={tunnelUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="rounded-lg bg-white p-3 block cursor-pointer hover:opacity-80 transition-opacity"
+              >
                 <QRCodeSVG value={tunnelUrl} size={200} />
               </a>
               <p className="text-xs text-muted-foreground text-center break-all max-w-[260px]">
@@ -215,7 +211,8 @@ export function TunnelDialog({ open, onOpenChange, onStopped, initialUrl, onTunn
           {step === "subdomain_taken" && (
             <>
               <p className="text-sm text-muted-foreground text-center">
-                The subdomain <strong>{settings.tunnelSubdomain}</strong> is already in use by another session.
+                The subdomain <strong>{settings.tunnelSubdomain}</strong> is already in use by
+                another session.
               </p>
               <p className="text-xs text-muted-foreground text-center">
                 You can change it in Settings &gt; Web Server.

--- a/apps/dashboard/src/components/TunnelToolbarButton.tsx
+++ b/apps/dashboard/src/components/TunnelToolbarButton.tsx
@@ -1,8 +1,8 @@
-import { Globe } from "lucide-react";
 import { Button, Tooltip, TooltipContent, TooltipTrigger } from "@band/ui";
+import { Globe } from "lucide-react";
+import { useTunnel } from "@/hooks/use-tunnel";
 import { PrereqDialog } from "./PrereqDialog";
 import { TunnelDialog } from "./TunnelDialog";
-import { useTunnel } from "@/hooks/use-tunnel";
 
 export function TunnelToolbarButton() {
   const {
@@ -31,16 +31,10 @@ export function TunnelToolbarButton() {
             <Globe className="size-5" />
           </Button>
         </TooltipTrigger>
-        <TooltipContent>
-          {webServerRunning ? "Mobile access" : "Start web server"}
-        </TooltipContent>
+        <TooltipContent>{webServerRunning ? "Mobile access" : "Start web server"}</TooltipContent>
       </Tooltip>
 
-      <PrereqDialog
-        open={showPrereq}
-        onOpenChange={setShowPrereq}
-        onReady={onPrereqReady}
-      />
+      <PrereqDialog open={showPrereq} onOpenChange={setShowPrereq} onReady={onPrereqReady} />
 
       <TunnelDialog
         open={showDialog}

--- a/apps/dashboard/src/hooks/use-tunnel.ts
+++ b/apps/dashboard/src/hooks/use-tunnel.ts
@@ -1,7 +1,7 @@
+import { useRawDashboardStore, useSettingsStore } from "@band/dashboard-core";
 import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
 import { useCallback, useEffect, useRef, useState } from "react";
-import { useRawDashboardStore, useSettingsStore } from "@band/dashboard-core";
 
 interface PrereqStatus {
   node: boolean;

--- a/apps/dashboard/src/main.tsx
+++ b/apps/dashboard/src/main.tsx
@@ -1,6 +1,6 @@
+import { TooltipProvider } from "@band/ui";
 import React from "react";
 import ReactDOM from "react-dom/client";
-import { TooltipProvider } from "@band/ui";
 import App from "./App";
 import "./styles/globals.css";
 

--- a/apps/web/src/components/DashboardView.tsx
+++ b/apps/web/src/components/DashboardView.tsx
@@ -1,5 +1,5 @@
 import { DashboardProvider, DashboardShell } from "@band/dashboard-core";
-import { WebDashboardAdapter, WebCapabilities } from "@band/dashboard-core/adapters/web";
+import { WebCapabilities, WebDashboardAdapter } from "@band/dashboard-core/adapters/web";
 import { TooltipProvider } from "@band/ui";
 
 const adapter = new WebDashboardAdapter();

--- a/apps/web/src/components/SessionList.tsx
+++ b/apps/web/src/components/SessionList.tsx
@@ -115,21 +115,21 @@ export function SessionList({
                   onClick={() => onSelectSession(session.sessionId)}
                   className={`flex flex-col gap-1 rounded-lg px-3 py-2.5 text-left transition-colors hover:bg-accent/50 active:bg-accent/50 ${isActive ? "bg-accent/50 ring-1 ring-primary/30" : ""}`}
                 >
-                <span className="line-clamp-2 text-sm font-medium text-foreground">
-                  {session.summary}
-                </span>
-                <div className="flex items-center gap-2 text-xs text-muted-foreground">
-                  <span>{relativeTime(session.lastModified)}</span>
-                  {session.gitBranch && (
-                    <>
-                      <span className="text-border">·</span>
-                      <span className="inline-flex items-center gap-1">
-                        <GitBranch className="size-3" />
-                        {session.gitBranch}
-                      </span>
-                    </>
-                  )}
-                </div>
+                  <span className="line-clamp-2 text-sm font-medium text-foreground">
+                    {session.summary}
+                  </span>
+                  <div className="flex items-center gap-2 text-xs text-muted-foreground">
+                    <span>{relativeTime(session.lastModified)}</span>
+                    {session.gitBranch && (
+                      <>
+                        <span className="text-border">·</span>
+                        <span className="inline-flex items-center gap-1">
+                          <GitBranch className="size-3" />
+                          {session.gitBranch}
+                        </span>
+                      </>
+                    )}
+                  </div>
                 </button>
               );
             })}

--- a/apps/web/src/components/ai-elements/group-parts.ts
+++ b/apps/web/src/components/ai-elements/group-parts.ts
@@ -6,16 +6,16 @@ import type { ToolPart } from "./tool";
 type Part = UIMessage["parts"][number];
 
 export type TextSegment = {
-	type: "text";
-	part: Part;
-	partIndex: number;
+  type: "text";
+  part: Part;
+  partIndex: number;
 };
 
 export type ToolGroupSegment = {
-	type: "tool-group";
-	parts: Array<{ part: ToolPart; partIndex: number }>;
-	/** Index of the first tool part in the group, used as a stable React key */
-	startIndex: number;
+  type: "tool-group";
+  parts: Array<{ part: ToolPart; partIndex: number }>;
+  /** Index of the first tool part in the group, used as a stable React key */
+  startIndex: number;
 };
 
 export type MessageSegment = TextSegment | ToolGroupSegment;
@@ -26,36 +26,36 @@ export type MessageSegment = TextSegment | ToolGroupSegment;
  * All other non-tool parts become individual TextSegments.
  */
 export function groupMessageParts(parts: Part[]): MessageSegment[] {
-	const segments: MessageSegment[] = [];
-	let currentToolGroup: ToolGroupSegment | null = null;
+  const segments: MessageSegment[] = [];
+  let currentToolGroup: ToolGroupSegment | null = null;
 
-	const flushToolGroup = () => {
-		if (currentToolGroup) {
-			segments.push(currentToolGroup);
-			currentToolGroup = null;
-		}
-	};
+  const flushToolGroup = () => {
+    if (currentToolGroup) {
+      segments.push(currentToolGroup);
+      currentToolGroup = null;
+    }
+  };
 
-	for (let i = 0; i < parts.length; i++) {
-		const part = parts[i];
+  for (let i = 0; i < parts.length; i++) {
+    const part = parts[i];
 
-		if (isToolUIPart(part)) {
-			if (!currentToolGroup) {
-				currentToolGroup = { type: "tool-group", parts: [], startIndex: i };
-			}
-			currentToolGroup.parts.push({ part: part as ToolPart, partIndex: i });
-			continue;
-		}
+    if (isToolUIPart(part)) {
+      if (!currentToolGroup) {
+        currentToolGroup = { type: "tool-group", parts: [], startIndex: i };
+      }
+      currentToolGroup.parts.push({ part: part as ToolPart, partIndex: i });
+      continue;
+    }
 
-		// Only non-empty text parts break tool grouping and become segments.
-		// Everything else (empty text, step-start, reasoning, source-url, etc.)
-		// is skipped so consecutive tool calls stay grouped.
-		if (part.type === "text" && part.text.trim()) {
-			flushToolGroup();
-			segments.push({ type: "text", part, partIndex: i });
-		}
-	}
+    // Only non-empty text parts break tool grouping and become segments.
+    // Everything else (empty text, step-start, reasoning, source-url, etc.)
+    // is skipped so consecutive tool calls stay grouped.
+    if (part.type === "text" && part.text.trim()) {
+      flushToolGroup();
+      segments.push({ type: "text", part, partIndex: i });
+    }
+  }
 
-	flushToolGroup();
-	return segments;
+  flushToolGroup();
+  return segments;
 }

--- a/apps/web/src/components/ai-elements/tool-call-group.tsx
+++ b/apps/web/src/components/ai-elements/tool-call-group.tsx
@@ -1,109 +1,98 @@
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@band/ui";
 import { getToolName } from "ai";
-import {
-	Collapsible,
-	CollapsibleContent,
-	CollapsibleTrigger,
-} from "@band/ui";
-import {
-	ChevronDownIcon,
-	WrenchIcon,
-} from "lucide-react";
+import { ChevronDownIcon, WrenchIcon } from "lucide-react";
 
 import type { ToolGroupSegment } from "./group-parts";
 import type { ToolPart } from "./tool";
 import { ToolInput, ToolOutput } from "./tool";
 
 const IN_PROGRESS_STATES = new Set<ToolPart["state"]>([
-	"input-available",
-	"input-streaming",
-	"approval-requested",
-	"approval-responded",
+  "input-available",
+  "input-streaming",
+  "approval-requested",
+  "approval-responded",
 ]);
 
-const ERROR_STATES = new Set<ToolPart["state"]>([
-	"output-error",
-	"output-denied",
-]);
+const ERROR_STATES = new Set<ToolPart["state"]>(["output-error", "output-denied"]);
 
 function StatusDot({ state }: { state: ToolPart["state"] }) {
-	if (ERROR_STATES.has(state)) {
-		return <span className="size-2 shrink-0 rounded-full bg-red-500" />;
-	}
-	if (IN_PROGRESS_STATES.has(state)) {
-		return <span className="size-2 shrink-0 animate-pulse rounded-full bg-orange-500" />;
-	}
-	return <span className="size-2 shrink-0 rounded-full bg-green-500" />;
+  if (ERROR_STATES.has(state)) {
+    return <span className="size-2 shrink-0 rounded-full bg-red-500" />;
+  }
+  if (IN_PROGRESS_STATES.has(state)) {
+    return <span className="size-2 shrink-0 animate-pulse rounded-full bg-orange-500" />;
+  }
+  return <span className="size-2 shrink-0 rounded-full bg-green-500" />;
 }
 
 export function ToolCallGroup({ segment }: { segment: ToolGroupSegment }) {
-	const inProgress = segment.parts.filter((p) =>
-		IN_PROGRESS_STATES.has(p.part.state),
-	);
-	const allDone = inProgress.length === 0;
-	const errorCount = segment.parts.filter((p) => ERROR_STATES.has(p.part.state)).length;
+  const inProgress = segment.parts.filter((p) => IN_PROGRESS_STATES.has(p.part.state));
+  const allDone = inProgress.length === 0;
+  const errorCount = segment.parts.filter((p) => ERROR_STATES.has(p.part.state)).length;
 
-	return (
-		<Collapsible className="group/outer not-prose mb-4 w-full rounded border border-border/50">
-			<CollapsibleTrigger className="flex w-full items-center justify-between gap-4 p-3">
-				<div className="flex min-w-0 flex-1 flex-col gap-1">
-					{allDone ? (
-						<div className="flex items-center gap-2">
-							<WrenchIcon className="size-4 shrink-0 text-muted-foreground" />
-							<span className="font-medium text-sm text-muted-foreground">
-								{segment.parts.length} tool{segment.parts.length !== 1 ? " calls" : " call"} completed
-								{errorCount > 0 && ` (${errorCount} failed)`}
-							</span>
-						</div>
-					) : (
-						<>
-							<div className="flex items-center gap-2">
-								<WrenchIcon className="size-4 shrink-0 text-muted-foreground" />
-								<span className="font-medium text-sm text-muted-foreground">
-									{segment.parts.length} tool{segment.parts.length !== 1 ? " calls" : " call"}
-								</span>
-							</div>
-							{inProgress.map((p) => {
-								const toolName = getToolName(p.part);
-								return (
-									<div key={p.part.toolCallId} className="flex items-center gap-2 pl-6">
-										<StatusDot state={p.part.state} />
-										<span className="truncate text-sm">{toolName}</span>
-									</div>
-								);
-							})}
-						</>
-					)}
-				</div>
-				<ChevronDownIcon className="size-4 shrink-0 text-muted-foreground transition-transform group-data-[state=open]/outer:rotate-180" />
-			</CollapsibleTrigger>
+  return (
+    <Collapsible className="group/outer not-prose mb-4 w-full rounded border border-border/50">
+      <CollapsibleTrigger className="flex w-full items-center justify-between gap-4 p-3">
+        <div className="flex min-w-0 flex-1 flex-col gap-1">
+          {allDone ? (
+            <div className="flex items-center gap-2">
+              <WrenchIcon className="size-4 shrink-0 text-muted-foreground" />
+              <span className="font-medium text-sm text-muted-foreground">
+                {segment.parts.length} tool{segment.parts.length !== 1 ? " calls" : " call"}{" "}
+                completed
+                {errorCount > 0 && ` (${errorCount} failed)`}
+              </span>
+            </div>
+          ) : (
+            <>
+              <div className="flex items-center gap-2">
+                <WrenchIcon className="size-4 shrink-0 text-muted-foreground" />
+                <span className="font-medium text-sm text-muted-foreground">
+                  {segment.parts.length} tool{segment.parts.length !== 1 ? " calls" : " call"}
+                </span>
+              </div>
+              {inProgress.map((p) => {
+                const toolName = getToolName(p.part);
+                return (
+                  <div key={p.part.toolCallId} className="flex items-center gap-2 pl-6">
+                    <StatusDot state={p.part.state} />
+                    <span className="truncate text-sm">{toolName}</span>
+                  </div>
+                );
+              })}
+            </>
+          )}
+        </div>
+        <ChevronDownIcon className="size-4 shrink-0 text-muted-foreground transition-transform group-data-[state=open]/outer:rotate-180" />
+      </CollapsibleTrigger>
 
-			<CollapsibleContent>
-				<div className="border-t border-border/50">
-					{segment.parts.map((p) => (
-						<ToolItem key={p.part.toolCallId} part={p.part} />
-					))}
-				</div>
-			</CollapsibleContent>
-		</Collapsible>
-	);
+      <CollapsibleContent>
+        <div className="border-t border-border/50">
+          {segment.parts.map((p) => (
+            <ToolItem key={p.part.toolCallId} part={p.part} />
+          ))}
+        </div>
+      </CollapsibleContent>
+    </Collapsible>
+  );
 }
 
 function ToolItem({ part }: { part: ToolPart }) {
-	const toolName = getToolName(part);
-	return (
-		<Collapsible className="group/inner border-b border-border/50 last:border-b-0">
-			<CollapsibleTrigger className="flex w-full items-center justify-between gap-4 px-4 py-2">
-				<div className="flex items-center gap-2">
-					<StatusDot state={part.state} />
-					<span className="text-sm">{toolName}</span>
-				</div>
-				<ChevronDownIcon className="size-3.5 text-muted-foreground transition-transform group-data-[state=open]/inner:rotate-180" />
-			</CollapsibleTrigger>
+  const toolName = getToolName(part);
+  return (
+    <Collapsible className="group/inner border-b border-border/50 last:border-b-0">
+      <CollapsibleTrigger className="flex w-full items-center justify-between gap-4 px-4 py-2">
+        <div className="flex items-center gap-2">
+          <StatusDot state={part.state} />
+          <span className="text-sm">{toolName}</span>
+        </div>
+        <ChevronDownIcon className="size-3.5 text-muted-foreground transition-transform group-data-[state=open]/inner:rotate-180" />
+      </CollapsibleTrigger>
 
-			<CollapsibleContent className="space-y-4 px-4 pb-3 text-popover-foreground">
-				<ToolInput input={part.input} />
-				<ToolOutput output={part.output} errorText={part.errorText} />
-			</CollapsibleContent>
-		</Collapsible>
-	);
+      <CollapsibleContent className="space-y-4 px-4 pb-3 text-popover-foreground">
+        <ToolInput input={part.input} />
+        <ToolOutput output={part.output} errorText={part.errorText} />
+      </CollapsibleContent>
+    </Collapsible>
+  );
 }

--- a/apps/web/src/lib/watcher.ts
+++ b/apps/web/src/lib/watcher.ts
@@ -1,7 +1,13 @@
-import { readFileSync, readdirSync } from "node:fs";
+import { readdirSync, readFileSync } from "node:fs";
 import { basename, extname, join } from "node:path";
 import { watch } from "chokidar";
-import { loadCurrentStatuses, loadStatusFile, statusDir, bandHome, type WorkspaceStatus } from "./state";
+import {
+  bandHome,
+  loadCurrentStatuses,
+  loadStatusFile,
+  statusDir,
+  type WorkspaceStatus,
+} from "./state";
 
 interface GitStatus {
   dirty: boolean;

--- a/apps/web/src/routes/api/projects.add.ts
+++ b/apps/web/src/routes/api/projects.add.ts
@@ -1,9 +1,8 @@
-import { createFileRoute } from "@tanstack/react-router";
 import { execFileSync } from "node:child_process";
-import { loadState, saveState, worktreesDir } from "../../lib/state";
+import { basename } from "node:path";
+import { createFileRoute } from "@tanstack/react-router";
 import { listWorktrees } from "../../lib/git";
-import { join, basename } from "node:path";
-import { mkdirSync } from "node:fs";
+import { loadState, saveState } from "../../lib/state";
 
 export const Route = createFileRoute("/api/projects/add")({
   server: {
@@ -27,11 +26,11 @@ export const Route = createFileRoute("/api/projects/add")({
           if (env.PATH) {
             env.PATH = `/opt/homebrew/bin:/usr/local/bin:${env.PATH}`;
           }
-          const output = execFileSync(
-            "git",
-            ["symbolic-ref", "--short", "HEAD"],
-            { cwd: path, env, encoding: "utf-8" },
-          ).trim();
+          const output = execFileSync("git", ["symbolic-ref", "--short", "HEAD"], {
+            cwd: path,
+            env,
+            encoding: "utf-8",
+          }).trim();
           if (output) defaultBranch = output;
         } catch {
           // Fall back to "main"

--- a/apps/web/src/routes/api/settings.ts
+++ b/apps/web/src/routes/api/settings.ts
@@ -1,6 +1,6 @@
-import { createFileRoute } from "@tanstack/react-router";
 import { readFileSync, writeFileSync } from "node:fs";
-import { settingsFile, ensureDirs, type Settings } from "../../lib/state";
+import { createFileRoute } from "@tanstack/react-router";
+import { ensureDirs, type Settings, settingsFile } from "../../lib/state";
 
 export const Route = createFileRoute("/api/settings")({
   server: {

--- a/apps/web/src/routes/api/workspaces.create.ts
+++ b/apps/web/src/routes/api/workspaces.create.ts
@@ -1,9 +1,9 @@
-import { createFileRoute } from "@tanstack/react-router";
 import { execFileSync } from "node:child_process";
-import { loadState, worktreesDir } from "../../lib/state";
-import { join } from "node:path";
 import { mkdirSync } from "node:fs";
+import { join } from "node:path";
+import { createFileRoute } from "@tanstack/react-router";
 import { gitCmd } from "../../lib/git";
+import { loadState, worktreesDir } from "../../lib/state";
 
 export const Route = createFileRoute("/api/workspaces/create")({
   server: {

--- a/apps/web/src/routes/api/workspaces.remove.ts
+++ b/apps/web/src/routes/api/workspaces.remove.ts
@@ -1,7 +1,7 @@
-import { createFileRoute } from "@tanstack/react-router";
 import { execFileSync } from "node:child_process";
-import { loadState } from "../../lib/state";
+import { createFileRoute } from "@tanstack/react-router";
 import { gitCmd } from "../../lib/git";
+import { loadState } from "../../lib/state";
 
 export const Route = createFileRoute("/api/workspaces/remove")({
   server: {
@@ -22,11 +22,11 @@ export const Route = createFileRoute("/api/workspaces/remove")({
 
         try {
           // First find the worktree path
-          const output = execFileSync(
-            command,
-            ["worktree", "list", "--porcelain"],
-            { cwd: proj.path, env, encoding: "utf-8" },
-          );
+          const output = execFileSync(command, ["worktree", "list", "--porcelain"], {
+            cwd: proj.path,
+            env,
+            encoding: "utf-8",
+          });
 
           let currentPath = "";
           let currentBranch = "";
@@ -41,18 +41,18 @@ export const Route = createFileRoute("/api/workspaces/remove")({
             } else if (line === "" && currentPath) {
               if (currentBranch === branch) {
                 // Remove the worktree
-                execFileSync(
-                  command,
-                  ["worktree", "remove", "--force", currentPath],
-                  { cwd: proj.path, env, encoding: "utf-8" },
-                );
+                execFileSync(command, ["worktree", "remove", "--force", currentPath], {
+                  cwd: proj.path,
+                  env,
+                  encoding: "utf-8",
+                });
                 // Delete the branch
                 try {
-                  execFileSync(
-                    command,
-                    ["branch", "-D", branch],
-                    { cwd: proj.path, env, encoding: "utf-8" },
-                  );
+                  execFileSync(command, ["branch", "-D", branch], {
+                    cwd: proj.path,
+                    env,
+                    encoding: "utf-8",
+                  });
                 } catch {
                   // Branch may already be deleted
                 }

--- a/apps/web/src/routes/api/workspaces.run-script.ts
+++ b/apps/web/src/routes/api/workspaces.run-script.ts
@@ -1,7 +1,7 @@
-import { createFileRoute } from "@tanstack/react-router";
 import { execFile } from "node:child_process";
-import { join } from "node:path";
 import { existsSync } from "node:fs";
+import { join } from "node:path";
+import { createFileRoute } from "@tanstack/react-router";
 
 export const Route = createFileRoute("/api/workspaces/run-script")({
   server: {

--- a/package.json
+++ b/package.json
@@ -12,11 +12,11 @@
     "build:cli": "cd apps/cli && cargo build --release && mkdir -p ../dashboard/src-tauri/binaries && cp target/release/band \"../dashboard/src-tauri/binaries/band-$(rustc -vV | sed -n 's/host: //p')\"",
     "build:extension": "pnpm --filter band-vscode build",
     "test": "pnpm --filter @band/web test && cargo test --manifest-path apps/cli/Cargo.toml && pnpm build:cli && mkdir -p apps/web/dist && touch apps/web/dist/start-server.mjs && cargo test --manifest-path apps/dashboard/src-tauri/Cargo.toml; rm -rf apps/web/dist",
-    "lint": "biome check . && cargo clippy --manifest-path apps/dashboard/src-tauri/Cargo.toml -- -D warnings",
-    "lint:fix": "biome check --fix . && cargo clippy --manifest-path apps/dashboard/src-tauri/Cargo.toml --fix --allow-dirty",
-    "format": "biome format . && cargo fmt --manifest-path apps/dashboard/src-tauri/Cargo.toml -- --check",
-    "format:fix": "biome format --fix . && cargo fmt --manifest-path apps/dashboard/src-tauri/Cargo.toml",
-    "check": "biome check . && cargo fmt --manifest-path apps/dashboard/src-tauri/Cargo.toml -- --check && cargo clippy --manifest-path apps/dashboard/src-tauri/Cargo.toml -- -D warnings"
+    "lint": "biome check . && cargo clippy --manifest-path apps/cli/Cargo.toml -- -D warnings && cargo clippy --manifest-path apps/dashboard/src-tauri/Cargo.toml -- -D warnings",
+    "lint:fix": "biome check --fix . && cargo clippy --manifest-path apps/cli/Cargo.toml --fix --allow-dirty && cargo clippy --manifest-path apps/dashboard/src-tauri/Cargo.toml --fix --allow-dirty",
+    "format": "biome format . && cargo fmt --manifest-path apps/cli/Cargo.toml -- --check && cargo fmt --manifest-path apps/dashboard/src-tauri/Cargo.toml -- --check",
+    "format:fix": "biome format --fix . && cargo fmt --manifest-path apps/cli/Cargo.toml && cargo fmt --manifest-path apps/dashboard/src-tauri/Cargo.toml",
+    "check": "biome check . && cargo fmt --manifest-path apps/cli/Cargo.toml -- --check && cargo fmt --manifest-path apps/dashboard/src-tauri/Cargo.toml -- --check && cargo clippy --manifest-path apps/cli/Cargo.toml -- -D warnings && cargo clippy --manifest-path apps/dashboard/src-tauri/Cargo.toml -- -D warnings"
   },
   "devDependencies": {
     "@biomejs/biome": "^2.4.5"

--- a/packages/dashboard-core/src/adapter.ts
+++ b/packages/dashboard-core/src/adapter.ts
@@ -34,9 +34,7 @@ export interface DashboardAdapter {
     onRemove: (workspaceId: string) => void,
   ): Unsubscribe;
 
-  subscribeActiveWorkspace(
-    onChange: (workspaceId: string | null) => void,
-  ): Unsubscribe;
+  subscribeActiveWorkspace(onChange: (workspaceId: string | null) => void): Unsubscribe;
 
   subscribeBranchStatus(
     onGit: (workspaceId: string, git: GitStatus) => void,

--- a/packages/dashboard-core/src/adapters/tauri.ts
+++ b/packages/dashboard-core/src/adapters/tauri.ts
@@ -97,9 +97,7 @@ export class TauriDashboardAdapter implements DashboardAdapter {
     return () => cleanup?.();
   }
 
-  subscribeActiveWorkspace(
-    onChange: (workspaceId: string | null) => void,
-  ): Unsubscribe {
+  subscribeActiveWorkspace(onChange: (workspaceId: string | null) => void): Unsubscribe {
     let cleanup: (() => void) | undefined;
 
     (async () => {
@@ -202,10 +200,7 @@ export class TauriCapabilities implements PlatformCapabilities {
     async install(): Promise<void> {
       await invoke("tunnel_install");
     },
-    subscribeTunnelUrl(
-      onUrl: (url: string) => void,
-      onError: (err: string) => void,
-    ): Unsubscribe {
+    subscribeTunnelUrl(onUrl: (url: string) => void, onError: (err: string) => void): Unsubscribe {
       let cleanup: (() => void) | undefined;
 
       (async () => {

--- a/packages/dashboard-core/src/adapters/web.ts
+++ b/packages/dashboard-core/src/adapters/web.ts
@@ -163,9 +163,7 @@ export class WebDashboardAdapter implements DashboardAdapter {
     });
   }
 
-  subscribeActiveWorkspace(
-    _onChange: (workspaceId: string | null) => void,
-  ): Unsubscribe {
+  subscribeActiveWorkspace(_onChange: (workspaceId: string | null) => void): Unsubscribe {
     // Web app doesn't have active workspace tracking
     return () => {};
   }

--- a/packages/dashboard-core/src/components/AddProjectDialog.tsx
+++ b/packages/dashboard-core/src/components/AddProjectDialog.tsx
@@ -1,5 +1,3 @@
-import { FolderOpen } from "lucide-react";
-import { useState } from "react";
 import {
   Button,
   Dialog,
@@ -11,6 +9,8 @@ import {
   Input,
   Label,
 } from "@band/ui";
+import { FolderOpen } from "lucide-react";
+import { useState } from "react";
 import { useCapabilities } from "../context";
 import { useDashboardStore } from "../stores/index";
 

--- a/packages/dashboard-core/src/components/CIStatusIndicator.tsx
+++ b/packages/dashboard-core/src/components/CIStatusIndicator.tsx
@@ -1,5 +1,5 @@
-import { CircleAlert, CircleCheck, GitMerge, Loader } from "lucide-react";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@band/ui";
+import { CircleAlert, CircleCheck, GitMerge, Loader } from "lucide-react";
 import { useCapabilities } from "../context";
 import type { CIStatus } from "../types";
 

--- a/packages/dashboard-core/src/components/DeleteWorkspaceDialog.tsx
+++ b/packages/dashboard-core/src/components/DeleteWorkspaceDialog.tsx
@@ -1,4 +1,3 @@
-import { AlertTriangle } from "lucide-react";
 import {
   Button,
   Dialog,
@@ -8,6 +7,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@band/ui";
+import { AlertTriangle } from "lucide-react";
 
 interface Props {
   open: boolean;

--- a/packages/dashboard-core/src/components/NewWorkspaceForm.tsx
+++ b/packages/dashboard-core/src/components/NewWorkspaceForm.tsx
@@ -1,4 +1,3 @@
-import { useState } from "react";
 import {
   Button,
   Dialog,
@@ -10,6 +9,7 @@ import {
   Input,
   Label,
 } from "@band/ui";
+import { useState } from "react";
 import { useDashboardStore } from "../stores/index";
 
 interface Props {

--- a/packages/dashboard-core/src/components/SettingsPage.tsx
+++ b/packages/dashboard-core/src/components/SettingsPage.tsx
@@ -1,5 +1,3 @@
-import { ChevronDown, ChevronLeft, ChevronRight, FolderOpen, Plus, Save, Trash2 } from "lucide-react";
-import { useEffect, useState } from "react";
 import {
   Button,
   ColorPicker,
@@ -16,6 +14,16 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@band/ui";
+import {
+  ChevronDown,
+  ChevronLeft,
+  ChevronRight,
+  FolderOpen,
+  Plus,
+  Save,
+  Trash2,
+} from "lucide-react";
+import { useEffect, useState } from "react";
 import { useCapabilities } from "../context";
 import { playSound, SOUNDS, type SoundId } from "../lib/sounds";
 import { useSettingsStore } from "../stores/index";
@@ -40,7 +48,14 @@ const DEFAULT_DEFAULTS = {
   ],
 };
 
-type Section = "menu" | "general" | "coding-agent" | "defaults" | "notifications" | "web-server" | "labels";
+type Section =
+  | "menu"
+  | "general"
+  | "coding-agent"
+  | "defaults"
+  | "notifications"
+  | "web-server"
+  | "labels";
 
 interface Props {
   onClose: () => void;
@@ -193,7 +208,8 @@ export function SettingsPage({ onClose }: Props) {
   const portPreview = tunnelSubdomain
     ? `${tunnelSubdomain}.instatunnel.my`
     : webServerPort || "3456";
-  const labelsPreview = labels.length > 0 ? `${labels.length} label${labels.length === 1 ? "" : "s"}` : "None";
+  const labelsPreview =
+    labels.length > 0 ? `${labels.length} label${labels.length === 1 ? "" : "s"}` : "None";
   const notificationsPreview = soundOnNeedsAttention
     ? (SOUNDS.find((s) => s.id === selectedSound)?.label ?? "On")
     : "Off";
@@ -238,7 +254,9 @@ export function SettingsPage({ onClose }: Props) {
                   id="worktrees-dir"
                   placeholder="~/.band/worktrees (default)"
                   value={worktreesDir}
-                  onChange={(e: React.ChangeEvent<HTMLInputElement>) => setWorktreesDir(e.target.value)}
+                  onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                    setWorktreesDir(e.target.value)
+                  }
                 />
                 {capabilities.pickFolder && (
                   <Button type="button" variant="ghost" size="icon" onClick={handleBrowse}>
@@ -260,9 +278,7 @@ export function SettingsPage({ onClose }: Props) {
                 <ColorPicker
                   value={lbl.color}
                   onChange={(color) =>
-                    setLabels((prev) =>
-                      prev.map((l) => (l.id === lbl.id ? { ...l, color } : l)),
-                    )
+                    setLabels((prev) => prev.map((l) => (l.id === lbl.id ? { ...l, color } : l)))
                   }
                   showHex={false}
                   className="w-auto h-7 px-1.5 shrink-0"
@@ -346,7 +362,9 @@ export function SettingsPage({ onClose }: Props) {
                   id="agent-command"
                   placeholder="claude --dangerously-skip-permissions"
                   value={agentCommand}
-                  onChange={(e: React.ChangeEvent<HTMLInputElement>) => setAgentCommand(e.target.value)}
+                  onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                    setAgentCommand(e.target.value)
+                  }
                 />
                 <p className="text-xs text-muted-foreground">
                   Custom command with arguments to run the agent. Leave empty to use the default
@@ -379,7 +397,9 @@ export function SettingsPage({ onClose }: Props) {
                 className="w-full min-h-[160px] rounded-md border border-input bg-background px-2 py-1.5 text-xs font-mono ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 dark:bg-input/30"
                 placeholder='{"layout": {...}, "terminals": [...]}'
                 value={defaultsJson}
-                onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) => handleDefaultsChange(e.target.value)}
+                onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) =>
+                  handleDefaultsChange(e.target.value)
+                }
                 autoCapitalize="off"
                 autoCorrect="off"
                 autoComplete="off"
@@ -465,7 +485,9 @@ export function SettingsPage({ onClose }: Props) {
                 type="number"
                 placeholder="3456 (default)"
                 value={webServerPort}
-                onChange={(e: React.ChangeEvent<HTMLInputElement>) => setWebServerPort(e.target.value)}
+                onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                  setWebServerPort(e.target.value)
+                }
                 min={1}
                 max={65535}
               />
@@ -483,8 +505,9 @@ export function SettingsPage({ onClose }: Props) {
                 onChange={(e) => setTunnelSubdomain(e.target.value)}
               />
               <p className="text-xs text-muted-foreground">
-                Fixed subdomain for your tunnel URL (e.g., <code className="text-xs">myapp</code> becomes{" "}
-                <code className="text-xs">myapp.instatunnel.my</code>). Requires instatunnel authentication.
+                Fixed subdomain for your tunnel URL (e.g., <code className="text-xs">myapp</code>{" "}
+                becomes <code className="text-xs">myapp.instatunnel.my</code>). Requires instatunnel
+                authentication.
               </p>
             </div>
             <div className="space-y-2">
@@ -502,7 +525,6 @@ export function SettingsPage({ onClose }: Props) {
             </div>
           </div>
         )}
-
       </div>
     );
   }
@@ -523,11 +545,7 @@ export function SettingsPage({ onClose }: Props) {
           onClick={() => setSection("general")}
         />
         <Separator />
-        <SettingsRow
-          label="Labels"
-          value={labelsPreview}
-          onClick={() => setSection("labels")}
-        />
+        <SettingsRow label="Labels" value={labelsPreview} onClick={() => setSection("labels")} />
         <Separator />
         <SettingsRow
           label="Coding Agent"

--- a/packages/dashboard-core/src/context.tsx
+++ b/packages/dashboard-core/src/context.tsx
@@ -1,8 +1,8 @@
-import { createContext, useContext, useMemo, type ReactNode } from "react";
+import { createContext, type ReactNode, useContext, useMemo } from "react";
 import type { DashboardAdapter, PlatformCapabilities } from "./adapter";
 import { createDashboardStore } from "./stores/dashboard-store";
-import { createSettingsStore } from "./stores/settings-store";
 import { StoreContext } from "./stores/index";
+import { createSettingsStore } from "./stores/settings-store";
 
 interface DashboardContextValue {
   adapter: DashboardAdapter;
@@ -40,9 +40,7 @@ export function DashboardProvider({ adapter, capabilities, children }: Dashboard
 
   return (
     <DashboardContext.Provider value={{ adapter, capabilities }}>
-      <StoreContext.Provider value={stores}>
-        {children}
-      </StoreContext.Provider>
+      <StoreContext.Provider value={stores}>{children}</StoreContext.Provider>
     </DashboardContext.Provider>
   );
 }

--- a/packages/dashboard-core/src/hooks/use-status.ts
+++ b/packages/dashboard-core/src/hooks/use-status.ts
@@ -1,8 +1,8 @@
 import { useEffect, useRef } from "react";
 import { useAdapter } from "../context";
+import { playSound, type SoundId } from "../lib/sounds";
 import { useDashboardStore, useRawSettingsStore } from "../stores/index";
 import type { AgentStatusType } from "../types";
-import { playSound, type SoundId } from "../lib/sounds";
 
 export function useStatusWatcher() {
   const adapter = useAdapter();

--- a/packages/dashboard-core/src/index.ts
+++ b/packages/dashboard-core/src/index.ts
@@ -1,4 +1,39 @@
 // Types
+
+// Adapter
+export type { DashboardAdapter, PlatformCapabilities, Unsubscribe } from "./adapter";
+// Components
+export { AddProjectDialog } from "./components/AddProjectDialog";
+export { AgentStatusBadge } from "./components/AgentStatusBadge";
+export { CIStatusIndicator } from "./components/CIStatusIndicator";
+export { DashboardShell } from "./components/DashboardShell";
+export { GitStatusIndicator } from "./components/GitStatusIndicator";
+export { NewWorkspaceDialog } from "./components/NewWorkspaceForm";
+export { ProjectList } from "./components/ProjectList";
+export { SettingsPage } from "./components/SettingsPage";
+export { WorkspaceCard } from "./components/WorkspaceCard";
+// Context
+export { DashboardProvider, useAdapter, useCapabilities } from "./context";
+export { type HooksSetupState, useHooksSetup } from "./hooks/use-hooks-setup";
+// Hooks
+export {
+  useActiveWorkspaceWatcher,
+  useBranchStatusWatcher,
+  useStatusWatcher,
+} from "./hooks/use-status";
+// Lib
+export { playSound, SOUNDS, type SoundId } from "./lib/sounds";
+export type { DashboardState, DashboardStore } from "./stores/dashboard-store";
+export { createDashboardStore } from "./stores/dashboard-store";
+// Stores
+export {
+  useDashboardStore,
+  useRawDashboardStore,
+  useRawSettingsStore,
+  useSettingsStore,
+} from "./stores/index";
+export type { SettingsState, SettingsStore } from "./stores/settings-store";
+export { createSettingsStore } from "./stores/settings-store";
 export type {
   AgentInfo,
   AgentStatusType,
@@ -18,34 +53,3 @@ export type {
   WorkspaceStatus,
   WorktreeInfo,
 } from "./types";
-
-// Adapter
-export type { DashboardAdapter, PlatformCapabilities, Unsubscribe } from "./adapter";
-
-// Context
-export { DashboardProvider, useAdapter, useCapabilities } from "./context";
-
-// Stores
-export { useDashboardStore, useSettingsStore, useRawDashboardStore, useRawSettingsStore } from "./stores/index";
-export type { DashboardState, DashboardStore } from "./stores/dashboard-store";
-export { createDashboardStore } from "./stores/dashboard-store";
-export type { SettingsState, SettingsStore } from "./stores/settings-store";
-export { createSettingsStore } from "./stores/settings-store";
-
-// Hooks
-export { useStatusWatcher, useActiveWorkspaceWatcher, useBranchStatusWatcher } from "./hooks/use-status";
-export { useHooksSetup, type HooksSetupState } from "./hooks/use-hooks-setup";
-
-// Components
-export { AddProjectDialog } from "./components/AddProjectDialog";
-export { AgentStatusBadge } from "./components/AgentStatusBadge";
-export { CIStatusIndicator } from "./components/CIStatusIndicator";
-export { DashboardShell } from "./components/DashboardShell";
-export { GitStatusIndicator } from "./components/GitStatusIndicator";
-export { NewWorkspaceDialog } from "./components/NewWorkspaceForm";
-export { ProjectList } from "./components/ProjectList";
-export { SettingsPage } from "./components/SettingsPage";
-export { WorkspaceCard } from "./components/WorkspaceCard";
-
-// Lib
-export { playSound, SOUNDS, type SoundId } from "./lib/sounds";

--- a/packages/dashboard-core/src/stores/index.ts
+++ b/packages/dashboard-core/src/stores/index.ts
@@ -9,13 +9,17 @@ interface StoreContextValue {
 
 export const StoreContext = createContext<StoreContextValue | null>(null);
 
-export function useDashboardStore<T>(selector: (state: import("./dashboard-store").DashboardState) => T): T {
+export function useDashboardStore<T>(
+  selector: (state: import("./dashboard-store").DashboardState) => T,
+): T {
   const ctx = useContext(StoreContext);
   if (!ctx) throw new Error("useDashboardStore must be used within DashboardProvider");
   return ctx.dashboardStore(selector);
 }
 
-export function useSettingsStore<T>(selector: (state: import("./settings-store").SettingsState) => T): T {
+export function useSettingsStore<T>(
+  selector: (state: import("./settings-store").SettingsState) => T,
+): T {
   const ctx = useContext(StoreContext);
   if (!ctx) throw new Error("useSettingsStore must be used within DashboardProvider");
   return ctx.settingsStore(selector);

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -26,9 +26,5 @@
   "peerDependencies": {
     "react": "^19.0.0",
     "react-dom": "^19.0.0"
-  },
-  "devDependencies": {
-    "@types/react": "^19.0.0",
-    "@types/react-dom": "^19.0.0"
   }
 }

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -19,7 +19,7 @@ export * from "./components/scroll-area";
 export * from "./components/select";
 export * from "./components/separator";
 export * from "./components/spinner";
-export * from "./components/textarea";
 export * from "./components/switch";
+export * from "./components/textarea";
 export * from "./components/tooltip";
 export { cn } from "./utils";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -335,6 +335,9 @@ importers:
       '@types/react-dom':
         specifier: ^19.0.0
         version: 19.2.3(@types/react@19.2.14)
+      typescript:
+        specifier: ^5.7.0
+        version: 5.9.3
 
 packages:
 

--- a/scripts/bump-version.mjs
+++ b/scripts/bump-version.mjs
@@ -1,0 +1,218 @@
+#!/usr/bin/env node
+
+import { readFileSync, writeFileSync } from "node:fs";
+import { execSync } from "node:child_process";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+
+const JSON_FILES = [
+  "package.json",
+  "apps/web/package.json",
+  "apps/dashboard/package.json",
+  "extensions/vscode/package.json",
+  "packages/ui/package.json",
+  "packages/dashboard-core/package.json",
+  "packages/coding-agent/package.json",
+  "packages/logger/package.json",
+  "packages/shared/package.json",
+];
+
+const TOML_FILES = [
+  "apps/cli/Cargo.toml",
+  "apps/dashboard/src-tauri/Cargo.toml",
+];
+
+const TAURI_CONF = "apps/dashboard/src-tauri/tauri.conf.json";
+
+function parseArgs() {
+  const args = process.argv.slice(2);
+  const opts = { dryRun: false, version: null, bump: null, fromCommits: false };
+
+  for (let i = 0; i < args.length; i++) {
+    switch (args[i]) {
+      case "--dry-run":
+        opts.dryRun = true;
+        break;
+      case "--version":
+        opts.version = args[++i];
+        break;
+      case "--bump":
+        opts.bump = args[++i];
+        break;
+      case "--from-commits":
+        opts.fromCommits = true;
+        break;
+      default:
+        console.error(`Unknown argument: ${args[i]}`);
+        process.exit(1);
+    }
+  }
+
+  const modes = [opts.version, opts.bump, opts.fromCommits].filter(Boolean);
+  if (modes.length === 0) {
+    console.error(
+      "Must specify one of: --version <ver>, --bump <patch|minor|major>, --from-commits"
+    );
+    process.exit(1);
+  }
+  if (modes.length > 1) {
+    console.error(
+      "Specify only one of: --version, --bump, or --from-commits"
+    );
+    process.exit(1);
+  }
+
+  if (opts.bump && !["patch", "minor", "major"].includes(opts.bump)) {
+    console.error(`Invalid bump type: ${opts.bump}. Use patch, minor, or major`);
+    process.exit(1);
+  }
+
+  return opts;
+}
+
+function getCurrentVersion() {
+  const pkg = JSON.parse(readFileSync(resolve(ROOT, "package.json"), "utf8"));
+  return pkg.version;
+}
+
+function bumpVersion(current, type) {
+  const parts = current.split(".").map(Number);
+  switch (type) {
+    case "major":
+      return `${parts[0] + 1}.0.0`;
+    case "minor":
+      return `${parts[0]}.${parts[1] + 1}.0`;
+    case "patch":
+      return `${parts[0]}.${parts[1]}.${parts[2] + 1}`;
+  }
+}
+
+function getLastTag() {
+  try {
+    return execSync("git describe --tags --abbrev=0", {
+      cwd: ROOT,
+      encoding: "utf8",
+    }).trim();
+  } catch {
+    return null;
+  }
+}
+
+function determineBumpFromCommits() {
+  const lastTag = getLastTag();
+  const range = lastTag ? `${lastTag}..HEAD` : "HEAD";
+  let log;
+  try {
+    log = execSync(`git log ${range} --pretty=format:"%s%n%b"`, {
+      cwd: ROOT,
+      encoding: "utf8",
+    });
+  } catch {
+    return "patch";
+  }
+
+  if (!log.trim()) return "patch";
+
+  const lines = log.split("\n");
+  let bump = "patch";
+
+  for (const line of lines) {
+    if (line.includes("BREAKING CHANGE") || line.includes("BREAKING-CHANGE")) {
+      return "major";
+    }
+    // Check for breaking change indicator with ! before :
+    if (/^[a-z]+(\(.+\))?!:/.test(line)) {
+      return "major";
+    }
+    if (/^feat(\(.+\))?:/.test(line)) {
+      bump = "minor";
+    }
+  }
+
+  return bump;
+}
+
+function updateJsonFile(filePath, newVersion, dryRun) {
+  const fullPath = resolve(ROOT, filePath);
+  const content = readFileSync(fullPath, "utf8");
+  const json = JSON.parse(content);
+  const oldVersion = json.version;
+  json.version = newVersion;
+  if (!dryRun) {
+    writeFileSync(fullPath, JSON.stringify(json, null, 2) + "\n");
+  }
+  console.log(`  ${filePath}: ${oldVersion} → ${newVersion}`);
+}
+
+function updateTomlFile(filePath, newVersion, dryRun) {
+  const fullPath = resolve(ROOT, filePath);
+  const content = readFileSync(fullPath, "utf8");
+  const versionRegex = /^(version\s*=\s*")([^"]+)(")/m;
+  const match = content.match(versionRegex);
+  if (!match) {
+    console.error(`  ${filePath}: could not find version field`);
+    process.exit(1);
+  }
+  const oldVersion = match[2];
+  const updated = content.replace(versionRegex, `$1${newVersion}$3`);
+  if (!dryRun) {
+    writeFileSync(fullPath, updated);
+  }
+  console.log(`  ${filePath}: ${oldVersion} → ${newVersion}`);
+}
+
+function updateCargoLock(dryRun) {
+  if (dryRun) return;
+  for (const toml of TOML_FILES) {
+    const dir = resolve(ROOT, dirname(toml));
+    console.log(`  Running cargo check in ${dirname(toml)}...`);
+    execSync("cargo check", { cwd: dir, stdio: "inherit" });
+  }
+}
+
+const opts = parseArgs();
+const currentVersion = getCurrentVersion();
+
+let newVersion;
+if (opts.version) {
+  if (!/^\d+\.\d+\.\d+$/.test(opts.version)) {
+    console.error(`Invalid version format: ${opts.version}. Use X.Y.Z`);
+    process.exit(1);
+  }
+  newVersion = opts.version;
+} else if (opts.bump) {
+  newVersion = bumpVersion(currentVersion, opts.bump);
+} else {
+  const bumpType = determineBumpFromCommits();
+  console.log(`Detected bump type from commits: ${bumpType}`);
+  newVersion = bumpVersion(currentVersion, bumpType);
+}
+
+console.log(`\nVersion: ${currentVersion} → ${newVersion}`);
+
+if (opts.dryRun) {
+  console.log("\n[dry-run] No files will be modified.\n");
+  console.log("Files that would be updated:");
+}
+
+console.log("\nJSON files:");
+for (const file of JSON_FILES) {
+  updateJsonFile(file, newVersion, opts.dryRun);
+}
+
+console.log("\nTauri config:");
+updateJsonFile(TAURI_CONF, newVersion, opts.dryRun);
+
+console.log("\nCargo.toml files:");
+for (const file of TOML_FILES) {
+  updateTomlFile(file, newVersion, opts.dryRun);
+}
+
+if (!opts.dryRun) {
+  console.log("\nUpdating Cargo.lock files...");
+  updateCargoLock(opts.dryRun);
+}
+
+console.log(`\nDone! Version bumped to ${newVersion}`);


### PR DESCRIPTION
## Summary

- Add GitHub Actions **CI workflow** (`ci.yml`) — runs lint, test, and DMG build on pull requests to `main`
- Add GitHub Actions **Release workflow** (`release.yml`) — manually triggered release that bumps versions, builds DMG, and publishes a GitHub release
- Add **version bump script** (`scripts/bump-version.mjs`) — zero-dependency Node.js script that updates all 12 version files (JSON + TOML + tauri.conf.json) with support for explicit version, bump type, or conventional commit auto-detection
- Fix `lint`/`lint:fix`/`format`/`format:fix`/`check` scripts in `package.json` to include the CLI crate (`apps/cli/Cargo.toml`)

## Test plan

- [ ] Push branch and verify CI workflow triggers on this PR
- [ ] Review lint/test/build steps pass in CI
- [ ] Run `node scripts/bump-version.mjs --bump patch --dry-run` locally to verify version detection
- [ ] After merging, manually trigger the Release workflow from GitHub Actions UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)