### PR TITLE
fix: fetch session history via tRPC and add Playwright e2e tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,6 +83,12 @@ jobs:
       - name: Test (web)
         run: pnpm --filter @band/web test
 
+      - name: Install Playwright Chromium
+        run: pnpm --filter @band/web exec playwright install --with-deps chromium
+
+      - name: Test e2e (web)
+        run: pnpm --filter @band/web test:e2e
+
       - name: Test (CLI)
         run: |
           export PATH="/root/.cargo/bin:$PATH"

--- a/.gitignore
+++ b/.gitignore
@@ -9,5 +9,8 @@ apps/dashboard/src-tauri/icons/android/
 apps/dashboard/src-tauri/icons/ios/
 apps/dashboard/src-tauri/gen/
 *.tsbuildinfo
+test-results/
+playwright-report/
+.last-run.json
 apps/dashboard/src-tauri/binaries/*
 !apps/dashboard/src-tauri/binaries/.gitkeep

--- a/apps/web/e2e/helpers/server.ts
+++ b/apps/web/e2e/helpers/server.ts
@@ -1,0 +1,106 @@
+import { spawn } from "node:child_process";
+import { mkdirSync, mkdtempSync, realpathSync, writeFileSync } from "node:fs";
+import { createServer } from "node:net";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const PROJECT_ROOT = join(import.meta.dirname, "../..");
+
+export interface ServerHandle {
+  url: string;
+  home: string;
+  close: () => Promise<void>;
+}
+
+export function createTmpHome(): string {
+  const tmp = realpathSync(mkdtempSync(join(tmpdir(), "band-e2e-test-")));
+  const bandDir = join(tmp, ".band");
+  mkdirSync(bandDir, { recursive: true });
+  mkdirSync(join(bandDir, "status"), { recursive: true });
+  return tmp;
+}
+
+export function seedState(tmpHome: string, state: object): void {
+  writeFileSync(join(tmpHome, ".band", "state.json"), JSON.stringify(state));
+}
+
+export function seedSettings(tmpHome: string, settings: object): void {
+  writeFileSync(join(tmpHome, ".band", "settings.json"), JSON.stringify(settings));
+}
+
+export function getRandomPort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const srv = createServer();
+    srv.listen(0, "127.0.0.1", () => {
+      const { port } = srv.address() as { port: number };
+      srv.close(() => resolve(port));
+    });
+    srv.on("error", reject);
+  });
+}
+
+export async function startServer(
+  opts: { tmpHome?: string; env?: Record<string, string> } = {},
+): Promise<ServerHandle> {
+  const home = opts.tmpHome || createTmpHome();
+  const port = await getRandomPort();
+
+  return new Promise((resolve, reject) => {
+    const child = spawn("node", ["dist/start-server.mjs"], {
+      cwd: PROJECT_ROOT,
+      env: {
+        ...process.env,
+        HOME: home,
+        PORT: String(port),
+        NODE_ENV: "production",
+        ...opts.env,
+      },
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+
+    let stderr = "";
+    let settled = false;
+
+    child.stderr!.on("data", (chunk: Buffer) => {
+      stderr += chunk.toString();
+    });
+
+    child.stdout!.on("data", (chunk: Buffer) => {
+      const text = chunk.toString();
+      if (text.includes("listening") && !settled) {
+        settled = true;
+        resolve({
+          url: `http://127.0.0.1:${port}`,
+          home,
+          close: () =>
+            new Promise<void>((r) => {
+              child.on("exit", () => r());
+              child.kill("SIGTERM");
+            }),
+        });
+      }
+    });
+
+    child.on("error", (err) => {
+      if (!settled) {
+        settled = true;
+        reject(err);
+      }
+    });
+
+    child.on("exit", (code) => {
+      if (!settled) {
+        settled = true;
+        reject(new Error(`Server exited with code ${code} before listening.\nstderr: ${stderr}`));
+      }
+    });
+
+    setTimeout(() => {
+      if (!settled) {
+        settled = true;
+        child.kill("SIGTERM");
+        reject(new Error(`Server did not start within 15 s.\nstderr: ${stderr}`));
+      }
+    }, 15_000);
+  });
+}

--- a/apps/web/e2e/helpers/trpc-mock.ts
+++ b/apps/web/e2e/helpers/trpc-mock.ts
@@ -1,0 +1,117 @@
+import type { Page } from "@playwright/test";
+import type { inferRouterInputs, inferRouterOutputs } from "@trpc/server";
+import type { AppRouter } from "../../src/trpc/router";
+
+// ---------------------------------------------------------------------------
+// Type helpers — map dot-notation paths to procedure input/output types
+// ---------------------------------------------------------------------------
+
+type RouterOutputs = inferRouterOutputs<AppRouter>;
+type RouterInputs = inferRouterInputs<AppRouter>;
+
+/**
+ * Union of all dot-notation procedure paths, e.g. "sessions.list" | "projects.list" | ...
+ */
+type ProcedurePath = {
+  [K in keyof RouterOutputs]: keyof RouterOutputs[K] extends string
+    ? `${K & string}.${keyof RouterOutputs[K] & string}`
+    : never;
+}[keyof RouterOutputs];
+
+type OutputForPath<P extends ProcedurePath> =
+  P extends `${infer NS extends string & keyof RouterOutputs}.${infer Proc}`
+    ? Proc extends keyof RouterOutputs[NS]
+      ? RouterOutputs[NS][Proc]
+      : never
+    : never;
+
+type InputForPath<P extends ProcedurePath> =
+  P extends `${infer NS extends string & keyof RouterInputs}.${infer Proc}`
+    ? Proc extends keyof RouterInputs[NS]
+      ? RouterInputs[NS][Proc]
+      : never
+    : never;
+
+type Handler<P extends ProcedurePath> =
+  | OutputForPath<P>
+  | ((input: InputForPath<P>) => OutputForPath<P>);
+
+// ---------------------------------------------------------------------------
+// createTrpcMock
+// ---------------------------------------------------------------------------
+
+export function createTrpcMock() {
+  const handlers = new Map<string, (input: unknown) => unknown>();
+
+  function query<P extends ProcedurePath>(path: P, handler: Handler<P>): void {
+    handlers.set(
+      path,
+      typeof handler === "function" ? (handler as (input: unknown) => unknown) : () => handler,
+    );
+  }
+
+  async function install(page: Page): Promise<void> {
+    await page.route("**/trpc/**", async (route) => {
+      const request = route.request();
+      const url = new URL(request.url());
+
+      // Extract procedure names from the URL path after /trpc/
+      const trpcPath = url.pathname.replace(/.*\/trpc\//, "");
+      const procedures = trpcPath.split(",");
+
+      // Parse inputs — batch uses indexed keys: {"0": ..., "1": ...}
+      let inputMap: Record<string, unknown> = {};
+      if (request.method() === "GET") {
+        const raw = url.searchParams.get("input");
+        if (raw) {
+          try {
+            inputMap = JSON.parse(raw);
+          } catch {
+            // ignore
+          }
+        }
+      } else {
+        try {
+          inputMap = await request.postDataJSON();
+        } catch {
+          // ignore
+        }
+      }
+
+      const results = procedures.map((proc, idx) => {
+        const handler = handlers.get(proc);
+        if (!handler) {
+          return {
+            error: {
+              message: `No mock for procedure: ${proc}`,
+              code: -32004,
+              data: { code: "NOT_FOUND", httpStatus: 404 },
+            },
+          };
+        }
+        const input = inputMap[String(idx)] ?? undefined;
+        try {
+          const data = handler(input);
+          return { result: { data } };
+        } catch (err) {
+          return {
+            error: {
+              message: err instanceof Error ? err.message : "Mock handler error",
+              code: -32603,
+              data: { code: "INTERNAL_SERVER_ERROR", httpStatus: 500 },
+            },
+          };
+        }
+      });
+
+      // Single procedure → still return array (httpBatchLink always expects array)
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(results),
+      });
+    });
+  }
+
+  return { query, install };
+}

