### PR TITLE
fix: allow agent to access uploaded files

### DIFF
--- a/apps/web/src/lib/agent-pool.ts
+++ b/apps/web/src/lib/agent-pool.ts
@@ -1,6 +1,7 @@
+import { join } from "node:path";
 import { type CodingAgent, type CodingAgentConfig, createCodingAgent } from "@band/coding-agent";
 import { createLogger } from "@band/logger";
-import { loadSettings } from "./state";
+import { bandHome, loadSettings } from "./state";
 
 const log = createLogger("agent-pool");
 
@@ -14,6 +15,7 @@ function getAgentConfig(worktreePath: string): CodingAgentConfig {
     type: agentType,
     workspaceDir: worktreePath,
     maxTurns: 50,
+    additionalDirectories: [join(bandHome(), "uploads")],
     options: {
       executablePath: settings.codingAgent?.command,
     },

--- a/packages/coding-agent/src/adapters/claude-code.ts
+++ b/packages/coding-agent/src/adapters/claude-code.ts
@@ -32,12 +32,14 @@ export class ClaudeCodeAdapter implements CodingAgent {
   private readonly maxTurns: number;
   private readonly model: string | undefined;
   private readonly executablePath: string | undefined;
+  private readonly additionalDirectories: string[] | undefined;
 
   constructor(config: ClaudeCodeConfig) {
     this.workspaceDir = config.workspaceDir;
     this.maxTurns = config.maxTurns;
     this.model = config.options.model;
     this.executablePath = config.options.executablePath;
+    this.additionalDirectories = config.additionalDirectories;
   }
 
   async *runSession(prompt: string, sessionId?: string): AsyncGenerator<AgentEvent> {
@@ -98,6 +100,7 @@ export class ClaudeCodeAdapter implements CodingAgent {
         resume: sessionId,
         canUseTool,
         env,
+        additionalDirectories: this.additionalDirectories,
         pathToClaudeCodeExecutable: this.executablePath,
         settingSources: ["user", "project"],
         stderr: (data) => log.warn({ data }, "claude-code stderr"),

--- a/packages/coding-agent/src/config.ts
+++ b/packages/coding-agent/src/config.ts
@@ -4,6 +4,7 @@ const claudeCodeConfigSchema = z.object({
   type: z.literal("claude-code"),
   workspaceDir: z.string().default(process.cwd()),
   maxTurns: z.number().int().positive().default(3),
+  additionalDirectories: z.array(z.string()).optional(),
   options: z
     .object({
       model: z.string().optional(),


### PR DESCRIPTION
## Summary
- Uploaded files are saved to `~/.band/uploads/` which is outside the workspace directory
- The Claude Code sandbox restricts file access to `cwd`, causing permission errors when the agent tries to read uploaded files
- Pass the uploads directory as `additionalDirectories` to the Claude Code SDK so the agent can access uploaded files

## Test plan
- [ ] Upload a file in the chat UI and verify the agent can read it without permission errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)