### PR TITLE
fix: resolve ZodError on tool permission requests in Band hooks

### DIFF
--- a/apps/cli/src/main.rs
+++ b/apps/cli/src/main.rs
@@ -524,7 +524,7 @@ fn cmd_notify() -> Result<CommandResult, String> {
         .unwrap_or("");
 
     let agent_status = match hook_event {
-        "Stop" | "PermissionRequest" => "needs_attention",
+        "Stop" => "needs_attention",
         _ => "working",
     };
 

--- a/apps/dashboard/src-tauri/src/commands/ide.rs
+++ b/apps/dashboard/src-tauri/src/commands/ide.rs
@@ -318,7 +318,23 @@ fn find_workspace<'a>(
 }
 
 /// Clear `needs_attention` status by calling the web server API.
+/// Only resets to "waiting" if the current status is actually `needs_attention`,
+/// so it won't clobber "working" status while an agent is running.
 fn clear_needs_attention(workspace_id: &str, api: &ApiClient) {
+    let current = api.trpc_query(
+        "statuses.get",
+        &serde_json::json!({ "workspaceId": workspace_id }),
+    );
+    let is_needs_attention = current
+        .ok()
+        .and_then(|v| v.get("agent")?.get("status")?.as_str().map(String::from))
+        .as_deref()
+        == Some("needs_attention");
+
+    if !is_needs_attention {
+        return;
+    }
+
     let _ = api.trpc_mutate(
         "statuses.update",
         &serde_json::json!({

--- a/apps/web/src/lib/hooks.ts
+++ b/apps/web/src/lib/hooks.ts
@@ -3,13 +3,7 @@ import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 import { whichBinary } from "./process-utils";
 
-const HOOK_EVENTS = [
-  "UserPromptSubmit",
-  "PostToolUse",
-  "PostToolUseFailure",
-  "Stop",
-  "PermissionRequest",
-];
+const HOOK_EVENTS = ["UserPromptSubmit", "PostToolUse", "Stop"];
 
 function claudeSettingsPath(): string {
   return join(homedir(), ".claude", "settings.json");
@@ -86,6 +80,22 @@ export async function installHooks(): Promise<void> {
 
   const settings = loadClaudeSettings();
   const hooks = (settings.hooks || {}) as Record<string, unknown[]>;
+
+  // Remove band hooks from any events not in HOOK_EVENTS
+  for (const [event, eventHooks] of Object.entries(hooks)) {
+    if (HOOK_EVENTS.includes(event)) continue;
+    if (!Array.isArray(eventHooks)) continue;
+    const filtered = eventHooks.filter((entry) => {
+      const e = entry as { hooks?: Array<{ type?: string; command?: string }> };
+      if (!e.hooks || !Array.isArray(e.hooks)) return true;
+      return !e.hooks.some((h) => h.type === "command" && h.command && isBandHook(h.command));
+    });
+    if (filtered.length > 0) {
+      hooks[event] = filtered;
+    } else {
+      delete hooks[event];
+    }
+  }
 
   for (const event of HOOK_EVENTS) {
     const existing = hooks[event] || [];

--- a/packages/coding-agent/src/adapters/claude-code.ts
+++ b/packages/coding-agent/src/adapters/claude-code.ts
@@ -71,7 +71,7 @@ export class ClaudeCodeAdapter implements CodingAgent {
 
     const canUseTool: CanUseTool = async (toolName, input, options) => {
       if (toolName !== "AskUserQuestion" || !this.onUserInputNeeded) {
-        return { behavior: "allow" };
+        return { behavior: "allow", updatedInput: input };
       }
 
       const approvalId = options.toolUseID;
@@ -96,7 +96,7 @@ export class ClaudeCodeAdapter implements CodingAgent {
         return { behavior: "deny", message: formatUserAnswer(answers) };
       } catch (err) {
         log.warn({ err, approvalId }, "AskUserQuestion timed out or errored, auto-allowing");
-        return { behavior: "allow" };
+        return { behavior: "allow", updatedInput: input };
       }
     };
 


### PR DESCRIPTION
## Summary
- Fix `canUseTool` callback to include `updatedInput` field required by Claude Agent SDK's Zod validation schema, preventing the ZodError that was being surfaced as a deny message and confusing the coding agent
- Simplify hook events to the minimum needed for status tracking: `UserPromptSubmit`, `PostToolUse`, `Stop` — removing `PermissionRequest` (the bug source) and `PostToolUseFailure` (redundant)
- `installHooks()` now cleans up stale band hooks from events no longer in use

## Test plan
- [x] All 114 web tests pass
- [x] All 33 CLI tests pass
- [x] Lint/clippy checks pass
- [ ] Verify tool permission requests no longer produce ZodError during web-based task execution
- [ ] Verify dashboard status correctly shows "working" and "needs_attention" with only 3 hooks

Closes #86

🤖 Generated with [Claude Code](https://claude.com/claude-code)