### PR TITLE
feat: switch tunnel provider from InstaTunnel to cloudflared

### DIFF
--- a/apps/cli/src/main.rs
+++ b/apps/cli/src/main.rs
@@ -220,11 +220,7 @@ enum TunnelCmd {
     /// Show tunnel status
     Status,
     /// Start the remote tunnel
-    Start {
-        /// Subdomain to use
-        #[arg(long)]
-        subdomain: Option<String>,
-    },
+    Start,
     /// Stop the remote tunnel
     Stop,
 }
@@ -331,7 +327,7 @@ fn main() {
         Commands::Settings => cmd_settings(json_output),
         Commands::Tunnel { cmd } => match cmd {
             TunnelCmd::Status => cmd_tunnel_status(),
-            TunnelCmd::Start { subdomain } => cmd_tunnel_start(subdomain.as_deref()),
+            TunnelCmd::Start => cmd_tunnel_start(),
             TunnelCmd::Stop => cmd_tunnel_stop(),
         },
         Commands::Notify => cmd_notify(),
@@ -1171,13 +1167,9 @@ fn cmd_tunnel_status() -> Result<CommandResult, String> {
     })
 }
 
-fn cmd_tunnel_start(subdomain: Option<&str>) -> Result<CommandResult, String> {
+fn cmd_tunnel_start() -> Result<CommandResult, String> {
     let client = api::ApiClient::from_settings()?;
-    let mut input = serde_json::json!({});
-    if let Some(s) = subdomain {
-        input["subdomain"] = serde_json::json!(s);
-    }
-    let data = client.trpc_mutate("tunnel.start", &input)?;
+    let data = client.trpc_mutate("tunnel.start", &serde_json::json!({}))?;
 
     let url = data.get("url").and_then(|v| v.as_str());
     let mut text = String::new();
@@ -1392,9 +1384,7 @@ fn build_schema(command: Option<&str>) -> Result<serde_json::Value, String> {
         serde_json::json!({
             "name": "tunnel start",
             "description": "Start the remote tunnel",
-            "parameters": [
-                {"name": "--subdomain", "type": "string", "required": false, "description": "Subdomain to use"},
-            ]
+            "parameters": []
         }),
         serde_json::json!({
             "name": "tunnel stop",

--- a/apps/cli/src/state.rs
+++ b/apps/cli/src/state.rs
@@ -18,8 +18,6 @@ pub struct Settings {
     pub labels: Option<serde_json::Value>,
     #[serde(rename = "tokenSecret", skip_serializing_if = "Option::is_none")]
     pub token_secret: Option<String>,
-    #[serde(rename = "tunnelSubdomain", skip_serializing_if = "Option::is_none")]
-    pub tunnel_subdomain: Option<String>,
     #[serde(rename = "autoStartTunnel", skip_serializing_if = "Option::is_none")]
     pub auto_start_tunnel: Option<bool>,
 }

--- a/apps/dashboard/src-tauri/src/state.rs
+++ b/apps/dashboard/src-tauri/src/state.rs
@@ -63,8 +63,6 @@ pub struct Settings {
     pub labels: Option<Vec<LabelDefinition>>,
     #[serde(rename = "tokenSecret", skip_serializing_if = "Option::is_none")]
     pub token_secret: Option<String>,
-    #[serde(rename = "tunnelSubdomain", skip_serializing_if = "Option::is_none")]
-    pub tunnel_subdomain: Option<String>,
     #[serde(rename = "autoStartTunnel", skip_serializing_if = "Option::is_none")]
     pub auto_start_tunnel: Option<bool>,
 }

--- a/apps/web/src/components/PrereqDialog.tsx
+++ b/apps/web/src/components/PrereqDialog.tsx
@@ -20,8 +20,6 @@ interface Props {
 
 export function PrereqDialog({ open, onOpenChange, onReady }: Props) {
   const [step, setStep] = useState<PrereqStep>("checking");
-  const [needNode, setNeedNode] = useState(false);
-  const [needInstatunnel, setNeedInstatunnel] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
@@ -34,12 +32,10 @@ export function PrereqDialog({ open, onOpenChange, onReady }: Props) {
       try {
         const status = await trpc.prereqs.check.query();
         if (cancelled) return;
-        if (status.node && status.instatunnel) {
+        if (status.cloudflared) {
           onReady();
           return;
         }
-        setNeedNode(!status.node);
-        setNeedInstatunnel(!status.instatunnel);
         setStep("missing");
       } catch (e) {
         if (!cancelled) {
@@ -57,12 +53,7 @@ export function PrereqDialog({ open, onOpenChange, onReady }: Props) {
   const handleInstall = async () => {
     try {
       setStep("installing");
-      if (needNode) {
-        await trpc.prereqs.installNode.mutate();
-      }
-      if (needInstatunnel) {
-        await trpc.prereqs.installTunnel.mutate();
-      }
+      await trpc.prereqs.installTunnel.mutate();
       onReady();
     } catch (e) {
       setError(String(e));
@@ -70,23 +61,16 @@ export function PrereqDialog({ open, onOpenChange, onReady }: Props) {
     }
   };
 
-  const missingLabel =
-    needNode && needInstatunnel ? "Node.js & instatunnel" : needNode ? "Node.js" : "instatunnel";
-
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="sm:max-w-[320px]">
         <DialogHeader>
           <DialogTitle>
-            {step === "missing" ? `Install ${missingLabel}` : "Checking Requirements"}
+            {step === "missing" ? "Install cloudflared" : "Checking Requirements"}
           </DialogTitle>
           {step === "missing" && (
             <DialogDescription>
-              {needNode && needInstatunnel
-                ? "Node.js and instatunnel are required for mobile access."
-                : needNode
-                  ? "Node.js is required to run the web server."
-                  : "instatunnel is required to create a secure tunnel."}
+              cloudflared is required to create a secure tunnel for mobile access.
             </DialogDescription>
           )}
         </DialogHeader>
@@ -100,15 +84,21 @@ export function PrereqDialog({ open, onOpenChange, onReady }: Props) {
           )}
 
           {step === "missing" && (
-            <Button onClick={handleInstall} className="w-full">
-              Install {missingLabel}
-            </Button>
+            <>
+              <Button onClick={handleInstall} className="w-full">
+                Install cloudflared
+              </Button>
+              <p className="text-xs text-muted-foreground text-center">
+                Or install manually:{" "}
+                <code className="text-xs bg-muted px-1 py-0.5 rounded">brew install cloudflared</code>
+              </p>
+            </>
           )}
 
           {step === "installing" && (
             <>
               <Loader2 className="size-8 animate-spin text-muted-foreground" />
-              <p className="text-sm text-muted-foreground">Installing {missingLabel}...</p>
+              <p className="text-sm text-muted-foreground">Installing cloudflared...</p>
             </>
           )}
 

--- a/apps/web/src/components/PrereqDialog.tsx
+++ b/apps/web/src/components/PrereqDialog.tsx
@@ -90,7 +90,9 @@ export function PrereqDialog({ open, onOpenChange, onReady }: Props) {
               </Button>
               <p className="text-xs text-muted-foreground text-center">
                 Or install manually:{" "}
-                <code className="text-xs bg-muted px-1 py-0.5 rounded">brew install cloudflared</code>
+                <code className="text-xs bg-muted px-1 py-0.5 rounded">
+                  brew install cloudflared
+                </code>
               </p>
             </>
           )}

--- a/apps/web/src/components/TunnelDialog.tsx
+++ b/apps/web/src/components/TunnelDialog.tsx
@@ -1,18 +1,10 @@
-import { useSettingsQuery } from "@band/dashboard-core";
 import { Button, Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from "@band/ui";
 import { Loader2 } from "lucide-react";
 import { QRCodeSVG } from "qrcode.react";
-import { useCallback, useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { trpc } from "../lib/trpc-client";
 
-type TunnelStep =
-  | "starting"
-  | "auth_required"
-  | "connecting"
-  | "ready"
-  | "subdomain_taken"
-  | "remote_host"
-  | "error";
+type TunnelStep = "starting" | "connecting" | "ready" | "error";
 
 interface Props {
   open: boolean;
@@ -26,150 +18,92 @@ export function TunnelDialog({ open, onOpenChange, onStopped, initialUrl, onTunn
   const [step, setStep] = useState<TunnelStep>("starting");
   const [tunnelUrl, setTunnelUrl] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
-  const [remoteHost, setRemoteHost] = useState<string | null>(null);
-  const { settings } = useSettingsQuery();
 
-  const startConnection = useCallback(async () => {
-    try {
-      setStep("starting");
-
-      // Web server is always running — just check health for tunnel state
-      const health = await trpc.services.health.query();
-
-      // If tunnel is already running on a different host, show message
-      if (health.tunnel && health.tunnel_remote_host) {
-        setRemoteHost(health.tunnel_remote_host);
-        setStep("remote_host");
-        return;
-      }
-
-      // If tunnel is already healthy (same machine, e.g. after restart), show QR
-      if (health.tunnel && health.tunnel_url) {
-        setTunnelUrl(health.tunnel_url);
-        setStep("ready");
-        onTunnelUrl?.(health.tunnel_url);
-        return;
-      }
-
-      if (settings.tunnelSubdomain) {
-        const { authenticated } = await trpc.tunnel.authCheck.query();
-        if (!authenticated) {
-          setStep("auth_required");
-          return;
-        }
-      }
-
-      setStep("connecting");
-      const result = await trpc.tunnel.start.mutate({});
-      if (result.url) {
-        setTunnelUrl(result.url);
-        setStep("ready");
-        onTunnelUrl?.(result.url);
-      }
-    } catch (e) {
-      setError(String(e));
-      setStep("error");
-    }
-  }, [settings.tunnelSubdomain, onTunnelUrl]);
+  // Use refs for values that shouldn't trigger effect re-runs
+  const onTunnelUrlRef = useRef(onTunnelUrl);
+  onTunnelUrlRef.current = onTunnelUrl;
+  const initialUrlRef = useRef(initialUrl);
+  initialUrlRef.current = initialUrl;
 
   useEffect(() => {
     if (!open) return;
 
-    if (initialUrl) {
-      setTunnelUrl(initialUrl);
+    if (initialUrlRef.current) {
+      setTunnelUrl(initialUrlRef.current);
       setStep("ready");
       setError(null);
-      setRemoteHost(null);
-    } else {
-      setStep("starting");
-      setTunnelUrl(null);
-      setError(null);
-      setRemoteHost(null);
+      return;
     }
+
+    setStep("starting");
+    setTunnelUrl(null);
+    setError(null);
 
     let cancelled = false;
 
     // Subscribe to tRPC status stream for tunnel events
     const subscription = trpc.status.stream.subscribe(undefined, {
-      onData: (event: { kind: string; url?: string; error?: string; host?: string }) => {
+      onData: (event: { kind: string; url?: string; error?: string }) => {
         if (cancelled) return;
         if (event.kind === "tunnel-url" && event.url) {
           setTunnelUrl(event.url);
           setStep("ready");
-          onTunnelUrl?.(event.url);
+          onTunnelUrlRef.current?.(event.url);
         } else if (event.kind === "tunnel-error" && event.error) {
           setError(event.error);
           setStep("error");
-        } else if (event.kind === "tunnel-subdomain-taken") {
-          setStep("subdomain_taken");
-        } else if (event.kind === "tunnel-remote-host" && event.host) {
-          setRemoteHost(event.host);
-          setStep("remote_host");
         }
       },
     });
 
-    if (!initialUrl) {
-      // Check if services are already running
-      (async () => {
-        try {
-          const health = await trpc.services.health.query();
-          if (cancelled) return;
+    // Check if services are already running, otherwise start tunnel
+    (async () => {
+      try {
+        const health = await trpc.services.health.query();
+        if (cancelled) return;
 
-          if (health.tunnel && health.tunnel_url && !cancelled) {
-            if (health.tunnel_remote_host) {
-              setRemoteHost(health.tunnel_remote_host);
-              setStep("remote_host");
-            } else {
-              setTunnelUrl(health.tunnel_url);
-              setStep("ready");
-              onTunnelUrl?.(health.tunnel_url);
-            }
-            return;
-          }
-        } catch {}
-
-        if (!cancelled) {
-          await startConnection();
+        if (health.tunnel && health.tunnel_url) {
+          setTunnelUrl(health.tunnel_url);
+          setStep("ready");
+          onTunnelUrlRef.current?.(health.tunnel_url);
+          return;
         }
-      })();
-    }
+      } catch {}
+
+      if (cancelled) return;
+
+      try {
+        setStep("connecting");
+        const result = await trpc.tunnel.start.mutate({});
+        if (cancelled) return;
+        if (result.url) {
+          setTunnelUrl(result.url);
+          setStep("ready");
+          onTunnelUrlRef.current?.(result.url);
+        }
+      } catch (e) {
+        if (!cancelled) {
+          setError(String(e));
+          setStep("error");
+        }
+      }
+    })();
 
     return () => {
       cancelled = true;
       subscription.unsubscribe();
     };
-  }, [open, startConnection, initialUrl, onTunnelUrl]);
+  }, [open]);
 
-  const handleRetryAuth = async () => {
+  const handleRetry = async () => {
     try {
-      setStep("starting");
-      const { authenticated } = await trpc.tunnel.authCheck.query();
-      if (!authenticated) {
-        setStep("auth_required");
-        return;
-      }
       setStep("connecting");
+      setError(null);
       const result = await trpc.tunnel.start.mutate({});
       if (result.url) {
         setTunnelUrl(result.url);
         setStep("ready");
-        onTunnelUrl?.(result.url);
-      }
-    } catch (e) {
-      setError(String(e));
-      setStep("error");
-    }
-  };
-
-  const handleContinueRandom = async () => {
-    try {
-      setStep("connecting");
-      const result = await trpc.tunnel.start.mutate({ skipSubdomain: true });
-      if (result.url) {
-        setTunnelUrl(result.url);
-        setStep("ready");
-        onTunnelUrl?.(result.url);
+        onTunnelUrlRef.current?.(result.url);
       }
     } catch (e) {
       setError(String(e));
@@ -200,25 +134,6 @@ export function TunnelDialog({ open, onOpenChange, onStopped, initialUrl, onTunn
             </>
           )}
 
-          {step === "auth_required" && (
-            <>
-              <p className="text-sm text-muted-foreground text-center">
-                You need to log in to instatunnel to use the subdomain{" "}
-                <strong>{settings.tunnelSubdomain}</strong>.
-              </p>
-              <p className="text-xs text-muted-foreground text-center">Run in your terminal:</p>
-              <code className="text-xs bg-muted px-2 py-1 rounded select-all">
-                instatunnel auth login
-              </code>
-              <Button onClick={handleRetryAuth} className="w-full">
-                Try Again
-              </Button>
-              <Button variant="ghost" size="sm" onClick={handleContinueRandom}>
-                Continue without subdomain
-              </Button>
-            </>
-          )}
-
           {step === "ready" && tunnelUrl && (
             <>
               <a
@@ -235,43 +150,10 @@ export function TunnelDialog({ open, onOpenChange, onStopped, initialUrl, onTunn
             </>
           )}
 
-          {step === "subdomain_taken" && (
-            <>
-              <p className="text-sm text-muted-foreground text-center">
-                The subdomain <strong>{settings.tunnelSubdomain}</strong> is already in use by
-                another session.
-              </p>
-              <p className="text-xs text-muted-foreground text-center">
-                You can change it in Settings &gt; Web Server.
-              </p>
-              <Button onClick={handleContinueRandom} className="w-full">
-                Continue with Random URL
-              </Button>
-            </>
-          )}
-
-          {step === "remote_host" && (
-            <>
-              <p className="text-sm text-muted-foreground text-center">
-                Tunnel subdomain <strong>{settings.tunnelSubdomain}</strong> is currently in use on{" "}
-                <strong>{remoteHost}</strong>.
-              </p>
-              <p className="text-xs text-muted-foreground text-center">
-                Stop it on the other computer first, or use a different subdomain.
-              </p>
-              <Button onClick={handleContinueRandom} className="w-full">
-                Continue with Random URL
-              </Button>
-              <Button variant="ghost" size="sm" onClick={() => onOpenChange(false)}>
-                Close
-              </Button>
-            </>
-          )}
-
           {step === "error" && (
             <>
               <p className="text-sm text-destructive text-center">{error}</p>
-              <Button variant="outline" size="sm" onClick={startConnection}>
+              <Button variant="outline" size="sm" onClick={handleRetry}>
                 Retry
               </Button>
             </>

--- a/apps/web/src/components/TunnelToolbarButton.tsx
+++ b/apps/web/src/components/TunnelToolbarButton.tsx
@@ -33,7 +33,11 @@ export function TunnelToolbarButton() {
           </Button>
         </TooltipTrigger>
         <TooltipContent>
-          {tunnelError ? `Tunnel error: ${tunnelError}` : webServerRunning ? "Mobile access" : "Start tunnel"}
+          {tunnelError
+            ? `Tunnel error: ${tunnelError}`
+            : webServerRunning
+              ? "Mobile access"
+              : "Start tunnel"}
         </TooltipContent>
       </Tooltip>
 

--- a/apps/web/src/components/TunnelToolbarButton.tsx
+++ b/apps/web/src/components/TunnelToolbarButton.tsx
@@ -8,6 +8,7 @@ export function TunnelToolbarButton() {
   const {
     webServerRunning,
     tunnelUrl,
+    tunnelError,
     setTunnelUrl,
     showPrereq,
     setShowPrereq,
@@ -25,13 +26,15 @@ export function TunnelToolbarButton() {
           <Button
             size="icon-sm"
             variant="ghost"
-            className={webServerRunning ? "text-green-500" : ""}
+            className={tunnelError ? "text-red-500" : webServerRunning ? "text-green-500" : ""}
             onClick={openDialog}
           >
             <Globe className="size-5" />
           </Button>
         </TooltipTrigger>
-        <TooltipContent>{webServerRunning ? "Mobile access" : "Start tunnel"}</TooltipContent>
+        <TooltipContent>
+          {tunnelError ? `Tunnel error: ${tunnelError}` : webServerRunning ? "Mobile access" : "Start tunnel"}
+        </TooltipContent>
       </Tooltip>
 
       <PrereqDialog open={showPrereq} onOpenChange={setShowPrereq} onReady={onPrereqReady} />

--- a/apps/web/src/hooks/use-tunnel.ts
+++ b/apps/web/src/hooks/use-tunnel.ts
@@ -1,4 +1,4 @@
-import { isServiceHealthy, useSettingsQuery } from "@band/dashboard-core";
+import { isServiceHealthy } from "@band/dashboard-core";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { trpc } from "../lib/trpc-client";
 
@@ -7,51 +7,31 @@ const HEALTH_POLL_INTERVAL = 30_000;
 export function useTunnel() {
   const [webServerRunning, setWebServerRunning] = useState(false);
   const [tunnelUrl, setTunnelUrl] = useState<string | null>(null);
-  const [tunnelRemoteHost, setTunnelRemoteHost] = useState<string | null>(null);
+  const [tunnelError, setTunnelError] = useState<string | null>(null);
   const [showPrereq, setShowPrereq] = useState(false);
   const [showDialog, setShowDialog] = useState(false);
-  const shouldBeRunningRef = useRef(false);
-  const isRecoveringRef = useRef(false);
-  const { settings } = useSettingsQuery();
+  const hadTunnelRef = useRef(false);
 
-  // Health polling — check service status every 30s, recover tunnel if shouldBeRunning
+  // Health polling — sync UI state with server every 30s
   useEffect(() => {
     let intervalId: ReturnType<typeof setInterval> | undefined;
     let cancelled = false;
-
-    const recover = async (health: { tunnel: boolean }) => {
-      if (isRecoveringRef.current) return;
-      isRecoveringRef.current = true;
-      try {
-        // Web server is always running (we are it), only restart tunnel
-        if (!health.tunnel && !cancelled) {
-          const result = await trpc.tunnel.start.mutate({});
-          if (result.url) {
-            setTunnelUrl(result.url);
-            setWebServerRunning(true);
-          }
-        }
-      } catch {
-        // swallow — next poll tick will retry
-      } finally {
-        isRecoveringRef.current = false;
-      }
-    };
 
     const poll = async () => {
       try {
         const health = await trpc.services.health.query();
         if (cancelled) return;
-        setWebServerRunning(isServiceHealthy(health, settings.tunnelSubdomain));
+        setWebServerRunning(isServiceHealthy(health));
         if (health.tunnel && health.tunnel_url) {
+          hadTunnelRef.current = true;
           setTunnelUrl((prev) => prev ?? health.tunnel_url);
+          setTunnelError(null);
         } else if (!health.tunnel) {
           setTunnelUrl(null);
-        }
-        setTunnelRemoteHost(health.tunnel_remote_host);
-
-        if (shouldBeRunningRef.current && !health.tunnel) {
-          recover(health);
+          if (hadTunnelRef.current) {
+            hadTunnelRef.current = false;
+            setTunnelError("Tunnel disconnected");
+          }
         }
       } catch {
         // ignore errors during polling
@@ -65,21 +45,22 @@ export function useTunnel() {
       cancelled = true;
       clearInterval(intervalId);
     };
-  }, [settings.tunnelSubdomain]);
+  }, []);
 
   // Persistent tRPC subscription listener for tunnel events (works even when dialog is closed)
   useEffect(() => {
     const subscription = trpc.status.stream.subscribe(undefined, {
-      onData: (event: { kind: string; url?: string; host?: string }) => {
+      onData: (event: { kind: string; url?: string; error?: string }) => {
         if (event.kind === "tunnel-url" && event.url) {
-          shouldBeRunningRef.current = true;
+          hadTunnelRef.current = true;
           setTunnelUrl(event.url);
+          setTunnelError(null);
           setWebServerRunning(true);
-        } else if (event.kind === "tunnel-remote-host" && event.host) {
-          setTunnelRemoteHost(event.host);
-        } else if (event.kind === "tunnel-subdomain-taken") {
-          shouldBeRunningRef.current = false;
-          setShowDialog(true);
+        } else if (event.kind === "tunnel-error" && event.error) {
+          hadTunnelRef.current = false;
+          setTunnelUrl(null);
+          setTunnelError(event.error);
+          setWebServerRunning(false);
         }
       },
     });
@@ -88,21 +69,20 @@ export function useTunnel() {
 
   // Globe click → fresh health check, update state, then open prereq dialog
   const openDialog = useCallback(async () => {
-    shouldBeRunningRef.current = true;
+    setTunnelError(null);
     try {
       const health = await trpc.services.health.query();
-      setWebServerRunning(isServiceHealthy(health, settings.tunnelSubdomain));
+      setWebServerRunning(isServiceHealthy(health));
       if (health.tunnel && health.tunnel_url) {
         setTunnelUrl((prev) => prev ?? health.tunnel_url);
       } else if (!health.tunnel) {
         setTunnelUrl(null);
       }
-      setTunnelRemoteHost(health.tunnel_remote_host ?? null);
     } catch {
       // continue to dialog even if check fails
     }
     setShowPrereq(true);
-  }, [settings.tunnelSubdomain]);
+  }, []);
 
   // Prereq passed → open tunnel dialog
   const onPrereqReady = useCallback(() => {
@@ -111,18 +91,17 @@ export function useTunnel() {
   }, []);
 
   const handleStopped = useCallback(() => {
-    shouldBeRunningRef.current = false;
-    isRecoveringRef.current = false;
+    hadTunnelRef.current = false;
     setWebServerRunning(false);
     setTunnelUrl(null);
-    setTunnelRemoteHost(null);
+    setTunnelError(null);
     setShowDialog(false);
   }, []);
 
   return {
     webServerRunning,
     tunnelUrl,
-    tunnelRemoteHost,
+    tunnelError,
     setTunnelUrl,
     showPrereq,
     setShowPrereq,

--- a/apps/web/src/lib/process-utils.ts
+++ b/apps/web/src/lib/process-utils.ts
@@ -47,7 +47,7 @@ export async function whichBinary(name: string): Promise<string | null> {
   }
 }
 
-export async function checkPrereqs(): Promise<{ node: boolean; instatunnel: boolean }> {
-  const [node, instatunnel] = await Promise.all([whichBinary("node"), whichBinary("instatunnel")]);
-  return { node: node !== null, instatunnel: instatunnel !== null };
+export async function checkPrereqs(): Promise<{ cloudflared: boolean }> {
+  const cloudflared = await whichBinary("cloudflared");
+  return { cloudflared: cloudflared !== null };
 }

--- a/apps/web/src/lib/tunnel.ts
+++ b/apps/web/src/lib/tunnel.ts
@@ -1,4 +1,4 @@
-import { type ChildProcess, execFile, spawn } from "node:child_process";
+import { type ChildProcess, spawn } from "node:child_process";
 import { createLogger } from "@band/logger";
 import { getToken } from "./auth-token";
 import { shellPath } from "./process-utils";
@@ -8,21 +8,20 @@ const log = createLogger("tunnel");
 
 let tunnelProcess: ChildProcess | null = null;
 let tunnelUrl: string | null = null;
-let tunnelSubdomain: string | null = null;
-let tunnelRemoteHost: string | null = null;
 let startInProgress: Promise<void> | null = null;
 
-function extractUrl(text: string): string | null {
-  const match = text.match(/https:\/\/[^\s]+\.instatunnel\.my/);
+/**
+ * Extract a trycloudflare.com URL from cloudflared output.
+ * cloudflared prints the tunnel URL to stderr in a line like:
+ *   ... | https://some-random-words.trycloudflare.com
+ * or sometimes with INF prefix:
+ *   INF +-------------------------------------------+
+ *   INF |  https://xxx.trycloudflare.com            |
+ *   INF +-------------------------------------------+
+ */
+export function extractUrl(text: string): string | null {
+  const match = text.match(/https:\/\/[^\s|]+\.trycloudflare\.com/);
   return match ? match[0] : null;
-}
-
-function extractSubdomain(url: string): string | null {
-  const match = url.match(/^https:\/\/(.+)\.instatunnel\.my/);
-  if (!match) return null;
-  const sub = match[1];
-  if (sub === "api") return null;
-  return sub;
 }
 
 function appendToken(baseUrl: string, token: string): string {
@@ -30,48 +29,22 @@ function appendToken(baseUrl: string, token: string): string {
   return `${baseUrl}${sep}token=${token}`;
 }
 
-async function killRemoteTunnel(subdomain: string): Promise<void> {
-  const resolvedPath = await shellPath();
-  log.debug("killing remote tunnel: %s", subdomain);
-  await new Promise<void>((resolve) => {
-    execFile(
-      "instatunnel",
-      ["--kill", subdomain],
-      { env: { ...process.env, PATH: resolvedPath }, timeout: 10_000 },
-      (err) => {
-        if (err) {
-          log.debug("kill remote result: error: %s", err.message);
-        } else {
-          log.debug("kill remote result: ok");
-        }
-        resolve();
-      },
-    );
-  });
-  // Give the server a moment to release the subdomain
-  await new Promise((r) => setTimeout(r, 1000));
-}
-
 function spawnTunnel(
-  options: { port: number; subdomain?: string; skipSubdomain?: boolean },
+  options: { port: number },
   resolvedPath: string,
-): Promise<{ subdomainTaken: boolean }> {
-  const args = [String(options.port)];
-  if (options.subdomain && !options.skipSubdomain) {
-    args.push("--subdomain", options.subdomain);
-  }
+): Promise<void> {
+  const args = ["tunnel", "--url", `http://localhost:${options.port}`];
 
-  log.debug("spawning instatunnel %s", args.join(" "));
+  log.debug("spawning cloudflared %s", args.join(" "));
 
   return new Promise((resolve, reject) => {
-    const child = spawn("instatunnel", args, {
+    const child = spawn("cloudflared", args, {
       env: { ...process.env, PATH: resolvedPath },
       stdio: ["ignore", "pipe", "pipe"],
     });
 
     tunnelProcess = child;
     let settled = false;
-    let subdomainTaken = false;
     const stderrChunks: string[] = [];
 
     const handleOutput = (data: Buffer) => {
@@ -84,29 +57,15 @@ function spawnTunnel(
 
         const url = extractUrl(trimmed);
         if (url) {
-          const sub = extractSubdomain(url);
-          if (sub) {
-            tunnelSubdomain = sub;
-            const token = getToken();
-            tunnelUrl = appendToken(url, token);
+          const token = getToken();
+          tunnelUrl = appendToken(url, token);
 
-            log.debug("detected URL: %s", tunnelUrl);
-            emit({ kind: "tunnel-url", url: tunnelUrl });
+          log.debug("detected URL: %s", tunnelUrl);
+          emit({ kind: "tunnel-url", url: tunnelUrl });
 
-            if (!settled) {
-              settled = true;
-              resolve({ subdomainTaken: false });
-            }
-          }
-        } else if (trimmed.includes("subdomain") && trimmed.toLowerCase().includes("taken")) {
-          log.debug("subdomain taken");
-          subdomainTaken = true;
-        } else if (trimmed.includes("remote host:")) {
-          const host = trimmed.split("remote host:")[1]?.trim();
-          if (host) {
-            log.debug("remote host: %s", host);
-            tunnelRemoteHost = host;
-            emit({ kind: "tunnel-remote-host", remoteHost: host });
+          if (!settled) {
+            settled = true;
+            resolve();
           }
         }
       }
@@ -122,8 +81,6 @@ function spawnTunnel(
       log.debug("process error: %s", err.message);
       tunnelProcess = null;
       tunnelUrl = null;
-      tunnelSubdomain = null;
-      tunnelRemoteHost = null;
       emit({ kind: "tunnel-error", error: err.message });
       if (!settled) {
         settled = true;
@@ -132,26 +89,22 @@ function spawnTunnel(
     });
 
     child.on("exit", (code) => {
-      log.debug("process exited with code: %d", code);
+      log.debug("process exited with code: %d", code ?? -1);
+      const wasRunning = tunnelProcess !== null && settled;
       tunnelProcess = null;
       tunnelUrl = null;
-      const sub = tunnelSubdomain;
-      tunnelSubdomain = null;
-      tunnelRemoteHost = null;
       if (!settled) {
         settled = true;
-        if (subdomainTaken) {
-          resolve({ subdomainTaken: true });
-        } else if (code !== 0) {
+        if (code !== 0) {
           reject(
-            new Error(`instatunnel exited with code ${code}: ${stderrChunks.join("").trim()}`),
+            new Error(`cloudflared exited with code ${code}: ${stderrChunks.join("").trim()}`),
           );
         } else {
-          resolve({ subdomainTaken: false });
+          resolve();
         }
-      }
-      if (sub) {
-        // Already exited, no more events
+      } else if (wasRunning && code !== 0) {
+        // Process died after tunnel was established — notify UI immediately
+        emit({ kind: "tunnel-error", error: `cloudflared exited unexpectedly (code ${code ?? -1})` });
       }
     });
 
@@ -160,7 +113,7 @@ function spawnTunnel(
       if (!settled) {
         log.debug("30s timeout reached, resolving without URL");
         settled = true;
-        resolve({ subdomainTaken: false });
+        resolve();
       }
     }, 30_000);
   });
@@ -168,8 +121,6 @@ function spawnTunnel(
 
 export async function startTunnel(options: {
   port: number;
-  subdomain?: string;
-  skipSubdomain?: boolean;
 }): Promise<void> {
   // If a start is already in progress, wait for it
   if (startInProgress) {
@@ -188,20 +139,7 @@ export async function startTunnel(options: {
 
   const doStart = async () => {
     const resolvedPath = await shellPath();
-
-    const result = await spawnTunnel(options, resolvedPath);
-
-    // If subdomain was taken, kill the stale remote reservation and retry once
-    if (result.subdomainTaken && options.subdomain && !options.skipSubdomain) {
-      log.debug("subdomain taken, killing stale reservation and retrying...");
-      await killRemoteTunnel(options.subdomain);
-      const retry = await spawnTunnel(options, resolvedPath);
-      if (retry.subdomainTaken) {
-        // Still taken after kill — emit event so UI can offer fallback
-        log.debug("subdomain still taken after retry");
-        emit({ kind: "tunnel-subdomain-taken", subdomain: options.subdomain });
-      }
-    }
+    await spawnTunnel(options, resolvedPath);
   };
 
   startInProgress = doStart();
@@ -213,70 +151,19 @@ export async function startTunnel(options: {
 }
 
 export async function stopTunnel(): Promise<void> {
-  const sub = tunnelSubdomain;
   if (tunnelProcess) {
     tunnelProcess.kill("SIGTERM");
     tunnelProcess = null;
   }
   tunnelUrl = null;
-  tunnelSubdomain = null;
-  tunnelRemoteHost = null;
-
-  // Also run instatunnel --kill to clean up remote
-  if (sub) {
-    await killRemoteTunnel(sub);
-  }
 }
 
 export function getTunnelStatus(): {
   running: boolean;
   url: string | null;
-  remoteHost: string | null;
 } {
   return {
     running: tunnelProcess !== null,
     url: tunnelUrl,
-    remoteHost: tunnelRemoteHost,
   };
-}
-
-export async function checkTunnelAuth(): Promise<boolean> {
-  const resolvedPath = await shellPath();
-  return new Promise((resolve) => {
-    execFile(
-      "instatunnel",
-      ["auth", "show-key"],
-      { env: { ...process.env, PATH: resolvedPath }, timeout: 10_000 },
-      (err) => {
-        resolve(!err);
-      },
-    );
-  });
-}
-
-export async function checkTunnelHealth(
-  subdomain: string,
-  token: string,
-): Promise<{ healthy: boolean; remoteHost?: string }> {
-  const maskedUrl = `https://${subdomain}.instatunnel.my/api/health?token=***`;
-  log.debug("checkTunnelHealth: fetching %s", maskedUrl);
-  const url = `https://${subdomain}.instatunnel.my/api/health?token=${token}`;
-  try {
-    const response = await fetch(url, { signal: AbortSignal.timeout(10_000) });
-    log.debug("checkTunnelHealth: status %d %s", response.status, response.statusText);
-    if (!response.ok) {
-      const text = await response.text().catch(() => "");
-      log.debug("checkTunnelHealth: non-ok body: %s", text.slice(0, 200));
-      return { healthy: false };
-    }
-    const body = (await response.json()) as { status?: string; hostname?: string };
-    log.debug({ body }, "checkTunnelHealth: response body");
-    return {
-      healthy: body.status === "ok",
-      remoteHost: body.hostname,
-    };
-  } catch (e) {
-    log.debug("checkTunnelHealth: fetch error: %s", e);
-    return { healthy: false };
-  }
 }

--- a/apps/web/src/lib/tunnel.ts
+++ b/apps/web/src/lib/tunnel.ts
@@ -29,10 +29,7 @@ function appendToken(baseUrl: string, token: string): string {
   return `${baseUrl}${sep}token=${token}`;
 }
 
-function spawnTunnel(
-  options: { port: number },
-  resolvedPath: string,
-): Promise<void> {
+function spawnTunnel(options: { port: number }, resolvedPath: string): Promise<void> {
   const args = ["tunnel", "--url", `http://localhost:${options.port}`];
 
   log.debug("spawning cloudflared %s", args.join(" "));
@@ -104,7 +101,10 @@ function spawnTunnel(
         }
       } else if (wasRunning && code !== 0) {
         // Process died after tunnel was established — notify UI immediately
-        emit({ kind: "tunnel-error", error: `cloudflared exited unexpectedly (code ${code ?? -1})` });
+        emit({
+          kind: "tunnel-error",
+          error: `cloudflared exited unexpectedly (code ${code ?? -1})`,
+        });
       }
     });
 
@@ -119,9 +119,7 @@ function spawnTunnel(
   });
 }
 
-export async function startTunnel(options: {
-  port: number;
-}): Promise<void> {
+export async function startTunnel(options: { port: number }): Promise<void> {
   // If a start is already in progress, wait for it
   if (startInProgress) {
     log.debug("startTunnel: start already in progress, waiting...");

--- a/apps/web/src/lib/watcher.ts
+++ b/apps/web/src/lib/watcher.ts
@@ -24,13 +24,7 @@ interface CIStatus {
 }
 
 export interface StatusEvent {
-  kind:
-    | "update"
-    | "remove"
-    | "snapshot"
-    | "branch-status"
-    | "tunnel-url"
-    | "tunnel-error";
+  kind: "update" | "remove" | "snapshot" | "branch-status" | "tunnel-url" | "tunnel-error";
   status?: WorkspaceStatus;
   statuses?: WorkspaceStatus[];
   workspaceId?: string;

--- a/apps/web/src/lib/watcher.ts
+++ b/apps/web/src/lib/watcher.ts
@@ -30,9 +30,7 @@ export interface StatusEvent {
     | "snapshot"
     | "branch-status"
     | "tunnel-url"
-    | "tunnel-error"
-    | "tunnel-subdomain-taken"
-    | "tunnel-remote-host";
+    | "tunnel-error";
   status?: WorkspaceStatus;
   statuses?: WorkspaceStatus[];
   workspaceId?: string;
@@ -40,8 +38,6 @@ export interface StatusEvent {
   ci?: CIStatus;
   url?: string;
   error?: string;
-  subdomain?: string;
-  remoteHost?: string;
 }
 
 type StatusListener = (event: StatusEvent) => void;

--- a/apps/web/src/trpc/router.ts
+++ b/apps/web/src/trpc/router.ts
@@ -8,7 +8,6 @@ import {
   writeFileSync,
 } from "node:fs";
 import { mkdir, readdir, readFile, stat, writeFile } from "node:fs/promises";
-import { hostname } from "node:os";
 import { basename, extname, join, resolve } from "node:path";
 import { toWorkspaceId } from "@band/dashboard-core";
 import { createLogger } from "@band/logger";
@@ -16,7 +15,6 @@ import { initTRPC, TRPCError } from "@trpc/server";
 import { Cron } from "croner";
 import { z } from "zod";
 import { getOrCreateAgent } from "../lib/agent-pool";
-import { getToken } from "../lib/auth-token";
 import { checkCli, installCli } from "../lib/cli";
 import { stopJobsForKey } from "../lib/cronjob-scheduler";
 import {
@@ -53,8 +51,6 @@ import {
 } from "../lib/task-runner";
 import { listTasks, loadTask } from "../lib/task-store";
 import {
-  checkTunnelAuth,
-  checkTunnelHealth,
   getTunnelStatus,
   startTunnel,
   stopTunnel,
@@ -661,37 +657,21 @@ const tunnelRouter = t.router({
   }),
 
   start: publicProcedure
-    .input(z.object({ subdomain: z.string().optional(), skipSubdomain: z.boolean().optional() }))
-    .mutation(async ({ input }) => {
-      log.debug({ input }, "tunnel.start called");
-      const settings = loadSettings();
+    .input(z.object({}).optional())
+    .mutation(async () => {
+      log.debug("tunnel.start called");
       const port = parseInt(process.env.PORT || "3456", 10);
-      const subdomain = input.subdomain || (settings as Record<string, unknown>).tunnelSubdomain;
-      log.debug(
-        "tunnel.start: port=%d subdomain=%s skipSubdomain=%s",
-        port,
-        subdomain,
-        input.skipSubdomain,
-      );
-      await startTunnel({
-        port,
-        subdomain: subdomain as string | undefined,
-        skipSubdomain: input.skipSubdomain,
-      });
+      log.debug("tunnel.start: port=%d", port);
+      try {
+        await startTunnel({ port });
+      } catch (err) {
+        log.debug({ err }, "tunnel.start: startTunnel failed");
+        return { ok: true, url: null as string | null };
+      }
       const status = getTunnelStatus();
       log.debug({ status }, "tunnel.start: after startTunnel");
       if (status.url) {
         return { ok: true, url: status.url };
-      }
-      // No URL (e.g. subdomain taken) — check if tunnel is already alive remotely
-      const resolvedSubdomain = (subdomain as string | undefined) ?? undefined;
-      if (resolvedSubdomain) {
-        const token = getToken();
-        const health = await checkTunnelHealth(resolvedSubdomain, token);
-        log.debug({ health }, "tunnel.start: remote health check");
-        if (health.healthy) {
-          return { ok: true, url: `https://${resolvedSubdomain}.instatunnel.my?token=${token}` };
-        }
       }
       log.debug("tunnel.start: no URL available");
       return { ok: true, url: null as string | null };
@@ -700,11 +680,6 @@ const tunnelRouter = t.router({
   stop: publicProcedure.mutation(async () => {
     await stopTunnel();
     return { ok: true };
-  }),
-
-  authCheck: publicProcedure.query(async () => {
-    const authenticated = await checkTunnelAuth();
-    return { authenticated };
   }),
 });
 
@@ -717,31 +692,12 @@ const prereqsRouter = t.router({
     return await checkPrereqs();
   }),
 
-  installNode: publicProcedure.mutation(async () => {
-    const resolvedPath = await shellPath();
-    await new Promise<void>((resolve, reject) => {
-      execFile(
-        "brew",
-        ["install", "node"],
-        { env: { ...process.env, PATH: resolvedPath }, timeout: 120_000 },
-        (err, _stdout, stderr) => {
-          if (err) {
-            reject(new Error(stderr || err.message));
-            return;
-          }
-          resolve();
-        },
-      );
-    });
-    return { ok: true };
-  }),
-
   installTunnel: publicProcedure.mutation(async () => {
     const resolvedPath = await shellPath();
     await new Promise<void>((resolve, reject) => {
       execFile(
-        "npm",
-        ["install", "-g", "instatunnel"],
+        "brew",
+        ["install", "cloudflared"],
         { env: { ...process.env, PATH: resolvedPath }, timeout: 120_000 },
         (err, _stdout, stderr) => {
           if (err) {
@@ -1007,63 +963,15 @@ const sessionsRouter = t.router({
 // ---------------------------------------------------------------------------
 
 const servicesRouter = t.router({
-  health: publicProcedure.query(async () => {
+  health: publicProcedure.query(() => {
     log.debug("services.health called");
     const tunnel = getTunnelStatus();
     log.debug({ tunnel }, "services.health: tunnel status");
-    let tunnelHealthy = false;
-    let tunnelUrl = tunnel.url;
-    let tunnelRemoteHost: string | undefined;
-    const token = getToken();
-    const localHostname = hostname();
-
-    // Check local tunnel process first
-    if (tunnel.running && tunnel.url) {
-      const urlMatch = tunnel.url.match(/https:\/\/(.+)\.instatunnel\.my/);
-      if (urlMatch) {
-        log.debug("services.health: checking tunnel health for %s", urlMatch[1]);
-        const health = await checkTunnelHealth(urlMatch[1], token);
-        log.debug({ health }, "services.health: tunnel health");
-        tunnelHealthy = health.healthy;
-        // Only report as remote if it's a different machine
-        if (health.remoteHost && health.remoteHost !== localHostname) {
-          tunnelRemoteHost = health.remoteHost;
-        }
-      }
-    }
-
-    // If no local tunnel, check if the configured subdomain is alive remotely
-    // (handles app restart while tunnel is still active on the server)
-    if (!tunnelHealthy) {
-      const settings = loadSettings();
-      const subdomain = (settings as Record<string, unknown>).tunnelSubdomain as string | undefined;
-      log.debug(
-        "services.health: tunnelSubdomain=%s token=%s",
-        subdomain ?? "none",
-        token ? `${token.slice(0, 6)}...` : "null",
-      );
-      if (subdomain) {
-        log.debug("services.health: checking remote subdomain %s", subdomain);
-        const health = await checkTunnelHealth(subdomain, token);
-        log.debug({ health }, "services.health: remote health");
-        if (health.healthy) {
-          tunnelHealthy = true;
-          // Only report as remote if it's a different machine
-          if (health.remoteHost && health.remoteHost !== localHostname) {
-            tunnelRemoteHost = health.remoteHost;
-          }
-          tunnelUrl = `https://${subdomain}.instatunnel.my?token=${token}`;
-        }
-      } else {
-        log.debug("services.health: no tunnelSubdomain configured, skipping remote check");
-      }
-    }
 
     const result = {
       webserver: true,
-      tunnel: tunnelHealthy,
-      tunnel_url: tunnelUrl,
-      tunnel_remote_host: tunnelRemoteHost || tunnel.remoteHost,
+      tunnel: tunnel.running,
+      tunnel_url: tunnel.url,
     };
     log.debug({ result }, "services.health result");
     return result;

--- a/apps/web/src/trpc/router.ts
+++ b/apps/web/src/trpc/router.ts
@@ -50,11 +50,7 @@ import {
   TaskConflictError,
 } from "../lib/task-runner";
 import { listTasks, loadTask } from "../lib/task-store";
-import {
-  getTunnelStatus,
-  startTunnel,
-  stopTunnel,
-} from "../lib/tunnel";
+import { getTunnelStatus, startTunnel, stopTunnel } from "../lib/tunnel";
 import { subscribe as subscribeStatus } from "../lib/watcher";
 import { resolveWorkspace } from "../lib/workspace";
 import type { Context } from "./context";
@@ -656,26 +652,24 @@ const tunnelRouter = t.router({
     return getTunnelStatus();
   }),
 
-  start: publicProcedure
-    .input(z.object({}).optional())
-    .mutation(async () => {
-      log.debug("tunnel.start called");
-      const port = parseInt(process.env.PORT || "3456", 10);
-      log.debug("tunnel.start: port=%d", port);
-      try {
-        await startTunnel({ port });
-      } catch (err) {
-        log.debug({ err }, "tunnel.start: startTunnel failed");
-        return { ok: true, url: null as string | null };
-      }
-      const status = getTunnelStatus();
-      log.debug({ status }, "tunnel.start: after startTunnel");
-      if (status.url) {
-        return { ok: true, url: status.url };
-      }
-      log.debug("tunnel.start: no URL available");
+  start: publicProcedure.input(z.object({}).optional()).mutation(async () => {
+    log.debug("tunnel.start called");
+    const port = parseInt(process.env.PORT || "3456", 10);
+    log.debug("tunnel.start: port=%d", port);
+    try {
+      await startTunnel({ port });
+    } catch (err) {
+      log.debug({ err }, "tunnel.start: startTunnel failed");
       return { ok: true, url: null as string | null };
-    }),
+    }
+    const status = getTunnelStatus();
+    log.debug({ status }, "tunnel.start: after startTunnel");
+    if (status.url) {
+      return { ok: true, url: status.url };
+    }
+    log.debug("tunnel.start: no URL available");
+    return { ok: true, url: null as string | null };
+  }),
 
   stop: publicProcedure.mutation(async () => {
     await stopTunnel();

--- a/apps/web/start-server.ts
+++ b/apps/web/start-server.ts
@@ -139,11 +139,8 @@ async function main() {
     if (settings.autoStartTunnel) {
       checkPrereqs()
         .then((prereqs) => {
-          if (prereqs.instatunnel) {
-            return startTunnel({
-              port,
-              subdomain: settings.tunnelSubdomain as string | undefined,
-            });
+          if (prereqs.cloudflared) {
+            return startTunnel({ port });
           }
         })
         .catch((err) => {

--- a/apps/web/tests/trpc.test.ts
+++ b/apps/web/tests/trpc.test.ts
@@ -334,7 +334,6 @@ describe("tRPC — settings CRUD", () => {
   it("settings.update persists settings", async () => {
     const settings = {
       worktreesDir: "/tmp/worktrees",
-      tunnelSubdomain: "my-sub",
       autoStartTunnel: true,
     };
     const res = await trpcMutate(server.url, "settings.update", settings);
@@ -344,7 +343,6 @@ describe("tRPC — settings CRUD", () => {
     const getRes = await trpcQuery(server.url, "settings.get");
     const data = await trpcData<Record<string, unknown>>(getRes);
     expect(data.worktreesDir).toBe("/tmp/worktrees");
-    expect(data.tunnelSubdomain).toBe("my-sub");
     expect(data.autoStartTunnel).toBe(true);
   });
 
@@ -356,7 +354,7 @@ describe("tRPC — settings CRUD", () => {
     const data = await trpcData<Record<string, unknown>>(getRes);
     expect(data.worktreesDir).toBeNull();
     // Previous keys should be gone since update replaces the whole file
-    expect(data.tunnelSubdomain).toBeUndefined();
+    expect(data.autoStartTunnel).toBeUndefined();
   });
 });
 

--- a/apps/web/tests/tunnel-and-services.test.ts
+++ b/apps/web/tests/tunnel-and-services.test.ts
@@ -1,5 +1,5 @@
 import { spawn } from "node:child_process";
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { createServer } from "node:net";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -194,7 +194,6 @@ describe("services.health", () => {
       webserver: boolean;
       tunnel: boolean;
       tunnel_url: string | null;
-      tunnel_remote_host: string | null;
     }>(res);
     expect(body.webserver).toBe(true);
     expect(typeof body.tunnel).toBe("boolean");
@@ -231,11 +230,9 @@ describe("tunnel.status", () => {
     const body = await trpcData<{
       running: boolean;
       url: string | null;
-      remoteHost: string | null;
     }>(res);
     expect(body.running).toBe(false);
     expect(body.url).toBeNull();
-    expect(body.remoteHost).toBeNull();
   });
 });
 
@@ -289,24 +286,21 @@ describe("prereqs.check", () => {
     rmSync(tmpHome, { recursive: true, force: true });
   });
 
-  it("returns prerequisite status with node and instatunnel booleans", async () => {
+  it("returns prerequisite status with cloudflared boolean", async () => {
     const res = await trpcQuery(server.url, "prereqs.check", undefined, {
       headers: { Cookie: authCookie(DEFAULT_TOKEN) },
     });
     expect(res.status).toBe(200);
-    const body = await trpcData<{ node: boolean; instatunnel: boolean }>(res);
-    expect(typeof body.node).toBe("boolean");
-    expect(typeof body.instatunnel).toBe("boolean");
-    // Node.js is always available since we're running this test with it
-    expect(body.node).toBe(true);
+    const body = await trpcData<{ cloudflared: boolean }>(res);
+    expect(typeof body.cloudflared).toBe("boolean");
   });
 });
 
 // ---------------------------------------------------------------------------
-// tunnel.authCheck
+// prereqs.check — cloudflared not installed
 // ---------------------------------------------------------------------------
 
-describe("tunnel.authCheck", () => {
+describe("prereqs.check — cloudflared not installed", () => {
   let server: ServerHandle;
   let tmpHome: string;
 
@@ -314,7 +308,23 @@ describe("tunnel.authCheck", () => {
     tmpHome = createTmpHome();
     seedState(tmpHome, createDefaultState(tmpHome));
     seedSettings(tmpHome, { tokenSecret: DEFAULT_TOKEN });
-    server = await startServer({ tmpHome });
+
+    // Create a bin dir containing only a symlink to node — cloudflared
+    // won't be found since it's not linked here.
+    const binDir = join(tmpHome, "bin");
+    mkdirSync(binDir, { recursive: true });
+    const nodePath = process.execPath;
+    symlinkSync(nodePath, join(binDir, "node"));
+    // which(1) is needed by checkPrereqs
+    symlinkSync("/usr/bin/which", join(binDir, "which"));
+
+    server = await startServer({
+      tmpHome,
+      env: {
+        PATH: binDir,
+        SHELL: "/bin/sh",
+      },
+    });
   });
 
   afterAll(async () => {
@@ -322,13 +332,26 @@ describe("tunnel.authCheck", () => {
     rmSync(tmpHome, { recursive: true, force: true });
   });
 
-  it("returns an authenticated boolean", async () => {
-    const res = await trpcQuery(server.url, "tunnel.authCheck", undefined, {
+  it("returns cloudflared: false when not on PATH", async () => {
+    const res = await trpcQuery(server.url, "prereqs.check", undefined, {
       headers: { Cookie: authCookie(DEFAULT_TOKEN) },
     });
     expect(res.status).toBe(200);
-    const body = await trpcData<{ authenticated: boolean }>(res);
-    expect(typeof body.authenticated).toBe("boolean");
+    const body = await trpcData<{ cloudflared: boolean }>(res);
+    expect(body.cloudflared).toBe(false);
+  });
+
+  it("tunnel.start returns null URL when cloudflared is missing", async () => {
+    const res = await trpcMutate(
+      server.url,
+      "tunnel.start",
+      {},
+      { headers: { Cookie: authCookie(DEFAULT_TOKEN) } },
+    );
+    expect(res.status).toBe(200);
+    const data = await trpcData<{ ok: boolean; url: string | null }>(res);
+    expect(data.ok).toBe(true);
+    expect(data.url).toBeNull();
   });
 });
 
@@ -463,18 +486,6 @@ describe("Tunnel and service endpoints require auth when token is set", () => {
 
   it("returns 200 for prereqs.check with auth", async () => {
     const res = await trpcQuery(server.url, "prereqs.check", undefined, {
-      headers: { Cookie: authCookie(TOKEN) },
-    });
-    expect(res.status).toBe(200);
-  });
-
-  it("returns 401 for tunnel.authCheck without auth", async () => {
-    const res = await trpcQuery(server.url, "tunnel.authCheck");
-    expect(res.status).toBe(401);
-  });
-
-  it("returns 200 for tunnel.authCheck with auth", async () => {
-    const res = await trpcQuery(server.url, "tunnel.authCheck", undefined, {
       headers: { Cookie: authCookie(TOKEN) },
     });
     expect(res.status).toBe(200);

--- a/apps/web/tests/tunnel.test.ts
+++ b/apps/web/tests/tunnel.test.ts
@@ -61,37 +61,51 @@ function createDefaultState(tmpHome: string) {
 }
 
 /**
- * Create a fake instatunnel script that prints output matching the real CLI
- * format (with emoji prefixes) then sleeps so the process stays alive.
+ * Create a fake cloudflared script that prints output matching the real CLI
+ * format (URL printed to stderr) then sleeps so the process stays alive.
  */
-function createFakeInstatunnel(binDir: string, subdomain: string): void {
+function createFakeCloudflared(binDir: string, subdomain: string): void {
   const script = `#!/bin/sh
-PORT="$1"
-echo "Using config file: /tmp/fake.yaml"
-echo "🚀 Starting tunnel for localhost:$PORT..."
-echo "🚀 Your app is now live at https://${subdomain}.instatunnel.my"
-echo "📋 URL copied to clipboard!"
-echo "🔗 Forwarding https://${subdomain}.instatunnel.my -> localhost:$PORT"
-echo "⚡ Ready to receive requests! Press Ctrl+C to stop"
+# Simulate cloudflared tunnel startup output on stderr
+echo "2024-01-01T00:00:00Z INF Starting tunnel" >&2
+echo "2024-01-01T00:00:00Z INF +-------------------------------------------+" >&2
+echo "2024-01-01T00:00:00Z INF |  https://${subdomain}.trycloudflare.com    |" >&2
+echo "2024-01-01T00:00:00Z INF +-------------------------------------------+" >&2
 # Keep running until killed
 while true; do sleep 1; done
 `;
-  const scriptPath = join(binDir, "instatunnel");
+  const scriptPath = join(binDir, "cloudflared");
   writeFileSync(scriptPath, script);
   chmodSync(scriptPath, 0o755);
 }
 
 /**
- * Create a fake instatunnel that exits with "subdomain already taken" error.
+ * Create a fake cloudflared that exits with an error.
  */
-function createFakeInstatunnelSubdomainTaken(binDir: string): void {
+function createFakeCloudflaredError(binDir: string): void {
   const script = `#!/bin/sh
-echo "Using config file: /tmp/fake.yaml"
-echo "🚀 Starting tunnel for localhost:$1..."
-echo 'Error: failed to create tunnel: {"error":"subdomain already taken"}' >&2
+echo "failed to connect to edge" >&2
 exit 1
 `;
-  const scriptPath = join(binDir, "instatunnel");
+  const scriptPath = join(binDir, "cloudflared");
+  writeFileSync(scriptPath, script);
+  chmodSync(scriptPath, 0o755);
+}
+
+/**
+ * Create a fake cloudflared that prints a URL then crashes after a delay.
+ */
+function createFakeCloudflaredCrash(binDir: string, subdomain: string, delaySecs: number): void {
+  const script = `#!/bin/sh
+echo "2024-01-01T00:00:00Z INF Starting tunnel" >&2
+echo "2024-01-01T00:00:00Z INF +-------------------------------------------+" >&2
+echo "2024-01-01T00:00:00Z INF |  https://${subdomain}.trycloudflare.com    |" >&2
+echo "2024-01-01T00:00:00Z INF +-------------------------------------------+" >&2
+sleep ${delaySecs}
+echo "2024-01-01T00:00:00Z ERR connection lost" >&2
+exit 1
+`;
+  const scriptPath = join(binDir, "cloudflared");
   writeFileSync(scriptPath, script);
   chmodSync(scriptPath, 0o755);
 }
@@ -218,10 +232,10 @@ function authCookie(token: string): string {
 }
 
 // ---------------------------------------------------------------------------
-// Tests: tunnel URL parsing with emoji-prefixed output
+// Tests: tunnel URL parsing with cloudflared output
 // ---------------------------------------------------------------------------
 
-describe("tunnel.start — parses URL from emoji-prefixed instatunnel output", () => {
+describe("tunnel.start — parses URL from cloudflared stderr output", () => {
   let server: ServerHandle;
   let tmpHome: string;
 
@@ -232,7 +246,7 @@ describe("tunnel.start — parses URL from emoji-prefixed instatunnel output", (
 
     const binDir = join(tmpHome, "bin");
     mkdirSync(binDir, { recursive: true });
-    createFakeInstatunnel(binDir, "test123");
+    createFakeCloudflared(binDir, "test-abc-123");
 
     server = await startServer({
       tmpHome,
@@ -252,7 +266,7 @@ describe("tunnel.start — parses URL from emoji-prefixed instatunnel output", (
     rmSync(tmpHome, { recursive: true, force: true });
   });
 
-  it("starts tunnel and extracts URL with subdomain", async () => {
+  it("starts tunnel and extracts trycloudflare.com URL", async () => {
     const res = await trpcMutate(
       server.url,
       "tunnel.start",
@@ -278,7 +292,7 @@ describe("tunnel.start — parses URL from emoji-prefixed instatunnel output", (
     const status = await trpcData<{ running: boolean; url: string | null }>(statusRes);
 
     expect(status.running).toBe(true);
-    expect(status.url).toContain("https://test123.instatunnel.my");
+    expect(status.url).toContain("https://test-abc-123.trycloudflare.com");
   });
 });
 
@@ -297,7 +311,7 @@ describe("tunnel.start — returns URL in mutation response", () => {
 
     const binDir = join(tmpHome, "bin");
     mkdirSync(binDir, { recursive: true });
-    createFakeInstatunnel(binDir, "directurl");
+    createFakeCloudflared(binDir, "directurl-test");
 
     server = await startServer({
       tmpHome,
@@ -328,15 +342,15 @@ describe("tunnel.start — returns URL in mutation response", () => {
     expect(res.status).toBe(200);
     const data = await trpcData<{ ok: boolean; url: string | null }>(res);
     expect(data.ok).toBe(true);
-    expect(data.url).toContain("https://directurl.instatunnel.my");
+    expect(data.url).toContain("https://directurl-test.trycloudflare.com");
   });
 });
 
 // ---------------------------------------------------------------------------
-// Tests: subdomain taken — resolves without error and returns null URL
+// Tests: cloudflared error — resolves without crashing
 // ---------------------------------------------------------------------------
 
-describe("tunnel.start — subdomain taken resolves without error", () => {
+describe("tunnel.start — cloudflared error returns null URL", () => {
   let server: ServerHandle;
   let tmpHome: string;
 
@@ -347,7 +361,7 @@ describe("tunnel.start — subdomain taken resolves without error", () => {
 
     const binDir = join(tmpHome, "bin");
     mkdirSync(binDir, { recursive: true });
-    createFakeInstatunnelSubdomainTaken(binDir);
+    createFakeCloudflaredError(binDir);
 
     server = await startServer({
       tmpHome,
@@ -363,11 +377,11 @@ describe("tunnel.start — subdomain taken resolves without error", () => {
     rmSync(tmpHome, { recursive: true, force: true });
   });
 
-  it("returns 200 with null URL when subdomain is taken", async () => {
+  it("returns 200 with null URL when cloudflared fails", async () => {
     const res = await trpcMutate(
       server.url,
       "tunnel.start",
-      { subdomain: "taken-sub" },
+      {},
       {
         headers: { Cookie: authCookie(DEFAULT_TOKEN) },
       },
@@ -375,88 +389,12 @@ describe("tunnel.start — subdomain taken resolves without error", () => {
     expect(res.status).toBe(200);
     const data = await trpcData<{ ok: boolean; url: string | null }>(res);
     expect(data.ok).toBe(true);
-    // URL is null because the subdomain is taken and no remote tunnel is reachable
     expect(data.url).toBeNull();
   });
 });
 
 // ---------------------------------------------------------------------------
-// Tests: services.health — remote detection with configured subdomain
-// ---------------------------------------------------------------------------
-
-describe("services.health — configured subdomain, no tunnel running, remote unreachable", () => {
-  const TOKEN = "unreachable-test-token";
-  let server: ServerHandle;
-  let tmpHome: string;
-
-  beforeAll(async () => {
-    tmpHome = createTmpHome();
-    seedState(tmpHome, createDefaultState(tmpHome));
-    // Configure a subdomain that won't resolve to a real tunnel
-    seedSettings(tmpHome, { tunnelSubdomain: "nonexistent-test-sub", tokenSecret: TOKEN });
-    server = await startServer({ tmpHome });
-  });
-
-  afterAll(async () => {
-    await server.close();
-    rmSync(tmpHome, { recursive: true, force: true });
-  });
-
-  it("returns tunnel as not healthy when remote is unreachable", async () => {
-    const res = await trpcQuery(server.url, "services.health", undefined, {
-      headers: { Cookie: authCookie(TOKEN) },
-    });
-    expect(res.status).toBe(200);
-    const data = await trpcData<{
-      webserver: boolean;
-      tunnel: boolean;
-      tunnel_url: string | null;
-      tunnel_remote_host: string | null;
-    }>(res);
-    expect(data.webserver).toBe(true);
-    expect(data.tunnel).toBe(false);
-    expect(data.tunnel_url).toBeNull();
-    expect(data.tunnel_remote_host).toBeNull();
-  });
-});
-
-describe("services.health — configured subdomain, no tunnel, with token, remote unreachable", () => {
-  const TOKEN = "health-check-test-token";
-  let server: ServerHandle;
-  let tmpHome: string;
-
-  beforeAll(async () => {
-    tmpHome = createTmpHome();
-    seedState(tmpHome, createDefaultState(tmpHome));
-    seedSettings(tmpHome, { tunnelSubdomain: "nonexistent-test-sub", tokenSecret: TOKEN });
-    server = await startServer({ tmpHome });
-  });
-
-  afterAll(async () => {
-    await server.close();
-    rmSync(tmpHome, { recursive: true, force: true });
-  });
-
-  it("returns tunnel as not healthy when remote is unreachable (with token)", async () => {
-    const res = await trpcQuery(server.url, "services.health", undefined, {
-      headers: { Cookie: authCookie(TOKEN) },
-    });
-    expect(res.status).toBe(200);
-    const data = await trpcData<{
-      webserver: boolean;
-      tunnel: boolean;
-      tunnel_url: string | null;
-      tunnel_remote_host: string | null;
-    }>(res);
-    expect(data.webserver).toBe(true);
-    expect(data.tunnel).toBe(false);
-    expect(data.tunnel_url).toBeNull();
-    expect(data.tunnel_remote_host).toBeNull();
-  });
-});
-
-// ---------------------------------------------------------------------------
-// Tests: services.health — local tunnel process running
+// Tests: services.health — with running local tunnel process
 // ---------------------------------------------------------------------------
 
 describe("services.health — with running local tunnel process", () => {
@@ -470,7 +408,7 @@ describe("services.health — with running local tunnel process", () => {
 
     const binDir = join(tmpHome, "bin");
     mkdirSync(binDir, { recursive: true });
-    createFakeInstatunnel(binDir, "healthcheck");
+    createFakeCloudflared(binDir, "healthcheck-test");
 
     server = await startServer({
       tmpHome,
@@ -509,7 +447,7 @@ describe("services.health — with running local tunnel process", () => {
       return status.running && status.url !== null;
     });
 
-    // Now check services.health — it should report the tunnel URL
+    // Now check services.health — it should report the tunnel as running with URL
     const healthRes = await trpcQuery(server.url, "services.health", undefined, {
       headers: { Cookie: authCookie(DEFAULT_TOKEN) },
     });
@@ -518,34 +456,65 @@ describe("services.health — with running local tunnel process", () => {
       webserver: boolean;
       tunnel: boolean;
       tunnel_url: string | null;
-      tunnel_remote_host: string | null;
     }>(healthRes);
     expect(health.webserver).toBe(true);
-    // tunnel_url should be set (local process has it)
-    expect(health.tunnel_url).toContain("https://healthcheck.instatunnel.my");
-    // Note: tunnel may report as not healthy because the fake tunnel URL
-    // doesn't actually forward requests — but the URL should still be present
+    expect(health.tunnel).toBe(true);
+    expect(health.tunnel_url).toContain("https://healthcheck-test.trycloudflare.com");
   });
 });
 
 // ---------------------------------------------------------------------------
-// Tests: tunnel.start — subdomain taken with token triggers remote fallback
+// Tests: services.health — no tunnel running
 // ---------------------------------------------------------------------------
 
-describe("tunnel.start — subdomain taken attempts remote fallback", () => {
-  const TOKEN = "fallback-test-token";
+describe("services.health — no tunnel running", () => {
   let server: ServerHandle;
   let tmpHome: string;
 
   beforeAll(async () => {
     tmpHome = createTmpHome();
     seedState(tmpHome, createDefaultState(tmpHome));
-    // Configure a subdomain that will be "taken" by the fake script
-    seedSettings(tmpHome, { tunnelSubdomain: "taken-remote", tokenSecret: TOKEN });
+    seedSettings(tmpHome, { tokenSecret: DEFAULT_TOKEN });
+    server = await startServer({ tmpHome });
+  });
+
+  afterAll(async () => {
+    await server.close();
+    rmSync(tmpHome, { recursive: true, force: true });
+  });
+
+  it("returns tunnel false when no tunnel is running", async () => {
+    const res = await trpcQuery(server.url, "services.health", undefined, {
+      headers: { Cookie: authCookie(DEFAULT_TOKEN) },
+    });
+    expect(res.status).toBe(200);
+    const data = await trpcData<{
+      webserver: boolean;
+      tunnel: boolean;
+      tunnel_url: string | null;
+    }>(res);
+    expect(data.webserver).toBe(true);
+    expect(data.tunnel).toBe(false);
+    expect(data.tunnel_url).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: tunnel crash — server detects cloudflared death
+// ---------------------------------------------------------------------------
+
+describe("tunnel crash — health reflects down state after cloudflared dies", () => {
+  let server: ServerHandle;
+  let tmpHome: string;
+
+  beforeAll(async () => {
+    tmpHome = createTmpHome();
+    seedState(tmpHome, createDefaultState(tmpHome));
+    seedSettings(tmpHome, { tokenSecret: DEFAULT_TOKEN });
 
     const binDir = join(tmpHome, "bin");
     mkdirSync(binDir, { recursive: true });
-    createFakeInstatunnelSubdomainTaken(binDir);
+    createFakeCloudflaredCrash(binDir, "crash-test", 1);
 
     server = await startServer({
       tmpHome,
@@ -561,55 +530,54 @@ describe("tunnel.start — subdomain taken attempts remote fallback", () => {
     rmSync(tmpHome, { recursive: true, force: true });
   });
 
-  it("returns null URL when subdomain is taken and remote is unreachable", async () => {
-    const res = await trpcMutate(
+  it("starts tunnel, cloudflared crashes, status and health reflect the crash", async () => {
+    // 1. Start tunnel — should get URL before crash
+    const startRes = await trpcMutate(
       server.url,
       "tunnel.start",
       {},
-      {
-        headers: { Cookie: authCookie(TOKEN) },
-      },
+      { headers: { Cookie: authCookie(DEFAULT_TOKEN) } },
     );
-    expect(res.status).toBe(200);
-    const data = await trpcData<{ ok: boolean; url: string | null }>(res);
-    expect(data.ok).toBe(true);
-    // Remote tunnel (taken-remote.instatunnel.my) doesn't exist, so fallback returns null
-    expect(data.url).toBeNull();
-  });
-});
+    expect(startRes.status).toBe(200);
+    const startData = await trpcData<{ ok: boolean; url: string | null }>(startRes);
+    expect(startData.ok).toBe(true);
+    expect(startData.url).toContain("https://crash-test.trycloudflare.com");
 
-// ---------------------------------------------------------------------------
-// Tests: services.health — no subdomain configured skips remote check
-// ---------------------------------------------------------------------------
-
-describe("services.health — no subdomain configured, no tunnel", () => {
-  let server: ServerHandle;
-  let tmpHome: string;
-
-  beforeAll(async () => {
-    tmpHome = createTmpHome();
-    seedState(tmpHome, createDefaultState(tmpHome));
-    seedSettings(tmpHome, { tokenSecret: DEFAULT_TOKEN }); // No tunnelSubdomain
-    server = await startServer({ tmpHome });
-  });
-
-  afterAll(async () => {
-    await server.close();
-    rmSync(tmpHome, { recursive: true, force: true });
-  });
-
-  it("returns tunnel false without attempting remote check", async () => {
-    const res = await trpcQuery(server.url, "services.health", undefined, {
+    // 2. Verify tunnel is initially running
+    const statusRes = await trpcQuery(server.url, "tunnel.status", undefined, {
       headers: { Cookie: authCookie(DEFAULT_TOKEN) },
     });
-    expect(res.status).toBe(200);
-    const data = await trpcData<{
+    const status = await trpcData<{ running: boolean; url: string | null }>(statusRes);
+    expect(status.running).toBe(true);
+
+    // 3. Wait for cloudflared to crash (exits after 1s) and server to detect it
+    await waitFor(async () => {
+      const res = await trpcQuery(server.url, "tunnel.status", undefined, {
+        headers: { Cookie: authCookie(DEFAULT_TOKEN) },
+      });
+      const s = await trpcData<{ running: boolean; url: string | null }>(res);
+      return !s.running;
+    });
+
+    // 4. Verify tunnel.status shows not running
+    const afterCrashStatus = await trpcQuery(server.url, "tunnel.status", undefined, {
+      headers: { Cookie: authCookie(DEFAULT_TOKEN) },
+    });
+    const crashed = await trpcData<{ running: boolean; url: string | null }>(afterCrashStatus);
+    expect(crashed.running).toBe(false);
+    expect(crashed.url).toBeNull();
+
+    // 5. Verify services.health reflects tunnel is down
+    const healthRes = await trpcQuery(server.url, "services.health", undefined, {
+      headers: { Cookie: authCookie(DEFAULT_TOKEN) },
+    });
+    const health = await trpcData<{
       webserver: boolean;
       tunnel: boolean;
       tunnel_url: string | null;
-    }>(res);
-    expect(data.webserver).toBe(true);
-    expect(data.tunnel).toBe(false);
-    expect(data.tunnel_url).toBeNull();
+    }>(healthRes);
+    expect(health.webserver).toBe(true);
+    expect(health.tunnel).toBe(false);
+    expect(health.tunnel_url).toBeNull();
   });
 });

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -1,8 +1,11 @@
 import { resolve } from "node:path";
+import { createLogger } from "@band/logger";
 import tailwindcss from "@tailwindcss/vite";
 import { tanstackStart } from "@tanstack/react-start/plugin/vite";
 import react from "@vitejs/plugin-react";
 import { defineConfig, type Plugin } from "vite";
+
+const log = createLogger("vite-plugin");
 
 function trpcDevPlugin(): Plugin {
   return {
@@ -25,11 +28,37 @@ function trpcDevPlugin(): Plugin {
           endpoint: "",
         });
       });
+
+      // Auto-start tunnel if configured
+      server.ssrLoadModule("./src/lib/state").then(async ({ loadSettings }) => {
+        const settings = loadSettings() as Record<string, unknown>;
+        if (!settings.autoStartTunnel) return;
+
+        const { checkPrereqs } = await server.ssrLoadModule("./src/lib/process-utils");
+        const prereqs = await checkPrereqs();
+        if (!prereqs.cloudflared) return;
+
+        const { startTunnel } = await server.ssrLoadModule("./src/lib/tunnel");
+        const port = server.config.server.port ?? 3000;
+        await startTunnel({ port }).catch((err: Error) => {
+          log.error("Failed to auto-start tunnel: %s", err.message);
+        });
+      });
+
+      // Clean up tunnel on dev server shutdown
+      server.httpServer?.on("close", () => {
+        server.ssrLoadModule("./src/lib/tunnel").then(({ stopTunnel }) => {
+          stopTunnel().catch(() => {});
+        });
+      });
     },
   };
 }
 
 export default defineConfig(({ command }) => ({
+  server: {
+    allowedHosts: [".trycloudflare.com"],
+  },
   plugins: [trpcDevPlugin(), tanstackStart(), react(), tailwindcss()],
   resolve: {
     alias: {

--- a/packages/dashboard-core/src/components/SettingsPage.tsx
+++ b/packages/dashboard-core/src/components/SettingsPage.tsx
@@ -23,7 +23,7 @@ import {
   Save,
   Trash2,
 } from "lucide-react";
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useCapabilities } from "../context";
 import { useUpdateSettings } from "../hooks/use-settings-mutations";
 import { useSettingsQuery } from "../hooks/use-settings-query";
@@ -107,8 +107,33 @@ export function SettingsPage({ onClose }: Props) {
     (settings.notifications?.sound as SoundId) ?? "chime",
   );
   const [labels, setLabels] = useState<LabelDefinition[]>(settings.labels ?? []);
-  const [tunnelSubdomain, setTunnelSubdomain] = useState(settings.tunnelSubdomain ?? "");
   const [autoStartTunnel, setAutoStartTunnel] = useState(settings.autoStartTunnel ?? false);
+
+  const isDirty = useMemo(() => {
+    if (worktreesDir !== (settings.worktreesDir ?? "")) return true;
+    const savedDefaults = settings.defaults ? JSON.stringify(settings.defaults, null, 2) : "";
+    if (defaultsJson !== savedDefaults) return true;
+    if (agentType !== (settings.codingAgent?.type ?? "")) return true;
+    if (agentCommand !== (settings.codingAgent?.command ?? "")) return true;
+    if (webServerPort !== (settings.webServerPort?.toString() ?? "")) return true;
+    if (soundOnNeedsAttention !== (settings.notifications?.soundOnNeedsAttention ?? false))
+      return true;
+    if (selectedSound !== ((settings.notifications?.sound as SoundId) ?? "chime")) return true;
+    if (JSON.stringify(labels) !== JSON.stringify(settings.labels ?? [])) return true;
+    if (autoStartTunnel !== (settings.autoStartTunnel ?? false)) return true;
+    return false;
+  }, [
+    worktreesDir,
+    defaultsJson,
+    agentType,
+    agentCommand,
+    webServerPort,
+    soundOnNeedsAttention,
+    selectedSound,
+    labels,
+    autoStartTunnel,
+    settings,
+  ]);
 
   useEffect(() => {
     setWorktreesDir(settings.worktreesDir ?? "");
@@ -119,7 +144,6 @@ export function SettingsPage({ onClose }: Props) {
     setSoundOnNeedsAttention(settings.notifications?.soundOnNeedsAttention ?? false);
     setSelectedSound((settings.notifications?.sound as SoundId) ?? "chime");
     setLabels(settings.labels ?? []);
-    setTunnelSubdomain(settings.tunnelSubdomain ?? "");
     setAutoStartTunnel(settings.autoStartTunnel ?? false);
   }, [
     settings.worktreesDir,
@@ -128,7 +152,6 @@ export function SettingsPage({ onClose }: Props) {
     settings.webServerPort,
     settings.notifications,
     settings.labels,
-    settings.tunnelSubdomain,
     settings.autoStartTunnel,
   ]);
 
@@ -192,7 +215,6 @@ export function SettingsPage({ onClose }: Props) {
       notifications: { soundOnNeedsAttention, sound: selectedSound },
       labels: labels.length > 0 ? labels : undefined,
       tokenSecret: settings.tokenSecret,
-      tunnelSubdomain: tunnelSubdomain.trim() || undefined,
       autoStartTunnel: autoStartTunnel || undefined,
     });
   };
@@ -200,9 +222,7 @@ export function SettingsPage({ onClose }: Props) {
   const worktreesDirPreview = worktreesDir || "Default";
   const agentPreview = agentType ? AGENT_LABEL[agentType] : "None";
   const defaultsPreview = defaultsJson.trim() ? "Configured" : "None";
-  const portPreview = tunnelSubdomain
-    ? `${tunnelSubdomain}.instatunnel.my`
-    : webServerPort || "3456";
+  const portPreview = webServerPort || "3456";
   const labelsPreview =
     labels.length > 0 ? `${labels.length} label${labels.length === 1 ? "" : "s"}` : "None";
   const notificationsPreview = soundOnNeedsAttention
@@ -231,8 +251,12 @@ export function SettingsPage({ onClose }: Props) {
                 size="icon-sm"
                 onClick={handleSave}
                 disabled={section === "defaults" && !!defaultsError}
+                className="relative"
               >
                 <Save className="size-5" />
+                {isDirty && (
+                  <span className="absolute top-0.5 right-0.5 size-2 rounded-full bg-blue-500" />
+                )}
               </Button>
             </TooltipTrigger>
             <TooltipContent>Save</TooltipContent>
@@ -489,20 +513,6 @@ export function SettingsPage({ onClose }: Props) {
               <p className="text-xs text-muted-foreground">
                 Port the web server listens on for mobile access. Leave empty for the default
                 (3456). Requires restart.
-              </p>
-            </div>
-            <div className="space-y-2">
-              <Label htmlFor="tunnel-subdomain">Tunnel subdomain</Label>
-              <Input
-                id="tunnel-subdomain"
-                placeholder="e.g., myapp"
-                value={tunnelSubdomain}
-                onChange={(e) => setTunnelSubdomain(e.target.value)}
-              />
-              <p className="text-xs text-muted-foreground">
-                Fixed subdomain for your tunnel URL (e.g., <code className="text-xs">myapp</code>{" "}
-                becomes <code className="text-xs">myapp.instatunnel.my</code>). Requires instatunnel
-                authentication.
               </p>
             </div>
             <div className="space-y-2">

--- a/packages/dashboard-core/src/lib/service-health.ts
+++ b/packages/dashboard-core/src/lib/service-health.ts
@@ -2,17 +2,12 @@ export interface ServiceHealth {
   webserver: boolean;
   tunnel: boolean;
   tunnel_url: string | null;
-  tunnel_remote_host: string | null;
 }
 
 /**
  * Determine whether the globe button should show as active (green).
- *
- * When a tunnel subdomain is configured, both the web server AND the tunnel
- * must be healthy.  Without a subdomain the web server alone is enough.
+ * Both the web server AND the tunnel must be healthy.
  */
-export function isServiceHealthy(health: ServiceHealth, tunnelSubdomain?: string | null): boolean {
-  if (!health.webserver) return false;
-  if (tunnelSubdomain) return health.tunnel;
-  return true;
+export function isServiceHealthy(health: ServiceHealth): boolean {
+  return health.webserver && health.tunnel;
 }

--- a/packages/dashboard-core/src/lib/sse.ts
+++ b/packages/dashboard-core/src/lib/sse.ts
@@ -1,13 +1,7 @@
 import type { CIStatus, GitStatus, WorkspaceStatus } from "../types";
 
 export type SSEEvent = {
-  kind:
-    | "update"
-    | "remove"
-    | "snapshot"
-    | "branch-status"
-    | "tunnel-url"
-    | "tunnel-error";
+  kind: "update" | "remove" | "snapshot" | "branch-status" | "tunnel-url" | "tunnel-error";
   status?: WorkspaceStatus;
   statuses?: WorkspaceStatus[];
   workspaceId?: string;

--- a/packages/dashboard-core/src/lib/sse.ts
+++ b/packages/dashboard-core/src/lib/sse.ts
@@ -7,9 +7,7 @@ export type SSEEvent = {
     | "snapshot"
     | "branch-status"
     | "tunnel-url"
-    | "tunnel-error"
-    | "tunnel-subdomain-taken"
-    | "tunnel-remote-host";
+    | "tunnel-error";
   status?: WorkspaceStatus;
   statuses?: WorkspaceStatus[];
   workspaceId?: string;
@@ -17,5 +15,4 @@ export type SSEEvent = {
   ci?: CIStatus;
   url?: string;
   error?: string;
-  host?: string;
 };

--- a/packages/dashboard-core/src/types.ts
+++ b/packages/dashboard-core/src/types.ts
@@ -126,7 +126,6 @@ export interface Settings {
   notifications?: NotificationSettings;
   labels?: LabelDefinition[];
   tokenSecret?: string;
-  tunnelSubdomain?: string;
   autoStartTunnel?: boolean;
 }
 


### PR DESCRIPTION
## Summary
- Replace InstaTunnel with cloudflared Quick Tunnels (`cloudflared tunnel --url`) for mobile access, using ephemeral random `*.trycloudflare.com` URLs
- Add crash detection: globe turns red with error tooltip when cloudflared dies, health poll fallback within 30s
- Auto-start tunnel in both production and Vite dev server when `autoStartTunnel` setting is enabled
- Add settings dirty badge (blue dot on Save icon when unsaved changes exist)
- Remove `tunnelSubdomain` setting and all InstaTunnel-specific code (auth check, remote host, subdomain management)

Closes #106

## Test plan
- [x] `tunnel.start` parses URL from cloudflared stderr output
- [x] `tunnel.start` returns URL in mutation response
- [x] `tunnel.start` with cloudflared error returns null URL gracefully
- [x] `services.health` reflects running tunnel with URL
- [x] `services.health` returns tunnel false when no tunnel running
- [x] Tunnel crash detection: cloudflared dies → status/health reflect down state
- [x] Prereqs check returns `cloudflared: boolean`
- [x] Prereqs check returns false when cloudflared not on PATH
- [x] Auth enforcement on all tunnel/service endpoints
- [x] Tunnel stop succeeds even when no tunnel running

🤖 Generated with [Claude Code](https://claude.com/claude-code)