### PR TITLE
fix: show chat tab first when opening workspace on mobile web

### DIFF
--- a/packages/dashboard-core/src/adapters/web.ts
+++ b/packages/dashboard-core/src/adapters/web.ts
@@ -213,6 +213,6 @@ export class WebCapabilities implements PlatformCapabilities {
   navigate?: (href: string) => void;
 
   getWorkspaceHref(workspaceId: string): string {
-    return `/workspace/${encodeURIComponent(workspaceId)}/changes`;
+    return `/workspace/${encodeURIComponent(workspaceId)}`;
   }
 }


### PR DESCRIPTION
## Summary
- The workspace href in `WebCapabilities.getWorkspaceHref()` hardcoded `/changes`, so mobile users always landed on the Changes tab
- Changed to point to the index route instead — the index already renders chat on mobile and redirects to `/changes` on desktop

## Test plan
- [ ] Open a workspace on mobile web → chat tab should be active
- [ ] Open a workspace on desktop web → changes tab should still be active (index redirects)

🤖 Generated with [Claude Code](https://claude.com/claude-code)