### PR TITLE
feat: add git pull and push to workspace context menu

### DIFF
--- a/apps/web/e2e/tasks-page.spec.ts
+++ b/apps/web/e2e/tasks-page.spec.ts
@@ -101,6 +101,10 @@ test.beforeAll(async () => {
     completedAt: Date.now() - 7100_000,
   });
 
+  server = await startServer({ tmpHome });
+
+  // Seed the running task AFTER the server starts so that cleanupStaleTasks()
+  // (which marks all running tasks as failed on startup) doesn't clobber it.
   seedTask(tmpHome, {
     id: "tsk_3000",
     workspaceId: "backend-main",
@@ -110,8 +114,6 @@ test.beforeAll(async () => {
     status: "running",
     startedAt: Date.now() - 60_000,
   });
-
-  server = await startServer({ tmpHome });
 });
 
 test.afterAll(async () => {

--- a/apps/web/src/trpc/router.ts
+++ b/apps/web/src/trpc/router.ts
@@ -362,6 +362,37 @@ const workspacesRouter = t.router({
       throw new Error(`Workspace "${input.branch}" not found`);
     }),
 
+  gitPull: publicProcedure
+    .input(z.object({ project: z.string(), branch: z.string() }))
+    .mutation(async ({ input }) => {
+      const workspaceId = toWorkspaceId(input.project, input.branch);
+      const workspace = resolveWorkspace(workspaceId);
+      if (!workspace) {
+        throw new Error("Workspace not found");
+      }
+      const cwd = workspace.worktree.path;
+      await execGit(["pull"], cwd);
+      return { ok: true };
+    }),
+
+  gitPush: publicProcedure
+    .input(z.object({ project: z.string(), branch: z.string() }))
+    .mutation(async ({ input }) => {
+      const workspaceId = toWorkspaceId(input.project, input.branch);
+      const workspace = resolveWorkspace(workspaceId);
+      if (!workspace) {
+        throw new Error("Workspace not found");
+      }
+      const cwd = workspace.worktree.path;
+      try {
+        await execGit(["push"], cwd);
+      } catch {
+        // First push may need to set upstream
+        await execGit(["push", "--set-upstream", "origin", input.branch], cwd);
+      }
+      return { ok: true };
+    }),
+
   runScript: publicProcedure
     .input(z.object({ path: z.string(), scriptType: z.string() }))
     .mutation(({ input }) => {

--- a/packages/dashboard-core/src/adapter.ts
+++ b/packages/dashboard-core/src/adapter.ts
@@ -27,6 +27,8 @@ export interface DashboardAdapter {
   removeWorkspace(project: string, branch: string): Promise<void>;
   openWorkspace(workspaceId: string): Promise<void>;
   runScript(path: string, scriptType: string): Promise<void>;
+  gitPull(project: string, branch: string): Promise<void>;
+  gitPush(project: string, branch: string): Promise<void>;
 
   // Settings
   getSettings(): Promise<Settings>;

--- a/packages/dashboard-core/src/adapters/web.ts
+++ b/packages/dashboard-core/src/adapters/web.ts
@@ -82,6 +82,14 @@ export class WebDashboardAdapter implements DashboardAdapter {
     await this.trpc.workspaces.runScript.mutate({ path, scriptType });
   }
 
+  async gitPull(project: string, branch: string): Promise<void> {
+    await this.trpc.workspaces.gitPull.mutate({ project, branch });
+  }
+
+  async gitPush(project: string, branch: string): Promise<void> {
+    await this.trpc.workspaces.gitPush.mutate({ project, branch });
+  }
+
   async getSettings(): Promise<Settings> {
     return (await this.trpc.settings.get.query()) as Settings;
   }

--- a/packages/dashboard-core/src/components/WorkspaceCard.tsx
+++ b/packages/dashboard-core/src/components/WorkspaceCard.tsx
@@ -7,7 +7,16 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@band/ui";
-import { Clipboard, FolderOpen, GitBranch, Play, Square, Trash2 } from "lucide-react";
+import {
+  ArrowDownToLine,
+  ArrowUpFromLine,
+  Clipboard,
+  FolderOpen,
+  GitBranch,
+  Play,
+  Square,
+  Trash2,
+} from "lucide-react";
 import { useEffect, useRef } from "react";
 import { useCapabilities } from "../context";
 import { useRemoveWorkspace } from "../hooks/use-project-mutations";
@@ -59,6 +68,8 @@ export function WorkspaceCard({
 
   const openWorkspace = useDashboardStore((s) => s.openWorkspace);
   const runScript = useDashboardStore((s) => s.runScript);
+  const gitPull = useDashboardStore((s) => s.gitPull);
+  const gitPush = useDashboardStore((s) => s.gitPush);
   const activeWorkspaceId = useDashboardStore((s) => s.activeWorkspaceId);
   const removeWorkspaceMutation = useRemoveWorkspace();
 
@@ -163,6 +174,14 @@ export function WorkspaceCard({
             Run teardown
           </ContextMenuItem>
         )}
+        <ContextMenuItem onClick={() => gitPull(projectName, worktree.branch)}>
+          <ArrowDownToLine />
+          Git pull
+        </ContextMenuItem>
+        <ContextMenuItem onClick={() => gitPush(projectName, worktree.branch)}>
+          <ArrowUpFromLine />
+          Git push
+        </ContextMenuItem>
         {worktree.branch !== defaultBranch && (
           <ContextMenuItem variant="destructive" onClick={handleDelete}>
             <Trash2 />

--- a/packages/dashboard-core/src/stores/dashboard-store.ts
+++ b/packages/dashboard-core/src/stores/dashboard-store.ts
@@ -23,6 +23,8 @@ export interface DashboardState {
   removeStatus: (workspaceId: string) => void;
   setActiveWorkspace: (workspaceId: string | null) => void;
   runScript: (path: string, scriptType: string) => Promise<void>;
+  gitPull: (project: string, branch: string) => Promise<void>;
+  gitPush: (project: string, branch: string) => Promise<void>;
   updateGitStatus: (workspaceId: string, git: GitStatus) => void;
   updateCIStatus: (workspaceId: string, ci: CIStatus) => void;
   updateSetupStatus: (workspaceId: string, status: SetupStatus) => void;
@@ -98,6 +100,22 @@ export function createDashboardStore(adapter: DashboardAdapter): DashboardStore 
     runScript: async (path: string, scriptType: string) => {
       try {
         await adapter.runScript(path, scriptType);
+      } catch (e) {
+        set({ error: String(e) });
+      }
+    },
+
+    gitPull: async (project: string, branch: string) => {
+      try {
+        await adapter.gitPull(project, branch);
+      } catch (e) {
+        set({ error: String(e) });
+      }
+    },
+
+    gitPush: async (project: string, branch: string) => {
+      try {
+        await adapter.gitPush(project, branch);
       } catch (e) {
         set({ error: String(e) });
       }


### PR DESCRIPTION
## Summary
- Add **Git pull** and **Git push** actions to the workspace right-click context menu
- Available in both web and Tauri dashboard
- Server-side tRPC mutations run `git pull` / `git push` in the worktree directory
- Push automatically sets upstream on first push

## Test plan
- [ ] Right-click a workspace → verify "Git pull" and "Git push" menu items appear
- [ ] Test git pull on a workspace with upstream changes
- [ ] Test git push on a workspace with local commits
- [ ] Test first push on a new branch (sets upstream)
- [ ] Verify error dialog appears on failure (e.g., merge conflicts)

🤖 Generated with [Claude Code](https://claude.com/claude-code)