### PR TITLE
feat: add task lifecycle management — stale cleanup, cancel, re-run

### DIFF
--- a/apps/cli/src/main.rs
+++ b/apps/cli/src/main.rs
@@ -31,6 +31,11 @@ enum Commands {
     },
     /// Show current settings
     Settings,
+    /// Manage tasks
+    Tasks {
+        #[command(subcommand)]
+        cmd: TasksCmd,
+    },
     /// Manage the remote tunnel
     Tunnel {
         #[command(subcommand)]
@@ -94,6 +99,29 @@ enum WorkspacesCmd {
 }
 
 #[derive(Subcommand)]
+enum TasksCmd {
+    /// List tasks
+    List {
+        /// Filter by project name
+        #[arg(long)]
+        project: Option<String>,
+        /// Filter by status (running, completed, failed)
+        #[arg(long)]
+        status: Option<String>,
+    },
+    /// Cancel a running task
+    Cancel {
+        /// Task ID (e.g. tsk_1234567890)
+        task_id: String,
+    },
+    /// Re-run a completed or failed task
+    Rerun {
+        /// Task ID (e.g. tsk_1234567890)
+        task_id: String,
+    },
+}
+
+#[derive(Subcommand)]
 enum TunnelCmd {
     /// Show tunnel status
     Status,
@@ -139,6 +167,13 @@ fn main() {
                 prompt,
             } => cmd_workspaces_create(&project, &branch, base.as_deref(), prompt.as_deref()),
             WorkspacesCmd::Remove { project, branch } => cmd_workspaces_remove(&project, &branch),
+        },
+        Commands::Tasks { cmd } => match cmd {
+            TasksCmd::List { project, status } => {
+                cmd_tasks_list(project.as_deref(), status.as_deref())
+            }
+            TasksCmd::Cancel { task_id } => cmd_tasks_cancel(&task_id),
+            TasksCmd::Rerun { task_id } => cmd_tasks_rerun(&task_id),
         },
         Commands::Settings => cmd_settings(json_output),
         Commands::Tunnel { cmd } => match cmd {
@@ -439,6 +474,87 @@ fn cmd_workspaces_remove(project: &str, branch: &str) -> Result<CommandResult, S
     })
 }
 
