### PR TITLE
fix: render task list widget above prompt input

### DIFF
--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -313,6 +313,17 @@ export function ChatView({
     return historicalMessages;
   }, [historicalMessages, reconnectedPrompt]);
 
+  const historyToolResultMap = useMemo(
+    () => buildToolResultMap(filteredHistoricalMessages),
+    [filteredHistoricalMessages],
+  );
+  const { taskMap: historyTaskMap } = useMemo(
+    () => buildHistoryTaskMap(filteredHistoricalMessages, historyToolResultMap),
+    [filteredHistoricalMessages, historyToolResultMap],
+  );
+
+  const displayTaskMap = liveTaskMap.size > 0 ? liveTaskMap : historyTaskMap;
+
   const getLastUserMessage = useCallback((): string | undefined => {
     // Check live messages first (most recent)
     for (let i = messages.length - 1; i >= 0; i--) {
@@ -398,7 +409,6 @@ export function ChatView({
           )}
 
           {(() => {
-            let taskWidgetRendered = false;
             return messages.map((message, messageIndex) => {
               const isLastMessage = messageIndex === messages.length - 1;
               const isLastAssistant = message.role === "assistant" && isLastMessage;
@@ -435,10 +445,6 @@ export function ChatView({
                       }
                       const item = toolPartToItem(segment.part);
                       if (isTaskTool(item.toolName)) {
-                        if (!taskWidgetRendered && liveTaskMap.size > 0) {
-                          taskWidgetRendered = true;
-                          return <TaskListWidget key="task-list-widget" tasks={liveTaskMap} />;
-                        }
                         return null;
                       }
                       return (
@@ -471,6 +477,7 @@ export function ChatView({
       </Conversation>
 
       <div className="mx-auto w-full max-w-3xl shrink-0 px-3 lg:px-4 pt-2 pb-[max(1rem,env(safe-area-inset-bottom))]">
+        <TaskListWidget tasks={displayTaskMap} />
         <PromptInput onSubmit={handleSubmit}>
           <SlashCommandSuggestions skills={skills} />
           <PromptInputTextarea
@@ -589,12 +596,10 @@ function parseSharedFiles(text: string): {
 
 function HistoryMessages({ messages }: { messages: HistoryMessage[] }) {
   const toolResultMap = useMemo(() => buildToolResultMap(messages), [messages]);
-  const { taskMap, taskToolCallIds } = useMemo(
+  const { taskToolCallIds } = useMemo(
     () => buildHistoryTaskMap(messages, toolResultMap),
     [messages, toolResultMap],
   );
-
-  let taskWidgetRendered = false;
 
   return (
     <>
@@ -603,12 +608,7 @@ function HistoryMessages({ messages }: { messages: HistoryMessage[] }) {
           key={msg.id}
           message={msg}
           toolResultMap={toolResultMap}
-          taskMap={taskMap}
           taskToolCallIds={taskToolCallIds}
-          taskWidgetRendered={taskWidgetRendered}
-          onTaskWidgetRendered={() => {
-            taskWidgetRendered = true;
-          }}
         />
       ))}
     </>
@@ -618,17 +618,11 @@ function HistoryMessages({ messages }: { messages: HistoryMessage[] }) {
 function HistoryMessageView({
   message,
   toolResultMap,
-  taskMap,
   taskToolCallIds,
-  taskWidgetRendered,
-  onTaskWidgetRendered,
 }: {
   message: HistoryMessage;
   toolResultMap: Map<string, HistoryMessageContent>;
-  taskMap: TaskMap;
   taskToolCallIds: Set<string>;
-  taskWidgetRendered: boolean;
-  onTaskWidgetRendered: () => void;
 }) {
   const textBlocks = message.content.filter((b) => b.type === "text" && b.text?.trim());
   const toolUseBlocks = message.content.filter((b) => b.type === "tool_use");
@@ -657,10 +651,7 @@ function HistoryMessageView({
         {renderHistoryContent(
           message,
           toolResultMap,
-          taskMap,
           taskToolCallIds,
-          taskWidgetRendered,
-          onTaskWidgetRendered,
         )}
       </MessageContent>
     </Message>
@@ -685,10 +676,7 @@ function historyToolToItem(
 function renderHistoryContent(
   message: HistoryMessage,
   toolResultMap: Map<string, HistoryMessageContent>,
-  taskMap: TaskMap,
   taskToolCallIds: Set<string>,
-  taskWidgetRendered: boolean,
-  onTaskWidgetRendered: () => void,
 ) {
   const elements: React.ReactNode[] = [];
 
@@ -700,11 +688,6 @@ function renderHistoryContent(
     } else if (block.type === "tool_use") {
       const callId = block.toolCallId ?? "";
       if (taskToolCallIds.has(callId)) {
-        if (!taskWidgetRendered && taskMap.size > 0) {
-          taskWidgetRendered = true;
-          onTaskWidgetRendered();
-          elements.push(<TaskListWidget key="task-list-widget" tasks={taskMap} />);
-        }
         continue;
       }
       const item = historyToolToItem(block, toolResultMap.get(callId));

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -648,11 +648,7 @@ function HistoryMessageView({
   return (
     <Message from="assistant">
       <MessageContent>
-        {renderHistoryContent(
-          message,
-          toolResultMap,
-          taskToolCallIds,
-        )}
+        {renderHistoryContent(message, toolResultMap, taskToolCallIds)}
       </MessageContent>
     </Message>
   );

--- a/apps/web/src/components/ai-elements/task-list-widget.tsx
+++ b/apps/web/src/components/ai-elements/task-list-widget.tsx
@@ -1,37 +1,53 @@
 import { cn } from "@band/ui";
-import { CheckCircle2, Circle, Loader2 } from "lucide-react";
+import { CheckCircle2, ChevronDown, ChevronRight, Circle, Loader2 } from "lucide-react";
+import { useState } from "react";
 
 import type { TaskMap } from "./task-state";
 
 export function TaskListWidget({ tasks }: { tasks: TaskMap }) {
+  const [collapsed, setCollapsed] = useState(false);
+
   if (tasks.size === 0) return null;
 
   const taskList = Array.from(tasks.values());
   const completedCount = taskList.filter((t) => t.status === "completed").length;
 
   return (
-    <div className="not-prose mb-4 w-full rounded border border-border/50">
-      <div className="flex items-center justify-between gap-2 p-3">
-        <span className="font-medium text-base">Todos</span>
-        <span className="text-sm text-muted-foreground">
+    <div className="not-prose mb-2 w-full rounded border border-border/50">
+      <button
+        type="button"
+        onClick={() => setCollapsed(!collapsed)}
+        className="flex w-full items-center justify-between gap-2 px-2.5 py-1.5 transition-colors hover:bg-white/5"
+      >
+        <div className="flex items-center gap-1.5">
+          {collapsed ? (
+            <ChevronRight className="size-3 text-muted-foreground" />
+          ) : (
+            <ChevronDown className="size-3 text-muted-foreground" />
+          )}
+          <span className="text-xs font-medium">Todos</span>
+        </div>
+        <span className="text-xs text-muted-foreground">
           {completedCount}/{taskList.length}
         </span>
-      </div>
-      <div className="border-t border-border/50 px-3 py-2">
-        {taskList.map((task) => (
-          <div key={task.id} className="flex items-center gap-2 py-1.5">
-            <TaskStatusIcon status={task.status} />
-            <span
-              className={cn(
-                "text-base",
-                task.status === "completed" && "text-muted-foreground line-through",
-              )}
-            >
-              {task.status === "in_progress" && task.activeForm ? task.activeForm : task.subject}
-            </span>
-          </div>
-        ))}
-      </div>
+      </button>
+      {!collapsed && (
+        <div className="border-t border-border/50 px-2.5 py-1">
+          {taskList.map((task) => (
+            <div key={task.id} className="flex items-center gap-1.5 py-0.5">
+              <TaskStatusIcon status={task.status} />
+              <span
+                className={cn(
+                  "text-xs",
+                  task.status === "completed" && "text-muted-foreground line-through",
+                )}
+              >
+                {task.status === "in_progress" && task.activeForm ? task.activeForm : task.subject}
+              </span>
+            </div>
+          ))}
+        </div>
+      )}
     </div>
   );
 }
@@ -39,10 +55,10 @@ export function TaskListWidget({ tasks }: { tasks: TaskMap }) {
 function TaskStatusIcon({ status }: { status: string }) {
   switch (status) {
     case "completed":
-      return <CheckCircle2 className="size-4 shrink-0 text-green-500" />;
+      return <CheckCircle2 className="size-3 shrink-0 text-green-500" />;
     case "in_progress":
-      return <Loader2 className="size-4 shrink-0 animate-spin text-orange-500" />;
+      return <Loader2 className="size-3 shrink-0 animate-spin text-orange-500" />;
     default:
-      return <Circle className="size-4 shrink-0 text-muted-foreground" />;
+      return <Circle className="size-3 shrink-0 text-muted-foreground" />;
   }
 }


### PR DESCRIPTION
## Summary
- Move TaskListWidget from inline message rendering to a fixed position above the prompt input, so it stays visible regardless of scroll
- Make the widget compact (smaller text, tighter spacing) with a collapsible toggle
- Simplify history message rendering by removing per-message task widget logic

## Test plan
- [ ] Verify task list appears above prompt input during active agent work
- [ ] Verify task list shows correctly when viewing historical sessions
- [ ] Verify collapse/expand toggle works
- [ ] Verify completed/in-progress/pending states render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)