### PR TITLE
refactor: restructure CLI to resource-based subcommands

### DIFF
--- a/apps/cli/Cargo.toml
+++ b/apps/cli/Cargo.toml
@@ -9,7 +9,7 @@ name = "band"
 path = "src/main.rs"
 
 [dependencies]
-clap = { version = "4", features = ["derive"] }
+clap = { version = "4", features = ["derive", "env"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 dirs = "6"

--- a/apps/cli/SKILL.md
+++ b/apps/cli/SKILL.md
@@ -1,0 +1,179 @@
+---
+name: band
+version: 0.1.0
+description: Programmatic workspace management for Band
+---
+
+# Band CLI
+
+Thin client for the Band web server. All state, git operations, and script execution happen server-side.
+
+## Prerequisites
+
+The Band server must be running (started by the Band dashboard app). Connects to `http://localhost:3456` by default.
+
+## JSON Output
+
+All commands support `--output json` (or `BAND_OUTPUT=json` env var) for structured output.
+
+- **Success**: JSON object to stdout, exit code 0
+- **Error**: `{"error": "message"}` to stderr, exit code 1
+
+## Schema Introspection
+
+```sh
+# List all commands with parameters and types
+band schema
+
+# Show a specific command's schema
+band schema "workspaces create"
+```
+
+## Commands
+
+### List projects
+
+```sh
+band projects list
+```
+
+Text output: `name\tpath\tN worktree(s)` (tab-separated).
+JSON output: `{"projects": [{"name": "...", "path": "...", "worktreeCount": N}]}`
+
+### Register a project
+
+```sh
+band projects add <path> [--label <label>]
+```
+
+Registers an existing git repository. Detects the default branch automatically. Returns the project name.
+
+### Unregister a project
+
+```sh
+band projects remove <name>
+```
+
+Removes the project from Band's registry (does not delete the repository).
+
+### List workspaces
+
+```sh
+band workspaces list [project]
+```
+
+Text output: `project\tbranch\tpath` (tab-separated, one per line).
+JSON output: `{"workspaces": [{"project": "...", "branch": "...", "path": "..."}]}`
+
+### Create a workspace
+
+```sh
+band workspaces create <project> <branch> [--base <branch>] [--prompt <text>]
+```
+
+Returns the worktree path. Idempotent — creating an existing workspace returns its path. Runs `.band/config.json` `setup` script if present (non-fatal). With `--prompt`, also submits a task to the coding agent.
+
+### Remove a workspace
+
+```sh
+band workspaces remove <project> <branch>
+```
+
+Runs `.band/config.json` `teardown` script before removal (non-fatal). Cleans up all associated files.
+
+### Show settings
+
+```sh
+band settings
+```
+
+Pretty-prints the current settings as JSON. With `--output json`, outputs compact JSON.
+
+### Tunnel status
+
+```sh
+band tunnel status
+```
+
+Shows whether the tunnel is running and its URL.
+
+### Start tunnel
+
+```sh
+band tunnel start [--subdomain <name>]
+```
+
+Starts the remote tunnel. Returns the tunnel URL.
+
+### Stop tunnel
+
+```sh
+band tunnel stop
+```
+
+Stops the remote tunnel.
+
+### Hook notifications
+
+```sh
+echo '{"hook_event_name":"Stop","cwd":"/path"}' | band notify
+```
+
+Not called directly — registered as a Claude Code hook by the Band dashboard.
+
+## Workflows
+
+### Feature branch workflow
+
+```sh
+# Create workspace, get path
+path=$(band workspaces create my-app feat/login --output json | jq -r .path)
+cd "$path"
+
+# ... do work ...
+
+# Clean up
+band workspaces remove my-app feat/login
+```
+
+### Agent task submission
+
+```sh
+band workspaces create my-app feat/auth --prompt "Add JWT authentication to the API"
+```
+
+### Enumerate workspaces
+
+```sh
+band workspaces list --output json | jq '.workspaces[] | select(.project == "my-app") | .branch'
+```
+
+### Project management
+
+```sh
+# Register a project
+band projects add /Users/me/code/my-app
+
+# List all projects
+band projects list
+
+# Remove a project
+band projects remove my-app
+```
+
+## Invariants
+
+- The CLI never modifies files directly — all operations go through the server API
+- `workspaces create` is idempotent — creating an existing workspace returns its path
+- `setup` scripts run after workspace creation, `teardown` before removal (both non-fatal)
+- Project and branch names must not contain control characters or path traversals (`../`)
+- Exit code 0 = success, 1 = error
+
+## Configuration
+
+| Setting | Env var | Default |
+|---|---|---|
+| Server URL | `BAND_SERVER_URL` | `http://localhost:3456` |
+| Auth token | `BAND_TOKEN` | from `~/.band/settings.json` |
+| Output format | `BAND_OUTPUT` | `text` |
+| Band home dir | `BAND_HOME` | `~/.band` |

--- a/apps/cli/SKILL.md
+++ b/apps/cli/SKILL.md
@@ -177,3 +177,5 @@ band projects remove my-app
 | Auth token | `BAND_TOKEN` | from `~/.band/settings.json` |
 | Output format | `BAND_OUTPUT` | `text` |
 | Band home dir | `BAND_HOME` | `~/.band` |
+
+

--- a/apps/cli/bin/band.sh
+++ b/apps/cli/bin/band.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# Wrapper script for the band CLI binary.
+# Looks for the Cargo-built binary relative to this script's location.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+
+# Prefer release build, fall back to debug
+if [ -x "$SCRIPT_DIR/target/release/band" ]; then
+  exec "$SCRIPT_DIR/target/release/band" "$@"
+elif [ -x "$SCRIPT_DIR/target/debug/band" ]; then
+  exec "$SCRIPT_DIR/target/debug/band" "$@"
+else
+  echo "error: band binary not found. Run 'pnpm --filter @band/cli build' first." >&2
+  exit 1
+fi

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@band/cli",
+  "version": "0.1.0",
+  "private": true,
+  "bin": {
+    "band": "bin/band.sh"
+  },
+  "scripts": {
+    "build": "cargo build --release",
+    "build:dev": "cargo build",
+    "build:test-server": "pnpm --filter @band/web build:test-server",
+    "test": "pnpm build:test-server && cargo test",
+    "lint": "cargo clippy -- -D warnings",
+    "format": "cargo fmt -- --check",
+    "format:fix": "cargo fmt"
+  }
+}

--- a/apps/cli/src/api.rs
+++ b/apps/cli/src/api.rs
@@ -5,16 +5,14 @@ use ureq::Body;
 pub struct ApiClient {
     agent: ureq::Agent,
     base_url: String,
-    token: String,
+    token: Option<String>,
 }
 
 impl ApiClient {
     pub fn from_settings() -> Result<Self, String> {
         let settings = state::load_settings()?;
         let port = settings.web_server_port.unwrap_or(3456);
-        let token = settings
-            .token_secret
-            .ok_or("tokenSecret not found in settings.json — start the web server first")?;
+        let token = settings.token_secret;
         let agent = ureq::Agent::new_with_config(
             ureq::config::Config::builder()
                 .http_status_as_error(false)
@@ -40,15 +38,29 @@ impl ApiClient {
             urlencoded(&input_str),
         );
 
-        let cookie = format!("band_token={}", self.token);
-        let response = self
-            .agent
-            .get(&url)
-            .header("Cookie", &cookie)
-            .call()
-            .map_err(|e| {
-                format!("Cannot connect to Band web server. Make sure it's running.\n{e}")
-            })?;
+        let mut req = self.agent.get(&url);
+        if let Some(ref token) = self.token {
+            req = req.header("Cookie", &format!("band_token={token}"));
+        }
+
+        let response = req.call().map_err(|e| {
+            format!("Cannot connect to Band web server. Make sure it's running.\n{e}")
+        })?;
+
+        parse_trpc_body(response)
+    }
+
+    pub fn trpc_query_no_input(&self, procedure: &str) -> Result<serde_json::Value, String> {
+        let url = format!("{}/trpc/{procedure}", self.base_url);
+
+        let mut req = self.agent.get(&url);
+        if let Some(ref token) = self.token {
+            req = req.header("Cookie", &format!("band_token={token}"));
+        }
+
+        let response = req.call().map_err(|e| {
+            format!("Cannot connect to Band web server. Make sure it's running.\n{e}")
+        })?;
 
         parse_trpc_body(response)
     }
@@ -58,16 +70,17 @@ impl ApiClient {
         procedure: &str,
         input: &serde_json::Value,
     ) -> Result<serde_json::Value, String> {
-        let cookie = format!("band_token={}", self.token);
-        let response = self
+        let mut req = self
             .agent
             .post(&format!("{}/trpc/{procedure}", self.base_url))
-            .header("Content-Type", "application/json")
-            .header("Cookie", &cookie)
-            .send_json(input)
-            .map_err(|e| {
-                format!("Cannot connect to Band web server. Make sure it's running.\n{e}")
-            })?;
+            .header("Content-Type", "application/json");
+        if let Some(ref token) = self.token {
+            req = req.header("Cookie", &format!("band_token={token}"));
+        }
+
+        let response = req.send_json(input).map_err(|e| {
+            format!("Cannot connect to Band web server. Make sure it's running.\n{e}")
+        })?;
 
         parse_trpc_body(response)
     }

--- a/apps/cli/src/main.rs
+++ b/apps/cli/src/main.rs
@@ -1,18 +1,76 @@
 mod api;
 mod shell;
 mod state;
+mod validate;
 
 use clap::{Parser, Subcommand};
+use std::fmt::Write;
+use std::process;
 
 #[derive(Parser)]
 #[command(name = "band", about = "Band CLI — programmatic workspace management")]
 struct Cli {
+    /// Output format: text or json
+    #[arg(long, global = true, default_value = "text", env = "BAND_OUTPUT")]
+    output: String,
     #[command(subcommand)]
     command: Commands,
 }
 
 #[derive(Subcommand)]
 enum Commands {
+    /// Manage registered projects
+    Projects {
+        #[command(subcommand)]
+        cmd: ProjectsCmd,
+    },
+    /// Manage workspaces (git worktrees)
+    Workspaces {
+        #[command(subcommand)]
+        cmd: WorkspacesCmd,
+    },
+    /// Show current settings
+    Settings,
+    /// Manage the remote tunnel
+    Tunnel {
+        #[command(subcommand)]
+        cmd: TunnelCmd,
+    },
+    /// Receive hook notifications from Claude Code (reads JSON from stdin)
+    Notify,
+    /// Show command schemas as JSON
+    Schema {
+        /// Command name (omit to list all commands)
+        command: Option<String>,
+    },
+}
+
+#[derive(Subcommand)]
+enum ProjectsCmd {
+    /// List registered projects
+    List,
+    /// Register an existing repository as a project
+    Add {
+        /// Path to the git repository
+        path: String,
+        /// Label for the project
+        #[arg(long)]
+        label: Option<String>,
+    },
+    /// Unregister a project
+    Remove {
+        /// Project name
+        name: String,
+    },
+}
+
+#[derive(Subcommand)]
+enum WorkspacesCmd {
+    /// List workspaces, optionally filtered by project
+    List {
+        /// Project name (optional filter)
+        project: Option<String>,
+    },
     /// Create a new workspace (git worktree + state registration)
     Create {
         /// Project name
@@ -22,24 +80,9 @@ enum Commands {
         /// Base branch to create from (defaults to project's default branch)
         #[arg(long)]
         base: Option<String>,
-    },
-    /// Create a workspace and dispatch a prompt to the coding agent
-    Run {
-        /// Project name
-        project: String,
-        /// Branch name
-        branch: String,
         /// Prompt to pass to the coding agent
         #[arg(long)]
-        prompt: String,
-        /// Base branch to create from (defaults to project's default branch)
-        #[arg(long)]
-        base: Option<String>,
-    },
-    /// List workspaces, optionally filtered by project
-    List {
-        /// Project name (optional filter)
-        project: Option<String>,
+        prompt: Option<String>,
     },
     /// Remove a workspace (git worktree + state cleanup)
     Remove {
@@ -48,76 +91,82 @@ enum Commands {
         /// Branch name
         branch: String,
     },
-    /// List registered projects
-    Projects,
-    /// Receive hook notifications from Claude Code (reads JSON from stdin)
-    Notify,
+}
+
+#[derive(Subcommand)]
+enum TunnelCmd {
+    /// Show tunnel status
+    Status,
+    /// Start the remote tunnel
+    Start {
+        /// Subdomain to use
+        #[arg(long)]
+        subdomain: Option<String>,
+    },
+    /// Stop the remote tunnel
+    Stop,
+}
+
+// --- Output types ---
+
+struct CommandResult {
+    text: String,
+    json: serde_json::Value,
 }
 
 fn main() {
     let cli = Cli::parse();
+    let json_output = cli.output == "json";
+
+    // Schema always outputs JSON, handle separately
+    if let Commands::Schema { ref command } = cli.command {
+        handle_schema(command.as_deref());
+        return;
+    }
 
     let result = match cli.command {
-        Commands::Create {
-            project,
-            branch,
-            base,
-        } => cmd_create(&project, &branch, base.as_deref()),
-        Commands::Run {
-            project,
-            branch,
-            prompt,
-            base,
-        } => cmd_run(&project, &branch, &prompt, base.as_deref()),
-        Commands::List { project } => cmd_list(project.as_deref()),
-        Commands::Remove { project, branch } => cmd_remove(&project, &branch),
-        Commands::Projects => cmd_projects(),
+        Commands::Projects { cmd } => match cmd {
+            ProjectsCmd::List => cmd_projects_list(),
+            ProjectsCmd::Add { path, label } => cmd_projects_add(&path, label.as_deref()),
+            ProjectsCmd::Remove { name } => cmd_projects_remove(&name),
+        },
+        Commands::Workspaces { cmd } => match cmd {
+            WorkspacesCmd::List { project } => cmd_workspaces_list(project.as_deref()),
+            WorkspacesCmd::Create {
+                project,
+                branch,
+                base,
+                prompt,
+            } => cmd_workspaces_create(&project, &branch, base.as_deref(), prompt.as_deref()),
+            WorkspacesCmd::Remove { project, branch } => cmd_workspaces_remove(&project, &branch),
+        },
+        Commands::Settings => cmd_settings(json_output),
+        Commands::Tunnel { cmd } => match cmd {
+            TunnelCmd::Status => cmd_tunnel_status(),
+            TunnelCmd::Start { subdomain } => cmd_tunnel_start(subdomain.as_deref()),
+            TunnelCmd::Stop => cmd_tunnel_stop(),
+        },
         Commands::Notify => cmd_notify(),
+        Commands::Schema { .. } => unreachable!(),
     };
 
-    if let Err(e) = result {
-        eprintln!("error: {e}");
-        std::process::exit(1);
+    match result {
+        Ok(output) => {
+            if json_output {
+                println!("{}", serde_json::to_string(&output.json).unwrap());
+            } else if !output.text.is_empty() {
+                print!("{}", output.text);
+            }
+        }
+        Err(e) => {
+            if json_output {
+                eprintln!("{}", serde_json::json!({"error": e}));
+            } else {
+                eprintln!("error: {e}");
+            }
+            process::exit(1);
+        }
     }
-}
-
-fn cmd_create(project: &str, branch: &str, base: Option<&str>) -> Result<(), String> {
-    let client = api::ApiClient::from_settings()?;
-    let mut input = serde_json::json!({
-        "project": project,
-        "branch": branch,
-    });
-    if let Some(base) = base {
-        input["base"] = serde_json::json!(base);
-    }
-    let data = client.trpc_mutate("workspaces.create", &input)?;
-    let path = data.get("path").and_then(|p| p.as_str()).unwrap_or("");
-    println!("{path}");
-    Ok(())
-}
-
-fn cmd_run(project: &str, branch: &str, prompt: &str, base: Option<&str>) -> Result<(), String> {
-    let client = api::ApiClient::from_settings()?;
-    let mut input = serde_json::json!({
-        "project": project,
-        "branch": branch,
-        "prompt": prompt,
-    });
-    if let Some(base) = base {
-        input["base"] = serde_json::json!(base);
-    }
-    let data = client.trpc_mutate("workspaces.create", &input)?;
-    let worktree_path = data
-        .get("path")
-        .and_then(|p| p.as_str())
-        .unwrap_or("")
-        .to_string();
-
-    // Open the editor configured in .band/config.json (or fall back to VS Code)
-    open_configured_editor(&worktree_path);
-
-    println!("{worktree_path}");
-    Ok(())
 }
 
 /// Open the editor configured in .band/config.json or settings.json defaults.
@@ -191,9 +240,100 @@ fn load_apps_config(worktree_path: &str) -> Vec<serde_json::Value> {
     Vec::new()
 }
 
-fn cmd_list(project_filter: Option<&str>) -> Result<(), String> {
+fn handle_schema(command: Option<&str>) {
+    match build_schema(command) {
+        Ok(schema) => println!("{}", serde_json::to_string_pretty(&schema).unwrap()),
+        Err(e) => {
+            eprintln!("{}", serde_json::json!({"error": e}));
+            process::exit(1);
+        }
+    }
+}
+
+// --- Projects commands ---
+
+fn cmd_projects_list() -> Result<CommandResult, String> {
     let client = api::ApiClient::from_settings()?;
-    let data = client.trpc_query("projects.list", &serde_json::json!({}))?;
+    let data = client.trpc_query_no_input("projects.list")?;
+
+    let projects = data
+        .get("projects")
+        .and_then(|p| p.as_array())
+        .cloned()
+        .unwrap_or_default();
+
+    let mut json_projects = Vec::new();
+    let mut rows: Vec<[String; 3]> = Vec::new();
+    for proj in &projects {
+        let name = proj.get("name").and_then(|n| n.as_str()).unwrap_or("");
+        let path = proj.get("path").and_then(|p| p.as_str()).unwrap_or("");
+        let wt_count = proj
+            .get("worktrees")
+            .and_then(|w| w.as_array())
+            .map_or(0, Vec::len);
+        rows.push([
+            name.to_string(),
+            path.to_string(),
+            format!(
+                "{} worktree{}",
+                wt_count,
+                if wt_count == 1 { "" } else { "s" }
+            ),
+        ]);
+        json_projects.push(serde_json::json!({
+            "name": name,
+            "path": path,
+            "worktreeCount": wt_count,
+        }));
+    }
+
+    let text = format_table(&["NAME", "PATH", "WORKTREES"], &rows);
+
+    Ok(CommandResult {
+        text,
+        json: serde_json::json!({"projects": json_projects}),
+    })
+}
+
+fn cmd_projects_add(path: &str, label: Option<&str>) -> Result<CommandResult, String> {
+    validate::validate_path(path, "Path")?;
+
+    let client = api::ApiClient::from_settings()?;
+    let mut input = serde_json::json!({"path": path});
+    if let Some(label) = label {
+        input["label"] = serde_json::json!(label);
+    }
+    let data = client.trpc_mutate("projects.add", &input)?;
+    let name = data.get("name").and_then(|n| n.as_str()).unwrap_or("");
+    let result_path = data.get("path").and_then(|p| p.as_str()).unwrap_or("");
+
+    Ok(CommandResult {
+        text: format!("{name}\n"),
+        json: serde_json::json!({"name": name, "path": result_path}),
+    })
+}
+
+fn cmd_projects_remove(name: &str) -> Result<CommandResult, String> {
+    validate::validate_name(name, "Project name")?;
+
+    let client = api::ApiClient::from_settings()?;
+    client.trpc_mutate("projects.remove", &serde_json::json!({"name": name}))?;
+
+    Ok(CommandResult {
+        text: String::new(),
+        json: serde_json::json!({"ok": true}),
+    })
+}
+
+// --- Workspaces commands ---
+
+fn cmd_workspaces_list(project_filter: Option<&str>) -> Result<CommandResult, String> {
+    if let Some(name) = project_filter {
+        validate::validate_name(name, "Project name")?;
+    }
+
+    let client = api::ApiClient::from_settings()?;
+    let data = client.trpc_query_no_input("projects.list")?;
 
     let projects = data
         .get("projects")
@@ -202,6 +342,8 @@ fn cmd_list(project_filter: Option<&str>) -> Result<(), String> {
         .unwrap_or_default();
 
     let mut found_any = false;
+    let mut rows: Vec<[String; 3]> = Vec::new();
+    let mut workspaces = Vec::new();
     for proj in &projects {
         let name = proj.get("name").and_then(|n| n.as_str()).unwrap_or("");
         if let Some(filter) = project_filter {
@@ -217,7 +359,12 @@ fn cmd_list(project_filter: Option<&str>) -> Result<(), String> {
         for wt in &worktrees {
             let branch = wt.get("branch").and_then(|b| b.as_str()).unwrap_or("");
             let path = wt.get("path").and_then(|p| p.as_str()).unwrap_or("");
-            println!("{name}\t{branch}\t{path}");
+            rows.push([name.to_string(), branch.to_string(), path.to_string()]);
+            workspaces.push(serde_json::json!({
+                "project": name,
+                "branch": branch,
+                "path": path,
+            }));
             found_any = true;
         }
     }
@@ -228,10 +375,55 @@ fn cmd_list(project_filter: Option<&str>) -> Result<(), String> {
         }
     }
 
-    Ok(())
+    let text = format_table(&["PROJECT", "BRANCH", "PATH"], &rows);
+
+    Ok(CommandResult {
+        text,
+        json: serde_json::json!({"workspaces": workspaces}),
+    })
 }
 
-fn cmd_remove(project: &str, branch: &str) -> Result<(), String> {
+fn cmd_workspaces_create(
+    project: &str,
+    branch: &str,
+    base: Option<&str>,
+    prompt: Option<&str>,
+) -> Result<CommandResult, String> {
+    validate::validate_name(project, "Project name")?;
+    validate::validate_name(branch, "Branch name")?;
+    if let Some(b) = base {
+        validate::validate_name(b, "Base branch")?;
+    }
+
+    let client = api::ApiClient::from_settings()?;
+    let mut input = serde_json::json!({
+        "project": project,
+        "branch": branch,
+    });
+    if let Some(base) = base {
+        input["base"] = serde_json::json!(base);
+    }
+    if let Some(prompt) = prompt {
+        input["prompt"] = serde_json::json!(prompt);
+    }
+    let data = client.trpc_mutate("workspaces.create", &input)?;
+    let path = data.get("path").and_then(|p| p.as_str()).unwrap_or("");
+
+    // When a prompt is provided, open the editor so the extension picks up the task
+    if prompt.is_some() && !path.is_empty() {
+        open_configured_editor(path);
+    }
+
+    Ok(CommandResult {
+        text: format!("{path}\n"),
+        json: serde_json::json!({"path": path}),
+    })
+}
+
+fn cmd_workspaces_remove(project: &str, branch: &str) -> Result<CommandResult, String> {
+    validate::validate_name(project, "Project name")?;
+    validate::validate_name(branch, "Branch name")?;
+
     let client = api::ApiClient::from_settings()?;
     client.trpc_mutate(
         "workspaces.remove",
@@ -240,39 +432,84 @@ fn cmd_remove(project: &str, branch: &str) -> Result<(), String> {
             "branch": branch,
         }),
     )?;
-    Ok(())
+
+    Ok(CommandResult {
+        text: String::new(),
+        json: serde_json::json!({"ok": true}),
+    })
 }
 
-fn cmd_projects() -> Result<(), String> {
+// --- Settings command ---
+
+fn cmd_settings(json_output: bool) -> Result<CommandResult, String> {
     let client = api::ApiClient::from_settings()?;
-    let data = client.trpc_query("projects.list", &serde_json::json!({}))?;
+    let result = client.trpc_query_no_input("settings.get")?;
 
-    let projects = data
-        .get("projects")
-        .and_then(|p| p.as_array())
-        .cloned()
-        .unwrap_or_default();
+    let text = if json_output {
+        String::new()
+    } else {
+        serde_json::to_string_pretty(&result).unwrap_or_default() + "\n"
+    };
 
-    for proj in &projects {
-        let name = proj.get("name").and_then(|n| n.as_str()).unwrap_or("");
-        let path = proj.get("path").and_then(|p| p.as_str()).unwrap_or("");
-        let wt_count = proj
-            .get("worktrees")
-            .and_then(|w| w.as_array())
-            .map_or(0, Vec::len);
-        println!(
-            "{name}\t{path}\t{wt_count} worktree{}",
-            if wt_count == 1 { "" } else { "s" }
-        );
+    Ok(CommandResult { text, json: result })
+}
+
+// --- Tunnel commands ---
+
+fn cmd_tunnel_status() -> Result<CommandResult, String> {
+    let client = api::ApiClient::from_settings()?;
+    let data = client.trpc_query_no_input("tunnel.status")?;
+
+    let running = data
+        .get("running")
+        .and_then(serde_json::Value::as_bool)
+        .unwrap_or(false);
+    let url = data.get("url").and_then(|v| v.as_str());
+
+    let mut text = String::new();
+    let _ = writeln!(text, "running: {}", if running { "yes" } else { "no" });
+    if let Some(u) = url {
+        let _ = writeln!(text, "url: {u}");
     }
 
-    Ok(())
+    Ok(CommandResult {
+        text,
+        json: serde_json::json!({"running": running, "url": url}),
+    })
 }
 
-fn cmd_notify() -> Result<(), String> {
+fn cmd_tunnel_start(subdomain: Option<&str>) -> Result<CommandResult, String> {
+    let client = api::ApiClient::from_settings()?;
+    let mut input = serde_json::json!({});
+    if let Some(s) = subdomain {
+        input["subdomain"] = serde_json::json!(s);
+    }
+    let data = client.trpc_mutate("tunnel.start", &input)?;
+
+    let url = data.get("url").and_then(|v| v.as_str());
+    let mut text = String::new();
+    if let Some(u) = url {
+        let _ = writeln!(text, "{u}");
+    }
+
+    Ok(CommandResult { text, json: data })
+}
+
+fn cmd_tunnel_stop() -> Result<CommandResult, String> {
+    let client = api::ApiClient::from_settings()?;
+    client.trpc_mutate("tunnel.stop", &serde_json::json!({}))?;
+
+    Ok(CommandResult {
+        text: String::new(),
+        json: serde_json::json!({"ok": true}),
+    })
+}
+
+// --- Notify command ---
+
+fn cmd_notify() -> Result<CommandResult, String> {
     use std::io::Read;
 
-    // Read JSON from stdin
     let mut input = String::new();
     std::io::stdin()
         .read_to_string(&mut input)
@@ -286,13 +523,11 @@ fn cmd_notify() -> Result<(), String> {
         .and_then(|v| v.as_str())
         .unwrap_or("");
 
-    // Map hook event to agent status
     let agent_status = match hook_event {
         "Stop" | "PermissionRequest" => "needs_attention",
         _ => "working",
     };
 
-    // Get CWD from the hook payload, or fall back to current dir
     let cwd = payload
         .get("cwd")
         .and_then(|v| v.as_str())
@@ -307,7 +542,10 @@ fn cmd_notify() -> Result<(), String> {
     // All API calls for notify are fire-and-forget — fail silently
     // because this runs from git hooks and must not break git workflows
     let Ok(client) = api::ApiClient::from_settings() else {
-        return Ok(());
+        return Ok(CommandResult {
+            text: String::new(),
+            json: serde_json::json!({"ok": true}),
+        });
     };
 
     // Resolve CWD to workspace ID
@@ -317,11 +555,19 @@ fn cmd_notify() -> Result<(), String> {
             .get("workspaceId")
             .and_then(|v| v.as_str())
             .map(String::from),
-        Err(_) => return Ok(()),
+        Err(_) => {
+            return Ok(CommandResult {
+                text: String::new(),
+                json: serde_json::json!({"ok": true}),
+            });
+        }
     };
 
     let Some(workspace_id) = workspace_id else {
-        return Ok(()); // Not a tracked workspace, silently ignore
+        return Ok(CommandResult {
+            text: String::new(),
+            json: serde_json::json!({"ok": true}),
+        });
     };
 
     // Update status via API
@@ -336,7 +582,154 @@ fn cmd_notify() -> Result<(), String> {
         }),
     );
 
-    Ok(())
+    Ok(CommandResult {
+        text: String::new(),
+        json: serde_json::json!({"ok": true}),
+    })
+}
+
+// --- Table formatting ---
+
+fn format_table<const N: usize>(headers: &[&str; N], rows: &[[String; N]]) -> String {
+    if rows.is_empty() {
+        return String::new();
+    }
+
+    let mut widths = [0usize; N];
+    for (i, h) in headers.iter().enumerate() {
+        widths[i] = h.len();
+    }
+    for row in rows {
+        for (i, cell) in row.iter().enumerate() {
+            widths[i] = widths[i].max(cell.len());
+        }
+    }
+
+    let mut out = String::new();
+
+    for (i, h) in headers.iter().enumerate() {
+        if i > 0 {
+            out.push_str("  ");
+        }
+        if i < N - 1 {
+            let _ = write!(out, "{:<width$}", h, width = widths[i]);
+        } else {
+            out.push_str(h);
+        }
+    }
+    out.push('\n');
+
+    for row in rows {
+        for (i, cell) in row.iter().enumerate() {
+            if i > 0 {
+                out.push_str("  ");
+            }
+            if i < N - 1 {
+                let _ = write!(out, "{:<width$}", cell, width = widths[i]);
+            } else {
+                out.push_str(cell);
+            }
+        }
+        out.push('\n');
+    }
+
+    out
+}
+
+// --- Schema ---
+
+fn build_schema(command: Option<&str>) -> Result<serde_json::Value, String> {
+    let commands = vec![
+        serde_json::json!({
+            "name": "projects list",
+            "description": "List registered projects",
+            "parameters": []
+        }),
+        serde_json::json!({
+            "name": "projects add",
+            "description": "Register an existing repository as a project",
+            "parameters": [
+                {"name": "path", "type": "string", "required": true, "positional": true, "description": "Path to the git repository"},
+                {"name": "--label", "type": "string", "required": false, "description": "Label for the project"},
+            ]
+        }),
+        serde_json::json!({
+            "name": "projects remove",
+            "description": "Unregister a project",
+            "parameters": [
+                {"name": "name", "type": "string", "required": true, "positional": true, "description": "Project name"},
+            ]
+        }),
+        serde_json::json!({
+            "name": "workspaces list",
+            "description": "List workspaces, optionally filtered by project",
+            "parameters": [
+                {"name": "project", "type": "string", "required": false, "positional": true, "description": "Project name (optional filter)"},
+            ]
+        }),
+        serde_json::json!({
+            "name": "workspaces create",
+            "description": "Create a new workspace (git worktree + state registration)",
+            "parameters": [
+                {"name": "project", "type": "string", "required": true, "positional": true, "description": "Project name"},
+                {"name": "branch", "type": "string", "required": true, "positional": true, "description": "Branch name"},
+                {"name": "--base", "type": "string", "required": false, "description": "Base branch to create from (defaults to project's default branch)"},
+                {"name": "--prompt", "type": "string", "required": false, "description": "Prompt to pass to the coding agent"},
+            ]
+        }),
+        serde_json::json!({
+            "name": "workspaces remove",
+            "description": "Remove a workspace (git worktree + state cleanup)",
+            "parameters": [
+                {"name": "project", "type": "string", "required": true, "positional": true, "description": "Project name"},
+                {"name": "branch", "type": "string", "required": true, "positional": true, "description": "Branch name"},
+            ]
+        }),
+        serde_json::json!({
+            "name": "settings",
+            "description": "Show current settings",
+            "parameters": []
+        }),
+        serde_json::json!({
+            "name": "tunnel status",
+            "description": "Show tunnel status",
+            "parameters": []
+        }),
+        serde_json::json!({
+            "name": "tunnel start",
+            "description": "Start the remote tunnel",
+            "parameters": [
+                {"name": "--subdomain", "type": "string", "required": false, "description": "Subdomain to use"},
+            ]
+        }),
+        serde_json::json!({
+            "name": "tunnel stop",
+            "description": "Stop the remote tunnel",
+            "parameters": []
+        }),
+        serde_json::json!({
+            "name": "notify",
+            "description": "Receive hook notifications from Claude Code (reads JSON from stdin)",
+            "parameters": []
+        }),
+        serde_json::json!({
+            "name": "schema",
+            "description": "Show command schemas as JSON",
+            "parameters": [
+                {"name": "command", "type": "string", "required": false, "positional": true, "description": "Command name (omit to list all commands)"},
+            ]
+        }),
+    ];
+
+    if let Some(name) = command {
+        commands
+            .iter()
+            .find(|c| c["name"] == name)
+            .cloned()
+            .ok_or_else(|| format!("Unknown command: {name}"))
+    } else {
+        Ok(serde_json::json!({"commands": commands}))
+    }
 }
 
 /// Simple Unix timestamp without pulling in chrono crate.

--- a/apps/cli/src/shell.rs
+++ b/apps/cli/src/shell.rs
@@ -2,6 +2,7 @@ use std::process::{Command, Stdio};
 use std::sync::OnceLock;
 
 /// Resolve the user's full shell PATH once (includes nvm/volta/homebrew paths).
+#[allow(dead_code)]
 pub fn shell_path() -> &'static str {
     static PATH: OnceLock<String> = OnceLock::new();
     PATH.get_or_init(|| {

--- a/apps/cli/src/validate.rs
+++ b/apps/cli/src/validate.rs
@@ -1,0 +1,34 @@
+/// Validate a user-provided name (project name, branch name, etc.).
+///
+/// Rejects empty strings, control characters, path traversals, and excessively long inputs.
+pub fn validate_name(value: &str, label: &str) -> Result<(), String> {
+    if value.is_empty() {
+        return Err(format!("{label} cannot be empty"));
+    }
+    if value.len() > 255 {
+        return Err(format!("{label} is too long (max 255 characters)"));
+    }
+    if value.bytes().any(|b| b < 0x20) {
+        return Err(format!("{label} cannot contain control characters"));
+    }
+    if value.split('/').any(|seg| seg == "..") {
+        return Err(format!("{label} cannot contain path traversals (..)"));
+    }
+    Ok(())
+}
+
+/// Validate a user-provided filesystem path (e.g. for `projects add`).
+///
+/// Rejects empty strings, control characters, and excessively long inputs.
+pub fn validate_path(value: &str, label: &str) -> Result<(), String> {
+    if value.is_empty() {
+        return Err(format!("{label} cannot be empty"));
+    }
+    if value.len() > 4096 {
+        return Err(format!("{label} is too long (max 4096 characters)"));
+    }
+    if value.bytes().any(|b| b < 0x20) {
+        return Err(format!("{label} cannot contain control characters"));
+    }
+    Ok(())
+}

--- a/apps/cli/tests/integration.rs
+++ b/apps/cli/tests/integration.rs
@@ -157,10 +157,12 @@ fn stderr(output: &std::process::Output) -> String {
     String::from_utf8_lossy(&output.stderr).trim().to_string()
 }
 
+// --- Projects tests ---
+
 #[test]
-fn projects_lists_registered_project() {
+fn projects_list_shows_registered_project() {
     let env = TestEnv::new();
-    let output = env.band(&["projects"]);
+    let output = env.band(&["projects", "list"]);
 
     assert!(output.status.success(), "stderr: {}", stderr(&output));
     let out = stdout(&output);
@@ -168,9 +170,66 @@ fn projects_lists_registered_project() {
 }
 
 #[test]
-fn create_makes_worktree_and_returns_path() {
+fn projects_add_registers_new_project() {
     let env = TestEnv::new();
-    let output = env.band(&["create", "my-project", "feat/test"]);
+
+    // Create a new git repo to add
+    let new_repo = env._tmp.path().join("new-project");
+    fs::create_dir_all(&new_repo).unwrap();
+    git(&new_repo, &["init", "-b", "main"]);
+    git(&new_repo, &["commit", "--allow-empty", "-m", "init"]);
+
+    let output = env.band(&["projects", "add", new_repo.to_str().unwrap()]);
+    assert!(output.status.success(), "stderr: {}", stderr(&output));
+    let out = stdout(&output);
+    assert!(
+        out.contains("new-project"),
+        "expected project name in output: {out}"
+    );
+
+    // Verify it appears in projects list
+    let list_output = env.band(&["projects", "list"]);
+    assert!(list_output.status.success());
+    let list_out = stdout(&list_output);
+    assert!(
+        list_out.contains("new-project"),
+        "expected new-project in list: {list_out}"
+    );
+}
+
+#[test]
+fn projects_remove_unregisters_project() {
+    let env = TestEnv::new();
+
+    // First add a new project
+    let new_repo = env._tmp.path().join("to-remove");
+    fs::create_dir_all(&new_repo).unwrap();
+    git(&new_repo, &["init", "-b", "main"]);
+    git(&new_repo, &["commit", "--allow-empty", "-m", "init"]);
+
+    let add_output = env.band(&["projects", "add", new_repo.to_str().unwrap()]);
+    assert!(add_output.status.success());
+
+    // Now remove it
+    let output = env.band(&["projects", "remove", "to-remove"]);
+    assert!(output.status.success(), "stderr: {}", stderr(&output));
+
+    // Verify it's gone from projects list
+    let list_output = env.band(&["projects", "list"]);
+    assert!(list_output.status.success());
+    let list_out = stdout(&list_output);
+    assert!(
+        !list_out.contains("to-remove"),
+        "expected to-remove to be gone: {list_out}"
+    );
+}
+
+// --- Workspaces tests ---
+
+#[test]
+fn workspaces_create_makes_worktree_and_registers_state() {
+    let env = TestEnv::new();
+    let output = env.band(&["workspaces", "create", "my-project", "feat/test"]);
 
     assert!(output.status.success(), "stderr: {}", stderr(&output));
 
@@ -191,13 +250,13 @@ fn create_makes_worktree_and_returns_path() {
 }
 
 #[test]
-fn create_is_idempotent() {
+fn workspaces_create_is_idempotent() {
     let env = TestEnv::new();
 
-    let out1 = env.band(&["create", "my-project", "feat/idem"]);
+    let out1 = env.band(&["workspaces", "create", "my-project", "feat/idem"]);
     assert!(out1.status.success(), "stderr: {}", stderr(&out1));
 
-    let out2 = env.band(&["create", "my-project", "feat/idem"]);
+    let out2 = env.band(&["workspaces", "create", "my-project", "feat/idem"]);
     assert!(out2.status.success(), "stderr: {}", stderr(&out2));
 
     // Both return the same path
@@ -205,7 +264,7 @@ fn create_is_idempotent() {
 }
 
 #[test]
-fn create_with_base_branch() {
+fn workspaces_create_with_base_branch() {
     let env = TestEnv::new();
 
     // Create a commit on main so there's something to branch from
@@ -214,11 +273,17 @@ fn create_with_base_branch() {
     git(&env.repo_path, &["add", "marker.txt"]);
     git(&env.repo_path, &["commit", "-m", "add marker"]);
 
-    let output = env.band(&["create", "my-project", "feat/from-main", "--base", "main"]);
+    let output = env.band(&[
+        "workspaces",
+        "create",
+        "my-project",
+        "feat/from-main",
+        "--base",
+        "main",
+    ]);
     assert!(output.status.success(), "stderr: {}", stderr(&output));
 
     let path = stdout(&output);
-    // The new worktree should contain the marker file
     assert!(
         Path::new(&path).join("marker.txt").exists(),
         "worktree should have marker.txt from main"
@@ -226,9 +291,9 @@ fn create_with_base_branch() {
 }
 
 #[test]
-fn create_unknown_project_fails() {
+fn workspaces_create_unknown_project_fails() {
     let env = TestEnv::new();
-    let output = env.band(&["create", "nonexistent", "feat/x"]);
+    let output = env.band(&["workspaces", "create", "nonexistent", "feat/x"]);
 
     assert!(!output.status.success());
     assert!(
@@ -239,12 +304,12 @@ fn create_unknown_project_fails() {
 }
 
 #[test]
-fn list_shows_created_worktrees() {
+fn workspaces_list_shows_created_worktrees() {
     let env = TestEnv::new();
-    env.band(&["create", "my-project", "feat/a"]);
-    env.band(&["create", "my-project", "feat/b"]);
+    env.band(&["workspaces", "create", "my-project", "feat/a"]);
+    env.band(&["workspaces", "create", "my-project", "feat/b"]);
 
-    let output = env.band(&["list"]);
+    let output = env.band(&["workspaces", "list"]);
     assert!(output.status.success(), "stderr: {}", stderr(&output));
     let out = stdout(&output);
     assert!(out.contains("feat/a"), "should list feat/a: {out}");
@@ -252,24 +317,24 @@ fn list_shows_created_worktrees() {
 }
 
 #[test]
-fn list_filters_by_project() {
+fn workspaces_list_filters_by_project() {
     let env = TestEnv::new();
-    env.band(&["create", "my-project", "feat/filtered"]);
+    env.band(&["workspaces", "create", "my-project", "feat/filtered"]);
 
-    let output = env.band(&["list", "my-project"]);
+    let output = env.band(&["workspaces", "list", "my-project"]);
     assert!(output.status.success(), "stderr: {}", stderr(&output));
     assert!(stdout(&output).contains("feat/filtered"));
 
-    let output = env.band(&["list", "nonexistent"]);
+    let output = env.band(&["workspaces", "list", "nonexistent"]);
     assert!(!output.status.success());
     assert!(stderr(&output).contains("not found"));
 }
 
 #[test]
-fn remove_cleans_up_worktree_and_state() {
+fn workspaces_remove_cleans_up_worktree_and_state() {
     let env = TestEnv::new();
 
-    let create_out = env.band(&["create", "my-project", "feat/rm"]);
+    let create_out = env.band(&["workspaces", "create", "my-project", "feat/rm"]);
     assert!(
         create_out.status.success(),
         "stderr: {}",
@@ -277,7 +342,7 @@ fn remove_cleans_up_worktree_and_state() {
     );
     let path = stdout(&create_out);
 
-    let output = env.band(&["remove", "my-project", "feat/rm"]);
+    let output = env.band(&["workspaces", "remove", "my-project", "feat/rm"]);
     assert!(output.status.success(), "stderr: {}", stderr(&output));
 
     // Worktree removed from state
@@ -290,9 +355,9 @@ fn remove_cleans_up_worktree_and_state() {
 }
 
 #[test]
-fn remove_unknown_branch_fails() {
+fn workspaces_remove_unknown_branch_fails() {
     let env = TestEnv::new();
-    let output = env.band(&["remove", "my-project", "nonexistent"]);
+    let output = env.band(&["workspaces", "remove", "my-project", "nonexistent"]);
 
     assert!(!output.status.success());
     assert!(
@@ -303,9 +368,9 @@ fn remove_unknown_branch_fails() {
 }
 
 #[test]
-fn remove_unknown_project_fails() {
+fn workspaces_remove_unknown_project_fails() {
     let env = TestEnv::new();
-    let output = env.band(&["remove", "nonexistent", "main"]);
+    let output = env.band(&["workspaces", "remove", "nonexistent", "main"]);
 
     assert!(!output.status.success());
     assert!(
@@ -319,7 +384,6 @@ fn remove_unknown_project_fails() {
 fn setup_script_runs_on_create() {
     let env = TestEnv::new();
 
-    // Write a .band/config.json in the repo with a setup script
     let band_dir = env.repo_path.join(".band");
     fs::create_dir_all(&band_dir).unwrap();
     fs::write(
@@ -330,7 +394,7 @@ fn setup_script_runs_on_create() {
     git(&env.repo_path, &["add", ".band/config.json"]);
     git(&env.repo_path, &["commit", "-m", "add config"]);
 
-    let output = env.band(&["create", "my-project", "feat/setup"]);
+    let output = env.band(&["workspaces", "create", "my-project", "feat/setup"]);
     assert!(output.status.success(), "stderr: {}", stderr(&output));
 
     let path = stdout(&output);
@@ -344,7 +408,6 @@ fn setup_script_runs_on_create() {
 fn teardown_script_runs_on_remove() {
     let env = TestEnv::new();
 
-    // Write a .band/config.json with a teardown that creates a marker in BAND_HOME
     let band_dir = env.repo_path.join(".band");
     fs::create_dir_all(&band_dir).unwrap();
     let marker_path = env.band_dir.join("teardown-ran.txt");
@@ -359,10 +422,10 @@ fn teardown_script_runs_on_remove() {
     git(&env.repo_path, &["add", ".band/config.json"]);
     git(&env.repo_path, &["commit", "-m", "add config"]);
 
-    let create_out = env.band(&["create", "my-project", "feat/teardown"]);
+    let create_out = env.band(&["workspaces", "create", "my-project", "feat/teardown"]);
     assert!(create_out.status.success());
 
-    let output = env.band(&["remove", "my-project", "feat/teardown"]);
+    let output = env.band(&["workspaces", "remove", "my-project", "feat/teardown"]);
     assert!(output.status.success(), "stderr: {}", stderr(&output));
 
     assert!(
@@ -372,17 +435,22 @@ fn teardown_script_runs_on_remove() {
 }
 
 #[test]
-fn run_creates_worktree_and_dispatches_task() {
+fn workspaces_create_with_prompt_submits_task() {
     let env = TestEnv::new();
-    let output = env.band(&["run", "my-project", "feat/run", "--prompt", "hello world"]);
+    let output = env.band(&[
+        "workspaces",
+        "create",
+        "my-project",
+        "feat/run",
+        "--prompt",
+        "hello world",
+    ]);
 
     assert!(output.status.success(), "stderr: {}", stderr(&output));
 
     let path = stdout(&output);
-    // Worktree directory exists on disk
     assert!(Path::new(&path).exists(), "worktree dir should exist");
 
-    // State was updated
     let state = env.state_json();
     let worktrees = &state["projects"][0]["worktrees"];
     assert!(
@@ -396,9 +464,44 @@ fn run_creates_worktree_and_dispatches_task() {
 }
 
 #[test]
-fn run_unknown_project_fails() {
+fn workspaces_create_with_prompt_and_base() {
     let env = TestEnv::new();
-    let output = env.band(&["run", "nonexistent", "feat/x", "--prompt", "hello"]);
+
+    let marker = env.repo_path.join("marker.txt");
+    fs::write(&marker, "hello").unwrap();
+    git(&env.repo_path, &["add", "marker.txt"]);
+    git(&env.repo_path, &["commit", "-m", "add marker"]);
+
+    let output = env.band(&[
+        "workspaces",
+        "create",
+        "my-project",
+        "feat/run-base",
+        "--prompt",
+        "do stuff",
+        "--base",
+        "main",
+    ]);
+    assert!(output.status.success(), "stderr: {}", stderr(&output));
+
+    let path = stdout(&output);
+    assert!(
+        Path::new(&path).join("marker.txt").exists(),
+        "worktree should have marker.txt from main"
+    );
+}
+
+#[test]
+fn workspaces_create_unknown_project_with_prompt_fails() {
+    let env = TestEnv::new();
+    let output = env.band(&[
+        "workspaces",
+        "create",
+        "nonexistent",
+        "feat/x",
+        "--prompt",
+        "hello",
+    ]);
 
     assert!(!output.status.success());
     assert!(
@@ -418,18 +521,15 @@ fn setup_failure_is_non_fatal() {
     git(&env.repo_path, &["add", ".band/config.json"]);
     git(&env.repo_path, &["commit", "-m", "add failing setup"]);
 
-    let output = env.band(&["create", "my-project", "feat/fail-setup"]);
-    // Should still succeed — setup failure is non-fatal
+    let output = env.band(&["workspaces", "create", "my-project", "feat/fail-setup"]);
     assert!(output.status.success(), "stderr: {}", stderr(&output));
 
-    // Path still printed
     let path = stdout(&output);
     assert!(Path::new(&path).exists());
 }
 
 #[test]
 fn notify_silently_succeeds_when_server_unreachable() {
-    // Use a completely isolated env with wrong port so server is unreachable
     let tmp = tempfile::tempdir().expect("create tempdir");
     let band_home = tmp.path().join("band-home");
     fs::create_dir_all(&band_home).unwrap();
@@ -460,10 +560,243 @@ fn notify_silently_succeeds_when_server_unreachable() {
         })
         .expect("failed to execute band notify");
 
-    // Should succeed (exit 0) even when server is unreachable
     assert!(
         output.status.success(),
         "notify should not fail when server is down. stderr: {}",
         stderr(&output)
+    );
+}
+
+// --- Settings tests ---
+
+#[test]
+fn settings_shows_config() {
+    let env = TestEnv::new();
+    let output = env.band(&["settings", "--output", "json"]);
+
+    assert!(output.status.success(), "stderr: {}", stderr(&output));
+    let json: serde_json::Value = serde_json::from_str(&stdout(&output))
+        .unwrap_or_else(|e| panic!("invalid JSON: {e}\nstdout: {}", stdout(&output)));
+    assert!(
+        json.get("worktreesDir").is_some(),
+        "expected worktreesDir in settings: {json}"
+    );
+}
+
+// --- Tunnel tests ---
+
+#[test]
+fn tunnel_status_shows_not_running() {
+    let env = TestEnv::new();
+    let output = env.band(&["tunnel", "status"]);
+
+    assert!(output.status.success(), "stderr: {}", stderr(&output));
+    let out = stdout(&output);
+    assert!(
+        out.contains("running: no"),
+        "expected tunnel not running: {out}"
+    );
+}
+
+#[test]
+fn tunnel_status_json_output() {
+    let env = TestEnv::new();
+    let output = env.band(&["tunnel", "status", "--output", "json"]);
+
+    assert!(output.status.success(), "stderr: {}", stderr(&output));
+    let json: serde_json::Value = serde_json::from_str(&stdout(&output))
+        .unwrap_or_else(|e| panic!("invalid JSON: {e}\nstdout: {}", stdout(&output)));
+    assert_eq!(json["running"], false, "json: {json}");
+}
+
+// --- JSON output tests ---
+
+#[test]
+fn workspaces_create_json_output() {
+    let env = TestEnv::new();
+    let output = env.band(&[
+        "workspaces",
+        "create",
+        "my-project",
+        "feat/json",
+        "--output",
+        "json",
+    ]);
+
+    assert!(output.status.success(), "stderr: {}", stderr(&output));
+    let json: serde_json::Value = serde_json::from_str(&stdout(&output))
+        .unwrap_or_else(|e| panic!("invalid JSON: {e}\nstdout: {}", stdout(&output)));
+    assert!(
+        json["path"].as_str().unwrap().contains("feat/json"),
+        "json: {json}"
+    );
+}
+
+#[test]
+fn workspaces_list_json_output() {
+    let env = TestEnv::new();
+    env.band(&["workspaces", "create", "my-project", "feat/j1"]);
+
+    let output = env.band(&["workspaces", "list", "--output", "json"]);
+    assert!(output.status.success(), "stderr: {}", stderr(&output));
+    let json: serde_json::Value = serde_json::from_str(&stdout(&output))
+        .unwrap_or_else(|e| panic!("invalid JSON: {e}\nstdout: {}", stdout(&output)));
+    let workspaces = json["workspaces"].as_array().expect("workspaces array");
+    assert!(
+        workspaces.iter().any(|w| w["branch"] == "feat/j1"),
+        "should contain feat/j1: {json}"
+    );
+}
+
+#[test]
+fn projects_list_json_output() {
+    let env = TestEnv::new();
+    let output = env.band(&["projects", "list", "--output", "json"]);
+
+    assert!(output.status.success(), "stderr: {}", stderr(&output));
+    let json: serde_json::Value = serde_json::from_str(&stdout(&output))
+        .unwrap_or_else(|e| panic!("invalid JSON: {e}\nstdout: {}", stdout(&output)));
+    let projects = json["projects"].as_array().expect("projects array");
+    assert!(
+        projects.iter().any(|p| p["name"] == "my-project"),
+        "should contain my-project: {json}"
+    );
+}
+
+#[test]
+fn workspaces_remove_json_output() {
+    let env = TestEnv::new();
+    env.band(&["workspaces", "create", "my-project", "feat/rmjson"]);
+
+    let output = env.band(&[
+        "workspaces",
+        "remove",
+        "my-project",
+        "feat/rmjson",
+        "--output",
+        "json",
+    ]);
+    assert!(output.status.success(), "stderr: {}", stderr(&output));
+    let json: serde_json::Value = serde_json::from_str(&stdout(&output))
+        .unwrap_or_else(|e| panic!("invalid JSON: {e}\nstdout: {}", stdout(&output)));
+    assert_eq!(json["ok"], true, "json: {json}");
+}
+
+#[test]
+fn error_json_output() {
+    let env = TestEnv::new();
+    let output = env.band(&[
+        "workspaces",
+        "create",
+        "nonexistent",
+        "feat/x",
+        "--output",
+        "json",
+    ]);
+
+    assert!(!output.status.success());
+    let json: serde_json::Value = serde_json::from_str(&stderr(&output))
+        .unwrap_or_else(|e| panic!("invalid JSON error: {e}\nstderr: {}", stderr(&output)));
+    assert!(json["error"].as_str().is_some(), "json: {json}");
+}
+
+// --- Input validation tests ---
+
+#[test]
+fn workspaces_create_rejects_path_traversal() {
+    let env = TestEnv::new();
+    let output = env.band(&["workspaces", "create", "my-project", "feat/../etc"]);
+
+    assert!(!output.status.success());
+    assert!(
+        stderr(&output).contains("path traversal"),
+        "stderr: {}",
+        stderr(&output)
+    );
+}
+
+#[test]
+fn workspaces_create_rejects_control_chars() {
+    let env = TestEnv::new();
+    let output = env.band(&["workspaces", "create", "my-project", "feat/\x01test"]);
+
+    assert!(!output.status.success());
+    assert!(
+        stderr(&output).contains("control character"),
+        "stderr: {}",
+        stderr(&output)
+    );
+}
+
+#[test]
+fn workspaces_create_rejects_empty_branch() {
+    let env = TestEnv::new();
+    let output = env.band(&["workspaces", "create", "my-project", ""]);
+
+    assert!(!output.status.success());
+    assert!(
+        stderr(&output).contains("cannot be empty"),
+        "stderr: {}",
+        stderr(&output)
+    );
+}
+
+// --- Schema tests ---
+
+#[test]
+fn schema_lists_all_commands() {
+    let env = TestEnv::new();
+    let output = env.band(&["schema"]);
+
+    assert!(output.status.success(), "stderr: {}", stderr(&output));
+    let json: serde_json::Value = serde_json::from_str(&stdout(&output))
+        .unwrap_or_else(|e| panic!("invalid JSON: {e}\nstdout: {}", stdout(&output)));
+    let commands = json["commands"].as_array().expect("commands array");
+    let names: Vec<&str> = commands
+        .iter()
+        .map(|c| c["name"].as_str().unwrap())
+        .collect();
+    assert!(names.contains(&"projects list"), "missing: {names:?}");
+    assert!(names.contains(&"projects add"), "missing: {names:?}");
+    assert!(names.contains(&"projects remove"), "missing: {names:?}");
+    assert!(names.contains(&"workspaces list"), "missing: {names:?}");
+    assert!(names.contains(&"workspaces create"), "missing: {names:?}");
+    assert!(names.contains(&"workspaces remove"), "missing: {names:?}");
+    assert!(names.contains(&"settings"), "missing: {names:?}");
+    assert!(names.contains(&"tunnel status"), "missing: {names:?}");
+    assert!(names.contains(&"tunnel start"), "missing: {names:?}");
+    assert!(names.contains(&"tunnel stop"), "missing: {names:?}");
+    assert!(names.contains(&"notify"), "missing: {names:?}");
+    assert!(names.contains(&"schema"), "missing: {names:?}");
+}
+
+#[test]
+fn schema_shows_single_command() {
+    let env = TestEnv::new();
+    let output = env.band(&["schema", "workspaces create"]);
+
+    assert!(output.status.success(), "stderr: {}", stderr(&output));
+    let json: serde_json::Value = serde_json::from_str(&stdout(&output))
+        .unwrap_or_else(|e| panic!("invalid JSON: {e}\nstdout: {}", stdout(&output)));
+    assert_eq!(json["name"], "workspaces create");
+    let params = json["parameters"].as_array().expect("parameters array");
+    assert!(
+        params.iter().any(|p| p["name"] == "project"),
+        "json: {json}"
+    );
+    assert!(params.iter().any(|p| p["name"] == "branch"), "json: {json}");
+}
+
+#[test]
+fn schema_unknown_command_fails() {
+    let env = TestEnv::new();
+    let output = env.band(&["schema", "nonexistent"]);
+
+    assert!(!output.status.success());
+    let json: serde_json::Value = serde_json::from_str(&stderr(&output))
+        .unwrap_or_else(|e| panic!("invalid JSON: {e}\nstderr: {}", stderr(&output)));
+    assert!(
+        json["error"].as_str().unwrap().contains("Unknown command"),
+        "json: {json}"
     );
 }

--- a/apps/dashboard/src-tauri/src/commands/ax_windows.rs
+++ b/apps/dashboard/src-tauri/src/commands/ax_windows.rs
@@ -963,6 +963,49 @@ pub fn focus_window(pid: i32, cg_id: u32) -> bool {
     raised
 }
 
+/// Check if a window still exists (is reachable via AX APIs).
+pub fn window_exists(pid: i32, cg_id: u32) -> bool {
+    unsafe {
+        let result = find_ax_window(pid, cg_id);
+        if let Some(ax_win) = result {
+            CFRelease(ax_win);
+            true
+        } else {
+            false
+        }
+    }
+}
+
+/// Close a window by performing `AXPress` on its close button.
+pub fn close_window(pid: i32, cg_id: u32) -> bool {
+    if !check_accessibility() {
+        return false;
+    }
+
+    unsafe {
+        let Some(ax_win) = find_ax_window(pid, cg_id) else {
+            return false;
+        };
+
+        let attr = cfstr("AXCloseButton");
+        let mut close_btn: *const c_void = std::ptr::null();
+        let err = AXUIElementCopyAttributeValue(ax_win, attr, &raw mut close_btn);
+        CFRelease(attr);
+
+        if err != 0 || close_btn.is_null() {
+            CFRelease(ax_win);
+            return false;
+        }
+
+        let action = cfstr("AXPress");
+        let press_err = AXUIElementPerformAction(close_btn, action);
+        CFRelease(action);
+        CFRelease(close_btn);
+        CFRelease(ax_win);
+        press_err == 0
+    }
+}
+
 // --- Screen size ---
 
 /// Get screen size via `CGDisplayBounds`.

--- a/apps/dashboard/src-tauri/src/commands/ide.rs
+++ b/apps/dashboard/src-tauri/src/commands/ide.rs
@@ -563,6 +563,36 @@ pub fn workspace_focus(
     Ok(())
 }
 
+/// Close all windows associated with a workspace.
+#[tauri::command]
+pub fn workspace_close(
+    workspace_id: String,
+    project_cache: tauri::State<'_, ProjectCache>,
+) -> Result<(), String> {
+    let app_state = project_cache
+        .get()
+        .or_else(|| refresh_project_cache(&project_cache))
+        .ok_or("Project state not available yet")?;
+
+    let folder_name = if let Some((_path, folder)) = workspace_info(&workspace_id, &app_state) {
+        folder
+    } else {
+        // Workspace may already be removed from state; derive folder_name from workspace_id
+        // by taking everything after the first '-' (project-branch format).
+        workspace_id
+            .split_once('-')
+            .map(|(_, branch)| branch.to_string())
+            .unwrap_or_default()
+    };
+
+    if folder_name.is_empty() {
+        return Ok(());
+    }
+
+    let wm = WindowManager::global();
+    wm.close_all_for_folder(&folder_name)
+}
+
 /// Return the currently active workspace ID from in-memory state.
 #[tauri::command]
 pub fn get_active_workspace(

--- a/apps/dashboard/src-tauri/src/commands/ide_stub.rs
+++ b/apps/dashboard/src-tauri/src/commands/ide_stub.rs
@@ -17,6 +17,14 @@ pub fn workspace_focus(
 }
 
 #[tauri::command]
+pub fn workspace_close(
+    _workspace_id: String,
+    _project_cache: tauri::State<'_, ProjectCache>,
+) -> Result<(), String> {
+    Ok(())
+}
+
+#[tauri::command]
 pub fn get_active_workspace(
     _active_state: tauri::State<'_, ActiveWorkspaceState>,
 ) -> Result<Option<String>, String> {

--- a/apps/dashboard/src-tauri/src/commands/window_manager.rs
+++ b/apps/dashboard/src-tauri/src/commands/window_manager.rs
@@ -154,6 +154,62 @@ impl WindowManager {
             }
         }
     }
+
+    /// Close all windows matching a given folder name, wait for them to disappear,
+    /// then unregister them. Returns an error if any window is still open after the timeout.
+    pub fn close_all_for_folder(&self, folder_name: &str) -> Result<(), String> {
+        let suffix = format!(":{folder_name}");
+        let matching: Vec<(String, WindowEntry)> = {
+            let map = self.registry.lock().unwrap();
+            map.iter()
+                .filter(|(key, _)| key.ends_with(&suffix))
+                .map(|(k, v)| (k.clone(), v.clone()))
+                .collect()
+        };
+
+        if matching.is_empty() {
+            return Ok(());
+        }
+
+        // Press close button on each window
+        for (_key, entry) in &matching {
+            ax_windows::close_window(entry.pid, entry.cg_window_id);
+        }
+
+        // Poll until all windows are gone or timeout (5s)
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+        loop {
+            let still_open: Vec<&str> = matching
+                .iter()
+                .filter(|(_key, entry)| ax_windows::window_exists(entry.pid, entry.cg_window_id))
+                .map(|(key, _)| key.as_str())
+                .collect();
+
+            if still_open.is_empty() {
+                break;
+            }
+
+            if std::time::Instant::now() >= deadline {
+                return Err(format!(
+                    "Windows still open: {}. Close them before deleting the workspace.",
+                    still_open.join(", ")
+                ));
+            }
+
+            std::thread::sleep(std::time::Duration::from_millis(100));
+        }
+
+        // All windows closed — unregister and persist
+        {
+            let mut map = self.registry.lock().unwrap();
+            for (key, _) in &matching {
+                map.remove(key);
+            }
+            save_to_disk(&map);
+        }
+
+        Ok(())
+    }
 }
 
 // --- Persistence helpers ---

--- a/apps/dashboard/src-tauri/src/lib.rs
+++ b/apps/dashboard/src-tauri/src/lib.rs
@@ -21,6 +21,7 @@ pub fn run() {
         .manage(ProjectCache::new())
         .invoke_handler(tauri::generate_handler![
             commands::ide::workspace_focus,
+            commands::ide::workspace_close,
             commands::ide::get_active_workspace,
             commands::ide::detect_active_workspace,
             commands::ide::pick_folder,

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -7,6 +7,7 @@
     "dev": "vite dev --port 3456 --host 0.0.0.0",
     "build": "vite build && esbuild start-server.ts --bundle --platform=node --format=esm --outfile=dist/start-server.mjs --external:./server/server.js --banner:js=\"import{createRequire}from'module';import{fileURLToPath as __fu}from'url';import{dirname as __dn}from'path';const require=createRequire(import.meta.url);const __filename=__fu(import.meta.url);const __dirname=__dn(__filename);\"",
     "start": "node dist/start-server.mjs",
+    "build:test-server": "esbuild test-server.ts --bundle --platform=node --format=esm --outfile=dist/test-server.mjs --banner:js=\"import{createRequire}from'module';import{fileURLToPath as __fu}from'url';import{dirname as __dn}from'path';const require=createRequire(import.meta.url);const __filename=__fu(import.meta.url);const __dirname=__dn(__filename);\"",
     "pretest": "pnpm build",
     "test": "vitest run"
   },

--- a/apps/web/src/lib/state.ts
+++ b/apps/web/src/lib/state.ts
@@ -55,6 +55,7 @@ export interface Settings {
 }
 
 export function bandHome(): string {
+  if (process.env.BAND_HOME) return process.env.BAND_HOME;
   return join(homedir(), ".band");
 }
 

--- a/apps/web/src/trpc/router.ts
+++ b/apps/web/src/trpc/router.ts
@@ -1,16 +1,8 @@
 import { execFile, execFileSync } from "node:child_process";
-import {
-  existsSync,
-  mkdirSync,
-  readFileSync,
-  renameSync,
-  unlinkSync,
-  writeFileSync,
-} from "node:fs";
+import { existsSync, mkdirSync, readFileSync, renameSync, unlinkSync, writeFileSync } from "node:fs";
 import { mkdir, readdir, readFile, stat, writeFile } from "node:fs/promises";
 import { hostname } from "node:os";
 import { basename, extname, join, resolve } from "node:path";
-import { createLogger } from "@band/logger";
 import { initTRPC, TRPCError } from "@trpc/server";
 import { z } from "zod";
 import { getOrCreateAgent } from "../lib/agent-pool";
@@ -28,17 +20,9 @@ import {
   loadState,
   saveState,
   settingsFile,
-  statusDir,
   worktreesDir,
 } from "../lib/state";
-import {
-  abortTask,
-  getBufferedChunks,
-  getTask,
-  submitTask,
-  subscribe as subscribeTask,
-  TaskConflictError,
-} from "../lib/task-runner";
+import { abortTask, getTask, submitTask, TaskConflictError } from "../lib/task-runner";
 import {
   checkTunnelAuth,
   checkTunnelHealth,
@@ -46,11 +30,8 @@ import {
   startTunnel,
   stopTunnel,
 } from "../lib/tunnel";
-import { subscribe as subscribeStatus } from "../lib/watcher";
 import { resolveWorkspace } from "../lib/workspace";
 import type { Context } from "./context";
-
-const log = createLogger("trpc");
 
 const t = initTRPC.context<Context>().create();
 
@@ -212,8 +193,8 @@ const workspacesRouter = t.router({
         throw new Error(`Project "${input.project}" not found`);
       }
 
-      const existing = proj.worktrees.find((wt) => wt.branch === input.branch);
-      if (existing) {
+      if (proj.worktrees.some((wt) => wt.branch === input.branch)) {
+        const existing = proj.worktrees.find((wt) => wt.branch === input.branch)!;
         return { ok: true, path: existing.path };
       }
 
@@ -238,22 +219,26 @@ const workspacesRouter = t.router({
       proj.worktrees.push({ branch: input.branch, path: worktreePath });
       saveState(state);
 
-      // Run setup script if configured
-      const configPath = join(worktreePath, ".band", "config.json");
+      // Run setup script if configured (non-fatal)
       try {
+        const configPath = join(worktreePath, ".band", "config.json");
         if (existsSync(configPath)) {
           const config = JSON.parse(readFileSync(configPath, "utf-8"));
           if (config.setup) {
+            const env = { ...process.env };
+            if (env.PATH) {
+              env.PATH = `/opt/homebrew/bin:/usr/local/bin:${env.PATH}`;
+            }
             execFileSync("bash", ["-c", config.setup], {
               cwd: worktreePath,
-              env: { ...process.env, PATH: `/opt/homebrew/bin:/usr/local/bin:${process.env.PATH}` },
+              env,
               encoding: "utf-8",
               timeout: 60_000,
             });
           }
         }
-      } catch {
-        // Setup script failure is non-fatal
+      } catch (e) {
+        console.error(`Setup script failed: ${e instanceof Error ? e.message : e}`);
       }
 
       if (input.prompt) {
@@ -293,30 +278,29 @@ const workspacesRouter = t.router({
             : branchRef;
         } else if (line === "" && currentPath) {
           if (currentBranch === input.branch) {
-            const worktreePath = currentPath;
-
-            // Run teardown script before removing worktree so it can access project files
-            const configPath = join(worktreePath, ".band", "config.json");
+            // Run teardown script if configured (non-fatal)
             try {
+              const configPath = join(currentPath, ".band", "config.json");
               if (existsSync(configPath)) {
                 const config = JSON.parse(readFileSync(configPath, "utf-8"));
                 if (config.teardown) {
+                  const teardownEnv = { ...process.env };
+                  if (teardownEnv.PATH) {
+                    teardownEnv.PATH = `/opt/homebrew/bin:/usr/local/bin:${teardownEnv.PATH}`;
+                  }
                   execFileSync("bash", ["-c", config.teardown], {
-                    cwd: worktreePath,
-                    env: {
-                      ...process.env,
-                      PATH: `/opt/homebrew/bin:/usr/local/bin:${process.env.PATH}`,
-                    },
+                    cwd: currentPath,
+                    env: teardownEnv,
                     encoding: "utf-8",
                     timeout: 60_000,
                   });
                 }
               }
-            } catch {
-              // Teardown script failure is non-fatal
+            } catch (e) {
+              console.error(`Teardown script failed: ${e instanceof Error ? e.message : e}`);
             }
 
-            execFileSync(command, ["worktree", "remove", "--force", worktreePath], {
+            execFileSync(command, ["worktree", "remove", "--force", currentPath], {
               cwd: proj.path,
               env,
               encoding: "utf-8",
@@ -340,7 +324,7 @@ const workspacesRouter = t.router({
               // Prompt file may not exist
             }
             try {
-              unlinkSync(join(statusDir(), `${workspaceId}.json`));
+              unlinkSync(join(bandHome(), "status", `${workspaceId}.json`));
             } catch {
               // Status file may not exist
             }
@@ -371,6 +355,61 @@ const workspacesRouter = t.router({
           }
         });
       });
+    }),
+
+  notify: publicProcedure
+    .input(
+      z.object({
+        cwd: z.string(),
+        hookPayload: z.record(z.string(), z.unknown()),
+      }),
+    )
+    .mutation(({ input }) => {
+      const hookEvent = (input.hookPayload.hook_event_name as string) || "";
+      const agentStatus =
+        hookEvent === "Stop" || hookEvent === "PermissionRequest" ? "needs_attention" : "working";
+
+      // Match CWD to a tracked workspace
+      const state = loadState();
+      let workspaceId: string | null = null;
+      for (const proj of state.projects) {
+        for (const wt of proj.worktrees) {
+          if (input.cwd.startsWith(wt.path) || wt.path === input.cwd) {
+            workspaceId = `${proj.name}-${wt.branch}`;
+            break;
+          }
+        }
+        if (workspaceId) break;
+      }
+
+      if (!workspaceId) {
+        return { ok: true, matched: false };
+      }
+
+      // Write status file atomically
+      const dir = join(bandHome(), "status");
+      mkdirSync(dir, { recursive: true });
+      const statusFile = join(dir, `${workspaceId}.json`);
+
+      let status: Record<string, unknown> = {};
+      try {
+        status = JSON.parse(readFileSync(statusFile, "utf-8"));
+      } catch {
+        // New file
+      }
+
+      status.workspaceId = workspaceId;
+      if (!status.agent || typeof status.agent !== "object") {
+        status.agent = {};
+      }
+      (status.agent as Record<string, unknown>).status = agentStatus;
+      (status.agent as Record<string, unknown>).lastActivity = new Date().toISOString();
+
+      const tmpFile = join(dir, `.${workspaceId}.json.tmp`);
+      writeFileSync(tmpFile, JSON.stringify(status, null, 2));
+      renameSync(tmpFile, statusFile);
+
+      return { ok: true, matched: true };
     }),
 });
 
@@ -640,23 +679,15 @@ const tunnelRouter = t.router({
   start: publicProcedure
     .input(z.object({ subdomain: z.string().optional(), skipSubdomain: z.boolean().optional() }))
     .mutation(async ({ input }) => {
-      log.debug({ input }, "tunnel.start called");
       const settings = loadSettings();
       const port = parseInt(process.env.PORT || "3456", 10);
       const subdomain = input.subdomain || (settings as Record<string, unknown>).tunnelSubdomain;
-      log.debug(
-        "tunnel.start: port=%d subdomain=%s skipSubdomain=%s",
-        port,
-        subdomain,
-        input.skipSubdomain,
-      );
       await startTunnel({
         port,
         subdomain: subdomain as string | undefined,
         skipSubdomain: input.skipSubdomain,
       });
       const status = getTunnelStatus();
-      log.debug({ status }, "tunnel.start: after startTunnel");
       if (status.url) {
         return { ok: true, url: status.url };
       }
@@ -665,12 +696,10 @@ const tunnelRouter = t.router({
       if (resolvedSubdomain) {
         const token = getToken();
         const health = await checkTunnelHealth(resolvedSubdomain, token);
-        log.debug({ health }, "tunnel.start: remote health check");
         if (health.healthy) {
           return { ok: true, url: `https://${resolvedSubdomain}.instatunnel.my?token=${token}` };
         }
       }
-      log.debug("tunnel.start: no URL available");
       return { ok: true, url: null as string | null };
     }),
 
@@ -820,59 +849,6 @@ const tasksRouter = t.router({
     }
     return { aborted: true };
   }),
-
-  stream: publicProcedure
-    .input(z.object({ workspaceId: z.string() }))
-    .subscription(async function* (opts) {
-      const workspaceId = opts.input.workspaceId;
-      const task = getTask(workspaceId);
-      const buffered = getBufferedChunks(workspaceId);
-
-      // No task and no buffered chunks — nothing to stream
-      if (!task && buffered.length === 0) return;
-
-      // Replay buffered chunks
-      for (const chunk of buffered) {
-        yield chunk;
-      }
-
-      // If task is already done, stop
-      if (!task || task.status !== "running") return;
-
-      // Stream live chunks
-      type Chunk = Parameters<Parameters<typeof subscribeTask>[1]>[0];
-      const queue: Chunk[] = [];
-      let resolve: (() => void) | null = null;
-      let done = false;
-
-      const unsubscribe = subscribeTask(workspaceId, (chunk) => {
-        queue.push(chunk);
-        if (chunk.type === "finish" || chunk.type === "error") {
-          done = true;
-        }
-        resolve?.();
-      });
-
-      opts.signal.addEventListener("abort", () => {
-        unsubscribe();
-        resolve?.();
-      });
-
-      try {
-        while (!opts.signal.aborted) {
-          while (queue.length > 0) {
-            yield queue.shift()!;
-          }
-          if (done) return;
-          await new Promise<void>((r) => {
-            resolve = r;
-          });
-          resolve = null;
-        }
-      } finally {
-        unsubscribe();
-      }
-    }),
 });
 
 // ---------------------------------------------------------------------------
@@ -921,9 +897,7 @@ const sessionsRouter = t.router({
 
 const servicesRouter = t.router({
   health: publicProcedure.query(async () => {
-    log.debug("services.health called");
     const tunnel = getTunnelStatus();
-    log.debug({ tunnel }, "services.health: tunnel status");
     let tunnelHealthy = false;
     let tunnelUrl = tunnel.url;
     let tunnelRemoteHost: string | undefined;
@@ -934,9 +908,7 @@ const servicesRouter = t.router({
     if (tunnel.running && tunnel.url) {
       const urlMatch = tunnel.url.match(/https:\/\/(.+)\.instatunnel\.my/);
       if (urlMatch) {
-        log.debug("services.health: checking tunnel health for %s", urlMatch[1]);
         const health = await checkTunnelHealth(urlMatch[1], token);
-        log.debug({ health }, "services.health: tunnel health");
         tunnelHealthy = health.healthy;
         // Only report as remote if it's a different machine
         if (health.remoteHost && health.remoteHost !== localHostname) {
@@ -950,15 +922,8 @@ const servicesRouter = t.router({
     if (!tunnelHealthy) {
       const settings = loadSettings();
       const subdomain = (settings as Record<string, unknown>).tunnelSubdomain as string | undefined;
-      log.debug(
-        "services.health: tunnelSubdomain=%s token=%s",
-        subdomain ?? "none",
-        token ? `${token.slice(0, 6)}...` : "null",
-      );
       if (subdomain) {
-        log.debug("services.health: checking remote subdomain %s", subdomain);
         const health = await checkTunnelHealth(subdomain, token);
-        log.debug({ health }, "services.health: remote health");
         if (health.healthy) {
           tunnelHealthy = true;
           // Only report as remote if it's a different machine
@@ -967,19 +932,15 @@ const servicesRouter = t.router({
           }
           tunnelUrl = `https://${subdomain}.instatunnel.my?token=${token}`;
         }
-      } else {
-        log.debug("services.health: no tunnelSubdomain configured, skipping remote check");
       }
     }
 
-    const result = {
+    return {
       webserver: true,
       tunnel: tunnelHealthy,
       tunnel_url: tunnelUrl,
       tunnel_remote_host: tunnelRemoteHost || tunnel.remoteHost,
     };
-    log.debug({ result }, "services.health result");
-    return result;
   }),
 });
 
@@ -1003,109 +964,6 @@ const chatRouter = t.router({
 });
 
 // ---------------------------------------------------------------------------
-// Statuses
-// ---------------------------------------------------------------------------
-
-const statusesRouter = t.router({
-  get: publicProcedure.input(z.object({ workspaceId: z.string() })).query(({ input }) => {
-    const filePath = join(statusDir(), `${input.workspaceId}.json`);
-    try {
-      const data = readFileSync(filePath, "utf-8");
-      return JSON.parse(data);
-    } catch {
-      return null;
-    }
-  }),
-
-  update: publicProcedure
-    .input(
-      z.object({
-        workspaceId: z.string(),
-        agent: z.object({
-          status: z.string(),
-          lastActivity: z.string().optional(),
-        }),
-      }),
-    )
-    .mutation(({ input }) => {
-      ensureDirs();
-      const filePath = join(statusDir(), `${input.workspaceId}.json`);
-
-      // Read existing status file to preserve fields
-      let status: Record<string, unknown> = {};
-      try {
-        const data = readFileSync(filePath, "utf-8");
-        status = JSON.parse(data);
-      } catch {
-        // File doesn't exist or is invalid — start fresh
-      }
-
-      status.workspaceId = input.workspaceId;
-
-      // Merge agent fields
-      const existing = (status.agent as Record<string, unknown>) ?? {};
-      status.agent = { ...existing, ...input.agent };
-
-      const json = JSON.stringify(status, null, 2);
-
-      // Atomic write: write to temp file then rename
-      const tmpPath = join(statusDir(), `.${input.workspaceId}.json.tmp`);
-      writeFileSync(tmpPath, json, "utf-8");
-      renameSync(tmpPath, filePath);
-
-      return { ok: true };
-    }),
-
-  resolve: publicProcedure.input(z.object({ cwd: z.string() })).query(({ input }) => {
-    const state = loadState();
-    for (const proj of state.projects) {
-      for (const wt of proj.worktrees) {
-        if (input.cwd === wt.path || input.cwd.startsWith(`${wt.path}/`)) {
-          return { workspaceId: `${proj.name}-${wt.branch}` };
-        }
-      }
-    }
-    return { workspaceId: null };
-  }),
-});
-
-// ---------------------------------------------------------------------------
-// Status (SSE subscription)
-// ---------------------------------------------------------------------------
-
-const statusRouter = t.router({
-  stream: publicProcedure.subscription(async function* (opts) {
-    type QueueItem = Parameters<Parameters<typeof subscribeStatus>[0]>[0];
-    const queue: QueueItem[] = [];
-    let resolve: (() => void) | null = null;
-
-    const unsubscribe = subscribeStatus((event) => {
-      queue.push(event);
-      resolve?.();
-    });
-
-    opts.signal.addEventListener("abort", () => {
-      unsubscribe();
-      resolve?.();
-    });
-
-    try {
-      while (!opts.signal.aborted) {
-        while (queue.length > 0) {
-          yield queue.shift()!;
-        }
-        await new Promise<void>((r) => {
-          resolve = r;
-        });
-        resolve = null;
-      }
-    } finally {
-      unsubscribe();
-    }
-  }),
-});
-
-// ---------------------------------------------------------------------------
 // App Router
 // ---------------------------------------------------------------------------
 
@@ -1122,8 +980,6 @@ export const appRouter = t.router({
   sessions: sessionsRouter,
   services: servicesRouter,
   chat: chatRouter,
-  statuses: statusesRouter,
-  status: statusRouter,
 });
 
 export type AppRouter = typeof appRouter;

--- a/apps/web/src/trpc/router.ts
+++ b/apps/web/src/trpc/router.ts
@@ -1,8 +1,16 @@
 import { execFile, execFileSync } from "node:child_process";
-import { existsSync, mkdirSync, readFileSync, renameSync, unlinkSync, writeFileSync } from "node:fs";
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
 import { mkdir, readdir, readFile, stat, writeFile } from "node:fs/promises";
 import { hostname } from "node:os";
 import { basename, extname, join, resolve } from "node:path";
+import { createLogger } from "@band/logger";
 import { initTRPC, TRPCError } from "@trpc/server";
 import { z } from "zod";
 import { getOrCreateAgent } from "../lib/agent-pool";
@@ -20,9 +28,17 @@ import {
   loadState,
   saveState,
   settingsFile,
+  statusDir,
   worktreesDir,
 } from "../lib/state";
-import { abortTask, getTask, submitTask, TaskConflictError } from "../lib/task-runner";
+import {
+  abortTask,
+  getBufferedChunks,
+  getTask,
+  submitTask,
+  subscribe as subscribeTask,
+  TaskConflictError,
+} from "../lib/task-runner";
 import {
   checkTunnelAuth,
   checkTunnelHealth,
@@ -30,8 +46,11 @@ import {
   startTunnel,
   stopTunnel,
 } from "../lib/tunnel";
+import { subscribe as subscribeStatus } from "../lib/watcher";
 import { resolveWorkspace } from "../lib/workspace";
 import type { Context } from "./context";
+
+const log = createLogger("trpc");
 
 const t = initTRPC.context<Context>().create();
 
@@ -193,8 +212,8 @@ const workspacesRouter = t.router({
         throw new Error(`Project "${input.project}" not found`);
       }
 
-      if (proj.worktrees.some((wt) => wt.branch === input.branch)) {
-        const existing = proj.worktrees.find((wt) => wt.branch === input.branch)!;
+      const existing = proj.worktrees.find((wt) => wt.branch === input.branch);
+      if (existing) {
         return { ok: true, path: existing.path };
       }
 
@@ -219,26 +238,22 @@ const workspacesRouter = t.router({
       proj.worktrees.push({ branch: input.branch, path: worktreePath });
       saveState(state);
 
-      // Run setup script if configured (non-fatal)
+      // Run setup script if configured
+      const configPath = join(worktreePath, ".band", "config.json");
       try {
-        const configPath = join(worktreePath, ".band", "config.json");
         if (existsSync(configPath)) {
           const config = JSON.parse(readFileSync(configPath, "utf-8"));
           if (config.setup) {
-            const env = { ...process.env };
-            if (env.PATH) {
-              env.PATH = `/opt/homebrew/bin:/usr/local/bin:${env.PATH}`;
-            }
             execFileSync("bash", ["-c", config.setup], {
               cwd: worktreePath,
-              env,
+              env: { ...process.env, PATH: `/opt/homebrew/bin:/usr/local/bin:${process.env.PATH}` },
               encoding: "utf-8",
               timeout: 60_000,
             });
           }
         }
-      } catch (e) {
-        console.error(`Setup script failed: ${e instanceof Error ? e.message : e}`);
+      } catch {
+        // Setup script failure is non-fatal
       }
 
       if (input.prompt) {
@@ -278,29 +293,30 @@ const workspacesRouter = t.router({
             : branchRef;
         } else if (line === "" && currentPath) {
           if (currentBranch === input.branch) {
-            // Run teardown script if configured (non-fatal)
+            const worktreePath = currentPath;
+
+            // Run teardown script before removing worktree so it can access project files
+            const configPath = join(worktreePath, ".band", "config.json");
             try {
-              const configPath = join(currentPath, ".band", "config.json");
               if (existsSync(configPath)) {
                 const config = JSON.parse(readFileSync(configPath, "utf-8"));
                 if (config.teardown) {
-                  const teardownEnv = { ...process.env };
-                  if (teardownEnv.PATH) {
-                    teardownEnv.PATH = `/opt/homebrew/bin:/usr/local/bin:${teardownEnv.PATH}`;
-                  }
                   execFileSync("bash", ["-c", config.teardown], {
-                    cwd: currentPath,
-                    env: teardownEnv,
+                    cwd: worktreePath,
+                    env: {
+                      ...process.env,
+                      PATH: `/opt/homebrew/bin:/usr/local/bin:${process.env.PATH}`,
+                    },
                     encoding: "utf-8",
                     timeout: 60_000,
                   });
                 }
               }
-            } catch (e) {
-              console.error(`Teardown script failed: ${e instanceof Error ? e.message : e}`);
+            } catch {
+              // Teardown script failure is non-fatal
             }
 
-            execFileSync(command, ["worktree", "remove", "--force", currentPath], {
+            execFileSync(command, ["worktree", "remove", "--force", worktreePath], {
               cwd: proj.path,
               env,
               encoding: "utf-8",
@@ -324,7 +340,7 @@ const workspacesRouter = t.router({
               // Prompt file may not exist
             }
             try {
-              unlinkSync(join(bandHome(), "status", `${workspaceId}.json`));
+              unlinkSync(join(statusDir(), `${workspaceId}.json`));
             } catch {
               // Status file may not exist
             }
@@ -355,61 +371,6 @@ const workspacesRouter = t.router({
           }
         });
       });
-    }),
-
-  notify: publicProcedure
-    .input(
-      z.object({
-        cwd: z.string(),
-        hookPayload: z.record(z.string(), z.unknown()),
-      }),
-    )
-    .mutation(({ input }) => {
-      const hookEvent = (input.hookPayload.hook_event_name as string) || "";
-      const agentStatus =
-        hookEvent === "Stop" || hookEvent === "PermissionRequest" ? "needs_attention" : "working";
-
-      // Match CWD to a tracked workspace
-      const state = loadState();
-      let workspaceId: string | null = null;
-      for (const proj of state.projects) {
-        for (const wt of proj.worktrees) {
-          if (input.cwd.startsWith(wt.path) || wt.path === input.cwd) {
-            workspaceId = `${proj.name}-${wt.branch}`;
-            break;
-          }
-        }
-        if (workspaceId) break;
-      }
-
-      if (!workspaceId) {
-        return { ok: true, matched: false };
-      }
-
-      // Write status file atomically
-      const dir = join(bandHome(), "status");
-      mkdirSync(dir, { recursive: true });
-      const statusFile = join(dir, `${workspaceId}.json`);
-
-      let status: Record<string, unknown> = {};
-      try {
-        status = JSON.parse(readFileSync(statusFile, "utf-8"));
-      } catch {
-        // New file
-      }
-
-      status.workspaceId = workspaceId;
-      if (!status.agent || typeof status.agent !== "object") {
-        status.agent = {};
-      }
-      (status.agent as Record<string, unknown>).status = agentStatus;
-      (status.agent as Record<string, unknown>).lastActivity = new Date().toISOString();
-
-      const tmpFile = join(dir, `.${workspaceId}.json.tmp`);
-      writeFileSync(tmpFile, JSON.stringify(status, null, 2));
-      renameSync(tmpFile, statusFile);
-
-      return { ok: true, matched: true };
     }),
 });
 
@@ -679,15 +640,23 @@ const tunnelRouter = t.router({
   start: publicProcedure
     .input(z.object({ subdomain: z.string().optional(), skipSubdomain: z.boolean().optional() }))
     .mutation(async ({ input }) => {
+      log.debug({ input }, "tunnel.start called");
       const settings = loadSettings();
       const port = parseInt(process.env.PORT || "3456", 10);
       const subdomain = input.subdomain || (settings as Record<string, unknown>).tunnelSubdomain;
+      log.debug(
+        "tunnel.start: port=%d subdomain=%s skipSubdomain=%s",
+        port,
+        subdomain,
+        input.skipSubdomain,
+      );
       await startTunnel({
         port,
         subdomain: subdomain as string | undefined,
         skipSubdomain: input.skipSubdomain,
       });
       const status = getTunnelStatus();
+      log.debug({ status }, "tunnel.start: after startTunnel");
       if (status.url) {
         return { ok: true, url: status.url };
       }
@@ -696,10 +665,12 @@ const tunnelRouter = t.router({
       if (resolvedSubdomain) {
         const token = getToken();
         const health = await checkTunnelHealth(resolvedSubdomain, token);
+        log.debug({ health }, "tunnel.start: remote health check");
         if (health.healthy) {
           return { ok: true, url: `https://${resolvedSubdomain}.instatunnel.my?token=${token}` };
         }
       }
+      log.debug("tunnel.start: no URL available");
       return { ok: true, url: null as string | null };
     }),
 
@@ -849,6 +820,59 @@ const tasksRouter = t.router({
     }
     return { aborted: true };
   }),
+
+  stream: publicProcedure
+    .input(z.object({ workspaceId: z.string() }))
+    .subscription(async function* (opts) {
+      const workspaceId = opts.input.workspaceId;
+      const task = getTask(workspaceId);
+      const buffered = getBufferedChunks(workspaceId);
+
+      // No task and no buffered chunks — nothing to stream
+      if (!task && buffered.length === 0) return;
+
+      // Replay buffered chunks
+      for (const chunk of buffered) {
+        yield chunk;
+      }
+
+      // If task is already done, stop
+      if (!task || task.status !== "running") return;
+
+      // Stream live chunks
+      type Chunk = Parameters<Parameters<typeof subscribeTask>[1]>[0];
+      const queue: Chunk[] = [];
+      let resolve: (() => void) | null = null;
+      let done = false;
+
+      const unsubscribe = subscribeTask(workspaceId, (chunk) => {
+        queue.push(chunk);
+        if (chunk.type === "finish" || chunk.type === "error") {
+          done = true;
+        }
+        resolve?.();
+      });
+
+      opts.signal.addEventListener("abort", () => {
+        unsubscribe();
+        resolve?.();
+      });
+
+      try {
+        while (!opts.signal.aborted) {
+          while (queue.length > 0) {
+            yield queue.shift()!;
+          }
+          if (done) return;
+          await new Promise<void>((r) => {
+            resolve = r;
+          });
+          resolve = null;
+        }
+      } finally {
+        unsubscribe();
+      }
+    }),
 });
 
 // ---------------------------------------------------------------------------
@@ -897,7 +921,9 @@ const sessionsRouter = t.router({
 
 const servicesRouter = t.router({
   health: publicProcedure.query(async () => {
+    log.debug("services.health called");
     const tunnel = getTunnelStatus();
+    log.debug({ tunnel }, "services.health: tunnel status");
     let tunnelHealthy = false;
     let tunnelUrl = tunnel.url;
     let tunnelRemoteHost: string | undefined;
@@ -908,7 +934,9 @@ const servicesRouter = t.router({
     if (tunnel.running && tunnel.url) {
       const urlMatch = tunnel.url.match(/https:\/\/(.+)\.instatunnel\.my/);
       if (urlMatch) {
+        log.debug("services.health: checking tunnel health for %s", urlMatch[1]);
         const health = await checkTunnelHealth(urlMatch[1], token);
+        log.debug({ health }, "services.health: tunnel health");
         tunnelHealthy = health.healthy;
         // Only report as remote if it's a different machine
         if (health.remoteHost && health.remoteHost !== localHostname) {
@@ -922,8 +950,15 @@ const servicesRouter = t.router({
     if (!tunnelHealthy) {
       const settings = loadSettings();
       const subdomain = (settings as Record<string, unknown>).tunnelSubdomain as string | undefined;
+      log.debug(
+        "services.health: tunnelSubdomain=%s token=%s",
+        subdomain ?? "none",
+        token ? `${token.slice(0, 6)}...` : "null",
+      );
       if (subdomain) {
+        log.debug("services.health: checking remote subdomain %s", subdomain);
         const health = await checkTunnelHealth(subdomain, token);
+        log.debug({ health }, "services.health: remote health");
         if (health.healthy) {
           tunnelHealthy = true;
           // Only report as remote if it's a different machine
@@ -932,15 +967,19 @@ const servicesRouter = t.router({
           }
           tunnelUrl = `https://${subdomain}.instatunnel.my?token=${token}`;
         }
+      } else {
+        log.debug("services.health: no tunnelSubdomain configured, skipping remote check");
       }
     }
 
-    return {
+    const result = {
       webserver: true,
       tunnel: tunnelHealthy,
       tunnel_url: tunnelUrl,
       tunnel_remote_host: tunnelRemoteHost || tunnel.remoteHost,
     };
+    log.debug({ result }, "services.health result");
+    return result;
   }),
 });
 
@@ -964,6 +1003,109 @@ const chatRouter = t.router({
 });
 
 // ---------------------------------------------------------------------------
+// Statuses
+// ---------------------------------------------------------------------------
+
+const statusesRouter = t.router({
+  get: publicProcedure.input(z.object({ workspaceId: z.string() })).query(({ input }) => {
+    const filePath = join(statusDir(), `${input.workspaceId}.json`);
+    try {
+      const data = readFileSync(filePath, "utf-8");
+      return JSON.parse(data);
+    } catch {
+      return null;
+    }
+  }),
+
+  update: publicProcedure
+    .input(
+      z.object({
+        workspaceId: z.string(),
+        agent: z.object({
+          status: z.string(),
+          lastActivity: z.string().optional(),
+        }),
+      }),
+    )
+    .mutation(({ input }) => {
+      ensureDirs();
+      const filePath = join(statusDir(), `${input.workspaceId}.json`);
+
+      // Read existing status file to preserve fields
+      let status: Record<string, unknown> = {};
+      try {
+        const data = readFileSync(filePath, "utf-8");
+        status = JSON.parse(data);
+      } catch {
+        // File doesn't exist or is invalid — start fresh
+      }
+
+      status.workspaceId = input.workspaceId;
+
+      // Merge agent fields
+      const existing = (status.agent as Record<string, unknown>) ?? {};
+      status.agent = { ...existing, ...input.agent };
+
+      const json = JSON.stringify(status, null, 2);
+
+      // Atomic write: write to temp file then rename
+      const tmpPath = join(statusDir(), `.${input.workspaceId}.json.tmp`);
+      writeFileSync(tmpPath, json, "utf-8");
+      renameSync(tmpPath, filePath);
+
+      return { ok: true };
+    }),
+
+  resolve: publicProcedure.input(z.object({ cwd: z.string() })).query(({ input }) => {
+    const state = loadState();
+    for (const proj of state.projects) {
+      for (const wt of proj.worktrees) {
+        if (input.cwd === wt.path || input.cwd.startsWith(`${wt.path}/`)) {
+          return { workspaceId: `${proj.name}-${wt.branch}` };
+        }
+      }
+    }
+    return { workspaceId: null };
+  }),
+});
+
+// ---------------------------------------------------------------------------
+// Status (SSE subscription)
+// ---------------------------------------------------------------------------
+
+const statusRouter = t.router({
+  stream: publicProcedure.subscription(async function* (opts) {
+    type QueueItem = Parameters<Parameters<typeof subscribeStatus>[0]>[0];
+    const queue: QueueItem[] = [];
+    let resolve: (() => void) | null = null;
+
+    const unsubscribe = subscribeStatus((event) => {
+      queue.push(event);
+      resolve?.();
+    });
+
+    opts.signal.addEventListener("abort", () => {
+      unsubscribe();
+      resolve?.();
+    });
+
+    try {
+      while (!opts.signal.aborted) {
+        while (queue.length > 0) {
+          yield queue.shift()!;
+        }
+        await new Promise<void>((r) => {
+          resolve = r;
+        });
+        resolve = null;
+      }
+    } finally {
+      unsubscribe();
+    }
+  }),
+});
+
+// ---------------------------------------------------------------------------
 // App Router
 // ---------------------------------------------------------------------------
 
@@ -980,6 +1122,8 @@ export const appRouter = t.router({
   sessions: sessionsRouter,
   services: servicesRouter,
   chat: chatRouter,
+  statuses: statusesRouter,
+  status: statusRouter,
 });
 
 export type AppRouter = typeof appRouter;

--- a/apps/web/test-server.ts
+++ b/apps/web/test-server.ts
@@ -1,0 +1,75 @@
+/**
+ * Minimal tRPC-only server for CLI integration tests.
+ * No SSR, no static assets, no auth — just the tRPC router.
+ *
+ * Usage: BAND_HOME=/tmp/test PORT=0 node dist/test-server.mjs
+ * Prints the actual port to stdout once listening.
+ */
+import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
+import { fetchRequestHandler } from "@trpc/server/adapters/fetch";
+import { createContext } from "./src/trpc/context.ts";
+import { appRouter } from "./src/trpc/router.ts";
+
+const port = parseInt(process.env.PORT || "0", 10);
+
+const server = createServer(async (req: IncomingMessage, res: ServerResponse) => {
+  const url = new URL(req.url!, `http://${req.headers.host}`);
+
+  if (!url.pathname.startsWith("/trpc")) {
+    res.writeHead(404);
+    res.end("Not found");
+    return;
+  }
+
+  const headers = new Headers();
+  for (const [key, value] of Object.entries(req.headers)) {
+    if (value) {
+      if (Array.isArray(value)) {
+        for (const v of value) headers.append(key, v);
+      } else {
+        headers.set(key, value);
+      }
+    }
+  }
+
+  let body: Buffer | undefined;
+  if (req.method !== "GET" && req.method !== "HEAD") {
+    body = await new Promise<Buffer>((resolve, reject) => {
+      const chunks: Buffer[] = [];
+      req.on("data", (chunk: Buffer) => chunks.push(chunk));
+      req.on("end", () => resolve(Buffer.concat(chunks)));
+      req.on("error", reject);
+    });
+  }
+
+  const request = new Request(url.toString(), {
+    method: req.method,
+    headers,
+    body,
+    duplex: "half",
+  } as RequestInit);
+
+  const response = await fetchRequestHandler({
+    endpoint: "/trpc",
+    req: request,
+    router: appRouter,
+    createContext,
+  });
+
+  res.writeHead(response.status, Object.fromEntries(response.headers.entries()));
+  const text = await response.text();
+  res.end(text);
+});
+
+server.listen(port, "127.0.0.1", () => {
+  const addr = server.address();
+  if (addr && typeof addr === "object") {
+    // Print the port so the test harness can read it
+    console.log(addr.port);
+  }
+});
+
+process.on("SIGTERM", () => {
+  server.close();
+  process.exit(0);
+});

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,0 +1,3 @@
+# Band CLI
+
+See [`apps/cli/SKILL.md`](../apps/cli/SKILL.md) for the full command reference.

--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
     "dev:web": "pnpm --filter @band/web dev",
     "build:dashboard": "pnpm --filter @band/dashboard tauri build",
     "build:web": "pnpm --filter @band/web build",
-    "build:cli": "cd apps/cli && cargo build --release && mkdir -p ../dashboard/src-tauri/binaries && cp target/release/band \"../dashboard/src-tauri/binaries/band-$(rustc -vV | sed -n 's/host: //p')\"",
-    "build:cli:dev": "cd apps/cli && cargo build && mkdir -p ../dashboard/src-tauri/binaries && cp target/debug/band \"../dashboard/src-tauri/binaries/band-$(rustc -vV | sed -n 's/host: //p')\"",
+    "build:cli": "pnpm --filter @band/cli build && mkdir -p apps/dashboard/src-tauri/binaries && cp apps/cli/target/release/band \"apps/dashboard/src-tauri/binaries/band-$(rustc -vV | sed -n 's/host: //p')\"",
+    "build:cli:dev": "pnpm --filter @band/cli build:dev && mkdir -p apps/dashboard/src-tauri/binaries && cp apps/cli/target/debug/band \"apps/dashboard/src-tauri/binaries/band-$(rustc -vV | sed -n 's/host: //p')\"",
     "build:extension": "pnpm --filter band-vscode build",
     "test": "pnpm --filter @band/web test && cargo test --manifest-path apps/cli/Cargo.toml && pnpm build:cli && mkdir -p apps/web/dist && touch apps/web/dist/start-server.mjs && cargo test --manifest-path apps/dashboard/src-tauri/Cargo.toml; rm -rf apps/web/dist",
     "lint": "biome check . && cargo clippy --manifest-path apps/cli/Cargo.toml -- -D warnings && cargo clippy --manifest-path apps/dashboard/src-tauri/Cargo.toml -- -D warnings",
@@ -21,6 +21,7 @@
     "prepare": "husky"
   },
   "devDependencies": {
+    "@band/cli": "workspace:^",
     "@biomejs/biome": "^2.4.5",
     "husky": "^9.1.7"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,12 +18,17 @@ importers:
         specifier: ^11.12.0
         version: 11.12.0(typescript@5.9.3)
     devDependencies:
+      '@band/cli':
+        specifier: workspace:^
+        version: link:apps/cli
       '@biomejs/biome':
         specifier: ^2.4.5
         version: 2.4.5
       husky:
         specifier: ^9.1.7
         version: 9.1.7
+
+  apps/cli: {}
 
   apps/dashboard:
     dependencies:


### PR DESCRIPTION
## Summary
- Restructure CLI from flat commands to nested resource-based subcommands (`band projects list`, `band workspaces create`, `band settings`, `band tunnel status`)
- Add new commands: `projects add/remove`, `settings`, `tunnel start/stop/status`
- Add table-formatted output for list commands
- Fold `run` into `workspaces create --prompt`

## Test plan
- [x] `cargo clippy` — no warnings
- [x] `cargo test` — all integration tests pass
- [x] `npx band --help` — shows new structure
- [x] Manual: `npx band projects list`, `npx band workspaces list`, `npx band settings`, `npx band tunnel status`, `npx band schema`

🤖 Generated with [Claude Code](https://claude.com/claude-code)