### PR TITLE
ci: switch to ephemeral Hetzner Cloud runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       label: ${{ steps.create.outputs.label }}
+      name: ${{ steps.create.outputs.name }}
       server_id: ${{ steps.create.outputs.server_id }}
     steps:
       - uses: Cyclenerd/hcloud-github-runner@v1
@@ -31,7 +32,7 @@ jobs:
               libwebkit2gtk-4.1-dev libgtk-3-dev libayatana-appindicator3-dev \
               librsvg2-dev libxdo-dev patchelf
             curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
-            source "$HOME/.cargo/env"
+            source /root/.cargo/env
             curl -fsSL https://deb.nodesource.com/setup_22.x | bash -
             apt-get install -y nodejs
             corepack enable
@@ -48,7 +49,7 @@ jobs:
 
       - name: Build CLI
         run: |
-          source "$HOME/.cargo/env"
+          source /root/.cargo/env
           cargo build --release --manifest-path apps/cli/Cargo.toml
 
       - name: Install dependencies
@@ -59,18 +60,18 @@ jobs:
 
       - name: Lint (cargo fmt)
         run: |
-          source "$HOME/.cargo/env"
+          source /root/.cargo/env
           cargo fmt --manifest-path apps/cli/Cargo.toml -- --check
           cargo fmt --manifest-path apps/dashboard/src-tauri/Cargo.toml -- --check
 
       - name: Lint (cargo clippy — CLI)
         run: |
-          source "$HOME/.cargo/env"
+          source /root/.cargo/env
           cargo clippy --manifest-path apps/cli/Cargo.toml -- -D warnings
 
       - name: Lint (cargo clippy — Dashboard)
         run: |
-          source "$HOME/.cargo/env"
+          source /root/.cargo/env
           mkdir -p apps/web/dist apps/dashboard/src-tauri/binaries
           touch apps/web/dist/start-server.mjs
           cp apps/cli/target/release/band "apps/dashboard/src-tauri/binaries/band-$(rustc -vV | sed -n 's/host: //p')"
@@ -84,12 +85,12 @@ jobs:
 
       - name: Test (CLI)
         run: |
-          source "$HOME/.cargo/env"
+          source /root/.cargo/env
           cargo test --manifest-path apps/cli/Cargo.toml
 
       - name: Test (Dashboard)
         run: |
-          source "$HOME/.cargo/env"
+          source /root/.cargo/env
           cargo test --manifest-path apps/dashboard/src-tauri/Cargo.toml
 
       - name: Build frontend
@@ -106,4 +107,5 @@ jobs:
           mode: delete
           github_token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
           hcloud_token: ${{ secrets.HCLOUD_TOKEN }}
