### PR TITLE
feat: switch dashboard to NativeShellCapabilities + HTTP tunnel UI (Phase 3)

### DIFF
--- a/apps/dashboard/src/App.tsx
+++ b/apps/dashboard/src/App.tsx
@@ -1,14 +1,16 @@
 import { DashboardProvider, DashboardShell } from "@band/dashboard-core";
-import { TauriCapabilities, TauriDashboardAdapter } from "@band/dashboard-core/adapters/tauri";
-import { TunnelToolbarButton } from "@/components/TunnelToolbarButton";
+import {
+  HybridDashboardAdapter,
+  NativeShellCapabilities,
+} from "@band/dashboard-core/adapters/hybrid";
 
-const adapter = new TauriDashboardAdapter();
-const capabilities = new TauriCapabilities();
+const adapter = new HybridDashboardAdapter();
+const capabilities = new NativeShellCapabilities();
 
 export default function App() {
   return (
     <DashboardProvider adapter={adapter} capabilities={capabilities}>
-      <DashboardShell toolbarExtra={<TunnelToolbarButton />} />
+      <DashboardShell />
     </DashboardProvider>
   );
 }

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -7,6 +7,7 @@
     "dev": "vite dev --port 3456 --host 0.0.0.0",
     "build": "vite build && esbuild start-server.ts --bundle --platform=node --format=esm --outfile=dist/start-server.mjs --external:./server/server.js",
     "start": "node dist/start-server.mjs",
