### PR TITLE
fix: handle server crashes with logging and auto-restart

### DIFF
--- a/apps/dashboard/src-tauri/src/commands/webserver.rs
+++ b/apps/dashboard/src-tauri/src/commands/webserver.rs
@@ -1,9 +1,10 @@
+use std::fs::OpenOptions;
 use std::os::unix::process::CommandExt;
 use std::process::{Child, Command, Stdio};
 use std::sync::{Arc, Mutex, OnceLock};
 use tauri::State;
 
-use crate::state::load_settings;
+use crate::state::{band_home, load_settings};
 
 const DEFAULT_WEB_SERVER_PORT: u16 = 3456;
 
@@ -66,7 +67,7 @@ pub(crate) fn shell_path() -> &'static str {
 }
 
 /// Read the token from settings.json (web server creates it).
-fn get_token() -> Result<String, String> {
+pub(crate) fn get_token() -> Result<String, String> {
     let settings = load_settings()?;
     settings.token_secret.ok_or_else(|| {
         "tokenSecret not found in settings.json — start the web server first".to_string()
@@ -95,6 +96,36 @@ fn set_process_group(cmd: &mut Command) -> &mut Command {
             Ok(())
         })
     }
+}
+
+/// Open (or create) `~/.band/server.log` in append mode and return two
+/// `Stdio` handles (one for stdout, one for stderr).  If the log file
+/// exceeds 5 MB it is rotated to `server.log.old` first.
+fn server_log_stdio() -> Result<(Stdio, Stdio), String> {
+    const MAX_LOG_BYTES: u64 = 5 * 1024 * 1024;
+
+    let log_dir = band_home();
+    std::fs::create_dir_all(&log_dir)
+        .map_err(|e| format!("Failed to create log directory: {e}"))?;
+
+    let log_path = log_dir.join("server.log");
+    if let Ok(meta) = std::fs::metadata(&log_path) {
+        if meta.len() > MAX_LOG_BYTES {
+            let _ = std::fs::rename(&log_path, log_dir.join("server.log.old"));
+        }
+    }
+
+    let file = OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&log_path)
+        .map_err(|e| format!("Failed to open server log: {e}"))?;
+
+    let file_clone = file
+        .try_clone()
+        .map_err(|e| format!("Failed to clone log file handle: {e}"))?;
+
+    Ok((Stdio::from(file), Stdio::from(file_clone)))
 }
 
 // ---------------------------------------------------------------------------
@@ -158,7 +189,7 @@ fn parse_local_health(body: &str) -> bool {
 }
 
 /// Check the local web server health endpoint.
