### PR TITLE
Fix diff overflow, add change summary header and badge

### DIFF
--- a/apps/web/src/routes/chat.$workspaceId.tsx
+++ b/apps/web/src/routes/chat.$workspaceId.tsx
@@ -41,6 +41,7 @@ function ChatPage() {
   const [initialSessionId, setInitialSessionId] = useState<string | undefined>(undefined);
   const [showSessionList, setShowSessionList] = useState(false);
   const [activeTab, setActiveTab] = useState<WorkspaceTab>("chat");
+  const [diffFileCount, setDiffFileCount] = useState(0);
   const isTasksWindow = useRef<boolean | null>(null);
   const navigate = useNavigate();
   const appHeight = useAppHeight();
@@ -83,6 +84,24 @@ function ChatPage() {
     };
   }, [decoded]);
 
+  useEffect(() => {
+    let cancelled = false;
+    const fetchCount = () => {
+      trpc.workspace.getDiff
+        .query({ workspaceId: decoded })
+        .then((result) => {
+          if (!cancelled) setDiffFileCount(result.stats?.filesChanged ?? 0);
+        })
+        .catch(() => {});
+    };
+    fetchCount();
+    const interval = setInterval(fetchCount, 15_000);
+    return () => {
+      cancelled = true;
+      clearInterval(interval);
+    };
+  }, [decoded]);
+
   const handleToggleSessionList = useCallback(() => {
     setShowSessionList((prev) => !prev);
   }, []);
@@ -113,7 +132,11 @@ function ChatPage() {
           </button>
         )}
       </header>
-      <WorkspaceTabNav activeTab={activeTab} onTabChange={setActiveTab} />
+      <WorkspaceTabNav
+        activeTab={activeTab}
+        onTabChange={setActiveTab}
+        diffFileCount={diffFileCount}
+      />
       <main className="flex min-h-0 flex-1 flex-col">
         <div className={activeTab === "chat" ? "flex min-h-0 flex-1 flex-col" : "hidden"}>
           <ChatView
@@ -127,7 +150,7 @@ function ChatPage() {
         </div>
         <DashboardProvider adapter={adapter} capabilities={capabilities}>
           <div className={activeTab === "diff" ? "min-h-0 flex-1" : "hidden"}>
-            <DiffView workspaceId={decoded} />
+            <DiffView workspaceId={decoded} active={activeTab === "diff"} />
           </div>
           <div className={activeTab === "code" ? "min-h-0 flex-1" : "hidden"}>
             <CodeBrowserView workspaceId={decoded} />

--- a/packages/dashboard-core/src/components/DiffView.tsx
+++ b/packages/dashboard-core/src/components/DiffView.tsx
@@ -5,6 +5,7 @@ import type { FileStatus, WorkspaceDiff } from "../types";
 
 interface DiffViewProps {
   workspaceId: string;
+  active?: boolean;
 }
 
 interface ParsedFile {
@@ -180,8 +181,8 @@ function DiffFileContent({ hunks, filename }: { hunks: string; filename: string 
     highlighted ?? diffLines.map((l) => ({ type: l.type, tokens: [{ content: l.text }] }));
 
   return (
-    <div className="overflow-x-auto">
-      <pre className="text-xs leading-5">
+    <pre className="overflow-x-auto text-xs leading-5">
+      <code className="block w-max min-w-full">
         {lines.map((line, lineIdx) => (
           <div
             // biome-ignore lint/suspicious/noArrayIndexKey: diff lines have no stable id
@@ -209,12 +210,12 @@ function DiffFileContent({ hunks, filename }: { hunks: string; filename: string 
                 ))}
           </div>
         ))}
-      </pre>
-    </div>
+      </code>
+    </pre>
   );
 }
 
-export function DiffView({ workspaceId }: DiffViewProps) {
+export function DiffView({ workspaceId, active = true }: DiffViewProps) {
   const adapter = useAdapter();
   const [data, setData] = useState<WorkspaceDiff | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -229,21 +230,31 @@ export function DiffView({ workspaceId }: DiffViewProps) {
     }
 
     let cancelled = false;
-    adapter
-      .getWorkspaceDiff(workspaceId)
-      .then((result) => {
-        if (!cancelled) setData(result);
-      })
-      .catch((err) => {
-        if (!cancelled) setError(err instanceof Error ? err.message : "Failed to load diff");
-      })
-      .finally(() => {
-        if (!cancelled) setLoading(false);
-      });
+    const fetchDiff = () => {
+      adapter
+        .getWorkspaceDiff(workspaceId)
+        .then((result) => {
+          if (!cancelled) {
+            setData(result);
+            setError(null);
+          }
+        })
+        .catch((err) => {
+          if (!cancelled) setError(err instanceof Error ? err.message : "Failed to load diff");
+        })
+        .finally(() => {
+          if (!cancelled) setLoading(false);
+        });
+    };
+
+    fetchDiff();
+    const interval = active ? setInterval(fetchDiff, 15_000) : undefined;
+
     return () => {
       cancelled = true;
+      if (interval) clearInterval(interval);
     };
-  }, [adapter, workspaceId]);
+  }, [adapter, workspaceId, active]);
 
   if (loading) {
     return (
@@ -284,6 +295,18 @@ export function DiffView({ workspaceId }: DiffViewProps) {
     });
   };
 