+    "pretest": "pnpm build",
     "test": "vitest run"
   },
   "dependencies": {
@@ -30,6 +31,7 @@
     "clsx": "^2.1.1",
     "lucide-react": "^0.576.0",
     "nanoid": "^5.1.6",
+    "qrcode.react": "^4.2.0",
     "radix-ui": "^1.4.3",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",

--- a/apps/web/src/components/DashboardView.tsx
+++ b/apps/web/src/components/DashboardView.tsx
@@ -1,15 +1,19 @@
 import { DashboardProvider, DashboardShell } from "@band/dashboard-core";
-import { HybridCapabilities, HybridDashboardAdapter } from "@band/dashboard-core/adapters/hybrid";
+import {
+  HybridDashboardAdapter,
+  NativeShellCapabilities,
+} from "@band/dashboard-core/adapters/hybrid";
 import { TooltipProvider } from "@band/ui";
+import { TunnelToolbarButton } from "./TunnelToolbarButton";
 
 const adapter = new HybridDashboardAdapter();
-const capabilities = new HybridCapabilities();
+const capabilities = new NativeShellCapabilities();
 
 export function DashboardView() {
   return (
     <DashboardProvider adapter={adapter} capabilities={capabilities}>
       <TooltipProvider>
-        <DashboardShell />
+        <DashboardShell toolbarExtra={<TunnelToolbarButton />} />
       </TooltipProvider>
     </DashboardProvider>
   );

--- a/apps/web/src/components/PrereqDialog.tsx
+++ b/apps/web/src/components/PrereqDialog.tsx
@@ -1,0 +1,135 @@
+import {
+  Button,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@band/ui";
+import { Loader2 } from "lucide-react";
+import { useEffect, useState } from "react";
+
+type PrereqStep = "checking" | "missing" | "installing" | "error";
+
+interface PrereqStatus {
+  node: boolean;
+  instatunnel: boolean;
+}
+
+interface Props {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onReady: () => void;
+}
+
+export function PrereqDialog({ open, onOpenChange, onReady }: Props) {
+  const [step, setStep] = useState<PrereqStep>("checking");
+  const [needNode, setNeedNode] = useState(false);
+  const [needInstatunnel, setNeedInstatunnel] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    setStep("checking");
+    setError(null);
+
+    let cancelled = false;
+    (async () => {
+      try {
+        const res = await fetch("/api/prereqs/check");
+        if (!res.ok) throw new Error("Failed to check prerequisites");
+        const status = (await res.json()) as PrereqStatus;
+        if (cancelled) return;
+        if (status.node && status.instatunnel) {
+          onReady();
+          return;
+        }
+        setNeedNode(!status.node);
+        setNeedInstatunnel(!status.instatunnel);
+        setStep("missing");
+      } catch (e) {
+        if (!cancelled) {
+          setError(String(e));
+          setStep("error");
+        }
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [open, onReady]);
+
+  const handleInstall = async () => {
+    try {
+      setStep("installing");
+      if (needNode) {
+        const res = await fetch("/api/prereqs/install-node", { method: "POST" });
+        if (!res.ok) throw new Error("Failed to install Node.js");
+      }
+      if (needInstatunnel) {
+        const res = await fetch("/api/prereqs/install-tunnel", { method: "POST" });
+        if (!res.ok) throw new Error("Failed to install instatunnel");
+      }
+      onReady();
+    } catch (e) {
+      setError(String(e));
+      setStep("error");
+    }
+  };
+
+  const missingLabel =
+    needNode && needInstatunnel ? "Node.js & instatunnel" : needNode ? "Node.js" : "instatunnel";
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-[320px]">
+        <DialogHeader>
+          <DialogTitle>
+            {step === "missing" ? `Install ${missingLabel}` : "Checking Requirements"}
+          </DialogTitle>
+          {step === "missing" && (
+            <DialogDescription>
+              {needNode && needInstatunnel
+                ? "Node.js and instatunnel are required for mobile access."
+                : needNode
+                  ? "Node.js is required to run the web server."
+                  : "instatunnel is required to create a secure tunnel."}
+            </DialogDescription>
+          )}
+        </DialogHeader>
+
+        <div className="flex flex-col items-center gap-4 py-2">
+          {step === "checking" && (
+            <>
+              <Loader2 className="size-8 animate-spin text-muted-foreground" />
+              <p className="text-sm text-muted-foreground">Checking requirements...</p>
+            </>
+          )}
+
+          {step === "missing" && (
+            <Button onClick={handleInstall} className="w-full">
+              Install {missingLabel}
+            </Button>
+          )}
+
+          {step === "installing" && (
+            <>
+              <Loader2 className="size-8 animate-spin text-muted-foreground" />
+              <p className="text-sm text-muted-foreground">Installing {missingLabel}...</p>
+            </>
+          )}
+
+          {step === "error" && (
+            <>
+              <p className="text-sm text-destructive text-center">{error}</p>
+              <Button variant="outline" size="sm" onClick={handleInstall}>
+                Retry
+              </Button>
+            </>
+          )}
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/web/src/components/TunnelDialog.tsx
+++ b/apps/web/src/components/TunnelDialog.tsx
@@ -1,0 +1,296 @@
+import { type ServiceHealth, subscribeSSE, useSettingsStore } from "@band/dashboard-core";
+import { Button, Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from "@band/ui";
+import { Loader2 } from "lucide-react";
+import { QRCodeSVG } from "qrcode.react";
+import { useCallback, useEffect, useState } from "react";
+
+type TunnelStep =
+  | "starting"
+  | "auth_required"
+  | "connecting"
+  | "ready"
+  | "subdomain_taken"
+  | "remote_host"
+  | "error";
+
+interface Props {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onStopped: () => void;
+  initialUrl?: string | null;
+  onTunnelUrl?: (url: string) => void;
+}
+
+export function TunnelDialog({ open, onOpenChange, onStopped, initialUrl, onTunnelUrl }: Props) {
+  const [step, setStep] = useState<TunnelStep>("starting");
+  const [tunnelUrl, setTunnelUrl] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [remoteHost, setRemoteHost] = useState<string | null>(null);
+  const settings = useSettingsStore((s) => s.settings);
+
+  const startConnection = useCallback(async () => {
+    try {
+      setStep("starting");
+
+      // Web server is always running — just check health for tunnel state
+      const healthRes = await fetch("/api/service-health");
+      if (!healthRes.ok) throw new Error("Failed to check service health");
+      const health = (await healthRes.json()) as ServiceHealth;
+
+      // If tunnel is already running on a different host, show message
+      if (health.tunnel && health.tunnel_remote_host) {
+        setRemoteHost(health.tunnel_remote_host);
+        setStep("remote_host");
+        return;
+      }
+
+      // If tunnel is broken (subdomain configured but not healthy), stop it first
+      if (settings.tunnelSubdomain && !health.tunnel) {
+        await fetch("/api/tunnel/stop", { method: "POST" }).catch(() => {});
+      }
+
+      if (settings.tunnelSubdomain) {
+        const authRes = await fetch("/api/tunnel/auth-check");
+        if (!authRes.ok) throw new Error("Failed to check auth");
+        const { authenticated } = (await authRes.json()) as { authenticated: boolean };
+        if (!authenticated) {
+          setStep("auth_required");
+          return;
+        }
+      }
+
+      setStep("connecting");
+      const startRes = await fetch("/api/tunnel/start", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({}),
+      });
+      if (!startRes.ok) {
+        const data = (await startRes.json()) as { error?: string };
+        throw new Error(data.error || "Failed to start tunnel");
+      }
+    } catch (e) {
+      setError(String(e));
+      setStep("error");
+    }
+  }, [settings.tunnelSubdomain]);
+
+  useEffect(() => {
+    if (!open) return;
+
+    if (initialUrl) {
+      setTunnelUrl(initialUrl);
+      setStep("ready");
+      setError(null);
+      setRemoteHost(null);
+    } else {
+      setStep("starting");
+      setTunnelUrl(null);
+      setError(null);
+      setRemoteHost(null);
+    }
+
+    let cancelled = false;
+
+    // Subscribe to SSE tunnel events
+    const unsubscribe = subscribeSSE((event) => {
+      if (cancelled) return;
+      if (event.kind === "tunnel-url" && event.url) {
+        setTunnelUrl(event.url);
+        setStep("ready");
+        onTunnelUrl?.(event.url);
+      } else if (event.kind === "tunnel-error" && event.error) {
+        setError(event.error);
+        setStep("error");
+      } else if (event.kind === "tunnel-subdomain-taken") {
+        setStep("subdomain_taken");
+      } else if (event.kind === "tunnel-remote-host" && event.host) {
+        setRemoteHost(event.host);
+        setStep("remote_host");
+      }
+    });
+
+    if (!initialUrl) {
+      // Check if services are already running
+      (async () => {
+        try {
+          const healthRes = await fetch("/api/service-health");
+          if (!healthRes.ok || cancelled) return;
+          const health = (await healthRes.json()) as ServiceHealth;
+
+          if (health.tunnel && health.tunnel_url && !cancelled) {
+            const tokenRes = await fetch("/api/token");
+            const token = tokenRes.ok ? ((await tokenRes.json()) as { token: string }).token : null;
+            const url = token ? `${health.tunnel_url}?token=${token}` : health.tunnel_url;
+            if (health.tunnel_remote_host) {
+              setRemoteHost(health.tunnel_remote_host);
+              setStep("remote_host");
+            } else {
+              setTunnelUrl(url);
+              setStep("ready");
+              onTunnelUrl?.(url);
+            }
+            return;
+          }
+        } catch {}
+
+        if (!cancelled) {
+          await startConnection();
+        }
+      })();
+    }
+
+    return () => {
+      cancelled = true;
+      unsubscribe();
+    };
+  }, [open, startConnection, initialUrl, onTunnelUrl]);
+
+  const handleRetryAuth = async () => {
+    try {
+      setStep("starting");
+      const authRes = await fetch("/api/tunnel/auth-check");
+      if (!authRes.ok) throw new Error("Failed to check auth");
+      const { authenticated } = (await authRes.json()) as { authenticated: boolean };
+      if (!authenticated) {
+        setStep("auth_required");
+        return;
+      }
+      setStep("connecting");
+      await fetch("/api/tunnel/start", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({}),
+      });
+    } catch (e) {
+      setError(String(e));
+      setStep("error");
+    }
+  };
+
+  const handleContinueRandom = async () => {
+    try {
+      setStep("connecting");
+      await fetch("/api/tunnel/start", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ skipSubdomain: true }),
+      });
+    } catch (e) {
+      setError(String(e));
+      setStep("error");
+    }
+  };
+
+  const handleStop = async () => {
+    await fetch("/api/tunnel/stop", { method: "POST" }).catch(() => {});
+    onStopped();
+    onOpenChange(false);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-[320px]">
+        <DialogHeader>
+          <DialogTitle>Mobile Access</DialogTitle>
+        </DialogHeader>
+
+        <div className="flex flex-col items-center gap-4 py-2">
+          {(step === "starting" || step === "connecting") && (
+            <>
+              <Loader2 className="size-8 animate-spin text-muted-foreground" />
+              <p className="text-sm text-muted-foreground">
+                {step === "starting" ? "Checking services..." : "Creating tunnel..."}
+              </p>
+            </>
+          )}
+
+          {step === "auth_required" && (
+            <>
+              <p className="text-sm text-muted-foreground text-center">
+                You need to log in to instatunnel to use the subdomain{" "}
+                <strong>{settings.tunnelSubdomain}</strong>.
+              </p>
+              <p className="text-xs text-muted-foreground text-center">Run in your terminal:</p>
+              <code className="text-xs bg-muted px-2 py-1 rounded select-all">
+                instatunnel auth login
+              </code>
+              <Button onClick={handleRetryAuth} className="w-full">
+                Try Again
+              </Button>
+              <Button variant="ghost" size="sm" onClick={handleContinueRandom}>
+                Continue without subdomain
+              </Button>
+            </>
+          )}
+
+          {step === "ready" && tunnelUrl && (
+            <>
+              <a
+                href={tunnelUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="rounded-lg bg-white p-3 block cursor-pointer hover:opacity-80 transition-opacity"
+              >
+                <QRCodeSVG value={tunnelUrl} size={200} />
+              </a>
+              <p className="text-xs text-muted-foreground text-center break-all max-w-[260px]">
+                {tunnelUrl.replace(/\?token=[^&]+/, "")}
+              </p>
+            </>
+          )}
+
+          {step === "subdomain_taken" && (
+            <>
+              <p className="text-sm text-muted-foreground text-center">
+                The subdomain <strong>{settings.tunnelSubdomain}</strong> is already in use by
+                another session.
+              </p>
+              <p className="text-xs text-muted-foreground text-center">
+                You can change it in Settings &gt; Web Server.
+              </p>
+              <Button onClick={handleContinueRandom} className="w-full">
+                Continue with Random URL
+              </Button>
+            </>
+          )}
+
+          {step === "remote_host" && (
+            <>
+              <p className="text-sm text-muted-foreground text-center">
+                Tunnel subdomain <strong>{settings.tunnelSubdomain}</strong> is currently in use on{" "}
+                <strong>{remoteHost}</strong>.
+              </p>
+              <p className="text-xs text-muted-foreground text-center">
+                Stop it on the other computer first, or use a different subdomain.
+              </p>
+              <Button onClick={handleContinueRandom} className="w-full">
+                Continue with Random URL
+              </Button>
+              <Button variant="ghost" size="sm" onClick={() => onOpenChange(false)}>
+                Close
+              </Button>
+            </>
+          )}
+
+          {step === "error" && (
+            <>
+              <p className="text-sm text-destructive text-center">{error}</p>
+              <Button variant="outline" size="sm" onClick={startConnection}>
+                Retry
+              </Button>
+            </>
+          )}
+        </div>
+
+        {step === "ready" && (
+          <DialogFooter>
+            <Button variant="ghost" size="sm" onClick={handleStop}>
+              Stop Tunnel
+            </Button>
+          </DialogFooter>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/web/src/components/TunnelToolbarButton.tsx
+++ b/apps/web/src/components/TunnelToolbarButton.tsx
@@ -1,0 +1,48 @@
+import { Button, Tooltip, TooltipContent, TooltipTrigger } from "@band/ui";
+import { Globe } from "lucide-react";
+import { useTunnel } from "@/hooks/use-tunnel";
+import { PrereqDialog } from "./PrereqDialog";
+import { TunnelDialog } from "./TunnelDialog";
+
+export function TunnelToolbarButton() {
+  const {
+    webServerRunning,
+    tunnelUrl,
+    setTunnelUrl,
+    showPrereq,
+    setShowPrereq,
+    onPrereqReady,
+    showDialog,
+    setShowDialog,
+    openDialog,
+    handleStopped,
+  } = useTunnel();
+
+  return (
+    <>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Button
+            size="icon-sm"
+            variant="ghost"
+            className={webServerRunning ? "text-green-500" : ""}
+            onClick={openDialog}
+          >
+            <Globe className="size-5" />
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent>{webServerRunning ? "Mobile access" : "Start tunnel"}</TooltipContent>
+      </Tooltip>
+
+      <PrereqDialog open={showPrereq} onOpenChange={setShowPrereq} onReady={onPrereqReady} />
+
+      <TunnelDialog
+        open={showDialog}
+        onOpenChange={setShowDialog}
+        onStopped={handleStopped}
+        initialUrl={tunnelUrl}
+        onTunnelUrl={setTunnelUrl}
+      />
+    </>
+  );
+}

--- a/apps/web/src/hooks/use-tunnel.ts
+++ b/apps/web/src/hooks/use-tunnel.ts
@@ -1,0 +1,163 @@
+import {
+  isServiceHealthy,
+  type ServiceHealth,
+  subscribeSSE,
+  useSettingsStore,
+} from "@band/dashboard-core";
+import { useCallback, useEffect, useRef, useState } from "react";
+
+const HEALTH_POLL_INTERVAL = 30_000;
+
+export function useTunnel() {
+  const [webServerRunning, setWebServerRunning] = useState(false);
+  const [tunnelUrl, setTunnelUrl] = useState<string | null>(null);
+  const [tunnelRemoteHost, setTunnelRemoteHost] = useState<string | null>(null);
+  const [showPrereq, setShowPrereq] = useState(false);
+  const [showDialog, setShowDialog] = useState(false);
+  const shouldBeRunningRef = useRef(false);
+  const isRecoveringRef = useRef(false);
+  const settings = useSettingsStore((s) => s.settings);
+
+  // Health polling — check service status every 30s, recover tunnel if shouldBeRunning
+  useEffect(() => {
+    let intervalId: ReturnType<typeof setInterval> | undefined;
+    let cancelled = false;
+
+    const recover = async (health: ServiceHealth) => {
+      if (isRecoveringRef.current) return;
+      isRecoveringRef.current = true;
+      try {
+        // Web server is always running (we are it), only restart tunnel
+        if (!health.tunnel && !cancelled) {
+          await fetch("/api/tunnel/start", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({}),
+          });
+        }
+      } catch {
+        // swallow — next poll tick will retry
+      } finally {
+        isRecoveringRef.current = false;
+      }
+    };
+
+    const poll = async () => {
+      try {
+        const res = await fetch("/api/service-health");
+        if (!res.ok || cancelled) return;
+        const health = (await res.json()) as ServiceHealth;
+        if (cancelled) return;
+        setWebServerRunning(isServiceHealthy(health, settings.tunnelSubdomain));
+        if (health.tunnel && health.tunnel_url) {
+          setTunnelUrl((prev) => prev ?? health.tunnel_url);
+        } else if (!health.tunnel) {
+          setTunnelUrl(null);
+        }
+        setTunnelRemoteHost(health.tunnel_remote_host);
+
+        if (shouldBeRunningRef.current && !health.tunnel) {
+          recover(health);
+        }
+      } catch {
+        // ignore errors during polling
+      }
+    };
+
+    poll();
+    intervalId = setInterval(poll, HEALTH_POLL_INTERVAL);
+
+    return () => {
+      cancelled = true;
+      clearInterval(intervalId);
+    };
+  }, [settings.tunnelSubdomain]);
+
+  // Persistent SSE listener for tunnel events (works even when dialog is closed)
+  useEffect(() => {
+    return subscribeSSE((event) => {
+      if (event.kind === "tunnel-url" && event.url) {
+        shouldBeRunningRef.current = true;
+        setTunnelUrl(event.url);
+        setWebServerRunning(true);
+      } else if (event.kind === "tunnel-remote-host" && event.host) {
+        setTunnelRemoteHost(event.host);
+      } else if (event.kind === "tunnel-subdomain-taken") {
+        shouldBeRunningRef.current = false;
+        setShowDialog(true);
+      }
+    });
+  }, []);
+
+  // Auto-start on app launch if enabled
+  useEffect(() => {
+    if (!settings.autoStartTunnel) return;
+
+    let cancelled = false;
+    (async () => {
+      try {
+        const res = await fetch("/api/prereqs/check");
+        if (!res.ok || cancelled) return;
+        const status = (await res.json()) as { node: boolean; instatunnel: boolean };
+        if (!status.node || !status.instatunnel || cancelled) return;
+        shouldBeRunningRef.current = true;
+      } catch {
+        // ignore — health poll will retry
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [settings.autoStartTunnel]);
+
+  // Globe click → fresh health check, update state, then open prereq dialog
+  const openDialog = useCallback(async () => {
+    shouldBeRunningRef.current = true;
+    try {
+      const res = await fetch("/api/service-health");
+      if (res.ok) {
+        const health = (await res.json()) as ServiceHealth;
+        setWebServerRunning(isServiceHealthy(health, settings.tunnelSubdomain));
+        if (health.tunnel && health.tunnel_url) {
+          setTunnelUrl((prev) => prev ?? health.tunnel_url);
+        } else if (!health.tunnel) {
+          setTunnelUrl(null);
+        }
+        setTunnelRemoteHost(health.tunnel_remote_host);
+      }
+    } catch {
+      // continue to dialog even if check fails
+    }
+    setShowPrereq(true);
+  }, [settings.tunnelSubdomain]);
+
+  // Prereq passed → open tunnel dialog
+  const onPrereqReady = useCallback(() => {
+    setShowPrereq(false);
+    setShowDialog(true);
+  }, []);
+
+  const handleStopped = useCallback(() => {
+    shouldBeRunningRef.current = false;
+    isRecoveringRef.current = false;
+    setWebServerRunning(false);
+    setTunnelUrl(null);
+    setTunnelRemoteHost(null);
+    setShowDialog(false);
+  }, []);
+
+  return {
+    webServerRunning,
+    tunnelUrl,
+    tunnelRemoteHost,
+    setTunnelUrl,
+    showPrereq,
+    setShowPrereq,
+    onPrereqReady,
+    showDialog,
+    setShowDialog,
+    openDialog,
+    handleStopped,
+  };
+}

--- a/apps/web/tests/tunnel-and-services.test.ts
+++ b/apps/web/tests/tunnel-and-services.test.ts
@@ -1,0 +1,554 @@
+import { spawn } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { createServer } from "node:net";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+const PROJECT_ROOT = join(import.meta.dirname, "..");
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+interface ServerHandle {
+  url: string;
+  home: string;
+  close: () => Promise<void>;
+}
+
+function createTmpHome(): string {
+  const tmp = mkdtempSync(join(tmpdir(), "band-test-"));
+  const bandDir = join(tmp, ".band");
+  mkdirSync(bandDir, { recursive: true });
+  mkdirSync(join(bandDir, "status"), { recursive: true });
+  return tmp;
+}
+
+function seedState(tmpHome: string, state: object): void {
+  writeFileSync(join(tmpHome, ".band", "state.json"), JSON.stringify(state));
+}
+
+function seedSettings(tmpHome: string, settings: object): void {
+  writeFileSync(join(tmpHome, ".band", "settings.json"), JSON.stringify(settings));
+}
+
+function getRandomPort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const srv = createServer();
+    srv.listen(0, "127.0.0.1", () => {
+      const { port } = srv.address() as { port: number };
+      srv.close(() => resolve(port));
+    });
+    srv.on("error", reject);
+  });
+}
+
+function createDefaultState(tmpHome: string) {
+  const repoDir = join(tmpHome, "repo");
+  mkdirSync(repoDir, { recursive: true });
+  return {
+    projects: [
+      {
+        name: "testproject",
+        path: repoDir,
+        defaultBranch: "main",
+        worktrees: [{ branch: "main", path: repoDir }],
+      },
+    ],
+  };
+}
+
+async function startServer(
+  opts: { tmpHome?: string; env?: Record<string, string> } = {},
+): Promise<ServerHandle> {
+  const home = opts.tmpHome || createTmpHome();
+  const port = await getRandomPort();
+
+  return new Promise((resolve, reject) => {
+    const child = spawn("node", ["dist/start-server.mjs"], {
+      cwd: PROJECT_ROOT,
+      env: {
+        ...process.env,
+        HOME: home,
+        PORT: String(port),
+        NODE_ENV: "production",
+        ...opts.env,
+      },
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+
+    let stderr = "";
+    let settled = false;
+
+    child.stderr!.on("data", (chunk: Buffer) => {
+      stderr += chunk.toString();
+    });
+
+    child.stdout!.on("data", (chunk: Buffer) => {
+      const text = chunk.toString();
+      if (text.includes("listening") && !settled) {
+        settled = true;
+        resolve({
+          url: `http://127.0.0.1:${port}`,
+          home,
+          close: () =>
+            new Promise<void>((r) => {
+              child.on("exit", () => r());
+              child.kill("SIGTERM");
+            }),
+        });
+      }
+    });
+
+    child.on("error", (err) => {
+      if (!settled) {
+        settled = true;
+        reject(err);
+      }
+    });
+
+    child.on("exit", (code) => {
+      if (!settled) {
+        settled = true;
+        reject(new Error(`Server exited with code ${code} before listening.\nstderr: ${stderr}`));
+      }
+    });
+
+    setTimeout(() => {
+      if (!settled) {
+        settled = true;
+        child.kill("SIGTERM");
+        reject(new Error(`Server did not start within 15 s.\nstderr: ${stderr}`));
+      }
+    }, 15_000);
+  });
+}
+
+// ---------------------------------------------------------------------------
+// GET /api/service-health
+// ---------------------------------------------------------------------------
+
+describe("GET /api/service-health", () => {
+  let server: ServerHandle;
+  let tmpHome: string;
+
+  beforeAll(async () => {
+    tmpHome = createTmpHome();
+    seedState(tmpHome, createDefaultState(tmpHome));
+    seedSettings(tmpHome, {});
+    server = await startServer({ tmpHome });
+  });
+
+  afterAll(async () => {
+    await server.close();
+    rmSync(tmpHome, { recursive: true, force: true });
+  });
+
+  it("returns webserver as healthy since the web server is running", async () => {
+    const res = await fetch(`${server.url}/api/service-health`);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      webserver: boolean;
+      tunnel: boolean;
+      tunnel_url: string | null;
+      tunnel_remote_host: string | null;
+    };
+    expect(body.webserver).toBe(true);
+    expect(typeof body.tunnel).toBe("boolean");
+    expect(body.tunnel).toBe(false);
+    expect(body.tunnel_url).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// GET /api/tunnel/status
+// ---------------------------------------------------------------------------
+
+describe("GET /api/tunnel/status", () => {
+  let server: ServerHandle;
+  let tmpHome: string;
+
+  beforeAll(async () => {
+    tmpHome = createTmpHome();
+    seedState(tmpHome, createDefaultState(tmpHome));
+    seedSettings(tmpHome, {});
+    server = await startServer({ tmpHome });
+  });
+
+  afterAll(async () => {
+    await server.close();
+    rmSync(tmpHome, { recursive: true, force: true });
+  });
+
+  it("returns tunnel not running when no tunnel has been started", async () => {
+    const res = await fetch(`${server.url}/api/tunnel/status`);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      running: boolean;
+      url: string | null;
+      remoteHost: string | null;
+    };
+    expect(body.running).toBe(false);
+    expect(body.url).toBeNull();
+    expect(body.remoteHost).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// POST /api/tunnel/stop
+// ---------------------------------------------------------------------------
+
+describe("POST /api/tunnel/stop", () => {
+  let server: ServerHandle;
+  let tmpHome: string;
+
+  beforeAll(async () => {
+    tmpHome = createTmpHome();
+    seedState(tmpHome, createDefaultState(tmpHome));
+    seedSettings(tmpHome, {});
+    server = await startServer({ tmpHome });
+  });
+
+  afterAll(async () => {
+    await server.close();
+    rmSync(tmpHome, { recursive: true, force: true });
+  });
+
+  it("succeeds even when no tunnel is running", async () => {
+    const res = await fetch(`${server.url}/api/tunnel/stop`, { method: "POST" });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { ok: boolean };
+    expect(body.ok).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// GET /api/prereqs/check
+// ---------------------------------------------------------------------------
+
+describe("GET /api/prereqs/check", () => {
+  let server: ServerHandle;
+  let tmpHome: string;
+
+  beforeAll(async () => {
+    tmpHome = createTmpHome();
+    seedState(tmpHome, createDefaultState(tmpHome));
+    seedSettings(tmpHome, {});
+    server = await startServer({ tmpHome });
+  });
+
+  afterAll(async () => {
+    await server.close();
+    rmSync(tmpHome, { recursive: true, force: true });
+  });
+
+  it("returns prerequisite status with node and instatunnel booleans", async () => {
+    const res = await fetch(`${server.url}/api/prereqs/check`);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { node: boolean; instatunnel: boolean };
+    expect(typeof body.node).toBe("boolean");
+    expect(typeof body.instatunnel).toBe("boolean");
+    // Node.js is always available since we're running this test with it
+    expect(body.node).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// GET /api/cli/check
+// ---------------------------------------------------------------------------
+
+describe("GET /api/cli/check", () => {
+  let server: ServerHandle;
+  let tmpHome: string;
+
+  beforeAll(async () => {
+    tmpHome = createTmpHome();
+    seedState(tmpHome, createDefaultState(tmpHome));
+    seedSettings(tmpHome, {});
+    server = await startServer({ tmpHome });
+  });
+
+  afterAll(async () => {
+    await server.close();
+    rmSync(tmpHome, { recursive: true, force: true });
+  });
+
+  it("returns a valid CLI status string", async () => {
+    const res = await fetch(`${server.url}/api/cli/check`);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { status: string };
+    expect(typeof body.status).toBe("string");
+    expect([
+      "Installed",
+      "NotInstalled",
+      "ConflictingBinary",
+      "DirNotFound",
+      "NotWritable",
+    ]).toContain(body.status);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// GET /api/token
+// ---------------------------------------------------------------------------
+
+describe("GET /api/token", () => {
+  let server: ServerHandle;
+  let tmpHome: string;
+
+  beforeAll(async () => {
+    tmpHome = createTmpHome();
+    seedState(tmpHome, createDefaultState(tmpHome));
+    seedSettings(tmpHome, {});
+    server = await startServer({ tmpHome, env: { BAND_TOKEN_SECRET: "test-secret-for-token" } });
+  });
+
+  afterAll(async () => {
+    await server.close();
+    rmSync(tmpHome, { recursive: true, force: true });
+  });
+
+  it("returns a token when BAND_TOKEN_SECRET is configured", async () => {
+    // We need to auth first to access the endpoint
+    const { createHmac } = await import("node:crypto");
+    const expectedToken = createHmac("sha256", "test-secret-for-token")
+      .update("band-access")
+      .digest("hex");
+
+    const res = await fetch(`${server.url}/api/token`, {
+      headers: { Cookie: `band_token=${expectedToken}` },
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { token: string };
+    expect(typeof body.token).toBe("string");
+    expect(body.token.length).toBeGreaterThan(0);
+  });
+});
+
+describe("GET /api/token — no secret configured", () => {
+  let server: ServerHandle;
+  let tmpHome: string;
+
+  beforeAll(async () => {
+    tmpHome = createTmpHome();
+    seedState(tmpHome, createDefaultState(tmpHome));
+    seedSettings(tmpHome, {});
+    // No BAND_TOKEN_SECRET env var
+    server = await startServer({ tmpHome });
+  });
+
+  afterAll(async () => {
+    await server.close();
+    rmSync(tmpHome, { recursive: true, force: true });
+  });
+
+  it("returns 404 when no token secret is configured", async () => {
+    const res = await fetch(`${server.url}/api/token`);
+    expect(res.status).toBe(404);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBeTruthy();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// GET /api/tunnel/auth-check
+// ---------------------------------------------------------------------------
+
+describe("GET /api/tunnel/auth-check", () => {
+  let server: ServerHandle;
+  let tmpHome: string;
+
+  beforeAll(async () => {
+    tmpHome = createTmpHome();
+    seedState(tmpHome, createDefaultState(tmpHome));
+    seedSettings(tmpHome, {});
+    server = await startServer({ tmpHome });
+  });
+
+  afterAll(async () => {
+    await server.close();
+    rmSync(tmpHome, { recursive: true, force: true });
+  });
+
+  it("returns an authenticated boolean", async () => {
+    const res = await fetch(`${server.url}/api/tunnel/auth-check`);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { authenticated: boolean };
+    expect(typeof body.authenticated).toBe("boolean");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// POST /api/tunnel/stop — resets tunnel status
+// ---------------------------------------------------------------------------
+
+describe("POST /api/tunnel/stop — resets tunnel status", () => {
+  let server: ServerHandle;
+  let tmpHome: string;
+
+  beforeAll(async () => {
+    tmpHome = createTmpHome();
+    seedState(tmpHome, createDefaultState(tmpHome));
+    seedSettings(tmpHome, {});
+    server = await startServer({ tmpHome });
+  });
+
+  afterAll(async () => {
+    await server.close();
+    rmSync(tmpHome, { recursive: true, force: true });
+  });
+
+  it("tunnel status remains not-running after stop", async () => {
+    // Stop tunnel (even though none is running — should succeed)
+    const stopRes = await fetch(`${server.url}/api/tunnel/stop`, { method: "POST" });
+    expect(stopRes.status).toBe(200);
+
+    // Verify tunnel status is still not running
+    const statusRes = await fetch(`${server.url}/api/tunnel/status`);
+    expect(statusRes.status).toBe(200);
+    const status = (await statusRes.json()) as { running: boolean; url: string | null };
+    expect(status.running).toBe(false);
+    expect(status.url).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// SSE stream — tunnel events propagate
+// ---------------------------------------------------------------------------
+
+describe("GET /api/status/stream — SSE event format", () => {
+  let server: ServerHandle;
+  let tmpHome: string;
+
+  beforeAll(async () => {
+    tmpHome = createTmpHome();
+    seedState(tmpHome, createDefaultState(tmpHome));
+    seedSettings(tmpHome, {});
+    server = await startServer({ tmpHome });
+  });
+
+  afterAll(async () => {
+    await server.close();
+    rmSync(tmpHome, { recursive: true, force: true });
+  });
+
+  it("returns SSE content-type and streams events", async () => {
+    const controller = new AbortController();
+
+    const res = await fetch(`${server.url}/api/status/stream`, {
+      signal: controller.signal,
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toContain("text/event-stream");
+
+    // Read one chunk then abort — the stream stays open indefinitely
+    const reader = res.body!.getReader();
+    const decoder = new TextDecoder();
+
+    const readPromise = reader.read().then(({ value }) => {
+      return value ? decoder.decode(value) : "";
+    });
+
+    const timeout = new Promise<string>((resolve) => setTimeout(() => resolve(""), 2000));
+    const chunk = await Promise.race([readPromise, timeout]);
+
+    controller.abort();
+
+    // The stream should have sent at least a snapshot event (even if empty)
+    // because subscribe() in watcher.ts sends a snapshot on connect
+    expect(typeof chunk).toBe("string");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Auth enforcement on tunnel/service endpoints
+// ---------------------------------------------------------------------------
+
+describe("Tunnel and service endpoints require auth when secret is set", () => {
+  let server: ServerHandle;
+  let tmpHome: string;
+  let authCookie: string;
+
+  beforeAll(async () => {
+    tmpHome = createTmpHome();
+    seedState(tmpHome, createDefaultState(tmpHome));
+    seedSettings(tmpHome, {});
+    server = await startServer({ tmpHome, env: { BAND_TOKEN_SECRET: "my-test-secret" } });
+
+    const { createHmac } = await import("node:crypto");
+    const token = createHmac("sha256", "my-test-secret").update("band-access").digest("hex");
+    authCookie = `band_token=${token}`;
+  });
+
+  afterAll(async () => {
+    await server.close();
+    rmSync(tmpHome, { recursive: true, force: true });
+  });
+
+  it("returns 401 for /api/service-health without auth", async () => {
+    const res = await fetch(`${server.url}/api/service-health`);
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 200 for /api/service-health with auth", async () => {
+    const res = await fetch(`${server.url}/api/service-health`, {
+      headers: { Cookie: authCookie },
+    });
+    expect(res.status).toBe(200);
+  });
+
+  it("returns 401 for /api/tunnel/status without auth", async () => {
+    const res = await fetch(`${server.url}/api/tunnel/status`);
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 200 for /api/tunnel/status with auth", async () => {
+    const res = await fetch(`${server.url}/api/tunnel/status`, {
+      headers: { Cookie: authCookie },
+    });
+    expect(res.status).toBe(200);
+  });
+
+  it("returns 401 for /api/tunnel/stop without auth", async () => {
+    const res = await fetch(`${server.url}/api/tunnel/stop`, { method: "POST" });
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 401 for /api/prereqs/check without auth", async () => {
+    const res = await fetch(`${server.url}/api/prereqs/check`);
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 200 for /api/prereqs/check with auth", async () => {
+    const res = await fetch(`${server.url}/api/prereqs/check`, {
+      headers: { Cookie: authCookie },
+    });
+    expect(res.status).toBe(200);
+  });
+
+  it("returns 401 for /api/cli/check without auth", async () => {
+    const res = await fetch(`${server.url}/api/cli/check`);
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 200 for /api/cli/check with auth", async () => {
+    const res = await fetch(`${server.url}/api/cli/check`, {
+      headers: { Cookie: authCookie },
+    });
+    expect(res.status).toBe(200);
+  });
+
+  it("returns 401 for /api/tunnel/auth-check without auth", async () => {
+    const res = await fetch(`${server.url}/api/tunnel/auth-check`);
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 200 for /api/tunnel/auth-check with auth", async () => {
+    const res = await fetch(`${server.url}/api/tunnel/auth-check`, {
+      headers: { Cookie: authCookie },
+    });
+    expect(res.status).toBe(200);
+  });
+});

--- a/packages/dashboard-core/src/adapter.ts
+++ b/packages/dashboard-core/src/adapter.ts
@@ -64,16 +64,4 @@ export interface PlatformCapabilities {
   pickFolder?(): Promise<string | null>;
   openUrl?(url: string): Promise<void>;
   getWorkspaceHref?(workspaceId: string): string;
-  tunnel?: {
-    check(): Promise<boolean>;
-    start(): Promise<void>;
-    stop(): Promise<void>;
-    install(): Promise<void>;
-    subscribeTunnelUrl(onUrl: (url: string) => void, onError: (err: string) => void): Unsubscribe;
-  };
-  webserver?: {
-    start(): Promise<void>;
-    stop(): Promise<void>;
-    getToken(): Promise<string>;
-  };
 }

--- a/packages/dashboard-core/src/adapters/hybrid.ts
+++ b/packages/dashboard-core/src/adapters/hybrid.ts
@@ -56,10 +56,11 @@ export class HybridDashboardAdapter extends WebDashboardAdapter {
 }
 
 /**
- * Hybrid capabilities: delegates to TauriCapabilities for native features
- * when inside Tauri, falls back to WebCapabilities otherwise.
+ * Native shell capabilities: Tauri IPC for native OS features
+ * (copy path, reveal in finder, pick folder, open URL).
+ * Tunnel and web server management are handled via HTTP endpoints.
  */
-export class HybridCapabilities implements PlatformCapabilities {
+export class NativeShellCapabilities implements PlatformCapabilities {
   private web = new WebCapabilities();
 
   get copyPath(): boolean {
@@ -88,53 +89,7 @@ export class HybridCapabilities implements PlatformCapabilities {
     const { open } = await import("@tauri-apps/plugin-shell");
     await open(url);
   }
-
-  tunnel = isTauri()
-    ? {
-        async check(): Promise<boolean> {
-          return tauriInvoke<boolean>("tunnel_check");
-        },
-        async start(): Promise<void> {
-          await tauriInvoke("tunnel_start");
-        },
-        async stop(): Promise<void> {
-          await tauriInvoke("tunnel_stop");
-        },
-        async install(): Promise<void> {
-          await tauriInvoke("tunnel_install");
-        },
-        subscribeTunnelUrl(
-          onUrl: (url: string) => void,
-          onError: (err: string) => void,
-        ): Unsubscribe {
-          let cleanup: (() => void) | undefined;
-
-          (async () => {
-            const unlistenUrl = await tauriListen<string>("tunnel-url", onUrl);
-            const unlistenError = await tauriListen<string>("tunnel-error", onError);
-
-            cleanup = () => {
-              unlistenUrl();
-              unlistenError();
-            };
-          })();
-
-          return () => cleanup?.();
-        },
-      }
-    : undefined;
-
-  webserver = isTauri()
-    ? {
-        async start(): Promise<void> {
-          await tauriInvoke("webserver_start");
-        },
-        async stop(): Promise<void> {
-          await tauriInvoke("webserver_stop");
-        },
-        async getToken(): Promise<string> {
-          return tauriInvoke<string>("webserver_get_token");
-        },
-      }
-    : undefined;
 }
+
+/** @deprecated Use NativeShellCapabilities instead */
+export const HybridCapabilities = NativeShellCapabilities;

--- a/packages/dashboard-core/src/adapters/tauri.ts
+++ b/packages/dashboard-core/src/adapters/tauri.ts
@@ -188,46 +188,4 @@ export class TauriCapabilities implements PlatformCapabilities {
     const { open } = await import("@tauri-apps/plugin-shell");
     await open(url);
   }
-
-  tunnel = {
-    async check(): Promise<boolean> {
-      return invoke<boolean>("tunnel_check");
-    },
-    async start(): Promise<void> {
-      await invoke("tunnel_start");
-    },
-    async stop(): Promise<void> {
-      await invoke("tunnel_stop");
-    },
-    async install(): Promise<void> {
-      await invoke("tunnel_install");
-    },
-    subscribeTunnelUrl(onUrl: (url: string) => void, onError: (err: string) => void): Unsubscribe {
-      let cleanup: (() => void) | undefined;
-
-      (async () => {
-        const unlistenUrl = await listen<string>("tunnel-url", onUrl);
-        const unlistenError = await listen<string>("tunnel-error", onError);
-
-        cleanup = () => {
-          unlistenUrl();
-          unlistenError();
-        };
-      })();
-
-      return () => cleanup?.();
-    },
-  };
-
-  webserver = {
-    async start(): Promise<void> {
-      await invoke("webserver_start");
-    },
-    async stop(): Promise<void> {
-      await invoke("webserver_stop");
-    },
-    async getToken(): Promise<string> {
-      return invoke<string>("webserver_get_token");
-    },
-  };
 }

--- a/packages/dashboard-core/src/adapters/web.ts
+++ b/packages/dashboard-core/src/adapters/web.ts
@@ -1,4 +1,5 @@
 import type { DashboardAdapter, PlatformCapabilities, Unsubscribe } from "../adapter";
+import { subscribeSSE } from "../lib/sse";
 import type {
   CIStatus,
   CliStatus,
@@ -11,48 +12,6 @@ import type {
   WorkspaceDiff,
   WorkspaceStatus,
 } from "../types";
-
-type SSEEvent = {
-  kind: "update" | "remove" | "snapshot" | "branch-status";
-  status?: WorkspaceStatus;
-  statuses?: WorkspaceStatus[];
-  workspaceId?: string;
-  git?: GitStatus;
-  ci?: CIStatus;
-};
-
-type SSEHandler = (data: SSEEvent) => void;
-
-let _eventSource: EventSource | null = null;
-const _handlers = new Set<SSEHandler>();
-
-function _ensureEventSource(): void {
-  if (_eventSource) return;
-  const es = new EventSource("/api/status/stream");
-  es.onmessage = (event) => {
-    try {
-      const data = JSON.parse(event.data) as SSEEvent;
-      for (const handler of _handlers) {
-        handler(data);
-      }
-    } catch {
-      // Skip malformed events
-    }
-  };
-  _eventSource = es;
-}
-
-function _addHandler(handler: SSEHandler): Unsubscribe {
-  _handlers.add(handler);
-  _ensureEventSource();
-  return () => {
-    _handlers.delete(handler);
-    if (_handlers.size === 0) {
-      _eventSource?.close();
-      _eventSource = null;
-    }
-  };
-}
 
 export class WebDashboardAdapter implements DashboardAdapter {
   async listProjects(): Promise<ProjectInfo[]> {
@@ -153,7 +112,7 @@ export class WebDashboardAdapter implements DashboardAdapter {
     onUpdate: (status: WorkspaceStatus) => void,
     onRemove: (workspaceId: string) => void,
   ): Unsubscribe {
-    return _addHandler((data) => {
+    return subscribeSSE((data) => {
       if (data.kind === "snapshot" && data.statuses) {
         for (const status of data.statuses) {
           onUpdate(status);
@@ -175,7 +134,7 @@ export class WebDashboardAdapter implements DashboardAdapter {
     onGit: (workspaceId: string, git: GitStatus) => void,
     onCI: (workspaceId: string, ci: CIStatus) => void,
   ): Unsubscribe {
-    return _addHandler((data) => {
+    return subscribeSSE((data) => {
       if (data.kind === "branch-status" && data.workspaceId) {
         if (data.git) onGit(data.workspaceId, data.git);
         if (data.ci) onCI(data.workspaceId, data.ci);
@@ -195,11 +154,15 @@ export class WebDashboardAdapter implements DashboardAdapter {
   }
 
   async checkCli(): Promise<CliStatus> {
-    return "Installed";
+    const res = await fetch("/api/cli/check");
+    if (!res.ok) throw new Error("Failed to check CLI");
+    const data = (await res.json()) as { status: CliStatus };
+    return data.status;
   }
 
   async installCli(): Promise<void> {
-    // CLI install not supported in web adapter
+    const res = await fetch("/api/cli/install", { method: "POST" });
+    if (!res.ok) throw new Error("Failed to install CLI");
   }
 
   async getWorkspaceDiff(workspaceId: string): Promise<WorkspaceDiff> {

--- a/packages/dashboard-core/src/index.ts
+++ b/packages/dashboard-core/src/index.ts
@@ -28,6 +28,7 @@ export {
 export { isServiceHealthy, type ServiceHealth } from "./lib/service-health";
 // Lib
 export { playSound, SOUNDS, type SoundId } from "./lib/sounds";
+export { type SSEEvent, subscribeSSE } from "./lib/sse";
 export type { DashboardState, DashboardStore } from "./stores/dashboard-store";
 export { createDashboardStore } from "./stores/dashboard-store";
 // Stores

--- a/packages/dashboard-core/src/lib/sse.ts
+++ b/packages/dashboard-core/src/lib/sse.ts
@@ -1,0 +1,55 @@
+import type { CIStatus, GitStatus, WorkspaceStatus } from "../types";
+
+export type SSEEvent = {
+  kind:
+    | "update"
+    | "remove"
+    | "snapshot"
+    | "branch-status"
+    | "tunnel-url"
+    | "tunnel-error"
+    | "tunnel-subdomain-taken"
+    | "tunnel-remote-host";
+  status?: WorkspaceStatus;
+  statuses?: WorkspaceStatus[];
+  workspaceId?: string;
+  git?: GitStatus;
+  ci?: CIStatus;
+  url?: string;
+  error?: string;
+  host?: string;
+};
+
+type SSEHandler = (data: SSEEvent) => void;
+type Unsubscribe = () => void;
+
+let _eventSource: EventSource | null = null;
+const _handlers = new Set<SSEHandler>();
+
+function _ensureEventSource(): void {
+  if (_eventSource) return;
+  const es = new EventSource("/api/status/stream");
+  es.onmessage = (event) => {
+    try {
+      const data = JSON.parse(event.data) as SSEEvent;
+      for (const handler of _handlers) {
+        handler(data);
+      }
+    } catch {
+      // Skip malformed events
+    }
+  };
+  _eventSource = es;
+}
+
+export function subscribeSSE(handler: SSEHandler): Unsubscribe {
+  _handlers.add(handler);
+  _ensureEventSource();
+  return () => {
+    _handlers.delete(handler);
+    if (_handlers.size === 0) {
+      _eventSource?.close();
+      _eventSource = null;
+    }
+  };
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -174,6 +174,9 @@ importers:
       nanoid:
         specifier: ^5.1.6
         version: 5.1.6
+      qrcode.react:
+        specifier: ^4.2.0
+        version: 4.2.0(react@19.2.4)
       radix-ui:
         specifier: ^1.4.3
         version: 1.4.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)


### PR DESCRIPTION
## Summary
- Extract shared SSE subscription module (`packages/dashboard-core/src/lib/sse.ts`) with tunnel event types
- Wire `WebDashboardAdapter.checkCli()` / `installCli()` to real HTTP endpoints instead of hardcoded stubs
- Simplify `PlatformCapabilities` — remove `tunnel` and `webserver` (now HTTP-only), rename `HybridCapabilities` → `NativeShellCapabilities`
- Move tunnel UI (`TunnelToolbarButton`, `TunnelDialog`, `PrereqDialog`, `use-tunnel` hook) from Tauri IPC to web-served dashboard using HTTP + SSE
- Switch `apps/dashboard/src/App.tsx` from `TauriDashboardAdapter` + `TauriCapabilities` to `HybridDashboardAdapter` + `NativeShellCapabilities`
- Add `pretest` build step so tests work without a prior manual build
- Add 21 integration tests covering service-health, tunnel status/stop, prereqs, CLI check, token, auth-check, SSE stream, and auth enforcement

## Test plan
- [x] TypeScript type-checks pass for dashboard-core, apps/web, apps/dashboard
- [x] `pnpm build:web` succeeds
- [x] All 56 integration tests pass (21 new + 35 existing)
- [x] `biome check` passes
- [ ] CI passes
- [ ] Manual: open dashboard in browser → projects load, tunnel globe button works
- [ ] Manual: click globe → prereq dialog → tunnel dialog → QR code
- [ ] Manual: in Tauri app → open workspace still launches VS Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)