### PR TITLE
feat: support image output from coding agents in dashboard webchat

### DIFF
--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -313,6 +313,14 @@ export function ChatView({
                         }
                         return null;
                       }
+                      if (segment.type === "file") {
+                        return (
+                          <MessageFilePart
+                            key={`${message.id}-file-${segment.partIndex}`}
+                            part={segment.part}
+                          />
+                        );
+                      }
                       const item = toolPartToItem(segment.part);
                       if (isTaskTool(item.toolName)) {
                         if (!taskWidgetRendered && liveTaskMap.size > 0) {

--- a/apps/web/src/components/ai-elements/group-parts.ts
+++ b/apps/web/src/components/ai-elements/group-parts.ts
@@ -17,10 +17,16 @@ export type ToolSegment = {
   partIndex: number;
 };
 
-export type MessageSegment = TextSegment | ToolSegment;
+export type FileSegment = {
+  type: "file";
+  part: { type: "file"; mediaType: string; url: string; filename?: string };
+  partIndex: number;
+};
+
+export type MessageSegment = TextSegment | ToolSegment | FileSegment;
 
 /**
- * Separates message parts into text and tool segments.
+ * Separates message parts into text, tool, and file segments.
  * Empty/whitespace-only text parts are skipped.
  */
 export function groupMessageParts(parts: Part[]): MessageSegment[] {
@@ -31,6 +37,15 @@ export function groupMessageParts(parts: Part[]): MessageSegment[] {
 
     if (isToolUIPart(part)) {
       segments.push({ type: "tool", part: part as ToolPart, partIndex: i });
+      continue;
+    }
+
+    if (part.type === "file") {
+      segments.push({
+        type: "file",
+        part: part as FileSegment["part"],
+        partIndex: i,
+      });
       continue;
     }
 

--- a/apps/web/src/lib/task-runner.ts
+++ b/apps/web/src/lib/task-runner.ts
@@ -267,6 +267,16 @@ async function runTask(workspaceId: string, task: InternalTask) {
           break;
         }
 
+        case "file": {
+          endText();
+          emit(workspaceId, task, {
+            type: "file",
+            mediaType: event.mediaType,
+            url: event.url,
+          });
+          break;
+        }
+
         case "session-result": {
           endText();
 

--- a/packages/coding-agent/src/adapters/claude-code.ts
+++ b/packages/coding-agent/src/adapters/claude-code.ts
@@ -336,6 +336,9 @@ function* mapClaudeCodeEvent(
               output,
               isError: block.is_error ?? false,
             };
+
+            // Emit file events for any images in the tool result content
+            yield* extractImageEvents(block.content);
           }
         }
       }
@@ -391,6 +394,35 @@ function* mapClaudeCodeEvent(
         message: "message" in message ? String(message.message) : "Unknown error",
       };
       break;
+    }
+  }
+}
+
+/**
+ * Extract image blocks from tool result content and yield them as FileEvents.
+ *
+ * Tool result content can be a string or an array of content blocks.
+ * Image blocks follow the Anthropic API format:
+ *   { type: "image", source: { type: "base64", media_type: "image/png", data: "..." } }
+ */
+function* extractImageEvents(content: unknown): Generator<AgentEvent> {
+  if (!Array.isArray(content)) return;
+
+  for (const item of content) {
+    if (typeof item !== "object" || item === null) continue;
+    const block = item as Record<string, unknown>;
+
+    if (block.type === "image" && typeof block.source === "object" && block.source !== null) {
+      const source = block.source as Record<string, unknown>;
+      const mediaType = String(source.media_type ?? "image/png");
+      const data = source.data as string | undefined;
+      if (data) {
+        yield {
+          type: "file",
+          mediaType,
+          url: `data:${mediaType};base64,${data}`,
+        };
+      }
     }
   }
 }

--- a/packages/coding-agent/src/events.ts
+++ b/packages/coding-agent/src/events.ts
@@ -33,6 +33,12 @@ export interface SessionResultEvent {
   errors: string[];
 }
 
+export interface FileEvent {
+  type: "file";
+  mediaType: string;
+  url: string;
+}
+
 export interface ErrorEvent {
   type: "error";
   message: string;
@@ -43,5 +49,6 @@ export type AgentEvent =
   | TextDeltaEvent
   | ToolUseEvent
   | ToolResultEvent
+  | FileEvent
   | SessionResultEvent
   | ErrorEvent;


### PR DESCRIPTION
## Summary
- Extract image blocks from tool result content in the Claude Code adapter and emit them as `file` events
- Pass `file` chunks through the task runner streaming pipeline to connected clients
- Render agent-produced images inline in assistant messages via the existing `MessageFilePart` component

Closes #87

## Test plan
- [ ] Run a coding agent task that uses the `Read` tool on an image file (e.g. a screenshot)
- [ ] Verify the image appears inline in the dashboard chat
- [ ] Verify non-image tool results still render as text
- [ ] Verify user-uploaded image files still work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)