### PR TITLE
Reorganise toolbar into grouped dropdown menus

### DIFF
--- a/apps/web/src/components/DashboardView.tsx
+++ b/apps/web/src/components/DashboardView.tsx
@@ -4,9 +4,19 @@ import {
   HybridDashboardAdapter,
   NativeShellCapabilities,
 } from "@band/dashboard-core/adapters/hybrid";
-import { Button, Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@band/ui";
-import { Link } from "@tanstack/react-router";
-import { ListTodo, Timer } from "lucide-react";
+import {
+  Button,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@band/ui";
+import { useNavigate } from "@tanstack/react-router";
+import { ListTodo, Timer, Zap } from "lucide-react";
 import { useCallback } from "react";
 import { useIsDesktop } from "../hooks/useIsDesktop";
 import { DesktopLayout } from "./DesktopLayout";
@@ -32,53 +42,42 @@ class DesktopWebCapabilities implements PlatformCapabilities {
 
 const desktopCapabilities = new DesktopWebCapabilities();
 
-function TasksButton() {
-  const handleClick = useCallback(async () => {
-    const { invoke } = await import("@tauri-apps/api/core");
-    await invoke("open_tasks_window");
-  }, []);
-
-  if (inTauri) {
-    return (
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <Button size="icon-sm" variant="ghost" onClick={handleClick}>
-            <ListTodo className="size-5" />
-          </Button>
-        </TooltipTrigger>
-        <TooltipContent>Tasks</TooltipContent>
-      </Tooltip>
-    );
-  }
-
-  return (
-    <Tooltip>
-      <TooltipTrigger asChild>
-        <Button size="icon-sm" variant="ghost" asChild>
-          <Link to="/tasks">
-            <ListTodo className="size-5" />
-          </Link>
-        </Button>
-      </TooltipTrigger>
-      <TooltipContent>Tasks</TooltipContent>
-    </Tooltip>
-  );
-}
-
 function ToolbarButtons() {
+  const navigate = useNavigate();
+
+  const handleTasksClick = useCallback(async () => {
+    if (inTauri) {
+      const { invoke } = await import("@tauri-apps/api/core");
+      await invoke("open_tasks_window");
+    } else {
+      navigate({ to: "/tasks" });
+    }
+  }, [navigate]);
+
   return (
     <>
-      <TasksButton />
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <Button size="icon-sm" variant="ghost" asChild>
-            <Link to="/cronjobs">
-              <Timer className="size-5" />
-            </Link>
-          </Button>
-        </TooltipTrigger>
-        <TooltipContent>Cronjobs</TooltipContent>
-      </Tooltip>
+      <DropdownMenu>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <DropdownMenuTrigger asChild>
+              <Button size="icon-sm" variant="ghost">
+                <Zap className="size-5" />
+              </Button>
+            </DropdownMenuTrigger>
+          </TooltipTrigger>
+          <TooltipContent>Run agent</TooltipContent>
+        </Tooltip>
+        <DropdownMenuContent align="start">
+          <DropdownMenuItem onClick={handleTasksClick}>
+            <ListTodo className="size-4" />
+            Tasks
+          </DropdownMenuItem>
+          <DropdownMenuItem onClick={() => navigate({ to: "/cronjobs" })}>
+            <Timer className="size-4" />
+            Cronjobs
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
       <TunnelToolbarButton />
     </>
   );

--- a/packages/dashboard-core/src/components/DashboardShell.tsx
+++ b/packages/dashboard-core/src/components/DashboardShell.tsx
@@ -69,26 +69,28 @@ export function DashboardShell({ toolbarExtra }: DashboardShellProps) {
         <>
           <div className="flex items-center justify-between px-4 py-2">
             <div className="flex items-center gap-1">
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <Button size="icon-sm" variant="ghost" onClick={() => setView("settings")}>
-                    <Settings className="size-5" />
-                  </Button>
-                </TooltipTrigger>
-                <TooltipContent>Settings</TooltipContent>
-              </Tooltip>
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <Button
-                    size="icon-sm"
-                    variant={editMode ? "secondary" : "ghost"}
-                    onClick={() => setEditMode((v) => !v)}
-                  >
-                    <Pencil className="size-5" />
-                  </Button>
-                </TooltipTrigger>
-                <TooltipContent>{editMode ? "Done editing" : "Edit projects"}</TooltipContent>
-              </Tooltip>
+              <DropdownMenu>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <DropdownMenuTrigger asChild>
+                      <Button size="icon-sm" variant="ghost">
+                        <Settings className="size-5" />
+                      </Button>
+                    </DropdownMenuTrigger>
+                  </TooltipTrigger>
+                  <TooltipContent>Manage</TooltipContent>
+                </Tooltip>
+                <DropdownMenuContent align="start">
+                  <DropdownMenuItem onClick={() => setEditMode((v) => !v)}>
+                    <Pencil className="size-4" />
+                    {editMode ? "Done editing" : "Edit list"}
+                  </DropdownMenuItem>
+                  <DropdownMenuItem onClick={() => setView("settings")}>
+                    <Settings className="size-4" />
+                    Settings
+                  </DropdownMenuItem>
+                </DropdownMenuContent>
+              </DropdownMenu>
               {toolbarExtra}
               {labels.length > 0 && (
                 <DropdownMenu>

--- a/packages/ui/src/components/context-menu.tsx
+++ b/packages/ui/src/components/context-menu.tsx
@@ -27,7 +27,7 @@ function ContextMenuContent({
       <ContextMenuPrimitive.Content
         data-slot="context-menu-content"
         className={cn(
-          "z-50 max-h-(--radix-context-menu-content-available-height) min-w-[8rem] origin-(--radix-context-menu-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border bg-popover p-1 text-popover-foreground shadow-md data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95",
+          "z-50 max-h-(--radix-context-menu-content-available-height) min-w-[8rem] origin-(--radix-context-menu-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border border-[oklch(0.4_0_0)] bg-[oklch(0.26_0_0)] p-1 text-popover-foreground shadow-md data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95",
           className,
         )}
         {...props}
@@ -95,7 +95,7 @@ function ContextMenuSubContent({
     <ContextMenuPrimitive.SubContent
       data-slot="context-menu-sub-content"
       className={cn(
-        "z-50 min-w-[8rem] origin-(--radix-context-menu-content-transform-origin) overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-lg data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95",
+        "z-50 min-w-[8rem] origin-(--radix-context-menu-content-transform-origin) overflow-hidden rounded-md border border-[oklch(0.4_0_0)] bg-[oklch(0.26_0_0)] p-1 text-popover-foreground shadow-lg data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95",
         className,
       )}
       {...props}

--- a/packages/ui/src/components/dropdown-menu.tsx
+++ b/packages/ui/src/components/dropdown-menu.tsx
@@ -31,7 +31,7 @@ function DropdownMenuContent({
         data-slot="dropdown-menu-content"
         sideOffset={sideOffset}
         className={cn(
-          "z-50 max-h-(--radix-dropdown-menu-content-available-height) min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border bg-popover p-1 text-popover-foreground shadow-md data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95",
+          "z-50 max-h-(--radix-dropdown-menu-content-available-height) min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border border-[oklch(0.4_0_0)] bg-[oklch(0.26_0_0)] p-1 text-popover-foreground shadow-md data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95",
           className,
         )}
         {...props}
@@ -199,7 +199,7 @@ function DropdownMenuSubContent({
     <DropdownMenuPrimitive.SubContent
       data-slot="dropdown-menu-sub-content"
       className={cn(
-        "z-50 min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-lg data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95",
+        "z-50 min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-hidden rounded-md border border-[oklch(0.4_0_0)] bg-[oklch(0.26_0_0)] p-1 text-popover-foreground shadow-lg data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95",
         className,
       )}
       {...props}


### PR DESCRIPTION
## Summary
- Group toolbar actions into two dropdown menus: **Manage** (gear icon: Edit list + Settings) and **Run agent** (zap icon: Tasks + Cronjobs)
- Tunnel button remains standalone
- Improve dropdown/context menu visibility with lighter background and darker border

## Test plan
- [ ] Open dashboard, verify gear menu shows "Edit list" and "Settings" items with icons
- [ ] Verify zap menu shows "Tasks" and "Cronjobs" items with icons
- [ ] Verify tunnel button still works independently
- [ ] Right-click a project to verify context menu has updated styling
- [ ] Test in Tauri app: Tasks menu item should open tasks window

🤖 Generated with [Claude Code](https://claude.com/claude-code)