### PR TITLE
feat: file and image preview with fullscreen overlay in chat

### DIFF
--- a/apps/web/src/components/ai-elements/file-preview-overlay.tsx
+++ b/apps/web/src/components/ai-elements/file-preview-overlay.tsx
@@ -1,0 +1,192 @@
+import { cn } from "@band/ui";
+import { Download, X } from "lucide-react";
+import { useCallback, useEffect, useState } from "react";
+import { Dialog as DialogPrimitive } from "radix-ui";
+
+import { detectLanguageFromFilename, downloadFile, isTextMediaType } from "./file-preview-utils";
+import { useSyntaxHighlight, type TokenLine } from "./use-syntax-highlight";
+
+interface FilePreviewOverlayProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  part: {
+    mediaType: string;
+    url: string;
+    filename?: string;
+  };
+}
+
+export function FilePreviewOverlay({ open, onOpenChange, part }: FilePreviewOverlayProps) {
+  const isImage = part.mediaType.startsWith("image/");
+  const isText = isTextMediaType(part.mediaType);
+  const filename = part.filename ?? "file";
+
+  const handleDownload = useCallback(() => {
+    downloadFile(part.url, filename);
+  }, [part.url, filename]);
+
+  return (
+    <DialogPrimitive.Root open={open} onOpenChange={onOpenChange}>
+      <DialogPrimitive.Portal>
+        <DialogPrimitive.Overlay
+          className={cn(
+            "fixed inset-0 z-50 bg-black/80 backdrop-blur-sm",
+            "data-[state=closed]:animate-out data-[state=closed]:fade-out-0",
+            "data-[state=open]:animate-in data-[state=open]:fade-in-0",
+          )}
+        />
+        <DialogPrimitive.Content
+          className={cn(
+            "fixed inset-0 z-50 flex flex-col outline-none",
+            "h-[100dvh] w-screen",
+            "data-[state=closed]:animate-out data-[state=closed]:fade-out-0",
+            "data-[state=open]:animate-in data-[state=open]:fade-in-0",
+          )}
+          aria-describedby={undefined}
+        >
+          {/* Accessible title (hidden) */}
+          <DialogPrimitive.Title className="sr-only">{filename}</DialogPrimitive.Title>
+
+          {/* Top bar */}
+          <div className="flex shrink-0 items-center justify-between px-4 py-3">
+            <span className="min-w-0 truncate font-mono text-sm text-white/90">{filename}</span>
+            <div className="flex items-center gap-1">
+              <button
+                type="button"
+                onClick={handleDownload}
+                className="inline-flex size-9 items-center justify-center rounded-md text-white/70 transition-colors hover:bg-white/10 hover:text-white"
+                aria-label="Download file"
+              >
+                <Download className="size-4" />
+              </button>
+              <DialogPrimitive.Close
+                className="inline-flex size-9 items-center justify-center rounded-md text-white/70 transition-colors hover:bg-white/10 hover:text-white"
+                aria-label="Close preview"
+              >
+                <X className="size-4" />
+              </DialogPrimitive.Close>
+            </div>
+          </div>
+
+          {/* Content area */}
+          <div className="min-h-0 flex-1 overflow-auto">
+            {isImage && <ImagePreview url={part.url} alt={filename} />}
+            {isText && <TextPreview url={part.url} filename={filename} />}
+            {!isImage && !isText && (
+              <div className="flex h-full items-center justify-center text-white/50">
+                <p>Preview not available for this file type</p>
+              </div>
+            )}
+          </div>
+        </DialogPrimitive.Content>
+      </DialogPrimitive.Portal>
+    </DialogPrimitive.Root>
+  );
+}
+
+function ImagePreview({ url, alt }: { url: string; alt: string }) {
+  return (
+    <div className="flex h-full items-center justify-center p-4">
+      <img src={url} alt={alt} className="max-h-full max-w-full object-contain" />
+    </div>
+  );
+}
+
+function TextPreview({ url, filename }: { url: string; filename: string }) {
+  const [content, setContent] = useState<string | null>(null);
+  const [error, setError] = useState(false);
+  const language = detectLanguageFromFilename(filename);
+  const { lines } = useSyntaxHighlight(content, language);
+
+  useEffect(() => {
+    let cancelled = false;
+    fetch(url)
+      .then((res) => res.text())
+      .then((text) => {
+        if (!cancelled) setContent(text);
+      })
+      .catch(() => {
+        if (!cancelled) setError(true);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [url]);
+
+  if (error) {
+    return (
+      <div className="flex h-full items-center justify-center text-white/50">
+        Failed to load file content
+      </div>
+    );
+  }
+
+  if (content === null) {
+    return (
+      <div className="flex h-32 items-center justify-center text-sm text-white/50">Loading…</div>
+    );
+  }
+
+  if (lines) {
+    return <HighlightedCode lines={lines} />;
+  }
+
+  return <PlainCode content={content} />;
+}
+
+function lineNumberWidth(totalLines: number): string {
+  const digits = String(totalLines).length;
+  return `${Math.max(2, digits)}ch`;
+}
+
+function HighlightedCode({ lines }: { lines: TokenLine[] }) {
+  const gutterWidth = lineNumberWidth(lines.length);
+  return (
+    <div className="overflow-x-auto p-4">
+      <pre className="text-xs leading-5">
+        {lines.map((tokens, lineIdx) => (
+          // biome-ignore lint/suspicious/noArrayIndexKey: code lines have no stable id
+          <div key={lineIdx} className="flex">
+            <span
+              className="shrink-0 select-none pr-4 text-right text-white/25"
+              style={{ width: gutterWidth }}
+            >
+              {lineIdx + 1}
+            </span>
+            <span className="flex-1">
+              {tokens.map((token, tIdx) => (
+                // biome-ignore lint/suspicious/noArrayIndexKey: tokens have no stable id
+                <span key={tIdx} style={token.color ? { color: token.color } : undefined}>
+                  {token.content}
+                </span>
+              ))}
+            </span>
+          </div>
+        ))}
+      </pre>
+    </div>
+  );
+}
+
+function PlainCode({ content }: { content: string }) {
+  const lines = content.split("\n");
+  const gutterWidth = lineNumberWidth(lines.length);
+  return (
+    <div className="overflow-x-auto p-4">
+      <pre className="text-xs leading-5 text-white/80">
+        {lines.map((line, lineIdx) => (
+          // biome-ignore lint/suspicious/noArrayIndexKey: code lines have no stable id
+          <div key={lineIdx} className="flex">
+            <span
+              className="shrink-0 select-none pr-4 text-right text-white/25"
+              style={{ width: gutterWidth }}
+            >
+              {lineIdx + 1}
+            </span>
+            <span className="flex-1">{line}</span>
+          </div>
+        ))}
+      </pre>
+    </div>
+  );
+}

--- a/apps/web/src/components/ai-elements/file-preview-overlay.tsx
+++ b/apps/web/src/components/ai-elements/file-preview-overlay.tsx
@@ -1,10 +1,10 @@
 import { cn } from "@band/ui";
 import { Download, X } from "lucide-react";
-import { useCallback, useEffect, useState } from "react";
 import { Dialog as DialogPrimitive } from "radix-ui";
+import { useCallback, useEffect, useState } from "react";
 
 import { detectLanguageFromFilename, downloadFile, isTextMediaType } from "./file-preview-utils";
-import { useSyntaxHighlight, type TokenLine } from "./use-syntax-highlight";
+import { type TokenLine, useSyntaxHighlight } from "./use-syntax-highlight";
 
 interface FilePreviewOverlayProps {
   open: boolean;

--- a/apps/web/src/components/ai-elements/file-preview-utils.ts
+++ b/apps/web/src/components/ai-elements/file-preview-utils.ts
@@ -1,0 +1,50 @@
+import { extensionToLanguage, filenameToLanguage } from "@band/dashboard-core";
+
+/**
+ * Detect the Shiki language identifier from a filename.
+ * Tries filename-based match (e.g. "Dockerfile"), then extension-based.
+ */
+export function detectLanguageFromFilename(filename: string): string {
+  const fromName = filenameToLanguage(filename);
+  if (fromName) return fromName;
+
+  const dot = filename.lastIndexOf(".");
+  if (dot >= 0) {
+    const ext = filename.slice(dot).toLowerCase();
+    const fromExt = extensionToLanguage(ext);
+    if (fromExt) return fromExt;
+  }
+
+  return "plaintext";
+}
+
+const TEXT_APPLICATION_TYPES = new Set([
+  "application/json",
+  "application/xml",
+  "application/javascript",
+  "application/typescript",
+  "application/x-yaml",
+  "application/toml",
+  "application/x-sh",
+]);
+
+/**
+ * Returns true if the MIME type represents a text-based file that can be
+ * syntax-highlighted and displayed as code.
+ */
+export function isTextMediaType(mediaType: string): boolean {
+  if (mediaType.startsWith("text/")) return true;
+  return TEXT_APPLICATION_TYPES.has(mediaType);
+}
+
+/**
+ * Trigger a browser download for a blob or data URL.
+ */
+export function downloadFile(url: string, filename: string): void {
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = filename;
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+}

--- a/apps/web/src/components/ai-elements/message.tsx
+++ b/apps/web/src/components/ai-elements/message.tsx
@@ -121,19 +121,13 @@ export function MessageFilePart({ part }: { part: FilePartData }) {
         <FileIcon className="size-4 shrink-0 text-muted-foreground" />
         <span className="min-w-0 flex-1 truncate text-left text-base">{filename}</span>
         <span className="shrink-0 text-sm text-muted-foreground">{part.mediaType}</span>
-        <span
-          role="button"
-          tabIndex={0}
+        <button
+          type="button"
           onClick={handleDownload}
-          onKeyDown={(e) => {
-            if (e.key === "Enter" || e.key === " ") {
-              handleDownload(e as unknown as React.MouseEvent);
-            }
-          }}
           className="shrink-0 rounded p-1 text-muted-foreground hover:bg-accent hover:text-foreground"
         >
           <Download className="size-3.5" />
-        </span>
+        </button>
       </button>
       {canPreview && (
         <FilePreviewOverlay open={overlayOpen} onOpenChange={setOverlayOpen} part={part} />

--- a/apps/web/src/components/ai-elements/message.tsx
+++ b/apps/web/src/components/ai-elements/message.tsx
@@ -4,10 +4,13 @@ import { code } from "@streamdown/code";
 import { math } from "@streamdown/math";
 import { mermaid } from "@streamdown/mermaid";
 import type { UIMessage } from "ai";
-import { FileIcon } from "lucide-react";
+import { Download, Expand, FileIcon } from "lucide-react";
 import type { ComponentProps, HTMLAttributes } from "react";
-import { memo } from "react";
+import { memo, useCallback, useState } from "react";
 import { Streamdown } from "streamdown";
+
+import { FilePreviewOverlay } from "./file-preview-overlay";
+import { downloadFile, isTextMediaType } from "./file-preview-utils";
 
 export type MessageProps = HTMLAttributes<HTMLDivElement> & {
   from: UIMessage["role"];
@@ -69,19 +72,72 @@ interface FilePartData {
 }
 
 export function MessageFilePart({ part }: { part: FilePartData }) {
+  const [overlayOpen, setOverlayOpen] = useState(false);
   const isImage = part.mediaType.startsWith("image/");
+  const isText = isTextMediaType(part.mediaType);
+  const canPreview = isImage || isText;
+  const filename = part.filename ?? "File";
+
+  const handleDownload = useCallback(
+    (e: React.MouseEvent) => {
+      e.stopPropagation();
+      downloadFile(part.url, filename);
+    },
+    [part.url, filename],
+  );
 
   if (isImage) {
     return (
-      <img src={part.url} alt={part.filename ?? "Uploaded image"} className="max-w-xs rounded-md" />
+      <>
+        <button
+          type="button"
+          onClick={() => setOverlayOpen(true)}
+          className="group/img relative max-w-xs cursor-pointer overflow-hidden rounded-md"
+        >
+          <img
+            src={part.url}
+            alt={filename}
+            className="rounded-md transition-opacity group-hover/img:opacity-90"
+          />
+          <div className="absolute inset-0 flex items-center justify-center bg-black/0 transition-colors group-hover/img:bg-black/20">
+            <Expand className="size-6 text-white opacity-0 drop-shadow-md transition-opacity group-hover/img:opacity-100" />
+          </div>
+        </button>
+        <FilePreviewOverlay open={overlayOpen} onOpenChange={setOverlayOpen} part={part} />
+      </>
     );
   }
 
   return (
-    <div className="flex items-center gap-2 rounded-md border border-border/30 bg-muted/30 px-3 py-2">
-      <FileIcon className="size-4 shrink-0 text-muted-foreground" />
-      <span className="truncate text-base">{part.filename ?? "File"}</span>
-      <span className="text-sm text-muted-foreground">{part.mediaType}</span>
-    </div>
+    <>
+      <button
+        type="button"
+        onClick={() => canPreview && setOverlayOpen(true)}
+        className={cn(
+          "flex max-w-sm items-center gap-2 rounded-md border border-border/30 bg-muted/30 px-3 py-2 transition-colors",
+          canPreview && "cursor-pointer hover:bg-muted/50",
+        )}
+      >
+        <FileIcon className="size-4 shrink-0 text-muted-foreground" />
+        <span className="min-w-0 flex-1 truncate text-left text-base">{filename}</span>
+        <span className="shrink-0 text-sm text-muted-foreground">{part.mediaType}</span>
+        <span
+          role="button"
+          tabIndex={0}
+          onClick={handleDownload}
+          onKeyDown={(e) => {
+            if (e.key === "Enter" || e.key === " ") {
+              handleDownload(e as unknown as React.MouseEvent);
+            }
+          }}
+          className="shrink-0 rounded p-1 text-muted-foreground hover:bg-accent hover:text-foreground"
+        >
+          <Download className="size-3.5" />
+        </span>
+      </button>
+      {canPreview && (
+        <FilePreviewOverlay open={overlayOpen} onOpenChange={setOverlayOpen} part={part} />
+      )}
+    </>
   );
 }

--- a/apps/web/src/components/ai-elements/use-syntax-highlight.ts
+++ b/apps/web/src/components/ai-elements/use-syntax-highlight.ts
@@ -47,9 +47,7 @@ export function useSyntaxHighlight(
         });
         if (!cancelled) {
           setLines(
-            result.tokens.map((line) =>
-              line.map((t) => ({ content: t.content, color: t.color })),
-            ),
+            result.tokens.map((line) => line.map((t) => ({ content: t.content, color: t.color }))),
           );
         }
       } catch {

--- a/apps/web/src/components/ai-elements/use-syntax-highlight.ts
+++ b/apps/web/src/components/ai-elements/use-syntax-highlight.ts
@@ -1,0 +1,68 @@
+import { useEffect, useState } from "react";
+
+export interface TokenSpan {
+  content: string;
+  color?: string;
+}
+
+export type TokenLine = TokenSpan[];
+
+let shikiPromise: Promise<typeof import("shiki")> | null = null;
+
+function getShiki() {
+  if (!shikiPromise) {
+    shikiPromise = import("shiki");
+  }
+  return shikiPromise;
+}
+
+/**
+ * Lazily loads Shiki and syntax-highlights the given content.
+ * Returns tokenized lines for rendering, or null while loading / on failure.
+ */
+export function useSyntaxHighlight(
+  content: string | null,
+  language: string,
+): { lines: TokenLine[] | null; loading: boolean } {
+  const [lines, setLines] = useState<TokenLine[] | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    if (!content) {
+      setLines(null);
+      return;
+    }
+
+    let cancelled = false;
+    setLoading(true);
+
+    (async () => {
+      try {
+        const shiki = await getShiki();
+        const result = await shiki.codeToTokens(content, {
+          lang: language as Parameters<typeof shiki.codeToTokens>[1] extends { lang: infer L }
+            ? L
+            : never,
+          theme: "github-dark",
+        });
+        if (!cancelled) {
+          setLines(
+            result.tokens.map((line) =>
+              line.map((t) => ({ content: t.content, color: t.color })),
+            ),
+          );
+        }
+      } catch {
+        // Fall back — lines stays null, caller renders plain text
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [content, language]);
+
+  return { lines, loading };
+}

--- a/packages/dashboard-core/src/index.ts
+++ b/packages/dashboard-core/src/index.ts
@@ -36,8 +36,8 @@ export {
   useBranchStatusWatcher,
   useStatusWatcher,
 } from "./hooks/use-status";
-export { isServiceHealthy, type ServiceHealth } from "./lib/service-health";
 export { extensionToLanguage, filenameToLanguage } from "./lib/language-map";
+export { isServiceHealthy, type ServiceHealth } from "./lib/service-health";
 // Lib
 export { playSound, SOUNDS, type SoundId } from "./lib/sounds";
 export type { SSEEvent } from "./lib/sse";

--- a/packages/dashboard-core/src/index.ts
+++ b/packages/dashboard-core/src/index.ts
@@ -37,6 +37,7 @@ export {
   useStatusWatcher,
 } from "./hooks/use-status";
 export { isServiceHealthy, type ServiceHealth } from "./lib/service-health";
+export { extensionToLanguage, filenameToLanguage } from "./lib/language-map";
 // Lib
 export { playSound, SOUNDS, type SoundId } from "./lib/sounds";
 export type { SSEEvent } from "./lib/sse";


### PR DESCRIPTION
## Summary
- Add inline image thumbnails in chat messages with hover expand overlay; clicking opens a fullscreen view
- Add clickable text file chips with syntax highlighting (Shiki) that expand to a fullscreen code viewer with line numbers
- Add download button on all file attachments (images, text, binary)
- Fullscreen overlay dismisses with Escape key or clicking outside, uses `100dvh` for mobile PWA support

Closes #113

## Test plan
- [ ] Send an image in chat → verify inline thumbnail with hover expand icon
- [ ] Click image → fullscreen overlay with full-res image, download button, close button
- [ ] Send a text file (.ts, .json, .py) → verify clickable chip with download icon
- [ ] Click text file chip → fullscreen overlay with syntax-highlighted code and line numbers
- [ ] Send a binary file → verify chip with download button only
- [ ] Press Escape / click outside overlay → dismisses
- [ ] Test on mobile viewport (Chrome DevTools responsive mode)
- [ ] Run `pnpm --filter @band/web build` → no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)