### PR TITLE
feat: async workspace setup with UI indicator

### DIFF
--- a/apps/web/src/lib/setup-runner.ts
+++ b/apps/web/src/lib/setup-runner.ts
@@ -1,4 +1,4 @@
-import { spawn, type ChildProcess } from "node:child_process";
+import { type ChildProcess, spawn } from "node:child_process";
 import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { emit } from "./watcher";
@@ -15,11 +15,7 @@ export function getRunningSetups(): string[] {
   return Array.from(setups.keys());
 }
 
-export function runSetup(
-  workspaceId: string,
-  worktreePath: string,
-  onComplete?: () => void,
-): void {
+export function runSetup(workspaceId: string, worktreePath: string, onComplete?: () => void): void {
   // Guard against concurrent setups on same workspace
   if (setups.has(workspaceId)) return;
 

--- a/apps/web/src/lib/setup-runner.ts
+++ b/apps/web/src/lib/setup-runner.ts
@@ -1,0 +1,98 @@
+import { spawn, type ChildProcess } from "node:child_process";
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { emit } from "./watcher";
+
+interface SetupInfo {
+  workspaceId: string;
+  process: ChildProcess;
+  startedAt: number;
+}
+
+const setups = new Map<string, SetupInfo>();
+
+export function getRunningSetups(): string[] {
+  return Array.from(setups.keys());
+}
+
+export function runSetup(
+  workspaceId: string,
+  worktreePath: string,
+  onComplete?: () => void,
+): void {
+  // Guard against concurrent setups on same workspace
+  if (setups.has(workspaceId)) return;
+
+  const configPath = join(worktreePath, ".band", "config.json");
+  if (!existsSync(configPath)) {
+    onComplete?.();
+    return;
+  }
+
+  let setupCommand: string | undefined;
+  try {
+    const config = JSON.parse(readFileSync(configPath, "utf-8"));
+    setupCommand = config.setup;
+  } catch {
+    onComplete?.();
+    return;
+  }
+
+  if (!setupCommand) {
+    onComplete?.();
+    return;
+  }
+
+  const child = spawn("bash", ["-c", setupCommand], {
+    cwd: worktreePath,
+    env: {
+      ...process.env,
+      PATH: `/opt/homebrew/bin:/usr/local/bin:${process.env.PATH}`,
+    },
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+
+  const info: SetupInfo = {
+    workspaceId,
+    process: child,
+    startedAt: Date.now(),
+  };
+  setups.set(workspaceId, info);
+
+  emit({ kind: "setup-status", workspaceId, setupState: "running" });
+
+  let stderr = "";
+  child.stderr?.on("data", (data: Buffer) => {
+    stderr += data.toString();
+    // Keep only last 1KB of stderr for error reporting
+    if (stderr.length > 1024) {
+      stderr = stderr.slice(-1024);
+    }
+  });
+
+  child.on("error", (err) => {
+    setups.delete(workspaceId);
+    emit({
+      kind: "setup-status",
+      workspaceId,
+      setupState: "failed",
+      setupError: err.message,
+    });
+  });
+
+  child.on("exit", (code) => {
+    setups.delete(workspaceId);
+    if (code === 0) {
+      emit({ kind: "setup-status", workspaceId, setupState: "completed" });
+      onComplete?.();
+    } else {
+      const errorMsg = stderr.trim() || `Setup exited with code ${code}`;
+      emit({
+        kind: "setup-status",
+        workspaceId,
+        setupState: "failed",
+        setupError: errorMsg,
+      });
+    }
+  });
+}

--- a/apps/web/src/lib/watcher.ts
+++ b/apps/web/src/lib/watcher.ts
@@ -2,6 +2,7 @@ import { readdirSync, readFileSync } from "node:fs";
 import { basename, extname, join } from "node:path";
 import { watch } from "chokidar";
 import { startBranchStatusPoller, stopBranchStatusPoller } from "./branch-status-poller";
+import { getRunningSetups } from "./setup-runner";
 import {
   bandHome,
   loadCurrentStatuses,
@@ -24,7 +25,14 @@ interface CIStatus {
 }
 
 export interface StatusEvent {
-  kind: "update" | "remove" | "snapshot" | "branch-status" | "tunnel-url" | "tunnel-error";
+  kind:
+    | "update"
+    | "remove"
+    | "snapshot"
+    | "branch-status"
+    | "tunnel-url"
+    | "tunnel-error"
+    | "setup-status";
   status?: WorkspaceStatus;
   statuses?: WorkspaceStatus[];
   workspaceId?: string;
@@ -32,6 +40,8 @@ export interface StatusEvent {
   ci?: CIStatus;
   url?: string;
   error?: string;
+  setupState?: "running" | "completed" | "failed";
+  setupError?: string;
 }
 
 type StatusListener = (event: StatusEvent) => void;
@@ -148,6 +158,11 @@ export function subscribe(listener: StatusListener): () => void {
   // Send current branch status snapshots
   for (const event of loadCurrentBranchStatuses()) {
     listener(event);
+  }
+
+  // Send current setup status snapshots
+  for (const workspaceId of getRunningSetups()) {
+    listener({ kind: "setup-status", workspaceId, setupState: "running" });
   }
 
   return () => {

--- a/apps/web/src/trpc/router.ts
+++ b/apps/web/src/trpc/router.ts
@@ -28,6 +28,7 @@ import type { CronjobDefinition } from "../lib/cronjob-types";
 import { execGit, gitCmd, listWorktrees } from "../lib/git";
 import { checkHooks, installHooks } from "../lib/hooks";
 import { resolvePendingInput } from "../lib/pending-inputs";
+import { runSetup } from "../lib/setup-runner";
 import { checkPrereqs, shellPath } from "../lib/process-utils";
 import {
   bandHome,
@@ -248,28 +249,20 @@ const workspacesRouter = t.router({
       proj.worktrees.push({ branch: input.branch, path: worktreePath });
       saveState(state);
 
-      // Run setup script if configured
-      const configPath = join(worktreePath, ".band", "config.json");
-      try {
-        if (existsSync(configPath)) {
-          const config = JSON.parse(readFileSync(configPath, "utf-8"));
-          if (config.setup) {
-            execFileSync("bash", ["-c", config.setup], {
-              cwd: worktreePath,
-              env: { ...process.env, PATH: `/opt/homebrew/bin:/usr/local/bin:${process.env.PATH}` },
-              encoding: "utf-8",
-              timeout: 60_000,
-            });
-          }
-        }
-      } catch {
-        // Setup script failure is non-fatal
-      }
+      const workspaceId = toWorkspaceId(input.project, input.branch);
 
-      if (input.prompt) {
-        const workspaceId = toWorkspaceId(input.project, input.branch);
-        submitTask(workspaceId, input.prompt);
-      }
+      // Run setup script in the background (non-blocking).
+      // If a prompt is provided, defer task submission until setup completes
+      // so the agent has dependencies installed.
+      const onSetupComplete = input.prompt
+        ? () => submitTask(workspaceId, input.prompt!)
+        : undefined;
+
+      runSetup(workspaceId, worktreePath, onSetupComplete);
+
+      // If there's no setup command, runSetup calls onComplete synchronously,
+      // so the task is submitted immediately. If there IS a setup command,
+      // the task will be submitted when setup finishes.
 
       return { ok: true, path: worktreePath };
     }),

--- a/apps/web/src/trpc/router.ts
+++ b/apps/web/src/trpc/router.ts
@@ -28,8 +28,8 @@ import type { CronjobDefinition } from "../lib/cronjob-types";
 import { execGit, gitCmd, listWorktrees } from "../lib/git";
 import { checkHooks, installHooks } from "../lib/hooks";
 import { resolvePendingInput } from "../lib/pending-inputs";
-import { runSetup } from "../lib/setup-runner";
 import { checkPrereqs, shellPath } from "../lib/process-utils";
+import { runSetup } from "../lib/setup-runner";
 import {
   bandHome,
   ensureDirs,

--- a/packages/dashboard-core/src/components/DashboardShell.tsx
+++ b/packages/dashboard-core/src/components/DashboardShell.tsx
@@ -25,6 +25,7 @@ import { useSettingsQuery } from "../hooks/use-settings-query";
 import {
   useActiveWorkspaceWatcher,
   useBranchStatusWatcher,
+  useSetupStatusWatcher,
   useStatusWatcher,
 } from "../hooks/use-status";
 import { useDashboardStore } from "../stores/index";
@@ -53,6 +54,7 @@ export function DashboardShell({ toolbarExtra }: DashboardShellProps) {
   useStatusWatcher();
   useActiveWorkspaceWatcher();
   useBranchStatusWatcher();
+  useSetupStatusWatcher();
 
   return (
     <div className="h-dvh w-full overflow-hidden flex flex-col bg-background text-foreground p-0 pt-[env(safe-area-inset-top)]">

--- a/packages/dashboard-core/src/components/ProjectList.tsx
+++ b/packages/dashboard-core/src/components/ProjectList.tsx
@@ -56,6 +56,7 @@ import type {
   DeleteDialogInfo,
   LabelDefinition,
   ProjectInfo,
+  SetupStatus,
   WorkspaceBranchStatus,
   WorkspaceStatus,
 } from "../types";
@@ -67,6 +68,7 @@ interface SortableProjectProps {
   project: ProjectInfo;
   statuses: Map<string, WorkspaceStatus>;
   branchStatuses: Map<string, WorkspaceBranchStatus>;
+  setupStatuses: Map<string, SetupStatus>;
   removeProject: (name: string) => void;
   updateProjectLabel: (name: string, label: string | null) => void;
   labels: LabelDefinition[];
@@ -81,6 +83,7 @@ function SortableProject({
   project,
   statuses,
   branchStatuses,
+  setupStatuses,
   removeProject,
   updateProjectLabel,
   labels,
@@ -218,6 +221,7 @@ function SortableProject({
                 defaultBranch={project.defaultBranch}
                 status={statuses.get(wsId)}
                 branchStatus={branchStatuses.get(wsId)}
+                setupStatus={setupStatuses.get(wsId)}
                 isFocused={currentIndex === focusedIndex}
                 onShowDeleteDialog={onShowDeleteDialog}
                 editMode={editMode}
@@ -266,6 +270,7 @@ export function ProjectList({ labelFilter, editMode }: ProjectListProps) {
   const labels = settings.labels ?? [];
   const statuses = useDashboardStore((s) => s.statuses);
   const branchStatuses = useDashboardStore((s) => s.branchStatuses);
+  const setupStatuses = useDashboardStore((s) => s.setupStatuses);
   const openWorkspace = useDashboardStore((s) => s.openWorkspace);
   const activeWorkspaceId = useDashboardStore((s) => s.activeWorkspaceId);
 
@@ -490,6 +495,7 @@ export function ProjectList({ labelFilter, editMode }: ProjectListProps) {
                       project={project}
                       statuses={statuses}
                       branchStatuses={branchStatuses}
+                      setupStatuses={setupStatuses}
                       removeProject={(name) => removeProjectMutation.mutate(name)}
                       updateProjectLabel={(name, label) =>
                         updateProjectLabelMutation.mutate({ name, label })

--- a/packages/dashboard-core/src/components/SetupStatusIndicator.tsx
+++ b/packages/dashboard-core/src/components/SetupStatusIndicator.tsx
@@ -1,0 +1,37 @@
+import { Tooltip, TooltipContent, TooltipTrigger } from "@band/ui";
+import { CircleAlert, Loader } from "lucide-react";
+import type { SetupStatus } from "../types";
+
+interface Props {
+  setup?: SetupStatus;
+}
+
+export function SetupStatusIndicator({ setup }: Props) {
+  if (!setup) return null;
+
+  if (setup.state === "running") {
+    return (
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Loader className="size-3.5 shrink-0 text-blue-400 animate-spin" />
+        </TooltipTrigger>
+        <TooltipContent side="top">Setting up workspace...</TooltipContent>
+      </Tooltip>
+    );
+  }
+
+  if (setup.state === "failed") {
+    return (
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <CircleAlert className="size-3.5 shrink-0 text-red-400" />
+        </TooltipTrigger>
+        <TooltipContent side="top">
+          Setup failed{setup.error ? `: ${setup.error}` : ""}
+        </TooltipContent>
+      </Tooltip>
+    );
+  }
+
+  return null;
+}

--- a/packages/dashboard-core/src/components/WorkspaceCard.tsx
+++ b/packages/dashboard-core/src/components/WorkspaceCard.tsx
@@ -15,6 +15,7 @@ import { toWorkspaceId } from "../lib/workspace-id";
 import { useDashboardStore } from "../stores/index";
 import type {
   DeleteDialogInfo,
+  SetupStatus,
   WorkspaceBranchStatus,
   WorkspaceStatus,
   WorktreeInfo,
@@ -22,6 +23,7 @@ import type {
 import { AgentStatusBadge } from "./AgentStatusBadge";
 import { CIStatusIndicator } from "./CIStatusIndicator";
 import { GitStatusIndicator } from "./GitStatusIndicator";
+import { SetupStatusIndicator } from "./SetupStatusIndicator";
 
 interface Props {
   worktree: WorktreeInfo;
@@ -29,6 +31,7 @@ interface Props {
   defaultBranch: string;
   status?: WorkspaceStatus;
   branchStatus?: WorkspaceBranchStatus;
+  setupStatus?: SetupStatus;
   isFocused?: boolean;
   onShowDeleteDialog: (info: DeleteDialogInfo) => void;
   editMode?: boolean;
@@ -40,6 +43,7 @@ export function WorkspaceCard({
   defaultBranch,
   status,
   branchStatus,
+  setupStatus,
   isFocused,
   onShowDeleteDialog,
   editMode,
@@ -133,6 +137,7 @@ export function WorkspaceCard({
               <TooltipContent side="top">{worktree.branch}</TooltipContent>
             </Tooltip>
             {!editMode && <AgentStatusBadge agent={status?.agent} />}
+            {!editMode && <SetupStatusIndicator setup={setupStatus} />}
           </div>
           {!editMode && (
             <div className="flex items-center gap-2 shrink-0">

--- a/packages/dashboard-core/src/hooks/use-status.ts
+++ b/packages/dashboard-core/src/hooks/use-status.ts
@@ -1,6 +1,7 @@
 import { useEffect, useRef } from "react";
 import { useAdapter } from "../context";
 import { playSound, type SoundId } from "../lib/sounds";
+import type { SSEEvent } from "../lib/sse";
 import { queryClient, queryKeys } from "../query-client";
 import { useDashboardStore } from "../stores/index";
 import type { AgentStatusType, Settings } from "../types";
@@ -75,4 +76,30 @@ export function useBranchStatusWatcher() {
 
     return unsubscribe;
   }, [adapter, updateGitStatus, updateCIStatus]);
+}
+
+export function useSetupStatusWatcher() {
+  const adapter = useAdapter();
+  const updateSetupStatus = useDashboardStore((s) => s.updateSetupStatus);
+  const removeSetupStatus = useDashboardStore((s) => s.removeSetupStatus);
+
+  useEffect(() => {
+    const unsubscribe = adapter.subscribeStatusEvents((event) => {
+      const data = event as SSEEvent;
+      if (data.kind !== "setup-status" || !data.workspaceId) return;
+
+      if (data.setupState === "running") {
+        updateSetupStatus(data.workspaceId, { state: "running" });
+      } else if (data.setupState === "completed") {
+        removeSetupStatus(data.workspaceId);
+      } else if (data.setupState === "failed") {
+        updateSetupStatus(data.workspaceId, {
+          state: "failed",
+          error: data.setupError,
+        });
+      }
+    });
+
+    return unsubscribe;
+  }, [adapter, updateSetupStatus, removeSetupStatus]);
 }

--- a/packages/dashboard-core/src/index.ts
+++ b/packages/dashboard-core/src/index.ts
@@ -6,7 +6,6 @@ export type { DashboardAdapter, PlatformCapabilities, Unsubscribe } from "./adap
 export { AddProjectDialog } from "./components/AddProjectDialog";
 export { AgentStatusBadge } from "./components/AgentStatusBadge";
 export { CIStatusIndicator } from "./components/CIStatusIndicator";
-export { SetupStatusIndicator } from "./components/SetupStatusIndicator";
 export { CodeMirrorViewer } from "./components/CodeMirrorViewer";
 export { DashboardShell } from "./components/DashboardShell";
 export { type DiffStats, DiffView } from "./components/DiffView";
@@ -16,6 +15,7 @@ export { GitStatusIndicator } from "./components/GitStatusIndicator";
 export { NewWorkspaceDialog } from "./components/NewWorkspaceForm";
 export { ProjectList } from "./components/ProjectList";
 export { SettingsPage } from "./components/SettingsPage";
+export { SetupStatusIndicator } from "./components/SetupStatusIndicator";
 export { WorkspaceCard } from "./components/WorkspaceCard";
 export { type WorkspaceTab, WorkspaceTabNav } from "./components/WorkspaceTabNav";
 // Context
@@ -72,9 +72,9 @@ export type {
   LabelDefinition,
   NotificationSettings,
   ProjectInfo,
+  Settings,
   SetupState,
   SetupStatus,
-  Settings,
   WorkspaceBranchStatus,
   WorkspaceDiff,
   WorkspaceStatus,

--- a/packages/dashboard-core/src/index.ts
+++ b/packages/dashboard-core/src/index.ts
@@ -6,6 +6,7 @@ export type { DashboardAdapter, PlatformCapabilities, Unsubscribe } from "./adap
 export { AddProjectDialog } from "./components/AddProjectDialog";
 export { AgentStatusBadge } from "./components/AgentStatusBadge";
 export { CIStatusIndicator } from "./components/CIStatusIndicator";
+export { SetupStatusIndicator } from "./components/SetupStatusIndicator";
 export { CodeMirrorViewer } from "./components/CodeMirrorViewer";
 export { DashboardShell } from "./components/DashboardShell";
 export { type DiffStats, DiffView } from "./components/DiffView";
@@ -35,6 +36,7 @@ export { useSettingsQuery } from "./hooks/use-settings-query";
 export {
   useActiveWorkspaceWatcher,
   useBranchStatusWatcher,
+  useSetupStatusWatcher,
   useStatusWatcher,
 } from "./hooks/use-status";
 export { extensionToLanguage, filenameToLanguage } from "./lib/language-map";
@@ -70,6 +72,8 @@ export type {
   LabelDefinition,
   NotificationSettings,
   ProjectInfo,
+  SetupState,
+  SetupStatus,
   Settings,
   WorkspaceBranchStatus,
   WorkspaceDiff,

--- a/packages/dashboard-core/src/lib/sse.ts
+++ b/packages/dashboard-core/src/lib/sse.ts
@@ -1,7 +1,14 @@
 import type { CIStatus, GitStatus, WorkspaceStatus } from "../types";
 
 export type SSEEvent = {
-  kind: "update" | "remove" | "snapshot" | "branch-status" | "tunnel-url" | "tunnel-error";
+  kind:
+    | "update"
+    | "remove"
+    | "snapshot"
+    | "branch-status"
+    | "tunnel-url"
+    | "tunnel-error"
+    | "setup-status";
   status?: WorkspaceStatus;
   statuses?: WorkspaceStatus[];
   workspaceId?: string;
@@ -9,4 +16,6 @@ export type SSEEvent = {
   ci?: CIStatus;
   url?: string;
   error?: string;
+  setupState?: "running" | "completed" | "failed";
+  setupError?: string;
 };

--- a/packages/dashboard-core/src/stores/dashboard-store.ts
+++ b/packages/dashboard-core/src/stores/dashboard-store.ts
@@ -1,12 +1,19 @@
 import { create, type StoreApi, type UseBoundStore } from "zustand";
 import type { DashboardAdapter } from "../adapter";
-import type { CIStatus, GitStatus, WorkspaceBranchStatus, WorkspaceStatus } from "../types";
+import type {
+  CIStatus,
+  GitStatus,
+  SetupStatus,
+  WorkspaceBranchStatus,
+  WorkspaceStatus,
+} from "../types";
 
 export interface DashboardState {
   statuses: Map<string, WorkspaceStatus>;
   activeWorkspaceId: string | null;
   error: string | null;
   branchStatuses: Map<string, WorkspaceBranchStatus>;
+  setupStatuses: Map<string, SetupStatus>;
   _openingWorkspace: boolean;
 
   openWorkspace: (workspaceId: string) => void;
@@ -18,6 +25,8 @@ export interface DashboardState {
   runScript: (path: string, scriptType: string) => Promise<void>;
   updateGitStatus: (workspaceId: string, git: GitStatus) => void;
   updateCIStatus: (workspaceId: string, ci: CIStatus) => void;
+  updateSetupStatus: (workspaceId: string, status: SetupStatus) => void;
+  removeSetupStatus: (workspaceId: string) => void;
 }
 
 export type DashboardStore = UseBoundStore<StoreApi<DashboardState>>;
@@ -26,6 +35,7 @@ export function createDashboardStore(adapter: DashboardAdapter): DashboardStore 
   return create<DashboardState>((set, get) => ({
     statuses: new Map(),
     branchStatuses: new Map(),
+    setupStatuses: new Map(),
     activeWorkspaceId: null,
     error: null,
     _openingWorkspace: false,
@@ -120,6 +130,22 @@ export function createDashboardStore(adapter: DashboardAdapter): DashboardStore 
           ci,
         });
         return { branchStatuses };
+      });
+    },
+
+    updateSetupStatus: (workspaceId: string, status: SetupStatus) => {
+      set((state) => {
+        const setupStatuses = new Map(state.setupStatuses);
+        setupStatuses.set(workspaceId, status);
+        return { setupStatuses };
+      });
+    },
+
+    removeSetupStatus: (workspaceId: string) => {
+      set((state) => {
+        const setupStatuses = new Map(state.setupStatuses);
+        setupStatuses.delete(workspaceId);
+        return { setupStatuses };
       });
     },
   }));

--- a/packages/dashboard-core/src/types.ts
+++ b/packages/dashboard-core/src/types.ts
@@ -60,6 +60,13 @@ export interface WorkspaceBranchStatus {
   ci: CIStatus;
 }
 
+export type SetupState = "running" | "completed" | "failed";
+
+export interface SetupStatus {
+  state: SetupState;
+  error?: string;
+}
+
 export type AppType = "vscode" | "zed" | "iterm" | "chrome";
 
 export interface VsCodeAppConfig {


### PR DESCRIPTION
## Summary
- Setup commands (e.g. `pnpm install`) now run **asynchronously** after workspace creation instead of blocking the API response for up to 60 seconds
- A **spinning blue loader** appears on the workspace card while setup is running; a red alert icon shows if setup fails
- When a prompt is provided, the coding agent task is **deferred until setup completes** so dependencies are installed first

## Test plan
- [ ] Create a workspace with a project that has `.band/config.json` setup command — verify API returns immediately and spinner shows
- [ ] Verify spinner disappears when setup finishes
- [ ] Create workspace with `--prompt` — verify agent task starts only after setup completes
- [ ] Verify setup failure shows red alert icon with error tooltip
- [ ] Verify same behavior in both web and Tauri dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)