### PR TITLE
fix: preserve CI status and Tauri workspace selection

### DIFF
--- a/apps/web/src/lib/branch-status-poller.ts
+++ b/apps/web/src/lib/branch-status-poller.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, writeFileSync } from "node:fs";
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { execGh, execGit } from "./git";
 import { bandHome, loadState } from "./state";
@@ -225,9 +225,21 @@ async function pollTick() {
   await Promise.allSettled(
     workspaces.map(async (ws) => {
       const git = await getGitStatus(ws.worktreePath);
+
       let ci: CIStatus = { state: "none" };
       if (isCITick) {
         ci = await getCIStatus(ws.worktreePath, ws.branch);
+      } else {
+        // Preserve existing CI status from file on non-CI ticks
+        const filePath = join(dir, `${ws.workspaceId}.json`);
+        try {
+          const existing = JSON.parse(readFileSync(filePath, "utf-8")) as {
+            ci?: CIStatus;
+          };
+          if (existing.ci) ci = existing.ci;
+        } catch {
+          // File may not exist yet
+        }
       }
 
       const data = {

--- a/packages/dashboard-core/src/adapter.ts
+++ b/packages/dashboard-core/src/adapter.ts
@@ -63,5 +63,5 @@ export interface PlatformCapabilities {
   revealInFinder?(path: string): Promise<void>;
   pickFolder?(): Promise<string | null>;
   openUrl?(url: string): Promise<void>;
-  getWorkspaceHref?(workspaceId: string): string;
+  getWorkspaceHref?(workspaceId: string): string | undefined;
 }

--- a/packages/dashboard-core/src/adapters/hybrid.ts
+++ b/packages/dashboard-core/src/adapters/hybrid.ts
@@ -67,7 +67,10 @@ export class NativeShellCapabilities implements PlatformCapabilities {
     return isTauri();
   }
 
-  getWorkspaceHref(workspaceId: string): string {
+  getWorkspaceHref(workspaceId: string): string | undefined {
+    // Inside Tauri, clicking a workspace should focus the IDE window
+    // via openWorkspace (Tauri IPC), not navigate to the chat page.
+    if (isTauri()) return undefined;
     return this.web.getWorkspaceHref(workspaceId);
   }
 


### PR DESCRIPTION
## Summary
- **CI status flickering fix**: The branch-status poller only fetches CI status every 30s (6th tick), but on intermediate ticks it was overwriting CI with `{ state: "none" }`. The file watcher would emit the change, causing CI indicators to appear then vanish ~5 seconds later. Now non-CI ticks preserve the existing CI status from disk.
- **Tauri workspace click fix**: Inside Tauri, `getWorkspaceHref` was returning a `/chat/...` URL causing workspace cards to render as `<a>` links instead of calling `openWorkspace` via Tauri IPC. Now returns `undefined` inside Tauri so clicks focus the IDE window.

## Test plan
- [ ] Verify CI status indicators persist between polling intervals
- [ ] In Tauri app: click workspace card → IDE window should focus (not navigate to chat)
- [ ] In browser: click workspace card → should navigate to chat page
- [ ] All existing tests pass (56 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)