### PR TITLE
feat: restore keyboard shortcuts, search dialogs, terminal tab, and chat UX

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -11,7 +11,8 @@
     "pretest": "pnpm build",
     "test": "vitest run",
     "test:e2e": "playwright test",
-    "test:e2e:ui": "playwright test --ui"
+    "test:e2e:ui": "playwright test --ui",
+    "postinstall": "chmod +x node_modules/node-pty/prebuilds/darwin-*/spawn-helper 2>/dev/null || true"
   },
   "dependencies": {
     "@ai-sdk/react": "^3.0.0",

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -163,6 +163,12 @@ export function ChatView({
 
   const isStreaming = status === "submitted" || status === "streaming";
 
+  const handleEscape = useCallback(() => {
+    if (isStreaming) {
+      handleStop();
+    }
+  }, [isStreaming, handleStop]);
+
   const [queuedMessages, setQueuedMessages] = useState<QueuedMessage[]>([]);
   const sendingQueuedRef = useRef(false);
 
@@ -307,6 +313,34 @@ export function ChatView({
     return historicalMessages;
   }, [historicalMessages, reconnectedPrompt]);
 
+  const getLastUserMessage = useCallback((): string | undefined => {
+    // Check live messages first (most recent)
+    for (let i = messages.length - 1; i >= 0; i--) {
+      if (messages[i].role === "user") {
+        const text = messages[i].parts
+          .filter((p): p is { type: "text"; text: string } => p.type === "text")
+          .map((p) => p.text)
+          .join("\n")
+          .trim();
+        if (text) return text;
+      }
+    }
+    // Fall back to reconnected prompt
+    if (reconnectedPrompt) return reconnectedPrompt;
+    // Fall back to historical messages
+    for (let i = filteredHistoricalMessages.length - 1; i >= 0; i--) {
+      if (filteredHistoricalMessages[i].role === "user") {
+        const text = filteredHistoricalMessages[i].content
+          .filter((b) => b.type === "text")
+          .map((b) => b.text ?? "")
+          .join("\n")
+          .trim();
+        if (text) return text;
+      }
+    }
+    return undefined;
+  }, [messages, reconnectedPrompt, filteredHistoricalMessages]);
+
   const hasHistory = filteredHistoricalMessages.length > 0;
   const hasLiveMessages = messages.length > 0;
   // Show the reconnected prompt as a user message when the stream is
@@ -439,7 +473,11 @@ export function ChatView({
       <div className="mx-auto w-full max-w-3xl shrink-0 px-3 lg:px-4 pt-2 pb-[max(1rem,env(safe-area-inset-bottom))]">
         <PromptInput onSubmit={handleSubmit}>
           <SlashCommandSuggestions skills={skills} />
-          <PromptInputTextarea placeholder="Type a message..." />
+          <PromptInputTextarea
+            placeholder="Type a message..."
+            onEscape={handleEscape}
+            onPreviousMessage={getLastUserMessage}
+          />
           <PromptInputActions>
             <PromptInputAttach />
             <PromptInputSubmit

--- a/apps/web/src/components/TerminalPanel.tsx
+++ b/apps/web/src/components/TerminalPanel.tsx
@@ -1,6 +1,5 @@
-import { FitAddon } from "@xterm/addon-fit";
-import { Terminal } from "@xterm/xterm";
-import "@xterm/xterm/css/xterm.css";
+import type { FitAddon } from "@xterm/addon-fit";
+import type { Terminal } from "@xterm/xterm";
 import { useEffect, useRef } from "react";
 
 interface TerminalPanelProps {
@@ -17,92 +16,115 @@ export function TerminalPanel({ workspaceId, visible }: TerminalPanelProps) {
   useEffect(() => {
     if (!containerRef.current) return;
 
-    const terminal = new Terminal({
-      cursorBlink: true,
-      fontSize: 13,
-      fontFamily: "'SF Mono', Menlo, Monaco, 'Courier New', monospace",
-      theme: {
-        background: "#181818",
-        foreground: "#e8e8e8",
-        cursor: "#e8e8e8",
-        selectionBackground: "rgba(255, 255, 255, 0.2)",
-      },
-    });
+    let cancelled = false;
+    let cleanup: (() => void) | undefined;
 
-    const fitAddon = new FitAddon();
-    terminal.loadAddon(fitAddon);
-    terminal.open(containerRef.current);
+    // Dynamic import so @xterm (CJS) is never evaluated during SSR
+    Promise.all([import("@xterm/xterm"), import("@xterm/addon-fit")]).then(
+      ([{ Terminal: XTerm }, { FitAddon: XFitAddon }]) => {
+        if (cancelled || !containerRef.current) return;
 
-    terminalRef.current = terminal;
-    fitAddonRef.current = fitAddon;
+        // CSS loaded on client only
+        import("@xterm/xterm/css/xterm.css");
 
-    // Connect WebSocket
-    const proto = location.protocol === "https:" ? "wss:" : "ws:";
-    const ws = new WebSocket(
-      `${proto}//${location.host}/terminal?workspaceId=${encodeURIComponent(workspaceId)}`,
-    );
-    wsRef.current = ws;
+        const terminal = new XTerm({
+          cursorBlink: true,
+          fontSize: 13,
+          fontFamily: "'SF Mono', Menlo, Monaco, 'Courier New', monospace",
+          theme: {
+            background: "#181818",
+            foreground: "#e8e8e8",
+            cursor: "#e8e8e8",
+            selectionBackground: "rgba(255, 255, 255, 0.2)",
+          },
+        });
 
-    ws.onopen = () => {
-      fitAddon.fit();
-      // Send initial terminal size
-      ws.send(
-        JSON.stringify({
-          type: "resize",
-          cols: terminal.cols,
-          rows: terminal.rows,
-        }),
-      );
-    };
+        const fitAddon = new XFitAddon();
+        terminal.loadAddon(fitAddon);
+        terminal.open(containerRef.current!);
 
-    ws.onmessage = (event) => {
-      terminal.write(event.data);
-    };
+        terminalRef.current = terminal;
+        fitAddonRef.current = fitAddon;
 
-    ws.onclose = () => {
-      terminal.write("\r\n\x1b[90m[Terminal disconnected]\x1b[0m\r\n");
-    };
-
-    // Terminal input -> WebSocket
-    terminal.onData((data) => {
-      if (ws.readyState === WebSocket.OPEN) {
-        ws.send(data);
-      }
-    });
-
-    // Auto-fit on container resize
-    const resizeObserver = new ResizeObserver(() => {
-      fitAddon.fit();
-      if (ws.readyState === WebSocket.OPEN) {
-        ws.send(
-          JSON.stringify({
-            type: "resize",
-            cols: terminal.cols,
-            rows: terminal.rows,
-          }),
+        // Connect WebSocket
+        const proto = location.protocol === "https:" ? "wss:" : "ws:";
+        const ws = new WebSocket(
+          `${proto}//${location.host}/terminal?workspaceId=${encodeURIComponent(workspaceId)}`,
         );
-      }
-    });
-    resizeObserver.observe(containerRef.current);
+        wsRef.current = ws;
+
+        ws.onopen = () => {
+          fitAddon.fit();
+          ws.send(
+            JSON.stringify({
+              type: "resize",
+              cols: terminal.cols,
+              rows: terminal.rows,
+            }),
+          );
+        };
+
+        ws.onmessage = (event) => {
+          terminal.write(event.data);
+        };
+
+        ws.onclose = () => {
+          terminal.write("\r\n\x1b[90m[Terminal disconnected]\x1b[0m\r\n");
+        };
+
+        terminal.onData((data) => {
+          if (ws.readyState === WebSocket.OPEN) {
+            ws.send(data);
+          }
+        });
+
+        // Auto-fit on container resize (skip zero-size to avoid killing server PTY)
+        const resizeObserver = new ResizeObserver((entries) => {
+          const entry = entries[0];
+          if (!entry || entry.contentRect.width === 0 || entry.contentRect.height === 0) return;
+          fitAddon.fit();
+          if (ws.readyState === WebSocket.OPEN && terminal.cols > 0 && terminal.rows > 0) {
+            ws.send(
+              JSON.stringify({
+                type: "resize",
+                cols: terminal.cols,
+                rows: terminal.rows,
+              }),
+            );
+          }
+        });
+        resizeObserver.observe(containerRef.current!);
+
+        cleanup = () => {
+          resizeObserver.disconnect();
+          ws.close();
+          terminal.dispose();
+          terminalRef.current = null;
+          fitAddonRef.current = null;
+          wsRef.current = null;
+        };
+      },
+    );
 
     return () => {
-      resizeObserver.disconnect();
-      ws.close();
-      terminal.dispose();
-      terminalRef.current = null;
-      fitAddonRef.current = null;
-      wsRef.current = null;
+      cancelled = true;
+      cleanup?.();
     };
   }, [workspaceId]);
 
-  // Refit when visibility changes
+  // Refit when visibility changes and notify server of new size
   useEffect(() => {
     if (visible && fitAddonRef.current) {
       requestAnimationFrame(() => {
         fitAddonRef.current?.fit();
+        const term = terminalRef.current;
+        const ws = wsRef.current;
+        if (term && ws?.readyState === WebSocket.OPEN && term.cols > 0 && term.rows > 0) {
+          ws.send(JSON.stringify({ type: "resize", cols: term.cols, rows: term.rows }));
+        }
       });
     }
   }, [visible]);
 
-  return <div ref={containerRef} className="h-full w-full overflow-hidden" />;
+  return <div ref={containerRef} className="h-full w-full overflow-hidden p-3" />;
 }

--- a/apps/web/src/components/ai-elements/prompt-input.tsx
+++ b/apps/web/src/components/ai-elements/prompt-input.tsx
@@ -298,6 +298,10 @@ export const PromptInputAttach = ({ className, ...props }: PromptInputAttachProp
 export type PromptInputTextareaProps = HTMLAttributes<HTMLTextAreaElement> & {
   placeholder?: string;
   disabled?: boolean;
+  /** Called when Escape is pressed (e.g. to stop streaming). */
+  onEscape?: () => void;
+  /** Called when ArrowUp is pressed on an empty input. Return the previous message text to load it, or undefined to do nothing. */
+  onPreviousMessage?: () => string | undefined;
 };
 
 /**
@@ -353,10 +357,13 @@ function shouldShowGhostHint(inputValue: string, commandHint: string | null): bo
 export const PromptInputTextarea = ({
   className,
   placeholder = "Type a message...",
+  onEscape,
+  onPreviousMessage,
   ...props
 }: PromptInputTextareaProps) => {
   const [isComposing, setIsComposing] = useState(false);
-  const { onTextChange, textareaRef, commandHint, inputValue } = useContext(PromptInputContext);
+  const { onTextChange, textareaRef, setTextareaValue, commandHint, inputValue } =
+    useContext(PromptInputContext);
 
   const handleKeyDown: KeyboardEventHandler<HTMLTextAreaElement> = useCallback(
     (e) => {
@@ -365,9 +372,20 @@ export const PromptInputTextarea = ({
         if (e.shiftKey) return;
         e.preventDefault();
         e.currentTarget.form?.requestSubmit();
+      } else if (e.key === "Escape") {
+        onEscape?.();
+      } else if (e.key === "ArrowUp" && onPreviousMessage) {
+        const textarea = e.currentTarget;
+        if (textarea.value === "") {
+          const prevText = onPreviousMessage();
+          if (prevText) {
+            e.preventDefault();
+            setTextareaValue(prevText);
+          }
+        }
       }
     },
-    [isComposing],
+    [isComposing, onEscape, onPreviousMessage, setTextareaValue],
   );
 
   const hasSlashCommand = inputValue.includes("/");

--- a/apps/web/src/lib/terminal-manager.ts
+++ b/apps/web/src/lib/terminal-manager.ts
@@ -1,3 +1,4 @@
+import { existsSync } from "node:fs";
 import { createLogger } from "@band/logger";
 import pty from "node-pty";
 import { shellPath } from "./process-utils";
@@ -41,15 +42,30 @@ export async function getOrSpawnTerminal(workspaceId: string): Promise<TerminalS
   env.PATH = resolvedPath;
   env.TERM = "xterm-256color";
 
-  log.debug("Spawning shell %s in %s", shell, workspace.worktree.path);
+  const cwd = workspace.worktree.path;
+  if (!existsSync(cwd)) {
+    throw new Error(`Workspace directory does not exist: ${cwd}`);
+  }
+  if (!existsSync(shell)) {
+    throw new Error(`Shell not found: ${shell}`);
+  }
 
-  const ptyProcess = pty.spawn(shell, [], {
-    name: "xterm-256color",
-    cols: 80,
-    rows: 24,
-    cwd: workspace.worktree.path,
-    env,
-  });
+  log.debug("Spawning shell %s in %s (PATH=%s)", shell, cwd, resolvedPath.slice(0, 200));
+
+  let ptyProcess: pty.IPty;
+  try {
+    ptyProcess = pty.spawn(shell, [], {
+      name: "xterm-256color",
+      cols: 80,
+      rows: 24,
+      cwd,
+      env,
+    });
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    log.error("pty.spawn failed: %s (shell=%s, cwd=%s)", msg, shell, cwd);
+    throw err;
+  }
 
   const session: TerminalSession = { pty: ptyProcess, scrollback: "" };
   terminals.set(workspaceId, session);

--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -14,6 +14,7 @@ import { Route as CronjobsRouteImport } from './routes/cronjobs'
 import { Route as IndexRouteImport } from './routes/index'
 import { Route as WorkspaceWorkspaceIdRouteImport } from './routes/workspace.$workspaceId'
 import { Route as WorkspaceWorkspaceIdIndexRouteImport } from './routes/workspace.$workspaceId.index'
+import { Route as WorkspaceWorkspaceIdTerminalRouteImport } from './routes/workspace.$workspaceId.terminal'
 import { Route as WorkspaceWorkspaceIdCodeRouteImport } from './routes/workspace.$workspaceId.code'
 import { Route as WorkspaceWorkspaceIdChangesRouteImport } from './routes/workspace.$workspaceId.changes'
 import { Route as WorkspaceWorkspaceIdCodeIndexRouteImport } from './routes/workspace.$workspaceId.code.index'
@@ -43,6 +44,12 @@ const WorkspaceWorkspaceIdIndexRoute =
   WorkspaceWorkspaceIdIndexRouteImport.update({
     id: '/',
     path: '/',
+    getParentRoute: () => WorkspaceWorkspaceIdRoute,
+  } as any)
+const WorkspaceWorkspaceIdTerminalRoute =
+  WorkspaceWorkspaceIdTerminalRouteImport.update({
+    id: '/terminal',
+    path: '/terminal',
     getParentRoute: () => WorkspaceWorkspaceIdRoute,
   } as any)
 const WorkspaceWorkspaceIdCodeRoute =
@@ -77,6 +84,7 @@ export interface FileRoutesByFullPath {
   '/workspace/$workspaceId': typeof WorkspaceWorkspaceIdRouteWithChildren
   '/workspace/$workspaceId/changes': typeof WorkspaceWorkspaceIdChangesRoute
   '/workspace/$workspaceId/code': typeof WorkspaceWorkspaceIdCodeRouteWithChildren
+  '/workspace/$workspaceId/terminal': typeof WorkspaceWorkspaceIdTerminalRoute
   '/workspace/$workspaceId/': typeof WorkspaceWorkspaceIdIndexRoute
   '/workspace/$workspaceId/code/$': typeof WorkspaceWorkspaceIdCodeSplatRoute
   '/workspace/$workspaceId/code/': typeof WorkspaceWorkspaceIdCodeIndexRoute
@@ -86,6 +94,7 @@ export interface FileRoutesByTo {
   '/cronjobs': typeof CronjobsRoute
   '/tasks': typeof TasksRoute
   '/workspace/$workspaceId/changes': typeof WorkspaceWorkspaceIdChangesRoute
+  '/workspace/$workspaceId/terminal': typeof WorkspaceWorkspaceIdTerminalRoute
   '/workspace/$workspaceId': typeof WorkspaceWorkspaceIdIndexRoute
   '/workspace/$workspaceId/code/$': typeof WorkspaceWorkspaceIdCodeSplatRoute
   '/workspace/$workspaceId/code': typeof WorkspaceWorkspaceIdCodeIndexRoute
@@ -98,6 +107,7 @@ export interface FileRoutesById {
   '/workspace/$workspaceId': typeof WorkspaceWorkspaceIdRouteWithChildren
   '/workspace/$workspaceId/changes': typeof WorkspaceWorkspaceIdChangesRoute
   '/workspace/$workspaceId/code': typeof WorkspaceWorkspaceIdCodeRouteWithChildren
+  '/workspace/$workspaceId/terminal': typeof WorkspaceWorkspaceIdTerminalRoute
   '/workspace/$workspaceId/': typeof WorkspaceWorkspaceIdIndexRoute
   '/workspace/$workspaceId/code/$': typeof WorkspaceWorkspaceIdCodeSplatRoute
   '/workspace/$workspaceId/code/': typeof WorkspaceWorkspaceIdCodeIndexRoute
@@ -111,6 +121,7 @@ export interface FileRouteTypes {
     | '/workspace/$workspaceId'
     | '/workspace/$workspaceId/changes'
     | '/workspace/$workspaceId/code'
+    | '/workspace/$workspaceId/terminal'
     | '/workspace/$workspaceId/'
     | '/workspace/$workspaceId/code/$'
     | '/workspace/$workspaceId/code/'
@@ -120,6 +131,7 @@ export interface FileRouteTypes {
     | '/cronjobs'
     | '/tasks'
     | '/workspace/$workspaceId/changes'
+    | '/workspace/$workspaceId/terminal'
     | '/workspace/$workspaceId'
     | '/workspace/$workspaceId/code/$'
     | '/workspace/$workspaceId/code'
@@ -131,6 +143,7 @@ export interface FileRouteTypes {
     | '/workspace/$workspaceId'
     | '/workspace/$workspaceId/changes'
     | '/workspace/$workspaceId/code'
+    | '/workspace/$workspaceId/terminal'
     | '/workspace/$workspaceId/'
     | '/workspace/$workspaceId/code/$'
     | '/workspace/$workspaceId/code/'
@@ -178,6 +191,13 @@ declare module '@tanstack/react-router' {
       path: '/'
       fullPath: '/workspace/$workspaceId/'
       preLoaderRoute: typeof WorkspaceWorkspaceIdIndexRouteImport
+      parentRoute: typeof WorkspaceWorkspaceIdRoute
+    }
+    '/workspace/$workspaceId/terminal': {
+      id: '/workspace/$workspaceId/terminal'
+      path: '/terminal'
+      fullPath: '/workspace/$workspaceId/terminal'
+      preLoaderRoute: typeof WorkspaceWorkspaceIdTerminalRouteImport
       parentRoute: typeof WorkspaceWorkspaceIdRoute
     }
     '/workspace/$workspaceId/code': {
@@ -230,12 +250,14 @@ const WorkspaceWorkspaceIdCodeRouteWithChildren =
 interface WorkspaceWorkspaceIdRouteChildren {
   WorkspaceWorkspaceIdChangesRoute: typeof WorkspaceWorkspaceIdChangesRoute
   WorkspaceWorkspaceIdCodeRoute: typeof WorkspaceWorkspaceIdCodeRouteWithChildren
+  WorkspaceWorkspaceIdTerminalRoute: typeof WorkspaceWorkspaceIdTerminalRoute
   WorkspaceWorkspaceIdIndexRoute: typeof WorkspaceWorkspaceIdIndexRoute
 }
 
 const WorkspaceWorkspaceIdRouteChildren: WorkspaceWorkspaceIdRouteChildren = {
   WorkspaceWorkspaceIdChangesRoute: WorkspaceWorkspaceIdChangesRoute,
   WorkspaceWorkspaceIdCodeRoute: WorkspaceWorkspaceIdCodeRouteWithChildren,
+  WorkspaceWorkspaceIdTerminalRoute: WorkspaceWorkspaceIdTerminalRoute,
   WorkspaceWorkspaceIdIndexRoute: WorkspaceWorkspaceIdIndexRoute,
 }
 

--- a/apps/web/src/routes/workspace.$workspaceId.code.$.tsx
+++ b/apps/web/src/routes/workspace.$workspaceId.code.$.tsx
@@ -1,6 +1,7 @@
 import { createFileRoute, useNavigate } from "@tanstack/react-router";
 import { useCallback } from "react";
 import { CodeBrowserView } from "../components/CodeBrowserView";
+import { useFindInFileContext } from "./workspace.$workspaceId";
 
 export const Route = createFileRoute("/workspace/$workspaceId/code/$")({
   component: CodeFile,
@@ -9,6 +10,7 @@ export const Route = createFileRoute("/workspace/$workspaceId/code/$")({
 function CodeFile() {
   const { workspaceId, _splat } = Route.useParams();
   const navigate = useNavigate();
+  const { setFindInFile } = useFindInFileContext();
 
   const handleSelectFile = useCallback(
     (filePath: string | null) => {
@@ -32,6 +34,7 @@ function CodeFile() {
       workspaceId={decodeURIComponent(workspaceId)}
       file={_splat || undefined}
       onSelectFile={handleSelectFile}
+      onFindInFile={setFindInFile}
     />
   );
 }

--- a/apps/web/src/routes/workspace.$workspaceId.terminal.tsx
+++ b/apps/web/src/routes/workspace.$workspaceId.terminal.tsx
@@ -16,10 +16,7 @@ function WorkspaceTerminal() {
   const { workspaceId } = Route.useParams();
   return (
     <Suspense fallback={null}>
-      <TerminalPanel
-        workspaceId={decodeURIComponent(workspaceId)}
-        visible={true}
-      />
+      <TerminalPanel workspaceId={decodeURIComponent(workspaceId)} visible={true} />
     </Suspense>
   );
 }

--- a/apps/web/src/routes/workspace.$workspaceId.terminal.tsx
+++ b/apps/web/src/routes/workspace.$workspaceId.terminal.tsx
@@ -1,0 +1,25 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { lazy, Suspense } from "react";
+
+// Lazy-load to avoid importing @xterm/xterm (CJS) in SSR context
+const TerminalPanel = lazy(() =>
+  import("../components/TerminalPanel").then((m) => ({
+    default: m.TerminalPanel,
+  })),
+);
+
+export const Route = createFileRoute("/workspace/$workspaceId/terminal")({
+  component: WorkspaceTerminal,
+});
+
+function WorkspaceTerminal() {
+  const { workspaceId } = Route.useParams();
+  return (
+    <Suspense fallback={null}>
+      <TerminalPanel
+        workspaceId={decodeURIComponent(workspaceId)}
+        visible={true}
+      />
+    </Suspense>
+  );
+}

--- a/apps/web/src/routes/workspace.$workspaceId.tsx
+++ b/apps/web/src/routes/workspace.$workspaceId.tsx
@@ -1,11 +1,13 @@
 import {
   type DiffStats,
+  QuickOpenDialog,
+  SearchFilesDialog,
   useDashboardStore,
   type WorkspaceTab,
   WorkspaceTabNav,
 } from "@band/dashboard-core";
 import { createFileRoute, Link, Outlet, useNavigate, useRouterState } from "@tanstack/react-router";
-import { ArrowLeft, Clock, Code, GitCompare } from "lucide-react";
+import { ArrowLeft, Clock, Code, GitCompare, Terminal } from "lucide-react";
 import {
   createContext,
   useCallback,
@@ -38,6 +40,19 @@ const DiffStatsContext = createContext<DiffStatsContextValue>({
 
 export function useDiffStatsContext() {
   return useContext(DiffStatsContext);
+}
+
+// Context for child routes to register a find-in-file callback with the layout
+interface FindInFileContextValue {
+  setFindInFile: (fn: (() => void) | null) => void;
+}
+
+const FindInFileContext = createContext<FindInFileContextValue>({
+  setFindInFile: () => {},
+});
+
+export function useFindInFileContext() {
+  return useContext(FindInFileContext);
 }
 
 // ---------------------------------------------------------------------------
@@ -128,8 +143,9 @@ function DesktopDetailTabNav({
   const prefix = `/workspace/${workspaceId}`;
   const isChanges = pathname.startsWith(`${prefix}/changes`);
   const isCode = pathname.startsWith(`${prefix}/code`);
+  const isTerminal = pathname.startsWith(`${prefix}/terminal`);
 
-  const linkClass = (active: boolean) =>
+  const tabClass = (active: boolean) =>
     `flex h-full flex-1 items-center justify-center gap-2 text-sm font-medium transition-colors ${
       active
         ? "border-b border-foreground text-foreground"
@@ -141,7 +157,7 @@ function DesktopDetailTabNav({
       <Link
         to="/workspace/$workspaceId/changes"
         params={{ workspaceId }}
-        className={linkClass(isChanges)}
+        className={tabClass(isChanges)}
       >
         <GitCompare className="size-4" />
         Changes
@@ -154,10 +170,18 @@ function DesktopDetailTabNav({
       <Link
         to="/workspace/$workspaceId/code"
         params={{ workspaceId }}
-        className={linkClass(isCode)}
+        className={tabClass(isCode)}
       >
         <Code className="size-4" />
         Code
+      </Link>
+      <Link
+        to="/workspace/$workspaceId/terminal"
+        params={{ workspaceId }}
+        className={tabClass(isTerminal)}
+      >
+        <Terminal className="size-4" />
+        Terminal
       </Link>
     </div>
   );
@@ -171,15 +195,63 @@ function DesktopWorkspaceLayout({
   encodedId: string;
 }) {
   const { diffStats } = useDiffStatsContext();
+  const navigate = useNavigate();
+
+  // Dialog state
+  const [quickOpenOpen, setQuickOpenOpen] = useState(false);
+  const [searchFilesOpen, setSearchFilesOpen] = useState(false);
+
+  // Find-in-file: child code routes register a callback here
+  const findInFileRef = useRef<(() => void) | null>(null);
+  const setFindInFile = useCallback((fn: (() => void) | null) => {
+    findInFileRef.current = fn;
+  }, []);
+
+  // Global keyboard shortcuts (capture phase to beat browser defaults)
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      const mod = e.metaKey || e.ctrlKey;
+      if (!mod) return;
+
+      const key = e.key.toLowerCase();
+      if (key === "p" && !e.shiftKey) {
+        e.preventDefault();
+        setQuickOpenOpen(true);
+      } else if (key === "f" && e.shiftKey) {
+        e.preventDefault();
+        setSearchFilesOpen(true);
+      } else if (key === "f" && !e.shiftKey) {
+        if (findInFileRef.current) {
+          e.preventDefault();
+          findInFileRef.current();
+        }
+      }
+    };
+    window.addEventListener("keydown", handler, true);
+    return () => window.removeEventListener("keydown", handler, true);
+  }, []);
+
+  // Open file from Quick Open / Search dialogs → navigate to code route
+  const handleOpenFile = useCallback(
+    (path: string) => {
+      navigate({
+        to: "/workspace/$workspaceId/code/$",
+        params: { workspaceId: encodedId, _splat: path },
+      });
+    },
+    [navigate, encodedId],
+  );
 
   return (
     <div className="flex h-full overflow-hidden">
-      {/* Middle Panel — Changes / Code */}
+      {/* Middle Panel — Changes / Code / Terminal */}
       <div className="flex-1 min-w-0 border-r border-white/20 overflow-hidden">
         <div className="flex h-full flex-col overflow-hidden">
           <DesktopDetailTabNav workspaceId={encodedId} diffStats={diffStats} />
-          <div className="min-h-0 flex-1">
-            <Outlet />
+          <div className="min-h-0 flex-1 overflow-hidden">
+            <FindInFileContext.Provider value={{ setFindInFile }}>
+              <Outlet />
+            </FindInFileContext.Provider>
           </div>
         </div>
       </div>
@@ -188,6 +260,20 @@ function DesktopWorkspaceLayout({
       <div className="max-w-[768px] flex-1 min-w-0 overflow-hidden">
         <WorkspaceChatPanel key={workspaceId} workspaceId={workspaceId} />
       </div>
+
+      {/* Dialogs */}
+      <QuickOpenDialog
+        workspaceId={workspaceId}
+        open={quickOpenOpen}
+        onOpenChange={setQuickOpenOpen}
+        onOpenFile={handleOpenFile}
+      />
+      <SearchFilesDialog
+        workspaceId={workspaceId}
+        open={searchFilesOpen}
+        onOpenChange={setSearchFilesOpen}
+        onOpenFile={handleOpenFile}
+      />
     </div>
   );
 }

--- a/apps/web/src/routes/workspace.$workspaceId.tsx
+++ b/apps/web/src/routes/workspace.$workspaceId.tsx
@@ -167,11 +167,7 @@ function DesktopDetailTabNav({
           </span>
         )}
       </Link>
-      <Link
-        to="/workspace/$workspaceId/code"
-        params={{ workspaceId }}
-        className={tabClass(isCode)}
-      >
+      <Link to="/workspace/$workspaceId/code" params={{ workspaceId }} className={tabClass(isCode)}>
         <Code className="size-4" />
         Code
       </Link>


### PR DESCRIPTION
## Summary
- Restore Cmd+P (quick open), Cmd+Shift+F (search files), Cmd+F (find in file) keyboard shortcuts lost in PR #137's routing refactor
- Add Terminal as a dedicated route tab (`/workspace/$id/terminal`) with SSR-compatible dynamic imports for xterm
- Fix node-pty `posix_spawnp` failure by adding postinstall script to set spawn-helper execute permissions
- Add Escape to stop streaming and ArrowUp to recall last message in chat input

## Test plan
- [ ] In a workspace on desktop, verify Cmd+P opens quick file search and selecting a file navigates to code tab
- [ ] Verify Cmd+Shift+F opens search in files and selecting a result navigates to code tab
- [ ] Verify Cmd+F while viewing a file activates CodeMirror's find-in-file panel
- [ ] Verify Terminal tab shows a working terminal session
- [ ] Verify Escape stops streaming in chat
- [ ] Verify ArrowUp on empty input recalls last user message

🤖 Generated with [Claude Code](https://claude.com/claude-code)