--- a/apps/web/e2e/session-history.spec.ts
+++ b/apps/web/e2e/session-history.spec.ts
@@ -1,0 +1,145 @@
+import { rmSync } from "node:fs";
+import { expect, test } from "@playwright/test";
+import {
+  createTmpHome,
+  type ServerHandle,
+  seedSettings,
+  seedState,
+  startServer,
+} from "./helpers/server";
+import { createTrpcMock } from "./helpers/trpc-mock";
+
+const TOKEN = "e2e-test-token";
+
+let server: ServerHandle;
+let tmpHome: string;
+
+test.beforeAll(async () => {
+  tmpHome = createTmpHome();
+  seedState(tmpHome, { projects: [] });
+  seedSettings(tmpHome, { tokenSecret: TOKEN });
+  server = await startServer({ tmpHome });
+});
+
+test.afterAll(async () => {
+  await server.close();
+  rmSync(tmpHome, { recursive: true, force: true });
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+test("sessions load and display in the session list", async ({ page }) => {
+  const mock = createTrpcMock();
+  mock.query("sessions.list", {
+    sessions: [
+      {
+        sessionId: "s1",
+        summary: "Fix login bug",
+        lastModified: Date.now() - 60_000 * 5,
+        gitBranch: "fix-login",
+      },
+      {
+        sessionId: "s2",
+        summary: "Add tests",
+        lastModified: Date.now() - 60_000 * 120,
+      },
+    ],
+    supported: true,
+  });
+  await mock.install(page);
+
+  await page.goto(`${server.url}/chat/test-workspace?token=${TOKEN}`);
+
+  // The clock button should be visible since sessions are supported
+  const clockButton = page.locator("button").filter({ has: page.locator("svg.lucide-clock") });
+  await expect(clockButton).toBeVisible();
+
+  // Click the clock button to open the session list
+  await clockButton.click();
+
+  // Verify session summaries are displayed
+  await expect(page.getByText("Fix login bug")).toBeVisible();
+  await expect(page.getByText("Add tests")).toBeVisible();
+
+  // Verify git branch badge
+  await expect(page.getByText("fix-login")).toBeVisible();
+
+  // Verify relative times
+  await expect(page.getByText("5m ago")).toBeVisible();
+  await expect(page.getByText("2h ago")).toBeVisible();
+});
+
+test("empty state shows 'No sessions yet' message", async ({ page }) => {
+  const mock = createTrpcMock();
+  mock.query("sessions.list", { sessions: [], supported: true });
+  await mock.install(page);
+
+  await page.goto(`${server.url}/chat/test-workspace?token=${TOKEN}`);
+
+  // Open session list
+  const clockButton = page.locator("button").filter({ has: page.locator("svg.lucide-clock") });
+  await expect(clockButton).toBeVisible();
+  await clockButton.click();
+
+  await expect(page.getByText("No sessions yet")).toBeVisible();
+});
+
+test("session toggle is hidden when not supported", async ({ page }) => {
+  const mock = createTrpcMock();
+  mock.query("sessions.list", { sessions: [], supported: false });
+  await mock.install(page);
+
+  await page.goto(`${server.url}/chat/test-workspace?token=${TOKEN}`);
+
+  // Wait for the page to settle — the header with the workspace name should be visible
+  await expect(page.locator("h1", { hasText: "test-workspace" })).toBeVisible();
+
+  // The clock button should NOT be present
+  const clockButton = page.locator("button").filter({ has: page.locator("svg.lucide-clock") });
+  await expect(clockButton).not.toBeVisible();
+});
+
+test("selecting a session loads its messages", async ({ page }) => {
+  const mock = createTrpcMock();
+  mock.query("sessions.list", {
+    sessions: [
+      {
+        sessionId: "s1",
+        summary: "Fix login bug",
+        lastModified: Date.now() - 60_000,
+      },
+    ],
+    supported: true,
+  });
+  mock.query("sessions.messages", () => ({
+    messages: [
+      {
+        role: "user" as const,
+        id: "m1",
+        content: [{ type: "text" as const, text: "Please fix the login bug" }],
+      },
+      {
+        role: "assistant" as const,
+        id: "m2",
+        content: [{ type: "text" as const, text: "I found the issue in auth.ts and fixed it." }],
+      },
+    ],
+  }));
+  await mock.install(page);
+
+  await page.goto(`${server.url}/chat/test-workspace?token=${TOKEN}`);
+
+  // Open session list
+  const clockButton = page.locator("button").filter({ has: page.locator("svg.lucide-clock") });
+  await expect(clockButton).toBeVisible();
+  await clockButton.click();
+
+  // Click the session
+  await page.getByText("Fix login bug").click();
+
+  // Verify historical messages render
+  await expect(page.getByText("Please fix the login bug")).toBeVisible();
+  await expect(page.getByText("I found the issue in auth.ts and fixed it.")).toBeVisible();
+});

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -8,7 +8,9 @@
     "build": "vite build && esbuild start-server.ts --bundle --platform=node --format=esm --outfile=dist/start-server.mjs --external:./server/server.js --banner:js=\"import{createRequire}from'module';import{fileURLToPath as __fu}from'url';import{dirname as __dn}from'path';const require=createRequire(import.meta.url);const __filename=__fu(import.meta.url);const __dirname=__dn(__filename);\"",
     "start": "node dist/start-server.mjs",
     "pretest": "pnpm build",
-    "test": "vitest run"
+    "test": "vitest run",
+    "test:e2e": "playwright test",
+    "test:e2e:ui": "playwright test --ui"
   },
   "dependencies": {
     "@ai-sdk/react": "^3.0.0",
@@ -48,6 +50,7 @@
     "zod": "^3.25.67"
   },
   "devDependencies": {
+    "@playwright/test": "^1.58.2",
     "@tailwindcss/vite": "^4.0.0",
     "@tanstack/router-plugin": "^1.154.0",
     "@types/node": "^22.19.13",

--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./e2e",
+  timeout: 30_000,
+  use: {
+    baseURL: "http://127.0.0.1",
+  },
+  projects: [{ name: "chromium", use: { browserName: "chromium" } }],
+});

