### PR TITLE
feat: add edit mode toggle to project list

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,8 +42,9 @@ jobs:
       - name: Lint (cargo clippy — Dashboard)
         run: |
           source "$HOME/.cargo/env"
-          mkdir -p apps/web/dist
+          mkdir -p apps/web/dist apps/dashboard/src-tauri/binaries
           touch apps/web/dist/start-server.mjs
+          cp apps/cli/target/release/band "apps/dashboard/src-tauri/binaries/band-$(rustc -vV | sed -n 's/host: //p')"
           cargo clippy --manifest-path apps/dashboard/src-tauri/Cargo.toml -- -D warnings
 
       - name: Build web (needed by tests)

--- a/apps/dashboard/src-tauri/src/commands/ide_stub.rs
+++ b/apps/dashboard/src-tauri/src/commands/ide_stub.rs
@@ -1,12 +1,14 @@
 //! Stub implementations of the IDE commands for non-macOS platforms.
 //! The real implementation lives in `ide.rs` and uses macOS-specific APIs.
 
+#[allow(dead_code)]
 pub fn write_active_marker(_workspace_id: &str) {}
 
 pub fn start_focus_polling(_app_handle: tauri::AppHandle) {}
 
 pub fn raise_vscode_window(_branch: &str) {}
 
+#[allow(dead_code)]
 pub fn align_vscode_window(_branch: &str) {}
 
 #[tauri::command]

--- a/apps/dashboard/src-tauri/src/commands/ide_stub.rs
+++ b/apps/dashboard/src-tauri/src/commands/ide_stub.rs
@@ -1,0 +1,35 @@
+//! Stub implementations of the IDE commands for non-macOS platforms.
+//! The real implementation lives in `ide.rs` and uses macOS-specific APIs.
+
+pub fn write_active_marker(_workspace_id: &str) {}
+
+pub fn start_focus_polling(_app_handle: tauri::AppHandle) {}
+
+pub fn raise_vscode_window(_branch: &str) {}
+
+pub fn align_vscode_window(_branch: &str) {}
+
+#[tauri::command]
+pub fn workspace_focus(_workspace_id: String) -> Result<(), String> {
+    Err("Not supported on this platform".to_string())
+}
+
+#[tauri::command]
+pub fn get_active_workspace() -> Result<Option<String>, String> {
+    Ok(None)
+}
+
+#[tauri::command]
+pub fn detect_active_workspace() -> Result<Option<String>, String> {
+    Ok(None)
+}
+
+#[tauri::command]
+pub fn pick_folder() -> Result<Option<String>, String> {
+    Err("Not supported on this platform".to_string())
+}
+
+#[tauri::command]
+pub fn reveal_in_finder(_path: String) -> Result<(), String> {
+    Err("Not supported on this platform".to_string())
+}

--- a/apps/dashboard/src-tauri/src/commands/mod.rs
+++ b/apps/dashboard/src-tauri/src/commands/mod.rs
@@ -1,2 +1,7 @@
+#[cfg(target_os = "macos")]
 pub mod ide;
+#[cfg(not(target_os = "macos"))]
+pub mod ide_stub;
+#[cfg(not(target_os = "macos"))]
+pub use ide_stub as ide;
 pub mod webserver;

--- a/packages/dashboard-core/src/components/DashboardShell.tsx
+++ b/packages/dashboard-core/src/components/DashboardShell.tsx
@@ -17,7 +17,7 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@band/ui";
-import { Check, FolderPlus, Plus, Settings, Tag, X } from "lucide-react";
+import { Check, FolderPlus, Pencil, Plus, Settings, Tag, X } from "lucide-react";
 import { type ReactNode, useState } from "react";
 import { useCliSetup } from "../hooks/use-cli-setup";
 import { useHooksSetup } from "../hooks/use-hooks-setup";
