### PR TITLE
fix: prevent assistant message overflow on mobile chat view

### DIFF
--- a/apps/web/src/components/ai-elements/conversation.tsx
+++ b/apps/web/src/components/ai-elements/conversation.tsx
@@ -20,7 +20,10 @@ export type ConversationContentProps = ComponentProps<typeof StickToBottom.Conte
 
 export const ConversationContent = ({ className, ...props }: ConversationContentProps) => (
   <StickToBottom.Content
-    className={cn("mx-auto flex w-full max-w-3xl flex-col gap-4 overflow-hidden px-3 py-4 lg:px-4", className)}
+    className={cn(
+      "mx-auto flex w-full max-w-3xl flex-col gap-4 overflow-hidden px-3 py-4 lg:px-4",
+      className,
+    )}
     {...props}
   />
 );

--- a/apps/web/src/components/ai-elements/conversation.tsx
+++ b/apps/web/src/components/ai-elements/conversation.tsx
@@ -20,7 +20,7 @@ export type ConversationContentProps = ComponentProps<typeof StickToBottom.Conte
 
 export const ConversationContent = ({ className, ...props }: ConversationContentProps) => (
   <StickToBottom.Content
-    className={cn("mx-auto flex w-full max-w-3xl flex-col gap-4 px-3 py-4 lg:px-4", className)}
+    className={cn("mx-auto flex w-full max-w-3xl flex-col gap-4 overflow-hidden px-3 py-4 lg:px-4", className)}
     {...props}
   />
 );

--- a/apps/web/src/components/ai-elements/message.tsx
+++ b/apps/web/src/components/ai-elements/message.tsx
@@ -19,7 +19,7 @@ export type MessageProps = HTMLAttributes<HTMLDivElement> & {
 export const Message = ({ className, from, ...props }: MessageProps) => (
   <div
     className={cn(
-      "group flex w-full max-w-[95%] flex-col gap-2",
+      "group flex w-full min-w-0 max-w-[95%] flex-col gap-2",
       from === "user" ? "is-user ml-auto justify-end" : "is-assistant",
       className,
     )}


### PR DESCRIPTION
## Summary
- Add `min-w-0` to the `Message` component's outer flex container so flex children can shrink below content size on narrow viewports
- Add `overflow-hidden` to `ConversationContent` wrapper to prevent any remaining overflow from escaping the container
- These two changes allow `break-words` and `overflow-wrap: anywhere` on Streamdown content to work correctly on mobile

## Test plan
- [ ] Open the chat view on a narrow mobile viewport (≤375px)
- [ ] Send/receive assistant messages with long unbreakable content (URLs, code blocks)
- [ ] Verify messages no longer overflow beyond the left edge of the viewport
- [ ] Verify desktop chat layout is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)