### PR TITLE
fix: unify tunnel lifecycle with shouldBeRunning state and health poll recovery

### DIFF
--- a/apps/dashboard/package.json
+++ b/apps/dashboard/package.json
@@ -7,6 +7,7 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "preview": "vite preview",
+    "test": "vitest run",
     "tauri": "tauri",
     "tauri:dev": "node scripts/tauri-dev.mjs"
   },
@@ -37,8 +38,10 @@
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
     "@vitejs/plugin-react": "^4.3.0",
+    "jsdom": "^26.1.0",
     "tailwindcss": "^4.0.0",
     "typescript": "^5.7.0",
-    "vite": "^6.0.0"
+    "vite": "^6.0.0",
+    "vitest": "^4.0.18"
   }
 }

--- a/apps/dashboard/src-tauri/src/commands/webserver.rs
+++ b/apps/dashboard/src-tauri/src/commands/webserver.rs
@@ -312,7 +312,7 @@ pub async fn webserver_start(state: State<'_, WebServerState>) -> Result<(), Str
     }
 
     let web_dir = resolve_web_dir()?;
-    let start_script = web_dir.join("start-server.mjs");
+    let start_script = web_dir.join("dist/start-server.mjs");
 
     let mut cmd = Command::new("node");
     cmd.arg(&start_script)
@@ -621,10 +621,7 @@ pub async fn tunnel_start(
             }
             // Keep draining so instatunnel doesn't get SIGPIPE
         }
