### PR TITLE
fix: smart web server & tunnel lifecycle with health checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,11 +95,7 @@ jobs:
         run: cargo test --manifest-path apps/cli/Cargo.toml
 
       - name: Test (Dashboard)
-        run: |
-          mkdir -p apps/web/dist
-          touch apps/web/dist/start-server.mjs
-          cargo test --manifest-path apps/dashboard/src-tauri/Cargo.toml
-          rm -rf apps/web/dist
+        run: cargo test --manifest-path apps/dashboard/src-tauri/Cargo.toml
 
       - name: Build frontend
         run: pnpm --filter @band/dashboard build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,6 +85,9 @@ jobs:
           touch apps/web/dist/start-server.mjs
           cargo clippy --manifest-path apps/dashboard/src-tauri/Cargo.toml -- -D warnings
 
+      - name: Build web (needed by tests)
+        run: pnpm build:web
+
       - name: Test (web)
         run: pnpm --filter @band/web test
 
@@ -99,9 +102,7 @@ jobs:
           rm -rf apps/web/dist
 
       - name: Build frontend
-        run: |
-          pnpm build:web
-          pnpm --filter @band/dashboard build
+        run: pnpm --filter @band/dashboard build
 
       - name: Build DMG
         run: pnpm --filter @band/dashboard tauri build --ci --config '{"build":{"beforeBuildCommand":""}}'

