### PR TITLE
feat: sync state.json with actual git worktrees on disk

### DIFF
--- a/apps/web/src/lib/branch-status-poller.ts
+++ b/apps/web/src/lib/branch-status-poller.ts
@@ -2,6 +2,7 @@ import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { execGh, execGit } from "./git";
 import { bandHome, loadState } from "./state";
+import { syncWorktrees } from "./sync-state";
 
 interface GitStatus {
   dirty: boolean;
@@ -205,6 +206,13 @@ function statePriority(state: string): number {
 async function pollTick() {
   tickCount++;
   const isCITick = tickCount % CI_POLL_TICKS === 0;
+
+  if (tickCount === 1 || isCITick) {
+    await syncWorktrees().catch((err) =>
+      console.error("syncWorktrees error:", err),
+    );
+  }
+
   const workspaces = getWorkspaces();
 
   if (workspaces.length === 0) return;

--- a/apps/web/src/lib/branch-status-poller.ts
+++ b/apps/web/src/lib/branch-status-poller.ts
@@ -208,9 +208,7 @@ async function pollTick() {
   const isCITick = tickCount % CI_POLL_TICKS === 0;
 
   if (tickCount === 1 || isCITick) {
-    await syncWorktrees().catch((err) =>
-      console.error("syncWorktrees error:", err),
-    );
+    await syncWorktrees().catch((err) => console.error("syncWorktrees error:", err));
   }
 
   const workspaces = getWorkspaces();

--- a/apps/web/src/lib/sync-state.ts
+++ b/apps/web/src/lib/sync-state.ts
@@ -1,0 +1,39 @@
+import { listWorktrees } from "./git";
+import { loadState, saveState, type WorktreeState } from "./state";
+
+export async function syncWorktrees(): Promise<void> {
+  const state = loadState();
+  let changed = false;
+
+  for (const project of state.projects) {
+    let diskWorktrees: WorktreeState[];
+    try {
+      const gitWorktrees = await listWorktrees(project.path);
+      diskWorktrees = gitWorktrees
+        .filter((wt) => !wt.isBare)
+        .map((wt) => ({ branch: wt.branch, path: wt.path, head: wt.head }));
+    } catch {
+      // If git fails for this project (e.g. path doesn't exist), skip it
+      continue;
+    }
+
+    const existingSet = new Set(
+      project.worktrees.map((wt) => `${wt.branch}\0${wt.path}`),
+    );
+    const diskSet = new Set(
+      diskWorktrees.map((wt) => `${wt.branch}\0${wt.path}`),
+    );
+
+    if (
+      existingSet.size !== diskSet.size ||
+      Array.from(existingSet).some((key) => !diskSet.has(key))
+    ) {
+      project.worktrees = diskWorktrees;
+      changed = true;
+    }
+  }
+
+  if (changed) {
+    saveState(state);
+  }
+}

--- a/apps/web/src/lib/sync-state.ts
+++ b/apps/web/src/lib/sync-state.ts
@@ -17,12 +17,8 @@ export async function syncWorktrees(): Promise<void> {
       continue;
     }
 
-    const existingSet = new Set(
-      project.worktrees.map((wt) => `${wt.branch}\0${wt.path}`),
-    );
-    const diskSet = new Set(
-      diskWorktrees.map((wt) => `${wt.branch}\0${wt.path}`),
-    );
+    const existingSet = new Set(project.worktrees.map((wt) => `${wt.branch}\0${wt.path}`));
+    const diskSet = new Set(diskWorktrees.map((wt) => `${wt.branch}\0${wt.path}`));
 
     if (
       existingSet.size !== diskSet.size ||

--- a/apps/web/tests/sync-state.test.ts
+++ b/apps/web/tests/sync-state.test.ts
@@ -11,8 +11,8 @@ import {
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { syncWorktrees } from "../src/lib/sync-state";
 import type { AppState } from "../src/lib/state";
+import { syncWorktrees } from "../src/lib/sync-state";
 
 const gitEnv = {
   ...process.env,
@@ -86,15 +86,11 @@ describe("syncWorktrees", () => {
     const state = readState(bandHome);
     expect(state.projects[0].worktrees.length).toBe(2);
 
-    const mainWt = state.projects[0].worktrees.find(
-      (wt) => wt.branch === "main",
-    );
+    const mainWt = state.projects[0].worktrees.find((wt) => wt.branch === "main");
     expect(mainWt).toBeDefined();
     expect(mainWt!.path).toBe(repoPath);
 
-    const featureWt = state.projects[0].worktrees.find(
-      (wt) => wt.branch === "feature",
-    );
+    const featureWt = state.projects[0].worktrees.find((wt) => wt.branch === "feature");
     expect(featureWt).toBeDefined();
     expect(featureWt!.path).toBe(wtPath);
   });
@@ -165,9 +161,7 @@ describe("syncWorktrees", () => {
           name: "broken-project",
           path: join(tmp, "does-not-exist"),
           defaultBranch: "main",
-          worktrees: [
-            { branch: "stale", path: join(tmp, "does-not-exist", "wt") },
-          ],
+          worktrees: [{ branch: "stale", path: join(tmp, "does-not-exist", "wt") }],
         },
         {
           name: "good-project",
@@ -188,8 +182,6 @@ describe("syncWorktrees", () => {
 
     // Good project gets synced
     expect(state.projects[1].worktrees.length).toBe(2);
-    expect(
-      state.projects[1].worktrees.find((wt) => wt.branch === "feature"),
-    ).toBeDefined();
+    expect(state.projects[1].worktrees.find((wt) => wt.branch === "feature")).toBeDefined();
   });
 });

--- a/apps/web/tests/sync-state.test.ts
+++ b/apps/web/tests/sync-state.test.ts
@@ -1,0 +1,195 @@
+import { execFileSync } from "node:child_process";
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  realpathSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { syncWorktrees } from "../src/lib/sync-state";
+import type { AppState } from "../src/lib/state";
+
+const gitEnv = {
+  ...process.env,
+  GIT_AUTHOR_NAME: "Test",
+  GIT_AUTHOR_EMAIL: "test@test.com",
+  GIT_COMMITTER_NAME: "Test",
+  GIT_COMMITTER_EMAIL: "test@test.com",
+};
+
+function git(cwd: string, args: string[]): string {
+  return execFileSync("git", args, { cwd, env: gitEnv, encoding: "utf-8" });
+}
+
+function createRepo(tmp: string, name = "repo"): string {
+  const repoPath = join(tmp, name);
+  mkdirSync(repoPath, { recursive: true });
+  git(repoPath, ["init", "-b", "main"]);
+  writeFileSync(join(repoPath, "file.txt"), "hello");
+  git(repoPath, ["add", "file.txt"]);
+  git(repoPath, ["commit", "-m", "initial"]);
+  return repoPath;
+}
+
+function writeState(bandHome: string, state: AppState): void {
+  mkdirSync(bandHome, { recursive: true });
+  writeFileSync(join(bandHome, "state.json"), JSON.stringify(state, null, 2));
+}
+
+function readState(bandHome: string): AppState {
+  return JSON.parse(readFileSync(join(bandHome, "state.json"), "utf-8"));
+}
+
+describe("syncWorktrees", () => {
+  let tmp: string;
+  let originalHome: string | undefined;
+
+  beforeEach(() => {
+    tmp = realpathSync(mkdtempSync(join(tmpdir(), "band-sync-test-")));
+    originalHome = process.env.HOME;
+    process.env.HOME = tmp;
+  });
+
+  afterEach(() => {
+    if (originalHome !== undefined) {
+      process.env.HOME = originalHome;
+    } else {
+      delete process.env.HOME;
+    }
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it("adds worktree created outside Band", async () => {
+    const repoPath = createRepo(tmp);
+    const wtPath = join(tmp, "wt-feature");
+    git(repoPath, ["worktree", "add", "-b", "feature", wtPath]);
+
+    const bandHome = join(tmp, ".band");
+    writeState(bandHome, {
+      projects: [
+        {
+          name: "test-project",
+          path: repoPath,
+          defaultBranch: "main",
+          worktrees: [],
+        },
+      ],
+    });
+
+    await syncWorktrees();
+
+    const state = readState(bandHome);
+    expect(state.projects[0].worktrees.length).toBe(2);
+
+    const mainWt = state.projects[0].worktrees.find(
+      (wt) => wt.branch === "main",
+    );
+    expect(mainWt).toBeDefined();
+    expect(mainWt!.path).toBe(repoPath);
+
+    const featureWt = state.projects[0].worktrees.find(
+      (wt) => wt.branch === "feature",
+    );
+    expect(featureWt).toBeDefined();
+    expect(featureWt!.path).toBe(wtPath);
+  });
+
+  it("removes stale worktree from state", async () => {
+    const repoPath = createRepo(tmp);
+
+    const bandHome = join(tmp, ".band");
+    writeState(bandHome, {
+      projects: [
+        {
+          name: "test-project",
+          path: repoPath,
+          defaultBranch: "main",
+          worktrees: [
+            { branch: "main", path: repoPath },
+            { branch: "gone", path: join(tmp, "nonexistent-wt") },
+          ],
+        },
+      ],
+    });
+
+    await syncWorktrees();
+
+    const state = readState(bandHome);
+    expect(state.projects[0].worktrees.length).toBe(1);
+    expect(state.projects[0].worktrees[0].branch).toBe("main");
+    expect(state.projects[0].worktrees[0].path).toBe(repoPath);
+  });
+
+  it("does not write state when already in sync", async () => {
+    const repoPath = createRepo(tmp);
+    const head = git(repoPath, ["rev-parse", "HEAD"]).trim();
+
+    const bandHome = join(tmp, ".band");
+    writeState(bandHome, {
+      projects: [
+        {
+          name: "test-project",
+          path: repoPath,
+          defaultBranch: "main",
+          worktrees: [{ branch: "main", path: repoPath, head }],
+        },
+      ],
+    });
+
+    const stateFilePath = join(bandHome, "state.json");
+    const mtimeBefore = statSync(stateFilePath).mtimeMs;
+
+    // Small delay to ensure mtime would differ if file were rewritten
+    await new Promise((r) => setTimeout(r, 50));
+
+    await syncWorktrees();
+
+    const mtimeAfter = statSync(stateFilePath).mtimeMs;
+    expect(mtimeAfter).toBe(mtimeBefore);
+  });
+
+  it("skips projects where git fails", async () => {
+    const repoPath = createRepo(tmp);
+    const wtPath = join(tmp, "wt-feature");
+    git(repoPath, ["worktree", "add", "-b", "feature", wtPath]);
+
+    const bandHome = join(tmp, ".band");
+    writeState(bandHome, {
+      projects: [
+        {
+          name: "broken-project",
+          path: join(tmp, "does-not-exist"),
+          defaultBranch: "main",
+          worktrees: [
+            { branch: "stale", path: join(tmp, "does-not-exist", "wt") },
+          ],
+        },
+        {
+          name: "good-project",
+          path: repoPath,
+          defaultBranch: "main",
+          worktrees: [],
+        },
+      ],
+    });
+
+    await syncWorktrees();
+
+    const state = readState(bandHome);
+
+    // Broken project keeps its stale worktrees (skipped)
+    expect(state.projects[0].worktrees.length).toBe(1);
+    expect(state.projects[0].worktrees[0].branch).toBe("stale");
+
+    // Good project gets synced
+    expect(state.projects[1].worktrees.length).toBe(2);
+    expect(
+      state.projects[1].worktrees.find((wt) => wt.branch === "feature"),
+    ).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `syncWorktrees()` that reconciles each project's worktrees in `state.json` with what `git worktree list` reports on disk
- Calls it from the branch-status poller on startup and every CI tick (30s), so worktrees created/deleted outside Band are reflected in the dashboard
- Includes 4 integration tests using real git repos in temp directories

Closes #65

## Test plan
- [x] `pnpm vitest run tests/sync-state.test.ts` — all 4 tests pass
- [x] Existing `tests/git.test.ts` still passes
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)