### PR TITLE
fix: open tasks in separate window (#94)

### DIFF
--- a/apps/dashboard/src-tauri/capabilities/default.json
+++ b/apps/dashboard/src-tauri/capabilities/default.json
@@ -1,7 +1,7 @@
 {
   "identifier": "default",
   "description": "Default permissions for Band dashboard",
-  "windows": ["main"],
+  "windows": ["main", "tasks"],
   "remote": {
     "urls": ["http://localhost:*"]
   },

--- a/apps/dashboard/src-tauri/src/commands/ide.rs
+++ b/apps/dashboard/src-tauri/src/commands/ide.rs
@@ -376,13 +376,17 @@ unsafe fn raise_dashboard_windows() {
         return;
     }
 
+    type MsgSendBool = unsafe extern "C" fn(*const c_void, *const c_void) -> i8;
+    let msg_bool: MsgSendBool = std::mem::transmute(objc_msgSend as unsafe extern "C" fn());
+
     let count = msg_count(windows, sel_registerName(c"count".as_ptr()));
     let obj_at = sel_registerName(c"objectAtIndex:".as_ptr());
     let raise = sel_registerName(c"orderFrontRegardless".as_ptr());
+    let is_visible = sel_registerName(c"isVisible".as_ptr());
 
     for i in 0..count {
         let win = msg_idx(windows, obj_at, i);
-        if !win.is_null() {
+        if !win.is_null() && msg_bool(win, is_visible) != 0 {
             msg(win, raise);
         }
     }

--- a/apps/dashboard/src-tauri/src/commands/mod.rs
+++ b/apps/dashboard/src-tauri/src/commands/mod.rs
@@ -11,3 +11,4 @@ pub mod window_manager;
 #[cfg(not(target_os = "macos"))]
 pub use ide_stub as ide;
 pub mod webserver;
+pub mod window;

--- a/apps/dashboard/src-tauri/src/commands/window.rs
+++ b/apps/dashboard/src-tauri/src/commands/window.rs
@@ -1,0 +1,55 @@
+use tauri::{AppHandle, Manager, WebviewUrl, WebviewWindowBuilder};
+
+use crate::commands::webserver;
+use crate::state::load_settings;
+
+const DEV_PORT: u16 = 3456;
+
+#[tauri::command]
+pub async fn open_tasks_window(app: AppHandle) -> Result<(), String> {
+    // If the tasks window already exists, just focus it
+    if let Some(existing) = app.get_webview_window("tasks") {
+        let _ = existing.set_focus();
+        return Ok(());
+    }
+
+    // Build the URL
+    let url = if cfg!(debug_assertions) {
+        format!("http://localhost:{DEV_PORT}/tasks")
+    } else {
+        let port = webserver::get_configured_port();
+        let settings = load_settings()?;
+        let token = settings.token_secret.ok_or_else(|| {
+            "tokenSecret not found in settings.json — start the web server first".to_string()
+        })?;
+        format!("http://localhost:{port}/tasks?token={token}")
+    };
+
+    let window = WebviewWindowBuilder::new(
+        &app,
+        "tasks",
+        WebviewUrl::External(url.parse().map_err(|e| format!("Invalid URL: {e}"))?),
+    )
+    .title("Tasks - Band")
+    .inner_size(900.0, 700.0)
+    .center()
+    .title_bar_style(tauri::TitleBarStyle::Transparent)
+    .build()
+    .map_err(|e| format!("Failed to create tasks window: {e}"))?;
+
+    // Set dark background color on macOS (same as main window)
+    #[cfg(target_os = "macos")]
+    #[allow(deprecated)]
+    {
+        use cocoa::appkit::NSColor;
+        use cocoa::appkit::NSWindow;
+        use cocoa::base::{id, nil};
+        let ns_window = window.ns_window().unwrap() as id;
+        unsafe {
+            let color = NSColor::colorWithSRGBRed_green_blue_alpha_(nil, 0.0, 0.0, 0.0, 1.0);
+            ns_window.setBackgroundColor_(color);
+        }
+    }
+
+    Ok(())
+}

--- a/apps/dashboard/src-tauri/src/commands/window.rs
+++ b/apps/dashboard/src-tauri/src/commands/window.rs
@@ -25,17 +25,23 @@ pub async fn open_tasks_window(app: AppHandle) -> Result<(), String> {
         format!("http://localhost:{port}/tasks?token={token}")
     };
 
-    let window = WebviewWindowBuilder::new(
+    let mut builder = WebviewWindowBuilder::new(
         &app,
         "tasks",
         WebviewUrl::External(url.parse().map_err(|e| format!("Invalid URL: {e}"))?),
     )
     .title("Tasks - Band")
     .inner_size(900.0, 700.0)
-    .center()
-    .title_bar_style(tauri::TitleBarStyle::Transparent)
-    .build()
-    .map_err(|e| format!("Failed to create tasks window: {e}"))?;
+    .center();
+
+    #[cfg(target_os = "macos")]
+    {
+        builder = builder.title_bar_style(tauri::TitleBarStyle::Transparent);
+    }
+
+    let _window = builder
+        .build()
+        .map_err(|e| format!("Failed to create tasks window: {e}"))?;
 
     // Set dark background color on macOS (same as main window)
     #[cfg(target_os = "macos")]
@@ -44,7 +50,7 @@ pub async fn open_tasks_window(app: AppHandle) -> Result<(), String> {
         use cocoa::appkit::NSColor;
         use cocoa::appkit::NSWindow;
         use cocoa::base::{id, nil};
-        let ns_window = window.ns_window().unwrap() as id;
+        let ns_window = _window.ns_window().unwrap() as id;
         unsafe {
             let color = NSColor::colorWithSRGBRed_green_blue_alpha_(nil, 0.0, 0.0, 0.0, 1.0);
             ns_window.setBackgroundColor_(color);

--- a/apps/dashboard/src-tauri/src/commands/window.rs
+++ b/apps/dashboard/src-tauri/src/commands/window.rs
@@ -25,7 +25,7 @@ pub async fn open_tasks_window(app: AppHandle) -> Result<(), String> {
         format!("http://localhost:{port}/tasks?token={token}")
     };
 
-    let mut builder = WebviewWindowBuilder::new(
+    let builder = WebviewWindowBuilder::new(
         &app,
         "tasks",
         WebviewUrl::External(url.parse().map_err(|e| format!("Invalid URL: {e}"))?),
@@ -35,9 +35,7 @@ pub async fn open_tasks_window(app: AppHandle) -> Result<(), String> {
     .center();
 
     #[cfg(target_os = "macos")]
-    {
-        builder = builder.title_bar_style(tauri::TitleBarStyle::Transparent);
-    }
+    let builder = builder.title_bar_style(tauri::TitleBarStyle::Transparent);
 
     let _window = builder
         .build()

--- a/apps/dashboard/src-tauri/src/lib.rs
+++ b/apps/dashboard/src-tauri/src/lib.rs
@@ -28,6 +28,7 @@ pub fn run() {
             commands::ide::reveal_in_finder,
             commands::webserver::webserver_start,
             commands::webserver::webserver_stop,
+            commands::window::open_tasks_window,
         ])
         .setup(|app| {
             let window = app.get_webview_window("main").unwrap();
@@ -89,10 +90,15 @@ pub fn run() {
             // (handles projects without the Band VS Code extension)
             commands::ide::start_focus_polling(app.handle().clone());
 
-            // Kill web server on app exit
+            // Kill web server and close secondary windows on app exit
             let web_proc = app.state::<WebServerState>().inner().0.clone();
+            let app_handle_for_close = app.handle().clone();
             window.on_window_event(move |event| {
                 if let tauri::WindowEvent::CloseRequested { .. } = event {
+                    // Close the tasks window so the app can exit fully
+                    if let Some(tasks_win) = app_handle_for_close.get_webview_window("tasks") {
+                        let _ = tasks_win.destroy();
+                    }
                     web_proc.kill();
                     // Kill any server on the port (handles the detached process
                     // spawned by ensure_webserver_running in release builds)

--- a/apps/web/e2e/tasks-page.spec.ts
+++ b/apps/web/e2e/tasks-page.spec.ts
@@ -192,7 +192,11 @@ test("back button navigates to dashboard", async ({ page }) => {
   await page.goto(`${server.url}/tasks?token=${TOKEN}`);
   await expect(page.locator("h1", { hasText: "Tasks" })).toBeVisible();
 
-  // Click the back arrow
-  const backLink = page.locator("a[href='/']");
-  await expect(backLink).toBeVisible();
+  // Click the back arrow button
+  const backButton = page.locator("header button").first();
+  await expect(backButton).toBeVisible();
+  await backButton.click();
+
+  // Should navigate to the dashboard
+  await page.waitForURL(`${server.url}/?token=${TOKEN}`);
 });

--- a/apps/web/e2e/tasks-page.spec.ts
+++ b/apps/web/e2e/tasks-page.spec.ts
@@ -197,6 +197,6 @@ test("back button navigates to dashboard", async ({ page }) => {
   await expect(backButton).toBeVisible();
   await backButton.click();
 
-  // Should navigate to the dashboard
-  await page.waitForURL(`${server.url}/?token=${TOKEN}`);
+  // Should navigate away from /tasks
+  await page.waitForURL((url) => !url.pathname.includes("/tasks"));
 });

--- a/apps/web/src/components/DashboardView.tsx
+++ b/apps/web/src/components/DashboardView.tsx
@@ -6,10 +6,46 @@ import {
 import { Button, Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@band/ui";
 import { Link } from "@tanstack/react-router";
 import { ListTodo } from "lucide-react";
+import { useCallback } from "react";
 import { TunnelToolbarButton } from "./TunnelToolbarButton";
 
 const adapter = new HybridDashboardAdapter();
 const capabilities = new NativeShellCapabilities();
+
+const inTauri = typeof window !== "undefined" && "__TAURI_INTERNALS__" in window;
+
+function TasksButton() {
+  const handleClick = useCallback(async () => {
+    const { invoke } = await import("@tauri-apps/api/core");
+    await invoke("open_tasks_window");
+  }, []);
+
+  if (inTauri) {
+    return (
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Button size="icon-sm" variant="ghost" onClick={handleClick}>
+            <ListTodo className="size-5" />
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent>Tasks</TooltipContent>
+      </Tooltip>
+    );
+  }
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <Button size="icon-sm" variant="ghost" asChild>
+          <Link to="/tasks">
+            <ListTodo className="size-5" />
+          </Link>
+        </Button>
+      </TooltipTrigger>
+      <TooltipContent>Tasks</TooltipContent>
+    </Tooltip>
+  );
+}
 
 export function DashboardView() {
   return (
@@ -18,16 +54,7 @@ export function DashboardView() {
         <DashboardShell
           toolbarExtra={
             <>
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <Button size="icon-sm" variant="ghost" asChild>
-                    <Link to="/tasks">
-                      <ListTodo className="size-5" />
-                    </Link>
-                  </Button>
-                </TooltipTrigger>
-                <TooltipContent>Tasks</TooltipContent>
-              </Tooltip>
+              <TasksButton />
               <TunnelToolbarButton />
             </>
           }

--- a/apps/web/src/routes/chat.$workspaceId.tsx
+++ b/apps/web/src/routes/chat.$workspaceId.tsx
@@ -5,9 +5,9 @@ import {
   WorkspaceTabNav,
 } from "@band/dashboard-core";
 import { WebCapabilities, WebDashboardAdapter } from "@band/dashboard-core/adapters/web";
-import { createFileRoute, Link } from "@tanstack/react-router";
+import { createFileRoute, useNavigate } from "@tanstack/react-router";
 import { ArrowLeft, Clock } from "lucide-react";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { ChatView } from "../components/ChatView";
 import { CodeBrowserView } from "../components/CodeBrowserView";
 import { trpc } from "../lib/trpc-client";
@@ -19,6 +19,10 @@ export const Route = createFileRoute("/chat/$workspaceId")({
   component: ChatPage,
 });
 
+function isTauri(): boolean {
+  return typeof window !== "undefined" && "__TAURI_INTERNALS__" in window;
+}
+
 function ChatPage() {
   const { workspaceId } = Route.useParams();
   const decoded = decodeURIComponent(workspaceId);
@@ -26,6 +30,22 @@ function ChatPage() {
   const [initialSessionId, setInitialSessionId] = useState<string | undefined>(undefined);
   const [showSessionList, setShowSessionList] = useState(false);
   const [activeTab, setActiveTab] = useState<WorkspaceTab>("chat");
+  const isTasksWindow = useRef<boolean | null>(null);
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    if (!isTauri()) {
+      isTasksWindow.current = false;
+      return;
+    }
+    import("@tauri-apps/api/webviewWindow").then(({ getCurrentWebviewWindow }) => {
+      isTasksWindow.current = getCurrentWebviewWindow().label === "tasks";
+    });
+  }, []);
+
+  const handleBack = useCallback(() => {
+    navigate({ to: isTasksWindow.current ? "/tasks" : "/" });
+  }, [navigate]);
 
   useEffect(() => {
     let cancelled = false;
@@ -58,12 +78,13 @@ function ChatPage() {
   return (
     <div className="flex h-dvh flex-col overflow-hidden">
       <header className="flex shrink-0 items-center gap-3 border-b border-border/50 px-4 py-3 pt-[max(0.75rem,env(safe-area-inset-top))]">
-        <Link
-          to="/"
+        <button
+          type="button"
+          onClick={handleBack}
           className="inline-flex size-8 items-center justify-center rounded-md hover:bg-accent"
         >
           <ArrowLeft className="size-4" />
-        </Link>
+        </button>
         <div className="min-w-0 flex-1">
           <h1 className="truncate text-sm font-semibold">{decoded}</h1>
         </div>

--- a/apps/web/src/routes/tasks.tsx
+++ b/apps/web/src/routes/tasks.tsx
@@ -27,8 +27,12 @@ import {
   Plus,
   RefreshCw,
 } from "lucide-react";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { trpc } from "../lib/trpc-client";
+
+function isTauri(): boolean {
+  return typeof window !== "undefined" && "__TAURI_INTERNALS__" in window;
+}
 
 export const Route = createFileRoute("/tasks")({
   component: TasksPage,
@@ -87,6 +91,27 @@ function TasksPage() {
   const [projectFilter, setProjectFilter] = useState<string>("all");
   const [statusFilter, setStatusFilter] = useState<StatusFilter>("all");
   const [showNewTask, setShowNewTask] = useState(false);
+  const isTasksWindow = useRef<boolean | null>(null);
+  const navigate = Route.useNavigate();
+
+  useEffect(() => {
+    if (!isTauri()) {
+      isTasksWindow.current = false;
+      return;
+    }
+    import("@tauri-apps/api/webviewWindow").then(({ getCurrentWebviewWindow }) => {
+      isTasksWindow.current = getCurrentWebviewWindow().label === "tasks";
+    });
+  }, []);
+
+  const handleBack = useCallback(async () => {
+    if (isTasksWindow.current) {
+      const { getCurrentWebviewWindow } = await import("@tauri-apps/api/webviewWindow");
+      getCurrentWebviewWindow().close();
+    } else {
+      navigate({ to: "/" });
+    }
+  }, [navigate]);
 
   const fetchData = useCallback(async () => {
     setLoading(true);
@@ -134,12 +159,13 @@ function TasksPage() {
   return (
     <div className="flex h-dvh flex-col overflow-hidden">
       <header className="flex shrink-0 items-center gap-3 border-b border-border/50 px-4 py-3 pt-[max(0.75rem,env(safe-area-inset-top))]">
-        <Link
-          to="/"
+        <button
+          type="button"
+          onClick={handleBack}
           className="inline-flex size-8 items-center justify-center rounded-md hover:bg-accent"
         >
           <ArrowLeft className="size-4" />
-        </Link>
+        </button>
         <div className="min-w-0 flex-1">
           <h1 className="text-sm font-semibold">Tasks</h1>
         </div>


### PR DESCRIPTION
## Summary
- Add `open_tasks_window` Tauri IPC command that creates a separate 900x700 window for the tasks view, keeping the dashboard sidebar untouched
- Fix `raise_dashboard_windows` to check `isVisible` on NSWindows before raising — prevents zombie windows from reappearing as black rectangles after closing
- Destroy the tasks window when the main dashboard closes so the web server cleanup handler runs properly

## Test plan
- [ ] Click "Tasks" in sidebar → separate 900x700 window opens at `/tasks`
- [ ] Click "Tasks" again → existing window is focused (no duplicate)
- [ ] Click session link in tasks → navigates to chat within tasks window
- [ ] Back arrow on chat → returns to `/tasks`
- [ ] Back arrow on tasks → tasks window closes
- [ ] Close tasks window, focus VS Code → no black zombie windows appear
- [ ] Close main dashboard → tasks window also closes, web server is killed
- [ ] Open `http://localhost:3456` in browser → Tasks button navigates inline

Closes #94

🤖 Generated with [Claude Code](https://claude.com/claude-code)