@@ -46,6 +46,7 @@ export function DashboardShell({ toolbarExtra }: DashboardShellProps) {
   const [showAddDialog, setShowAddDialog] = useState(false);
   const [showErrorDialog, setShowErrorDialog] = useState(false);
   const [view, setView] = useState<"dashboard" | "settings">("dashboard");
+  const [editMode, setEditMode] = useState(false);
   const [labelFilter, setLabelFilter] = useState<string | null>(null);
   const { state: hooksState, install: installHooks } = useHooksSetup();
   const { state: cliState, install: installCli } = useCliSetup();
@@ -75,6 +76,18 @@ export function DashboardShell({ toolbarExtra }: DashboardShellProps) {
                   </Button>
                 </TooltipTrigger>
                 <TooltipContent>Settings</TooltipContent>
+              </Tooltip>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button
+                    size="icon-sm"
+                    variant={editMode ? "secondary" : "ghost"}
+                    onClick={() => setEditMode((v) => !v)}
+                  >
+                    <Pencil className="size-5" />
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent>{editMode ? "Done editing" : "Edit projects"}</TooltipContent>
               </Tooltip>
               {toolbarExtra}
               {labels.length > 0 && (
@@ -165,7 +178,7 @@ export function DashboardShell({ toolbarExtra }: DashboardShellProps) {
                   </Button>
                 </div>
               ) : (
-                <ProjectList labelFilter={labelFilter} />
+                <ProjectList labelFilter={labelFilter} editMode={editMode} />
               )}
             </main>
           </ScrollArea>

--- a/packages/dashboard-core/src/components/ProjectList.tsx
+++ b/packages/dashboard-core/src/components/ProjectList.tsx
@@ -30,7 +30,16 @@ import {
   verticalListSortingStrategy,
 } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
-import { Check, Clipboard, FolderOpen, ListMinus, Plus, Tag } from "lucide-react";
+import {
+  Check,
+  Clipboard,
+  FolderOpen,
+  GripVertical,
+  ListMinus,
+  Plus,
+  Tag,
+  Trash2,
+} from "lucide-react";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useCapabilities } from "../context";
 import {
@@ -64,6 +73,7 @@ interface SortableProjectProps {
   onShowDeleteDialog: (info: DeleteDialogInfo) => void;
   focusedIndex: number;
   workspaceIndexStart: number;
+  editMode: boolean;
 }
 
 function SortableProject({
@@ -77,9 +87,11 @@ function SortableProject({
   onShowDeleteDialog,
   focusedIndex,
   workspaceIndexStart,
+  editMode,
 }: SortableProjectProps) {
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
     id: project.name,
+    disabled: !editMode,
   });
   const capabilities = useCapabilities();
 
@@ -97,25 +109,43 @@ function SortableProject({
         <ContextMenuTrigger asChild>
           <div className="flex items-center justify-between mb-1 px-1">
             <div
-              className="flex items-center gap-2 min-w-0 cursor-grab touch-none"
-              {...attributes}
-              {...listeners}
+              className={`flex items-center gap-2 min-w-0 ${editMode ? "cursor-grab touch-none" : ""}`}
+              {...(editMode ? { ...attributes, ...listeners } : {})}
             >
+              {editMode && <GripVertical className="size-4 shrink-0 text-muted-foreground" />}
               <FolderOpen className="size-4 shrink-0 text-muted-foreground" />
               <h2 className="text-sm font-semibold text-foreground truncate">{project.name}</h2>
             </div>
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <Button
-                  variant="ghost"
-                  size="icon-xs"
-                  onClick={() => setWorkspaceDialog(project.name)}
-                >
-                  <Plus />
-                </Button>
-              </TooltipTrigger>
-              <TooltipContent>Add workspace</TooltipContent>
-            </Tooltip>
+            <div className="flex items-center gap-1">
+              {editMode ? (
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Button
+                      variant="ghost"
+                      size="icon-xs"
+                      className="text-destructive hover:text-destructive"
+                      onClick={() => removeProject(project.name)}
+                    >
+                      <Trash2 />
+                    </Button>
+                  </TooltipTrigger>
+                  <TooltipContent>Remove project</TooltipContent>
+                </Tooltip>
+              ) : (
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Button
+                      variant="ghost"
+                      size="icon-xs"
+                      onClick={() => setWorkspaceDialog(project.name)}
+                    >
+                      <Plus />
+                    </Button>
+                  </TooltipTrigger>
+                  <TooltipContent>Add workspace</TooltipContent>
+                </Tooltip>
+              )}
+            </div>
           </div>
         </ContextMenuTrigger>
         <ContextMenuContent>
@@ -184,6 +214,7 @@ function SortableProject({
                 branchStatus={branchStatuses.get(wsId)}
                 isFocused={currentIndex === focusedIndex}
                 onShowDeleteDialog={onShowDeleteDialog}
+                editMode={editMode}
               />
             );
           })
@@ -220,9 +251,10 @@ function DroppableUnlabeledHeader() {
 
 interface ProjectListProps {
   labelFilter: string | null;
+  editMode: boolean;
 }
 
-export function ProjectList({ labelFilter }: ProjectListProps) {
+export function ProjectList({ labelFilter, editMode }: ProjectListProps) {
   const { projects } = useProjects();
   const { settings } = useSettingsQuery();
   const labels = settings.labels ?? [];
@@ -415,6 +447,7 @@ export function ProjectList({ labelFilter }: ProjectListProps) {
                       onShowDeleteDialog={setDeleteDialog}
                       focusedIndex={focusedIndex}
                       workspaceIndexStart={workspaceIndexMap.get(project.name) ?? 0}
+                      editMode={editMode}
                     />
                   </div>
                 ))}

--- a/packages/dashboard-core/src/components/WorkspaceCard.tsx
+++ b/packages/dashboard-core/src/components/WorkspaceCard.tsx
@@ -22,6 +22,7 @@ interface Props {
   branchStatus?: WorkspaceBranchStatus;
   isFocused?: boolean;
   onShowDeleteDialog: (info: DeleteDialogInfo) => void;
+  editMode?: boolean;
 }
 
 export function WorkspaceCard({
@@ -32,6 +33,7 @@ export function WorkspaceCard({
   branchStatus,
   isFocused,
   onShowDeleteDialog,
+  editMode,
 }: Props) {
   const cardRef = useRef<HTMLDivElement>(null);
   const capabilities = useCapabilities();
@@ -103,12 +105,14 @@ export function WorkspaceCard({
             >
               {worktree.branch}
             </span>
-            <AgentStatusBadge agent={status?.agent} />
+            {!editMode && <AgentStatusBadge agent={status?.agent} />}
           </div>
-          <div className="flex items-center gap-2 shrink-0">
-            {branchStatus && <GitStatusIndicator git={branchStatus.git} />}
-            {branchStatus && <CIStatusIndicator ci={branchStatus.ci} />}
-          </div>
+          {!editMode && (
+            <div className="flex items-center gap-2 shrink-0">
+              {branchStatus && <GitStatusIndicator git={branchStatus.git} />}
+              {branchStatus && <CIStatusIndicator ci={branchStatus.ci} />}
+            </div>
+          )}
         </Container>
       </ContextMenuTrigger>
       <ContextMenuContent>


### PR DESCRIPTION
## Summary
- Adds a pencil icon toggle button in the dashboard toolbar to switch between browse and edit modes
- When edit mode is ON: shows drag handles for reordering, shows delete (trash) buttons on each project, hides agent statuses, "add workspace" buttons, and CI/git status badges
- When edit mode is OFF (default): normal browsing with all statuses visible and drag-to-reorder disabled

Closes #62

## Test plan
- [ ] Toggle edit mode on — verify drag handles appear, delete buttons show, statuses/badges hide
- [ ] Drag a project to reorder — verify it works only in edit mode
- [ ] Click delete button — verify project is removed
- [ ] Toggle edit mode off — verify everything returns to normal browsing state
- [ ] Verify the pencil button shows "secondary" variant when active, "ghost" when inactive

🤖 Generated with [Claude Code](https://claude.com/claude-code)