-async fn check_local_health(port: u16, token: &str) -> bool {
+pub(crate) async fn check_local_health(port: u16, token: &str) -> bool {
     let output = tokio::process::Command::new("curl")
         .args([
             "-s",
@@ -223,13 +254,15 @@ pub(crate) fn ensure_webserver_running() -> Result<(u16, String), String> {
     let web_dir = resolve_web_dir()?;
     let start_script = web_dir.join("dist/start-server.mjs");
 
+    let (log_out, log_err) = server_log_stdio().unwrap_or_else(|_| (Stdio::null(), Stdio::null()));
+
     let mut cmd = Command::new("node");
     cmd.arg(&start_script)
         .current_dir(&web_dir)
         .env("PATH", shell_path())
         .env("PORT", port.to_string())
-        .stdout(Stdio::null())
-        .stderr(Stdio::null());
+        .stdout(log_out)
+        .stderr(log_err);
     set_process_group(&mut cmd);
 
     let _child = cmd.spawn().map_err(|e| {
@@ -278,13 +311,15 @@ pub async fn webserver_start(state: State<'_, WebServerState>) -> Result<(), Str
     let web_dir = resolve_web_dir()?;
     let start_script = web_dir.join("dist/start-server.mjs");
 
+    let (log_out, log_err) = server_log_stdio().unwrap_or_else(|_| (Stdio::null(), Stdio::null()));
+
     let mut cmd = Command::new("node");
     cmd.arg(&start_script)
         .current_dir(&web_dir)
         .env("PATH", shell_path())
         .env("PORT", port.to_string())
-        .stdout(Stdio::null())
-        .stderr(Stdio::null());
+        .stdout(log_out)
+        .stderr(log_err);
     set_process_group(&mut cmd);
 
     let child = cmd.spawn().map_err(|e| {

--- a/apps/dashboard/src-tauri/src/lib.rs
+++ b/apps/dashboard/src-tauri/src/lib.rs
@@ -4,6 +4,9 @@ mod commands;
 mod git;
 mod state;
 
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+
 use commands::webserver::{self as webserver, ManagedProcess, WebServerState};
 use state::{ActiveWorkspaceState, ProjectCache};
 use tauri::Manager;
@@ -33,6 +36,9 @@ pub fn run() {
         .setup(|app| {
             let window = app.get_webview_window("main").unwrap();
 
+            // Flag to stop the health monitor when the app closes
+            let health_stop = Arc::new(AtomicBool::new(false));
+
             // Auto-start the web server in release builds.
             // In dev mode, `beforeDevCommand` already starts the Vite dev server.
             if cfg!(not(debug_assertions)) {
@@ -47,6 +53,47 @@ pub fn run() {
                         eprintln!("Failed to start web server: {e}");
                     }
                 }
+
+                // Spawn a background health monitor that restarts the server
+                // if it crashes unexpectedly.
+                let stop = health_stop.clone();
+                tauri::async_runtime::spawn(async move {
+                    let mut interval = tokio::time::interval(std::time::Duration::from_secs(10));
+                    // The first tick fires immediately — skip it so we don't
+                    // check right after startup.
+                    interval.tick().await;
+
+                    loop {
+                        interval.tick().await;
+                        if stop.load(Ordering::Relaxed) {
+                            break;
+                        }
+
+                        let port = webserver::get_configured_port();
+                        let healthy = match webserver::get_token() {
+                            Ok(token) => webserver::check_local_health(port, &token).await,
+                            Err(_) => continue, // No token yet, skip this tick
+                        };
+
+                        if !healthy {
+                            eprintln!("[health-monitor] Server appears down, restarting…");
+                            let result =
+                                tokio::task::spawn_blocking(webserver::ensure_webserver_running)
+                                    .await;
+                            match result {
+                                Ok(Ok((p, _))) => {
+                                    eprintln!("[health-monitor] Server restarted on port {p}");
+                                }
+                                Ok(Err(e)) => {
+                                    eprintln!("[health-monitor] Restart failed: {e}");
+                                }
+                                Err(e) => {
+                                    eprintln!("[health-monitor] Restart task panicked: {e}");
+                                }
+                            }
+                        }
+                    }
+                });
             }
 
             // Set window title with git branch if available
@@ -93,8 +140,13 @@ pub fn run() {
             // Kill web server and close secondary windows on app exit
             let web_proc = app.state::<WebServerState>().inner().0.clone();
             let app_handle_for_close = app.handle().clone();
+            let health_stop_close = health_stop;
             window.on_window_event(move |event| {
                 if let tauri::WindowEvent::CloseRequested { .. } = event {
+                    // Stop the health monitor first so it doesn't try to
+                    // restart the server after we kill it.
+                    health_stop_close.store(true, Ordering::Relaxed);
+
                     // Close the tasks window so the app can exit fully
                     if let Some(tasks_win) = app_handle_for_close.get_webview_window("tasks") {
                         let _ = tasks_win.destroy();

--- a/apps/web/start-server.ts
+++ b/apps/web/start-server.ts
@@ -1,3 +1,4 @@
+import { appendFileSync } from "node:fs";
 import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
 import { join } from "node:path";
 import { fetchRequestHandler } from "@trpc/server/adapters/fetch";
@@ -6,11 +7,38 @@ import { createAuthMiddleware } from "./auth.ts";
 import { stopBranchStatusPoller } from "./src/lib/branch-status-poller.ts";
 import { startCronjobScheduler, stopCronjobScheduler } from "./src/lib/cronjob-scheduler.ts";
 import { checkPrereqs } from "./src/lib/process-utils.ts";
-import { getOrCreateToken, loadSettings } from "./src/lib/state.ts";
+import { bandHome, ensureDirs, getOrCreateToken, loadSettings } from "./src/lib/state.ts";
 import { cleanupStaleTasks } from "./src/lib/task-store.ts";
 import { startTunnel, stopTunnel } from "./src/lib/tunnel.ts";
 import { createContext } from "./src/trpc/context.ts";
 import { appRouter } from "./src/trpc/router.ts";
+
+// ---------------------------------------------------------------------------
+// Crash handlers — log to file since stdout/stderr may be piped to a log file
+// that is only readable after the process exits.
+// ---------------------------------------------------------------------------
+
+function logCrash(message: string): void {
+  try {
+    ensureDirs();
+    appendFileSync(join(bandHome(), "server.log"), message, "utf-8");
+  } catch {
+    // Best-effort logging — nothing we can do if this fails
+  }
+}
+
+process.on("unhandledRejection", (reason: unknown) => {
+  const timestamp = new Date().toISOString();
+  const error = reason instanceof Error ? reason.stack || reason.message : String(reason);
+  logCrash(`[${timestamp}] Unhandled rejection:\n${error}\n\n`);
+  process.exit(1);
+});
+
+process.on("uncaughtException", (error: Error) => {
+  const timestamp = new Date().toISOString();
+  logCrash(`[${timestamp}] Uncaught exception:\n${error.stack || error.message}\n\n`);
+  process.exit(1);
+});
 
 // After bundling, this file lives at dist/start-server.mjs,
 // so paths are relative to dist/.

--- a/apps/web/tests/crash-handler.test.ts
+++ b/apps/web/tests/crash-handler.test.ts
@@ -1,0 +1,119 @@
+import { spawn } from "node:child_process";
+import {
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  realpathSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+// The real built server entry point — same binary the Tauri app spawns.
+const serverScript = join(import.meta.dirname, "../dist/start-server.mjs");
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function createTmpBandHome(): string {
+  return realpathSync(mkdtempSync(join(tmpdir(), "band-crash-test-")));
+}
+
+/**
+ * Start the real production server (`dist/start-server.mjs`) with a
+ * preloaded ESM module that triggers a crash after a short delay.
+ *
+ * Uses Node's `--import` flag so the crash-trigger module is loaded before
+ * the server, but the setTimeout callback fires *after* the server's
+ * top-level crash handlers have been registered.
+ */
+function runServerWithCrash(
+  bandHome: string,
+  triggerCode: string,
+): Promise<{ exitCode: number | null; logContent: string }> {
+  const triggerPath = join(bandHome, "crash-trigger.mjs");
+  writeFileSync(triggerPath, triggerCode, "utf-8");
+
+  return new Promise((resolve, reject) => {
+    const child = spawn("node", [`--import`, pathToFileURL(triggerPath).href, serverScript], {
+      env: { ...process.env, BAND_HOME: bandHome, PORT: "0" },
+      stdio: "pipe",
+    });
+
+    const timer = setTimeout(() => {
+      child.kill("SIGKILL");
+      reject(new Error("Server did not exit within 15 seconds"));
+    }, 15_000);
+
+    child.on("exit", (code) => {
+      clearTimeout(timer);
+      const logPath = join(bandHome, "server.log");
+      const logContent = existsSync(logPath) ? readFileSync(logPath, "utf-8") : "";
+      resolve({ exitCode: code, logContent });
+    });
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("server crash handlers", () => {
+  let bandHome: string;
+
+  beforeEach(() => {
+    bandHome = createTmpBandHome();
+  });
+
+  afterEach(() => {
+    rmSync(bandHome, { recursive: true, force: true });
+  });
+
+  it("logs unhandled promise rejection to server.log and exits with code 1", async () => {
+    const { exitCode, logContent } = await runServerWithCrash(
+      bandHome,
+      `setTimeout(() => { Promise.reject(new Error("test unhandled rejection")); }, 500);`,
+    );
+
+    expect(exitCode).toBe(1);
+    expect(logContent).toContain("Unhandled rejection");
+    expect(logContent).toContain("test unhandled rejection");
+    expect(logContent).toMatch(/\[\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/);
+  });
+
+  it("logs uncaught exception to server.log and exits with code 1", async () => {
+    const { exitCode, logContent } = await runServerWithCrash(
+      bandHome,
+      `setTimeout(() => { throw new Error("test uncaught exception"); }, 500);`,
+    );
+
+    expect(exitCode).toBe(1);
+    expect(logContent).toContain("Uncaught exception");
+    expect(logContent).toContain("test uncaught exception");
+    expect(logContent).toMatch(/\[\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/);
+  });
+
+  it("includes stack trace in log output", async () => {
+    const { logContent } = await runServerWithCrash(
+      bandHome,
+      `setTimeout(() => { throw new Error("stack trace test"); }, 500);`,
+    );
+
+    expect(logContent).toContain("stack trace test");
+    expect(logContent).toMatch(/at\s/);
+  });
+
+  it("logs non-Error rejection values as strings", async () => {
+    const { exitCode, logContent } = await runServerWithCrash(
+      bandHome,
+      `setTimeout(() => { Promise.reject("plain string rejection"); }, 500);`,
+    );
+
+    expect(exitCode).toBe(1);
+    expect(logContent).toContain("plain string rejection");
+  });
+});


### PR DESCRIPTION
## Summary
- Add `unhandledRejection` and `uncaughtException` handlers in `start-server.ts` that log timestamp + stack trace to `~/.band/server.log` before exiting
- Redirect server stdout/stderr to `~/.band/server.log` (append mode with 5 MB rotation) instead of `/dev/null` in `webserver.rs`
- Add background health monitor in `lib.rs` (10s interval) that auto-restarts the server if it crashes

Closes #107

## Test plan
- [x] Integration tests verify the real `dist/start-server.mjs` crash handlers by injecting crashes via `--import` and asserting on log file output and exit code
- [ ] Manual: build DMG, run app, verify `~/.band/server.log` captures server output
- [ ] Manual: kill server process, verify health monitor restarts it within ~10s

🤖 Generated with [Claude Code](https://claude.com/claude-code)