### PR TITLE
feat: support slash commands in web chat

### DIFF
--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -20,6 +20,7 @@ import {
   PromptInputSubmit,
   PromptInputTextarea,
 } from "./ai-elements/prompt-input";
+import { SlashCommandSuggestions } from "./ai-elements/slash-command-suggestions";
 import { TaskListWidget } from "./ai-elements/task-list-widget";
 import { applyTaskToolCall, isTaskTool, type TaskMap } from "./ai-elements/task-state";
 import type { ToolPart } from "./ai-elements/tool";
@@ -102,6 +103,16 @@ export function ChatView({
   const [historicalMessages, setHistoricalMessages] = useState<HistoryMessage[]>([]);
   const [loadingHistory, setLoadingHistory] = useState(false);
   const initialSessionLoadedRef = useRef(false);
+
+  const [skills, setSkills] = useState<
+    { name: string; description: string; argumentHint?: string }[]
+  >([]);
+  useEffect(() => {
+    trpc.skills.list
+      .query({ workspaceId })
+      .then((data) => setSkills(data.skills))
+      .catch(() => setSkills([]));
+  }, [workspaceId]);
 
   const transport = useMemo(
     () => new TaskChatTransport(workspaceId, () => sessionIdRef.current),
@@ -285,22 +296,6 @@ export function ChatView({
               return (
                 <Message key={message.id} from={message.role}>
                   <MessageContent>
-                    {message.role === "user" &&
-                      message.parts.map((part, partIdx) =>
-                        part.type === "file" ? (
-                          <MessageFilePart
-                            key={`${message.id}-file-${part.filename ?? partIdx}`}
-                            part={
-                              part as {
-                                type: "file";
-                                mediaType: string;
-                                url: string;
-                                filename?: string;
-                              }
-                            }
-                          />
-                        ) : null,
-                      )}
                     {groupMessageParts(message.parts).map((segment) => {
                       if (segment.type === "text") {
                         const { part, partIndex } = segment;
@@ -352,6 +347,7 @@ export function ChatView({
 
       <div className="mx-auto w-full max-w-3xl shrink-0 px-4 pt-2 pb-[max(1rem,env(safe-area-inset-bottom))]">
         <PromptInput onSubmit={handleSubmit}>
+          <SlashCommandSuggestions skills={skills} />
           <PromptInputTextarea placeholder="Type a message..." />
           <PromptInputActions>
             <PromptInputAttach />
@@ -391,6 +387,41 @@ function buildHistoryTaskMap(
     }
   }
   return { taskMap: map, taskToolCallIds };
+}
+
+const IMAGE_EXTENSIONS = new Set([".png", ".jpg", ".jpeg", ".gif", ".webp"]);
+
+/**
+ * Parse the "I'm sharing these files with you:" prefix that the backend
+ * prepends to prompts with file attachments.  Returns the display text
+ * (without the prefix) and an array of file-part objects for rendering.
+ */
+function parseSharedFiles(text: string): {
+  displayText: string;
+  files: { type: "file"; mediaType: string; url: string; filename: string }[];
+} {
+  const match = text.match(/^I'm sharing these files with you:\n((?:- .+\n)+)\n([\s\S]*)$/);
+  if (!match) return { displayText: text, files: [] };
+
+  const fileLines = match[1].trim().split("\n");
+  const displayText = match[2].trim();
+
+  const files = fileLines.map((line) => {
+    const filePath = line.replace(/^- /, "").trim();
+    const filename = filePath.split("/").pop() ?? filePath;
+    const ext = filename.includes(".") ? `.${filename.split(".").pop()!.toLowerCase()}` : "";
+    const isImage = IMAGE_EXTENSIONS.has(ext);
+    return {
+      type: "file" as const,
+      mediaType: isImage
+        ? `image/${ext.slice(1).replace("jpg", "jpeg")}`
+        : "application/octet-stream",
+      url: `/api/uploads/${encodeURIComponent(filename)}`,
+      filename,
+    };
+  });
+
+  return { displayText, files };
 }
 
 function HistoryMessages({ messages }: { messages: HistoryMessage[] }) {
@@ -442,10 +473,14 @@ function HistoryMessageView({
   if (message.role === "user") {
     const userText = textBlocks.map((b) => b.text).join("\n");
     if (!userText) return null;
+    const { displayText, files } = parseSharedFiles(userText);
     return (
       <Message from="user">
         <MessageContent>
-          <MessageResponse>{userText}</MessageResponse>
+          {files.map((file) => (
+            <MessageFilePart key={file.url} part={file} />
+          ))}
+          {displayText && <MessageResponse>{displayText}</MessageResponse>}
         </MessageContent>
       </Message>
     );

--- a/apps/web/src/components/ai-elements/prompt-input.tsx
+++ b/apps/web/src/components/ai-elements/prompt-input.tsx
@@ -8,6 +8,8 @@ import type {
   FormEventHandler,
   HTMLAttributes,
   KeyboardEventHandler,
+  ReactNode,
+  RefObject,
 } from "react";
 import { createContext, useCallback, useContext, useRef, useState } from "react";
 
@@ -47,9 +49,12 @@ export type PromptInputProps = Omit<HTMLAttributes<HTMLFormElement>, "onSubmit">
 
 export const PromptInput = ({ className, onSubmit, children, ...props }: PromptInputProps) => {
   const formRef = useRef<HTMLFormElement | null>(null);
+  const textareaRef = useRef<HTMLTextAreaElement | null>(null);
   const [fileEntries, setFileEntries] = useState<FileEntry[]>([]);
   const [isDragging, setIsDragging] = useState(false);
   const [hasText, setHasText] = useState(false);
+  const [inputValue, setInputValue] = useState("");
+  const [commandHint, setCommandHint] = useState<string | null>(null);
 
   const addFiles = useCallback((newFiles: FileList | File[]) => {
     const valid = Array.from(newFiles).filter((f) => f.size <= MAX_FILE_SIZE);
@@ -72,6 +77,8 @@ export const PromptInput = ({ className, onSubmit, children, ...props }: PromptI
       onSubmit({ text, files: files.length > 0 ? files : undefined }, event);
       setFileEntries([]);
       setHasText(false);
+      setInputValue("");
+      setCommandHint(null);
     },
     [onSubmit, fileEntries],
   );
@@ -110,10 +117,30 @@ export const PromptInput = ({ className, onSubmit, children, ...props }: PromptI
     [addFiles],
   );
 
+  const handleInputChange = useCallback((value: string) => {
+    setInputValue(value);
+    setHasText(value.trim().length > 0);
+  }, []);
+
+  const setTextareaValue = useCallback((value: string) => {
+    const textarea = textareaRef.current;
+    if (!textarea) return;
+    // Use native setter to trigger React's synthetic event system
+    const nativeSetter = Object.getOwnPropertyDescriptor(
+      HTMLTextAreaElement.prototype,
+      "value",
+    )?.set;
+    nativeSetter?.call(textarea, value);
+    textarea.dispatchEvent(new Event("input", { bubbles: true }));
+    textarea.focus();
+    // Move cursor to end
+    textarea.selectionStart = textarea.selectionEnd = value.length;
+  }, []);
+
   return (
     <form
       className={cn(
-        "flex w-full flex-col rounded-md border border-border/50 bg-card p-2",
+        "relative flex w-full flex-col rounded-md border border-border/50 bg-card p-2",
         isDragging && "border-primary/50 bg-primary/5",
         className,
       )}
@@ -130,7 +157,12 @@ export const PromptInput = ({ className, onSubmit, children, ...props }: PromptI
         value={{
           addFiles,
           hasContent: hasText || fileEntries.length > 0,
-          onTextChange: setHasText,
+          onTextChange: handleInputChange,
+          inputValue,
+          textareaRef,
+          setTextareaValue,
+          commandHint,
+          setCommandHint,
         }}
       >
         {children}
@@ -139,15 +171,31 @@ export const PromptInput = ({ className, onSubmit, children, ...props }: PromptI
   );
 };
 
-const PromptInputContext = createContext<{
+interface PromptInputContextValue {
   addFiles: (files: FileList | File[]) => void;
   hasContent: boolean;
   onTextChange: (hasText: boolean) => void;
-}>({
+  inputValue: string;
+  textareaRef: RefObject<HTMLTextAreaElement | null>;
+  setTextareaValue: (value: string) => void;
+  commandHint: string | null;
+  setCommandHint: (hint: string | null) => void;
+}
+
+const PromptInputContext = createContext<PromptInputContextValue>({
   addFiles: () => {},
   hasContent: false,
   onTextChange: () => {},
+  inputValue: "",
+  textareaRef: { current: null },
+  setTextareaValue: () => {},
+  commandHint: null,
+  setCommandHint: () => {},
 });
+
+export function usePromptInputContext() {
+  return useContext(PromptInputContext);
+}
 
 // File preview chips
 function PromptInputFiles({
@@ -252,13 +300,63 @@ export type PromptInputTextareaProps = HTMLAttributes<HTMLTextAreaElement> & {
   disabled?: boolean;
 };
 
+/**
+ * Build highlighted segments from the input text, colouring any
+ * `/<command>` token blue. A command token is a `/` at position 0 or
+ * preceded by whitespace, followed by word-chars / colons / dots / hyphens.
+ */
+function highlightSlashCommands(text: string): ReactNode[] {
+  const segments: ReactNode[] = [];
+  const regex = /(?:^|\s)(\/[\w:.+-]+)/g;
+  let lastIndex = 0;
+  let match = regex.exec(text);
+
+  while (match !== null) {
+    const commandStr = match[1]; // the /command part
+    const commandStart = match.index + match[0].length - commandStr.length;
+
+    // Plain text before the command
+    if (commandStart > lastIndex) {
+      segments.push(text.slice(lastIndex, commandStart));
+    }
+
+    // Command in blue
+    segments.push(
+      <span key={commandStart} className="text-blue-400">
+        {commandStr}
+      </span>,
+    );
+    lastIndex = commandStart + commandStr.length;
+    match = regex.exec(text);
+  }
+
+  // Remaining plain text
+  if (lastIndex < text.length) {
+    segments.push(text.slice(lastIndex));
+  }
+
+  return segments;
+}
+
+/**
+ * Detect whether the ghost argument-hint should be shown.
+ * The hint appears when a slash command token is followed by exactly one
+ * trailing space with nothing typed after it — works for mid-text commands
+ * too (e.g. "please /band:start ").
+ */
+function shouldShowGhostHint(inputValue: string, commandHint: string | null): boolean {
+  if (!commandHint) return false;
+  // Match a command token (at start or after space) followed by a single trailing space
+  return /(?:^|\s)\/[\w:.+-]+ $/.test(inputValue);
+}
+
 export const PromptInputTextarea = ({
   className,
   placeholder = "Type a message...",
   ...props
 }: PromptInputTextareaProps) => {
   const [isComposing, setIsComposing] = useState(false);
-  const { onTextChange } = useContext(PromptInputContext);
+  const { onTextChange, textareaRef, commandHint, inputValue } = useContext(PromptInputContext);
 
   const handleKeyDown: KeyboardEventHandler<HTMLTextAreaElement> = useCallback(
     (e) => {
@@ -272,23 +370,39 @@ export const PromptInputTextarea = ({
     [isComposing],
   );
 
+  const hasSlashCommand = inputValue.includes("/");
+  const showGhostHint = shouldShowGhostHint(inputValue, commandHint);
+
   return (
-    <textarea
-      autoComplete="off"
-      autoCorrect="off"
-      spellCheck={false}
-      className={cn(
-        "min-h-[44px] max-h-48 w-full resize-none bg-transparent px-2 py-2.5 text-base outline-none placeholder:text-muted-foreground field-sizing-content",
-        className,
+    <div className="relative">
+      <textarea
+        ref={textareaRef}
+        autoComplete="off"
+        autoCorrect="off"
+        spellCheck={false}
+        className={cn(
+          "min-h-[44px] max-h-48 w-full resize-none bg-transparent px-2 py-2.5 text-base outline-none placeholder:text-muted-foreground field-sizing-content",
+          hasSlashCommand && "text-transparent caret-foreground",
+          className,
+        )}
+        name="message"
+        onCompositionEnd={() => setIsComposing(false)}
+        onCompositionStart={() => setIsComposing(true)}
+        onInput={(e) => onTextChange(e.currentTarget.value)}
+        onKeyDown={handleKeyDown}
+        placeholder={placeholder}
+        {...props}
+      />
+      {hasSlashCommand && (
+        <div
+          className="pointer-events-none absolute top-0 left-0 min-h-[44px] w-full whitespace-pre-wrap break-words px-2 py-2.5 text-base text-foreground"
+          aria-hidden
+        >
+          {highlightSlashCommands(inputValue)}
+          {showGhostHint && <span className="text-muted-foreground/50">{commandHint}</span>}
+        </div>
       )}
-      name="message"
-      onCompositionEnd={() => setIsComposing(false)}
-      onCompositionStart={() => setIsComposing(true)}
-      onInput={(e) => onTextChange(e.currentTarget.value.trim().length > 0)}
-      onKeyDown={handleKeyDown}
-      placeholder={placeholder}
-      {...props}
-    />
+    </div>
   );
 };
 

--- a/apps/web/src/components/ai-elements/slash-command-suggestions.tsx
+++ b/apps/web/src/components/ai-elements/slash-command-suggestions.tsx
@@ -1,0 +1,175 @@
+import { cn } from "@band/ui";
+import { Command as CommandIcon } from "lucide-react";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { usePromptInputContext } from "./prompt-input";
+
+export interface SlashCommandSkill {
+  name: string;
+  description: string;
+  argumentHint?: string;
+}
+
+interface SlashCommandSuggestionsProps {
+  skills: SlashCommandSkill[];
+}
+
+/**
+ * Find the slash-command token being typed. The command can appear anywhere
+ * in the text — at the beginning or after a space.
+ *
+ * Returns `{ prefix, query }` where:
+ *   - `prefix` is everything before the `/`
+ *   - `query` is the partial command name (without the `/`)
+ *
+ * Returns `null` when no command is being typed (e.g. cursor past a space
+ * after the command, or no `/` present).
+ */
+function getCommandContext(inputValue: string): { prefix: string; query: string } | null {
+  // Find the last `/` that is at position 0 or preceded by whitespace
+  for (let i = inputValue.length - 1; i >= 0; i--) {
+    if (inputValue[i] === "/") {
+      if (i === 0 || /\s/.test(inputValue[i - 1])) {
+        const afterSlash = inputValue.slice(i + 1);
+        // Still typing the command name — no spaces after the slash
+        if (/\s/.test(afterSlash)) return null;
+        return { prefix: inputValue.slice(0, i), query: afterSlash };
+      }
+    }
+  }
+  return null;
+}
+
+/**
+ * Filter skills by fuzzy-matching against the partial command name.
+ */
+function filterSkills(skills: SlashCommandSkill[], query: string): SlashCommandSkill[] {
+  if (!query) return skills;
+  const lower = query.toLowerCase();
+  return skills.filter(
+    (skill) =>
+      skill.name.toLowerCase().includes(lower) || skill.description.toLowerCase().includes(lower),
+  );
+}
+
+export function SlashCommandSuggestions({ skills }: SlashCommandSuggestionsProps) {
+  const { inputValue, setTextareaValue, setCommandHint } = usePromptInputContext();
+  const [selectedIndex, setSelectedIndex] = useState(0);
+  const listRef = useRef<HTMLDivElement>(null);
+
+  const ctx = skills.length > 0 ? getCommandContext(inputValue) : null;
+  const isOpen = ctx !== null;
+  const query = ctx?.query ?? "";
+  const filteredSkills = isOpen ? filterSkills(skills, query) : [];
+  const hasResults = filteredSkills.length > 0;
+
+  // Reset selection when query changes
+  // biome-ignore lint/correctness/useExhaustiveDependencies: query is the intentional trigger
+  useEffect(() => {
+    setSelectedIndex(0);
+  }, [query]);
+
+  // Scroll selected item into view
+  useEffect(() => {
+    if (!isOpen || !listRef.current) return;
+    const items = listRef.current.querySelectorAll("[data-slash-item]");
+    items[selectedIndex]?.scrollIntoView({ block: "nearest" });
+  }, [selectedIndex, isOpen]);
+
+  const handleSelect = useCallback(
+    (skill: SlashCommandSkill) => {
+      const current = getCommandContext(inputValue);
+      const prefix = current?.prefix ?? "";
+      setTextareaValue(`${prefix}/${skill.name} `);
+      setCommandHint(skill.argumentHint ?? null);
+    },
+    [inputValue, setTextareaValue, setCommandHint],
+  );
+
+  // Intercept keyboard events on the textarea for navigation
+  useEffect(() => {
+    if (!isOpen || !hasResults) return;
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "ArrowDown") {
+        e.preventDefault();
+        setSelectedIndex((prev) => (prev + 1) % filteredSkills.length);
+      } else if (e.key === "ArrowUp") {
+        e.preventDefault();
+        setSelectedIndex((prev) => (prev - 1 + filteredSkills.length) % filteredSkills.length);
+      } else if (e.key === "Enter" && !e.shiftKey) {
+        e.preventDefault();
+        e.stopPropagation();
+        handleSelect(filteredSkills[selectedIndex]);
+      } else if (e.key === "Escape") {
+        e.preventDefault();
+        setTextareaValue("");
+        setCommandHint(null);
+      } else if (e.key === "Tab") {
+        e.preventDefault();
+        handleSelect(filteredSkills[selectedIndex]);
+      }
+    };
+
+    // Use capture phase to intercept before the textarea's own handler
+    document.addEventListener("keydown", handleKeyDown, true);
+    return () => document.removeEventListener("keydown", handleKeyDown, true);
+  }, [
+    isOpen,
+    hasResults,
+    filteredSkills,
+    selectedIndex,
+    handleSelect,
+    setTextareaValue,
+    setCommandHint,
+  ]);
+
+  if (!isOpen || !hasResults) return null;
+
+  return (
+    <div className="absolute right-0 bottom-full left-0 z-50 mb-1 px-0">
+      <div
+        ref={listRef}
+        className="max-h-[280px] overflow-y-auto rounded-md border border-border/50 bg-popover p-1 shadow-md"
+        role="listbox"
+        aria-label="Slash commands"
+      >
+        {filteredSkills.map((skill, index) => (
+          <button
+            key={skill.name}
+            type="button"
+            role="option"
+            aria-selected={index === selectedIndex}
+            data-slash-item
+            className={cn(
+              "flex w-full cursor-pointer items-start gap-3 rounded-sm px-3 py-2 text-left text-sm outline-none transition-colors",
+              index === selectedIndex
+                ? "bg-accent text-accent-foreground"
+                : "text-popover-foreground hover:bg-accent/50",
+            )}
+            onMouseEnter={() => setSelectedIndex(index)}
+            onMouseDown={(e) => {
+              // Prevent textarea blur
+              e.preventDefault();
+              handleSelect(skill);
+            }}
+          >
+            <CommandIcon className="mt-0.5 size-4 shrink-0 text-muted-foreground" />
+            <div className="min-w-0 flex-1">
+              <div className="flex items-baseline gap-2">
+                <span className="font-medium">/{skill.name}</span>
+                {skill.argumentHint && (
+                  <span className="truncate text-xs text-muted-foreground">
+                    {skill.argumentHint}
+                  </span>
+                )}
+              </div>
+              <p className="mt-0.5 line-clamp-1 text-xs text-muted-foreground">
+                {skill.description}
+              </p>
+            </div>
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/trpc/router.ts
+++ b/apps/web/src/trpc/router.ts
@@ -1268,6 +1268,27 @@ const cronjobsRouter = t.router({
 });
 
 // ---------------------------------------------------------------------------
+// Skills
+// ---------------------------------------------------------------------------
+
+const skillsRouter = t.router({
+  list: publicProcedure.input(z.object({ workspaceId: z.string() })).query(async ({ input }) => {
+    const workspace = resolveWorkspace(input.workspaceId);
+    if (!workspace) {
+      return { skills: [] };
+    }
+
+    const agent = await getOrCreateAgent(input.workspaceId, workspace.worktree.path);
+    if (agent.listSkills) {
+      const skills = await agent.listSkills();
+      return { skills };
+    }
+
+    return { skills: [] };
+  }),
+});
+
+// ---------------------------------------------------------------------------
 // App Router
 // ---------------------------------------------------------------------------
 
@@ -1287,6 +1308,7 @@ export const appRouter = t.router({
   statuses: statusesRouter,
   status: statusRouter,
   cronjobs: cronjobsRouter,
+  skills: skillsRouter,
 });
 
 export type AppRouter = typeof appRouter;

--- a/apps/web/start-server.ts
+++ b/apps/web/start-server.ts
@@ -1,6 +1,6 @@
-import { appendFileSync } from "node:fs";
+import { appendFileSync, createReadStream, statSync } from "node:fs";
 import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
-import { join } from "node:path";
+import { basename, extname, join } from "node:path";
 import { fetchRequestHandler } from "@trpc/server/adapters/fetch";
 import sirv from "sirv";
 import { createAuthMiddleware } from "./auth.ts";
@@ -68,6 +68,44 @@ async function main() {
   const httpServer = createServer(async (req: IncomingMessage, res: ServerResponse) => {
     // Auth check runs first
     if (handleAuth(req, res)) return;
+
+    // Serve uploaded files (images, attachments)
+    if (req.url?.startsWith("/api/uploads/")) {
+      const filename = basename(decodeURIComponent(req.url.slice("/api/uploads/".length)));
+      if (!filename || filename.includes("..")) {
+        res.writeHead(400);
+        res.end("Bad request");
+        return;
+      }
+      const filePath = join(bandHome(), "uploads", filename);
+      try {
+        const fileStat = statSync(filePath);
+        const ext = extname(filename).toLowerCase();
+        const mimeTypes: Record<string, string> = {
+          ".png": "image/png",
+          ".jpg": "image/jpeg",
+          ".jpeg": "image/jpeg",
+          ".gif": "image/gif",
+          ".webp": "image/webp",
+          ".pdf": "application/pdf",
+          ".json": "application/json",
+          ".txt": "text/plain",
+          ".md": "text/markdown",
+          ".csv": "text/csv",
+        };
+        const contentType = mimeTypes[ext] || "application/octet-stream";
+        res.writeHead(200, {
+          "Content-Type": contentType,
+          "Content-Length": fileStat.size.toString(),
+          "Cache-Control": "private, max-age=86400",
+        });
+        createReadStream(filePath).pipe(res);
+      } catch {
+        res.writeHead(404);
+        res.end("Not found");
+      }
+      return;
+    }
 
     // Try serving static assets first (sirv calls next() if no match)
     assets(req, res, async () => {

--- a/apps/web/tests/slash-commands.test.ts
+++ b/apps/web/tests/slash-commands.test.ts
@@ -1,0 +1,430 @@
+import { spawn } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { createServer } from "node:net";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+const PROJECT_ROOT = join(import.meta.dirname, "..");
+const FAKE_AGENT_PATH = join(import.meta.dirname, "fake-agent.mjs");
+const DEFAULT_TOKEN = "slash-test-token";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+interface ServerHandle {
+  url: string;
+  home: string;
+  close: () => Promise<void>;
+}
+
+function createTmpHome(): string {
+  const tmp = mkdtempSync(join(tmpdir(), "band-test-slash-"));
+  const bandDir = join(tmp, ".band");
+  mkdirSync(bandDir, { recursive: true });
+  mkdirSync(join(bandDir, "status"), { recursive: true });
+  return tmp;
+}
+
+function seedState(tmpHome: string, state: object): void {
+  writeFileSync(join(tmpHome, ".band", "state.json"), JSON.stringify(state));
+}
+
+function seedSettings(tmpHome: string, settings: object): void {
+  writeFileSync(join(tmpHome, ".band", "settings.json"), JSON.stringify(settings));
+}
+
+function createDefaultState(tmpHome: string) {
+  const repoDir = join(tmpHome, "repo");
+  mkdirSync(repoDir, { recursive: true });
+  return {
+    projects: [
+      {
+        name: "testproject",
+        path: repoDir,
+        defaultBranch: "main",
+        worktrees: [{ branch: "main", path: repoDir }],
+      },
+    ],
+  };
+}
+
+function defaultSettings() {
+  return {
+    tokenSecret: DEFAULT_TOKEN,
+    codingAgent: {
+      type: "claude-code",
+      command: FAKE_AGENT_PATH,
+    },
+  };
+}
+
+function getRandomPort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const srv = createServer();
+    srv.listen(0, "127.0.0.1", () => {
+      const { port } = srv.address() as { port: number };
+      srv.close(() => resolve(port));
+    });
+    srv.on("error", reject);
+  });
+}
+
+/**
+ * Seed skill directories in the temp HOME's ~/.claude/skills/ folder.
+ */
+function seedSkills(tmpHome: string, skills: Array<{ dirName: string; skillMd: string }>): void {
+  const skillsDir = join(tmpHome, ".claude", "skills");
+  mkdirSync(skillsDir, { recursive: true });
+  for (const skill of skills) {
+    const skillDir = join(skillsDir, skill.dirName);
+    mkdirSync(skillDir, { recursive: true });
+    writeFileSync(join(skillDir, "SKILL.md"), skill.skillMd);
+  }
+}
+
+/**
+ * Seed project-level skill directories inside a workspace's .claude/skills/ folder.
+ */
+function seedProjectSkills(
+  repoDir: string,
+  skills: Array<{ dirName: string; skillMd: string }>,
+): void {
+  const skillsDir = join(repoDir, ".claude", "skills");
+  mkdirSync(skillsDir, { recursive: true });
+  for (const skill of skills) {
+    const skillDir = join(skillsDir, skill.dirName);
+    mkdirSync(skillDir, { recursive: true });
+    writeFileSync(join(skillDir, "SKILL.md"), skill.skillMd);
+  }
+}
+
+async function startServer(
+  opts: { tmpHome?: string; env?: Record<string, string> } = {},
+): Promise<ServerHandle> {
+  const home = opts.tmpHome || createTmpHome();
+  const port = await getRandomPort();
+
+  return new Promise((resolve, reject) => {
+    const child = spawn("node", ["dist/start-server.mjs"], {
+      cwd: PROJECT_ROOT,
+      env: {
+        ...process.env,
+        HOME: home,
+        PORT: String(port),
+        NODE_ENV: "production",
+        FAKE_AGENT_SCENARIO: "",
+        ...opts.env,
+      },
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+
+    let stderr = "";
+    let settled = false;
+
+    child.stderr!.on("data", (chunk: Buffer) => {
+      stderr += chunk.toString();
+    });
+
+    child.stdout!.on("data", (chunk: Buffer) => {
+      const text = chunk.toString();
+      if (text.includes("listening") && !settled) {
+        settled = true;
+        resolve({
+          url: `http://127.0.0.1:${port}`,
+          home,
+          close: () =>
+            new Promise<void>((r) => {
+              child.on("exit", () => r());
+              child.kill("SIGTERM");
+            }),
+        });
+      }
+    });
+
+    child.on("error", (err) => {
+      if (!settled) {
+        settled = true;
+        reject(err);
+      }
+    });
+
+    child.on("exit", (code) => {
+      if (!settled) {
+        settled = true;
+        reject(new Error(`Server exited with code ${code} before listening.\nstderr: ${stderr}`));
+      }
+    });
+
+    setTimeout(() => {
+      if (!settled) {
+        settled = true;
+        child.kill("SIGTERM");
+        reject(new Error(`Server did not start within 15 s.\nstderr: ${stderr}`));
+      }
+    }, 15_000);
+  });
+}
+
+// ---------------------------------------------------------------------------
+// tRPC HTTP helpers
+// ---------------------------------------------------------------------------
+
+const defaultHeaders = { Cookie: `band_token=${DEFAULT_TOKEN}` };
+
+async function trpcQuery(
+  serverUrl: string,
+  procedure: string,
+  input?: unknown,
+  opts?: { headers?: Record<string, string> },
+) {
+  const url =
+    input !== undefined
+      ? `${serverUrl}/trpc/${procedure}?input=${encodeURIComponent(JSON.stringify(input))}`
+      : `${serverUrl}/trpc/${procedure}`;
+  return fetch(url, { headers: { ...defaultHeaders, ...opts?.headers } });
+}
+
+async function trpcData<T>(res: Response): Promise<T> {
+  const body = (await res.json()) as { result: { data: T } };
+  return body.result.data;
+}
+
+// ---------------------------------------------------------------------------
+// skills.list — with seeded global skills
+// ---------------------------------------------------------------------------
+
+describe("skills.list — with seeded global skills", () => {
+  let server: ServerHandle;
+  let tmpHome: string;
+
+  beforeAll(async () => {
+    tmpHome = createTmpHome();
+    seedState(tmpHome, createDefaultState(tmpHome));
+    seedSettings(tmpHome, defaultSettings());
+
+    seedSkills(tmpHome, [
+      {
+        dirName: "commit",
+        skillMd: [
+          "---",
+          "name: commit",
+          "description: Create a git commit with a message.",
+          "argument-hint: -m <message>",
+          "---",
+          "",
+          "# Commit Skill",
+          "",
+          "Creates a git commit.",
+        ].join("\n"),
+      },
+      {
+        dirName: "review-pr",
+        skillMd: [
+          "---",
+          "name: review-pr",
+          "description: Review a GitHub pull request.",
+          "argument-hint: <pr-url>",
+          "---",
+          "",
+          "# Review PR Skill",
+        ].join("\n"),
+      },
+      {
+        dirName: "no-description",
+        skillMd: ["---", "name: no-description", "---", "", "# No Description"].join("\n"),
+      },
+    ]);
+
+    server = await startServer({ tmpHome });
+  });
+
+  afterAll(async () => {
+    await server.close();
+    rmSync(tmpHome, { recursive: true, force: true });
+  });
+
+  it("returns parsed skills from SKILL.md files", async () => {
+    const res = await trpcQuery(server.url, "skills.list", {
+      workspaceId: "testproject-main",
+    });
+    expect(res.status).toBe(200);
+
+    const data = await trpcData<{
+      skills: Array<{ name: string; description: string; argumentHint?: string }>;
+    }>(res);
+
+    expect(data.skills).toBeInstanceOf(Array);
+    expect(data.skills.length).toBe(2); // no-description skill is excluded
+
+    const commit = data.skills.find((s) => s.name === "commit");
+    expect(commit).toBeDefined();
+    expect(commit!.description).toBe("Create a git commit with a message.");
+    expect(commit!.argumentHint).toBe("-m <message>");
+
+    const reviewPr = data.skills.find((s) => s.name === "review-pr");
+    expect(reviewPr).toBeDefined();
+    expect(reviewPr!.description).toBe("Review a GitHub pull request.");
+    expect(reviewPr!.argumentHint).toBe("<pr-url>");
+  });
+
+  it("returns skills sorted alphabetically by name", async () => {
+    const res = await trpcQuery(server.url, "skills.list", {
+      workspaceId: "testproject-main",
+    });
+    const data = await trpcData<{
+      skills: Array<{ name: string }>;
+    }>(res);
+
+    const names = data.skills.map((s) => s.name);
+    expect(names).toEqual(["commit", "review-pr"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// skills.list — no skills directory
+// ---------------------------------------------------------------------------
+
+describe("skills.list — no skills directory", () => {
+  let server: ServerHandle;
+  let tmpHome: string;
+
+  beforeAll(async () => {
+    tmpHome = createTmpHome();
+    seedState(tmpHome, createDefaultState(tmpHome));
+    seedSettings(tmpHome, defaultSettings());
+    // Do NOT seed any skills
+    server = await startServer({ tmpHome });
+  });
+
+  afterAll(async () => {
+    await server.close();
+    rmSync(tmpHome, { recursive: true, force: true });
+  });
+
+  it("returns empty array when skills directory does not exist", async () => {
+    const res = await trpcQuery(server.url, "skills.list", {
+      workspaceId: "testproject-main",
+    });
+    expect(res.status).toBe(200);
+
+    const data = await trpcData<{
+      skills: Array<{ name: string; description: string; argumentHint?: string }>;
+    }>(res);
+
+    expect(data.skills).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// skills.list — project-level skills override global
+// ---------------------------------------------------------------------------
+
+describe("skills.list — project-level skills", () => {
+  let server: ServerHandle;
+  let tmpHome: string;
+
+  beforeAll(async () => {
+    tmpHome = createTmpHome();
+    const state = createDefaultState(tmpHome);
+    seedState(tmpHome, state);
+    seedSettings(tmpHome, defaultSettings());
+
+    // Seed a global skill
+    seedSkills(tmpHome, [
+      {
+        dirName: "deploy",
+        skillMd: ["---", "name: deploy", "description: Deploy to production (global).", "---"].join(
+          "\n",
+        ),
+      },
+    ]);
+
+    // Seed a project-level skill that overrides a global one
+    const repoDir = join(tmpHome, "repo");
+    seedProjectSkills(repoDir, [
+      {
+        dirName: "deploy",
+        skillMd: [
+          "---",
+          "name: deploy",
+          "description: Deploy to staging (project-level).",
+          "---",
+        ].join("\n"),
+      },
+      {
+        dirName: "lint",
+        skillMd: ["---", "name: lint", "description: Run project linter.", "---"].join("\n"),
+      },
+    ]);
+
+    server = await startServer({ tmpHome });
+  });
+
+  afterAll(async () => {
+    await server.close();
+    rmSync(tmpHome, { recursive: true, force: true });
+  });
+
+  it("project-level skill overrides global skill with same name", async () => {
+    const res = await trpcQuery(server.url, "skills.list", {
+      workspaceId: "testproject-main",
+    });
+    expect(res.status).toBe(200);
+
+    const data = await trpcData<{
+      skills: Array<{ name: string; description: string }>;
+    }>(res);
+
+    const deploy = data.skills.find((s) => s.name === "deploy");
+    expect(deploy).toBeDefined();
+    expect(deploy!.description).toBe("Deploy to staging (project-level).");
+  });
+
+  it("includes both global and project-level skills", async () => {
+    const res = await trpcQuery(server.url, "skills.list", {
+      workspaceId: "testproject-main",
+    });
+    const data = await trpcData<{
+      skills: Array<{ name: string }>;
+    }>(res);
+
+    const names = data.skills.map((s) => s.name);
+    expect(names).toEqual(["deploy", "lint"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// skills.list — unknown workspace
+// ---------------------------------------------------------------------------
+
+describe("skills.list — unknown workspace", () => {
+  let server: ServerHandle;
+  let tmpHome: string;
+
+  beforeAll(async () => {
+    tmpHome = createTmpHome();
+    seedState(tmpHome, createDefaultState(tmpHome));
+    seedSettings(tmpHome, defaultSettings());
+    server = await startServer({ tmpHome });
+  });
+
+  afterAll(async () => {
+    await server.close();
+    rmSync(tmpHome, { recursive: true, force: true });
+  });
+
+  it("returns empty array for non-existent workspace", async () => {
+    const res = await trpcQuery(server.url, "skills.list", {
+      workspaceId: "nonexistent-main",
+    });
+    expect(res.status).toBe(200);
+
+    const data = await trpcData<{
+      skills: Array<{ name: string }>;
+    }>(res);
+
+    expect(data.skills).toEqual([]);
+  });
+});

--- a/packages/coding-agent/src/adapters/claude-code.ts
+++ b/packages/coding-agent/src/adapters/claude-code.ts
@@ -3,10 +3,12 @@ import { getSessionMessages, listSessions, query } from "@anthropic-ai/claude-ag
 import { createLogger } from "@band/logger";
 import type { ClaudeCodeConfig } from "../config.js";
 import type { AgentEvent } from "../events.js";
+import { discoverSkills } from "../skills.js";
 import type {
   CodingAgent,
   SessionListItem,
   SessionMessageItem,
+  SkillInfo,
   UserInputRequest,
 } from "../types.js";
 
@@ -166,6 +168,10 @@ export class ClaudeCodeAdapter implements CodingAgent {
       offset: options?.offset,
     });
     return messages.map(mapSessionMessage);
+  }
+
+  async listSkills(): Promise<SkillInfo[]> {
+    return discoverSkills(this.workspaceDir);
   }
 }
 

--- a/packages/coding-agent/src/adapters/gemini-cli.ts
+++ b/packages/coding-agent/src/adapters/gemini-cli.ts
@@ -4,7 +4,8 @@ import { createInterface } from "node:readline";
 import { createLogger } from "@band/logger";
 import type { GeminiCliConfig } from "../config.js";
 import type { AgentEvent } from "../events.js";
-import type { CodingAgent } from "../types.js";
+import { discoverSkills } from "../skills.js";
+import type { CodingAgent, SkillInfo } from "../types.js";
 
 const log = createLogger("coding-agent:gemini-cli");
 
@@ -153,5 +154,9 @@ export class GeminiCliAdapter implements CodingAgent {
     } finally {
       this.activeChild = null;
     }
+  }
+
+  async listSkills(): Promise<SkillInfo[]> {
+    return discoverSkills(this.workspaceDir);
   }
 }

--- a/packages/coding-agent/src/adapters/openai-codex.ts
+++ b/packages/coding-agent/src/adapters/openai-codex.ts
@@ -1,7 +1,8 @@
 import { createLogger } from "@band/logger";
 import type { OpenAICodexConfig } from "../config.js";
 import type { AgentEvent } from "../events.js";
-import type { CodingAgent } from "../types.js";
+import { discoverSkills } from "../skills.js";
+import type { CodingAgent, SkillInfo } from "../types.js";
 
 const log = createLogger("coding-agent:openai-codex");
 
@@ -154,6 +155,10 @@ export class OpenAICodexAdapter implements CodingAgent {
     } finally {
       this.activeIterator = null;
     }
+  }
+
+  async listSkills(): Promise<SkillInfo[]> {
+    return discoverSkills(this.workspaceDir);
   }
 }
 

--- a/packages/coding-agent/src/index.ts
+++ b/packages/coding-agent/src/index.ts
@@ -21,5 +21,6 @@ export type {
   CodingAgentFeatures,
   SessionListItem,
   SessionMessageItem,
+  SkillInfo,
   UserInputRequest,
 } from "./types.js";

--- a/packages/coding-agent/src/skills.ts
+++ b/packages/coding-agent/src/skills.ts
@@ -1,0 +1,108 @@
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { createLogger } from "@band/logger";
+import type { SkillInfo } from "./types.js";
+
+const log = createLogger("coding-agent:skills");
+
+/**
+ * Parse YAML frontmatter from a SKILL.md file.
+ *
+ * Frontmatter is delimited by `---` lines at the top of the file.
+ * We only need simple key-value pairs (string values), so a full
+ * YAML parser is not required.
+ */
+function parseFrontmatter(content: string): Record<string, string> {
+  const lines = content.split("\n");
+  if (lines[0]?.trim() !== "---") return {};
+
+  const result: Record<string, string> = {};
+  for (let i = 1; i < lines.length; i++) {
+    const line = lines[i];
+    if (line.trim() === "---") break;
+
+    const colonIndex = line.indexOf(":");
+    if (colonIndex === -1) continue;
+
+    const key = line.slice(0, colonIndex).trim();
+    const value = line.slice(colonIndex + 1).trim();
+    if (key && value) {
+      result[key] = value;
+    }
+  }
+  return result;
+}
+
+/**
+ * Read skills from a single directory.
+ *
+ * Each skill is a subdirectory containing a `SKILL.md` file with
+ * YAML frontmatter that includes `name`, `description`, and
+ * optionally `argument-hint`.
+ */
+export function readSkillsFromDir(skillsDir: string): SkillInfo[] {
+  let entries: string[];
+  try {
+    entries = readdirSync(skillsDir);
+  } catch {
+    return [];
+  }
+
+  const skills: SkillInfo[] = [];
+
+  for (const entry of entries) {
+    try {
+      const entryPath = join(skillsDir, entry);
+      const entryStat = statSync(entryPath);
+      if (!entryStat.isDirectory()) continue;
+
+      const skillMdPath = join(entryPath, "SKILL.md");
+      const content = readFileSync(skillMdPath, "utf-8");
+      const frontmatter = parseFrontmatter(content);
+
+      const name = frontmatter.name;
+      const description = frontmatter.description;
+      if (!name || !description) {
+        log.debug({ entry }, "skipping skill without name or description");
+        continue;
+      }
+
+      skills.push({
+        name,
+        description,
+        argumentHint: frontmatter["argument-hint"] || undefined,
+      });
+    } catch {
+      log.debug({ entry }, "failed to read skill");
+    }
+  }
+
+  return skills;
+}
+
+/**
+ * Discover skills from both global (~/.claude/skills/) and project-level
+ * (<workspaceDir>/.claude/skills/) directories.
+ *
+ * Project-level skills override global skills with the same name.
+ * This is agent-agnostic — any adapter with a workspaceDir can use it.
+ */
+export function discoverSkills(workspaceDir: string): SkillInfo[] {
+  const globalSkillsDir = join(homedir(), ".claude", "skills");
+  const projectSkillsDir = join(workspaceDir, ".claude", "skills");
+
+  const globalSkills = readSkillsFromDir(globalSkillsDir);
+  const projectSkills = readSkillsFromDir(projectSkillsDir);
+
+  // Merge: project-level skills override global ones with the same name
+  const skillMap = new Map<string, SkillInfo>();
+  for (const skill of globalSkills) {
+    skillMap.set(skill.name, skill);
+  }
+  for (const skill of projectSkills) {
+    skillMap.set(skill.name, skill);
+  }
+
+  return Array.from(skillMap.values()).sort((a, b) => a.name.localeCompare(b.name));
+}

--- a/packages/coding-agent/src/types.ts
+++ b/packages/coding-agent/src/types.ts
@@ -30,6 +30,12 @@ export interface SessionMessageItem {
   >;
 }
 
+export interface SkillInfo {
+  name: string;
+  description: string;
+  argumentHint?: string;
+}
+
 export interface CodingAgent {
   readonly name: string;
   readonly supportedFeatures: CodingAgentFeatures;
@@ -42,4 +48,5 @@ export interface CodingAgent {
     dir: string,
     options?: { limit?: number; offset?: number },
   ): Promise<SessionMessageItem[]>;
+  listSkills?(): Promise<SkillInfo[]>;
 }


### PR DESCRIPTION
## Summary

- Add slash command discovery and autocomplete to the web chat input, matching the CLI experience
- Skills are read from `~/.claude/skills/` (global) and `<project>/.claude/skills/` (project-level) via a new `listSkills()` method on the `CodingAgent` interface
- All agent adapters (Claude Code, OpenAI Codex, Gemini CLI) support skill listing
- Slash command popover triggers mid-sentence with keyboard navigation (↑/↓/Enter/Tab/Esc)
- Blue syntax highlighting for `/<command>` tokens and ghost argument-hint placeholder
- Fix: duplicate image rendering when sending files in live chat
- Fix: serve uploaded files via `/api/uploads/` and render image previews in history messages

Closes #112

## Test plan

- [x] 6 new integration tests for skill listing (global, project-level, overrides, empty, unknown workspace)
- [x] All 151 tests pass
- [x] Verified visually with agent-browser screenshots

🤖 Generated with [Claude Code](https://claude.com/claude-code)