### PR TITLE
feat: replace transparent title bar with custom HTML title bar

### DIFF
--- a/apps/dashboard/src-tauri/capabilities/default.json
+++ b/apps/dashboard/src-tauri/capabilities/default.json
@@ -17,6 +17,7 @@
     "shell:default",
     "shell:allow-open",
     "dialog:default",
-    "dialog:allow-open"
+    "dialog:allow-open",
+    "core:window:allow-start-dragging"
   ]
 }

--- a/apps/dashboard/src-tauri/src/commands/window.rs
+++ b/apps/dashboard/src-tauri/src/commands/window.rs
@@ -35,7 +35,9 @@ pub async fn open_tasks_window(app: AppHandle) -> Result<(), String> {
     .center();
 
     #[cfg(target_os = "macos")]
-    let builder = builder.title_bar_style(tauri::TitleBarStyle::Transparent);
+    let builder = builder
+        .title_bar_style(tauri::TitleBarStyle::Overlay)
+        .hidden_title(true);
 
     let window = builder
         .build()
@@ -56,4 +58,12 @@ pub async fn open_tasks_window(app: AppHandle) -> Result<(), String> {
     }
 
     Ok(())
+}
+
+#[tauri::command]
+pub fn get_app_title() -> String {
+    match crate::git::get_current_branch() {
+        Some(branch) => format!("Band - {branch}"),
+        None => "Band".to_string(),
+    }
 }

--- a/apps/dashboard/src-tauri/src/lib.rs
+++ b/apps/dashboard/src-tauri/src/lib.rs
@@ -1,48 +1,8 @@
 #[cfg(target_os = "macos")]
-#[macro_use]
-extern crate objc;
-
-#[cfg(target_os = "macos")]
 mod api;
 mod commands;
 mod git;
 mod state;
-
-/// Recursively find and remove all `NSVisualEffectView` instances from a view hierarchy.
-/// This prevents macOS from crashing in `NSViewUpdateVibrancyForSubtree` when using
-/// a transparent title bar style with `WebKit` content.
-#[cfg(target_os = "macos")]
-unsafe fn remove_visual_effect_views(view: cocoa::base::id) {
-    use cocoa::base::{id, nil};
-    use objc::runtime::Class;
-
-    let subviews: id = msg_send![view, subviews];
-    let count: usize = msg_send![subviews, count];
-
-    // Collect views to remove first (can't mutate while iterating)
-    let mut to_remove: Vec<id> = Vec::new();
-    let visual_effect_class = Class::get("NSVisualEffectView");
-
-    for i in (0..count).rev() {
-        let subview: id = msg_send![subviews, objectAtIndex: i];
-        if subview == nil {
-            continue;
-        }
-        if let Some(cls) = visual_effect_class {
-            let is_kind: bool = msg_send![subview, isKindOfClass: cls];
-            if is_kind {
-                to_remove.push(subview);
-                continue;
-            }
-        }
-        // Recurse into non-matching subviews
-        remove_visual_effect_views(subview);
-    }
-
-    for v in to_remove {
-        let () = msg_send![v, removeFromSuperview];
-    }
-}
 
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
@@ -78,6 +38,7 @@ pub fn run() {
             commands::webserver::webserver_start,
             commands::webserver::webserver_stop,
             commands::window::open_tasks_window,
+            commands::window::get_app_title,
         ])
         .setup(move |app| {
             let window = app.get_webview_window("main").unwrap();
@@ -143,17 +104,8 @@ pub fn run() {
                 });
             }
 
-            // Set window title with git branch if available
-            let title = match git::get_current_branch() {
-                Some(branch) => format!("Band - {branch}"),
-                None => "Band".to_string(),
-            };
-            let _ = window.set_title(&title);
-
-            // Set window background to black so the transparent title bar appears black,
-            // and remove any NSVisualEffectView that macOS creates for the transparent
-            // title bar — it causes crashes in NSViewUpdateVibrancyForSubtree during
-            // WebKit content updates.
+            // Set window background to black so the area behind macOS traffic
+            // light buttons matches the dark UI.
             #[cfg(target_os = "macos")]
             #[allow(deprecated)] // cocoa crate deprecated in favor of objc2-app-kit
             {
@@ -165,18 +117,6 @@ pub fn run() {
                     let color =
                         NSColor::colorWithSRGBRed_green_blue_alpha_(nil, 0.0, 0.0, 0.0, 1.0);
                     ns_window.setBackgroundColor_(color);
-
-                    // Remove NSVisualEffectView from the title bar to prevent
-                    // NSViewUpdateVibrancyForSubtree crashes. The transparent
-                    // title bar style causes macOS to insert a vibrancy layer
-                    // that can crash when WebKit updates its view hierarchy.
-                    let content_view: id = cocoa::appkit::NSWindow::contentView(ns_window);
-                    if content_view != nil {
-                        let superview: id = msg_send![content_view, superview];
-                        if superview != nil {
-                            remove_visual_effect_views(superview);
-                        }
-                    }
                 }
             }
 