+          name: ${{ needs.create-runner.outputs.name }}
           server_id: ${{ needs.create-runner.outputs.server_id }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,9 +9,38 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  create-runner:
+    name: Create Runner
+    runs-on: ubuntu-latest
+    outputs:
+      label: ${{ steps.create.outputs.label }}
+      server_id: ${{ steps.create.outputs.server_id }}
+    steps:
+      - uses: Cyclenerd/hcloud-github-runner@v1
+        id: create
+        with:
+          mode: create
+          github_token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+          hcloud_token: ${{ secrets.HCLOUD_TOKEN }}
+          server_type: cax21
+          image: ubuntu-24.04
+          location: nbg1
+          pre_runner_script: |
+            apt-get update
+            apt-get install -y build-essential curl wget pkg-config libssl-dev \
+              libwebkit2gtk-4.1-dev libgtk-3-dev libayatana-appindicator3-dev \
+              librsvg2-dev libxdo-dev patchelf
+            curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+            source "$HOME/.cargo/env"
+            curl -fsSL https://deb.nodesource.com/setup_22.x | bash -
+            apt-get install -y nodejs
+            corepack enable
+            corepack prepare pnpm@latest --activate
+
   check:
     name: Lint, Test & Build
-    runs-on: [self-hosted, linux, arm64]
+    needs: create-runner
+    runs-on: ${{ needs.create-runner.outputs.label }}
 
     steps:
       - name: Checkout
@@ -65,3 +94,16 @@ jobs:
 
       - name: Build frontend
         run: pnpm --filter @band/dashboard build
+
+  delete-runner:
+    name: Delete Runner
+    needs: [create-runner, check]
+    runs-on: ubuntu-latest
+    if: ${{ always() }}
+    steps:
+      - uses: Cyclenerd/hcloud-github-runner@v1
+        with:
+          mode: delete
+          github_token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+          hcloud_token: ${{ secrets.HCLOUD_TOKEN }}
+          server_id: ${{ needs.create-runner.outputs.server_id }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
               libwebkit2gtk-4.1-dev libgtk-3-dev libayatana-appindicator3-dev \
               librsvg2-dev libxdo-dev patchelf
             curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
-            source /root/.cargo/env
+            export PATH="/root/.cargo/bin:$PATH"
             curl -fsSL https://deb.nodesource.com/setup_22.x | bash -
             apt-get install -y nodejs
             corepack enable
@@ -49,7 +49,7 @@ jobs:
 
       - name: Build CLI
         run: |
-          source /root/.cargo/env
+          export PATH="/root/.cargo/bin:$PATH"
           cargo build --release --manifest-path apps/cli/Cargo.toml
 
       - name: Install dependencies
@@ -60,18 +60,18 @@ jobs:
 
       - name: Lint (cargo fmt)
         run: |
-          source /root/.cargo/env
+          export PATH="/root/.cargo/bin:$PATH"
           cargo fmt --manifest-path apps/cli/Cargo.toml -- --check
           cargo fmt --manifest-path apps/dashboard/src-tauri/Cargo.toml -- --check
 
       - name: Lint (cargo clippy — CLI)
         run: |
-          source /root/.cargo/env
+          export PATH="/root/.cargo/bin:$PATH"
           cargo clippy --manifest-path apps/cli/Cargo.toml -- -D warnings
 
       - name: Lint (cargo clippy — Dashboard)
         run: |
-          source /root/.cargo/env
+          export PATH="/root/.cargo/bin:$PATH"
           mkdir -p apps/web/dist apps/dashboard/src-tauri/binaries
           touch apps/web/dist/start-server.mjs
           cp apps/cli/target/release/band "apps/dashboard/src-tauri/binaries/band-$(rustc -vV | sed -n 's/host: //p')"
@@ -85,12 +85,12 @@ jobs:
 
       - name: Test (CLI)
         run: |
-          source /root/.cargo/env
+          export PATH="/root/.cargo/bin:$PATH"
           cargo test --manifest-path apps/cli/Cargo.toml
 
       - name: Test (Dashboard)
         run: |
-          source /root/.cargo/env
+          export PATH="/root/.cargo/bin:$PATH"
           cargo test --manifest-path apps/dashboard/src-tauri/Cargo.toml
 
       - name: Build frontend

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,6 +103,7 @@ jobs:
     if: ${{ always() }}
     steps:
       - uses: Cyclenerd/hcloud-github-runner@v1
+        continue-on-error: true
         with:
           mode: delete
           github_token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}

--- a/apps/dashboard/src-tauri/src/commands/webserver.rs
+++ b/apps/dashboard/src-tauri/src/commands/webserver.rs
@@ -82,9 +82,9 @@ pub(crate) fn which_binary(name: &str) -> Result<String, String> {
 /// Read the token from settings.json (web server creates it).
 fn get_token() -> Result<String, String> {
     let settings = load_settings()?;
-    settings
-        .token_secret
-        .ok_or_else(|| "tokenSecret not found in settings.json — start the web server first".to_string())
+    settings.token_secret.ok_or_else(|| {
+        "tokenSecret not found in settings.json — start the web server first".to_string()
+    })
 }
 
 /// Send SIGTERM to the entire process group, then fall back to SIGKILL.

--- a/apps/dashboard/src-tauri/src/commands/webserver.rs
+++ b/apps/dashboard/src-tauri/src/commands/webserver.rs
@@ -310,10 +310,7 @@ fn check_local_health_sync(port: u16, token: &str) -> bool {
 
 /// Kill any process listening on the given port.
 pub(crate) fn kill_port_sync(port: u16) {
-    if let Ok(output) = Command::new("lsof")
-        .args([&format!("-ti:{port}")])
-        .output()
-    {
+    if let Ok(output) = Command::new("lsof").args([&format!("-ti:{port}")]).output() {
         if output.status.success() {
             let pids = String::from_utf8_lossy(&output.stdout);
             for pid in pids.split_whitespace() {

--- a/apps/dashboard/src-tauri/src/state.rs
+++ b/apps/dashboard/src-tauri/src/state.rs
@@ -111,5 +111,3 @@ pub fn load_settings() -> Result<Settings, String> {
     let data = fs::read_to_string(&path).map_err(|e| format!("Failed to read settings: {e}"))?;
     serde_json::from_str(&data).map_err(|e| format!("Failed to parse settings: {e}"))
 }
-
-


### PR DESCRIPTION
## Summary
- Replace static `[self-hosted, linux, arm64]` runners with on-demand Hetzner Cloud VMs using [Cyclenerd/hcloud-github-runner](https://github.com/Cyclenerd/hcloud-github-runner)
- Each CI run creates a fresh `cax21` ARM64 server, runs all checks, and tears it down automatically
- Requires `PERSONAL_ACCESS_TOKEN` and `HCLOUD_TOKEN` repo secrets (already configured)

## Test plan
- [ ] Verify the `create-runner` job provisions a Hetzner VM successfully
- [ ] Verify the `check` job runs all lint/test/build steps on the ephemeral runner
- [ ] Verify the `delete-runner` job cleans up the server after completion
- [ ] Verify cleanup runs even when the check job fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)