### PR TITLE
feat: render task tool calls as a task list widget

### DIFF
--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -18,6 +18,8 @@ import {
   PromptInputSubmit,
   PromptInputTextarea,
 } from "./ai-elements/prompt-input";
+import { TaskListWidget } from "./ai-elements/task-list-widget";
+import { applyTaskToolCall, isTaskTool, type TaskMap } from "./ai-elements/task-state";
 import type { ToolPart } from "./ai-elements/tool";
 import type { ToolCallItem } from "./ai-elements/tool-call";
 import { ToolCall } from "./ai-elements/tool-call";
@@ -169,6 +171,21 @@ export function ChatView({
     [sendMessage],
   );
 
+  const liveTaskMap: TaskMap = useMemo(() => {
+    let map: TaskMap = new Map();
+    for (const msg of messages) {
+      for (const part of msg.parts) {
+        if (!isToolUIPart(part)) continue;
+        const toolPart = part as ToolPart;
+        const name = getToolName(toolPart);
+        if (!isTaskTool(name)) continue;
+        const item = toolPartToItem(toolPart);
+        map = applyTaskToolCall(map, item);
+      }
+    }
+    return map;
+  }, [messages]);
+
   if (supportsSessionListing && showSessionList) {
     return (
       <SessionList
@@ -212,56 +229,68 @@ export function ChatView({
             </div>
           )}
 
-          {messages.map((message, messageIndex) => {
-            const isLastMessage = messageIndex === messages.length - 1;
-            const isLastAssistant = message.role === "assistant" && isLastMessage;
-            const showThinking = isLastAssistant && isStreaming;
+          {(() => {
+            let taskWidgetRendered = false;
+            return messages.map((message, messageIndex) => {
+              const isLastMessage = messageIndex === messages.length - 1;
+              const isLastAssistant = message.role === "assistant" && isLastMessage;
+              const showThinking = isLastAssistant && isStreaming;
 
-            const visibleParts = message.parts.filter(
-              (p) => (p.type === "text" && p.text.trim()) || p.type === "file" || isToolUIPart(p),
-            );
-            if (message.role === "assistant" && visibleParts.length === 0 && !showThinking) {
-              return null;
-            }
-            return (
-              <Message key={message.id} from={message.role}>
-                <MessageContent>
-                  {message.role === "user" &&
-                    message.parts.map((part, partIdx) =>
-                      part.type === "file" ? (
-                        <MessageFilePart
-                          key={`${message.id}-file-${part.filename ?? partIdx}`}
-                          part={
-                            part as {
-                              type: "file";
-                              mediaType: string;
-                              url: string;
-                              filename?: string;
+              const visibleParts = message.parts.filter(
+                (p) => (p.type === "text" && p.text.trim()) || p.type === "file" || isToolUIPart(p),
+              );
+              if (message.role === "assistant" && visibleParts.length === 0 && !showThinking) {
+                return null;
+              }
+              return (
+                <Message key={message.id} from={message.role}>
+                  <MessageContent>
+                    {message.role === "user" &&
+                      message.parts.map((part, partIdx) =>
+                        part.type === "file" ? (
+                          <MessageFilePart
+                            key={`${message.id}-file-${part.filename ?? partIdx}`}
+                            part={
+                              part as {
+                                type: "file";
+                                mediaType: string;
+                                url: string;
+                                filename?: string;
+                              }
                             }
-                          }
-                        />
-                      ) : null,
-                    )}
-                  {groupMessageParts(message.parts).map((segment) => {
-                    if (segment.type === "text") {
-                      const { part, partIndex } = segment;
-                      if (part.type === "text" && part.text.trim()) {
-                        return (
-                          <MessageResponse key={`${message.id}-text-${partIndex}`}>
-                            {part.text}
-                          </MessageResponse>
-                        );
+                          />
+                        ) : null,
+                      )}
+                    {groupMessageParts(message.parts).map((segment) => {
+                      if (segment.type === "text") {
+                        const { part, partIndex } = segment;
+                        if (part.type === "text" && part.text.trim()) {
+                          return (
+                            <MessageResponse key={`${message.id}-text-${partIndex}`}>
+                              {part.text}
+                            </MessageResponse>
+                          );
+                        }
+                        return null;
                       }
-                      return null;
-                    }
-                    const item = toolPartToItem(segment.part);
-                    return <ToolCall key={`${message.id}-tool-${segment.partIndex}`} item={item} />;
-                  })}
-                  {showThinking && <ThinkingIndicator />}
-                </MessageContent>
-              </Message>
-            );
-          })}
+                      const item = toolPartToItem(segment.part);
+                      if (isTaskTool(item.toolName)) {
+                        if (!taskWidgetRendered && liveTaskMap.size > 0) {
+                          taskWidgetRendered = true;
+                          return <TaskListWidget key="task-list-widget" tasks={liveTaskMap} />;
+                        }
+                        return null;
+                      }
+                      return (
+                        <ToolCall key={`${message.id}-tool-${segment.partIndex}`} item={item} />
+                      );
+                    })}
+                    {showThinking && <ThinkingIndicator />}
+                  </MessageContent>
+                </Message>
+              );
+            });
+          })()}
           {isStreaming && (!messages.length || messages[messages.length - 1].role === "user") && (
             <Message from="assistant">
               <MessageContent>
@@ -298,13 +327,47 @@ function buildToolResultMap(messages: HistoryMessage[]) {
   return map;
 }
 
+function buildHistoryTaskMap(
+  messages: HistoryMessage[],
+  toolResultMap: Map<string, HistoryMessageContent>,
+): { taskMap: TaskMap; taskToolCallIds: Set<string> } {
+  const taskToolCallIds = new Set<string>();
+  let map: TaskMap = new Map();
+  for (const msg of messages) {
+    for (const block of msg.content) {
+      if (block.type !== "tool_use" || !block.toolName || !isTaskTool(block.toolName)) continue;
+      const id = block.toolCallId ?? "";
+      taskToolCallIds.add(id);
+      const item = historyToolToItem(block, toolResultMap.get(id));
+      map = applyTaskToolCall(map, item);
+    }
+  }
+  return { taskMap: map, taskToolCallIds };
+}
+
 function HistoryMessages({ messages }: { messages: HistoryMessage[] }) {
   const toolResultMap = useMemo(() => buildToolResultMap(messages), [messages]);
+  const { taskMap, taskToolCallIds } = useMemo(
+    () => buildHistoryTaskMap(messages, toolResultMap),
+    [messages, toolResultMap],
+  );
+
+  let taskWidgetRendered = false;
 
   return (
     <>
       {messages.map((msg) => (
-        <HistoryMessageView key={msg.id} message={msg} toolResultMap={toolResultMap} />
+        <HistoryMessageView
+          key={msg.id}
+          message={msg}
+          toolResultMap={toolResultMap}
+          taskMap={taskMap}
+          taskToolCallIds={taskToolCallIds}
+          taskWidgetRendered={taskWidgetRendered}
+          onTaskWidgetRendered={() => {
+            taskWidgetRendered = true;
+          }}
+        />
       ))}
     </>
   );
@@ -313,9 +376,17 @@ function HistoryMessages({ messages }: { messages: HistoryMessage[] }) {
 function HistoryMessageView({
   message,
   toolResultMap,
+  taskMap,
+  taskToolCallIds,
+  taskWidgetRendered,
+  onTaskWidgetRendered,
 }: {
   message: HistoryMessage;
   toolResultMap: Map<string, HistoryMessageContent>;
+  taskMap: TaskMap;
+  taskToolCallIds: Set<string>;
+  taskWidgetRendered: boolean;
+  onTaskWidgetRendered: () => void;
 }) {
   const textBlocks = message.content.filter((b) => b.type === "text" && b.text?.trim());
   const toolUseBlocks = message.content.filter((b) => b.type === "tool_use");
@@ -336,7 +407,16 @@ function HistoryMessageView({
 
   return (
     <Message from="assistant">
-      <MessageContent>{renderHistoryContent(message, toolResultMap)}</MessageContent>
+      <MessageContent>
+        {renderHistoryContent(
+          message,
+          toolResultMap,
+          taskMap,
+          taskToolCallIds,
+          taskWidgetRendered,
+          onTaskWidgetRendered,
+        )}
+      </MessageContent>
     </Message>
   );
 }
@@ -359,6 +439,10 @@ function historyToolToItem(
 function renderHistoryContent(
   message: HistoryMessage,
   toolResultMap: Map<string, HistoryMessageContent>,
+  taskMap: TaskMap,
+  taskToolCallIds: Set<string>,
+  taskWidgetRendered: boolean,
+  onTaskWidgetRendered: () => void,
 ) {
   const elements: React.ReactNode[] = [];
 
@@ -368,7 +452,16 @@ function renderHistoryContent(
         <MessageResponse key={`text-${elements.length}`}>{block.text}</MessageResponse>,
       );
     } else if (block.type === "tool_use") {
-      const item = historyToolToItem(block, toolResultMap.get(block.toolCallId ?? ""));
+      const callId = block.toolCallId ?? "";
+      if (taskToolCallIds.has(callId)) {
+        if (!taskWidgetRendered && taskMap.size > 0) {
+          taskWidgetRendered = true;
+          onTaskWidgetRendered();
+          elements.push(<TaskListWidget key="task-list-widget" tasks={taskMap} />);
+        }
+        continue;
+      }
+      const item = historyToolToItem(block, toolResultMap.get(callId));
       elements.push(<ToolCall key={`tool-${elements.length}`} item={item} />);
     }
   }

--- a/apps/web/src/components/ai-elements/task-list-widget.tsx
+++ b/apps/web/src/components/ai-elements/task-list-widget.tsx
@@ -1,0 +1,48 @@
+import { cn } from "@band/ui";
+import { CheckCircle2, Circle, Loader2 } from "lucide-react";
+
+import type { TaskMap } from "./task-state";
+
+export function TaskListWidget({ tasks }: { tasks: TaskMap }) {
+  if (tasks.size === 0) return null;
+
+  const taskList = Array.from(tasks.values());
+  const completedCount = taskList.filter((t) => t.status === "completed").length;
+
+  return (
+    <div className="not-prose mb-4 w-full rounded border border-border/50">
+      <div className="flex items-center justify-between gap-2 p-3">
+        <span className="font-medium text-sm">Tasks</span>
+        <span className="text-xs text-muted-foreground">
+          {completedCount}/{taskList.length}
+        </span>
+      </div>
+      <div className="border-t border-border/50 px-3 py-2">
+        {taskList.map((task) => (
+          <div key={task.id} className="flex items-center gap-2 py-1.5">
+            <TaskStatusIcon status={task.status} />
+            <span
+              className={cn(
+                "text-sm",
+                task.status === "completed" && "text-muted-foreground line-through",
+              )}
+            >
+              {task.status === "in_progress" && task.activeForm ? task.activeForm : task.subject}
+            </span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function TaskStatusIcon({ status }: { status: string }) {
+  switch (status) {
+    case "completed":
+      return <CheckCircle2 className="size-4 shrink-0 text-green-500" />;
+    case "in_progress":
+      return <Loader2 className="size-4 shrink-0 animate-spin text-orange-500" />;
+    default:
+      return <Circle className="size-4 shrink-0 text-muted-foreground" />;
+  }
+}

--- a/apps/web/src/components/ai-elements/task-state.ts
+++ b/apps/web/src/components/ai-elements/task-state.ts
@@ -1,0 +1,122 @@
+import type { ToolCallItem } from "./tool-call";
+
+export interface TaskItem {
+  id: string;
+  subject: string;
+  description?: string;
+  status: "pending" | "in_progress" | "completed";
+  activeForm?: string;
+  owner?: string;
+  blockedBy?: string[];
+}
+
+export type TaskMap = Map<string, TaskItem>;
+
+export const TASK_TOOL_NAMES = new Set(["TaskCreate", "TaskUpdate", "TaskList", "TaskGet"]);
+
+export function isTaskTool(toolName: string): boolean {
+  return TASK_TOOL_NAMES.has(toolName);
+}
+
+function parseTaskFromOutput(output: unknown): TaskItem | null {
+  if (!output) return null;
+  try {
+    const data = typeof output === "string" ? JSON.parse(output) : output;
+    if (!data || typeof data !== "object") return null;
+    const obj = data as Record<string, unknown>;
+    if (!obj.id || !obj.subject) return null;
+    return {
+      id: String(obj.id),
+      subject: String(obj.subject),
+      description: obj.description ? String(obj.description) : undefined,
+      status: validateStatus(obj.status),
+      activeForm: obj.activeForm ? String(obj.activeForm) : undefined,
+      owner: obj.owner ? String(obj.owner) : undefined,
+      blockedBy: Array.isArray(obj.blockedBy) ? obj.blockedBy.map(String) : undefined,
+    };
+  } catch {
+    return null;
+  }
+}
+
+function validateStatus(val: unknown): "pending" | "in_progress" | "completed" {
+  if (val === "pending" || val === "in_progress" || val === "completed") {
+    return val;
+  }
+  return "pending";
+}
+
+function parseTaskListOutput(output: unknown): TaskItem[] | null {
+  try {
+    const data = typeof output === "string" ? JSON.parse(output) : output;
+    if (!Array.isArray(data)) return null;
+    const tasks: TaskItem[] = [];
+    for (const entry of data) {
+      if (!entry || typeof entry !== "object") continue;
+      const obj = entry as Record<string, unknown>;
+      if (!obj.id || !obj.subject) continue;
+      tasks.push({
+        id: String(obj.id),
+        subject: String(obj.subject),
+        description: obj.description ? String(obj.description) : undefined,
+        status: validateStatus(obj.status),
+        activeForm: obj.activeForm ? String(obj.activeForm) : undefined,
+        owner: obj.owner ? String(obj.owner) : undefined,
+        blockedBy: Array.isArray(obj.blockedBy) ? obj.blockedBy.map(String) : undefined,
+      });
+    }
+    return tasks;
+  } catch {
+    return null;
+  }
+}
+
+export function applyTaskToolCall(map: TaskMap, item: ToolCallItem): TaskMap {
+  const next = new Map(map);
+
+  if (item.toolName === "TaskList") {
+    const tasks = parseTaskListOutput(item.output);
+    if (!tasks) return next;
+    next.clear();
+    for (const task of tasks) {
+      next.set(task.id, task);
+    }
+    return next;
+  }
+
+  // TaskCreate, TaskUpdate, TaskGet — upsert from output
+  const task = parseTaskFromOutput(item.output);
+  if (!task) return next;
+
+  // Check for deletion via TaskUpdate input
+  if (item.toolName === "TaskUpdate") {
+    const input = item.input as Record<string, unknown> | null;
+    if (input?.status === "deleted") {
+      next.delete(task.id);
+      return next;
+    }
+  }
+
+  if (task.status === ("deleted" as string)) {
+    next.delete(task.id);
+    return next;
+  }
+
+  const existing = next.get(task.id);
+  if (existing) {
+    next.set(task.id, { ...existing, ...task });
+  } else {
+    next.set(task.id, task);
+  }
+  return next;
+}
+
+export function buildTaskMapFromItems(items: ToolCallItem[]): TaskMap {
+  let map: TaskMap = new Map();
+  for (const item of items) {
+    if (isTaskTool(item.toolName)) {
+      map = applyTaskToolCall(map, item);
+    }
+  }
+  return map;
+}


### PR DESCRIPTION
## Summary
- Aggregates `TaskCreate`, `TaskUpdate`, `TaskList`, and `TaskGet` tool calls into a single inline `TaskListWidget` instead of showing individual collapsed tool accordions
- Shows completion count (e.g., "2/5"), status icons (green check, spinning loader, gray circle), and active form text for in-progress tasks
- Works in both live streaming and historical session views

Closes #43

## Test plan
- [ ] Start a chat session, have the agent use TaskCreate/TaskUpdate tools, verify the widget appears inline with live status updates
- [ ] Open a historical session that contained task tools, verify the widget reconstructs correctly
- [ ] Verify non-task tool calls still render normally as accordions

🤖 Generated with [Claude Code](https://claude.com/claude-code)