--- a/apps/dashboard/src-tauri/Cargo.lock
+++ b/apps/dashboard/src-tauri/Cargo.lock
@@ -88,10 +88,12 @@ version = "0.1.0"
 dependencies = [
  "cocoa",
  "dirs",
+ "hmac",
  "libc",
  "notify",
  "serde",
  "serde_json",
+ "sha2",
  "tauri",
  "tauri-build",
  "tauri-plugin-dialog",
@@ -563,6 +565,7 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -1271,6 +1274,15 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
 
 [[package]]
 name = "html5ever"
@@ -3368,6 +3380,12 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "swift-rs"

--- a/apps/dashboard/src-tauri/Cargo.toml
+++ b/apps/dashboard/src-tauri/Cargo.toml
@@ -21,6 +21,8 @@ tauri-plugin-shell = "2"
 tauri-plugin-dialog = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+hmac = "0.12"
+sha2 = "0.10"
 notify = "7"
 dirs = "6"
 libc = "0.2"

--- a/apps/dashboard/src-tauri/src/commands/webserver.rs
+++ b/apps/dashboard/src-tauri/src/commands/webserver.rs
@@ -1,3 +1,5 @@
+use hmac::{Hmac, Mac};
+use sha2::Sha256;
 use std::io::{BufRead, BufReader};
 use std::os::unix::process::CommandExt;
 use std::process::{Child, Command, Stdio};
@@ -106,6 +108,26 @@ fn get_or_create_secret() -> Result<String, String> {
     Ok(secret)
 }
 
+/// Compute the access token from the secret: HMAC-SHA256(secret, "band-access").
+fn compute_token(secret: &str) -> String {
+    type HmacSha256 = Hmac<Sha256>;
+    let mut mac =
+        HmacSha256::new_from_slice(secret.as_bytes()).expect("HMAC accepts any key length");
+    mac.update(b"band-access");
+    let result = mac.finalize().into_bytes();
+    result.iter().fold(String::with_capacity(64), |mut acc, b| {
+        use std::fmt::Write;
+        write!(acc, "{b:02x}").unwrap();
+        acc
+    })
+}
+
+/// Get the access token, computing it from the stored secret.
+fn get_token() -> Result<String, String> {
+    let secret = get_or_create_secret()?;
+    Ok(compute_token(&secret))
+}
+
 /// Send SIGTERM to the entire process group, then fall back to SIGKILL.
 fn kill_process_tree(child: &mut Child) {
     let pid = child.id() as libc::pid_t;
@@ -189,28 +211,108 @@ pub struct TunnelInner {
 
 pub struct TunnelState(pub Arc<Mutex<TunnelInner>>);
 
-pub struct AccessTokenState(pub Arc<Mutex<Option<String>>>);
+// ---------------------------------------------------------------------------
+// Health check helpers
+// ---------------------------------------------------------------------------
+
+/// Parse a health response body and return true if it's from our web server.
+fn parse_local_health(body: &str) -> bool {
+    if let Ok(parsed) = serde_json::from_str::<serde_json::Value>(body) {
+        parsed["app"].as_str() == Some("band-web-server")
+    } else {
+        false
+    }
+}
+
+/// Parse a tunnel health response body.
+/// Returns (`is_our_app`, `remote_hostname_if_different_machine`).
+fn parse_tunnel_health(body: &str, local_hostname: &str) -> (bool, Option<String>) {
+    if let Ok(parsed) = serde_json::from_str::<serde_json::Value>(body) {
+        if parsed["app"].as_str() == Some("band-web-server") {
+            let remote_host = parsed["hostname"].as_str().unwrap_or("").to_string();
+            if remote_host == local_hostname {
+                (true, None)
+            } else {
+                (true, Some(remote_host))
+            }
+        } else {
+            (false, None)
+        }
+    } else {
+        (false, None)
+    }
+}
+
+/// Check the local web server health endpoint.
+async fn check_local_health(port: u16, token: &str) -> bool {
+    let output = tokio::process::Command::new("curl")
+        .args([
+            "-s",
+            "-f",
+            "--max-time",
+            "2",
+            &format!("http://127.0.0.1:{port}/api/health?token={token}"),
+        ])
+        .output()
+        .await;
+    match output {
+        Ok(o) if o.status.success() => parse_local_health(&String::from_utf8_lossy(&o.stdout)),
+        _ => false,
+    }
+}
+
+/// Check the tunnel health endpoint. Returns (healthy, `remote_hostname`).
+async fn check_tunnel_health(subdomain: &str, token: &str) -> (bool, Option<String>) {
+    let url = format!("https://{subdomain}.instatunnel.my/api/health?token={token}");
+    let output = tokio::process::Command::new("curl")
+        .args(["-s", "-f", "--max-time", "5", &url])
+        .output()
+        .await;
+    match output {
+        Ok(o) if o.status.success() => {
+            parse_tunnel_health(&String::from_utf8_lossy(&o.stdout), &gethostname())
+        }
+        _ => (false, None),
+    }
+}
+
+fn gethostname() -> String {
+    let output = std::process::Command::new("hostname").output().ok();
+    match output {
+        Some(o) if o.status.success() => String::from_utf8_lossy(&o.stdout).trim().to_string(),
+        _ => String::new(),
+    }
+}
+
+#[derive(serde::Serialize)]
+pub struct ServiceHealth {
+    pub webserver: bool,
+    pub tunnel: bool,
+    pub tunnel_url: Option<String>,
+    pub tunnel_remote_host: Option<String>,
+}
 
 // ---------------------------------------------------------------------------
 // Web server commands
 // ---------------------------------------------------------------------------
 
 #[tauri::command]
-pub fn webserver_start(
-    state: State<'_, WebServerState>,
-    token_state: State<'_, AccessTokenState>,
-) -> Result<(), String> {
+pub async fn webserver_start(state: State<'_, WebServerState>) -> Result<(), String> {
     if state.0.is_running() {
+        return Ok(());
+    }
+
+    let port = get_configured_port();
+    let secret = get_or_create_secret()?;
+    let token = compute_token(&secret);
+
+    // Check if a server is already running (started externally)
+    if check_local_health(port, &token).await {
         return Ok(());
     }
 
     let web_dir = resolve_web_dir()?;
     let start_script = web_dir.join("start-server.mjs");
-    let port = get_configured_port();
-    let secret = get_or_create_secret()?;
-
-    // Clear any cached token from a previous session
-    *token_state.0.lock().unwrap() = None;
 
     let mut cmd = Command::new("node");
     cmd.arg(&start_script)
@@ -235,78 +337,102 @@ pub fn webserver_start(
 }
 
 #[tauri::command]
-pub fn webserver_stop(
+pub async fn webserver_stop(
     state: State<'_, WebServerState>,
-    token_state: State<'_, AccessTokenState>,
+    tunnel_state: State<'_, TunnelState>,
 ) -> Result<(), String> {
     state.0.kill();
-    *token_state.0.lock().unwrap() = None;
+
+    // Kill any process listening on the port (handles externally-started servers)
+    let port = get_configured_port();
+    if let Ok(output) = tokio::process::Command::new("lsof")
+        .args([&format!("-ti:{port}")])
+        .output()
+        .await
+    {
+        if output.status.success() {
+            let pids = String::from_utf8_lossy(&output.stdout);
+            for pid in pids.split_whitespace() {
+                if let Ok(pid_num) = pid.parse::<i32>() {
+                    unsafe {
+                        libc::kill(pid_num, libc::SIGTERM);
+                    }
+                }
+            }
+        }
+    }
+
+    // Also stop the tunnel
+    let subdomain = {
+        let mut guard = tunnel_state.0.lock().unwrap();
+        let sub = guard
+            .url
+            .as_ref()
+            .and_then(|url| extract_subdomain(url).map(std::string::ToString::to_string))
+            .or_else(|| {
+                load_settings()
+                    .ok()
+                    .and_then(|s| s.tunnel_subdomain)
+                    .filter(|s| !s.is_empty())
+            });
+        guard.process.kill();
+        guard.url = None;
+        sub
+    };
+    if let Some(ref name) = subdomain {
+        if let Ok(bin) = which_binary("instatunnel") {
+            let path = shell_path().to_string();
+            let _ = tokio::process::Command::new(&bin)
+                .args(["--kill", name])
+                .env("PATH", &path)
+                .output()
+                .await;
+        }
+    }
+
     Ok(())
 }
 
 #[tauri::command]
-pub fn webserver_status(state: State<'_, WebServerState>) -> Result<bool, String> {
-    Ok(state.0.is_running())
+pub fn webserver_get_token() -> Result<String, String> {
+    get_token()
 }
 
 #[tauri::command]
-pub async fn webserver_wait_ready() -> Result<(), String> {
+pub async fn service_health_check() -> Result<ServiceHealth, String> {
     let port = get_configured_port();
-    let addr = format!("127.0.0.1:{port}");
-    let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(10);
+    let settings = load_settings().unwrap_or_default();
 
-    loop {
-        if tokio::net::TcpStream::connect(&addr).await.is_ok() {
-            return Ok(());
-        }
-        if tokio::time::Instant::now() >= deadline {
-            return Err(format!(
-                "Web server did not become ready on port {port} within 10 seconds"
-            ));
-        }
-        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
-    }
-}
+    let token = get_token().ok();
 
-#[tauri::command]
-pub async fn webserver_get_token(
-    token_state: State<'_, AccessTokenState>,
-) -> Result<String, String> {
-    // Return cached token if available
-    {
-        let guard = token_state.0.lock().unwrap();
-        if let Some(ref token) = *guard {
-            return Ok(token.clone());
+    let webserver_healthy = match &token {
+        Some(t) => check_local_health(port, t).await,
+        None => false,
+    };
+
+    let mut tunnel_healthy = false;
+    let mut tunnel_url = None;
+    let mut tunnel_remote_host = None;
+
+    if let Some(ref subdomain) = settings.tunnel_subdomain {
+        if !subdomain.is_empty() {
+            if let Some(ref t) = token {
+                let (healthy, remote_host) = check_tunnel_health(subdomain, t).await;
+                if healthy {
+                    tunnel_healthy = true;
+                    tunnel_url = Some(format!("https://{subdomain}.instatunnel.my"));
+                    tunnel_remote_host = remote_host;
+                }
+            }
         }
     }
 
-    let port = get_configured_port();
-    let output = tokio::process::Command::new("curl")
-        .args([
-            "-s",
-            "-f",
-            &format!("http://127.0.0.1:{port}/api/auth/token"),
-        ])
-        .output()
-        .await
-        .map_err(|e| format!("Failed to fetch token: {e}"))?;
-
-    if !output.status.success() {
-        return Err("Failed to fetch auth token from web server".to_string());
-    }
-
-    let body = String::from_utf8_lossy(&output.stdout);
-    let parsed: serde_json::Value =
-        serde_json::from_str(&body).map_err(|e| format!("Failed to parse token response: {e}"))?;
-    let token = parsed["token"]
-        .as_str()
-        .ok_or_else(|| "Token not found in response".to_string())?
-        .to_string();
-
-    // Cache the token
-    *token_state.0.lock().unwrap() = Some(token.clone());
-
-    Ok(token)
+    Ok(ServiceHealth {
+        webserver: webserver_healthy,
+        tunnel: tunnel_healthy,
+        tunnel_url,
+        tunnel_remote_host,
+    })
 }
 
 // ---------------------------------------------------------------------------
@@ -364,27 +490,56 @@ pub async fn tunnel_install() -> Result<(), String> {
 }
 
 #[tauri::command]
-pub fn tunnel_start(
+pub async fn tunnel_start(
     app: AppHandle,
     state: State<'_, TunnelState>,
-    token_state: State<'_, AccessTokenState>,
     skip_subdomain: Option<bool>,
 ) -> Result<(), String> {
-    let mut guard = state.0.lock().unwrap();
+    let token = get_token().ok();
 
-    // Already running — re-emit URL (with token) if we have it
-    if guard.process.is_running() {
-        if let Some(ref base_url) = guard.url {
-            let url = append_token(base_url, &token_state);
-            let _ = app.emit("tunnel-url", url);
+    {
+        let guard = state.0.lock().unwrap();
+
+        // Already running — re-emit URL (with token) if we have it
+        if guard.process.is_running() {
+            if let Some(ref base_url) = guard.url {
+                let url = append_token(base_url, token.as_deref());
+                let _ = app.emit("tunnel-url", url);
+            }
+            return Ok(());
         }
-        return Ok(());
     }
 
     let port = get_configured_port();
     let settings = load_settings().unwrap_or_default();
     let subdomain = settings.tunnel_subdomain.clone();
+
+    // Check if the tunnel is already running (started externally)
+    if !skip_subdomain.unwrap_or(false) {
+        if let Some(ref name) = subdomain {
+            if !name.is_empty() {
+                if let Some(ref t) = token {
+                    let (healthy, remote_host) = check_tunnel_health(name, t).await;
+                    if healthy {
+                        let base_url = format!("https://{name}.instatunnel.my");
+                        if let Some(ref host) = remote_host {
+                            let _ = app.emit("tunnel-remote-host", host.clone());
+                        }
+                        {
+                            let mut guard = state.0.lock().unwrap();
+                            guard.url = Some(base_url.clone());
+                        }
+                        let url = append_token(&base_url, token.as_deref());
+                        let _ = app.emit("tunnel-url", url);
+                        return Ok(());
+                    }
+                }
+            }
+        }
+    }
+
     let bin = which_binary("instatunnel")?;
+    let mut guard = state.0.lock().unwrap();
 
     let mut cmd = Command::new(&bin);
     cmd.arg(format!("{port}"));
@@ -413,7 +568,7 @@ pub fn tunnel_start(
 
     let tunnel_state = state.0.clone();
     let app_handle = app.clone();
-    let token_arc = token_state.0.clone();
+    let token_for_thread = token.clone();
 
     // Merge stdout and stderr into a single channel
     let (tx, rx) = std::sync::mpsc::channel::<String>();
@@ -458,12 +613,7 @@ pub fn tunnel_start(
                         if let Ok(mut guard) = tunnel_state.lock() {
                             guard.url = Some(base_url.clone());
                         }
-                        let token_guard = token_arc.lock().ok();
-                        let token = token_guard.as_ref().and_then(|g| g.as_ref().cloned());
-                        let url = match token {
-                            Some(t) => format!("{base_url}?token={t}"),
-                            None => base_url,
-                        };
+                        let url = append_token(&base_url, token_for_thread.as_deref());
                         let _ = app_handle.emit("tunnel-url", url);
                         found = true;
                     }
@@ -534,12 +684,19 @@ pub async fn tunnel_stop(state: State<'_, TunnelState>) -> Result<(), String> {
         let sub = guard
             .url
             .as_ref()
-            .and_then(|url| extract_subdomain(url).map(std::string::ToString::to_string));
+            .and_then(|url| extract_subdomain(url).map(std::string::ToString::to_string))
+            .or_else(|| {
+                load_settings()
+                    .ok()
+                    .and_then(|s| s.tunnel_subdomain)
+                    .filter(|s| !s.is_empty())
+            });
+        guard.process.kill();
         guard.url = None;
         sub
     };
 
-    // Use CLI to close the tunnel — the process will exit on its own
+    // Use CLI to close the tunnel
     if let Some(ref name) = subdomain {
         if let Ok(bin) = which_binary("instatunnel") {
             let path = shell_path().to_string();
@@ -554,27 +711,270 @@ pub async fn tunnel_stop(state: State<'_, TunnelState>) -> Result<(), String> {
     Ok(())
 }
 
-#[tauri::command]
-pub fn tunnel_status(
-    state: State<'_, TunnelState>,
-    token_state: State<'_, AccessTokenState>,
-) -> Result<Option<String>, String> {
-    let guard = state.0.lock().unwrap();
-    if guard.process.is_running() {
-        Ok(guard
-            .url
-            .as_ref()
-            .map(|base_url| append_token(base_url, &token_state)))
-    } else {
-        Ok(None)
+/// Append ?token=XXX to a base URL if a token is available.
+fn append_token(base_url: &str, token: Option<&str>) -> String {
+    match token {
+        Some(t) => format!("{base_url}?token={t}"),
+        None => base_url.to_string(),
     }
 }
 
-/// Append ?token=XXX to a base URL if a cached token exists.
-fn append_token(base_url: &str, token_state: &State<'_, AccessTokenState>) -> String {
-    let guard = token_state.0.lock().unwrap();
-    match *guard {
-        Some(ref token) => format!("{base_url}?token={token}"),
-        None => base_url.to_string(),
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // -- compute_token --------------------------------------------------------
+
+    #[test]
+    fn compute_token_matches_js_hmac() {
+        // The JS side computes: createHmac("sha256", secret).update("band-access").digest("hex")
+        // Verified via: node -e "console.log(require('crypto').createHmac('sha256','test-secret-key-for-auth').update('band-access').digest('hex'))"
+        let token = compute_token("test-secret-key-for-auth");
+        assert_eq!(
+            token,
+            "6c2b86959205e665b407323dfe3ea35fb7fa84e450831720429dfccc99ed5bb3"
+        );
+    }
+
+    #[test]
+    fn compute_token_deterministic() {
+        let a = compute_token("my-secret");
+        let b = compute_token("my-secret");
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn compute_token_different_secrets_differ() {
+        let a = compute_token("secret-a");
+        let b = compute_token("secret-b");
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn compute_token_empty_secret() {
+        let token = compute_token("");
+        assert_eq!(token.len(), 64);
+        assert!(token.chars().all(|c| c.is_ascii_hexdigit()));
+    }
+
+    // -- extract_subdomain ----------------------------------------------------
+
+    #[test]
+    fn extract_subdomain_basic() {
+        assert_eq!(
+            extract_subdomain("https://band6.instatunnel.my"),
+            Some("band6")
+        );
+    }
+
+    #[test]
+    fn extract_subdomain_with_dashes() {
+        assert_eq!(
+            extract_subdomain("https://my-cool-app.instatunnel.my"),
+            Some("my-cool-app")
+        );
+    }
+
+    #[test]
+    fn extract_subdomain_http_rejected() {
+        // Only https:// prefix is supported
+        assert_eq!(extract_subdomain("http://band6.instatunnel.my"), None);
+    }
+
+    #[test]
+    fn extract_subdomain_wrong_domain() {
+        assert_eq!(extract_subdomain("https://band6.example.com"), None);
+    }
+
+    #[test]
+    fn extract_subdomain_with_path() {
+        // URL has trailing path — doesn't match because suffix isn't exact
+        assert_eq!(
+            extract_subdomain("https://band6.instatunnel.my/some/path"),
+            None
+        );
+    }
+
+    #[test]
+    fn extract_subdomain_empty_string() {
+        assert_eq!(extract_subdomain(""), None);
+    }
+
+    #[test]
+    fn extract_subdomain_bare_domain() {
+        assert_eq!(extract_subdomain("https://instatunnel.my"), None);
+    }
+
+    #[test]
+    fn extract_subdomain_no_protocol() {
+        assert_eq!(extract_subdomain("band6.instatunnel.my"), None);
+    }
+
+    // -- append_token ---------------------------------------------------------
+
+    #[test]
+    fn append_token_with_some() {
+        assert_eq!(
+            append_token("https://example.com", Some("abc123")),
+            "https://example.com?token=abc123"
+        );
+    }
+
+    #[test]
+    fn append_token_with_none() {
+        assert_eq!(
+            append_token("https://example.com", None),
+            "https://example.com"
+        );
+    }
+
+    #[test]
+    fn append_token_preserves_base_url() {
+        let base = "https://band6.instatunnel.my";
+        assert_eq!(append_token(base, None), base);
+    }
+
+    // -- generate_secret ------------------------------------------------------
+
+    #[test]
+    fn generate_secret_length_and_format() {
+        let secret = generate_secret().unwrap();
+        // 32 bytes → 64 hex chars
+        assert_eq!(secret.len(), 64);
+        assert!(secret.chars().all(|c| c.is_ascii_hexdigit()));
+    }
+
+    #[test]
+    fn generate_secret_unique() {
+        let a = generate_secret().unwrap();
+        let b = generate_secret().unwrap();
+        assert_ne!(a, b, "two generated secrets should differ");
+    }
+
+    // -- ManagedProcess -------------------------------------------------------
+
+    #[test]
+    fn managed_process_starts_empty() {
+        let mp = ManagedProcess::new();
+        assert!(!mp.is_running());
+    }
+
+    #[test]
+    fn managed_process_tracks_child() {
+        let mp = ManagedProcess::new();
+        let child = Command::new("sleep")
+            .arg("60")
+            .spawn()
+            .expect("failed to spawn sleep");
+        mp.set(child);
+        assert!(mp.is_running());
+        mp.kill();
+        assert!(!mp.is_running());
+    }
+
+    #[test]
+    fn managed_process_kill_when_empty() {
+        let mp = ManagedProcess::new();
+        // Should not panic
+        mp.kill();
+        assert!(!mp.is_running());
+    }
+
+    // -- parse_local_health ---------------------------------------------------
+
+    #[test]
+    fn parse_local_health_valid() {
+        let body = r#"{"status":"ok","app":"band-web-server","hostname":"my-mac.local"}"#;
+        assert!(parse_local_health(body));
+    }
+
+    #[test]
+    fn parse_local_health_wrong_app() {
+        let body = r#"{"status":"ok","app":"other-server"}"#;
+        assert!(!parse_local_health(body));
+    }
+
+    #[test]
+    fn parse_local_health_missing_app() {
+        let body = r#"{"status":"ok"}"#;
+        assert!(!parse_local_health(body));
+    }
+
+    #[test]
+    fn parse_local_health_invalid_json() {
+        assert!(!parse_local_health("not json"));
+    }
+
+    #[test]
+    fn parse_local_health_empty_body() {
+        assert!(!parse_local_health(""));
+    }
+
+    #[test]
+    fn parse_local_health_html_401() {
+        let body = "<!DOCTYPE html><html><body>Unauthorized</body></html>";
+        assert!(!parse_local_health(body));
+    }
+
+    // -- parse_tunnel_health --------------------------------------------------
+
+    #[test]
+    fn parse_tunnel_health_same_host() {
+        let body = r#"{"status":"ok","app":"band-web-server","hostname":"my-mac.local"}"#;
+        let (healthy, remote) = parse_tunnel_health(body, "my-mac.local");
+        assert!(healthy);
+        assert_eq!(remote, None);
+    }
+
+    #[test]
+    fn parse_tunnel_health_different_host() {
+        let body = r#"{"status":"ok","app":"band-web-server","hostname":"other-mac.local"}"#;
+        let (healthy, remote) = parse_tunnel_health(body, "my-mac.local");
+        assert!(healthy);
+        assert_eq!(remote, Some("other-mac.local".to_string()));
+    }
+
+    #[test]
+    fn parse_tunnel_health_wrong_app() {
+        let body = r#"{"status":"ok","app":"something-else","hostname":"my-mac.local"}"#;
+        let (healthy, remote) = parse_tunnel_health(body, "my-mac.local");
+        assert!(!healthy);
+        assert_eq!(remote, None);
+    }
+
+    #[test]
+    fn parse_tunnel_health_missing_hostname() {
+        let body = r#"{"status":"ok","app":"band-web-server"}"#;
+        let (healthy, remote) = parse_tunnel_health(body, "my-mac.local");
+        assert!(healthy);
+        // missing hostname → "" which differs from local → returns Some("")
+        assert_eq!(remote, Some("".to_string()));
+    }
+
+    #[test]
+    fn parse_tunnel_health_invalid_json() {
+        let (healthy, remote) = parse_tunnel_health("not json", "my-mac.local");
+        assert!(!healthy);
+        assert_eq!(remote, None);
+    }
+
+    #[test]
+    fn parse_tunnel_health_empty_body() {
+        let (healthy, remote) = parse_tunnel_health("", "my-mac.local");
+        assert!(!healthy);
+        assert_eq!(remote, None);
+    }
+
+    #[test]
+    fn parse_tunnel_health_tunnel_not_connected() {
+        // This is what instatunnel returns when the tunnel exists but isn't connected
+        let body = r#"{"error":"Tunnel not connected"}"#;
+        let (healthy, remote) = parse_tunnel_health(body, "my-mac.local");
+        assert!(!healthy);
+        assert_eq!(remote, None);
     }
 }

--- a/apps/dashboard/src-tauri/src/git.rs
+++ b/apps/dashboard/src-tauri/src/git.rs
@@ -168,10 +168,7 @@ fn resolve_detached_branch(worktree_path: &str) -> String {
         let head_name = gitdir.join(rebase_dir).join("head-name");
         if let Ok(name) = std::fs::read_to_string(&head_name) {
             let name = name.trim();
-            return name
-                .strip_prefix("refs/heads/")
-                .unwrap_or(name)
-                .to_string();
+            return name.strip_prefix("refs/heads/").unwrap_or(name).to_string();
         }
     }
 
@@ -436,19 +433,12 @@ mod tests {
 
         // Read gitdir from the worktree's .git file
         let git_content = fs::read_to_string(wt_path.join(".git")).unwrap();
-        let gitdir = git_content
-            .strip_prefix("gitdir: ")
-            .unwrap()
-            .trim();
+        let gitdir = git_content.strip_prefix("gitdir: ").unwrap().trim();
 
         // Simulate interactive rebase state
         let rebase_dir = Path::new(gitdir).join("rebase-merge");
         fs::create_dir_all(&rebase_dir).unwrap();
-        fs::write(
-            rebase_dir.join("head-name"),
-            "refs/heads/rebasing-branch\n",
-        )
-        .unwrap();
+        fs::write(rebase_dir.join("head-name"), "refs/heads/rebasing-branch\n").unwrap();
 
         let worktrees = list_worktrees(repo.to_str().unwrap()).unwrap();
 

--- a/apps/dashboard/src-tauri/src/lib.rs
+++ b/apps/dashboard/src-tauri/src/lib.rs
@@ -5,7 +5,7 @@ mod state;
 use commands::branch_status::BranchStatusPollerState;
 use commands::status::WatcherState;
 use commands::webserver::{
-    self as webserver, AccessTokenState, ManagedProcess, TunnelInner, TunnelState, WebServerState,
+    self as webserver, ManagedProcess, TunnelInner, TunnelState, WebServerState,
 };
 use std::sync::{Arc, Mutex};
 use tauri::Manager;
@@ -25,7 +25,6 @@ pub fn run() {
             process: ManagedProcess::new(),
             url: None,
         }))))
-        .manage(AccessTokenState(Arc::new(Mutex::new(None))))
         .invoke_handler(tauri::generate_handler![
             commands::project::project_init,
             commands::project::project_list,
@@ -54,15 +53,13 @@ pub fn run() {
             commands::branch_status::branch_status_watch_stop,
             commands::webserver::webserver_start,
             commands::webserver::webserver_stop,
-            commands::webserver::webserver_status,
-            commands::webserver::webserver_wait_ready,
+            commands::webserver::service_health_check,
             commands::webserver::prereq_check,
             commands::webserver::node_install,
             commands::webserver::tunnel_install,
             commands::webserver::tunnel_start,
             commands::webserver::tunnel_stop,
             commands::webserver::webserver_get_token,
-            commands::webserver::tunnel_status,
             commands::webserver::tunnel_auth_check,
         ])
         .setup(|app| {

--- a/apps/dashboard/src/components/TunnelDialog.tsx
+++ b/apps/dashboard/src/components/TunnelDialog.tsx
@@ -6,12 +6,20 @@ import { Loader2 } from "lucide-react";
 import { QRCodeSVG } from "qrcode.react";
 import { useCallback, useEffect, useState } from "react";
 
+interface ServiceHealth {
+  webserver: boolean;
+  tunnel: boolean;
+  tunnel_url: string | null;
+  tunnel_remote_host: string | null;
+}
+
 type TunnelStep =
   | "starting"
   | "auth_required"
   | "connecting"
   | "ready"
   | "subdomain_taken"
+  | "remote_host"
   | "error";
 
 interface Props {
@@ -26,21 +34,41 @@ export function TunnelDialog({ open, onOpenChange, onStopped, initialUrl, onTunn
   const [step, setStep] = useState<TunnelStep>("starting");
   const [tunnelUrl, setTunnelUrl] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [remoteHost, setRemoteHost] = useState<string | null>(null);
   const settings = useSettingsStore((s) => s.settings);
 
   const ensureWebServer = useCallback(async () => {
-    const running = await invoke<boolean>("webserver_status");
-    if (!running) {
+    const health = await invoke<ServiceHealth>("service_health_check");
+    if (!health.webserver) {
       await invoke("webserver_start");
-      await invoke("webserver_wait_ready");
+      // Wait for server to be ready by polling health
+      const deadline = Date.now() + 10_000;
+      while (Date.now() < deadline) {
+        const h = await invoke<ServiceHealth>("service_health_check");
+        if (h.webserver) break;
+        await new Promise((r) => setTimeout(r, 200));
+      }
       await invoke<string>("webserver_get_token");
     }
+    return health;
   }, []);
 
   const startConnection = useCallback(async () => {
     try {
       setStep("starting");
-      await ensureWebServer();
+      const health = await ensureWebServer();
+
+      // If tunnel is already running on a different host, show message
+      if (health.tunnel && health.tunnel_remote_host) {
+        setRemoteHost(health.tunnel_remote_host);
+        setStep("remote_host");
+        return;
+      }
+
+      // If tunnel is broken (subdomain configured but not healthy), kill it first
+      if (settings.tunnelSubdomain && !health.tunnel) {
+        await invoke("tunnel_stop").catch(() => {});
+      }
 
       if (settings.tunnelSubdomain) {
         const authed = await invoke<boolean>("tunnel_auth_check");
@@ -65,16 +93,19 @@ export function TunnelDialog({ open, onOpenChange, onStopped, initialUrl, onTunn
       setTunnelUrl(initialUrl);
       setStep("ready");
       setError(null);
+      setRemoteHost(null);
     } else {
       setStep("starting");
       setTunnelUrl(null);
       setError(null);
+      setRemoteHost(null);
     }
 
     let cancelled = false;
     let unlisten: (() => void) | undefined;
     let unlistenError: (() => void) | undefined;
     let unlistenSubdomainTaken: (() => void) | undefined;
+    let unlistenRemoteHost: (() => void) | undefined;
 
     (async () => {
       unlisten = await listen<string>("tunnel-url", (event) => {
@@ -98,14 +129,29 @@ export function TunnelDialog({ open, onOpenChange, onStopped, initialUrl, onTunn
         }
       });
 
+      unlistenRemoteHost = await listen<string>("tunnel-remote-host", (event) => {
+        if (!cancelled) {
+          setRemoteHost(event.payload);
+          setStep("remote_host");
+        }
+      });
+
       if (initialUrl) return;
 
+      // Check if services are already running
       try {
-        const existingUrl = await invoke<string | null>("tunnel_status");
-        if (existingUrl && !cancelled) {
-          setTunnelUrl(existingUrl);
-          setStep("ready");
-          onTunnelUrl?.(existingUrl);
+        const health = await invoke<ServiceHealth>("service_health_check");
+        if (health.tunnel && health.tunnel_url && !cancelled) {
+          const token = await invoke<string>("webserver_get_token").catch(() => null);
+          const url = token ? `${health.tunnel_url}?token=${token}` : health.tunnel_url;
+          if (health.tunnel_remote_host) {
+            setRemoteHost(health.tunnel_remote_host);
+            setStep("remote_host");
+          } else {
+            setTunnelUrl(url);
+            setStep("ready");
+            onTunnelUrl?.(url);
+          }
           return;
         }
       } catch {}
@@ -120,6 +166,7 @@ export function TunnelDialog({ open, onOpenChange, onStopped, initialUrl, onTunn
       unlisten?.();
       unlistenError?.();
       unlistenSubdomainTaken?.();
+      unlistenRemoteHost?.();
     };
   }, [open, startConnection, initialUrl, onTunnelUrl]);
 
@@ -219,6 +266,24 @@ export function TunnelDialog({ open, onOpenChange, onStopped, initialUrl, onTunn
               </p>
               <Button onClick={handleContinueRandom} className="w-full">
                 Continue with Random URL
+              </Button>
+            </>
+          )}
+
+          {step === "remote_host" && (
+            <>
+              <p className="text-sm text-muted-foreground text-center">
+                Tunnel subdomain <strong>{settings.tunnelSubdomain}</strong> is currently in use on{" "}
+                <strong>{remoteHost}</strong>.
+              </p>
+              <p className="text-xs text-muted-foreground text-center">
+                Stop it on the other computer first, or use a different subdomain.
+              </p>
+              <Button onClick={handleContinueRandom} className="w-full">
+                Continue with Random URL
+              </Button>
+              <Button variant="ghost" size="sm" onClick={() => onOpenChange(false)}>
+                Close
               </Button>
             </>
           )}

--- a/apps/dashboard/src/hooks/use-tunnel.ts
+++ b/apps/dashboard/src/hooks/use-tunnel.ts
@@ -1,4 +1,9 @@
-import { useRawDashboardStore, useSettingsStore } from "@band/dashboard-core";
+import {
+  isServiceHealthy,
+  type ServiceHealth,
+  useRawDashboardStore,
+  useSettingsStore,
+} from "@band/dashboard-core";
 import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
 import { useCallback, useEffect, useRef, useState } from "react";
@@ -8,25 +13,48 @@ interface PrereqStatus {
   instatunnel: boolean;
 }
 
+const HEALTH_POLL_INTERVAL = 30_000;
+
 export function useTunnel() {
   const dashboardStore = useRawDashboardStore();
   const [webServerRunning, setWebServerRunning] = useState(false);
   const [tunnelUrl, setTunnelUrl] = useState<string | null>(null);
+  const [tunnelRemoteHost, setTunnelRemoteHost] = useState<string | null>(null);
   const [showPrereq, setShowPrereq] = useState(false);
   const [showDialog, setShowDialog] = useState(false);
   const stoppedRef = useRef(false);
   const settings = useSettingsStore((s) => s.settings);
 
+  // Health polling — check service status every 30s
   useEffect(() => {
-    invoke<boolean>("webserver_status")
-      .then(setWebServerRunning)
-      .catch(() => {});
-    invoke<string | null>("tunnel_status")
-      .then((url) => {
-        if (url) setTunnelUrl(url);
-      })
-      .catch(() => {});
-  }, []);
+    let intervalId: ReturnType<typeof setInterval> | undefined;
+    let cancelled = false;
+
+    const poll = async () => {
+      try {
+        const health = await invoke<ServiceHealth>("service_health_check");
+        if (cancelled) return;
+        setWebServerRunning(isServiceHealthy(health, settings.tunnelSubdomain));
+        if (health.tunnel && health.tunnel_url) {
+          // Only update tunnel URL if we don't already have one (avoid overwriting token-bearing URL)
+          setTunnelUrl((prev) => prev ?? health.tunnel_url);
+        } else if (!health.tunnel) {
+          setTunnelUrl(null);
+        }
+        setTunnelRemoteHost(health.tunnel_remote_host);
+      } catch {
+        // ignore errors during polling
+      }
+    };
+
+    poll();
+    intervalId = setInterval(poll, HEALTH_POLL_INTERVAL);
+
+    return () => {
+      cancelled = true;
+      clearInterval(intervalId);
+    };
+  }, [settings.tunnelSubdomain]);
 
   // Persistent tunnel-url listener (works even when dialog is closed)
   useEffect(() => {
@@ -34,6 +62,19 @@ export function useTunnel() {
     listen<string>("tunnel-url", (event) => {
       setTunnelUrl(event.payload);
       setWebServerRunning(true);
+    }).then((fn) => {
+      unlisten = fn;
+    });
+    return () => {
+      unlisten?.();
+    };
+  }, []);
+
+  // Listen for tunnel-remote-host events
+  useEffect(() => {
+    let unlisten: (() => void) | undefined;
+    listen<string>("tunnel-remote-host", (event) => {
+      setTunnelRemoteHost(event.payload);
     }).then((fn) => {
       unlisten = fn;
     });
@@ -79,19 +120,40 @@ export function useTunnel() {
     let cancelled = false;
     (async () => {
       try {
-        const running = await invoke<boolean>("webserver_status");
-        if (running || cancelled) return;
+        // Check current health first — skip what's already running
+        const health = await invoke<ServiceHealth>("service_health_check");
+        if (cancelled) return;
+
+        if (health.webserver && health.tunnel) {
+          // Both already running
+          setWebServerRunning(true);
+          if (health.tunnel_url) setTunnelUrl(health.tunnel_url);
+          return;
+        }
 
         // Skip auto-start if prerequisites are missing
         const status = await invoke<PrereqStatus>("prereq_check");
         if (!status.node || !status.instatunnel || cancelled) return;
 
-        await invoke("webserver_start");
-        await invoke("webserver_wait_ready");
-        await invoke<string>("webserver_get_token");
+        if (!health.webserver) {
+          await invoke("webserver_start");
+          // Wait for server to be ready by polling health
+          const deadline = Date.now() + 10_000;
+          while (Date.now() < deadline) {
+            if (cancelled) return;
+            const h = await invoke<ServiceHealth>("service_health_check");
+            if (h.webserver) break;
+            await new Promise((r) => setTimeout(r, 200));
+          }
+          await invoke<string>("webserver_get_token");
+        }
+
         if (cancelled) return;
         setWebServerRunning(true);
-        await invoke("tunnel_start");
+
+        if (!health.tunnel) {
+          await invoke("tunnel_start");
+        }
       } catch (e) {
         if (!cancelled) {
           dashboardStore.getState().clearError();
@@ -105,11 +167,23 @@ export function useTunnel() {
     };
   }, [settings.autoStartTunnel, dashboardStore]);
 
-  // Globe click → open prereq check first
-  const openDialog = useCallback(() => {
+  // Globe click → fresh health check, update state, then open prereq dialog
+  const openDialog = useCallback(async () => {
     stoppedRef.current = false;
+    try {
+      const health = await invoke<ServiceHealth>("service_health_check");
+      setWebServerRunning(isServiceHealthy(health, settings.tunnelSubdomain));
+      if (health.tunnel && health.tunnel_url) {
+        setTunnelUrl((prev) => prev ?? health.tunnel_url);
+      } else if (!health.tunnel) {
+        setTunnelUrl(null);
+      }
+      setTunnelRemoteHost(health.tunnel_remote_host);
+    } catch {
+      // continue to dialog even if check fails
+    }
     setShowPrereq(true);
-  }, []);
+  }, [settings.tunnelSubdomain]);
 
   // Prereq passed → open tunnel dialog
   const onPrereqReady = useCallback(() => {
@@ -121,12 +195,14 @@ export function useTunnel() {
     stoppedRef.current = true;
     setWebServerRunning(false);
     setTunnelUrl(null);
+    setTunnelRemoteHost(null);
     setShowDialog(false);
   }, []);
 
   return {
     webServerRunning,
     tunnelUrl,
+    tunnelRemoteHost,
     setTunnelUrl,
     showPrereq,
     setShowPrereq,

--- a/apps/web/auth.ts
+++ b/apps/web/auth.ts
@@ -1,10 +1,6 @@
 import { createHmac, timingSafeEqual } from "node:crypto";
 import type { IncomingMessage, ServerResponse } from "node:http";
-
-function isLocalhost(req: IncomingMessage): boolean {
-  const addr = req.socket.remoteAddress;
-  return addr === "127.0.0.1" || addr === "::1" || addr === "::ffff:127.0.0.1";
-}
+import { hostname } from "node:os";
 
 function parseCookies(req: IncomingMessage): Record<string, string> {
   const header = req.headers.cookie || "";
@@ -39,14 +35,25 @@ export function createAuthMiddleware(secret: string | undefined) {
 
     const url = new URL(req.url!, `http://${req.headers.host}`);
 
-    // Localhost-only token endpoint
-    if (url.pathname === "/api/auth/token" && req.method === "GET") {
-      if (isLocalhost(req)) {
+    // Health check endpoint (auth-protected)
+    if (url.pathname === "/api/health" && req.method === "GET") {
+      const queryToken = url.searchParams.get("token");
+      const cookies = parseCookies(req);
+      if (
+        tokensEqual(queryToken, expectedToken) ||
+        tokensEqual(cookies.band_token, expectedToken)
+      ) {
         res.writeHead(200, { "Content-Type": "application/json" });
-        res.end(JSON.stringify({ token: expectedToken }));
+        res.end(
+          JSON.stringify({
+            status: "ok",
+            app: "band-web-server",
+            hostname: hostname(),
+          }),
+        );
       } else {
-        res.writeHead(403);
-        res.end("Forbidden");
+        res.writeHead(401);
+        res.end("Unauthorized");
       }
       return true;
     }

--- a/apps/web/tests/auth.test.ts
+++ b/apps/web/tests/auth.test.ts
@@ -60,13 +60,6 @@ describe("auth middleware (with secret)", () => {
     expect(res.status).toBe(401);
   });
 
-  it("token endpoint returns token from localhost", async () => {
-    const res = await fetch(`${server.url}/api/auth/token`);
-    expect(res.status).toBe(200);
-    const data = await res.json();
-    expect(data.token).toBe(EXPECTED_TOKEN);
-  });
-
   it("valid token query param sets cookie and passes through", async () => {
     const res = await fetch(`${server.url}/?token=${EXPECTED_TOKEN}`);
     expect(res.status).toBe(200);
@@ -106,14 +99,50 @@ describe("auth middleware (with secret)", () => {
     expect(res.status).toBe(200);
     expect(await res.text()).toBe("OK");
   });
+});
 
-  it("token endpoint is only accessible via GET", async () => {
-    const res = await fetch(`${server.url}/api/auth/token`, {
-      method: "POST",
+// -------------------------------------------------------------------------
+// /api/health endpoint
+// -------------------------------------------------------------------------
+
+describe("/api/health endpoint", () => {
+  let server: Awaited<ReturnType<typeof startServer>>;
+
+  beforeEach(async () => {
+    server = await startServer(TEST_SECRET);
+  });
+
+  afterEach(async () => {
+    await server.close();
+  });
+
+  it("returns 401 without auth", async () => {
+    const res = await fetch(`${server.url}/api/health`);
+    expect(res.status).toBe(401);
+  });
+
+  it("returns health JSON with valid token query param", async () => {
+    const res = await fetch(`${server.url}/api/health?token=${EXPECTED_TOKEN}`);
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.status).toBe("ok");
+    expect(data.app).toBe("band-web-server");
+    expect(typeof data.hostname).toBe("string");
+    expect(data.hostname.length).toBeGreaterThan(0);
+  });
+
+  it("returns health JSON with valid cookie", async () => {
+    const res = await fetch(`${server.url}/api/health`, {
       headers: { Cookie: `band_token=${EXPECTED_TOKEN}` },
     });
     expect(res.status).toBe(200);
-    expect(await res.text()).toBe("OK");
+    const data = await res.json();
+    expect(data.app).toBe("band-web-server");
+  });
+
+  it("returns 401 with invalid token", async () => {
+    const res = await fetch(`${server.url}/api/health?token=bad-token`);
+    expect(res.status).toBe(401);
   });
 });
 
@@ -144,8 +173,8 @@ describe("auth middleware (without secret — dev mode)", () => {
     expect(await res.text()).toBe("OK");
   });
 
-  it("token endpoint does not exist (passes through)", async () => {
-    const res = await fetch(`${server.url}/api/auth/token`);
+  it("passes unknown API paths through to app handler", async () => {
+    const res = await fetch(`${server.url}/api/something`);
     expect(res.status).toBe(200);
     expect(await res.text()).toBe("OK");
   });

--- a/packages/dashboard-core/package.json
+++ b/packages/dashboard-core/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "type": "module",
+  "scripts": {},
   "main": "src/index.ts",
   "types": "src/index.ts",
   "exports": {

--- a/packages/dashboard-core/src/adapter.ts
+++ b/packages/dashboard-core/src/adapter.ts
@@ -60,15 +60,12 @@ export interface PlatformCapabilities {
     check(): Promise<boolean>;
     start(): Promise<void>;
     stop(): Promise<void>;
-    status(): Promise<string | null>;
     install(): Promise<void>;
     subscribeTunnelUrl(onUrl: (url: string) => void, onError: (err: string) => void): Unsubscribe;
   };
   webserver?: {
-    status(): Promise<boolean>;
     start(): Promise<void>;
     stop(): Promise<void>;
-    waitReady(): Promise<void>;
     getToken(): Promise<string>;
   };
 }

--- a/packages/dashboard-core/src/adapters/tauri.ts
+++ b/packages/dashboard-core/src/adapters/tauri.ts
@@ -194,9 +194,6 @@ export class TauriCapabilities implements PlatformCapabilities {
     async stop(): Promise<void> {
       await invoke("tunnel_stop");
     },
-    async status(): Promise<string | null> {
-      return invoke<string | null>("tunnel_status");
-    },
     async install(): Promise<void> {
       await invoke("tunnel_install");
     },
@@ -218,17 +215,11 @@ export class TauriCapabilities implements PlatformCapabilities {
   };
 
   webserver = {
-    async status(): Promise<boolean> {
-      return invoke<boolean>("webserver_status");
-    },
     async start(): Promise<void> {
       await invoke("webserver_start");
     },
     async stop(): Promise<void> {
       await invoke("webserver_stop");
-    },
-    async waitReady(): Promise<void> {
-      await invoke("webserver_wait_ready");
     },
     async getToken(): Promise<string> {
       return invoke<string>("webserver_get_token");

--- a/packages/dashboard-core/src/index.ts
+++ b/packages/dashboard-core/src/index.ts
@@ -21,6 +21,7 @@ export {
   useBranchStatusWatcher,
   useStatusWatcher,
 } from "./hooks/use-status";
+export { isServiceHealthy, type ServiceHealth } from "./lib/service-health";
 // Lib
 export { playSound, SOUNDS, type SoundId } from "./lib/sounds";
 export type { DashboardState, DashboardStore } from "./stores/dashboard-store";

--- a/packages/dashboard-core/src/lib/service-health.ts
+++ b/packages/dashboard-core/src/lib/service-health.ts
@@ -1,0 +1,18 @@
+export interface ServiceHealth {
+  webserver: boolean;
+  tunnel: boolean;
+  tunnel_url: string | null;
+  tunnel_remote_host: string | null;
+}
+
+/**
+ * Determine whether the globe button should show as active (green).
+ *
+ * When a tunnel subdomain is configured, both the web server AND the tunnel
+ * must be healthy.  Without a subdomain the web server alone is enough.
+ */
+export function isServiceHealthy(health: ServiceHealth, tunnelSubdomain?: string | null): boolean {
+  if (!health.webserver) return false;
+  if (tunnelSubdomain) return health.tunnel;
+  return true;
+}


### PR DESCRIPTION
## Summary
- Add `/api/health` endpoint to web server for liveness detection with hostname identification
- Add `service_health_check` Tauri command that probes both web server and tunnel via health endpoints
- Compute auth token directly from secret using HMAC-SHA256 in Rust (removes `AccessTokenState`, `/api/auth/token` endpoint, and HTTP token fetching)
- Detect already-running services before spawning duplicates
- Detect tunnel subdomain in use on a different computer via hostname comparison
- Kill broken tunnel before starting a new one (fixes "subdomain already taken" error)
- Kill external processes on configured port during `webserver_stop` (handles externally-started servers)
- Add 30s health polling in `use-tunnel` hook for live globe status
- Extract `isServiceHealthy` pure function for consistent globe state logic
- Remove deprecated commands: `webserver_status`, `webserver_wait_ready`, `tunnel_status`
- Add 33 unit tests for `webserver.rs` (token computation, subdomain extraction, health response parsing, managed process lifecycle)

## Test plan
- [ ] Start web server manually → dashboard should detect it (green globe) and not spawn a duplicate
- [ ] Start instatunnel externally → dashboard should detect it via tunnel URL health check
- [ ] Click "Stop Server" → should kill both the external web server and tunnel
- [ ] With nothing running → auto-start should start both as before
- [ ] Globe button stays green while services are healthy, checked every 30s
- [ ] If subdomain is running on a different computer → shows message with the other computer's hostname
- [ ] "Subdomain already taken" → kills old tunnel and retries
- [ ] Rust tests pass: `cargo test --lib` (33 webserver tests)
- [ ] Auth tests pass: `pnpm --filter @band/web test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)