### PR TITLE
feat: queue user messages while coding agent is busy

### DIFF
--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -1,6 +1,7 @@
 import { useChat } from "@ai-sdk/react";
+import { Badge } from "@band/ui";
 import { getToolName, isToolUIPart } from "ai";
-import { Bot, Loader2 } from "lucide-react";
+import { Bot, Clock, Loader2, X } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { TaskChatTransport } from "../lib/task-chat-transport";
 import { trpc } from "../lib/trpc-client";
@@ -79,6 +80,12 @@ interface HistoryMessage {
   content: HistoryMessageContent[];
 }
 
+interface QueuedMessage {
+  id: string;
+  message: PromptInputMessage;
+  queuedAt: number;
+}
+
 interface ChatViewProps {
   workspaceId: string;
   workspaceName: string;
@@ -133,12 +140,35 @@ export function ChatView({
     },
   });
 
+  const abortingRef = useRef(false);
+
   const handleStop = useCallback(() => {
-    transport.abort();
-    stop();
+    abortingRef.current = true;
+    transport.abort().finally(() => {
+      abortingRef.current = false;
+      stop();
+    });
   }, [transport, stop]);
 
   const isStreaming = status === "submitted" || status === "streaming";
+
+  const [queuedMessages, setQueuedMessages] = useState<QueuedMessage[]>([]);
+  const sendingQueuedRef = useRef(false);
+
+  const doSendMessage = useCallback(
+    (message: PromptInputMessage) => {
+      if (message.files?.length) {
+        const dataTransfer = new DataTransfer();
+        for (const file of message.files) {
+          dataTransfer.items.add(file);
+        }
+        sendMessage({ text: message.text, files: dataTransfer.files });
+      } else {
+        sendMessage({ text: message.text });
+      }
+    },
+    [sendMessage],
+  );
 
   const loadMessages = useCallback(
     async (sessionId: string) => {
@@ -169,6 +199,7 @@ export function ChatView({
       setActiveSessionId(sessionId);
       setMessages([]);
       setHistoricalMessages([]);
+      setQueuedMessages([]);
       onShowSessionListChange(false);
       await loadMessages(sessionId);
     },
@@ -181,24 +212,50 @@ export function ChatView({
     setActiveSessionId(undefined);
     setHistoricalMessages([]);
     setMessages([]);
+    setQueuedMessages([]);
     onShowSessionListChange(false);
   }, [setMessages, onShowSessionListChange]);
 
   const handleSubmit = useCallback(
     (message: PromptInputMessage) => {
       if (!message.text.trim() && !message.files?.length) return;
-      if (message.files?.length) {
-        const dataTransfer = new DataTransfer();
-        for (const file of message.files) {
-          dataTransfer.items.add(file);
-        }
-        sendMessage({ text: message.text, files: dataTransfer.files });
-      } else {
-        sendMessage({ text: message.text });
+
+      if (isStreaming) {
+        // Agent is busy — queue the message instead of sending
+        setQueuedMessages((prev) => [
+          ...prev,
+          {
+            id: crypto.randomUUID(),
+            message,
+            queuedAt: Date.now(),
+          },
+        ]);
+        return;
       }
+
+      doSendMessage(message);
     },
-    [sendMessage],
+    [doSendMessage, isStreaming],
   );
+
+  // Auto-send queued messages when the agent becomes idle
+  useEffect(() => {
+    if (isStreaming) {
+      sendingQueuedRef.current = false;
+      return;
+    }
+    if (sendingQueuedRef.current) return;
+    if (queuedMessages.length === 0) return;
+
+    sendingQueuedRef.current = true;
+    const [next, ...rest] = queuedMessages;
+    setQueuedMessages(rest);
+    doSendMessage(next.message);
+  }, [isStreaming, queuedMessages, doSendMessage]);
+
+  const handleCancelQueued = useCallback((id: string) => {
+    setQueuedMessages((prev) => prev.filter((m) => m.id !== id));
+  }, []);
 
   const liveTaskMap: TaskMap = useMemo(() => {
     let map: TaskMap = new Map();
@@ -346,6 +403,14 @@ export function ChatView({
               </MessageContent>
             </Message>
           )}
+
+          {queuedMessages.map((qm) => (
+            <QueuedMessageBubble
+              key={qm.id}
+              queuedMessage={qm}
+              onCancel={() => handleCancelQueued(qm.id)}
+            />
+          ))}
         </ConversationContent>
         <ConversationScrollButton />
       </Conversation>
@@ -355,9 +420,43 @@ export function ChatView({
           <PromptInputTextarea placeholder="Type a message..." />
           <PromptInputActions>
             <PromptInputAttach />
-            <PromptInputSubmit status={status} onStop={handleStop} />
+            <PromptInputSubmit
+              status={status}
+              onStop={handleStop}
+              queueCount={queuedMessages.length}
+            />
           </PromptInputActions>
         </PromptInput>
+      </div>
+    </div>
+  );
+}
+
+function QueuedMessageBubble({
+  queuedMessage,
+  onCancel,
+}: {
+  queuedMessage: QueuedMessage;
+  onCancel: () => void;
+}) {
+  return (
+    <div className="group is-user flex w-full max-w-[95%] flex-col gap-2 ml-auto justify-end opacity-60">
+      <div className="flex min-w-0 max-w-full flex-col gap-2 break-words text-base ml-auto w-fit rounded-md bg-secondary px-4 py-3 text-foreground">
+        <MessageResponse>{queuedMessage.message.text}</MessageResponse>
+        <div className="flex items-center justify-end gap-2 mt-1">
+          <Badge variant="outline" className="text-xs text-muted-foreground">
+            <Clock className="size-3" />
+            Queued
+          </Badge>
+          <button
+            type="button"
+            onClick={onCancel}
+            className="inline-flex items-center gap-1 rounded px-1.5 py-0.5 text-xs text-muted-foreground transition-colors hover:bg-destructive/10 hover:text-destructive"
+          >
+            <X className="size-3" />
+            Cancel
+          </button>
+        </div>
       </div>
     </div>
   );

--- a/apps/web/src/components/ai-elements/prompt-input.tsx
+++ b/apps/web/src/components/ai-elements/prompt-input.tsx
@@ -1,6 +1,6 @@
-import { cn } from "@band/ui";
+import { Badge, cn } from "@band/ui";
 import type { ChatStatus } from "ai";
-import { ArrowUpIcon, FileIcon, Loader2, Paperclip, SquareIcon, X } from "lucide-react";
+import { ArrowUpIcon, Clock, FileIcon, Loader2, Paperclip, SquareIcon, X } from "lucide-react";
 import type {
   ComponentProps,
   DragEvent,
@@ -295,64 +295,68 @@ export const PromptInputTextarea = ({
 export type PromptInputSubmitProps = ComponentProps<"button"> & {
   status?: ChatStatus;
   onStop?: () => void;
+  queueCount?: number;
 };
 
 export const PromptInputSubmit = ({
   className,
   status,
   onStop,
+  queueCount,
   ...props
 }: PromptInputSubmitProps) => {
   const { hasContent } = useContext(PromptInputContext);
   const isSubmitting = status === "submitted";
   const isStreaming = status === "streaming";
-
-  if (isSubmitting) {
-    return (
-      <button
-        type="button"
-        className={cn(
-          "inline-flex size-8 shrink-0 items-center justify-center rounded-full bg-foreground/50 text-background transition-colors",
-          className,
-        )}
-        disabled
-        {...props}
-      >
-        <Loader2 className="size-5 animate-spin" />
-      </button>
-    );
-  }
-
-  if (isStreaming) {
-    return (
-      <button
-        type="button"
-        className={cn(
-          "inline-flex size-8 shrink-0 items-center justify-center rounded-full bg-foreground text-background transition-colors hover:bg-foreground/80",
-          className,
-        )}
-        onClick={onStop}
-        {...props}
-      >
-        <SquareIcon className="size-4 fill-current" />
-      </button>
-    );
-  }
+  const isBusy = isSubmitting || isStreaming;
 
   return (
-    <button
-      type="submit"
-      disabled={!hasContent}
-      className={cn(
-        "inline-flex size-8 shrink-0 items-center justify-center rounded-full transition-colors",
-        hasContent
-          ? "bg-foreground text-background hover:bg-foreground/80"
-          : "bg-muted text-muted-foreground",
-        className,
+    <div className="flex items-center gap-1">
+      {queueCount != null && queueCount > 0 && (
+        <Badge variant="secondary" className="text-xs tabular-nums">
+          <Clock className="size-3" />
+          {queueCount}
+        </Badge>
       )}
-      {...props}
-    >
-      <ArrowUpIcon className="size-5" />
-    </button>
+      {isStreaming && (
+        <button
+          type="button"
+          className="inline-flex size-8 shrink-0 items-center justify-center rounded-full bg-foreground text-background transition-colors hover:bg-foreground/80"
+          onClick={onStop}
+        >
+          <SquareIcon className="size-4 fill-current" />
+        </button>
+      )}
+      {isSubmitting && !hasContent ? (
+        <button
+          type="button"
+          className={cn(
+            "inline-flex size-8 shrink-0 items-center justify-center rounded-full bg-foreground/50 text-background transition-colors",
+            className,
+          )}
+          disabled
+          {...props}
+        >
+          <Loader2 className="size-5 animate-spin" />
+        </button>
+      ) : (
+        <button
+          type="submit"
+          disabled={!hasContent}
+          className={cn(
+            "inline-flex size-8 shrink-0 items-center justify-center rounded-full transition-colors",
+            hasContent
+              ? isBusy
+                ? "bg-primary text-primary-foreground hover:bg-primary/80"
+                : "bg-foreground text-background hover:bg-foreground/80"
+              : "bg-muted text-muted-foreground",
+            className,
+          )}
+          {...props}
+        >
+          <ArrowUpIcon className="size-5" />
+        </button>
+      )}
+    </div>
   );
 };

--- a/apps/web/src/lib/task-chat-transport.ts
+++ b/apps/web/src/lib/task-chat-transport.ts
@@ -38,10 +38,11 @@ export class TaskChatTransport implements ChatTransport<UIMessage> {
     this.getSessionId = getSessionId;
   }
 
-  abort(): void {
-    trpc.tasks.abort.mutate({ workspaceId: this.workspaceId }).catch(() => {
-      // fire-and-forget
-    });
+  abort(): Promise<void> {
+    return trpc.tasks.abort.mutate({ workspaceId: this.workspaceId }).then(
+      () => {},
+      () => {},
+    );
   }
 
   async sendMessages({


### PR DESCRIPTION
## Summary
- Allow users to type and submit messages while the coding agent is busy with a task
- Queued messages are visually shown in the chat with a dimmed style, clock icon "Queued" badge, and a cancel button
- Once the agent finishes the current task, the next queued message is automatically sent
- Pressing stop aborts the current task and automatically sends the next queued message
- Queue counter badge shows next to the input area buttons
- Input field remains functional at all times regardless of agent state

Closes #118

## Test plan
- [x] Submit messages while agent is busy — they appear as queued bubbles
- [x] Queue counter badge shows correct count
- [x] Cancel individual queued messages with ✕ button
- [x] Agent finishes → next queued message auto-sends
- [x] Press stop → current task aborts → next queued message auto-sends
- [x] Session switch / new session clears the queue
- [x] Build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)