-        if found {
-            // Process exited after successful connect — emit for auto-restart
-            let _ = app_handle.emit("tunnel-exited", ());
-        } else {
+        if !found {
             if let Ok(mut guard) = tunnel_state.lock() {
                 guard.process.kill();
                 guard.url = None;

--- a/apps/dashboard/src-tauri/tauri.conf.json
+++ b/apps/dashboard/src-tauri/tauri.conf.json
@@ -40,8 +40,7 @@
       "icons/icon.ico"
     ],
     "resources": {
-      "../../web/dist/": "web/dist/",
-      "../../web/dist/start-server.mjs": "web/start-server.mjs"
+      "../../web/dist/": "web/dist/"
     }
   },
   "plugins": {}

--- a/apps/dashboard/src/hooks/use-tunnel.ts
+++ b/apps/dashboard/src/hooks/use-tunnel.ts
@@ -1,9 +1,4 @@
-import {
-  isServiceHealthy,
-  type ServiceHealth,
-  useRawDashboardStore,
-  useSettingsStore,
-} from "@band/dashboard-core";
+import { isServiceHealthy, type ServiceHealth, useSettingsStore } from "@band/dashboard-core";
 import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
 import { useCallback, useEffect, useRef, useState } from "react";
@@ -16,19 +11,46 @@ interface PrereqStatus {
 const HEALTH_POLL_INTERVAL = 30_000;
 
 export function useTunnel() {
-  const dashboardStore = useRawDashboardStore();
   const [webServerRunning, setWebServerRunning] = useState(false);
   const [tunnelUrl, setTunnelUrl] = useState<string | null>(null);
   const [tunnelRemoteHost, setTunnelRemoteHost] = useState<string | null>(null);
   const [showPrereq, setShowPrereq] = useState(false);
   const [showDialog, setShowDialog] = useState(false);
-  const stoppedRef = useRef(false);
+  const shouldBeRunningRef = useRef(false);
+  const isRecoveringRef = useRef(false);
   const settings = useSettingsStore((s) => s.settings);
 
-  // Health polling — check service status every 30s
+  // Health polling — check service status every 30s, recover if shouldBeRunning
   useEffect(() => {
     let intervalId: ReturnType<typeof setInterval> | undefined;
     let cancelled = false;
+
+    const recover = async (health: ServiceHealth) => {
+      if (isRecoveringRef.current) return;
+      isRecoveringRef.current = true;
+      try {
+        if (!health.webserver) {
+          await invoke("webserver_start");
+          const deadline = Date.now() + 10_000;
+          while (Date.now() < deadline) {
+            if (cancelled) return;
+            const h = await invoke<ServiceHealth>("service_health_check");
+            if (h.webserver) break;
+            await new Promise((r) => setTimeout(r, 200));
+          }
+        }
+        if (cancelled) return;
+        await invoke<string>("webserver_get_token");
+        if (cancelled) return;
+        if (!health.tunnel) {
+          await invoke("tunnel_start");
+        }
+      } catch {
+        // swallow — next poll tick will retry
+      } finally {
+        isRecoveringRef.current = false;
+      }
+    };
 
     const poll = async () => {
       try {
@@ -36,12 +58,15 @@ export function useTunnel() {
         if (cancelled) return;
         setWebServerRunning(isServiceHealthy(health, settings.tunnelSubdomain));
         if (health.tunnel && health.tunnel_url) {
-          // Only update tunnel URL if we don't already have one (avoid overwriting token-bearing URL)
           setTunnelUrl((prev) => prev ?? health.tunnel_url);
         } else if (!health.tunnel) {
           setTunnelUrl(null);
         }
         setTunnelRemoteHost(health.tunnel_remote_host);
+
+        if (shouldBeRunningRef.current && (!health.webserver || !health.tunnel)) {
+          recover(health);
+        }
       } catch {
         // ignore errors during polling
       }
@@ -60,6 +85,7 @@ export function useTunnel() {
   useEffect(() => {
     let unlisten: (() => void) | undefined;
     listen<string>("tunnel-url", (event) => {
+      shouldBeRunningRef.current = true;
       setTunnelUrl(event.payload);
       setWebServerRunning(true);
     }).then((fn) => {
@@ -83,28 +109,12 @@ export function useTunnel() {
     };
   }, []);
 
-  // Auto-restart on tunnel-exited (handles 24h expiry)
-  useEffect(() => {
-    let unlisten: (() => void) | undefined;
-    listen("tunnel-exited", () => {
-      if (!stoppedRef.current) {
-        invoke("tunnel_start").catch(() => {});
-      }
-    }).then((fn) => {
-      unlisten = fn;
-    });
-    return () => {
-      unlisten?.();
-    };
-  }, []);
-
   // Open dialog when subdomain is taken so user can choose fallback
   useEffect(() => {
     let unlisten: (() => void) | undefined;
     listen("tunnel-subdomain-taken", () => {
-      if (!stoppedRef.current) {
-        setShowDialog(true);
-      }
+      shouldBeRunningRef.current = false;
+      setShowDialog(true);
     }).then((fn) => {
       unlisten = fn;
     });
@@ -120,56 +130,22 @@ export function useTunnel() {
     let cancelled = false;
     (async () => {
       try {
-        // Check current health first — skip what's already running
-        const health = await invoke<ServiceHealth>("service_health_check");
-        if (cancelled) return;
-
-        if (health.webserver && health.tunnel) {
-          // Both already running
-          setWebServerRunning(true);
-          if (health.tunnel_url) setTunnelUrl(health.tunnel_url);
-          return;
-        }
-
-        // Skip auto-start if prerequisites are missing
         const status = await invoke<PrereqStatus>("prereq_check");
         if (!status.node || !status.instatunnel || cancelled) return;
-
-        if (!health.webserver) {
-          await invoke("webserver_start");
-          // Wait for server to be ready by polling health
-          const deadline = Date.now() + 10_000;
-          while (Date.now() < deadline) {
-            if (cancelled) return;
-            const h = await invoke<ServiceHealth>("service_health_check");
-            if (h.webserver) break;
-            await new Promise((r) => setTimeout(r, 200));
-          }
-          await invoke<string>("webserver_get_token");
-        }
-
-        if (cancelled) return;
-        setWebServerRunning(true);
-
-        if (!health.tunnel) {
-          await invoke("tunnel_start");
-        }
-      } catch (e) {
-        if (!cancelled) {
-          dashboardStore.getState().clearError();
-          dashboardStore.setState({ error: String(e) });
-        }
+        shouldBeRunningRef.current = true;
+      } catch {
+        // ignore — health poll will retry
       }
     })();
 
     return () => {
       cancelled = true;
     };
-  }, [settings.autoStartTunnel, dashboardStore]);
+  }, [settings.autoStartTunnel]);
 
   // Globe click → fresh health check, update state, then open prereq dialog
   const openDialog = useCallback(async () => {
-    stoppedRef.current = false;
+    shouldBeRunningRef.current = true;
     try {
       const health = await invoke<ServiceHealth>("service_health_check");
       setWebServerRunning(isServiceHealthy(health, settings.tunnelSubdomain));
@@ -192,7 +168,8 @@ export function useTunnel() {
   }, []);
 
   const handleStopped = useCallback(() => {
-    stoppedRef.current = true;
+    shouldBeRunningRef.current = false;
+    isRecoveringRef.current = false;
     setWebServerRunning(false);
     setTunnelUrl(null);
     setTunnelRemoteHost(null);

--- a/apps/dashboard/tests/use-tunnel.test.tsx
+++ b/apps/dashboard/tests/use-tunnel.test.tsx
@@ -1,0 +1,441 @@
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// ---------------------------------------------------------------------------
+// Mocks — Tauri APIs are third-party boundaries we don't own
+// ---------------------------------------------------------------------------
+
+const mockInvoke = vi.fn();
+vi.mock("@tauri-apps/api/core", () => ({ invoke: mockInvoke }));
+
+const eventHandlers = new Map<string, (event: { payload: unknown }) => void>();
+const mockListen = vi.fn((eventName: string, handler: (event: { payload: unknown }) => void) => {
+  eventHandlers.set(eventName, handler);
+  return Promise.resolve(() => {
+    eventHandlers.delete(eventName);
+  });
+});
+vi.mock("@tauri-apps/api/event", () => ({ listen: mockListen }));
+
+function emitEvent(name: string, payload?: unknown) {
+  const handler = eventHandlers.get(name);
+  if (handler) handler({ payload });
+}
+
+// ---------------------------------------------------------------------------
+// Mock dashboard-core — useSettingsStore uses React Context internally,
+// so we replace it with a controlled mock.
+// isServiceHealthy is a pure function — we use the real logic.
+// ---------------------------------------------------------------------------
+
+let mockSettings = { tunnelSubdomain: "test-sub", autoStartTunnel: false };
+
+vi.mock("@band/dashboard-core", () => ({
+  isServiceHealthy: (
+    health: { webserver: boolean; tunnel: boolean },
+    subdomain?: string | null,
+  ) => {
+    if (!health.webserver) return false;
+    if (subdomain) return health.tunnel;
+    return true;
+  },
+  useSettingsStore: (selector: (state: { settings: typeof mockSettings }) => unknown) =>
+    selector({ settings: mockSettings }),
+}));
+
+// ---------------------------------------------------------------------------
+// Health response defaults
+// ---------------------------------------------------------------------------
+
+let healthResponse: {
+  webserver: boolean;
+  tunnel: boolean;
+  tunnel_url: string | null;
+  tunnel_remote_host: string | null;
+};
+
+function resetHealthResponse(overrides?: Partial<typeof healthResponse>) {
+  healthResponse = {
+    webserver: true,
+    tunnel: true,
+    tunnel_url: "https://test-sub.instatunnel.my",
+    tunnel_remote_host: null,
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Invoke mock implementation
+// ---------------------------------------------------------------------------
+
+function setupInvokeMock() {
+  mockInvoke.mockImplementation(async (command: string) => {
+    switch (command) {
+      case "service_health_check":
+        return { ...healthResponse };
+      case "prereq_check":
+        return { node: true, instatunnel: true };
+      case "webserver_start":
+        // After starting, the webserver becomes healthy
+        healthResponse = { ...healthResponse, webserver: true };
+        return;
+      case "webserver_get_token":
+        return "test-token";
+      case "tunnel_start":
+        return;
+      default:
+        throw new Error(`Unknown command: ${command}`);
+    }
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Minimal renderHook (no @testing-library/react needed)
+// ---------------------------------------------------------------------------
+
+interface HookResult<T> {
+  result: { current: T };
+  unmount: () => void;
+}
+
+function renderHook<T>(hookFn: () => T): HookResult<T> {
+  const result = { current: undefined as unknown as T };
+  function TestComponent() {
+    result.current = hookFn();
+    return null;
+  }
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root: Root = createRoot(container);
+  act(() => {
+    root.render(createElement(TestComponent));
+  });
+  return {
+    result,
+    unmount: () => {
+      act(() => root.unmount());
+      document.body.removeChild(container);
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Flush pending promises and microtasks */
+async function flush() {
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(0);
+  });
+}
+
+/** Advance the 30s health poll interval and flush */
+async function advancePoll() {
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(30_000);
+  });
+}
+
+function invokeCallsFor(command: string) {
+  return mockInvoke.mock.calls.filter((args: unknown[]) => args[0] === command);
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("useTunnel", () => {
+  let hook: HookResult<ReturnType<typeof import("../src/hooks/use-tunnel").useTunnel>>;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    resetHealthResponse();
+    mockSettings = { tunnelSubdomain: "test-sub", autoStartTunnel: false };
+    eventHandlers.clear();
+    mockInvoke.mockReset();
+    mockListen.mockClear();
+    setupInvokeMock();
+  });
+
+  afterEach(() => {
+    if (hook) hook.unmount();
+    vi.useRealTimers();
+  });
+
+  async function mountHook() {
+    const { useTunnel } = await import("../src/hooks/use-tunnel");
+    hook = renderHook(() => useTunnel());
+    await flush();
+  }
+
+  // -----------------------------------------------------------------------
+  // Health poll — UI state updates
+  // -----------------------------------------------------------------------
+
+  it("poll sets webServerRunning=true when services are healthy", async () => {
+    resetHealthResponse({ webserver: true, tunnel: true });
+    await mountHook();
+
+    expect(hook.result.current.webServerRunning).toBe(true);
+  });
+
+  it("poll sets webServerRunning=false when webserver is down", async () => {
+    resetHealthResponse({ webserver: false, tunnel: false });
+    await mountHook();
+
+    expect(hook.result.current.webServerRunning).toBe(false);
+  });
+
+  it("poll preserves existing tunnelUrl (avoids overwriting token-bearing URL)", async () => {
+    resetHealthResponse({ tunnel: true, tunnel_url: "https://test-sub.instatunnel.my" });
+    await mountHook();
+
+    // Simulate tunnel-url event with token-bearing URL
+    act(() => emitEvent("tunnel-url", "https://test-sub.instatunnel.my?token=abc"));
+    expect(hook.result.current.tunnelUrl).toBe("https://test-sub.instatunnel.my?token=abc");
+
+    // Next poll should NOT overwrite the token-bearing URL
+    await advancePoll();
+    expect(hook.result.current.tunnelUrl).toBe("https://test-sub.instatunnel.my?token=abc");
+  });
+
+  it("poll clears tunnelUrl when tunnel is not running", async () => {
+    resetHealthResponse({ tunnel: false, tunnel_url: null });
+    await mountHook();
+
+    expect(hook.result.current.tunnelUrl).toBeNull();
+  });
+
+  // -----------------------------------------------------------------------
+  // tunnel-url event
+  // -----------------------------------------------------------------------
+
+  it("tunnel-url event updates tunnelUrl and marks services running", async () => {
+    resetHealthResponse({ webserver: false, tunnel: false, tunnel_url: null });
+    await mountHook();
+    expect(hook.result.current.webServerRunning).toBe(false);
+
+    act(() => emitEvent("tunnel-url", "https://test-sub.instatunnel.my?token=xyz"));
+
+    expect(hook.result.current.tunnelUrl).toBe("https://test-sub.instatunnel.my?token=xyz");
+    expect(hook.result.current.webServerRunning).toBe(true);
+  });
+
+  // -----------------------------------------------------------------------
+  // Recovery — shouldBeRunning behavior
+  // -----------------------------------------------------------------------
+
+  it("recovers downed services after tunnel-url confirms running", async () => {
+    resetHealthResponse({ webserver: true, tunnel: true });
+    await mountHook();
+
+    // tunnel-url event sets shouldBeRunning=true
+    act(() => emitEvent("tunnel-url", "https://test-sub.instatunnel.my?token=abc"));
+    mockInvoke.mockClear();
+
+    // Now services go down
+    resetHealthResponse({ webserver: false, tunnel: false, tunnel_url: null });
+    await advancePoll();
+
+    // Recovery should have called webserver_start and tunnel_start
+    expect(invokeCallsFor("webserver_start").length).toBeGreaterThanOrEqual(1);
+    expect(invokeCallsFor("tunnel_start").length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("recovers only the tunnel when webserver is still up", async () => {
+    resetHealthResponse({ webserver: true, tunnel: true });
+    await mountHook();
+
+    act(() => emitEvent("tunnel-url", "https://test-sub.instatunnel.my?token=abc"));
+    mockInvoke.mockClear();
+
+    // Only tunnel goes down
+    resetHealthResponse({ webserver: true, tunnel: false, tunnel_url: null });
+    await advancePoll();
+
+    expect(invokeCallsFor("webserver_start")).toHaveLength(0);
+    expect(invokeCallsFor("tunnel_start").length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("does NOT recover when shouldBeRunning is false (never started)", async () => {
+    // Services are down but we never started them
+    resetHealthResponse({ webserver: false, tunnel: false, tunnel_url: null });
+    await mountHook();
+    mockInvoke.mockClear();
+
+    await advancePoll();
+
+    expect(invokeCallsFor("webserver_start")).toHaveLength(0);
+    expect(invokeCallsFor("tunnel_start")).toHaveLength(0);
+  });
+
+  // -----------------------------------------------------------------------
+  // handleStopped — disables recovery
+  // -----------------------------------------------------------------------
+
+  it("handleStopped disables recovery and clears state", async () => {
+    resetHealthResponse({ webserver: true, tunnel: true });
+    await mountHook();
+
+    // Start services (tunnel-url sets shouldBeRunning=true)
+    act(() => emitEvent("tunnel-url", "https://test-sub.instatunnel.my?token=abc"));
+    expect(hook.result.current.webServerRunning).toBe(true);
+
+    // User clicks stop
+    act(() => hook.result.current.handleStopped());
+
+    expect(hook.result.current.webServerRunning).toBe(false);
+    expect(hook.result.current.tunnelUrl).toBeNull();
+    expect(hook.result.current.tunnelRemoteHost).toBeNull();
+    expect(hook.result.current.showDialog).toBe(false);
+
+    // Services are down — recovery should NOT happen
+    mockInvoke.mockClear();
+    resetHealthResponse({ webserver: false, tunnel: false, tunnel_url: null });
+    await advancePoll();
+
+    expect(invokeCallsFor("webserver_start")).toHaveLength(0);
+    expect(invokeCallsFor("tunnel_start")).toHaveLength(0);
+  });
+
+  // -----------------------------------------------------------------------
+  // tunnel-subdomain-taken — disables recovery, shows dialog
+  // -----------------------------------------------------------------------
+
+  it("tunnel-subdomain-taken disables recovery and shows dialog", async () => {
+    resetHealthResponse({ webserver: true, tunnel: true });
+    await mountHook();
+
+    // Services were running
+    act(() => emitEvent("tunnel-url", "https://test-sub.instatunnel.my?token=abc"));
+    mockInvoke.mockClear();
+
+    act(() => emitEvent("tunnel-subdomain-taken"));
+    expect(hook.result.current.showDialog).toBe(true);
+
+    // Recovery should be disabled
+    resetHealthResponse({ webserver: false, tunnel: false, tunnel_url: null });
+    await advancePoll();
+
+    expect(invokeCallsFor("webserver_start")).toHaveLength(0);
+    expect(invokeCallsFor("tunnel_start")).toHaveLength(0);
+  });
+
+  it("recovery resumes after subdomain-taken + new tunnel-url", async () => {
+    resetHealthResponse({ webserver: true, tunnel: true });
+    await mountHook();
+
+    act(() => emitEvent("tunnel-url", "https://test-sub.instatunnel.my?token=abc"));
+    act(() => emitEvent("tunnel-subdomain-taken"));
+
+    // New tunnel URL (user picked a fallback subdomain)
+    act(() => emitEvent("tunnel-url", "https://new-sub.instatunnel.my?token=xyz"));
+    mockInvoke.mockClear();
+
+    // Services go down — recovery should kick in again
+    resetHealthResponse({ webserver: false, tunnel: false, tunnel_url: null });
+    await advancePoll();
+
+    expect(invokeCallsFor("webserver_start").length).toBeGreaterThanOrEqual(1);
+  });
+
+  // -----------------------------------------------------------------------
+  // Auto-start
+  // -----------------------------------------------------------------------
+
+  it("auto-start sets shouldBeRunning when prereqs pass", async () => {
+    mockSettings = { tunnelSubdomain: "test-sub", autoStartTunnel: true };
+    resetHealthResponse({ webserver: false, tunnel: false, tunnel_url: null });
+    await mountHook();
+
+    // prereq_check should have been called
+    expect(invokeCallsFor("prereq_check").length).toBeGreaterThanOrEqual(1);
+
+    // shouldBeRunning is now true — next poll should trigger recovery
+    mockInvoke.mockClear();
+    await advancePoll();
+
+    expect(invokeCallsFor("webserver_start").length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("auto-start does not recover when prereqs fail", async () => {
+    mockSettings = { tunnelSubdomain: "test-sub", autoStartTunnel: true };
+    mockInvoke.mockImplementation(async (command: string) => {
+      switch (command) {
+        case "service_health_check":
+          return { ...healthResponse };
+        case "prereq_check":
+          return { node: false, instatunnel: false };
+        default:
+          return;
+      }
+    });
+    resetHealthResponse({ webserver: false, tunnel: false, tunnel_url: null });
+    await mountHook();
+
+    mockInvoke.mockClear();
+    setupInvokeMock();
+    resetHealthResponse({ webserver: false, tunnel: false, tunnel_url: null });
+    await advancePoll();
+
+    // shouldBeRunning was never set to true, so no recovery
+    expect(invokeCallsFor("webserver_start")).toHaveLength(0);
+  });
+
+  // -----------------------------------------------------------------------
+  // openDialog
+  // -----------------------------------------------------------------------
+
+  it("openDialog enables recovery and refreshes health state", async () => {
+    resetHealthResponse({ webserver: false, tunnel: false, tunnel_url: null });
+    await mountHook();
+    mockInvoke.mockClear();
+    setupInvokeMock();
+
+    // User clicks globe
+    await act(async () => {
+      await hook.result.current.openDialog();
+    });
+
+    expect(hook.result.current.showPrereq).toBe(true);
+
+    // shouldBeRunning is now true — next poll should trigger recovery
+    resetHealthResponse({ webserver: false, tunnel: false, tunnel_url: null });
+    await advancePoll();
+
+    expect(invokeCallsFor("webserver_start").length).toBeGreaterThanOrEqual(1);
+  });
+
+  // -----------------------------------------------------------------------
+  // Event listeners setup
+  // -----------------------------------------------------------------------
+
+  it("registers all expected event listeners", async () => {
+    await mountHook();
+
+    const registeredEvents = mockListen.mock.calls.map((args) => args[0]);
+    expect(registeredEvents).toContain("tunnel-url");
+    expect(registeredEvents).toContain("tunnel-remote-host");
+    expect(registeredEvents).toContain("tunnel-subdomain-taken");
+  });
+
+  it("does NOT register a tunnel-exited listener", async () => {
+    await mountHook();
+
+    const registeredEvents = mockListen.mock.calls.map((args) => args[0]);
+    expect(registeredEvents).not.toContain("tunnel-exited");
+  });
+
+  // -----------------------------------------------------------------------
+  // tunnel-remote-host event
+  // -----------------------------------------------------------------------
+
+  it("tunnel-remote-host event updates tunnelRemoteHost", async () => {
+    await mountHook();
+
+    act(() => emitEvent("tunnel-remote-host", "other-machine.local"));
+    expect(hook.result.current.tunnelRemoteHost).toBe("other-machine.local");
+  });
+});

--- a/apps/dashboard/vitest.config.ts
+++ b/apps/dashboard/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "jsdom",
+    testTimeout: 30_000,
+    hookTimeout: 30_000,
+    fileParallelism: false,
+    include: ["tests/**/*.test.ts", "tests/**/*.test.tsx"],
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -90,6 +90,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^4.3.0
         version: 4.7.0(vite@6.4.1(@types/node@22.19.13)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+      jsdom:
+        specifier: ^26.1.0
+        version: 26.1.0
       tailwindcss:
         specifier: ^4.0.0
         version: 4.2.1
@@ -99,6 +102,9 @@ importers:
       vite:
         specifier: ^6.0.0
         version: 6.4.1(@types/node@22.19.13)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+      vitest:
+        specifier: ^4.0.18
+        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@22.19.13)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
 
   apps/web:
     dependencies:
@@ -225,7 +231,7 @@ importers:
         version: 7.3.1(@types/node@22.19.13)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
       vitest:
         specifier: ^4.0.18
-        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@22.19.13)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@22.19.13)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
 
   extensions/vscode:
     devDependencies:
@@ -377,6 +383,9 @@ packages:
     engines: {node: '>=18.0.0'}
     peerDependencies:
       zod: ^4.0.0
+
+  '@asamuzakjp/css-color@3.2.0':
+    resolution: {integrity: sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==}
 
   '@babel/code-frame@7.27.1':
     resolution: {integrity: sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==}
@@ -547,6 +556,34 @@ packages:
 
   '@chevrotain/utils@11.1.2':
     resolution: {integrity: sha512-4mudFAQ6H+MqBTfqLmU7G1ZwRzCLfJEooL/fsF6rCX5eePMbGhoy5n4g+G4vlh2muDcsCTJtL+uKbOzWxs5LHA==}
+
+  '@csstools/color-helpers@5.1.0':
+    resolution: {integrity: sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==}
+    engines: {node: '>=18'}
+
+  '@csstools/css-calc@2.1.4':
+    resolution: {integrity: sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^3.0.5
+      '@csstools/css-tokenizer': ^3.0.4
+
+  '@csstools/css-color-parser@3.1.0':
+    resolution: {integrity: sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^3.0.5
+      '@csstools/css-tokenizer': ^3.0.4
+
+  '@csstools/css-parser-algorithms@3.0.5':
+    resolution: {integrity: sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-tokenizer': ^3.0.4
+
+  '@csstools/css-tokenizer@3.0.4':
+    resolution: {integrity: sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==}
+    engines: {node: '>=18'}
 
   '@dnd-kit/accessibility@3.1.1':
     resolution: {integrity: sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==}
@@ -2566,6 +2603,10 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
+  agent-base@7.1.4:
+    resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
+    engines: {node: '>= 14'}
+
   ai@6.0.114:
     resolution: {integrity: sha512-X0nj5dZ/jJbOVrs5cd65ADhkbbkBEERMxs32c4PqNaXuS5JlJFxivUA9KicOcw+D1EKjrvEY6f1GrlSPiSD8zQ==}
     engines: {node: '>=18'}
@@ -2722,6 +2763,10 @@ packages:
   css-what@6.2.2:
     resolution: {integrity: sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==}
     engines: {node: '>= 6'}
+
+  cssstyle@4.6.0:
+    resolution: {integrity: sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==}
+    engines: {node: '>=18'}
 
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
@@ -2882,6 +2927,10 @@ packages:
   dagre-d3-es@7.0.13:
     resolution: {integrity: sha512-efEhnxpSuwpYOKRm/L5KbqoZmNNukHa/Flty4Wp62JRvgH2ojwVgPgdYyr4twpieZnyRDdIH7PY2mopX26+j2Q==}
 
+  data-urls@5.0.0:
+    resolution: {integrity: sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==}
+    engines: {node: '>=18'}
+
   dayjs@1.11.19:
     resolution: {integrity: sha512-t5EcLVS6QPBNqM2z8fakk/NKel+Xzshgt8FFKAn+qwlD1pzZWxh0nVCrvFK7ZDb6XucZeF9z8C7CBWTRIVApAw==}
 
@@ -2893,6 +2942,9 @@ packages:
     peerDependenciesMeta:
       supports-color:
         optional: true
+
+  decimal.js@10.6.0:
+    resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
 
   decode-named-character-reference@1.3.0:
     resolution: {integrity: sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==}
@@ -3102,6 +3154,10 @@ packages:
   hastscript@9.0.1:
     resolution: {integrity: sha512-g7df9rMFX/SPi34tyGCyUBREQoKkapwdY/T04Qn9TDWfHhAYt4/I0gMVirzK5wEzeUqIjEB+LXC/ypb7Aqno5w==}
 
+  html-encoding-sniffer@4.0.0:
+    resolution: {integrity: sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==}
+    engines: {node: '>=18'}
+
   html-url-attributes@3.0.1:
     resolution: {integrity: sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==}
 
@@ -3110,6 +3166,14 @@ packages:
 
   htmlparser2@10.1.0:
     resolution: {integrity: sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==}
+
+  http-proxy-agent@7.0.2:
+    resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
+    engines: {node: '>= 14'}
+
+  https-proxy-agent@7.0.6:
+    resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
+    engines: {node: '>= 14'}
 
   husky@9.1.7:
     resolution: {integrity: sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==}
@@ -3162,6 +3226,9 @@ packages:
     resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
     engines: {node: '>=12'}
 
+  is-potential-custom-element-name@1.0.1:
+    resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
+
   isbot@5.1.35:
     resolution: {integrity: sha512-waFfC72ZNfwLLuJ2iLaoVaqcNo+CAaLR7xCpAn0Y5WfGzkNHv7ZN39Vbi1y+kb+Zs46XHOX3tZNExroFUPX+Kg==}
     engines: {node: '>=18'}
@@ -3176,6 +3243,15 @@ packages:
   js-yaml@4.1.1:
     resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
     hasBin: true
+
+  jsdom@26.1.0:
+    resolution: {integrity: sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      canvas: ^3.0.0
+    peerDependenciesMeta:
+      canvas:
+        optional: true
 
   jsesc@3.1.0:
     resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
@@ -3282,6 +3358,9 @@ packages:
 
   longest-streak@3.1.0:
     resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
+
+  lru-cache@10.4.3:
+    resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
 
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
@@ -3504,6 +3583,9 @@ packages:
   nth-check@2.1.1:
     resolution: {integrity: sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==}
 
+  nwsapi@2.2.23:
+    resolution: {integrity: sha512-7wfH4sLbt4M0gCDzGE6vzQBo0bfTKjU7Sfpqy/7gs1qBfYz2vEJH6vXcBKpO3+6Yu1telwd0t9HpyOoLEQQbIQ==}
+
   obug@2.1.1:
     resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
 
@@ -3582,6 +3664,10 @@ packages:
 
   property-information@7.1.0:
     resolution: {integrity: sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==}
+
+  punycode@2.3.1:
+    resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
+    engines: {node: '>=6'}
 
   qrcode.react@4.2.0:
     resolution: {integrity: sha512-QpgqWi8rD9DsS9EP3z7BT+5lY5SFhsqGjpgW5DY/i3mK4M9DTBNz3ErMi8BWYEfI3L0d8GIbGmcdFAS1uIRGjA==}
@@ -3739,6 +3825,9 @@ packages:
   roughjs@4.6.6:
     resolution: {integrity: sha512-ZUz/69+SYpFN/g/lUlo2FXcIjRkSu3nDarreVdGGndHEBJ6cXPdKguS8JGxwj5HA5xIbVKSmLgr5b3AWxtRfvQ==}
 
+  rrweb-cssom@0.8.0:
+    resolution: {integrity: sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==}
+
   rw@1.3.3:
     resolution: {integrity: sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==}
 
@@ -3748,6 +3837,10 @@ packages:
 
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
+  saxes@6.0.0:
+    resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
+    engines: {node: '>=v12.22.7'}
 
   scheduler@0.27.0:
     resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
@@ -3839,6 +3932,9 @@ packages:
     peerDependencies:
       react: ^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
+  symbol-tree@3.2.4:
+    resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
+
   tailwind-merge@3.5.0:
     resolution: {integrity: sha512-I8K9wewnVDkL1NTGoqWmVEIlUcB9gFriAEkXkfCjX5ib8ezGxtR3xD7iZIxrfArjEsH7F1CHD4RFUtxefdqV/A==}
 
@@ -3882,6 +3978,13 @@ packages:
     resolution: {integrity: sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q==}
     engines: {node: '>=14.0.0'}
 
+  tldts-core@6.1.86:
+    resolution: {integrity: sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==}
+
+  tldts@6.1.86:
+    resolution: {integrity: sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==}
+    hasBin: true
+
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
@@ -3889,6 +3992,14 @@ packages:
   totalist@3.0.1:
     resolution: {integrity: sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==}
     engines: {node: '>=6'}
+
+  tough-cookie@5.1.2:
+    resolution: {integrity: sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==}
+    engines: {node: '>=16'}
+
+  tr46@5.1.1:
+    resolution: {integrity: sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==}
+    engines: {node: '>=18'}
 
   trim-lines@3.0.1:
     resolution: {integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==}
@@ -4145,8 +4256,16 @@ packages:
   vscode-uri@3.1.0:
     resolution: {integrity: sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==}
 
+  w3c-xmlserializer@5.0.0:
+    resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
+    engines: {node: '>=18'}
+
   web-namespaces@2.0.1:
     resolution: {integrity: sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==}
+
+  webidl-conversions@7.0.0:
+    resolution: {integrity: sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==}
+    engines: {node: '>=12'}
 
   webpack-virtual-modules@0.6.2:
     resolution: {integrity: sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ==}
@@ -4160,14 +4279,37 @@ packages:
     resolution: {integrity: sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==}
     engines: {node: '>=18'}
 
+  whatwg-url@14.2.0:
+    resolution: {integrity: sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==}
+    engines: {node: '>=18'}
+
   why-is-node-running@2.3.0:
     resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
     engines: {node: '>=8'}
     hasBin: true
 
+  ws@8.19.0:
+    resolution: {integrity: sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
+  xml-name-validator@5.0.0:
+    resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
+    engines: {node: '>=18'}
+
   xmlbuilder2@4.0.3:
     resolution: {integrity: sha512-bx8Q1STctnNaaDymWnkfQLKofs0mGNN7rLLapJlGuV3VlvegD7Ls4ggMjE3aUSWItCCzU0PEv45lI87iSigiCA==}
     engines: {node: '>=20.0'}
+
+  xmlchars@2.2.0:
+    resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
 
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
@@ -4249,6 +4391,14 @@ snapshots:
       '@img/sharp-linuxmusl-x64': 0.34.5
       '@img/sharp-win32-arm64': 0.34.5
       '@img/sharp-win32-x64': 0.34.5
+
+  '@asamuzakjp/css-color@3.2.0':
+    dependencies:
+      '@csstools/css-calc': 2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-color-parser': 3.1.0(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
+      lru-cache: 10.4.3
 
   '@babel/code-frame@7.27.1':
     dependencies:
@@ -4431,6 +4581,26 @@ snapshots:
   '@chevrotain/types@11.1.2': {}
 
   '@chevrotain/utils@11.1.2': {}
+
+  '@csstools/color-helpers@5.1.0': {}
+
+  '@csstools/css-calc@2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)':
+    dependencies:
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
+
+  '@csstools/css-color-parser@3.1.0(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)':
+    dependencies:
+      '@csstools/color-helpers': 5.1.0
+      '@csstools/css-calc': 2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
+
+  '@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4)':
+    dependencies:
+      '@csstools/css-tokenizer': 3.0.4
+
+  '@csstools/css-tokenizer@3.0.4': {}
 
   '@dnd-kit/accessibility@3.1.1(react@19.2.4)':
     dependencies:
@@ -6336,6 +6506,8 @@ snapshots:
 
   acorn@8.16.0: {}
 
+  agent-base@7.1.4: {}
+
   ai@6.0.114(zod@3.25.76):
     dependencies:
       '@ai-sdk/gateway': 3.0.64(zod@3.25.76)
@@ -6514,6 +6686,11 @@ snapshots:
       nth-check: 2.1.1
 
   css-what@6.2.2: {}
+
+  cssstyle@4.6.0:
+    dependencies:
+      '@asamuzakjp/css-color': 3.2.0
+      rrweb-cssom: 0.8.0
 
   csstype@3.2.3: {}
 
@@ -6701,11 +6878,18 @@ snapshots:
       d3: 7.9.0
       lodash-es: 4.17.23
 
+  data-urls@5.0.0:
+    dependencies:
+      whatwg-mimetype: 4.0.0
+      whatwg-url: 14.2.0
+
   dayjs@1.11.19: {}
 
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
+
+  decimal.js@10.6.0: {}
 
   decode-named-character-reference@1.3.0:
     dependencies:
@@ -7035,6 +7219,10 @@ snapshots:
       property-information: 7.1.0
       space-separated-tokens: 2.0.2
 
+  html-encoding-sniffer@4.0.0:
+    dependencies:
+      whatwg-encoding: 3.1.1
+
   html-url-attributes@3.0.1: {}
 
   html-void-elements@3.0.0: {}
@@ -7045,6 +7233,20 @@ snapshots:
       domhandler: 5.0.3
       domutils: 3.2.2
       entities: 7.0.1
+
+  http-proxy-agent@7.0.2:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  https-proxy-agent@7.0.6:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
 
   husky@9.1.7: {}
 
@@ -7083,6 +7285,8 @@ snapshots:
 
   is-plain-obj@4.1.0: {}
 
+  is-potential-custom-element-name@1.0.1: {}
+
   isbot@5.1.35: {}
 
   jiti@2.6.1: {}
@@ -7092,6 +7296,33 @@ snapshots:
   js-yaml@4.1.1:
     dependencies:
       argparse: 2.0.1
+
+  jsdom@26.1.0:
+    dependencies:
+      cssstyle: 4.6.0
+      data-urls: 5.0.0
+      decimal.js: 10.6.0
+      html-encoding-sniffer: 4.0.0
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6
+      is-potential-custom-element-name: 1.0.1
+      nwsapi: 2.2.23
+      parse5: 7.3.0
+      rrweb-cssom: 0.8.0
+      saxes: 6.0.0
+      symbol-tree: 3.2.4
+      tough-cookie: 5.1.2
+      w3c-xmlserializer: 5.0.0
+      webidl-conversions: 7.0.0
+      whatwg-encoding: 3.1.1
+      whatwg-mimetype: 4.0.0
+      whatwg-url: 14.2.0
+      ws: 8.19.0
+      xml-name-validator: 5.0.0
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
 
   jsesc@3.1.0: {}
 
@@ -7169,6 +7400,8 @@ snapshots:
   lodash-es@4.17.23: {}
 
   longest-streak@3.1.0: {}
+
+  lru-cache@10.4.3: {}
 
   lru-cache@5.1.1:
     dependencies:
@@ -7632,6 +7865,8 @@ snapshots:
     dependencies:
       boolbase: 1.0.0
 
+  nwsapi@2.2.23: {}
+
   obug@2.1.1: {}
 
   on-exit-leak-free@2.1.2: {}
@@ -7723,6 +7958,8 @@ snapshots:
   process-warning@5.0.0: {}
 
   property-information@7.1.0: {}
+
+  punycode@2.3.1: {}
 
   qrcode.react@4.2.0(react@19.2.4):
     dependencies:
@@ -7989,11 +8226,17 @@ snapshots:
       points-on-curve: 0.2.0
       points-on-path: 0.2.1
 
+  rrweb-cssom@0.8.0: {}
+
   rw@1.3.3: {}
 
   safe-stable-stringify@2.5.0: {}
 
   safer-buffer@2.1.2: {}
+
+  saxes@6.0.0:
+    dependencies:
+      xmlchars: 2.2.0
 
   scheduler@0.27.0: {}
 
@@ -8104,6 +8347,8 @@ snapshots:
       react: 19.2.4
       use-sync-external-store: 1.6.0(react@19.2.4)
 
+  symbol-tree@3.2.4: {}
+
   tailwind-merge@3.5.0: {}
 
   tailwindcss@4.2.1: {}
@@ -8139,11 +8384,25 @@ snapshots:
 
   tinyrainbow@3.0.3: {}
 
+  tldts-core@6.1.86: {}
+
+  tldts@6.1.86:
+    dependencies:
+      tldts-core: 6.1.86
+
   to-regex-range@5.0.1:
     dependencies:
       is-number: 7.0.0
 
   totalist@3.0.1: {}
+
+  tough-cookie@5.1.2:
+    dependencies:
+      tldts: 6.1.86
+
+  tr46@5.1.1:
+    dependencies:
+      punycode: 2.3.1
 
   trim-lines@3.0.1: {}
 
@@ -8304,7 +8563,7 @@ snapshots:
     optionalDependencies:
       vite: 7.3.1(@types/node@22.19.13)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
 
-  vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@22.19.13)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2):
+  vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@22.19.13)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2):
     dependencies:
       '@vitest/expect': 4.0.18
       '@vitest/mocker': 4.0.18(vite@7.3.1(@types/node@22.19.13)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
@@ -8329,6 +8588,7 @@ snapshots:
     optionalDependencies:
       '@opentelemetry/api': 1.9.0
       '@types/node': 22.19.13
+      jsdom: 26.1.0
     transitivePeerDependencies:
       - jiti
       - less
@@ -8359,7 +8619,13 @@ snapshots:
 
   vscode-uri@3.1.0: {}
 
+  w3c-xmlserializer@5.0.0:
+    dependencies:
+      xml-name-validator: 5.0.0
+
   web-namespaces@2.0.1: {}
+
+  webidl-conversions@7.0.0: {}
 
   webpack-virtual-modules@0.6.2: {}
 
@@ -8369,10 +8635,19 @@ snapshots:
 
   whatwg-mimetype@4.0.0: {}
 
+  whatwg-url@14.2.0:
+    dependencies:
+      tr46: 5.1.1
+      webidl-conversions: 7.0.0
+
   why-is-node-running@2.3.0:
     dependencies:
       siginfo: 2.0.0
       stackback: 0.0.2
+
+  ws@8.19.0: {}
+
+  xml-name-validator@5.0.0: {}
 
   xmlbuilder2@4.0.3:
     dependencies:
@@ -8380,6 +8655,8 @@ snapshots:
       '@oozcitak/infra': 2.0.2
       '@oozcitak/util': 10.0.0
       js-yaml: 4.1.1
+
+  xmlchars@2.2.0: {}
 
   yallist@3.1.1: {}
 


### PR DESCRIPTION
## Summary
- Replace fragmented tunnel lifecycle management (`stoppedRef`, `tunnel-exited` listener, complex auto-start sequence) with a single `shouldBeRunning` intent flag and health poll recovery
- The 30s health poll now serves as the sole recovery mechanism — when `shouldBeRunning` is true and services are down, it restarts webserver and tunnel automatically
- Remove the `tunnel-exited` event entirely (both the frontend listener and the Rust backend emit)
- Fix webserver startup bug: start script path was `start-server.mjs` but the file lives at `dist/start-server.mjs`
- Add 17 vitest tests for the tunnel hook state machine

## Test plan
- [x] 17 vitest tests covering: health poll UI updates, recovery when shouldBeRunning, no recovery when stopped, handleStopped clears state, tunnel-subdomain-taken disables recovery, auto-start with passing/failing prereqs, openDialog enables recovery, tunnel-exited listener is not registered
- [ ] Manual: start dashboard with autoStartTunnel enabled — services auto-start via health poll
- [ ] Manual: kill webserver/tunnel externally — poll recovers within 30s
- [ ] Manual: click Stop Server — services stop and poll does NOT restart them

🤖 Generated with [Claude Code](https://claude.com/claude-code)