### PR TITLE
fix: improve desktop layout widths and code browser

### DIFF
--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -59,8 +59,8 @@ function toolPartToItem(part: ToolPart): ToolCallItem {
 function ThinkingIndicator() {
   return (
     <div className="flex items-center gap-2 text-muted-foreground">
-      <Loader2 className="size-4 animate-spin" />
-      <span className="text-base">Thinking...</span>
+      <Loader2 className="size-4 lg:size-3.5 animate-spin" />
+      <span className="text-base lg:text-sm">Thinking...</span>
     </div>
   );
 }
@@ -436,7 +436,7 @@ export function ChatView({
         <ConversationScrollButton />
       </Conversation>
 
-      <div className="mx-auto w-full max-w-3xl shrink-0 px-4 pt-2 pb-[max(1rem,env(safe-area-inset-bottom))]">
+      <div className="mx-auto w-full max-w-3xl shrink-0 px-4 lg:px-12 pt-2 pb-[max(1rem,env(safe-area-inset-bottom))]">
         <PromptInput onSubmit={handleSubmit}>
           <SlashCommandSuggestions skills={skills} />
           <PromptInputTextarea placeholder="Type a message..." />

--- a/apps/web/src/components/CodeBrowserView.tsx
+++ b/apps/web/src/components/CodeBrowserView.tsx
@@ -1,34 +1,64 @@
 import { FileBrowser, FileViewer } from "@band/dashboard-core";
+import { File } from "lucide-react";
 import { useState } from "react";
+import { useIsDesktop } from "../hooks/useIsDesktop";
 
 interface CodeBrowserViewProps {
   workspaceId: string;
 }
 
 export function CodeBrowserView({ workspaceId }: CodeBrowserViewProps) {
-  const [mode, setMode] = useState<"browse" | "view">("browse");
+  const isDesktop = useIsDesktop();
   const [currentPath, setCurrentPath] = useState("");
   const [viewFilePath, setViewFilePath] = useState("");
 
-  const handleOpenFile = (path: string) => {
-    setViewFilePath(path);
-    setMode("view");
-  };
-
   const handleBack = () => {
-    setMode("browse");
+    setViewFilePath("");
   };
 
-  if (mode === "view") {
-    return <FileViewer workspaceId={workspaceId} filePath={viewFilePath} onBack={handleBack} />;
+  // Mobile: toggle between browse and view
+  if (!isDesktop) {
+    if (viewFilePath) {
+      return <FileViewer workspaceId={workspaceId} filePath={viewFilePath} onBack={handleBack} />;
+    }
+    return (
+      <FileBrowser
+        workspaceId={workspaceId}
+        currentPath={currentPath}
+        onNavigate={setCurrentPath}
+        onOpenFile={setViewFilePath}
+      />
+    );
   }
 
+  // Desktop: side-by-side layout
   return (
-    <FileBrowser
-      workspaceId={workspaceId}
-      currentPath={currentPath}
-      onNavigate={setCurrentPath}
-      onOpenFile={handleOpenFile}
-    />
+    <div className="flex h-full overflow-hidden">
+      {/* Left sidebar - file tree */}
+      <div className="w-60 shrink-0 border-r border-white/20 overflow-hidden">
+        <FileBrowser
+          workspaceId={workspaceId}
+          currentPath={currentPath}
+          onNavigate={setCurrentPath}
+          onOpenFile={setViewFilePath}
+          compact
+          selectedFile={viewFilePath}
+        />
+      </div>
+
+      {/* Right panel - file content */}
+      <div className="flex-1 min-w-0 overflow-hidden">
+        {viewFilePath ? (
+          <FileViewer workspaceId={workspaceId} filePath={viewFilePath} />
+        ) : (
+          <div className="flex h-full items-center justify-center">
+            <div className="flex flex-col items-center gap-3 text-center px-8">
+              <File className="size-8 text-muted-foreground/30" />
+              <p className="text-sm text-muted-foreground">Select a file to view</p>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
   );
 }

--- a/apps/web/src/components/DesktopLayout.tsx
+++ b/apps/web/src/components/DesktopLayout.tsx
@@ -25,27 +25,27 @@ export function DesktopLayout({ toolbarExtra }: DesktopLayoutProps) {
   return (
     <div className="flex h-dvh w-full overflow-hidden bg-background text-foreground">
       {/* Left Panel - Project List */}
-      <div className="w-72 shrink-0 border-r border-border overflow-hidden">
+      <div className="w-80 shrink-0 border-r border-white/20 overflow-hidden">
         <DashboardShell toolbarExtra={toolbarExtra} />
       </div>
 
-      {/* Middle Panel - Chat (narrower) */}
-      <div className="flex-[2] min-w-0 border-r border-border overflow-hidden">
-        {activeWorkspaceId ? (
-          <WorkspaceChatPanel key={activeWorkspaceId} workspaceId={activeWorkspaceId} />
-        ) : (
-          <EmptyStatePanel message="Select a workspace to start chatting" />
-        )}
-      </div>
+      {activeWorkspaceId ? (
+        <>
+          {/* Middle Panel - Changes & Code (takes remaining space) */}
+          <div className="flex-1 min-w-0 border-r border-white/20 overflow-hidden">
+            <WorkspaceDetailPanel key={activeWorkspaceId} workspaceId={activeWorkspaceId} />
+          </div>
 
-      {/* Right Panel - Changes & Code (wider for file diffs) */}
-      <div className="flex-[3] min-w-0 overflow-hidden">
-        {activeWorkspaceId ? (
-          <WorkspaceDetailPanel key={activeWorkspaceId} workspaceId={activeWorkspaceId} />
-        ) : (
-          <EmptyStatePanel message="Select a workspace to view changes" />
-        )}
-      </div>
+          {/* Right Panel - Chat (capped at 768px) */}
+          <div className="max-w-[768px] flex-1 min-w-0 overflow-hidden">
+            <WorkspaceChatPanel key={activeWorkspaceId} workspaceId={activeWorkspaceId} />
+          </div>
+        </>
+      ) : (
+        <div className="flex-1 min-w-0 overflow-hidden">
+          <EmptyStatePanel message="Select a workspace to get started" />
+        </div>
+      )}
     </div>
   );
 }

--- a/apps/web/src/components/WorkspaceChatPanel.tsx
+++ b/apps/web/src/components/WorkspaceChatPanel.tsx
@@ -42,7 +42,7 @@ export function WorkspaceChatPanel({ workspaceId }: WorkspaceChatPanelProps) {
 
   return (
     <div className="flex h-full flex-col overflow-hidden">
-      <header className="flex h-12 shrink-0 items-center gap-3 border-b border-border px-4">
+      <header className="flex h-12 shrink-0 items-center gap-3 border-b border-white/20 px-4">
         <div className="min-w-0 flex-1">
           <h1 className="truncate text-sm font-semibold">{workspaceId}</h1>
         </div>

--- a/apps/web/src/components/WorkspaceDetailPanel.tsx
+++ b/apps/web/src/components/WorkspaceDetailPanel.tsx
@@ -1,42 +1,48 @@
-import { DiffView } from "@band/dashboard-core";
+import { DiffView, type DiffStats } from "@band/dashboard-core";
 import { Code, GitCompare } from "lucide-react";
-import { useState } from "react";
+import { useCallback, useState } from "react";
 import { CodeBrowserView } from "./CodeBrowserView";
 
 type DetailTab = "diff" | "code";
 
-const tabs: { id: DetailTab; label: string; icon: typeof GitCompare }[] = [
-  { id: "diff", label: "Changes", icon: GitCompare },
-  { id: "code", label: "Code", icon: Code },
-];
-
 interface DetailTabNavProps {
   activeTab: DetailTab;
   onTabChange: (tab: DetailTab) => void;
+  diffStats: DiffStats | null;
 }
 
-function DetailTabNav({ activeTab, onTabChange }: DetailTabNavProps) {
+function DetailTabNav({ activeTab, onTabChange, diffStats }: DetailTabNavProps) {
   return (
-    <div className="flex h-12 shrink-0 items-center border-b border-border">
-      {tabs.map((tab) => {
-        const Icon = tab.icon;
-        const isActive = activeTab === tab.id;
-        return (
-          <button
-            key={tab.id}
-            type="button"
-            onClick={() => onTabChange(tab.id)}
-            className={`flex h-full flex-1 items-center justify-center gap-2 text-sm font-medium transition-colors ${
-              isActive
-                ? "border-b-2 border-foreground text-foreground"
-                : "text-muted-foreground hover:text-foreground"
-            }`}
-          >
-            <Icon className="size-4" />
-            {tab.label}
-          </button>
-        );
-      })}
+    <div className="flex h-12 shrink-0 items-center border-b border-white/20">
+      <button
+        type="button"
+        onClick={() => onTabChange("diff")}
+        className={`flex h-full flex-1 items-center justify-center gap-2 text-sm font-medium transition-colors ${
+          activeTab === "diff"
+            ? "border-b border-foreground text-foreground"
+            : "text-muted-foreground hover:text-foreground"
+        }`}
+      >
+        <GitCompare className="size-4" />
+        Changes
+        {diffStats && diffStats.filesChanged > 0 && (
+          <span className="inline-flex h-5 min-w-5 items-center justify-center rounded-full bg-blue-500/20 text-blue-400 px-1.5 text-xs font-medium">
+            {diffStats.filesChanged}
+          </span>
+        )}
+      </button>
+      <button
+        type="button"
+        onClick={() => onTabChange("code")}
+        className={`flex h-full flex-1 items-center justify-center gap-2 text-sm font-medium transition-colors ${
+          activeTab === "code"
+            ? "border-b border-foreground text-foreground"
+            : "text-muted-foreground hover:text-foreground"
+        }`}
+      >
+        <Code className="size-4" />
+        Code
+      </button>
     </div>
   );
 }
@@ -47,13 +53,18 @@ interface WorkspaceDetailPanelProps {
 
 export function WorkspaceDetailPanel({ workspaceId }: WorkspaceDetailPanelProps) {
   const [activeTab, setActiveTab] = useState<DetailTab>("diff");
+  const [diffStats, setDiffStats] = useState<DiffStats | null>(null);
+
+  const handleStatsChange = useCallback((stats: DiffStats | null) => {
+    setDiffStats(stats);
+  }, []);
 
   return (
     <div className="flex h-full flex-col overflow-hidden">
-      <DetailTabNav activeTab={activeTab} onTabChange={setActiveTab} />
+      <DetailTabNav activeTab={activeTab} onTabChange={setActiveTab} diffStats={diffStats} />
       <div className="min-h-0 flex-1">
         <div className={activeTab === "diff" ? "h-full" : "hidden"}>
-          <DiffView workspaceId={workspaceId} active={activeTab === "diff"} />
+          <DiffView workspaceId={workspaceId} active={activeTab === "diff"} onStatsChange={handleStatsChange} />
         </div>
         <div className={activeTab === "code" ? "h-full" : "hidden"}>
           <CodeBrowserView workspaceId={workspaceId} />

--- a/apps/web/src/components/WorkspaceDetailPanel.tsx
+++ b/apps/web/src/components/WorkspaceDetailPanel.tsx
@@ -1,4 +1,4 @@
-import { DiffView, type DiffStats } from "@band/dashboard-core";
+import { type DiffStats, DiffView } from "@band/dashboard-core";
 import { Code, GitCompare } from "lucide-react";
 import { useCallback, useState } from "react";
 import { CodeBrowserView } from "./CodeBrowserView";
@@ -64,7 +64,11 @@ export function WorkspaceDetailPanel({ workspaceId }: WorkspaceDetailPanelProps)
       <DetailTabNav activeTab={activeTab} onTabChange={setActiveTab} diffStats={diffStats} />
       <div className="min-h-0 flex-1">
         <div className={activeTab === "diff" ? "h-full" : "hidden"}>
-          <DiffView workspaceId={workspaceId} active={activeTab === "diff"} onStatsChange={handleStatsChange} />
+          <DiffView
+            workspaceId={workspaceId}
+            active={activeTab === "diff"}
+            onStatsChange={handleStatsChange}
+          />
         </div>
         <div className={activeTab === "code" ? "h-full" : "hidden"}>
           <CodeBrowserView workspaceId={workspaceId} />

--- a/apps/web/src/components/ai-elements/conversation.tsx
+++ b/apps/web/src/components/ai-elements/conversation.tsx
@@ -20,7 +20,7 @@ export type ConversationContentProps = ComponentProps<typeof StickToBottom.Conte
 
 export const ConversationContent = ({ className, ...props }: ConversationContentProps) => (
   <StickToBottom.Content
-    className={cn("mx-auto flex w-full max-w-3xl flex-col gap-4 p-4", className)}
+    className={cn("mx-auto flex w-full max-w-3xl flex-col gap-4 p-4 lg:px-12", className)}
     {...props}
   />
 );

--- a/apps/web/src/components/ai-elements/message.tsx
+++ b/apps/web/src/components/ai-elements/message.tsx
@@ -32,9 +32,9 @@ export type MessageContentProps = HTMLAttributes<HTMLDivElement>;
 export const MessageContent = ({ children, className, ...props }: MessageContentProps) => (
   <div
     className={cn(
-      "is-user:dark flex min-w-0 max-w-full flex-col gap-2 break-words text-base",
+      "is-user:dark flex min-w-0 max-w-full flex-col gap-2 break-words text-base lg:text-sm",
       "group-[.is-assistant]:w-full group-[.is-user]:w-fit",
-      "group-[.is-user]:ml-auto group-[.is-user]:rounded-md group-[.is-user]:bg-secondary group-[.is-user]:px-4 group-[.is-user]:py-3 group-[.is-user]:text-foreground",
+      "group-[.is-user]:ml-auto group-[.is-user]:rounded-md group-[.is-user]:bg-white/10 group-[.is-user]:px-4 group-[.is-user]:py-3 group-[.is-user]:text-foreground",
       "group-[.is-assistant]:text-foreground",
       className,
     )}

--- a/apps/web/src/components/ai-elements/prompt-input.tsx
+++ b/apps/web/src/components/ai-elements/prompt-input.tsx
@@ -140,7 +140,7 @@ export const PromptInput = ({ className, onSubmit, children, ...props }: PromptI
   return (
     <form
       className={cn(
-        "relative flex w-full flex-col rounded-md border border-border/50 bg-card p-2",
+        "relative flex w-full flex-col rounded-md border border-white/15 bg-white/10 p-2 shadow-[0_0_20px_rgba(255,255,255,0.06)]",
         isDragging && "border-primary/50 bg-primary/5",
         className,
       )}
@@ -283,13 +283,13 @@ export const PromptInputAttach = ({ className, ...props }: PromptInputAttachProp
       <button
         type="button"
         className={cn(
-          "inline-flex size-8 shrink-0 items-center justify-center rounded text-muted-foreground transition-colors hover:bg-muted hover:text-foreground",
+          "inline-flex size-8 lg:size-7 shrink-0 items-center justify-center rounded text-white/40 transition-colors hover:bg-muted hover:text-foreground",
           className,
         )}
         onClick={() => fileInputRef.current?.click()}
         {...props}
       >
-        <Paperclip className="size-5" />
+        <Paperclip className="size-5 lg:size-4" />
       </button>
     </>
   );
@@ -381,7 +381,7 @@ export const PromptInputTextarea = ({
         autoCorrect="off"
         spellCheck={false}
         className={cn(
-          "min-h-[44px] max-h-48 w-full resize-none bg-transparent px-2 py-2.5 text-base outline-none placeholder:text-muted-foreground field-sizing-content",
+          "min-h-[44px] lg:min-h-[36px] max-h-48 w-full resize-none bg-transparent px-2 py-2.5 lg:py-2 text-base lg:text-sm outline-none placeholder:text-white/40 field-sizing-content",
           hasSlashCommand && "text-transparent caret-foreground",
           className,
         )}
@@ -395,7 +395,7 @@ export const PromptInputTextarea = ({
       />
       {hasSlashCommand && (
         <div
-          className="pointer-events-none absolute top-0 left-0 min-h-[44px] w-full whitespace-pre-wrap break-words px-2 py-2.5 text-base text-foreground"
+          className="pointer-events-none absolute top-0 left-0 min-h-[44px] lg:min-h-[36px] w-full whitespace-pre-wrap break-words px-2 py-2.5 lg:py-2 text-base lg:text-sm text-foreground"
           aria-hidden
         >
           {highlightSlashCommands(inputValue)}
@@ -435,40 +435,40 @@ export const PromptInputSubmit = ({
       {isStreaming && (
         <button
           type="button"
-          className="inline-flex size-8 shrink-0 items-center justify-center rounded-full bg-foreground text-background transition-colors hover:bg-foreground/80"
+          className="inline-flex size-8 lg:size-7 shrink-0 items-center justify-center rounded-full bg-foreground text-background transition-colors hover:bg-foreground/80"
           onClick={onStop}
         >
-          <SquareIcon className="size-4 fill-current" />
+          <SquareIcon className="size-4 lg:size-3.5 fill-current" />
         </button>
       )}
       {isSubmitting && !hasContent ? (
         <button
           type="button"
           className={cn(
-            "inline-flex size-8 shrink-0 items-center justify-center rounded-full bg-foreground/50 text-background transition-colors",
+            "inline-flex size-8 lg:size-7 shrink-0 items-center justify-center rounded-full bg-foreground/50 text-background transition-colors",
             className,
           )}
           disabled
           {...props}
         >
-          <Loader2 className="size-5 animate-spin" />
+          <Loader2 className="size-5 lg:size-4 animate-spin" />
         </button>
       ) : (
         <button
           type="submit"
           disabled={!hasContent}
           className={cn(
-            "inline-flex size-8 shrink-0 items-center justify-center rounded-full transition-colors",
+            "inline-flex size-8 lg:size-7 shrink-0 items-center justify-center rounded-full transition-colors",
             hasContent
               ? isBusy
                 ? "bg-primary text-primary-foreground hover:bg-primary/80"
                 : "bg-foreground text-background hover:bg-foreground/80"
-              : "bg-muted text-muted-foreground",
+              : "bg-white/15 text-white/40",
             className,
           )}
           {...props}
         >
-          <ArrowUpIcon className="size-5" />
+          <ArrowUpIcon className="size-5 lg:size-4" />
         </button>
       )}
     </div>

--- a/packages/dashboard-core/src/components/DashboardShell.tsx
+++ b/packages/dashboard-core/src/components/DashboardShell.tsx
@@ -11,7 +11,6 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
   ScrollArea,
-  Separator,
   Spinner,
   Tooltip,
   TooltipContent,
@@ -57,8 +56,6 @@ export function DashboardShell({ toolbarExtra }: DashboardShellProps) {
 
   return (
     <div className="h-dvh w-full overflow-hidden flex flex-col bg-background text-foreground p-0 pt-[env(safe-area-inset-top)]">
-      <Separator />
-
       {view === "settings" ? (
         <ScrollArea className="flex-1 overflow-hidden">
           <div className="px-2 py-2">
@@ -67,7 +64,7 @@ export function DashboardShell({ toolbarExtra }: DashboardShellProps) {
         </ScrollArea>
       ) : (
         <>
-          <div className="flex items-center justify-between px-4 py-2">
+          <div className="flex h-12 shrink-0 items-center justify-between border-b border-white/20 px-4">
             <div className="flex items-center gap-1">
               <Tooltip>
                 <TooltipTrigger asChild>
@@ -144,8 +141,6 @@ export function DashboardShell({ toolbarExtra }: DashboardShellProps) {
               <TooltipContent>Add project</TooltipContent>
             </Tooltip>
           </div>
-
-          <Separator />
 
           <ScrollArea
             className="flex-1 overflow-hidden"

--- a/packages/dashboard-core/src/components/DiffView.tsx
+++ b/packages/dashboard-core/src/components/DiffView.tsx
@@ -3,9 +3,16 @@ import { useAdapter } from "../context";
 import { extensionToLanguage, filenameToLanguage } from "../lib/language-map";
 import type { FileStatus, WorkspaceDiff } from "../types";
 
+export interface DiffStats {
+  filesChanged: number;
+  insertions: number;
+  deletions: number;
+}
+
 interface DiffViewProps {
   workspaceId: string;
   active?: boolean;
+  onStatsChange?: (stats: DiffStats | null) => void;
 }
 
 interface ParsedFile {
@@ -197,7 +204,7 @@ function DiffFileContent({ hunks, filename }: { hunks: string; filename: string 
                     : ""
             }
           >
-            <span className="inline-block w-5 select-none text-center text-muted-foreground/50">
+            <span className="inline-block w-5 select-none text-center text-muted-foreground">
               {line.type === "add" ? "+" : line.type === "del" ? "-" : " "}
             </span>
             {line.type === "hunk"
@@ -215,7 +222,7 @@ function DiffFileContent({ hunks, filename }: { hunks: string; filename: string 
   );
 }
 
-export function DiffView({ workspaceId, active = true }: DiffViewProps) {
+export function DiffView({ workspaceId, active = true, onStatsChange }: DiffViewProps) {
   const adapter = useAdapter();
   const [data, setData] = useState<WorkspaceDiff | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -238,6 +245,7 @@ export function DiffView({ workspaceId, active = true }: DiffViewProps) {
           if (!cancelled) {
             setData(result);
             setError(null);
+            onStatsChange?.(result?.diff ? result.stats : null);
           }
         })
         .catch((err) => {
@@ -295,21 +303,10 @@ export function DiffView({ workspaceId, active = true }: DiffViewProps) {
     });
   };
 
-  const navigateToFile = (filename: string) => {
-    setOpenFiles((prev) => {
-      const next = new Set(prev);
-      next.add(filename);
-      return next;
-    });
-    setTimeout(() => {
-      const el = document.getElementById(`diff-file-${encodeURIComponent(filename)}`);
-      el?.scrollIntoView({ behavior: "smooth", block: "start" });
-    }, 0);
-  };
 
   return (
     <div className="flex h-full flex-col overflow-hidden">
-      <div className="shrink-0 border-b border-border/50 px-4 py-3">
+      <div className="shrink-0 border-b border-white/20 px-4 py-2">
         <div className="text-sm text-muted-foreground">
           <span className="font-medium text-foreground">{data.stats.filesChanged}</span>{" "}
           {data.stats.filesChanged === 1 ? "file" : "files"} changed
@@ -320,21 +317,8 @@ export function DiffView({ workspaceId, active = true }: DiffViewProps) {
             <span className="ml-1 text-red-400">-{data.stats.deletions}</span>
           )}
         </div>
-        <div className="mt-1 text-xs text-muted-foreground">
+        <div className="mt-0.5 text-xs text-muted-foreground">
           {data.baseBranch} ← {data.headBranch}
-        </div>
-        <div className="mt-2 flex max-h-28 flex-col gap-0.5 overflow-y-auto">
-          {files.map((file) => (
-            <button
-              key={file.filename}
-              type="button"
-              onClick={() => navigateToFile(file.filename)}
-              className="flex items-center gap-1.5 rounded px-1 py-0.5 text-left text-xs hover:bg-accent/50"
-            >
-              <FileStatusBadge status={fileStatuses[file.filename]} />
-              <span className="truncate font-mono text-muted-foreground">{file.filename}</span>
-            </button>
-          ))}
         </div>
       </div>
       <div className="min-h-0 flex-1 overflow-y-auto">

--- a/packages/dashboard-core/src/components/DiffView.tsx
+++ b/packages/dashboard-core/src/components/DiffView.tsx
@@ -262,7 +262,7 @@ export function DiffView({ workspaceId, active = true, onStatsChange }: DiffView
       cancelled = true;
       if (interval) clearInterval(interval);
     };
-  }, [adapter, workspaceId, active]);
+  }, [adapter, workspaceId, active, onStatsChange]);
 
   if (loading) {
     return (
@@ -302,7 +302,6 @@ export function DiffView({ workspaceId, active = true, onStatsChange }: DiffView
       return next;
     });
   };
-
 
   return (
     <div className="flex h-full flex-col overflow-hidden">

--- a/packages/dashboard-core/src/components/FileBrowser.tsx
+++ b/packages/dashboard-core/src/components/FileBrowser.tsx
@@ -76,7 +76,9 @@ export function FileBrowser({
   return (
     <div className="flex h-full flex-col overflow-hidden">
       {/* Breadcrumbs */}
-      <div className={`flex shrink-0 items-center gap-1 overflow-x-auto border-b border-border/50 text-xs ${compact ? "px-2 py-1.5" : "px-4 py-2"}`}>
+      <div
+        className={`flex shrink-0 items-center gap-1 overflow-x-auto border-b border-border/50 text-xs ${compact ? "px-2 py-1.5" : "px-4 py-2"}`}
+      >
         <button
           type="button"
           onClick={() => handleBreadcrumb(-1)}
@@ -136,7 +138,9 @@ export function FileBrowser({
                 {entry.type === "directory" ? (
                   <Folder className={`shrink-0 text-blue-400 ${compact ? "size-4" : "size-4"}`} />
                 ) : (
-                  <File className={`shrink-0 text-muted-foreground ${compact ? "size-4" : "size-4"}`} />
+                  <File
+                    className={`shrink-0 text-muted-foreground ${compact ? "size-4" : "size-4"}`}
+                  />
                 )}
                 <span className="min-w-0 flex-1 truncate">{entry.name}</span>
                 {!compact && entry.type === "directory" && (

--- a/packages/dashboard-core/src/components/FileBrowser.tsx
+++ b/packages/dashboard-core/src/components/FileBrowser.tsx
@@ -8,6 +8,10 @@ interface FileBrowserProps {
   currentPath: string;
   onNavigate: (path: string) => void;
   onOpenFile: (path: string) => void;
+  /** Compact mode for sidebar use — smaller items */
+  compact?: boolean;
+  /** Currently selected file path for highlighting */
+  selectedFile?: string;
 }
 
 export function FileBrowser({
@@ -15,6 +19,8 @@ export function FileBrowser({
   currentPath,
   onNavigate,
   onOpenFile,
+  compact,
+  selectedFile,
 }: FileBrowserProps) {
   const adapter = useAdapter();
   const [entries, setEntries] = useState<FileEntry[]>([]);
@@ -70,7 +76,7 @@ export function FileBrowser({
   return (
     <div className="flex h-full flex-col overflow-hidden">
       {/* Breadcrumbs */}
-      <div className="flex shrink-0 items-center gap-1 overflow-x-auto border-b border-border/50 px-4 py-2 text-xs">
+      <div className={`flex shrink-0 items-center gap-1 overflow-x-auto border-b border-border/50 text-xs ${compact ? "px-2 py-1.5" : "px-4 py-2"}`}>
         <button
           type="button"
           onClick={() => handleBreadcrumb(-1)}
@@ -115,24 +121,30 @@ export function FileBrowser({
         )}
         {!loading &&
           !error &&
-          entries.map((entry) => (
-            <button
-              key={entry.name}
-              type="button"
-              onClick={() => handleClick(entry)}
-              className="flex w-full items-center gap-3 px-4 py-2.5 text-left text-sm hover:bg-accent/50"
-            >
-              {entry.type === "directory" ? (
-                <Folder className="size-4 shrink-0 text-blue-400" />
-              ) : (
-                <File className="size-4 shrink-0 text-muted-foreground" />
-              )}
-              <span className="min-w-0 flex-1 truncate">{entry.name}</span>
-              {entry.type === "directory" && (
-                <ChevronRight className="size-3.5 shrink-0 text-muted-foreground/50" />
-              )}
-            </button>
-          ))}
+          entries.map((entry) => {
+            const entryPath = currentPath ? `${currentPath}/${entry.name}` : entry.name;
+            const isSelected = entry.type === "file" && selectedFile === entryPath;
+            return (
+              <button
+                key={entry.name}
+                type="button"
+                onClick={() => handleClick(entry)}
+                className={`flex w-full items-center text-left hover:bg-accent/50 ${
+                  compact ? "gap-2 px-3 py-2 text-sm" : "gap-3 px-4 py-2.5 text-sm"
+                } ${isSelected ? "bg-accent/50 text-foreground" : ""}`}
+              >
+                {entry.type === "directory" ? (
+                  <Folder className={`shrink-0 text-blue-400 ${compact ? "size-4" : "size-4"}`} />
+                ) : (
+                  <File className={`shrink-0 text-muted-foreground ${compact ? "size-4" : "size-4"}`} />
+                )}
+                <span className="min-w-0 flex-1 truncate">{entry.name}</span>
+                {!compact && entry.type === "directory" && (
+                  <ChevronRight className="size-3.5 shrink-0 text-muted-foreground/50" />
+                )}
+              </button>
+            );
+          })}
       </div>
     </div>
   );

--- a/packages/dashboard-core/src/components/FileViewer.tsx
+++ b/packages/dashboard-core/src/components/FileViewer.tsx
@@ -7,7 +7,7 @@ import type { FileContentResult } from "../types";
 interface FileViewerProps {
   workspaceId: string;
   filePath: string;
-  onBack: () => void;
+  onBack?: () => void;
 }
 
 interface TokenSpan {
@@ -101,19 +101,19 @@ export function FileViewer({ workspaceId, filePath, onBack }: FileViewerProps) {
     };
   }, [adapter, workspaceId, filePath]);
 
-  const filename = getFilename(filePath);
-
   return (
     <div className="flex h-full flex-col overflow-hidden">
       <div className="flex shrink-0 items-center gap-2 border-b border-border/50 px-4 py-2">
-        <button
-          type="button"
-          onClick={onBack}
-          className="inline-flex size-7 items-center justify-center rounded-md hover:bg-accent"
-        >
-          <ArrowLeft className="size-3.5" />
-        </button>
-        <span className="min-w-0 flex-1 truncate font-mono text-xs">{filename}</span>
+        {onBack && (
+          <button
+            type="button"
+            onClick={onBack}
+            className="inline-flex size-7 items-center justify-center rounded-md hover:bg-accent"
+          >
+            <ArrowLeft className="size-3.5" />
+          </button>
+        )}
+        <span className="min-w-0 flex-1 truncate font-mono text-xs">{filePath}</span>
         {data && (
           <span className="shrink-0 text-xs text-muted-foreground">{formatSize(data.size)}</span>
         )}
@@ -151,8 +151,7 @@ export function FileViewer({ workspaceId, filePath, onBack }: FileViewerProps) {
 
 function lineNumberWidth(totalLines: number): string {
   const digits = String(totalLines).length;
-  // Minimum 2ch width, scale with digit count
-  const ch = Math.max(2, digits);
+  const ch = Math.max(3, digits);
   return `${ch}ch`;
 }
 
@@ -163,9 +162,9 @@ function HighlightedCode({ lines }: { lines: TokenLine[] }) {
       <pre className="text-xs leading-5">
         {lines.map((tokens, lineIdx) => (
           // biome-ignore lint/suspicious/noArrayIndexKey: code lines have no stable id
-          <div key={lineIdx} className="flex">
+          <div key={lineIdx} className="flex gap-4">
             <span
-              className="shrink-0 select-none pr-4 text-right text-muted-foreground/50"
+              className="shrink-0 select-none text-right text-muted-foreground"
               style={{ width: gutterWidth }}
             >
               {lineIdx + 1}
@@ -193,9 +192,9 @@ function PlainCode({ content }: { content: string }) {
       <pre className="text-xs leading-5">
         {lines.map((line, lineIdx) => (
           // biome-ignore lint/suspicious/noArrayIndexKey: code lines have no stable id
-          <div key={lineIdx} className="flex">
+          <div key={lineIdx} className="flex gap-4">
             <span
-              className="shrink-0 select-none pr-4 text-right text-muted-foreground/50"
+              className="shrink-0 select-none text-right text-muted-foreground"
               style={{ width: gutterWidth }}
             >
               {lineIdx + 1}

--- a/packages/dashboard-core/src/components/ProjectList.tsx
+++ b/packages/dashboard-core/src/components/ProjectList.tsx
@@ -115,7 +115,12 @@ function SortableProject({
             >
               {editMode && <GripVertical className="size-4 shrink-0 text-muted-foreground" />}
               <FolderOpen className="size-4 shrink-0 text-muted-foreground" />
-              <h2 className="text-sm font-semibold text-foreground truncate">{project.name}</h2>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <h2 className="text-sm font-semibold text-foreground truncate">{project.name}</h2>
+                </TooltipTrigger>
+                <TooltipContent side="top">{project.name}</TooltipContent>
+              </Tooltip>
             </div>
             <div className="flex items-center gap-1">
               {editMode ? (

--- a/packages/dashboard-core/src/components/WorkspaceCard.tsx
+++ b/packages/dashboard-core/src/components/WorkspaceCard.tsx
@@ -1,4 +1,12 @@
-import { ContextMenu, ContextMenuContent, ContextMenuItem, ContextMenuTrigger, Tooltip, TooltipContent, TooltipTrigger } from "@band/ui";
+import {
+  ContextMenu,
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuTrigger,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@band/ui";
 import { Clipboard, FolderOpen, GitBranch, Play, Square, Trash2 } from "lucide-react";
 import { useEffect, useRef } from "react";
 import { useCapabilities } from "../context";

--- a/packages/dashboard-core/src/components/WorkspaceCard.tsx
+++ b/packages/dashboard-core/src/components/WorkspaceCard.tsx
@@ -1,4 +1,4 @@
-import { ContextMenu, ContextMenuContent, ContextMenuItem, ContextMenuTrigger } from "@band/ui";
+import { ContextMenu, ContextMenuContent, ContextMenuItem, ContextMenuTrigger, Tooltip, TooltipContent, TooltipTrigger } from "@band/ui";
 import { Clipboard, FolderOpen, GitBranch, Play, Square, Trash2 } from "lucide-react";
 import { useEffect, useRef } from "react";
 import { useCapabilities } from "../context";
@@ -103,12 +103,17 @@ export function WorkspaceCard({
             <GitBranch
               className={`size-3.5 shrink-0 ${isActive ? "text-primary" : "text-muted-foreground"}`}
             />
-            <span
-              className={`text-sm truncate ${isActive ? "font-semibold text-foreground" : "font-medium"}`}
-              style={isActive ? undefined : { color: "oklch(0.7 0 0)" }}
-            >
-              {worktree.branch}
-            </span>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <span
+                  className={`text-sm truncate ${isActive ? "font-semibold text-foreground" : "font-medium"}`}
+                  style={isActive ? undefined : { color: "oklch(0.7 0 0)" }}
+                >
+                  {worktree.branch}
+                </span>
+              </TooltipTrigger>
+              <TooltipContent side="top">{worktree.branch}</TooltipContent>
+            </Tooltip>
             {!editMode && <AgentStatusBadge agent={status?.agent} />}
           </div>
           {!editMode && (

--- a/packages/dashboard-core/src/components/WorkspaceTabNav.tsx
+++ b/packages/dashboard-core/src/components/WorkspaceTabNav.tsx
@@ -35,7 +35,7 @@ export function WorkspaceTabNav({ activeTab, onTabChange, diffFileCount }: Works
             <Icon className="size-4" />
             {tab.label}
             {badge && (
-              <span className="inline-flex h-5 min-w-5 items-center justify-center rounded-full bg-muted px-1.5 text-xs font-medium">
+              <span className="inline-flex h-5 min-w-5 items-center justify-center rounded-full bg-blue-500/20 text-blue-400 px-1.5 text-xs font-medium">
                 {diffFileCount}
               </span>
             )}

--- a/packages/dashboard-core/src/index.ts
+++ b/packages/dashboard-core/src/index.ts
@@ -7,7 +7,7 @@ export { AddProjectDialog } from "./components/AddProjectDialog";
 export { AgentStatusBadge } from "./components/AgentStatusBadge";
 export { CIStatusIndicator } from "./components/CIStatusIndicator";
 export { DashboardShell } from "./components/DashboardShell";
-export { DiffView } from "./components/DiffView";
+export { DiffView, type DiffStats } from "./components/DiffView";
 export { FileBrowser } from "./components/FileBrowser";
 export { FileViewer } from "./components/FileViewer";
 export { GitStatusIndicator } from "./components/GitStatusIndicator";

--- a/packages/dashboard-core/src/index.ts
+++ b/packages/dashboard-core/src/index.ts
@@ -7,7 +7,7 @@ export { AddProjectDialog } from "./components/AddProjectDialog";
 export { AgentStatusBadge } from "./components/AgentStatusBadge";
 export { CIStatusIndicator } from "./components/CIStatusIndicator";
 export { DashboardShell } from "./components/DashboardShell";
-export { DiffView, type DiffStats } from "./components/DiffView";
+export { type DiffStats, DiffView } from "./components/DiffView";
 export { FileBrowser } from "./components/FileBrowser";
 export { FileViewer } from "./components/FileViewer";
 export { GitStatusIndicator } from "./components/GitStatusIndicator";


### PR DESCRIPTION
## Summary
- Reorder desktop panels: projects (left), changes/code (middle), chat (right, capped at 768px)
- Widen project list (288→320px) with tooltips on truncated names/branches
- Add side-by-side code browser on desktop (file tree left, viewer right); mobile keeps toggle behavior
- Smaller chat font/input on desktop, brighter borders (`border-white/20`), user message bubbles (`bg-white/10`)
- Show diff file count as blue badge in Changes tab (desktop + mobile)
- Hide chat/changes panels when no workspace selected
- Remove duplicate file list from diff summary

## Test plan
- [ ] Verify desktop three-panel layout renders correctly at various widths
- [ ] Verify chat panel caps at 768px and code panel gets remaining space
- [ ] Verify project/branch names show tooltips on hover when truncated
- [ ] Verify code browser shows side-by-side on desktop, toggle on mobile
- [ ] Verify mobile layout is unchanged (chat, changes, code tabs)
- [ ] Verify blue badge shows file count in Changes tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)