### PR TITLE
feat: add file search, content search, and find-in-file

### DIFF
--- a/apps/web/src/components/CodeBrowserView.tsx
+++ b/apps/web/src/components/CodeBrowserView.tsx
@@ -1,16 +1,58 @@
-import { FileBrowser, FileViewer } from "@band/dashboard-core";
+import { FileBrowser, FileViewer, openFileSearchPanel } from "@band/dashboard-core";
 import { File } from "lucide-react";
-import { useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { useIsDesktop } from "../hooks/useIsDesktop";
 
 interface CodeBrowserViewProps {
   workspaceId: string;
+  /** Externally triggered file to open (e.g. from Quick Open or Search) */
+  openFilePath?: string | null;
+  /** Called after the external file path has been consumed */
+  onFileOpened?: () => void;
+  /** Reports a callback that triggers find-in-file search (null when unavailable) */
+  onFindInFile?: (fn: (() => void) | null) => void;
 }
 
-export function CodeBrowserView({ workspaceId }: CodeBrowserViewProps) {
+export function CodeBrowserView({
+  workspaceId,
+  openFilePath,
+  onFileOpened,
+  onFindInFile,
+}: CodeBrowserViewProps) {
   const isDesktop = useIsDesktop();
   const [currentPath, setCurrentPath] = useState("");
   const [viewFilePath, setViewFilePath] = useState("");
+
+  // Handle externally triggered file open
+  useEffect(() => {
+    if (openFilePath) {
+      setViewFilePath(openFilePath);
+      // Navigate the file browser to the file's parent directory
+      const lastSlash = openFilePath.lastIndexOf("/");
+      setCurrentPath(lastSlash > 0 ? openFilePath.slice(0, lastSlash) : "");
+      onFileOpened?.();
+    }
+  }, [openFilePath, onFileOpened]);
+
+  const handleEditorView = useCallback(
+    // EditorView type from @codemirror/view — kept untyped to avoid cross-package dependency
+    (view: { focus: () => void } | null) => {
+      if (view) {
+        onFindInFile?.(() => {
+          view.focus();
+          openFileSearchPanel(view);
+        });
+      } else {
+        onFindInFile?.(null);
+      }
+    },
+    [onFindInFile],
+  );
+
+  // Clean up on unmount
+  useEffect(() => {
+    return () => onFindInFile?.(null);
+  }, [onFindInFile]);
 
   const handleBack = () => {
     setViewFilePath("");
@@ -49,7 +91,11 @@ export function CodeBrowserView({ workspaceId }: CodeBrowserViewProps) {
       {/* Right panel - file content */}
       <div className="flex-1 min-w-0 overflow-hidden">
         {viewFilePath ? (
-          <FileViewer workspaceId={workspaceId} filePath={viewFilePath} />
+          <FileViewer
+            workspaceId={workspaceId}
+            filePath={viewFilePath}
+            onEditorView={handleEditorView}
+          />
         ) : (
           <div className="flex h-full items-center justify-center">
             <div className="flex flex-col items-center gap-3 text-center px-8">

--- a/apps/web/src/components/WorkspaceDetailPanel.tsx
+++ b/apps/web/src/components/WorkspaceDetailPanel.tsx
@@ -1,6 +1,6 @@
-import { type DiffStats, DiffView } from "@band/dashboard-core";
+import { type DiffStats, DiffView, QuickOpenDialog, SearchFilesDialog } from "@band/dashboard-core";
 import { ChevronDown, ChevronUp, Code, GitCompare, Terminal as TerminalIcon } from "lucide-react";
-import { lazy, Suspense, useCallback, useRef, useState } from "react";
+import { lazy, Suspense, useCallback, useEffect, useRef, useState } from "react";
 import { useIsDesktop } from "../hooks/useIsDesktop";
 import { CodeBrowserView } from "./CodeBrowserView";
 
@@ -63,9 +63,64 @@ export function WorkspaceDetailPanel({ workspaceId }: WorkspaceDetailPanelProps)
   const [terminalOpen, setTerminalOpen] = useState(false);
   const terminalMounted = useRef(false);
   if (terminalOpen) terminalMounted.current = true;
+  const [quickOpenOpen, setQuickOpenOpen] = useState(false);
+  const [searchFilesOpen, setSearchFilesOpen] = useState(false);
+  const [pendingFilePath, setPendingFilePath] = useState<string | null>(null);
+  const findInFileRef = useRef<(() => void) | null>(null);
 
   const handleStatsChange = useCallback((stats: DiffStats | null) => {
     setDiffStats(stats);
+  }, []);
+
+  const handleFindInFileReady = useCallback((fn: (() => void) | null) => {
+    findInFileRef.current = fn;
+  }, []);
+
+  // Global keyboard shortcuts — register on window in capture phase
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      const mod = e.metaKey || e.ctrlKey;
+      const key = e.key.toLowerCase();
+
+      // Cmd+P / Ctrl+P → Quick Open
+      if (mod && key === "p" && !e.shiftKey && !e.altKey) {
+        e.preventDefault();
+        e.stopPropagation();
+        e.stopImmediatePropagation();
+        setQuickOpenOpen(true);
+        return;
+      }
+
+      // Cmd+Shift+F / Ctrl+Shift+F → Search in Files
+      if (mod && e.shiftKey && key === "f" && !e.altKey) {
+        e.preventDefault();
+        e.stopPropagation();
+        e.stopImmediatePropagation();
+        setSearchFilesOpen(true);
+        return;
+      }
+
+      // Cmd+F / Ctrl+F → Find in current file (CodeMirror search)
+      if (mod && key === "f" && !e.shiftKey && !e.altKey && findInFileRef.current) {
+        e.preventDefault();
+        e.stopPropagation();
+        e.stopImmediatePropagation();
+        findInFileRef.current();
+        return;
+      }
+    };
+
+    window.addEventListener("keydown", handler, true);
+    return () => window.removeEventListener("keydown", handler, true);
+  }, []);
+
+  const handleOpenFile = useCallback((path: string) => {
+    setActiveTab("code");
+    setPendingFilePath(path);
+  }, []);
+
+  const handleFileOpened = useCallback(() => {
+    setPendingFilePath(null);
   }, []);
 
   return (
@@ -80,7 +135,12 @@ export function WorkspaceDetailPanel({ workspaceId }: WorkspaceDetailPanelProps)
           />
         </div>
         <div className={activeTab === "code" ? "h-full" : "hidden"}>
-          <CodeBrowserView workspaceId={workspaceId} />
+          <CodeBrowserView
+            workspaceId={workspaceId}
+            openFilePath={pendingFilePath}
+            onFileOpened={handleFileOpened}
+            onFindInFile={handleFindInFileReady}
+          />
         </div>
       </div>
 
@@ -115,6 +175,19 @@ export function WorkspaceDetailPanel({ workspaceId }: WorkspaceDetailPanelProps)
           )}
         </div>
       )}
+
+      <QuickOpenDialog
+        workspaceId={workspaceId}
+        open={quickOpenOpen}
+        onOpenChange={setQuickOpenOpen}
+        onOpenFile={handleOpenFile}
+      />
+      <SearchFilesDialog
+        workspaceId={workspaceId}
+        open={searchFilesOpen}
+        onOpenChange={setSearchFilesOpen}
+        onOpenFile={handleOpenFile}
+      />
     </div>
   );
 }

