### PR TITLE
Fix duplicate messages when reconnecting to active task stream

### DIFF
--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -215,17 +215,6 @@ export function ChatView({
     return map;
   }, [messages]);
 
-  if (supportsSessionListing && showSessionList) {
-    return (
-      <SessionList
-        workspaceId={workspaceId}
-        activeSessionId={activeSessionId ?? sessionIdRef.current}
-        onSelectSession={handleSelectSession}
-        onNewSession={handleNewSession}
-      />
-    );
-  }
-
   // When reconnecting to a stream, the buffered chunks replay the current
   // task's content which overlaps with the tail of the session history.
   // Strip the overlapping turn from history so each message appears once.
@@ -254,9 +243,19 @@ export function ChatView({
   const hasLiveMessages = messages.length > 0;
   // Show the reconnected prompt as a user message when the stream is
   // providing the current task (no user message in live stream).
-  const showReconnectedPrompt =
-    reconnectedPrompt && !messages.some((m) => m.role === "user");
+  const showReconnectedPrompt = reconnectedPrompt && !messages.some((m) => m.role === "user");
   const isEmpty = !hasHistory && !hasLiveMessages && !showReconnectedPrompt;
+
+  if (supportsSessionListing && showSessionList) {
+    return (
+      <SessionList
+        workspaceId={workspaceId}
+        activeSessionId={activeSessionId ?? sessionIdRef.current}
+        onSelectSession={handleSelectSession}
+        onNewSession={handleNewSession}
+      />
+    );
+  }
 
   return (
     <div className="flex min-h-0 flex-1 flex-col">

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -97,7 +97,7 @@ export function ChatView({
   onShowSessionListChange,
 }: ChatViewProps) {
   const sessionIdRef = useRef<string | undefined>(undefined);
-  const reconnectedPromptRef = useRef<string | undefined>(undefined);
+  const [reconnectedPrompt, setReconnectedPrompt] = useState<string | undefined>(undefined);
   const [activeSessionId, setActiveSessionId] = useState<string | undefined>(undefined);
   const [historicalMessages, setHistoricalMessages] = useState<HistoryMessage[]>([]);
   const [loadingHistory, setLoadingHistory] = useState(false);
@@ -128,7 +128,7 @@ export function ChatView({
         typeof dataPart.data === "object" &&
         "text" in (dataPart.data as Record<string, unknown>)
       ) {
-        reconnectedPromptRef.current = (dataPart.data as { text: string }).text;
+        setReconnectedPrompt((dataPart.data as { text: string }).text);
       }
     },
   });
@@ -165,7 +165,7 @@ export function ChatView({
   const handleSelectSession = useCallback(
     async (sessionId: string) => {
       sessionIdRef.current = sessionId;
-      reconnectedPromptRef.current = undefined;
+      setReconnectedPrompt(undefined);
       setActiveSessionId(sessionId);
       setMessages([]);
       setHistoricalMessages([]);
@@ -177,7 +177,7 @@ export function ChatView({
 
   const handleNewSession = useCallback(() => {
     sessionIdRef.current = undefined;
-    reconnectedPromptRef.current = undefined;
+    setReconnectedPrompt(undefined);
     setActiveSessionId(undefined);
     setHistoricalMessages([]);
     setMessages([]);
@@ -226,11 +226,36 @@ export function ChatView({
     );
   }
 
-  const hasHistory = historicalMessages.length > 0;
+  // When reconnecting to a stream, the buffered chunks replay the current
+  // task's content which overlaps with the tail of the session history.
+  // Strip the overlapping turn from history so each message appears once.
+  const filteredHistoricalMessages = useMemo(() => {
+    if (!reconnectedPrompt || historicalMessages.length === 0) {
+      return historicalMessages;
+    }
+    const promptText = reconnectedPrompt.trim();
+    for (let i = historicalMessages.length - 1; i >= 0; i--) {
+      if (historicalMessages[i].role === "user") {
+        const text = historicalMessages[i].content
+          .filter((b) => b.type === "text")
+          .map((b) => b.text)
+          .join("\n")
+          .trim();
+        if (text === promptText) {
+          return historicalMessages.slice(0, i);
+        }
+        break;
+      }
+    }
+    return historicalMessages;
+  }, [historicalMessages, reconnectedPrompt]);
+
+  const hasHistory = filteredHistoricalMessages.length > 0;
   const hasLiveMessages = messages.length > 0;
-  // Show reconnected prompt only when history doesn't already include it
+  // Show the reconnected prompt as a user message when the stream is
+  // providing the current task (no user message in live stream).
   const showReconnectedPrompt =
-    reconnectedPromptRef.current && !hasHistory && !messages.some((m) => m.role === "user");
+    reconnectedPrompt && !messages.some((m) => m.role === "user");
   const isEmpty = !hasHistory && !hasLiveMessages && !showReconnectedPrompt;
 
   return (
@@ -251,9 +276,11 @@ export function ChatView({
             </div>
           )}
 
-          {historicalMessages.length > 0 && <HistoryMessages messages={historicalMessages} />}
+          {filteredHistoricalMessages.length > 0 && (
+            <HistoryMessages messages={filteredHistoricalMessages} />
+          )}
 
-          {hasHistory && hasLiveMessages && (
+          {hasHistory && (hasLiveMessages || showReconnectedPrompt) && (
             <div className="flex items-center gap-3 py-2">
               <div className="h-px flex-1 bg-border/50" />
               <span className="text-sm text-muted-foreground">new messages</span>
@@ -264,7 +291,7 @@ export function ChatView({
           {showReconnectedPrompt && (
             <Message from="user">
               <MessageContent>
-                <MessageResponse>{reconnectedPromptRef.current}</MessageResponse>
+                <MessageResponse>{reconnectedPrompt}</MessageResponse>
               </MessageContent>
             </Message>
           )}

--- a/apps/web/tests/chat.test.ts
+++ b/apps/web/tests/chat.test.ts
@@ -1297,3 +1297,97 @@ describe("Task submit + stream — tool name with empty text before tool_use", (
     expect(toolEvent.toolCallId).toBe("tool-empty-1");
   });
 });
+
+// ---------------------------------------------------------------------------
+// tasks.stream — Reconnect replays data-prompt for deduplication
+// ---------------------------------------------------------------------------
+
+describe("tasks.stream — reconnect replays data-prompt for deduplication", () => {
+  let server: ServerHandle;
+  let tmpHome: string;
+
+  beforeAll(async () => {
+    tmpHome = createTmpHome();
+    seedState(tmpHome, createDefaultState(tmpHome));
+
+    const scenarioPath = writeScenario(tmpHome, [
+      {
+        type: "system",
+        subtype: "init",
+        session_id: "reconnect-session",
+      },
+      {
+        type: "assistant",
+        message: {
+          content: [{ type: "text", text: "Working on the fix..." }],
+        },
+      },
+      {
+        type: "result",
+        subtype: "success",
+        session_id: "reconnect-session",
+        duration_ms: 500,
+        num_turns: 1,
+        total_cost_usd: 0.01,
+      },
+    ]);
+
+    seedSettings(tmpHome, {
+      tokenSecret: DEFAULT_TOKEN,
+      codingAgent: { type: "claude-code", command: FAKE_AGENT_PATH },
+    });
+
+    server = await startServer({ tmpHome, scenarioPath });
+  });
+
+  afterAll(async () => {
+    await server.close();
+    rmSync(tmpHome, { recursive: true, force: true });
+  });
+
+  it("replays data-prompt with the exact prompt text when reconnecting after task completes", async () => {
+    const workspaceId = "testproject-main";
+    const prompt = "fix the auth bug";
+
+    // Submit the task
+    const submitRes = await trpcMutate(server.url, "tasks.submit", { workspaceId, prompt });
+    expect(submitRes.status).toBe(200);
+
+    // Wait for the task to complete
+    await waitFor(async () => {
+      const res = await trpcQuery(server.url, "tasks.get", { workspaceId });
+      const data = await trpcData<{ task?: { status: string } }>(res);
+      return data.task?.status !== "running";
+    });
+
+    // Reconnect to the stream (simulates navigating back to the chat)
+    const streamRes = await trpcSubscription(server.url, "tasks.stream", { workspaceId });
+    expect(streamRes.status).toBe(200);
+    const events = await parseTrpcSSEStream(streamRes);
+
+    // The data-prompt chunk must be the first event and contain the exact prompt
+    // text. The client uses this to deduplicate with session history.
+    const dataPromptEvents = events.filter((e) => e.event === "data-prompt");
+    expect(dataPromptEvents.length).toBe(1);
+
+    const promptChunk = dataPromptEvents[0].data as Record<string, unknown>;
+    const promptData = promptChunk.data as Record<string, unknown>;
+    expect(promptData.text).toBe(prompt);
+
+    // The stream should also contain the assistant's response and finish
+    const eventTypes = events.map((e) => e.event).filter(Boolean) as string[];
+    expect(eventTypes).toContain("text-delta");
+    expect(eventTypes).toContain("finish");
+  });
+
+  it("does not duplicate data-prompt across buffer replay and live events", async () => {
+    // The task already completed above; reconnecting again should still
+    // yield exactly one data-prompt chunk (no accumulation).
+    const streamRes = await trpcSubscription(server.url, "tasks.stream", {
+      workspaceId: "testproject-main",
+    });
+    const events = await parseTrpcSSEStream(streamRes);
+    const dataPromptEvents = events.filter((e) => e.event === "data-prompt");
+    expect(dataPromptEvents.length).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary
- **Fixes #119**: When navigating away from a chat and back while a task is running, messages appeared duplicated with a "new messages" separator between the original and duplicate content
- Root cause: both the session history (`sessions.messages`) and the stream buffer replay (`tasks.stream`) provided the same task content on reconnection
- Added `filteredHistoricalMessages` useMemo that strips the overlapping turn from history by matching the reconnected prompt text against the last user message in session history
- Changed `reconnectedPromptRef` from a ref to state to trigger proper re-renders for deduplication computation
- Added 2 integration tests verifying the stream's `data-prompt` contract the client dedup relies on

## Test plan
- [x] All 147 existing tests pass
- [x] New tests verify `data-prompt` chunk contains exact prompt text on reconnect
- [x] New tests verify no duplicate `data-prompt` chunks across multiple reconnections
- [x] Lint and build pass
- [ ] Manual: start a task, navigate away, navigate back — messages should appear once

🤖 Generated with [Claude Code](https://claude.com/claude-code)