### PR TITLE
fix: support BAND_SERVER_URL and BAND_TOKEN env var overrides in CLI

### DIFF
--- a/apps/cli/src/api.rs
+++ b/apps/cli/src/api.rs
@@ -11,12 +11,11 @@ pub struct ApiClient {
 impl ApiClient {
     pub fn from_settings() -> Result<Self, String> {
         let settings = state::load_settings()?;
-        let base_url = match std::env::var("BAND_SERVER_URL") {
-            Ok(url) => url,
-            Err(_) => {
-                let port = settings.web_server_port.unwrap_or(3456);
-                format!("http://127.0.0.1:{port}")
-            }
+        let base_url = if let Ok(url) = std::env::var("BAND_SERVER_URL") {
+            url
+        } else {
+            let port = settings.web_server_port.unwrap_or(3456);
+            format!("http://127.0.0.1:{port}")
         };
         let token = std::env::var("BAND_TOKEN").ok().or(settings.token_secret);
         let agent = ureq::Agent::new_with_config(

--- a/apps/cli/src/api.rs
+++ b/apps/cli/src/api.rs
@@ -11,8 +11,14 @@ pub struct ApiClient {
 impl ApiClient {
     pub fn from_settings() -> Result<Self, String> {
         let settings = state::load_settings()?;
-        let port = settings.web_server_port.unwrap_or(3456);
-        let token = settings.token_secret;
+        let base_url = match std::env::var("BAND_SERVER_URL") {
+            Ok(url) => url,
+            Err(_) => {
+                let port = settings.web_server_port.unwrap_or(3456);
+                format!("http://127.0.0.1:{port}")
+            }
+        };
+        let token = std::env::var("BAND_TOKEN").ok().or(settings.token_secret);
         let agent = ureq::Agent::new_with_config(
             ureq::config::Config::builder()
                 .http_status_as_error(false)
@@ -20,7 +26,7 @@ impl ApiClient {
         );
         Ok(Self {
             agent,
-            base_url: format!("http://127.0.0.1:{port}"),
+            base_url,
             token,
         })
     }


### PR DESCRIPTION
## Summary
- `BAND_SERVER_URL` env var now overrides the default `http://127.0.0.1:{port}` server URL
- `BAND_TOKEN` env var now overrides the `tokenSecret` from `~/.band/settings.json`
- Env vars take priority, falling back to settings file values when unset

Closes #74

## Test plan
- [ ] Set `BAND_SERVER_URL=http://localhost:9999` and verify CLI attempts to connect there
- [ ] Set `BAND_TOKEN=test-token` and verify it's sent as the auth cookie
- [ ] Verify default behavior (no env vars set) is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)