--- a/apps/web/src/trpc/router.ts
+++ b/apps/web/src/trpc/router.ts
@@ -641,6 +641,82 @@ const workspaceRouter = t.router({
         language,
       };
     }),
+
+  searchFiles: publicProcedure
+    .input(
+      z.object({
+        workspaceId: z.string(),
+        query: z.string().default(""),
+        limit: z.number().default(50),
+      }),
+    )
+    .query(async ({ input }) => {
+      const workspace = resolveWorkspace(input.workspaceId);
+      if (!workspace) {
+        throw new Error("Workspace not found");
+      }
+
+      const cwd = workspace.worktree.path;
+      const output = await execGit(["ls-files", "--cached", "--others", "--exclude-standard"], cwd);
+
+      let files = output.trim().split("\n").filter(Boolean);
+
+      if (input.query) {
+        const chars = input.query.split("").map((c) => c.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"));
+        const pattern = new RegExp(chars.join(".*"), "i");
+        files = files.filter((f) => pattern.test(f));
+      }
+
+      return { files: files.slice(0, input.limit) };
+    }),
+
+  searchContent: publicProcedure
+    .input(
+      z.object({
+        workspaceId: z.string(),
+        query: z.string().min(1),
+        caseSensitive: z.boolean().default(false),
+        limit: z.number().default(100),
+      }),
+    )
+    .query(async ({ input }) => {
+      const workspace = resolveWorkspace(input.workspaceId);
+      if (!workspace) {
+        throw new Error("Workspace not found");
+      }
+
+      const cwd = workspace.worktree.path;
+      const args = ["grep", "-n", "--no-color", "-I", "-F"];
+      if (!input.caseSensitive) args.push("-i");
+      args.push("--", input.query);
+
+      let output: string;
+      try {
+        output = await execGit(args, cwd);
+      } catch {
+        // git grep exits with status 1 when no matches found
+        return { results: [] };
+      }
+
+      const lines = output.trim().split("\n").filter(Boolean);
+      const results: Array<{ file: string; line: number; content: string }> = [];
+
+      for (const raw of lines) {
+        if (results.length >= input.limit) break;
+        const colonIdx1 = raw.indexOf(":");
+        if (colonIdx1 === -1) continue;
+        const colonIdx2 = raw.indexOf(":", colonIdx1 + 1);
+        if (colonIdx2 === -1) continue;
+
+        const file = raw.slice(0, colonIdx1);
+        const line = Number.parseInt(raw.slice(colonIdx1 + 1, colonIdx2), 10);
+        const content = raw.slice(colonIdx2 + 1);
+
+        results.push({ file, line, content });
+      }
+
+      return { results };
+    }),
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/dashboard-core/src/adapter.ts
+++ b/packages/dashboard-core/src/adapter.ts
@@ -1,6 +1,7 @@
 import type {
   CIStatus,
   CliStatus,
+  ContentSearchMatch,
   FileContentResult,
   FileListResult,
   GitStatus,
@@ -62,6 +63,18 @@ export interface DashboardAdapter {
   getWorkspaceDiff?(workspaceId: string): Promise<WorkspaceDiff>;
   listWorkspaceFiles?(workspaceId: string, path: string): Promise<FileListResult>;
   getWorkspaceFile?(workspaceId: string, path: string): Promise<FileContentResult>;
+
+  // Search (optional)
+  searchWorkspaceFiles?(
+    workspaceId: string,
+    query: string,
+    limit?: number,
+  ): Promise<{ files: string[] }>;
+  searchWorkspaceContent?(
+    workspaceId: string,
+    query: string,
+    options?: { caseSensitive?: boolean; limit?: number },
+  ): Promise<{ results: ContentSearchMatch[] }>;
 }
 
 export interface PlatformCapabilities {

--- a/packages/dashboard-core/src/adapters/web.ts
+++ b/packages/dashboard-core/src/adapters/web.ts
@@ -4,6 +4,7 @@ import type { SSEEvent } from "../lib/sse";
 import type {
   CIStatus,
   CliStatus,
+  ContentSearchMatch,
   FileContentResult,
   FileListResult,
   GitStatus,
@@ -179,6 +180,31 @@ export class WebDashboardAdapter implements DashboardAdapter {
 
   async getWorkspaceFile(workspaceId: string, path: string): Promise<FileContentResult> {
     return (await this.trpc.workspace.getFile.query({ workspaceId, path })) as FileContentResult;
+  }
+
+  async searchWorkspaceFiles(
+    workspaceId: string,
+    query: string,
+    limit?: number,
+  ): Promise<{ files: string[] }> {
+    return (await this.trpc.workspace.searchFiles.query({
+      workspaceId,
+      query,
+      limit,
+    })) as { files: string[] };
+  }
+
+  async searchWorkspaceContent(
+    workspaceId: string,
+    query: string,
+    options?: { caseSensitive?: boolean; limit?: number },
+  ): Promise<{ results: ContentSearchMatch[] }> {
+    return (await this.trpc.workspace.searchContent.query({
+      workspaceId,
+      query,
+      caseSensitive: options?.caseSensitive,
+      limit: options?.limit,
+    })) as { results: ContentSearchMatch[] };
   }
 }
 

--- a/packages/dashboard-core/src/components/CodeMirrorViewer.tsx
+++ b/packages/dashboard-core/src/components/CodeMirrorViewer.tsx
@@ -7,11 +7,20 @@ interface CodeMirrorViewerProps {
   content: string;
   language: string;
   className?: string;
+  /** Called when the EditorView is created or destroyed */
+  onEditorView?: (view: EditorView | null) => void;
 }
 
-export function CodeMirrorViewer({ content, language, className }: CodeMirrorViewerProps) {
+export function CodeMirrorViewer({
+  content,
+  language,
+  className,
+  onEditorView,
+}: CodeMirrorViewerProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const viewRef = useRef<EditorView | null>(null);
+  const onEditorViewRef = useRef(onEditorView);
+  onEditorViewRef.current = onEditorView;
 
   // Create/recreate the editor when content or language changes
   useEffect(() => {
@@ -28,6 +37,7 @@ export function CodeMirrorViewer({ content, language, className }: CodeMirrorVie
       if (viewRef.current) {
         viewRef.current.destroy();
         viewRef.current = null;
+        onEditorViewRef.current?.(null);
       }
 
       const extensions = [...baseViewerExtensions()];
@@ -44,6 +54,8 @@ export function CodeMirrorViewer({ content, language, className }: CodeMirrorVie
         state,
         parent: container,
       });
+
+      onEditorViewRef.current?.(viewRef.current);
     };
 
     setup();
@@ -53,6 +65,7 @@ export function CodeMirrorViewer({ content, language, className }: CodeMirrorVie
       if (viewRef.current) {
         viewRef.current.destroy();
         viewRef.current = null;
+        onEditorViewRef.current?.(null);
       }
     };
   }, [content, language]);

--- a/packages/dashboard-core/src/components/FileViewer.tsx
+++ b/packages/dashboard-core/src/components/FileViewer.tsx
@@ -1,3 +1,4 @@
+import type { EditorView } from "@codemirror/view";
 import { ArrowLeft, FileWarning } from "lucide-react";
 import { useEffect, useState } from "react";
 import { useAdapter } from "../context";
@@ -9,6 +10,8 @@ interface FileViewerProps {
   workspaceId: string;
   filePath: string;
   onBack?: () => void;
+  /** Called when the CodeMirror EditorView is created or destroyed */
+  onEditorView?: (view: EditorView | null) => void;
 }
 
 function getFilename(path: string): string {
@@ -30,7 +33,7 @@ function detectLanguage(filePath: string, serverHint?: string): string {
   return fromName || "plaintext";
 }
 
-export function FileViewer({ workspaceId, filePath, onBack }: FileViewerProps) {
+export function FileViewer({ workspaceId, filePath, onBack, onEditorView }: FileViewerProps) {
   const adapter = useAdapter();
   const [data, setData] = useState<FileContentResult | null>(null);
   const [loading, setLoading] = useState(true);
@@ -107,7 +110,12 @@ export function FileViewer({ workspaceId, filePath, onBack }: FileViewerProps) {
           </div>
         )}
         {data?.content && (
-          <CodeMirrorViewer content={data.content} language={lang} className="h-full" />
+          <CodeMirrorViewer
+            content={data.content}
+            language={lang}
+            className="h-full"
+            onEditorView={onEditorView}
+          />
         )}
       </div>
     </div>

--- a/packages/dashboard-core/src/components/QuickOpenDialog.tsx
+++ b/packages/dashboard-core/src/components/QuickOpenDialog.tsx
@@ -1,0 +1,113 @@
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@band/ui";
+import { File } from "lucide-react";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { useAdapter } from "../context";
+
+interface QuickOpenDialogProps {
+  workspaceId: string;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onOpenFile: (path: string) => void;
+}
+
+export function QuickOpenDialog({
+  workspaceId,
+  open,
+  onOpenChange,
+  onOpenFile,
+}: QuickOpenDialogProps) {
+  const adapter = useAdapter();
+  const [query, setQuery] = useState("");
+  const [files, setFiles] = useState<string[]>([]);
+  const [loading, setLoading] = useState(false);
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    if (!open || !adapter.searchWorkspaceFiles) return;
+
+    let cancelled = false;
+    setLoading(true);
+
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+
+    const delay = query ? 150 : 0;
+    debounceRef.current = setTimeout(() => {
+      adapter.searchWorkspaceFiles!(workspaceId, query, 50)
+        .then((result) => {
+          if (!cancelled) setFiles(result.files);
+        })
+        .catch(() => {})
+        .finally(() => {
+          if (!cancelled) setLoading(false);
+        });
+    }, delay);
+
+    return () => {
+      cancelled = true;
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+    };
+  }, [adapter, workspaceId, query, open]);
+
+  // Reset on close
+  useEffect(() => {
+    if (!open) {
+      setQuery("");
+      setFiles([]);
+    }
+  }, [open]);
+
+  const handleSelect = useCallback(
+    (filePath: string) => {
+      onOpenFile(filePath);
+      onOpenChange(false);
+    },
+    [onOpenFile, onOpenChange],
+  );
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="overflow-hidden p-0 sm:max-w-[520px]">
+        <DialogHeader className="sr-only">
+          <DialogTitle>Quick Open</DialogTitle>
+          <DialogDescription>Search for files by name</DialogDescription>
+        </DialogHeader>
+        <Command shouldFilter={false}>
+          <CommandInput
+            placeholder="Search files by name..."
+            value={query}
+            onValueChange={setQuery}
+          />
+          <CommandList className="max-h-[360px]">
+            <CommandEmpty>{loading ? "Searching..." : "No files found."}</CommandEmpty>
+            <CommandGroup>
+              {files.map((file) => {
+                const fileName = file.split("/").pop() || file;
+                return (
+                  <CommandItem key={file} value={file} onSelect={() => handleSelect(file)}>
+                    <File className="size-4 shrink-0 text-muted-foreground" />
+                    <div className="flex min-w-0 flex-1 items-baseline gap-2">
+                      <span className="shrink-0 text-sm font-medium">{fileName}</span>
+                      <span className="min-w-0 truncate text-xs text-muted-foreground">{file}</span>
+                    </div>
+                  </CommandItem>
+                );
+              })}
+            </CommandGroup>
+          </CommandList>
+        </Command>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/packages/dashboard-core/src/components/SearchFilesDialog.tsx
+++ b/packages/dashboard-core/src/components/SearchFilesDialog.tsx
@@ -1,0 +1,173 @@
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandItem,
+  CommandList,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@band/ui";
+import { CaseSensitive, File, SearchIcon } from "lucide-react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useAdapter } from "../context";
+import type { ContentSearchMatch } from "../types";
+
+interface SearchFilesDialogProps {
+  workspaceId: string;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onOpenFile: (path: string) => void;
+}
+
+export function SearchFilesDialog({
+  workspaceId,
+  open,
+  onOpenChange,
+  onOpenFile,
+}: SearchFilesDialogProps) {
+  const adapter = useAdapter();
+  const [query, setQuery] = useState("");
+  const [caseSensitive, setCaseSensitive] = useState(false);
+  const [results, setResults] = useState<ContentSearchMatch[]>([]);
+  const [loading, setLoading] = useState(false);
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    if (!open || !adapter.searchWorkspaceContent || query.length < 2) {
+      if (query.length < 2) setResults([]);
+      return;
+    }
+
+    let cancelled = false;
+    setLoading(true);
+
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+
+    debounceRef.current = setTimeout(() => {
+      adapter.searchWorkspaceContent!(workspaceId, query, {
+        caseSensitive,
+        limit: 100,
+      })
+        .then((result) => {
+          if (!cancelled) {
+            setResults(result.results);
+          }
+        })
+        .catch(() => {})
+        .finally(() => {
+          if (!cancelled) setLoading(false);
+        });
+    }, 300);
+
+    return () => {
+      cancelled = true;
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+    };
+  }, [adapter, workspaceId, query, caseSensitive, open]);
+
+  // Reset on close
+  useEffect(() => {
+    if (!open) {
+      setQuery("");
+      setResults([]);
+    }
+  }, [open]);
+
+  // Group results by file
+  const grouped = useMemo(() => {
+    const map = new Map<string, ContentSearchMatch[]>();
+    for (const r of results) {
+      const list = map.get(r.file) || [];
+      list.push(r);
+      map.set(r.file, list);
+    }
+    return Array.from(map.entries());
+  }, [results]);
+
+  const handleSelect = useCallback(
+    (filePath: string) => {
+      onOpenFile(filePath);
+      onOpenChange(false);
+    },
+    [onOpenFile, onOpenChange],
+  );
+
+  const totalMatches = results.length;
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="overflow-hidden p-0 sm:max-w-[640px]">
+        <DialogHeader className="sr-only">
+          <DialogTitle>Search in Files</DialogTitle>
+          <DialogDescription>Text search across workspace files</DialogDescription>
+        </DialogHeader>
+        <Command shouldFilter={false}>
+          <div className="flex items-center border-b px-3" cmdk-input-wrapper="">
+            <SearchIcon className="mr-2 size-4 shrink-0 opacity-50" />
+            <input
+              className="flex h-10 w-full bg-transparent py-3 text-sm outline-none placeholder:text-muted-foreground"
+              placeholder="Search in files..."
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              autoFocus
+            />
+            <button
+              type="button"
+              onClick={() => setCaseSensitive((v) => !v)}
+              className={`ml-2 inline-flex size-7 shrink-0 items-center justify-center rounded-sm transition-colors ${
+                caseSensitive
+                  ? "bg-accent text-accent-foreground"
+                  : "text-muted-foreground hover:text-foreground"
+              }`}
+              title="Match Case"
+            >
+              <CaseSensitive className="size-4" />
+            </button>
+          </div>
+          <CommandList className="max-h-[400px]">
+            <CommandEmpty>
+              {loading
+                ? "Searching..."
+                : query.length < 2
+                  ? "Type at least 2 characters to search."
+                  : "No results found."}
+            </CommandEmpty>
+            {grouped.map(([file, matches]) => (
+              <CommandGroup
+                key={file}
+                heading={
+                  <span className="inline-flex items-center gap-1.5">
+                    <File className="size-3" />
+                    {file}
+                  </span>
+                }
+              >
+                {matches.map((match) => (
+                  <CommandItem
+                    key={`${file}:${match.line}:${match.content}`}
+                    value={`${file}:${match.line}:${match.content}`}
+                    onSelect={() => handleSelect(file)}
+                  >
+                    <span className="w-8 shrink-0 text-right font-mono text-xs text-muted-foreground">
+                      {match.line}
+                    </span>
+                    <span className="min-w-0 truncate font-mono text-xs">{match.content}</span>
+                  </CommandItem>
+                ))}
+              </CommandGroup>
+            ))}
+          </CommandList>
+          {totalMatches > 0 && (
+            <div className="border-t px-3 py-1.5 text-xs text-muted-foreground">
+              {totalMatches} result{totalMatches !== 1 ? "s" : ""} in {grouped.length} file
+              {grouped.length !== 1 ? "s" : ""}
+            </div>
+          )}
+        </Command>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/packages/dashboard-core/src/index.ts
+++ b/packages/dashboard-core/src/index.ts
@@ -14,6 +14,8 @@ export { FileViewer } from "./components/FileViewer";
 export { GitStatusIndicator } from "./components/GitStatusIndicator";
 export { NewWorkspaceDialog } from "./components/NewWorkspaceForm";
 export { ProjectList } from "./components/ProjectList";
+export { QuickOpenDialog } from "./components/QuickOpenDialog";
+export { SearchFilesDialog } from "./components/SearchFilesDialog";
 export { SettingsPage } from "./components/SettingsPage";
 export { WorkspaceCard } from "./components/WorkspaceCard";
 export { type WorkspaceTab, WorkspaceTabNav } from "./components/WorkspaceTabNav";
@@ -37,6 +39,7 @@ export {
   useBranchStatusWatcher,
   useStatusWatcher,
 } from "./hooks/use-status";
+export { openFileSearchPanel } from "./lib/codemirror-setup";
 export { extensionToLanguage, filenameToLanguage } from "./lib/language-map";
 export { isServiceHealthy, type ServiceHealth } from "./lib/service-health";
 // Lib
@@ -60,6 +63,7 @@ export type {
   CIStatus,
   CodingAgentConfig,
   CodingAgentType,
+  ContentSearchMatch,
   FileContentResult,
   FileEntry,
   FileListResult,

--- a/packages/dashboard-core/src/lib/codemirror-setup.ts
+++ b/packages/dashboard-core/src/lib/codemirror-setup.ts
@@ -6,7 +6,7 @@ import {
   StreamLanguage,
   syntaxHighlighting,
 } from "@codemirror/language";
-import { highlightSelectionMatches, searchKeymap } from "@codemirror/search";
+import { highlightSelectionMatches, openSearchPanel, searchKeymap } from "@codemirror/search";
 import { EditorState, type Extension } from "@codemirror/state";
 import { oneDarkHighlightStyle } from "@codemirror/theme-one-dark";
 import { EditorView, keymap, lineNumbers } from "@codemirror/view";
@@ -151,4 +151,13 @@ export function baseViewerExtensions(): Extension[] {
       { dark: true },
     ),
   ];
+}
+
+/**
+ * Opens the CodeMirror search panel for find-in-file.
+ * Accepts a loose type so consumers don't need a direct @codemirror dependency.
+ */
+// biome-ignore lint/suspicious/noExplicitAny: EditorView type from @codemirror/view — kept untyped for cross-package use
+export function openFileSearchPanel(view: any): boolean {
+  return openSearchPanel(view as EditorView);
 }

--- a/packages/dashboard-core/src/types.ts
+++ b/packages/dashboard-core/src/types.ts
@@ -177,3 +177,9 @@ export interface FileContentResult {
   size: number;
   language?: string;
 }
+
+export interface ContentSearchMatch {
+  file: string;
+  line: number;
+  content: string;
+}


### PR DESCRIPTION
## Summary
- **Cmd+P / Ctrl+P**: Quick Open dialog — fuzzy search files by name/path using `git ls-files` with server-side filtering
- **Cmd+Shift+F / Ctrl+Shift+F**: Search in Files dialog — text search across all workspace files using `git grep`, with case-sensitivity toggle, results grouped by file with line numbers
- **Cmd+F / Ctrl+F**: Find in current file — opens CodeMirror's built-in search panel when a file is open in the code viewer
- All features are **desktop-only** (3-panel layout) — no search in mobile/Tauri view

## Test plan
- [ ] Open desktop layout, select a workspace, press Cmd+P — Quick Open dialog appears with file list
- [ ] Type a query in Quick Open — results filter with fuzzy matching
- [ ] Select a file from Quick Open — code browser opens that file
- [ ] Press Cmd+Shift+F — Search in Files dialog appears
- [ ] Type 2+ characters — results appear grouped by file with line numbers
- [ ] Toggle case sensitivity with "Aa" button
- [ ] Select a result — code browser opens that file
- [ ] Open a file in code browser, press Cmd+F — CodeMirror search panel appears
- [ ] Verify none of these features appear in mobile view (`/chat/$workspaceId`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)