### PR TITLE
feat: responsive desktop layout with three-panel view

### DIFF
--- a/apps/web/src/components/DashboardView.tsx
+++ b/apps/web/src/components/DashboardView.tsx
@@ -1,3 +1,4 @@
+import type { PlatformCapabilities } from "@band/dashboard-core";
 import { DashboardProvider, DashboardShell } from "@band/dashboard-core";
 import {
   HybridDashboardAdapter,
@@ -7,12 +8,29 @@ import { Button, Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from
 import { Link } from "@tanstack/react-router";
 import { ListTodo, Timer } from "lucide-react";
 import { useCallback } from "react";
+import { useIsDesktop } from "../hooks/useIsDesktop";
+import { DesktopLayout } from "./DesktopLayout";
 import { TunnelToolbarButton } from "./TunnelToolbarButton";
 
 const adapter = new HybridDashboardAdapter();
 const capabilities = new NativeShellCapabilities();
 
 const inTauri = typeof window !== "undefined" && "__TAURI_INTERNALS__" in window;
+
+/**
+ * On desktop web (non-Tauri), getWorkspaceHref returns undefined so that
+ * WorkspaceCard uses onClick → openWorkspace (zustand) instead of <a> navigation.
+ * This enables the three-panel layout where workspace selection is inline.
+ */
+class DesktopWebCapabilities implements PlatformCapabilities {
+  copyPath = false;
+
+  getWorkspaceHref(_workspaceId: string): string | undefined {
+    return undefined;
+  }
+}
+
+const desktopCapabilities = new DesktopWebCapabilities();
 
 function TasksButton() {
   const handleClick = useCallback(async () => {
@@ -47,28 +65,37 @@ function TasksButton() {
   );
 }
 
-export function DashboardView() {
+function ToolbarButtons() {
   return (
-    <DashboardProvider adapter={adapter} capabilities={capabilities}>
+    <>
+      <TasksButton />
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Button size="icon-sm" variant="ghost" asChild>
+            <Link to="/cronjobs">
+              <Timer className="size-5" />
+            </Link>
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent>Cronjobs</TooltipContent>
+      </Tooltip>
+      <TunnelToolbarButton />
+    </>
+  );
+}
+
+export function DashboardView() {
+  const isDesktop = useIsDesktop() && !inTauri;
+  const activeCapabilities = isDesktop ? desktopCapabilities : capabilities;
+
+  return (
+    <DashboardProvider adapter={adapter} capabilities={activeCapabilities}>
       <TooltipProvider>
-        <DashboardShell
-          toolbarExtra={
-            <>
-              <TasksButton />
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <Button size="icon-sm" variant="ghost" asChild>
-                    <Link to="/cronjobs">
-                      <Timer className="size-5" />
-                    </Link>
-                  </Button>
-                </TooltipTrigger>
-                <TooltipContent>Cronjobs</TooltipContent>
-              </Tooltip>
-              <TunnelToolbarButton />
-            </>
-          }
-        />
+        {isDesktop ? (
+          <DesktopLayout toolbarExtra={<ToolbarButtons />} />
+        ) : (
+          <DashboardShell toolbarExtra={<ToolbarButtons />} />
+        )}
       </TooltipProvider>
     </DashboardProvider>
   );

--- a/apps/web/src/components/DesktopLayout.tsx
+++ b/apps/web/src/components/DesktopLayout.tsx
@@ -1,0 +1,51 @@
+import { DashboardShell, useDashboardStore } from "@band/dashboard-core";
+import { MessageSquare } from "lucide-react";
+import type { ReactNode } from "react";
+import { WorkspaceChatPanel } from "./WorkspaceChatPanel";
+import { WorkspaceDetailPanel } from "./WorkspaceDetailPanel";
+
+interface DesktopLayoutProps {
+  toolbarExtra?: ReactNode;
+}
+
+function EmptyStatePanel({ message }: { message: string }) {
+  return (
+    <div className="flex h-full items-center justify-center">
+      <div className="flex flex-col items-center gap-3 text-center px-8">
+        <MessageSquare className="size-8 text-muted-foreground/30" />
+        <p className="text-sm text-muted-foreground">{message}</p>
+      </div>
+    </div>
+  );
+}
+
+export function DesktopLayout({ toolbarExtra }: DesktopLayoutProps) {
+  const activeWorkspaceId = useDashboardStore((s) => s.activeWorkspaceId);
+
+  return (
+    <div className="flex h-dvh w-full overflow-hidden bg-background text-foreground">
+      {/* Left Panel - Project List */}
+      <div className="w-72 shrink-0 border-r border-border overflow-hidden">
+        <DashboardShell toolbarExtra={toolbarExtra} />
+      </div>
+
+      {/* Middle Panel - Chat (narrower) */}
+      <div className="flex-[2] min-w-0 border-r border-border overflow-hidden">
+        {activeWorkspaceId ? (
+          <WorkspaceChatPanel key={activeWorkspaceId} workspaceId={activeWorkspaceId} />
+        ) : (
+          <EmptyStatePanel message="Select a workspace to start chatting" />
+        )}
+      </div>
+
+      {/* Right Panel - Changes & Code (wider for file diffs) */}
+      <div className="flex-[3] min-w-0 overflow-hidden">
+        {activeWorkspaceId ? (
+          <WorkspaceDetailPanel key={activeWorkspaceId} workspaceId={activeWorkspaceId} />
+        ) : (
+          <EmptyStatePanel message="Select a workspace to view changes" />
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/WorkspaceChatPanel.tsx
+++ b/apps/web/src/components/WorkspaceChatPanel.tsx
@@ -1,0 +1,71 @@
+import { Clock } from "lucide-react";
+import { useCallback, useEffect, useState } from "react";
+import { trpc } from "../lib/trpc-client";
+import { ChatView } from "./ChatView";
+
+interface WorkspaceChatPanelProps {
+  workspaceId: string;
+}
+
+export function WorkspaceChatPanel({ workspaceId }: WorkspaceChatPanelProps) {
+  const [supportsSessionListing, setSupportsSessionListing] = useState(false);
+  const [initialSessionId, setInitialSessionId] = useState<string | undefined>(undefined);
+  const [showSessionList, setShowSessionList] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    trpc.sessions.list
+      .query({ workspaceId })
+      .then((data) => {
+        if (cancelled) return;
+        if (data.supported) {
+          setSupportsSessionListing(true);
+          const latest = [...data.sessions].sort((a, b) => b.lastModified - a.lastModified)[0];
+          if (latest) {
+            setInitialSessionId(latest.sessionId);
+          }
+        }
+      })
+      .catch((err) => {
+        console.error("[sessions] error:", err);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [workspaceId]);
+
+  const handleToggleSessionList = useCallback(() => {
+    setShowSessionList((prev) => !prev);
+  }, []);
+
+  return (
+    <div className="flex h-full flex-col overflow-hidden">
+      <header className="flex h-12 shrink-0 items-center gap-3 border-b border-border px-4">
+        <div className="min-w-0 flex-1">
+          <h1 className="truncate text-sm font-semibold">{workspaceId}</h1>
+        </div>
+        {supportsSessionListing && (
+          <button
+            type="button"
+            onClick={handleToggleSessionList}
+            className={`inline-flex size-8 items-center justify-center rounded-md transition-colors hover:bg-accent ${showSessionList ? "bg-accent text-foreground" : "text-muted-foreground"}`}
+          >
+            <Clock className="size-4" />
+          </button>
+        )}
+      </header>
+      <div className="flex min-h-0 flex-1 flex-col">
+        <ChatView
+          workspaceId={workspaceId}
+          workspaceName={workspaceId}
+          supportsSessionListing={supportsSessionListing}
+          initialSessionId={initialSessionId}
+          showSessionList={showSessionList}
+          onShowSessionListChange={setShowSessionList}
+        />
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/WorkspaceDetailPanel.tsx
+++ b/apps/web/src/components/WorkspaceDetailPanel.tsx
@@ -1,0 +1,64 @@
+import { DiffView } from "@band/dashboard-core";
+import { Code, GitCompare } from "lucide-react";
+import { useState } from "react";
+import { CodeBrowserView } from "./CodeBrowserView";
+
+type DetailTab = "diff" | "code";
+
+const tabs: { id: DetailTab; label: string; icon: typeof GitCompare }[] = [
+  { id: "diff", label: "Changes", icon: GitCompare },
+  { id: "code", label: "Code", icon: Code },
+];
+
+interface DetailTabNavProps {
+  activeTab: DetailTab;
+  onTabChange: (tab: DetailTab) => void;
+}
+
+function DetailTabNav({ activeTab, onTabChange }: DetailTabNavProps) {
+  return (
+    <div className="flex h-12 shrink-0 items-center border-b border-border">
+      {tabs.map((tab) => {
+        const Icon = tab.icon;
+        const isActive = activeTab === tab.id;
+        return (
+          <button
+            key={tab.id}
+            type="button"
+            onClick={() => onTabChange(tab.id)}
+            className={`flex h-full flex-1 items-center justify-center gap-2 text-sm font-medium transition-colors ${
+              isActive
+                ? "border-b-2 border-foreground text-foreground"
+                : "text-muted-foreground hover:text-foreground"
+            }`}
+          >
+            <Icon className="size-4" />
+            {tab.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+interface WorkspaceDetailPanelProps {
+  workspaceId: string;
+}
+
+export function WorkspaceDetailPanel({ workspaceId }: WorkspaceDetailPanelProps) {
+  const [activeTab, setActiveTab] = useState<DetailTab>("diff");
+
+  return (
+    <div className="flex h-full flex-col overflow-hidden">
+      <DetailTabNav activeTab={activeTab} onTabChange={setActiveTab} />
+      <div className="min-h-0 flex-1">
+        <div className={activeTab === "diff" ? "h-full" : "hidden"}>
+          <DiffView workspaceId={workspaceId} />
+        </div>
+        <div className={activeTab === "code" ? "h-full" : "hidden"}>
+          <CodeBrowserView workspaceId={workspaceId} />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/WorkspaceDetailPanel.tsx
+++ b/apps/web/src/components/WorkspaceDetailPanel.tsx
@@ -53,7 +53,7 @@ export function WorkspaceDetailPanel({ workspaceId }: WorkspaceDetailPanelProps)
       <DetailTabNav activeTab={activeTab} onTabChange={setActiveTab} />
       <div className="min-h-0 flex-1">
         <div className={activeTab === "diff" ? "h-full" : "hidden"}>
-          <DiffView workspaceId={workspaceId} />
+          <DiffView workspaceId={workspaceId} active={activeTab === "diff"} />
         </div>
         <div className={activeTab === "code" ? "h-full" : "hidden"}>
           <CodeBrowserView workspaceId={workspaceId} />

--- a/apps/web/src/hooks/useIsDesktop.ts
+++ b/apps/web/src/hooks/useIsDesktop.ts
@@ -10,6 +10,7 @@ export function useIsDesktop(): boolean {
 
   useEffect(() => {
     const mql = window.matchMedia(DESKTOP_QUERY);
+    setIsDesktop(mql.matches);
     const handler = (e: MediaQueryListEvent) => setIsDesktop(e.matches);
     mql.addEventListener("change", handler);
     return () => mql.removeEventListener("change", handler);

--- a/apps/web/src/hooks/useIsDesktop.ts
+++ b/apps/web/src/hooks/useIsDesktop.ts
@@ -1,0 +1,19 @@
+import { useEffect, useState } from "react";
+
+const DESKTOP_QUERY = "(min-width: 1024px)";
+
+export function useIsDesktop(): boolean {
+  const [isDesktop, setIsDesktop] = useState(() => {
+    if (typeof window === "undefined") return false;
+    return window.matchMedia(DESKTOP_QUERY).matches;
+  });
+
+  useEffect(() => {
+    const mql = window.matchMedia(DESKTOP_QUERY);
+    const handler = (e: MediaQueryListEvent) => setIsDesktop(e.matches);
+    mql.addEventListener("change", handler);
+    return () => mql.removeEventListener("change", handler);
+  }, []);
+
+  return isDesktop;
+}

--- a/packages/dashboard-core/src/components/DiffView.tsx
+++ b/packages/dashboard-core/src/components/DiffView.tsx
@@ -223,7 +223,8 @@ export function DiffView({ workspaceId, active = true }: DiffViewProps) {
   const [openFiles, setOpenFiles] = useState<Set<string>>(new Set());
 
   useEffect(() => {
-    if (!adapter.getWorkspaceDiff) {
+    const getWorkspaceDiff = adapter.getWorkspaceDiff;
+    if (!getWorkspaceDiff) {
       setError("Diff viewing not supported");
       setLoading(false);
       return;
@@ -231,8 +232,8 @@ export function DiffView({ workspaceId, active = true }: DiffViewProps) {
 
     let cancelled = false;
     const fetchDiff = () => {
-      adapter
-        .getWorkspaceDiff(workspaceId)
+      getWorkspaceDiff
+        .call(adapter, workspaceId)
         .then((result) => {
           if (!cancelled) {
             setData(result);
@@ -249,7 +250,6 @@ export function DiffView({ workspaceId, active = true }: DiffViewProps) {
 
     fetchDiff();
     const interval = active ? setInterval(fetchDiff, 15_000) : undefined;
-
     return () => {
       cancelled = true;
       if (interval) clearInterval(interval);


### PR DESCRIPTION
## Summary

Closes #115

- On wide screens (≥1024px), renders a three-panel layout: project list (left), chat (middle), changes/code tabs (right)
- Clicking a workspace selects it inline without page navigation — leverages the existing Tauri adapter pattern (`getWorkspaceHref → undefined`)
- Mobile layout (<1024px) is fully preserved with standard route-based navigation
- No new dependencies — pure Tailwind CSS flexbox layout
- All three panel headers use consistent `h-12` height for visual alignment
- Fixes pre-existing TS2722 error in DiffView

## Test plan

- [ ] Open at ≥1024px width: three-panel layout renders with empty state placeholders
- [ ] Click workspace in left panel: chat loads in middle, changes/code in right panel
- [ ] Switch workspaces: panels update, previous chat state resets cleanly
- [ ] Resize below 1024px: reverts to single-panel dashboard
- [ ] In mobile layout, tap workspace: navigates to `/chat/$workspaceId` full-screen page
- [ ] Tauri desktop app is unaffected (guarded by `!isTauri()`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)