### PR TITLE
fix: keyboard Enter navigation in project list

### DIFF
--- a/packages/dashboard-core/src/components/ProjectList.tsx
+++ b/packages/dashboard-core/src/components/ProjectList.tsx
@@ -347,10 +347,42 @@ export function ProjectList({ labelFilter, editMode }: ProjectListProps) {
     }
   }, [activeWorkspaceId, allWorkspaceIds]);
 
+  // Focus the container so keyboard navigation works immediately.
+  // Depends on hasProjects because the container div only renders when
+  // projects.length > 0 (see the early return below). On first mount with no
+  // projects, containerRef.current is null; re-running when hasProjects flips
+  // to true ensures we focus the container once it exists in the DOM.
+  const hasProjects = projects.length > 0;
   useEffect(() => {
-    containerRef.current?.focus();
-  }, []);
+    if (hasProjects) {
+      containerRef.current?.focus();
+    }
+  }, [hasProjects]);
 
+  // ──────────────────────────────────────────────────────────────────────────
+  // KEYBOARD NAVIGATION — READ BEFORE MODIFYING
+  //
+  // This handler is the backbone of keyboard workspace switching. It has
+  // regressed multiple times because the interaction between this container-
+  // level handler and the card-level onKeyDown (in WorkspaceCard) is subtle:
+  //
+  //  • Arrow keys update `focusedIndex` which controls the visual highlight
+  //    ring on WorkspaceCards. However, arrow events may originate on a *child*
+  //    card that has DOM focus (e.g. after the user clicked a card or tabbed
+  //    into the list). They bubble up here because cards don't handle arrows.
+  //
+  //  • Enter on a *card* is handled by the card's own onKeyDown, which calls
+  //    stopPropagation — so this container handler would NEVER see it.
+  //    The card opens *itself*, not necessarily the keyboard-highlighted card.
+  //
+  //  • To fix this, arrow handlers explicitly re-focus the container via
+  //    containerRef.current?.focus(). This guarantees the next Enter fires
+  //    HERE, where we use the correct focusedIndex to open the right workspace.
+  //
+  // DO NOT remove the containerRef.current?.focus() calls. Without them,
+  // pressing Enter after arrow-key navigation opens the wrong workspace (or
+  // no workspace at all, depending on the platform).
+  // ──────────────────────────────────────────────────────────────────────────
   function handleKeyDown(e: React.KeyboardEvent) {
     if (allWorkspaceIds.length === 0) return;
 
@@ -358,11 +390,17 @@ export function ProjectList({ labelFilter, editMode }: ProjectListProps) {
       e.preventDefault();
       keyboardNavRef.current = true;
       setFocusedIndex((prev) => (prev < allWorkspaceIds.length - 1 ? prev + 1 : prev));
+      // Keep DOM focus on the container so Enter fires here, not on a child card.
+      // See block comment above — removing this breaks keyboard Enter navigation.
+      containerRef.current?.focus();
     } else if (e.key === "ArrowUp") {
       e.preventDefault();
       keyboardNavRef.current = true;
       setFocusedIndex((prev) => (prev > 0 ? prev - 1 : prev));
+      // Keep DOM focus on the container — same reasoning as ArrowDown above.
+      containerRef.current?.focus();
     } else if (e.key === "Enter") {
+      e.preventDefault();
       if (focusedIndex >= 0 && focusedIndex < allWorkspaceIds.length) {
         keyboardNavRef.current = false;
         openWorkspace(allWorkspaceIds[focusedIndex]);

--- a/packages/dashboard-core/src/components/WorkspaceCard.tsx
+++ b/packages/dashboard-core/src/components/WorkspaceCard.tsx
@@ -76,6 +76,16 @@ export function WorkspaceCard({
         className,
         tabIndex: 0,
         onClick: handleClick,
+        // Accessibility: handle Enter/Space for direct card activation (e.g. user
+        // tabs to this card and presses Enter). stopPropagation prevents the
+        // ProjectList container's handleKeyDown from ALSO firing.
+        //
+        // NOTE: During arrow-key navigation, the ProjectList container keeps DOM
+        // focus on itself (via containerRef.current?.focus() in its arrow handlers).
+        // That means this card-level handler will NOT fire after arrow navigation —
+        // the container's Enter handler fires instead and uses focusedIndex to open
+        // the correct workspace. This division of responsibility is intentional.
+        // See the keyboard navigation comment block in ProjectList.tsx.
         onKeyDown: (e: React.KeyboardEvent) => {
           if (e.key === "Enter" || e.key === " ") {
             e.stopPropagation();


### PR DESCRIPTION
## Summary
- Arrow key handlers now call `containerRef.current?.focus()` to keep DOM focus on the ProjectList container, ensuring the container's Enter handler (which uses the correct `focusedIndex`) fires instead of a child WorkspaceCard intercepting it via `stopPropagation`
- Fixed initial focus `useEffect` to re-run when projects load asynchronously (previously fired once on mount when `containerRef.current` was null)
- Added detailed comments explaining the container/card keyboard handler interaction to prevent future regressions

## Test plan
- [ ] Navigate workspace list with ArrowUp/ArrowDown, press Enter — should open the highlighted workspace
- [ ] Click a workspace card, then navigate with arrows, press Enter — should open the arrow-highlighted workspace, not the clicked one
- [ ] Tab into the list, press Enter on a focused card — should open that card's workspace
- [ ] Verify initial keyboard navigation works on page load (without clicking first)

🤖 Generated with [Claude Code](https://claude.com/claude-code)