### PR TITLE
Fix CI status navigation in web app

### DIFF
--- a/packages/dashboard-core/src/adapters/web.ts
+++ b/packages/dashboard-core/src/adapters/web.ts
@@ -215,4 +215,8 @@ export class WebCapabilities implements PlatformCapabilities {
   getWorkspaceHref(workspaceId: string): string {
     return `/workspace/${encodeURIComponent(workspaceId)}/changes`;
   }
+
+  async openUrl(url: string): Promise<void> {
+    window.open(url, "_blank");
+  }
 }

--- a/packages/dashboard-core/src/components/CIStatusIndicator.tsx
+++ b/packages/dashboard-core/src/components/CIStatusIndicator.tsx
@@ -1,5 +1,5 @@
 import { Tooltip, TooltipContent, TooltipTrigger } from "@band/ui";
-import { CircleAlert, CircleCheck, GitMerge, Loader } from "lucide-react";
+import { Ban, CircleAlert, CircleCheck, GitMerge, Loader } from "lucide-react";
 import { useCapabilities } from "../context";
 import type { CIStatus } from "../types";
 
@@ -70,6 +70,20 @@ export function CIStatusIndicator({ ci }: Props) {
           />
         </TooltipTrigger>
         <TooltipContent>{ci.state === "running" ? "CI running" : "CI pending"}</TooltipContent>
+      </Tooltip>
+    );
+  }
+
+  if (ci.state === "cancelled") {
+    return (
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Ban
+            className={`size-3.5 shrink-0 text-gray-400 ${cursorClass}`}
+            onClick={(e) => handleOpenUrl(ci.url, e)}
+          />
+        </TooltipTrigger>
+        <TooltipContent>CI cancelled</TooltipContent>
       </Tooltip>
     );
   }


### PR DESCRIPTION
## Summary
- Add `openUrl` to `WebCapabilities` so CI status icons are clickable in the browser (opens GitHub Actions/PR in a new tab)
- Add rendering for the `cancelled` CI state (was silently dropped, now shows a `Ban` icon in gray)

## Test plan
- [ ] Open the web app in a browser, verify CI status icons show cursor-pointer and open correct URLs on click
- [ ] Verify cancelled CI runs show the Ban icon and are navigatable
- [ ] Verify Tauri app CI navigation still works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)