--- a/apps/web/src/routes/chat.$workspaceId.tsx
+++ b/apps/web/src/routes/chat.$workspaceId.tsx
@@ -10,6 +10,7 @@ import { ArrowLeft, Clock } from "lucide-react";
 import { useCallback, useEffect, useState } from "react";
 import { ChatView } from "../components/ChatView";
 import { CodeBrowserView } from "../components/CodeBrowserView";
+import { trpc } from "../lib/trpc-client";
 
 const adapter = new WebDashboardAdapter();
 const capabilities = new WebCapabilities();
@@ -29,31 +30,18 @@ function ChatPage() {
   useEffect(() => {
     let cancelled = false;
 
-    fetch(`/api/sessions/${encodeURIComponent(decoded)}`)
-      .then((res) => {
-        if (!res.ok) {
-          console.error("[sessions] fetch failed:", res.status, res.statusText);
-          return null;
-        }
-        return res.json();
-      })
-      .then(
-        (
-          data: {
-            supported?: boolean;
-            sessions?: { sessionId: string; lastModified: number }[];
-          } | null,
-        ) => {
-          if (cancelled) return;
-          if (data?.supported) {
-            setSupportsSessionListing(true);
-            const latest = data.sessions?.sort((a, b) => b.lastModified - a.lastModified)[0];
-            if (latest) {
-              setInitialSessionId(latest.sessionId);
-            }
+    trpc.sessions.list
+      .query({ workspaceId: decoded })
+      .then((data) => {
+        if (cancelled) return;
+        if (data.supported) {
+          setSupportsSessionListing(true);
+          const latest = [...data.sessions].sort((a, b) => b.lastModified - a.lastModified)[0];
+          if (latest) {
+            setInitialSessionId(latest.sessionId);
           }
-        },
-      )
+        }
+      })
       .catch((err) => {
         console.error("[sessions] error:", err);
       });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -224,6 +224,9 @@ importers:
         specifier: ^3.25.67
         version: 3.25.76
     devDependencies:
+      '@playwright/test':
+        specifier: ^1.58.2
+        version: 1.58.2
       '@tailwindcss/vite':
         specifier: ^4.0.0
         version: 4.2.1(vite@7.3.1(@types/node@22.19.13)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
@@ -1267,6 +1270,11 @@ packages:
 
   '@pinojs/redact@0.4.0':
     resolution: {integrity: sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==}
+
+  '@playwright/test@1.58.2':
+    resolution: {integrity: sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   '@polka/url@1.0.0-next.29':
     resolution: {integrity: sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==}
@@ -3128,6 +3136,11 @@ packages:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
     engines: {node: '>=8'}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -3699,6 +3712,16 @@ packages:
 
   pkg-types@1.3.1:
     resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
+
+  playwright-core@1.58.2:
+    resolution: {integrity: sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.58.2:
+    resolution: {integrity: sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   points-on-curve@0.2.0:
     resolution: {integrity: sha512-0mYKnYYe9ZcqMCWhUjItv/oHjvgEsfKvnUTg8sAtnHr3GVy7rGkXCb6d5cSyqrWqL4k81b9CPg3urd+T7aop3A==}
@@ -5055,6 +5078,10 @@ snapshots:
   '@opentelemetry/api@1.9.0': {}
 
   '@pinojs/redact@0.4.0': {}
+
+  '@playwright/test@1.58.2':
+    dependencies:
+      playwright: 1.58.2
 
   '@polka/url@1.0.0-next.29': {}
 
@@ -7139,6 +7166,9 @@ snapshots:
     dependencies:
       to-regex-range: 5.0.1
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -8011,6 +8041,14 @@ snapshots:
       confbox: 0.1.8
       mlly: 1.8.1
       pathe: 2.0.3
+
+  playwright-core@1.58.2: {}
+
+  playwright@1.58.2:
+    dependencies:
+      playwright-core: 1.58.2
+    optionalDependencies:
+      fsevents: 2.3.2
 
   points-on-curve@0.2.0: {}
 


### PR DESCRIPTION
## Summary
- Fix chat page fetching session history through a non-existent REST endpoint instead of the tRPC client
- Add Playwright browser-level e2e tests with a type-safe tRPC mocking helper to prevent regressions
- Add e2e test step to CI workflow

## Test plan
- [x] `pnpm test:e2e` — 4 session history tests pass (session list, empty state, unsupported toggle, session selection)
- [x] `pnpm test` — all 114 existing vitest tests still pass
- [ ] CI passes with new Playwright e2e step

🤖 Generated with [Claude Code](https://claude.com/claude-code)