+// --- Tasks commands ---
+
+fn cmd_tasks_list(
+    project: Option<&str>,
+    status: Option<&str>,
+) -> Result<CommandResult, String> {
+    let client = api::ApiClient::from_settings()?;
+
+    let mut input = serde_json::json!({});
+    if let Some(p) = project {
+        input["project"] = serde_json::json!(p);
+    }
+    if let Some(s) = status {
+        input["status"] = serde_json::json!(s);
+    }
+
+    let data = client.trpc_query("tasks.list", &input)?;
+    let tasks = data
+        .get("tasks")
+        .and_then(|t| t.as_array())
+        .cloned()
+        .unwrap_or_default();
+
+    let mut rows: Vec<[String; 4]> = Vec::new();
+    let mut json_tasks = Vec::new();
+    for task in &tasks {
+        let id = task.get("id").and_then(|v| v.as_str()).unwrap_or("");
+        let prompt = task.get("prompt").and_then(|v| v.as_str()).unwrap_or("");
+        let task_status = task.get("status").and_then(|v| v.as_str()).unwrap_or("");
+        let project_name = task.get("project").and_then(|v| v.as_str()).unwrap_or("");
+        let branch = task.get("branch").and_then(|v| v.as_str()).unwrap_or("");
+
+        let truncated_prompt = if prompt.len() > 60 {
+            format!("{}...", &prompt[..57])
+        } else {
+            prompt.to_string()
+        };
+
+        rows.push([
+            id.to_string(),
+            task_status.to_string(),
+            format!("{project_name}/{branch}"),
+            truncated_prompt,
+        ]);
+
+        json_tasks.push(task.clone());
+    }
+
+    let text = format_table(&["ID", "STATUS", "WORKSPACE", "PROMPT"], &rows);
+
+    Ok(CommandResult {
+        text,
+        json: serde_json::json!({"tasks": json_tasks}),
+    })
+}
+
+fn cmd_tasks_cancel(task_id: &str) -> Result<CommandResult, String> {
+    let client = api::ApiClient::from_settings()?;
+    client.trpc_mutate("tasks.cancel", &serde_json::json!({"taskId": task_id}))?;
+
+    Ok(CommandResult {
+        text: format!("Task {task_id} cancelled\n"),
+        json: serde_json::json!({"cancelled": true, "taskId": task_id}),
+    })
+}
+
+fn cmd_tasks_rerun(task_id: &str) -> Result<CommandResult, String> {
+    let client = api::ApiClient::from_settings()?;
+    let data = client.trpc_mutate("tasks.rerun", &serde_json::json!({"taskId": task_id}))?;
+
+    let workspace_id = data
+        .get("workspaceId")
+        .and_then(|v| v.as_str())
+        .unwrap_or("");
+
+    Ok(CommandResult {
+        text: format!("Task re-run started for workspace {workspace_id}\n"),
+        json: data,
+    })
+}
+
 // --- Settings command ---
 
 fn cmd_settings(json_output: bool) -> Result<CommandResult, String> {
@@ -706,6 +822,28 @@ fn build_schema(command: Option<&str>) -> Result<serde_json::Value, String> {
             "name": "tunnel stop",
             "description": "Stop the remote tunnel",
             "parameters": []
+        }),
+        serde_json::json!({
+            "name": "tasks list",
+            "description": "List tasks, optionally filtered by project or status",
+            "parameters": [
+                {"name": "--project", "type": "string", "required": false, "description": "Filter by project name"},
+                {"name": "--status", "type": "string", "required": false, "description": "Filter by status (running, completed, failed)"},
+            ]
+        }),
+        serde_json::json!({
+            "name": "tasks cancel",
+            "description": "Cancel a running task",
+            "parameters": [
+                {"name": "task_id", "type": "string", "required": true, "positional": true, "description": "Task ID (e.g. tsk_1234567890)"},
+            ]
+        }),
+        serde_json::json!({
+            "name": "tasks rerun",
+            "description": "Re-run a completed or failed task",
+            "parameters": [
+                {"name": "task_id", "type": "string", "required": true, "positional": true, "description": "Task ID (e.g. tsk_1234567890)"},
+            ]
         }),
         serde_json::json!({
             "name": "notify",

--- a/apps/cli/src/main.rs
+++ b/apps/cli/src/main.rs
@@ -111,12 +111,12 @@ enum TasksCmd {
     },
     /// Cancel a running task
     Cancel {
-        /// Task ID (e.g. tsk_1234567890)
+        /// Task ID (e.g. `tsk_1234567890`)
         task_id: String,
     },
     /// Re-run a completed or failed task
     Rerun {
-        /// Task ID (e.g. tsk_1234567890)
+        /// Task ID (e.g. `tsk_1234567890`)
         task_id: String,
     },
 }
@@ -754,6 +754,7 @@ fn format_table<const N: usize>(headers: &[&str; N], rows: &[[String; N]]) -> St
 
 // --- Schema ---
 
+#[allow(clippy::too_many_lines)]
 fn build_schema(command: Option<&str>) -> Result<serde_json::Value, String> {
     let commands = vec![
         serde_json::json!({

--- a/apps/cli/src/main.rs
+++ b/apps/cli/src/main.rs
@@ -476,10 +476,7 @@ fn cmd_workspaces_remove(project: &str, branch: &str) -> Result<CommandResult, S
 
 // --- Tasks commands ---
 
-fn cmd_tasks_list(
-    project: Option<&str>,
-    status: Option<&str>,
-) -> Result<CommandResult, String> {
+fn cmd_tasks_list(project: Option<&str>, status: Option<&str>) -> Result<CommandResult, String> {
     let client = api::ApiClient::from_settings()?;
 
     let mut input = serde_json::json!({});

--- a/apps/web/src/lib/task-runner.ts
+++ b/apps/web/src/lib/task-runner.ts
@@ -2,7 +2,7 @@ import { createLogger } from "@band/logger";
 import type { UIMessageChunk } from "ai";
 import { getAgent, getOrCreateAgent } from "./agent-pool";
 import { createPendingInput } from "./pending-inputs";
-import { generateTaskId, saveTask } from "./task-store";
+import { generateTaskId, markTaskFailed, saveTask } from "./task-store";
 import { resolveWorkspace } from "./workspace";
 
 const log = createLogger("task-runner");
@@ -144,6 +144,37 @@ export function abortTask(workspaceId: string): boolean {
 
   log.info({ workspaceId }, "task aborted by user");
   return true;
+}
+
+export function cancelTask(taskId: string): { cancelled: boolean; workspaceId?: string } {
+  // Search in-memory tasks for a running task with this record ID
+  for (const [workspaceId, task] of tasks) {
+    if (task.taskRecordId === taskId && task.status === "running") {
+      const agent = getAgent(workspaceId);
+      if (agent?.abort) {
+        agent.abort();
+      }
+
+      task.status = "failed";
+      task.completedAt = Date.now();
+      persistTask(task);
+      emit(workspaceId, task, { type: "error", errorText: "Task cancelled" });
+      emit(workspaceId, task, { type: "finish" });
+      scheduleExpiry(workspaceId);
+
+      log.info({ workspaceId, taskId }, "task cancelled (was running in-memory)");
+      return { cancelled: true, workspaceId };
+    }
+  }
+
+  // Not found in memory — try marking the persisted record as failed (orphaned task)
+  const record = markTaskFailed(taskId);
+  if (record) {
+    log.info({ taskId, workspaceId: record.workspaceId }, "orphaned task cancelled");
+    return { cancelled: true, workspaceId: record.workspaceId };
+  }
+
+  return { cancelled: false };
 }
 
 async function runTask(workspaceId: string, task: InternalTask) {

--- a/apps/web/src/lib/task-store.ts
+++ b/apps/web/src/lib/task-store.ts
@@ -75,6 +75,37 @@ export function listTasks(filters?: TaskFilters): TaskRecord[] {
   return tasks;
 }
 
+/**
+ * Mark all persisted "running" tasks as "failed".
+ * Called on server start before listening — no agent can be running if the server just started.
+ */
+export function cleanupStaleTasks(): number {
+  const staleTasks = listTasks({ status: "running" });
+  for (const task of staleTasks) {
+    task.status = "failed";
+    task.completedAt = Date.now();
+    saveTask(task);
+    log.info({ taskId: task.id, workspaceId: task.workspaceId }, "marked stale task as failed");
+  }
+  if (staleTasks.length > 0) {
+    log.info({ count: staleTasks.length }, "cleaned up stale tasks on startup");
+  }
+  return staleTasks.length;
+}
+
+/**
+ * Mark a persisted task as "failed" by ID.
+ * Returns the updated record, or null if not found or already not running.
+ */
+export function markTaskFailed(id: string): TaskRecord | null {
+  const task = loadTask(id);
+  if (!task || task.status !== "running") return null;
+  task.status = "failed";
+  task.completedAt = Date.now();
+  saveTask(task);
+  return task;
+}
+
 function matchesFilters(task: TaskRecord, filters?: TaskFilters): boolean {
   if (!filters) return true;
   if (filters.project && task.project !== filters.project) return false;

--- a/apps/web/src/routes/tasks.tsx
+++ b/apps/web/src/routes/tasks.tsx
@@ -26,6 +26,8 @@ import {
   Loader2,
   Plus,
   RefreshCw,
+  RotateCcw,
+  XCircle,
 } from "lucide-react";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { trpc } from "../lib/trpc-client";
@@ -224,7 +226,7 @@ function TasksPage() {
         {filteredTasks.length > 0 && (
           <div className="flex flex-col gap-2 p-4">
             {filteredTasks.map((task) => (
-              <TaskCard key={task.id} task={task} />
+              <TaskCard key={task.id} task={task} onAction={fetchData} />
             ))}
           </div>
         )}
@@ -266,8 +268,35 @@ function StatusBadge({ status }: { status: TaskRecord["status"] }) {
   }
 }
 
-function TaskCard({ task }: { task: TaskRecord }) {
+function TaskCard({ task, onAction }: { task: TaskRecord; onAction: () => void }) {
   const sessionHref = task.sessionId ? `/chat/${encodeURIComponent(task.workspaceId)}` : undefined;
+  const [acting, setActing] = useState(false);
+
+  const handleCancel = useCallback(async () => {
+    setActing(true);
+    try {
+      await trpc.tasks.cancel.mutate({ taskId: task.id });
+      onAction();
+    } catch {
+      // Ignore — task may have already finished
+      onAction();
+    } finally {
+      setActing(false);
+    }
+  }, [task.id, onAction]);
+
+  const handleRerun = useCallback(async () => {
+    setActing(true);
+    try {
+      await trpc.tasks.rerun.mutate({ taskId: task.id });
+      onAction();
+    } catch {
+      // Ignore — workspace may already have a running task
+      onAction();
+    } finally {
+      setActing(false);
+    }
+  }, [task.id, onAction]);
 
   return (
     <div className="flex flex-col gap-2 rounded-lg border border-border/50 bg-card p-4 transition-colors hover:border-border">
@@ -275,7 +304,33 @@ function TaskCard({ task }: { task: TaskRecord }) {
         <p className="line-clamp-2 min-w-0 flex-1 text-sm font-medium text-foreground">
           {task.prompt}
         </p>
-        <StatusBadge status={task.status} />
+        <div className="flex items-center gap-2">
+          {task.status === "running" && (
+            <Button
+              variant="ghost"
+              size="icon"
+              className="size-7"
+              onClick={handleCancel}
+              disabled={acting}
+              title="Cancel task"
+            >
+              {acting ? <Loader2 className="size-3.5 animate-spin" /> : <XCircle className="size-3.5" />}
+            </Button>
+          )}
+          {(task.status === "completed" || task.status === "failed") && (
+            <Button
+              variant="ghost"
+              size="icon"
+              className="size-7"
+              onClick={handleRerun}
+              disabled={acting}
+              title="Re-run task"
+            >
+              {acting ? <Loader2 className="size-3.5 animate-spin" /> : <RotateCcw className="size-3.5" />}
+            </Button>
+          )}
+          <StatusBadge status={task.status} />
+        </div>
       </div>
 
       <div className="flex items-center gap-3 text-xs text-muted-foreground">

--- a/apps/web/src/routes/tasks.tsx
+++ b/apps/web/src/routes/tasks.tsx
@@ -314,7 +314,11 @@ function TaskCard({ task, onAction }: { task: TaskRecord; onAction: () => void }
               disabled={acting}
               title="Cancel task"
             >
-              {acting ? <Loader2 className="size-3.5 animate-spin" /> : <XCircle className="size-3.5" />}
+              {acting ? (
+                <Loader2 className="size-3.5 animate-spin" />
+              ) : (
+                <XCircle className="size-3.5" />
+              )}
             </Button>
           )}
           {(task.status === "completed" || task.status === "failed") && (
@@ -326,7 +330,11 @@ function TaskCard({ task, onAction }: { task: TaskRecord; onAction: () => void }
               disabled={acting}
               title="Re-run task"
             >
-              {acting ? <Loader2 className="size-3.5 animate-spin" /> : <RotateCcw className="size-3.5" />}
+              {acting ? (
+                <Loader2 className="size-3.5 animate-spin" />
+              ) : (
+                <RotateCcw className="size-3.5" />
+              )}
             </Button>
           )}
           <StatusBadge status={task.status} />

--- a/apps/web/src/trpc/router.ts
+++ b/apps/web/src/trpc/router.ts
@@ -34,13 +34,14 @@ import {
 } from "../lib/state";
 import {
   abortTask,
+  cancelTask,
   getBufferedChunks,
   getTask,
   submitTask,
   subscribe as subscribeTask,
   TaskConflictError,
 } from "../lib/task-runner";
-import { listTasks } from "../lib/task-store";
+import { listTasks, loadTask } from "../lib/task-store";
 import {
   checkTunnelAuth,
   checkTunnelHealth,
@@ -835,6 +836,37 @@ const tasksRouter = t.router({
       throw new TRPCError({ code: "NOT_FOUND", message: "No running task found" });
     }
     return { aborted: true };
+  }),
+
+  cancel: publicProcedure.input(z.object({ taskId: z.string() })).mutation(({ input }) => {
+    const result = cancelTask(input.taskId);
+    if (!result.cancelled) {
+      throw new TRPCError({
+        code: "NOT_FOUND",
+        message: "Task not found or not running",
+      });
+    }
+    return { cancelled: true };
+  }),
+
+  rerun: publicProcedure.input(z.object({ taskId: z.string() })).mutation(({ input }) => {
+    const record = loadTask(input.taskId);
+    if (!record) {
+      throw new TRPCError({ code: "NOT_FOUND", message: "Task not found" });
+    }
+
+    try {
+      const task = submitTask(record.workspaceId, record.prompt);
+      return { workspaceId: task.workspaceId, sessionId: task.sessionId };
+    } catch (err) {
+      if (err instanceof TaskConflictError) {
+        throw new TRPCError({
+          code: "CONFLICT",
+          message: "Task already running for this workspace",
+        });
+      }
+      throw err;
+    }
   }),
 
   stream: publicProcedure

--- a/apps/web/start-server.ts
+++ b/apps/web/start-server.ts
@@ -6,6 +6,7 @@ import { createAuthMiddleware } from "./auth.ts";
 import { stopBranchStatusPoller } from "./src/lib/branch-status-poller.ts";
 import { checkPrereqs } from "./src/lib/process-utils.ts";
 import { getOrCreateToken, loadSettings } from "./src/lib/state.ts";
+import { cleanupStaleTasks } from "./src/lib/task-store.ts";
 import { startTunnel, stopTunnel } from "./src/lib/tunnel.ts";
 import { createContext } from "./src/trpc/context.ts";
 import { appRouter } from "./src/trpc/router.ts";
@@ -25,6 +26,10 @@ const assets = sirv(clientDir, {
 });
 
 async function main() {
+  // Mark any persisted "running" tasks as "failed" — no agent can be running
+  // if the server just started.
+  cleanupStaleTasks();
+
   const mod = await import("./server/server.js");
   const server = mod.default as { fetch: (req: Request) => Promise<Response> };
 

--- a/apps/web/tests/chat.test.ts
+++ b/apps/web/tests/chat.test.ts
@@ -1,5 +1,5 @@
 import { spawn } from "node:child_process";
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { createServer } from "node:net";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -818,5 +818,384 @@ describe("Task submit + stream — AskUserQuestion", () => {
     // The stream completed successfully
     expect(eventTypes).toContain("data-result");
     expect(eventTypes).toContain("finish");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Helpers — task seeding
+// ---------------------------------------------------------------------------
+
+function seedTask(tmpHome: string, task: object & { id: string }): void {
+  const tasksDir = join(tmpHome, ".band", "tasks");
+  mkdirSync(tasksDir, { recursive: true });
+  writeFileSync(join(tasksDir, `${task.id}.json`), JSON.stringify(task));
+}
+
+function readTask(tmpHome: string, taskId: string): Record<string, unknown> {
+  const filePath = join(tmpHome, ".band", "tasks", `${taskId}.json`);
+  return JSON.parse(readFileSync(filePath, "utf-8"));
+}
+
+// ---------------------------------------------------------------------------
+// Stale task cleanup on server start
+// ---------------------------------------------------------------------------
+
+describe("stale task cleanup on server start", () => {
+  let server: ServerHandle;
+  let tmpHome: string;
+
+  beforeAll(async () => {
+    tmpHome = createTmpHome();
+    seedState(tmpHome, createDefaultState(tmpHome));
+    seedSettings(tmpHome, defaultSettings());
+
+    // Seed a "running" task before the server starts
+    seedTask(tmpHome, {
+      id: "tsk_stale_1",
+      workspaceId: "testproject-main",
+      project: "testproject",
+      branch: "main",
+      prompt: "stale task",
+      status: "running",
+      startedAt: Date.now() - 60_000,
+    });
+
+    // Seed a completed task that should NOT be changed
+    seedTask(tmpHome, {
+      id: "tsk_completed_1",
+      workspaceId: "testproject-main",
+      project: "testproject",
+      branch: "main",
+      prompt: "completed task",
+      status: "completed",
+      startedAt: Date.now() - 120_000,
+      completedAt: Date.now() - 60_000,
+    });
+
+    server = await startServer({ tmpHome });
+  });
+
+  afterAll(async () => {
+    await server.close();
+    rmSync(tmpHome, { recursive: true, force: true });
+  });
+
+  it("marks stale running tasks as failed on boot", async () => {
+    // The server should have cleaned up stale tasks during startup
+    const staleTask = readTask(tmpHome, "tsk_stale_1");
+    expect(staleTask.status).toBe("failed");
+    expect(staleTask.completedAt).toBeDefined();
+  });
+
+  it("does not modify non-running tasks", async () => {
+    const completedTask = readTask(tmpHome, "tsk_completed_1");
+    expect(completedTask.status).toBe("completed");
+  });
+
+  it("stale tasks appear as failed via tasks.list", async () => {
+    const res = await trpcQuery(server.url, "tasks.list", {});
+    const data = await trpcData<{ tasks: Array<{ id: string; status: string }> }>(res);
+    const staleTask = data.tasks.find((t) => t.id === "tsk_stale_1");
+    expect(staleTask).toBeDefined();
+    expect(staleTask!.status).toBe("failed");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// tasks.cancel — running task
+// ---------------------------------------------------------------------------
+
+describe("tasks.cancel — running task", () => {
+  let server: ServerHandle;
+  let tmpHome: string;
+
+  beforeAll(async () => {
+    tmpHome = createTmpHome();
+    seedState(tmpHome, createDefaultState(tmpHome));
+
+    // Use a scenario that blocks (waits for stdin) so the task stays running
+    const scenarioPath = writeScenario(tmpHome, [
+      {
+        type: "system",
+        subtype: "init",
+        session_id: "cancel-session",
+      },
+      {
+        type: "assistant",
+        message: {
+          content: [{ type: "text", text: "Working on it..." }],
+        },
+      },
+      {
+        type: "assistant",
+        message: {
+          content: [
+            {
+              type: "tool_use",
+              id: "tool-block-1",
+              name: "AskUserQuestion",
+              input: {
+                questions: [
+                  {
+                    question: "Continue?",
+                    header: "Confirm",
+                    options: [
+                      { label: "Yes", description: "Continue" },
+                      { label: "No", description: "Stop" },
+                    ],
+                    multiSelect: false,
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      },
+      {
+        type: "control_request",
+        request_id: "req-cancel-1",
+        request: {
+          subtype: "can_use_tool",
+          tool_name: "AskUserQuestion",
+          input: {},
+          tool_use_id: "tool-block-1",
+        },
+      },
+      // Block forever — the task will stay running until cancelled
+      { _wait_for_stdin: true },
+      {
+        type: "result",
+        subtype: "success",
+        session_id: "cancel-session",
+        duration_ms: 1000,
+        num_turns: 1,
+        total_cost_usd: 0.01,
+      },
+    ]);
+
+    seedSettings(tmpHome, {
+      tokenSecret: DEFAULT_TOKEN,
+      codingAgent: { type: "claude-code", command: FAKE_AGENT_PATH },
+    });
+
+    server = await startServer({ tmpHome, scenarioPath });
+  });
+
+  afterAll(async () => {
+    await server.close();
+    rmSync(tmpHome, { recursive: true, force: true });
+  });
+
+  it("cancels a running task by task ID", async () => {
+    const workspaceId = "testproject-main";
+
+    // Submit a task that will block
+    const submitRes = await trpcMutate(server.url, "tasks.submit", {
+      workspaceId,
+      prompt: "cancel me",
+    });
+    expect(submitRes.status).toBe(200);
+
+    // Wait for the task to be running
+    await waitFor(async () => {
+      const res = await trpcQuery(server.url, "tasks.get", { workspaceId });
+      const data = await trpcData<{ task?: { status: string } }>(res);
+      return data.task?.status === "running";
+    });
+
+    // Get the task ID from tasks.list
+    const listRes = await trpcQuery(server.url, "tasks.list", {
+      workspaceId,
+      status: "running",
+    });
+    const listData = await trpcData<{ tasks: Array<{ id: string }> }>(listRes);
+    expect(listData.tasks.length).toBeGreaterThan(0);
+    const taskId = listData.tasks[0].id;
+
+    // Cancel the task
+    const cancelRes = await trpcMutate(server.url, "tasks.cancel", { taskId });
+    expect(cancelRes.status).toBe(200);
+
+    // Verify the task is now failed
+    await waitFor(async () => {
+      const res = await trpcQuery(server.url, "tasks.get", { workspaceId });
+      const data = await trpcData<{ task?: { status: string } }>(res);
+      return data.task?.status === "failed";
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// tasks.cancel — orphaned task
+// ---------------------------------------------------------------------------
+
+describe("tasks.cancel — orphaned task", () => {
+  let server: ServerHandle;
+  let tmpHome: string;
+
+  beforeAll(async () => {
+    tmpHome = createTmpHome();
+    seedState(tmpHome, createDefaultState(tmpHome));
+    seedSettings(tmpHome, defaultSettings());
+
+    // Seed an orphaned "running" task (no in-memory agent for it).
+    // This task was created while the stale cleanup was being run (before listen),
+    // but we seed it AFTER the tasks dir has the stale cleaned up.
+    // Actually, we need the server to start first, then we seed the orphaned task.
+    server = await startServer({ tmpHome });
+  });
+
+  afterAll(async () => {
+    await server.close();
+    rmSync(tmpHome, { recursive: true, force: true });
+  });
+
+  it("cancels an orphaned running task by updating the persisted file", async () => {
+    // Seed an orphaned task AFTER the server is already running
+    // (so cleanup already ran and won't touch this one)
+    seedTask(tmpHome, {
+      id: "tsk_orphaned_1",
+      workspaceId: "testproject-main",
+      project: "testproject",
+      branch: "main",
+      prompt: "orphaned task",
+      status: "running",
+      startedAt: Date.now() - 30_000,
+    });
+
+    // Cancel the orphaned task
+    const cancelRes = await trpcMutate(server.url, "tasks.cancel", {
+      taskId: "tsk_orphaned_1",
+    });
+    expect(cancelRes.status).toBe(200);
+
+    // Verify the persisted file is now "failed"
+    const task = readTask(tmpHome, "tsk_orphaned_1");
+    expect(task.status).toBe("failed");
+    expect(task.completedAt).toBeDefined();
+  });
+
+  it("returns 404 when cancelling a non-existent task", async () => {
+    const res = await trpcMutate(server.url, "tasks.cancel", {
+      taskId: "tsk_nonexistent",
+    });
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 404 when cancelling an already completed task", async () => {
+    seedTask(tmpHome, {
+      id: "tsk_already_done",
+      workspaceId: "testproject-main",
+      project: "testproject",
+      branch: "main",
+      prompt: "already done",
+      status: "completed",
+      startedAt: Date.now() - 60_000,
+      completedAt: Date.now() - 30_000,
+    });
+
+    const res = await trpcMutate(server.url, "tasks.cancel", {
+      taskId: "tsk_already_done",
+    });
+    expect(res.status).toBe(404);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// tasks.rerun
+// ---------------------------------------------------------------------------
+
+describe("tasks.rerun", () => {
+  let server: ServerHandle;
+  let tmpHome: string;
+
+  beforeAll(async () => {
+    tmpHome = createTmpHome();
+    seedState(tmpHome, createDefaultState(tmpHome));
+
+    const scenarioPath = writeScenario(tmpHome, [
+      {
+        type: "system",
+        subtype: "init",
+        session_id: "rerun-session",
+      },
+      {
+        type: "assistant",
+        message: {
+          content: [{ type: "text", text: "Done!" }],
+        },
+      },
+      {
+        type: "result",
+        subtype: "success",
+        session_id: "rerun-session",
+        duration_ms: 500,
+        num_turns: 1,
+        total_cost_usd: 0.01,
+      },
+    ]);
+
+    seedSettings(tmpHome, {
+      tokenSecret: DEFAULT_TOKEN,
+      codingAgent: { type: "claude-code", command: FAKE_AGENT_PATH },
+    });
+
+    server = await startServer({ tmpHome, scenarioPath });
+  });
+
+  afterAll(async () => {
+    await server.close();
+    rmSync(tmpHome, { recursive: true, force: true });
+  });
+
+  it("re-runs a completed task with the same prompt and workspace", async () => {
+    const workspaceId = "testproject-main";
+
+    // Submit and wait for the original task to complete
+    const submitRes = await trpcMutate(server.url, "tasks.submit", {
+      workspaceId,
+      prompt: "rerun me",
+    });
+    expect(submitRes.status).toBe(200);
+
+    await waitFor(async () => {
+      const res = await trpcQuery(server.url, "tasks.get", { workspaceId });
+      const data = await trpcData<{ task?: { status: string } }>(res);
+      return data.task?.status !== "running";
+    });
+
+    // Get the completed task's ID
+    const listRes = await trpcQuery(server.url, "tasks.list", { workspaceId });
+    const listData = await trpcData<{ tasks: Array<{ id: string; prompt: string }> }>(listRes);
+    const originalTask = listData.tasks.find((t) => t.prompt === "rerun me");
+    expect(originalTask).toBeDefined();
+
+    // Re-run the task
+    const rerunRes = await trpcMutate(server.url, "tasks.rerun", {
+      taskId: originalTask!.id,
+    });
+    expect(rerunRes.status).toBe(200);
+    const rerunData = await trpcData<{ workspaceId: string }>(rerunRes);
+    expect(rerunData.workspaceId).toBe(workspaceId);
+
+    // Wait for the re-run task to complete
+    await waitFor(async () => {
+      const res = await trpcQuery(server.url, "tasks.get", { workspaceId });
+      const data = await trpcData<{ task?: { status: string } }>(res);
+      return data.task?.status !== "running";
+    });
+
+    // Verify there are now 2 tasks for this workspace
+    const finalList = await trpcQuery(server.url, "tasks.list", { workspaceId });
+    const finalData = await trpcData<{ tasks: Array<{ id: string; prompt: string }> }>(finalList);
+    const matchingTasks = finalData.tasks.filter((t) => t.prompt === "rerun me");
+    expect(matchingTasks.length).toBe(2);
+  });
+
+  it("returns 404 when re-running a non-existent task", async () => {
+    const res = await trpcMutate(server.url, "tasks.rerun", {
+      taskId: "tsk_nonexistent",
+    });
+    expect(res.status).toBe(404);
   });
 });


### PR DESCRIPTION
## Summary
- Mark orphaned "running" tasks as "failed" on server start (stale cleanup)
- Add `tasks.cancel` tRPC endpoint to cancel a task by ID (handles both in-memory running tasks and orphaned persisted tasks)
- Add `tasks.rerun` tRPC endpoint to re-run a completed/failed task with the same prompt
- Add Cancel and Re-run action buttons on the tasks page UI
- Add `band tasks list|cancel|rerun` CLI commands

Closes #96

## Test plan
- [x] Integration test: stale running tasks marked as failed on server boot
- [x] Integration test: cancel a running task by ID (with in-memory agent)
- [x] Integration test: cancel an orphaned task (persisted but no agent)
- [x] Integration test: 404 for cancelling non-existent/already-completed tasks
- [x] Integration test: re-run a completed task creates a new task with same prompt
- [x] Integration test: 404 for re-running non-existent task
- [x] All 123 web tests pass
- [x] All 33 CLI tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)