### PR TITLE
feat: wire stop button to abort agent on server

### DIFF
--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -132,6 +132,11 @@ export function ChatView({
     },
   });
 
+  const handleStop = useCallback(() => {
+    transport.abort();
+    stop();
+  }, [transport, stop]);
+
   const isStreaming = status === "submitted" || status === "streaming";
 
   const loadMessages = useCallback(
@@ -345,7 +350,7 @@ export function ChatView({
           <PromptInputTextarea placeholder="Type a message..." />
           <PromptInputActions>
             <PromptInputAttach />
-            <PromptInputSubmit status={status} onStop={stop} />
+            <PromptInputSubmit status={status} onStop={handleStop} />
           </PromptInputActions>
         </PromptInput>
       </div>

--- a/apps/web/src/lib/agent-pool.ts
+++ b/apps/web/src/lib/agent-pool.ts
@@ -22,6 +22,10 @@ function getAgentConfig(worktreePath: string): CodingAgentConfig {
   } as CodingAgentConfig;
 }
 
+export function getAgent(workspaceId: string): CodingAgent | undefined {
+  return pool.get(workspaceId);
+}
+
 export async function getOrCreateAgent(
   workspaceId: string,
   worktreePath: string,

--- a/apps/web/src/lib/task-chat-transport.ts
+++ b/apps/web/src/lib/task-chat-transport.ts
@@ -57,6 +57,14 @@ export class TaskChatTransport implements ChatTransport<UIMessage> {
     this.getSessionId = getSessionId;
   }
 
+  abort(): void {
+    fetch(`/api/tasks/${encodeURIComponent(this.workspaceId)}/abort`, {
+      method: "POST",
+    }).catch(() => {
+      // fire-and-forget
+    });
+  }
+
   async sendMessages({
     messages,
     abortSignal,

--- a/apps/web/src/lib/task-runner.ts
+++ b/apps/web/src/lib/task-runner.ts
@@ -1,6 +1,6 @@
 import { createLogger } from "@band/logger";
 import type { UIMessageChunk } from "ai";
-import { getOrCreateAgent } from "./agent-pool";
+import { getAgent, getOrCreateAgent } from "./agent-pool";
 import { createPendingInput } from "./pending-inputs";
 import { resolveWorkspace } from "./workspace";
 
@@ -90,6 +90,27 @@ export function submitTask(
   });
 
   return toTaskInfo(task);
+}
+
+export function abortTask(workspaceId: string): boolean {
+  const task = tasks.get(workspaceId);
+  if (!task || task.status !== "running") {
+    return false;
+  }
+
+  const agent = getAgent(workspaceId);
+  if (agent?.abort) {
+    agent.abort();
+  }
+
+  task.status = "failed";
+  task.completedAt = Date.now();
+  emit(workspaceId, task, { type: "error", errorText: "Task aborted by user" });
+  emit(workspaceId, task, { type: "finish" });
+  scheduleExpiry(workspaceId);
+
+  log.info({ workspaceId }, "task aborted by user");
+  return true;
 }
 
 async function runTask(workspaceId: string, task: InternalTask) {

--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -42,6 +42,7 @@ import { Route as ApiWorkspaceWorkspaceIdFilesRouteImport } from './routes/api/w
 import { Route as ApiWorkspaceWorkspaceIdFileRouteImport } from './routes/api/workspace.$workspaceId.file'
 import { Route as ApiWorkspaceWorkspaceIdDiffRouteImport } from './routes/api/workspace.$workspaceId.diff'
 import { Route as ApiTasksWorkspaceIdStreamRouteImport } from './routes/api/tasks.$workspaceId.stream'
+import { Route as ApiTasksWorkspaceIdAbortRouteImport } from './routes/api/tasks.$workspaceId.abort'
 import { Route as ApiSessionsWorkspaceIdSessionIdMessagesRouteImport } from './routes/api/sessions.$workspaceId.$sessionId.messages'
 
 const IndexRoute = IndexRouteImport.update({
@@ -213,6 +214,12 @@ const ApiTasksWorkspaceIdStreamRoute =
     path: '/stream',
     getParentRoute: () => ApiTasksWorkspaceIdRoute,
   } as any)
+const ApiTasksWorkspaceIdAbortRoute =
+  ApiTasksWorkspaceIdAbortRouteImport.update({
+    id: '/abort',
+    path: '/abort',
+    getParentRoute: () => ApiTasksWorkspaceIdRoute,
+  } as any)
 const ApiSessionsWorkspaceIdSessionIdMessagesRoute =
   ApiSessionsWorkspaceIdSessionIdMessagesRouteImport.update({
     id: '/$sessionId/messages',
@@ -250,6 +257,7 @@ export interface FileRoutesByFullPath {
   '/api/workspaces/create': typeof ApiWorkspacesCreateRoute
   '/api/workspaces/remove': typeof ApiWorkspacesRemoveRoute
   '/api/workspaces/run-script': typeof ApiWorkspacesRunScriptRoute
+  '/api/tasks/$workspaceId/abort': typeof ApiTasksWorkspaceIdAbortRoute
   '/api/tasks/$workspaceId/stream': typeof ApiTasksWorkspaceIdStreamRoute
   '/api/workspace/$workspaceId/diff': typeof ApiWorkspaceWorkspaceIdDiffRoute
   '/api/workspace/$workspaceId/file': typeof ApiWorkspaceWorkspaceIdFileRoute
@@ -286,6 +294,7 @@ export interface FileRoutesByTo {
   '/api/workspaces/create': typeof ApiWorkspacesCreateRoute
   '/api/workspaces/remove': typeof ApiWorkspacesRemoveRoute
   '/api/workspaces/run-script': typeof ApiWorkspacesRunScriptRoute
+  '/api/tasks/$workspaceId/abort': typeof ApiTasksWorkspaceIdAbortRoute
   '/api/tasks/$workspaceId/stream': typeof ApiTasksWorkspaceIdStreamRoute
   '/api/workspace/$workspaceId/diff': typeof ApiWorkspaceWorkspaceIdDiffRoute
   '/api/workspace/$workspaceId/file': typeof ApiWorkspaceWorkspaceIdFileRoute
@@ -323,6 +332,7 @@ export interface FileRoutesById {
   '/api/workspaces/create': typeof ApiWorkspacesCreateRoute
   '/api/workspaces/remove': typeof ApiWorkspacesRemoveRoute
   '/api/workspaces/run-script': typeof ApiWorkspacesRunScriptRoute
+  '/api/tasks/$workspaceId/abort': typeof ApiTasksWorkspaceIdAbortRoute
   '/api/tasks/$workspaceId/stream': typeof ApiTasksWorkspaceIdStreamRoute
   '/api/workspace/$workspaceId/diff': typeof ApiWorkspaceWorkspaceIdDiffRoute
   '/api/workspace/$workspaceId/file': typeof ApiWorkspaceWorkspaceIdFileRoute
@@ -361,6 +371,7 @@ export interface FileRouteTypes {
     | '/api/workspaces/create'
     | '/api/workspaces/remove'
     | '/api/workspaces/run-script'
+    | '/api/tasks/$workspaceId/abort'
     | '/api/tasks/$workspaceId/stream'
     | '/api/workspace/$workspaceId/diff'
     | '/api/workspace/$workspaceId/file'
@@ -397,6 +408,7 @@ export interface FileRouteTypes {
     | '/api/workspaces/create'
     | '/api/workspaces/remove'
     | '/api/workspaces/run-script'
+    | '/api/tasks/$workspaceId/abort'
     | '/api/tasks/$workspaceId/stream'
     | '/api/workspace/$workspaceId/diff'
     | '/api/workspace/$workspaceId/file'
@@ -433,6 +445,7 @@ export interface FileRouteTypes {
     | '/api/workspaces/create'
     | '/api/workspaces/remove'
     | '/api/workspaces/run-script'
+    | '/api/tasks/$workspaceId/abort'
     | '/api/tasks/$workspaceId/stream'
     | '/api/workspace/$workspaceId/diff'
     | '/api/workspace/$workspaceId/file'
@@ -704,6 +717,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ApiTasksWorkspaceIdStreamRouteImport
       parentRoute: typeof ApiTasksWorkspaceIdRoute
     }
+    '/api/tasks/$workspaceId/abort': {
+      id: '/api/tasks/$workspaceId/abort'
+      path: '/abort'
+      fullPath: '/api/tasks/$workspaceId/abort'
+      preLoaderRoute: typeof ApiTasksWorkspaceIdAbortRouteImport
+      parentRoute: typeof ApiTasksWorkspaceIdRoute
+    }
     '/api/sessions/$workspaceId/$sessionId/messages': {
       id: '/api/sessions/$workspaceId/$sessionId/messages'
       path: '/$sessionId/messages'
@@ -748,10 +768,12 @@ const ApiSessionsWorkspaceIdRouteWithChildren =
   )
 
 interface ApiTasksWorkspaceIdRouteChildren {
+  ApiTasksWorkspaceIdAbortRoute: typeof ApiTasksWorkspaceIdAbortRoute
   ApiTasksWorkspaceIdStreamRoute: typeof ApiTasksWorkspaceIdStreamRoute
 }
 
 const ApiTasksWorkspaceIdRouteChildren: ApiTasksWorkspaceIdRouteChildren = {
+  ApiTasksWorkspaceIdAbortRoute: ApiTasksWorkspaceIdAbortRoute,
   ApiTasksWorkspaceIdStreamRoute: ApiTasksWorkspaceIdStreamRoute,
 }
 

--- a/apps/web/src/routes/api/status.stream.ts
+++ b/apps/web/src/routes/api/status.stream.ts
@@ -11,6 +11,9 @@ export const Route = createFileRoute("/api/status/stream")({
 
         const stream = new ReadableStream({
           start(controller) {
+            // Flush an initial SSE comment so response headers are sent immediately
+            controller.enqueue(encoder.encode(": connected\n\n"));
+
             unsubscribe = subscribe((event) => {
               try {
                 const data = JSON.stringify(event);

--- a/apps/web/src/routes/api/tasks.$workspaceId.abort.ts
+++ b/apps/web/src/routes/api/tasks.$workspaceId.abort.ts
@@ -1,0 +1,17 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { abortTask } from "../../lib/task-runner";
+
+export const Route = createFileRoute("/api/tasks/$workspaceId/abort")({
+  server: {
+    handlers: {
+      POST: async ({ params }) => {
+        const workspaceId = decodeURIComponent(params.workspaceId);
+        const aborted = abortTask(workspaceId);
+        if (!aborted) {
+          return Response.json({ error: "No running task found" }, { status: 404 });
+        }
+        return Response.json({ aborted: true });
+      },
+    },
+  },
+});

--- a/packages/coding-agent/src/adapters/claude-code.ts
+++ b/packages/coding-agent/src/adapters/claude-code.ts
@@ -33,6 +33,7 @@ export class ClaudeCodeAdapter implements CodingAgent {
   private readonly model: string | undefined;
   private readonly executablePath: string | undefined;
   private readonly additionalDirectories: string[] | undefined;
+  private activeConversation: ReturnType<typeof query> | null = null;
 
   constructor(config: ClaudeCodeConfig) {
     this.workspaceDir = config.workspaceDir;
@@ -40,6 +41,14 @@ export class ClaudeCodeAdapter implements CodingAgent {
     this.model = config.options.model;
     this.executablePath = config.options.executablePath;
     this.additionalDirectories = config.additionalDirectories;
+  }
+
+  abort(): void {
+    if (this.activeConversation) {
+      log.info("aborting active conversation");
+      this.activeConversation.close();
+      this.activeConversation = null;
+    }
   }
 
   async *runSession(prompt: string, sessionId?: string): AsyncGenerator<AgentEvent> {
@@ -107,6 +116,7 @@ export class ClaudeCodeAdapter implements CodingAgent {
       },
     });
 
+    this.activeConversation = conversation;
     log.info("query() called, waiting for messages...");
 
     const state: ProcessedState = {
@@ -132,6 +142,7 @@ export class ClaudeCodeAdapter implements CodingAgent {
       log.error({ err }, "conversation error");
       throw err;
     } finally {
+      this.activeConversation = null;
       log.info("closing conversation");
       conversation.close();
     }

--- a/packages/coding-agent/src/adapters/cursor-cli.ts
+++ b/packages/coding-agent/src/adapters/cursor-cli.ts
@@ -57,10 +57,19 @@ export class CursorCliAdapter implements CodingAgent {
 
   private readonly maxTurns: number;
   private readonly model: string;
+  private activeIterator: AsyncIterator<unknown> | null = null;
 
   constructor(config: CursorCliConfig) {
     this.maxTurns = config.maxTurns;
     this.model = config.options.model;
+  }
+
+  abort(): void {
+    if (this.activeIterator) {
+      log.info("aborting active cursor stream");
+      this.activeIterator.return?.(undefined);
+      this.activeIterator = null;
+    }
   }
 
   async *runSession(prompt: string, sessionId?: string): AsyncGenerator<AgentEvent> {
@@ -89,8 +98,11 @@ export class CursorCliAdapter implements CodingAgent {
     const startMs = Date.now();
     let lastAssistantText = "";
 
+    const iterator = stream[Symbol.asyncIterator]();
+    this.activeIterator = iterator;
+
     try {
-      for await (const event of stream) {
+      for await (const event of { [Symbol.asyncIterator]: () => iterator }) {
         const type = event.type as string;
         log.debug(
           {
@@ -137,6 +149,8 @@ export class CursorCliAdapter implements CodingAgent {
     } catch (err) {
       log.error({ err }, "cursor error");
       throw err;
+    } finally {
+      this.activeIterator = null;
     }
   }
 }

--- a/packages/coding-agent/src/adapters/gemini-cli.ts
+++ b/packages/coding-agent/src/adapters/gemini-cli.ts
@@ -1,3 +1,4 @@
+import type { ChildProcess } from "node:child_process";
 import { spawn } from "node:child_process";
 import { createInterface } from "node:readline";
 import { createLogger } from "@band/logger";
@@ -18,12 +19,21 @@ export class GeminiCliAdapter implements CodingAgent {
   private readonly maxTurns: number;
   private readonly model: string | undefined;
   private readonly executablePath: string;
+  private activeChild: ChildProcess | null = null;
 
   constructor(config: GeminiCliConfig) {
     this.workspaceDir = config.workspaceDir;
     this.maxTurns = config.maxTurns;
     this.model = config.options.model;
     this.executablePath = config.options.executablePath ?? "gemini";
+  }
+
+  abort(): void {
+    if (this.activeChild) {
+      log.info("aborting active gemini process");
+      this.activeChild.kill();
+      this.activeChild = null;
+    }
   }
 
   async *runSession(prompt: string, _sessionId?: string): AsyncGenerator<AgentEvent> {
@@ -48,6 +58,7 @@ export class GeminiCliAdapter implements CodingAgent {
       stdio: ["ignore", "pipe", "pipe"],
       env: { ...process.env },
     });
+    this.activeChild = child;
 
     const startMs = Date.now();
     let turnCount = 0;
@@ -139,6 +150,8 @@ export class GeminiCliAdapter implements CodingAgent {
       log.error({ err }, "gemini error");
       child.kill();
       throw err;
+    } finally {
+      this.activeChild = null;
     }
   }
 }

--- a/packages/coding-agent/src/adapters/openai-codex.ts
+++ b/packages/coding-agent/src/adapters/openai-codex.ts
@@ -16,12 +16,21 @@ export class OpenAICodexAdapter implements CodingAgent {
   private readonly maxTurns: number;
   private readonly model: string;
   private readonly sandboxMode: string;
+  private activeIterator: AsyncIterator<unknown> | null = null;
 
   constructor(config: OpenAICodexConfig) {
     this.workspaceDir = config.workspaceDir;
     this.maxTurns = config.maxTurns;
     this.model = config.options.model ?? "codex-mini";
     this.sandboxMode = config.options.sandboxMode ?? "docker";
+  }
+
+  abort(): void {
+    if (this.activeIterator) {
+      log.info("aborting active codex stream");
+      this.activeIterator.return?.(undefined);
+      this.activeIterator = null;
+    }
   }
 
   async *runSession(prompt: string, sessionId?: string): AsyncGenerator<AgentEvent> {
@@ -59,8 +68,11 @@ export class OpenAICodexAdapter implements CodingAgent {
       sandbox: this.sandboxMode,
     });
 
+    const iterator = stream[Symbol.asyncIterator]();
+    this.activeIterator = iterator;
+
     try {
-      for await (const event of stream) {
+      for await (const event of { [Symbol.asyncIterator]: () => iterator }) {
         const type = event.type as string;
         log.debug({ eventType: type }, "codex event");
 
@@ -139,6 +151,8 @@ export class OpenAICodexAdapter implements CodingAgent {
     } catch (err) {
       log.error({ err }, "codex error");
       throw err;
+    } finally {
+      this.activeIterator = null;
     }
   }
 }

--- a/packages/coding-agent/src/types.ts
+++ b/packages/coding-agent/src/types.ts
@@ -35,6 +35,7 @@ export interface CodingAgent {
   readonly supportedFeatures: CodingAgentFeatures;
   onUserInputNeeded?: (request: UserInputRequest) => Promise<Record<string, string>>;
   runSession(prompt: string, sessionId?: string): AsyncGenerator<AgentEvent>;
+  abort?(): void;
   listSessions?(dir: string): Promise<SessionListItem[]>;
   getSessionMessages?(
     sessionId: string,


### PR DESCRIPTION
## Summary

- Adds `abort()` to the `CodingAgent` interface and implements it in all four adapters (Claude Code, Gemini CLI, OpenAI Codex, Cursor CLI)
- Adds `POST /api/tasks/:workspaceId/abort` endpoint that kills the running agent process and marks the task as failed
- Exposes a public `abort()` method on `TaskChatTransport`, called directly from the ChatView stop handler — works whether the stream was started fresh or reconnected after navigation

## Test plan

- [ ] Start a long-running task, click stop → agent process killed, task marked failed, UI shows error and returns to idle
- [ ] Start a task, navigate to project list, come back, click stop → same behavior as above
- [ ] After aborting, submit a new task to the same workspace → works without conflict
- [ ] Run `pnpm test` → existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)