--- a/apps/dashboard/src-tauri/tauri.conf.json
+++ b/apps/dashboard/src-tauri/tauri.conf.json
@@ -21,7 +21,8 @@
         "fullscreen": false,
         "decorations": true,
         "transparent": false,
-        "titleBarStyle": "Transparent"
+        "titleBarStyle": "Overlay",
+        "hiddenTitle": true
       }
     ],
     "security": {

--- a/packages/dashboard-core/src/components/DashboardShell.tsx
+++ b/packages/dashboard-core/src/components/DashboardShell.tsx
@@ -17,7 +17,7 @@ import {
   TooltipTrigger,
 } from "@band/ui";
 import { Check, FolderPlus, Pencil, Plus, Settings, Tag, X } from "lucide-react";
-import { type ReactNode, useState } from "react";
+import { type ReactNode, useEffect, useRef, useState } from "react";
 import { useCliSetup } from "../hooks/use-cli-setup";
 import { useHooksSetup } from "../hooks/use-hooks-setup";
 import { useProjects } from "../hooks/use-projects";
@@ -37,6 +37,8 @@ interface DashboardShellProps {
   toolbarExtra?: ReactNode;
 }
 
+const isTauri = typeof window !== "undefined" && "__TAURI_INTERNALS__" in window;
+
 export function DashboardShell({ toolbarExtra }: DashboardShellProps) {
   const { projects, isLoading: loading } = useProjects();
   const { settings } = useSettingsQuery();
@@ -51,13 +53,56 @@ export function DashboardShell({ toolbarExtra }: DashboardShellProps) {
   const { state: hooksState, install: installHooks } = useHooksSetup();
   const { state: cliState, install: installCli } = useCliSetup();
 
+  const [appTitle, setAppTitle] = useState("Band");
+  const titleBarRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!isTauri) return;
+    import("@tauri-apps/api/core").then(({ invoke }) => {
+      invoke<string>("get_app_title").then(setAppTitle);
+    });
+  }, []);
+
+  // Attach native mousedown listener for window dragging.
+  // Uses the official Tauri pattern: startDragging() on primary button press.
+  useEffect(() => {
+    const el = titleBarRef.current;
+    if (!isTauri || !el) return;
+
+    let appWindow: { startDragging: () => Promise<void> } | null = null;
+    import("@tauri-apps/api/window").then(({ getCurrentWindow }) => {
+      appWindow = getCurrentWindow();
+    });
+
+    const onMouseDown = (e: MouseEvent) => {
+      if (e.buttons === 1 && appWindow) {
+        appWindow.startDragging();
+      }
+    };
+    el.addEventListener("mousedown", onMouseDown);
+    return () => el.removeEventListener("mousedown", onMouseDown);
+  }, []);
+
   useStatusWatcher();
   useActiveWorkspaceWatcher();
   useBranchStatusWatcher();
   useSetupStatusWatcher();
 
   return (
-    <div className="h-dvh w-full overflow-hidden flex flex-col bg-background text-foreground p-0 pt-[env(safe-area-inset-top)]">
+    <div
+      className={`h-dvh w-full overflow-hidden flex flex-col bg-background text-foreground p-0 ${isTauri ? "" : "pt-[env(safe-area-inset-top)]"}`}
+    >
+      {isTauri && (
+        <div
+          ref={titleBarRef}
+          data-tauri-drag-region
+          className="h-[28px] shrink-0 flex items-center justify-center"
+        >
+          <span className="text-xs font-medium text-muted-foreground select-none pointer-events-none">
+            {appTitle}
+          </span>
+        </div>
+      )}
       {view === "settings" ? (
         <ScrollArea className="flex-1 overflow-hidden">
           <div className="px-2 py-2">


### PR DESCRIPTION
## Summary
- Switch from `Transparent` to `Overlay` titleBarStyle with `hiddenTitle: true` to eliminate NSVisualEffectView crashes on macOS
- Add custom HTML title bar with drag region, app title ("Band - branch"), and `startDragging()` API integration
- Add `core:window:allow-start-dragging` capability required for window dragging
- Remove `remove_visual_effect_views()` workaround and `objc` macro usage from lib.rs
- Preserve `pt-[env(safe-area-inset-top)]` for web/PWA mode (only apply Tauri title bar when running in Tauri)

## Test plan
- [ ] Verify window can be dragged by clicking the title bar area on macOS
- [ ] Verify traffic light buttons (close/minimize/maximize) work correctly
- [ ] Verify no NSVisualEffectView crash when switching between windows
- [ ] Verify web dashboard still renders correctly (no title bar, safe-area padding preserved)
- [ ] Verify app title shows "Band - branchName" in the title bar

🤖 Generated with [Claude Code](https://claude.com/claude-code)