+  const navigateToFile = (filename: string) => {
+    setOpenFiles((prev) => {
+      const next = new Set(prev);
+      next.add(filename);
+      return next;
+    });
+    setTimeout(() => {
+      const el = document.getElementById(`diff-file-${encodeURIComponent(filename)}`);
+      el?.scrollIntoView({ behavior: "smooth", block: "start" });
+    }, 0);
+  };
+
   return (
     <div className="flex h-full flex-col overflow-hidden">
       <div className="shrink-0 border-b border-border/50 px-4 py-3">
@@ -297,15 +320,32 @@ export function DiffView({ workspaceId }: DiffViewProps) {
             <span className="ml-1 text-red-400">-{data.stats.deletions}</span>
           )}
         </div>
-        <div className="mt-1 text-sm text-muted-foreground">
+        <div className="mt-1 text-xs text-muted-foreground">
           {data.baseBranch} ← {data.headBranch}
+        </div>
+        <div className="mt-2 flex max-h-28 flex-col gap-0.5 overflow-y-auto">
+          {files.map((file) => (
+            <button
+              key={file.filename}
+              type="button"
+              onClick={() => navigateToFile(file.filename)}
+              className="flex items-center gap-1.5 rounded px-1 py-0.5 text-left text-xs hover:bg-accent/50"
+            >
+              <FileStatusBadge status={fileStatuses[file.filename]} />
+              <span className="truncate font-mono text-muted-foreground">{file.filename}</span>
+            </button>
+          ))}
         </div>
       </div>
       <div className="min-h-0 flex-1 overflow-y-auto">
         {files.map((file) => {
           const isOpen = openFiles.has(file.filename);
           return (
-            <div key={file.filename} className="border-b border-border/30">
+            <div
+              key={file.filename}
+              id={`diff-file-${encodeURIComponent(file.filename)}`}
+              className="border-b border-border/30"
+            >
               <button
                 type="button"
                 onClick={() => toggleFile(file.filename)}

--- a/packages/dashboard-core/src/components/WorkspaceTabNav.tsx
+++ b/packages/dashboard-core/src/components/WorkspaceTabNav.tsx
@@ -5,6 +5,7 @@ export type WorkspaceTab = "chat" | "diff" | "code";
 interface WorkspaceTabNavProps {
   activeTab: WorkspaceTab;
   onTabChange: (tab: WorkspaceTab) => void;
+  diffFileCount?: number;
 }
 
 const tabs: { id: WorkspaceTab; label: string; icon: typeof MessageSquare }[] = [
@@ -13,12 +14,13 @@ const tabs: { id: WorkspaceTab; label: string; icon: typeof MessageSquare }[] = 
   { id: "code", label: "Code", icon: Code },
 ];
 
-export function WorkspaceTabNav({ activeTab, onTabChange }: WorkspaceTabNavProps) {
+export function WorkspaceTabNav({ activeTab, onTabChange, diffFileCount }: WorkspaceTabNavProps) {
   return (
     <div className="flex shrink-0 border-b border-border">
       {tabs.map((tab) => {
         const Icon = tab.icon;
         const isActive = activeTab === tab.id;
+        const badge = tab.id === "diff" && diffFileCount != null && diffFileCount > 0;
         return (
           <button
             key={tab.id}
@@ -32,6 +34,11 @@ export function WorkspaceTabNav({ activeTab, onTabChange }: WorkspaceTabNavProps
           >
             <Icon className="size-4" />
             {tab.label}
+            {badge && (
+              <span className="inline-flex h-5 min-w-5 items-center justify-center rounded-full bg-muted px-1.5 text-xs font-medium">
+                {diffFileCount}
+              </span>
+            )}
           </button>
         );
       })}


### PR DESCRIPTION
## Summary
- Fix code block horizontal overflow in Changes tab — long lines now scroll horizontally within their container (like GitHub diffs) instead of overflowing
- Add change summary header with clickable file navigation list and status badges, with smooth scroll-to-file
- Add file count badge on the Changes tab label showing number of modified files
- Add 15s polling for both badge count and diff view, with active/inactive awareness

## Test plan
- [ ] Open a workspace with changes and verify the Changes tab badge shows the file count
- [ ] Switch to Changes tab and verify the header shows stats, branch info, and clickable file list
- [ ] Click a filename in the header and verify it expands and scrolls to the file
- [ ] Expand a file with long lines and verify horizontal scrolling works without overflow
- [ ] Make changes in the Chat tab and verify the Changes tab updates within ~15s without page refresh

Closes #114

🤖 Generated with [Claude Code](https://claude.com/claude-code)