### PR TITLE
feat: persistent task management UI with filtering and session history

### DIFF
--- a/apps/web/e2e/tasks-page.spec.ts
+++ b/apps/web/e2e/tasks-page.spec.ts
@@ -1,0 +1,198 @@
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { expect, test } from "@playwright/test";
+import {
+  createTmpHome,
+  type ServerHandle,
+  seedSettings,
+  seedState,
+  startServer,
+} from "./helpers/server";
+
+const TOKEN = "e2e-test-token";
+
+let server: ServerHandle;
+let tmpHome: string;
+
+function seedTask(
+  tmpHome: string,
+  task: {
+    id: string;
+    workspaceId: string;
+    project: string;
+    branch: string;
+    prompt: string;
+    status: "running" | "completed" | "failed";
+    sessionId?: string;
+    startedAt: number;
+    completedAt?: number;
+  },
+): void {
+  const tasksDir = join(tmpHome, ".band", "tasks");
+  mkdirSync(tasksDir, { recursive: true });
+  writeFileSync(join(tasksDir, `${task.id}.json`), JSON.stringify(task));
+}
+
+test.beforeAll(async () => {
+  tmpHome = createTmpHome();
+  seedState(tmpHome, {
+    projects: [
+      {
+        name: "myapp",
+        path: "/tmp/myapp",
+        defaultBranch: "main",
+        worktrees: [
+          { branch: "main", path: "/tmp/myapp" },
+          { branch: "feat/auth", path: "/tmp/myapp-auth" },
+        ],
+      },
+      {
+        name: "backend",
+        path: "/tmp/backend",
+        defaultBranch: "main",
+        worktrees: [{ branch: "main", path: "/tmp/backend" }],
+      },
+    ],
+  });
+  seedSettings(tmpHome, { tokenSecret: TOKEN });
+
+  seedTask(tmpHome, {
+    id: "tsk_1000",
+    workspaceId: "myapp-main",
+    project: "myapp",
+    branch: "main",
+    prompt: "Add authentication to the API",
+    status: "completed",
+    sessionId: "session_abc",
+    startedAt: Date.now() - 3600_000,
+    completedAt: Date.now() - 3500_000,
+  });
+
+  seedTask(tmpHome, {
+    id: "tsk_2000",
+    workspaceId: "myapp-feat/auth",
+    project: "myapp",
+    branch: "feat/auth",
+    prompt: "Fix login validation bug",
+    status: "failed",
+    startedAt: Date.now() - 7200_000,
+    completedAt: Date.now() - 7100_000,
+  });
+
+  seedTask(tmpHome, {
+    id: "tsk_3000",
+    workspaceId: "backend-main",
+    project: "backend",
+    branch: "main",
+    prompt: "Optimize database queries",
+    status: "running",
+    startedAt: Date.now() - 60_000,
+  });
+
+  server = await startServer({ tmpHome });
+});
+
+test.afterAll(async () => {
+  await server.close();
+  rmSync(tmpHome, { recursive: true, force: true });
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+test("tasks page renders and shows seeded tasks", async ({ page }) => {
+  await page.goto(`${server.url}/tasks?token=${TOKEN}`);
+
+  await expect(page.getByText("Add authentication to the API")).toBeVisible();
+  await expect(page.getByText("Fix login validation bug")).toBeVisible();
+  await expect(page.getByText("Optimize database queries")).toBeVisible();
+});
+
+test("tasks page shows status badges", async ({ page }) => {
+  await page.goto(`${server.url}/tasks?token=${TOKEN}`);
+
+  await expect(page.getByText("Completed")).toBeVisible();
+  await expect(page.getByText("Failed")).toBeVisible();
+  await expect(page.getByText("Running")).toBeVisible();
+});
+
+test("filtering by status works", async ({ page }) => {
+  await page.goto(`${server.url}/tasks?token=${TOKEN}`);
+
+  // Wait for tasks to load
+  await expect(page.getByText("Add authentication to the API")).toBeVisible();
+
+  // Click "completed" status filter
+  await page.getByRole("button", { name: "completed" }).click();
+
+  // Only the completed task should be visible
+  await expect(page.getByText("Add authentication to the API")).toBeVisible();
+  await expect(page.getByText("Fix login validation bug")).not.toBeVisible();
+  await expect(page.getByText("Optimize database queries")).not.toBeVisible();
+});
+
+test("filtering by project works", async ({ page }) => {
+  await page.goto(`${server.url}/tasks?token=${TOKEN}`);
+
+  // Wait for tasks to load
+  await expect(page.getByText("Add authentication to the API")).toBeVisible();
+
+  // Select "backend" project from dropdown
+  await page.locator('[data-slot="select-trigger"]').first().click();
+  await page.getByRole("option", { name: "backend" }).click();
+
+  // Only the backend task should be visible
+  await expect(page.getByText("Optimize database queries")).toBeVisible();
+  await expect(page.getByText("Add authentication to the API")).not.toBeVisible();
+  await expect(page.getByText("Fix login validation bug")).not.toBeVisible();
+});
+
+test("empty state shows when no tasks match filters", async ({ page }) => {
+  await page.goto(`${server.url}/tasks?token=${TOKEN}`);
+
+  // Wait for tasks to load
+  await expect(page.getByText("Add authentication to the API")).toBeVisible();
+
+  // Select "backend" project + "completed" status — no tasks match
+  await page.locator('[data-slot="select-trigger"]').first().click();
+  await page.getByRole("option", { name: "backend" }).click();
+  await page.getByRole("button", { name: "completed" }).click();
+
+  await expect(page.getByText("No tasks found")).toBeVisible();
+  await expect(page.getByText("Try adjusting your filters")).toBeVisible();
+});
+
+test("completed task shows session link", async ({ page }) => {
+  await page.goto(`${server.url}/tasks?token=${TOKEN}`);
+
+  // The completed task with a sessionId should have a "Session" link
+  await expect(page.getByText("Add authentication to the API")).toBeVisible();
+  const sessionLink = page.getByRole("link", { name: "Session" });
+  await expect(sessionLink.first()).toBeVisible();
+});
+
+test("new task dialog opens and shows project/workspace selectors", async ({ page }) => {
+  await page.goto(`${server.url}/tasks?token=${TOKEN}`);
+
+  // Wait for page to load
+  await expect(page.getByText("Add authentication to the API")).toBeVisible();
+
+  // Click "New Task" button
+  await page.getByRole("button", { name: "New Task" }).click();
+
+  // Dialog should open with form elements
+  await expect(page.getByText("Dispatch a new task to a coding agent")).toBeVisible();
+  await expect(page.getByText("Project", { exact: true })).toBeVisible();
+  await expect(page.getByText("Workspace", { exact: true })).toBeVisible();
+  await expect(page.getByText("Prompt", { exact: true })).toBeVisible();
+});
+
+test("back button navigates to dashboard", async ({ page }) => {
+  await page.goto(`${server.url}/tasks?token=${TOKEN}`);
+  await expect(page.locator("h1", { hasText: "Tasks" })).toBeVisible();
+
+  // Click the back arrow
+  const backLink = page.locator("a[href='/']");
+  await expect(backLink).toBeVisible();
+});

--- a/apps/web/src/components/DashboardView.tsx
+++ b/apps/web/src/components/DashboardView.tsx
@@ -3,7 +3,9 @@ import {
   HybridDashboardAdapter,
   NativeShellCapabilities,
 } from "@band/dashboard-core/adapters/hybrid";
-import { TooltipProvider } from "@band/ui";
+import { Button, Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@band/ui";
+import { Link } from "@tanstack/react-router";
+import { ListTodo } from "lucide-react";
 import { TunnelToolbarButton } from "./TunnelToolbarButton";
 
 const adapter = new HybridDashboardAdapter();
@@ -13,7 +15,23 @@ export function DashboardView() {
   return (
     <DashboardProvider adapter={adapter} capabilities={capabilities}>
       <TooltipProvider>
-        <DashboardShell toolbarExtra={<TunnelToolbarButton />} />
+        <DashboardShell
+          toolbarExtra={
+            <>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button size="icon-sm" variant="ghost" asChild>
+                    <Link to="/tasks">
+                      <ListTodo className="size-5" />
+                    </Link>
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent>Tasks</TooltipContent>
+              </Tooltip>
+              <TunnelToolbarButton />
+            </>
+          }
+        />
       </TooltipProvider>
     </DashboardProvider>
   );

--- a/apps/web/src/lib/state.ts
+++ b/apps/web/src/lib/state.ts
@@ -63,6 +63,10 @@ export function statusDir(): string {
   return join(bandHome(), "status");
 }
 
+export function tasksDir(): string {
+  return join(bandHome(), "tasks");
+}
+
 export function stateFile(): string {
   return join(bandHome(), "state.json");
 }
@@ -74,6 +78,7 @@ export function settingsFile(): string {
 export function ensureDirs(): void {
   mkdirSync(bandHome(), { recursive: true });
   mkdirSync(statusDir(), { recursive: true });
+  mkdirSync(tasksDir(), { recursive: true });
 }
 
 export function loadState(): AppState {

--- a/apps/web/src/lib/task-runner.ts
+++ b/apps/web/src/lib/task-runner.ts
@@ -2,6 +2,7 @@ import { createLogger } from "@band/logger";
 import type { UIMessageChunk } from "ai";
 import { getAgent, getOrCreateAgent } from "./agent-pool";
 import { createPendingInput } from "./pending-inputs";
+import { generateTaskId, saveTask } from "./task-store";
 import { resolveWorkspace } from "./workspace";
 
 const log = createLogger("task-runner");
@@ -27,6 +28,7 @@ export interface TaskInfo {
 type Listener = (chunk: UIMessageChunk) => void;
 
 interface InternalTask extends TaskInfo {
+  taskRecordId: string;
   agentPrompt: string;
   chunks: UIMessageChunk[];
   expireTimer?: ReturnType<typeof setTimeout>;
@@ -45,6 +47,25 @@ const tasks = g[TASKS_KEY] as Map<string, InternalTask>;
 const listeners = g[LISTENERS_KEY] as Map<string, Set<Listener>>;
 
 const BUFFER_EXPIRE_MS = 30 * 60 * 1000; // 30 minutes
+
+function persistTask(task: InternalTask): void {
+  const workspace = resolveWorkspace(task.workspaceId);
+  try {
+    saveTask({
+      id: task.taskRecordId,
+      workspaceId: task.workspaceId,
+      project: workspace?.project.name ?? "",
+      branch: workspace?.worktree.branch ?? "",
+      prompt: task.prompt,
+      status: task.status,
+      sessionId: task.sessionId,
+      startedAt: task.startedAt,
+      completedAt: task.completedAt,
+    });
+  } catch (err) {
+    log.warn({ err, taskId: task.taskRecordId }, "failed to persist task");
+  }
+}
 
 function broadcast(workspaceId: string, chunk: UIMessageChunk) {
   const subs = listeners.get(workspaceId);
@@ -85,6 +106,7 @@ export function submitTask(
     status: "running",
     startedAt: Date.now(),
     prompt,
+    taskRecordId: generateTaskId(),
     agentPrompt: agentPrompt ?? prompt,
     chunks: [
       // Emit user-facing prompt so reconnecting clients can reconstruct the user message
@@ -92,6 +114,7 @@ export function submitTask(
     ],
   };
   tasks.set(workspaceId, task);
+  persistTask(task);
 
   // Fire-and-forget async execution
   runTask(workspaceId, task).catch((err) => {
@@ -114,6 +137,7 @@ export function abortTask(workspaceId: string): boolean {
 
   task.status = "failed";
   task.completedAt = Date.now();
+  persistTask(task);
   emit(workspaceId, task, { type: "error", errorText: "Task aborted by user" });
   emit(workspaceId, task, { type: "finish" });
   scheduleExpiry(workspaceId);
@@ -127,6 +151,7 @@ async function runTask(workspaceId: string, task: InternalTask) {
   if (!workspace) {
     task.status = "failed";
     task.completedAt = Date.now();
+    persistTask(task);
     emit(workspaceId, task, { type: "error", errorText: "Workspace not found" });
     scheduleExpiry(workspaceId);
     return;
@@ -157,6 +182,7 @@ async function runTask(workspaceId: string, task: InternalTask) {
       switch (event.type) {
         case "session-start": {
           task.sessionId = event.sessionId;
+          persistTask(task);
           emit(workspaceId, task, {
             type: "data-session" as UIMessageChunk["type"],
             data: { sessionId: event.sessionId },
@@ -216,6 +242,7 @@ async function runTask(workspaceId: string, task: InternalTask) {
           if (event.success) {
             task.status = "completed";
             task.completedAt = Date.now();
+            persistTask(task);
             emit(workspaceId, task, {
               type: "data-result" as UIMessageChunk["type"],
               data: {
@@ -233,6 +260,7 @@ async function runTask(workspaceId: string, task: InternalTask) {
           } else {
             task.status = "failed";
             task.completedAt = Date.now();
+            persistTask(task);
             emit(workspaceId, task, {
               type: "error",
               errorText: `Agent error: ${event.errors.join(", ") || "unknown error"}`,
@@ -259,6 +287,7 @@ async function runTask(workspaceId: string, task: InternalTask) {
         task.status = "completed";
         task.completedAt = Date.now();
       }
+      persistTask(task);
       emit(workspaceId, task, {
         type: "error",
         errorText: "Agent session ended without producing a result",
@@ -267,6 +296,7 @@ async function runTask(workspaceId: string, task: InternalTask) {
   } catch (err) {
     task.status = "failed";
     task.completedAt = Date.now();
+    persistTask(task);
     emit(workspaceId, task, {
       type: "error",
       errorText: err instanceof Error ? err.message : "Unknown error",

--- a/apps/web/src/lib/task-store.ts
+++ b/apps/web/src/lib/task-store.ts
@@ -1,0 +1,84 @@
+import { mkdirSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { createLogger } from "@band/logger";
+import { tasksDir } from "./state";
+
+const log = createLogger("task-store");
+
+export type TaskStatus = "running" | "completed" | "failed";
+
+export interface TaskRecord {
+  id: string;
+  workspaceId: string;
+  project: string;
+  branch: string;
+  prompt: string;
+  status: TaskStatus;
+  sessionId?: string;
+  startedAt: number;
+  completedAt?: number;
+}
+
+export interface TaskFilters {
+  project?: string;
+  workspaceId?: string;
+  status?: TaskStatus;
+}
+
+export function generateTaskId(): string {
+  return `tsk_${Date.now()}`;
+}
+
+export function ensureTasksDir(): void {
+  mkdirSync(tasksDir(), { recursive: true });
+}
+
+export function saveTask(task: TaskRecord): void {
+  ensureTasksDir();
+  const filePath = join(tasksDir(), `${task.id}.json`);
+  writeFileSync(filePath, JSON.stringify(task, null, 2), "utf-8");
+}
+
+export function loadTask(id: string): TaskRecord | null {
+  try {
+    const filePath = join(tasksDir(), `${id}.json`);
+    const data = readFileSync(filePath, "utf-8");
+    return JSON.parse(data) as TaskRecord;
+  } catch {
+    return null;
+  }
+}
+
+export function listTasks(filters?: TaskFilters): TaskRecord[] {
+  const dir = tasksDir();
+  const tasks: TaskRecord[] = [];
+
+  try {
+    for (const file of readdirSync(dir)) {
+      if (!file.endsWith(".json")) continue;
+      try {
+        const data = readFileSync(join(dir, file), "utf-8");
+        const task = JSON.parse(data) as TaskRecord;
+        if (matchesFilters(task, filters)) {
+          tasks.push(task);
+        }
+      } catch (err) {
+        log.warn({ file, err }, "skipping invalid task file");
+      }
+    }
+  } catch {
+    // Tasks dir may not exist yet
+  }
+
+  // Newest first
+  tasks.sort((a, b) => b.startedAt - a.startedAt);
+  return tasks;
+}
+
+function matchesFilters(task: TaskRecord, filters?: TaskFilters): boolean {
+  if (!filters) return true;
+  if (filters.project && task.project !== filters.project) return false;
+  if (filters.workspaceId && task.workspaceId !== filters.workspaceId) return false;
+  if (filters.status && task.status !== filters.status) return false;
+  return true;
+}

--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -9,9 +9,15 @@
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
 import { Route as rootRouteImport } from './routes/__root'
+import { Route as TasksRouteImport } from './routes/tasks'
 import { Route as IndexRouteImport } from './routes/index'
 import { Route as ChatWorkspaceIdRouteImport } from './routes/chat.$workspaceId'
 
+const TasksRoute = TasksRouteImport.update({
+  id: '/tasks',
+  path: '/tasks',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const IndexRoute = IndexRouteImport.update({
   id: '/',
   path: '/',
@@ -25,32 +31,43 @@ const ChatWorkspaceIdRoute = ChatWorkspaceIdRouteImport.update({
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
+  '/tasks': typeof TasksRoute
   '/chat/$workspaceId': typeof ChatWorkspaceIdRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
+  '/tasks': typeof TasksRoute
   '/chat/$workspaceId': typeof ChatWorkspaceIdRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
+  '/tasks': typeof TasksRoute
   '/chat/$workspaceId': typeof ChatWorkspaceIdRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
-  fullPaths: '/' | '/chat/$workspaceId'
+  fullPaths: '/' | '/tasks' | '/chat/$workspaceId'
   fileRoutesByTo: FileRoutesByTo
-  to: '/' | '/chat/$workspaceId'
-  id: '__root__' | '/' | '/chat/$workspaceId'
+  to: '/' | '/tasks' | '/chat/$workspaceId'
+  id: '__root__' | '/' | '/tasks' | '/chat/$workspaceId'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
+  TasksRoute: typeof TasksRoute
   ChatWorkspaceIdRoute: typeof ChatWorkspaceIdRoute
 }
 
 declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
+    '/tasks': {
+      id: '/tasks'
+      path: '/tasks'
+      fullPath: '/tasks'
+      preLoaderRoute: typeof TasksRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/': {
       id: '/'
       path: '/'
@@ -70,6 +87,7 @@ declare module '@tanstack/react-router' {
 
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
+  TasksRoute: TasksRoute,
   ChatWorkspaceIdRoute: ChatWorkspaceIdRoute,
 }
 export const routeTree = rootRouteImport

--- a/apps/web/src/routes/tasks.tsx
+++ b/apps/web/src/routes/tasks.tsx
@@ -1,0 +1,434 @@
+import {
+  Badge,
+  Button,
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+  Textarea,
+} from "@band/ui";
+import { createFileRoute, Link } from "@tanstack/react-router";
+import {
+  AlertCircle,
+  ArrowLeft,
+  CheckCircle2,
+  Clock,
+  ExternalLink,
+  ListTodo,
+  Loader2,
+  Plus,
+  RefreshCw,
+} from "lucide-react";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { trpc } from "../lib/trpc-client";
+
+export const Route = createFileRoute("/tasks")({
+  component: TasksPage,
+});
+
+interface TaskRecord {
+  id: string;
+  workspaceId: string;
+  project: string;
+  branch: string;
+  prompt: string;
+  status: "running" | "completed" | "failed";
+  sessionId?: string;
+  startedAt: number;
+  completedAt?: number;
+}
+
+interface ProjectInfo {
+  name: string;
+  worktrees: { branch: string }[];
+}
+
+function relativeTime(ms: number): string {
+  const seconds = Math.floor((Date.now() - ms) / 1000);
+  if (seconds < 60) return "just now";
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  if (days < 30) return `${days}d ago`;
+  const months = Math.floor(days / 30);
+  return `${months}mo ago`;
+}
+
+function formatDuration(startedAt: number, completedAt?: number): string {
+  const end = completedAt ?? Date.now();
+  const ms = end - startedAt;
+  const seconds = Math.floor(ms / 1000);
+  if (seconds < 60) return `${seconds}s`;
+  const minutes = Math.floor(seconds / 60);
+  const remainingSeconds = seconds % 60;
+  if (minutes < 60) return `${minutes}m ${remainingSeconds}s`;
+  const hours = Math.floor(minutes / 60);
+  const remainingMinutes = minutes % 60;
+  return `${hours}h ${remainingMinutes}m`;
+}
+
+type StatusFilter = "all" | "running" | "completed" | "failed";
+
+function TasksPage() {
+  const [tasks, setTasks] = useState<TaskRecord[]>([]);
+  const [projects, setProjects] = useState<ProjectInfo[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [projectFilter, setProjectFilter] = useState<string>("all");
+  const [statusFilter, setStatusFilter] = useState<StatusFilter>("all");
+  const [showNewTask, setShowNewTask] = useState(false);
+
+  const fetchData = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const [tasksData, projectsData] = await Promise.all([
+        trpc.tasks.list.query({}),
+        trpc.projects.list.query(),
+      ]);
+      setTasks(tasksData.tasks as TaskRecord[]);
+      setProjects(projectsData.projects as ProjectInfo[]);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to load tasks");
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchData();
+  }, [fetchData]);
+
+  const filteredTasks = useMemo(() => {
+    return tasks.filter((task) => {
+      if (projectFilter !== "all" && task.project !== projectFilter) return false;
+      if (statusFilter !== "all" && task.status !== statusFilter) return false;
+      return true;
+    });
+  }, [tasks, projectFilter, statusFilter]);
+
+  const projectNames = useMemo(() => {
+    const names = new Set(projects.map((p) => p.name));
+    return Array.from(names).sort();
+  }, [projects]);
+
+  const handleNewTaskSubmit = useCallback(
+    async (workspaceId: string, prompt: string) => {
+      await trpc.tasks.submit.mutate({ workspaceId, prompt });
+      setShowNewTask(false);
+      await fetchData();
+    },
+    [fetchData],
+  );
+
+  return (
+    <div className="flex h-dvh flex-col overflow-hidden">
+      <header className="flex shrink-0 items-center gap-3 border-b border-border/50 px-4 py-3 pt-[max(0.75rem,env(safe-area-inset-top))]">
+        <Link
+          to="/"
+          className="inline-flex size-8 items-center justify-center rounded-md hover:bg-accent"
+        >
+          <ArrowLeft className="size-4" />
+        </Link>
+        <div className="min-w-0 flex-1">
+          <h1 className="text-sm font-semibold">Tasks</h1>
+        </div>
+        <Button size="sm" onClick={() => setShowNewTask(true)}>
+          <Plus className="size-4" />
+          New Task
+        </Button>
+      </header>
+
+      <div className="flex shrink-0 items-center gap-2 border-b border-border/50 px-4 py-2">
+        <Select value={projectFilter} onValueChange={setProjectFilter}>
+          <SelectTrigger className="h-8 w-40 text-xs">
+            <SelectValue placeholder="All Projects" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">All Projects</SelectItem>
+            {projectNames.map((name) => (
+              <SelectItem key={name} value={name}>
+                {name}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+
+        <div className="flex items-center gap-1 rounded-md border border-border p-0.5">
+          {(["all", "running", "completed", "failed"] as const).map((status) => (
+            <button
+              key={status}
+              type="button"
+              onClick={() => setStatusFilter(status)}
+              className={`rounded px-2.5 py-1 text-xs font-medium capitalize transition-colors ${
+                statusFilter === status
+                  ? "bg-accent text-accent-foreground"
+                  : "text-muted-foreground hover:text-foreground"
+              }`}
+            >
+              {status}
+            </button>
+          ))}
+        </div>
+
+        <button
+          type="button"
+          onClick={fetchData}
+          className="ml-auto inline-flex size-8 items-center justify-center rounded-md text-muted-foreground hover:bg-accent hover:text-foreground"
+        >
+          <RefreshCw className="size-3.5" />
+        </button>
+      </div>
+
+      <main className="min-h-0 flex-1 overflow-y-auto">
+        {loading && tasks.length === 0 && (
+          <div className="flex items-center justify-center py-16">
+            <Loader2 className="size-6 animate-spin text-muted-foreground" />
+          </div>
+        )}
+
+        {error && (
+          <div className="flex flex-col items-center justify-center gap-4 py-16 text-center">
+            <p className="text-sm text-destructive">{error}</p>
+            <Button variant="secondary" size="sm" onClick={fetchData}>
+              <RefreshCw className="size-3.5" />
+              Retry
+            </Button>
+          </div>
+        )}
+
+        {!loading && !error && filteredTasks.length === 0 && (
+          <div className="flex flex-col items-center justify-center gap-3 py-16 text-center">
+            <ListTodo className="size-10 text-muted-foreground" />
+            <div>
+              <p className="font-medium">No tasks found</p>
+              <p className="text-sm text-muted-foreground">
+                {tasks.length > 0
+                  ? "Try adjusting your filters"
+                  : "Dispatch a new task to get started"}
+              </p>
+            </div>
+          </div>
+        )}
+
+        {filteredTasks.length > 0 && (
+          <div className="flex flex-col gap-2 p-4">
+            {filteredTasks.map((task) => (
+              <TaskCard key={task.id} task={task} />
+            ))}
+          </div>
+        )}
+      </main>
+
+      <NewTaskDialog
+        open={showNewTask}
+        onOpenChange={setShowNewTask}
+        projects={projects}
+        onSubmit={handleNewTaskSubmit}
+      />
+    </div>
+  );
+}
+
+function StatusBadge({ status }: { status: TaskRecord["status"] }) {
+  switch (status) {
+    case "running":
+      return (
+        <Badge variant="secondary" className="gap-1.5">
+          <Loader2 className="size-3 animate-spin" />
+          Running
+        </Badge>
+      );
+    case "completed":
+      return (
+        <Badge variant="secondary" className="gap-1.5 text-green-400">
+          <CheckCircle2 className="size-3" />
+          Completed
+        </Badge>
+      );
+    case "failed":
+      return (
+        <Badge variant="destructive" className="gap-1.5">
+          <AlertCircle className="size-3" />
+          Failed
+        </Badge>
+      );
+  }
+}
+
+function TaskCard({ task }: { task: TaskRecord }) {
+  const sessionHref = task.sessionId ? `/chat/${encodeURIComponent(task.workspaceId)}` : undefined;
+
+  return (
+    <div className="flex flex-col gap-2 rounded-lg border border-border/50 bg-card p-4 transition-colors hover:border-border">
+      <div className="flex items-start justify-between gap-3">
+        <p className="line-clamp-2 min-w-0 flex-1 text-sm font-medium text-foreground">
+          {task.prompt}
+        </p>
+        <StatusBadge status={task.status} />
+      </div>
+
+      <div className="flex items-center gap-3 text-xs text-muted-foreground">
+        <span className="font-medium text-foreground/70">
+          {task.project}/{task.branch}
+        </span>
+        <span className="text-border">·</span>
+        <span className="inline-flex items-center gap-1">
+          <Clock className="size-3" />
+          {relativeTime(task.startedAt)}
+        </span>
+        <span className="text-border">·</span>
+        <span>{formatDuration(task.startedAt, task.completedAt)}</span>
+        {sessionHref && (
+          <>
+            <span className="text-border">·</span>
+            <Link
+              to={sessionHref}
+              className="inline-flex items-center gap-1 text-primary hover:underline"
+            >
+              <ExternalLink className="size-3" />
+              Session
+            </Link>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function NewTaskDialog({
+  open,
+  onOpenChange,
+  projects,
+  onSubmit,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  projects: ProjectInfo[];
+  onSubmit: (workspaceId: string, prompt: string) => Promise<void>;
+}) {
+  const [selectedProject, setSelectedProject] = useState<string>("");
+  const [selectedBranch, setSelectedBranch] = useState<string>("");
+  const [prompt, setPrompt] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [submitError, setSubmitError] = useState<string | null>(null);
+
+  const branches = useMemo(() => {
+    const project = projects.find((p) => p.name === selectedProject);
+    return project?.worktrees.map((w) => w.branch) ?? [];
+  }, [projects, selectedProject]);
+
+  const workspaceId =
+    selectedProject && selectedBranch ? `${selectedProject}-${selectedBranch}` : "";
+
+  const handleProjectChange = useCallback((value: string) => {
+    setSelectedProject(value);
+    setSelectedBranch("");
+  }, []);
+
+  const handleSubmit = useCallback(async () => {
+    if (!workspaceId || !prompt.trim()) return;
+    setSubmitting(true);
+    setSubmitError(null);
+    try {
+      await onSubmit(workspaceId, prompt.trim());
+      setSelectedProject("");
+      setSelectedBranch("");
+      setPrompt("");
+    } catch (err) {
+      setSubmitError(err instanceof Error ? err.message : "Failed to submit task");
+    } finally {
+      setSubmitting(false);
+    }
+  }, [workspaceId, prompt, onSubmit]);
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>New Task</DialogTitle>
+          <DialogDescription>Dispatch a new task to a coding agent</DialogDescription>
+        </DialogHeader>
+
+        <div className="flex flex-col gap-4 py-2">
+          <div className="flex flex-col gap-2">
+            <label className="text-sm font-medium" htmlFor="project-select">
+              Project
+            </label>
+            <Select value={selectedProject} onValueChange={handleProjectChange}>
+              <SelectTrigger id="project-select">
+                <SelectValue placeholder="Select a project" />
+              </SelectTrigger>
+              <SelectContent>
+                {projects.map((p) => (
+                  <SelectItem key={p.name} value={p.name}>
+                    {p.name}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          <div className="flex flex-col gap-2">
+            <label className="text-sm font-medium" htmlFor="branch-select">
+              Workspace
+            </label>
+            <Select
+              value={selectedBranch}
+              onValueChange={setSelectedBranch}
+              disabled={!selectedProject}
+            >
+              <SelectTrigger id="branch-select">
+                <SelectValue
+                  placeholder={selectedProject ? "Select a workspace" : "Select a project first"}
+                />
+              </SelectTrigger>
+              <SelectContent>
+                {branches.map((branch) => (
+                  <SelectItem key={branch} value={branch}>
+                    {branch}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          <div className="flex flex-col gap-2">
+            <label className="text-sm font-medium" htmlFor="task-prompt">
+              Prompt
+            </label>
+            <Textarea
+              id="task-prompt"
+              placeholder="Describe what the agent should do..."
+              value={prompt}
+              onChange={(e) => setPrompt(e.target.value)}
+              rows={4}
+            />
+          </div>
+
+          {submitError && <p className="text-sm text-destructive">{submitError}</p>}
+        </div>
+
+        <DialogFooter>
+          <DialogClose asChild>
+            <Button variant="outline">Cancel</Button>
+          </DialogClose>
+          <Button onClick={handleSubmit} disabled={!workspaceId || !prompt.trim() || submitting}>
+            {submitting && <Loader2 className="size-4 animate-spin" />}
+            Submit Task
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/web/src/trpc/router.ts
+++ b/apps/web/src/trpc/router.ts
@@ -39,6 +39,7 @@ import {
   subscribe as subscribeTask,
   TaskConflictError,
 } from "../lib/task-runner";
+import { listTasks } from "../lib/task-store";
 import {
   checkTunnelAuth,
   checkTunnelHealth,
@@ -767,6 +768,20 @@ async function saveUploadedFiles(fileParts: FilePart[]): Promise<string[]> {
 }
 
 const tasksRouter = t.router({
+  list: publicProcedure
+    .input(
+      z
+        .object({
+          project: z.string().optional(),
+          workspaceId: z.string().optional(),
+          status: z.enum(["running", "completed", "failed"]).optional(),
+        })
+        .optional(),
+    )
+    .query(({ input }) => {
+      return { tasks: listTasks(input) };
+    }),
+
   submit: publicProcedure
     .input(
       z.object({


### PR DESCRIPTION
## Summary
- Add file-based task persistence in `~/.band/tasks/` so task history survives server restarts
- Create dedicated `/tasks` page with project/status filtering, task dispatch dialog, and session history links
- Add Tasks navigation button to dashboard toolbar

Closes #82

## Changes
- **`task-store.ts`** — new file-based persistence layer (`saveTask`, `listTasks`, `loadTask`)
- **`task-runner.ts`** — integrated persistence at every task lifecycle point (submit, session-start, complete, fail, abort)
- **`state.ts`** — added `tasksDir()` helper and `ensureDirs()` update
- **`router.ts`** — added `tasks.list` tRPC query with optional project/workspace/status filters
- **`tasks.tsx`** — new `/tasks` route with filter bar, task cards, status badges, and New Task dialog
- **`DashboardView.tsx`** — added ListTodo toolbar button linking to `/tasks`

## Test plan
- [x] 8 new Playwright E2E tests covering task list rendering, status/project filtering, empty state, session links, new task dialog, and back navigation
- [x] All 4 existing session history E2E tests still pass
- [x] Build passes with no lint/format errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)