### PR TITLE
feat: add file upload support to web chat

### DIFF
--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -10,9 +10,15 @@ import {
   ConversationScrollButton,
 } from "./ai-elements/conversation";
 import { groupMessageParts } from "./ai-elements/group-parts";
-import { Message, MessageContent, MessageResponse } from "./ai-elements/message";
+import { Message, MessageContent, MessageFilePart, MessageResponse } from "./ai-elements/message";
 import type { PromptInputMessage } from "./ai-elements/prompt-input";
-import { PromptInput, PromptInputSubmit, PromptInputTextarea } from "./ai-elements/prompt-input";
+import {
+  PromptInput,
+  PromptInputActions,
+  PromptInputAttach,
+  PromptInputSubmit,
+  PromptInputTextarea,
+} from "./ai-elements/prompt-input";
 import { ToolCallGroup } from "./ai-elements/tool-call-group";
 import { SessionList } from "./SessionList";
 
@@ -72,7 +78,7 @@ export function ChatView({
     [workspaceId],
   );
 
-  const { messages, sendMessage, status, setMessages } = useChat({
+  const { messages, sendMessage, status, setMessages, stop } = useChat({
     transport,
     onData: (dataPart) => {
       if (
@@ -127,8 +133,16 @@ export function ChatView({
 
   const handleSubmit = useCallback(
     (message: PromptInputMessage) => {
-      if (!message.text.trim()) return;
-      sendMessage({ text: message.text });
+      if (!message.text.trim() && !message.files?.length) return;
+      if (message.files?.length) {
+        const dataTransfer = new DataTransfer();
+        for (const file of message.files) {
+          dataTransfer.items.add(file);
+        }
+        sendMessage({ text: message.text, files: dataTransfer.files });
+      } else {
+        sendMessage({ text: message.text });
+      }
     },
     [sendMessage],
   );
@@ -182,7 +196,7 @@ export function ChatView({
             const showThinking = isLastAssistant && isStreaming;
 
             const visibleParts = message.parts.filter(
-              (p) => (p.type === "text" && p.text.trim()) || isToolUIPart(p),
+              (p) => (p.type === "text" && p.text.trim()) || p.type === "file" || isToolUIPart(p),
             );
             if (message.role === "assistant" && visibleParts.length === 0 && !showThinking) {
               return null;
@@ -190,6 +204,22 @@ export function ChatView({
             return (
               <Message key={message.id} from={message.role}>
                 <MessageContent>
+                  {message.role === "user" &&
+                    message.parts.map((part, partIdx) =>
+                      part.type === "file" ? (
+                        <MessageFilePart
+                          key={`${message.id}-file-${part.filename ?? partIdx}`}
+                          part={
+                            part as {
+                              type: "file";
+                              mediaType: string;
+                              url: string;
+                              filename?: string;
+                            }
+                          }
+                        />
+                      ) : null,
+                    )}
                   {groupMessageParts(message.parts).map((segment) => {
                     if (segment.type === "text") {
                       const { part, partIndex } = segment;
@@ -228,7 +258,10 @@ export function ChatView({
       <div className="shrink-0 px-4 pt-2 pb-[max(1rem,env(safe-area-inset-bottom))]">
         <PromptInput onSubmit={handleSubmit}>
           <PromptInputTextarea placeholder="Type a message..." />
-          <PromptInputSubmit status={status} />
+          <PromptInputActions>
+            <PromptInputAttach />
+            <PromptInputSubmit status={status} onStop={stop} />
+          </PromptInputActions>
         </PromptInput>
       </div>
     </div>

--- a/apps/web/src/components/ai-elements/message.tsx
+++ b/apps/web/src/components/ai-elements/message.tsx
@@ -4,6 +4,7 @@ import { code } from "@streamdown/code";
 import { math } from "@streamdown/math";
 import { mermaid } from "@streamdown/mermaid";
 import type { UIMessage } from "ai";
+import { FileIcon } from "lucide-react";
 import type { ComponentProps, HTMLAttributes } from "react";
 import { memo } from "react";
 import { Streamdown } from "streamdown";
@@ -56,3 +57,28 @@ export const MessageResponse = memo(
 );
 
 MessageResponse.displayName = "MessageResponse";
+
+interface FilePartData {
+  type: "file";
+  mediaType: string;
+  url: string;
+  filename?: string;
+}
+
+export function MessageFilePart({ part }: { part: FilePartData }) {
+  const isImage = part.mediaType.startsWith("image/");
+
+  if (isImage) {
+    return (
+      <img src={part.url} alt={part.filename ?? "Uploaded image"} className="max-w-xs rounded-md" />
+    );
+  }
+
+  return (
+    <div className="flex items-center gap-2 rounded-md border border-border/30 bg-muted/30 px-3 py-2">
+      <FileIcon className="size-4 shrink-0 text-muted-foreground" />
+      <span className="truncate text-xs">{part.filename ?? "File"}</span>
+      <span className="text-xs text-muted-foreground">{part.mediaType}</span>
+    </div>
+  );
+}

--- a/apps/web/src/components/ai-elements/prompt-input.tsx
+++ b/apps/web/src/components/ai-elements/prompt-input.tsx
@@ -1,17 +1,44 @@
 import { cn } from "@band/ui";
 import type { ChatStatus } from "ai";
-import { CornerDownLeftIcon, Loader2, SquareIcon } from "lucide-react";
+import { ArrowUpIcon, FileIcon, Loader2, Paperclip, SquareIcon, X } from "lucide-react";
 import type {
   ComponentProps,
+  DragEvent,
   FormEvent,
   FormEventHandler,
   HTMLAttributes,
   KeyboardEventHandler,
 } from "react";
-import { useCallback, useRef, useState } from "react";
+import { createContext, useCallback, useContext, useRef, useState } from "react";
+
+let fileIdCounter = 0;
+
+interface FileEntry {
+  id: string;
+  file: File;
+}
+
+const MAX_FILE_SIZE = 10 * 1024 * 1024; // 10MB
+
+const ACCEPTED_TYPES = [
+  "image/png",
+  "image/jpeg",
+  "image/gif",
+  "image/webp",
+  "application/pdf",
+  "text/plain",
+  "text/markdown",
+  "text/csv",
+  "application/json",
+  "application/xml",
+  "text/xml",
+  "text/yaml",
+  "application/x-yaml",
+].join(",");
 
 export interface PromptInputMessage {
   text: string;
+  files?: File[];
 }
 
 export type PromptInputProps = Omit<HTMLAttributes<HTMLFormElement>, "onSubmit"> & {
@@ -20,31 +47,203 @@ export type PromptInputProps = Omit<HTMLAttributes<HTMLFormElement>, "onSubmit">
 
 export const PromptInput = ({ className, onSubmit, children, ...props }: PromptInputProps) => {
   const formRef = useRef<HTMLFormElement | null>(null);
+  const [fileEntries, setFileEntries] = useState<FileEntry[]>([]);
+  const [isDragging, setIsDragging] = useState(false);
+  const [hasText, setHasText] = useState(false);
+
+  const addFiles = useCallback((newFiles: FileList | File[]) => {
+    const valid = Array.from(newFiles).filter((f) => f.size <= MAX_FILE_SIZE);
+    const entries = valid.map((file) => ({ id: `file-${++fileIdCounter}`, file }));
+    setFileEntries((prev) => [...prev, ...entries]);
+  }, []);
+
+  const removeFile = useCallback((id: string) => {
+    setFileEntries((prev) => prev.filter((entry) => entry.id !== id));
+  }, []);
 
   const handleSubmit: FormEventHandler<HTMLFormElement> = useCallback(
     (event) => {
       event.preventDefault();
       const formData = new FormData(event.currentTarget);
       const text = (formData.get("message") as string) || "";
-      if (!text.trim()) return;
+      if (!text.trim() && fileEntries.length === 0) return;
       event.currentTarget.reset();
-      onSubmit({ text }, event);
+      const files = fileEntries.map((e) => e.file);
+      onSubmit({ text, files: files.length > 0 ? files : undefined }, event);
+      setFileEntries([]);
+      setHasText(false);
     },
-    [onSubmit],
+    [onSubmit, fileEntries],
+  );
+
+  const handleDragOver = useCallback((e: DragEvent) => {
+    e.preventDefault();
+    setIsDragging(true);
+  }, []);
+
+  const handleDragLeave = useCallback((e: DragEvent) => {
+    e.preventDefault();
+    setIsDragging(false);
+  }, []);
+
+  const handleDrop = useCallback(
+    (e: DragEvent) => {
+      e.preventDefault();
+      setIsDragging(false);
+      if (e.dataTransfer.files.length > 0) {
+        addFiles(e.dataTransfer.files);
+      }
+    },
+    [addFiles],
+  );
+
+  const handlePaste = useCallback(
+    (e: React.ClipboardEvent) => {
+      const pastedFiles = Array.from(e.clipboardData.items)
+        .filter((item) => item.kind === "file")
+        .map((item) => item.getAsFile())
+        .filter((f): f is File => f != null);
+      if (pastedFiles.length > 0) {
+        addFiles(pastedFiles);
+      }
+    },
+    [addFiles],
   );
 
   return (
     <form
       className={cn(
-        "flex w-full items-end gap-2 rounded-md border border-border/50 bg-card p-2",
+        "flex w-full flex-col rounded-md border border-border/50 bg-card p-2",
+        isDragging && "border-primary/50 bg-primary/5",
         className,
       )}
       onSubmit={handleSubmit}
+      onDragOver={handleDragOver}
+      onDragLeave={handleDragLeave}
+      onDrop={handleDrop}
+      onPaste={handlePaste}
       ref={formRef}
       {...props}
     >
-      {children}
+      {fileEntries.length > 0 && <PromptInputFiles entries={fileEntries} onRemove={removeFile} />}
+      <PromptInputContext.Provider
+        value={{
+          addFiles,
+          hasContent: hasText || fileEntries.length > 0,
+          onTextChange: setHasText,
+        }}
+      >
+        {children}
+      </PromptInputContext.Provider>
     </form>
+  );
+};
+
+const PromptInputContext = createContext<{
+  addFiles: (files: FileList | File[]) => void;
+  hasContent: boolean;
+  onTextChange: (hasText: boolean) => void;
+}>({
+  addFiles: () => {},
+  hasContent: false,
+  onTextChange: () => {},
+});
+
+// File preview chips
+function PromptInputFiles({
+  entries,
+  onRemove,
+}: {
+  entries: FileEntry[];
+  onRemove: (id: string) => void;
+}) {
+  return (
+    <div className="mb-2 flex flex-wrap gap-2 px-1">
+      {entries.map((entry) => (
+        <FilePreview key={entry.id} file={entry.file} onRemove={() => onRemove(entry.id)} />
+      ))}
+    </div>
+  );
+}
+
+function FilePreview({ file, onRemove }: { file: File; onRemove: () => void }) {
+  const isImage = file.type.startsWith("image/");
+
+  return (
+    <div className="group/file relative flex items-center gap-2 rounded-md border border-border/50 bg-muted/50 px-2 py-1.5">
+      {isImage ? (
+        <img
+          src={URL.createObjectURL(file)}
+          alt={file.name}
+          className="size-8 rounded object-cover"
+        />
+      ) : (
+        <FileIcon className="size-4 text-muted-foreground" />
+      )}
+      <div className="flex flex-col">
+        <span className="max-w-[150px] truncate text-xs">{file.name}</span>
+        {!isImage && (
+          <span className="text-xs text-muted-foreground">{formatFileSize(file.size)}</span>
+        )}
+      </div>
+      <button
+        type="button"
+        onClick={onRemove}
+        className="ml-1 rounded-full p-0.5 text-muted-foreground hover:bg-muted hover:text-foreground"
+      >
+        <X className="size-3" />
+      </button>
+    </div>
+  );
+}
+
+function formatFileSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+// Actions row (bottom bar with attach + send)
+export type PromptInputActionsProps = HTMLAttributes<HTMLDivElement>;
+
+export const PromptInputActions = ({ className, ...props }: PromptInputActionsProps) => (
+  <div className={cn("flex w-full items-center justify-between", className)} {...props} />
+);
+
+// Attach button
+export type PromptInputAttachProps = ComponentProps<"button">;
+
+export const PromptInputAttach = ({ className, ...props }: PromptInputAttachProps) => {
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
+  const { addFiles } = useContext(PromptInputContext);
+
+  return (
+    <>
+      <input
+        ref={fileInputRef}
+        type="file"
+        multiple
+        accept={ACCEPTED_TYPES}
+        className="hidden"
+        onChange={(e) => {
+          if (e.target.files && e.target.files.length > 0) {
+            addFiles(e.target.files);
+            e.target.value = "";
+          }
+        }}
+      />
+      <button
+        type="button"
+        className={cn(
+          "inline-flex size-7 shrink-0 items-center justify-center rounded text-muted-foreground transition-colors hover:bg-muted hover:text-foreground",
+          className,
+        )}
+        onClick={() => fileInputRef.current?.click()}
+        {...props}
+      >
+        <Paperclip className="size-4" />
+      </button>
+    </>
   );
 };
 
@@ -58,6 +257,7 @@ export const PromptInputTextarea = ({
   ...props
 }: PromptInputTextareaProps) => {
   const [isComposing, setIsComposing] = useState(false);
+  const { onTextChange } = useContext(PromptInputContext);
 
   const handleKeyDown: KeyboardEventHandler<HTMLTextAreaElement> = useCallback(
     (e) => {
@@ -77,12 +277,13 @@ export const PromptInputTextarea = ({
       autoCorrect="off"
       spellCheck={false}
       className={cn(
-        "min-h-[44px] max-h-48 flex-1 resize-none bg-transparent px-2 py-2.5 text-sm outline-none placeholder:text-muted-foreground field-sizing-content",
+        "min-h-[44px] max-h-48 w-full resize-none bg-transparent px-2 py-2.5 text-sm outline-none placeholder:text-muted-foreground field-sizing-content",
         className,
       )}
       name="message"
       onCompositionEnd={() => setIsComposing(false)}
       onCompositionStart={() => setIsComposing(true)}
+      onInput={(e) => onTextChange(e.currentTarget.value.trim().length > 0)}
       onKeyDown={handleKeyDown}
       placeholder={placeholder}
       {...props}
@@ -92,29 +293,65 @@ export const PromptInputTextarea = ({
 
 export type PromptInputSubmitProps = ComponentProps<"button"> & {
   status?: ChatStatus;
+  onStop?: () => void;
 };
 
-export const PromptInputSubmit = ({ className, status, ...props }: PromptInputSubmitProps) => {
-  const isGenerating = status === "submitted" || status === "streaming";
+export const PromptInputSubmit = ({
+  className,
+  status,
+  onStop,
+  ...props
+}: PromptInputSubmitProps) => {
+  const { hasContent } = useContext(PromptInputContext);
+  const isSubmitting = status === "submitted";
+  const isStreaming = status === "streaming";
 
-  let Icon = <CornerDownLeftIcon className="size-4" />;
-  if (status === "submitted") {
-    Icon = <Loader2 className="size-4 animate-spin" />;
-  } else if (status === "streaming") {
-    Icon = <SquareIcon className="size-4" />;
+  if (isSubmitting) {
+    return (
+      <button
+        type="button"
+        className={cn(
+          "inline-flex size-7 shrink-0 items-center justify-center rounded-full bg-foreground/50 text-background transition-colors",
+          className,
+        )}
+        disabled
+        {...props}
+      >
+        <Loader2 className="size-4 animate-spin" />
+      </button>
+    );
+  }
+
+  if (isStreaming) {
+    return (
+      <button
+        type="button"
+        className={cn(
+          "inline-flex size-7 shrink-0 items-center justify-center rounded-full bg-foreground text-background transition-colors hover:bg-foreground/80",
+          className,
+        )}
+        onClick={onStop}
+        {...props}
+      >
+        <SquareIcon className="size-3.5 fill-current" />
+      </button>
+    );
   }
 
   return (
     <button
       type="submit"
+      disabled={!hasContent}
       className={cn(
-        "inline-flex size-7 shrink-0 items-center justify-center rounded bg-muted-foreground/80 text-background transition-colors hover:bg-muted-foreground disabled:opacity-50",
+        "inline-flex size-7 shrink-0 items-center justify-center rounded-full transition-colors",
+        hasContent
+          ? "bg-foreground text-background hover:bg-foreground/80"
+          : "bg-muted text-muted-foreground",
         className,
       )}
-      disabled={isGenerating}
       {...props}
     >
-      {Icon}
+      <ArrowUpIcon className="size-4" />
     </button>
   );
 };

--- a/apps/web/src/routes/api/chat.ts
+++ b/apps/web/src/routes/api/chat.ts
@@ -1,8 +1,48 @@
+import { mkdir, writeFile } from "node:fs/promises";
+import { join } from "node:path";
 import { createFileRoute } from "@tanstack/react-router";
 import { createUIMessageStream, createUIMessageStreamResponse } from "ai";
 import { getOrCreateAgent } from "../../lib/agent-pool";
 import { writeAgentStream } from "../../lib/stream-writer";
 import { resolveWorkspace } from "../../lib/workspace";
+
+interface FilePart {
+  type: "file";
+  mediaType: string;
+  url: string;
+  filename?: string;
+}
+
+interface MessagePart {
+  type: string;
+  text?: string;
+  mediaType?: string;
+  url?: string;
+  filename?: string;
+}
+
+async function saveUploadedFiles(fileParts: FilePart[], workspaceDir: string): Promise<string[]> {
+  const uploadDir = join(workspaceDir, ".band", "uploads");
+  await mkdir(uploadDir, { recursive: true });
+
+  const savedPaths: string[] = [];
+
+  for (const part of fileParts) {
+    const dataUrlMatch = part.url.match(/^data:[^;]+;base64,(.+)$/);
+    if (!dataUrlMatch) continue;
+
+    const buffer = Buffer.from(dataUrlMatch[1], "base64");
+    const timestamp = Date.now();
+    const filename = part.filename || `file-${timestamp}`;
+    const safeName = `${timestamp}-${filename.replace(/[^a-zA-Z0-9._-]/g, "_")}`;
+    const filePath = join(uploadDir, safeName);
+
+    await writeFile(filePath, buffer);
+    savedPaths.push(`.band/uploads/${safeName}`);
+  }
+
+  return savedPaths;
+}
 
 export const Route = createFileRoute("/api/chat")({
   server: {
@@ -11,7 +51,7 @@ export const Route = createFileRoute("/api/chat")({
         const body = await request.json();
         const { messages, sessionId, workspaceId } = body as {
           messages?: Array<{
-            parts?: Array<{ type: string; text?: string }>;
+            parts?: MessagePart[];
             content?: string;
           }>;
           sessionId?: string;
@@ -33,9 +73,22 @@ export const Route = createFileRoute("/api/chat")({
         const userText =
           lastMessage?.parts?.find((p) => p.type === "text")?.text ?? lastMessage?.content ?? "";
 
+        // Extract file parts and save them to the workspace
+        const fileParts = (lastMessage?.parts?.filter((p) => p.type === "file") ??
+          []) as FilePart[];
+        let enhancedText = userText;
+
+        if (fileParts.length > 0) {
+          const savedPaths = await saveUploadedFiles(fileParts, workspace.worktree.path);
+          if (savedPaths.length > 0) {
+            const fileList = savedPaths.map((p) => `- ${p}`).join("\n");
+            enhancedText = `I'm sharing these files with you:\n${fileList}\n\n${userText}`;
+          }
+        }
+
         const stream = createUIMessageStream({
           execute: async ({ writer }) => {
-            await writeAgentStream(agent, userText, sessionId, writer);
+            await writeAgentStream(agent, enhancedText, sessionId, writer);
           },
         });
 


### PR DESCRIPTION
## Summary
- Add file attachment UI (paperclip button, drag-and-drop, clipboard paste) with image thumbnails and file chips in the prompt input
- Send files as base64 data URLs via the AI SDK, decode and save to workspace `.band/uploads/` on the server, and reference by path in the agent prompt
- Render file parts in user message bubbles (inline images, styled chips for other files)
- Redesigned input layout: textarea on top, action buttons (attach + send) in a row below, with proper disabled/active states

## Test plan
- [x] Build succeeds (`pnpm build:web`)
- [x] All 8 existing chat integration tests pass (`pnpm vitest run tests/chat.test.ts`)
- [x] Lint clean (`pnpm biome check`)
- [ ] Manual: attach files via paperclip button, drag-and-drop, and clipboard paste
- [ ] Manual: verify image previews and file chips appear in input area
- [ ] Manual: verify files render in sent message bubbles
- [ ] Manual: verify files saved to `.band/uploads/` in workspace
- [ ] Manual: verify send button disabled when empty, enabled with content
- [ ] Manual: verify stop button works during streaming

🤖 Generated with [Claude Code](https://claude.com/claude-code)