### PR TITLE
fix: lazy-load per-file diffs to avoid maxBuffer errors

### DIFF
--- a/apps/web/src/lib/git.ts
+++ b/apps/web/src/lib/git.ts
@@ -17,16 +17,23 @@ export function gitCmd(): { command: string; env: NodeJS.ProcessEnv } {
   return { command: "git", env };
 }
 
+const MAX_BUFFER = 50 * 1024 * 1024; // 50 MB
+
 export function execGit(args: string[], cwd: string): Promise<string> {
   const { command, env } = gitCmd();
   return new Promise((resolve, reject) => {
-    execFile(command, args, { cwd, env }, (err, stdout, stderr) => {
-      if (err) {
-        reject(new Error(stderr || err.message));
-        return;
+    execFile(
+      command,
+      args,
+      { cwd, env, maxBuffer: MAX_BUFFER },
+      (err, stdout, stderr) => {
+        if (err) {
+          reject(new Error(stderr || err.message));
+          return;
+        }
+        resolve(stdout);
       }
-      resolve(stdout);
-    });
+    );
   });
 }
 
@@ -36,13 +43,18 @@ export function execGh(args: string[], cwd: string): Promise<string> {
     env.PATH = `/opt/homebrew/bin:/usr/local/bin:${env.PATH}`;
   }
   return new Promise((resolve, reject) => {
-    execFile("gh", args, { cwd, env }, (err, stdout, stderr) => {
-      if (err) {
-        reject(new Error(stderr || err.message));
-        return;
+    execFile(
+      "gh",
+      args,
+      { cwd, env, maxBuffer: MAX_BUFFER },
+      (err, stdout, stderr) => {
+        if (err) {
+          reject(new Error(stderr || err.message));
+          return;
+        }
+        resolve(stdout);
       }
-      resolve(stdout);
-    });
+    );
   });
 }
 

--- a/apps/web/src/lib/git.ts
+++ b/apps/web/src/lib/git.ts
@@ -22,18 +22,13 @@ const MAX_BUFFER = 50 * 1024 * 1024; // 50 MB
 export function execGit(args: string[], cwd: string): Promise<string> {
   const { command, env } = gitCmd();
   return new Promise((resolve, reject) => {
-    execFile(
-      command,
-      args,
-      { cwd, env, maxBuffer: MAX_BUFFER },
-      (err, stdout, stderr) => {
-        if (err) {
-          reject(new Error(stderr || err.message));
-          return;
-        }
-        resolve(stdout);
+    execFile(command, args, { cwd, env, maxBuffer: MAX_BUFFER }, (err, stdout, stderr) => {
+      if (err) {
+        reject(new Error(stderr || err.message));
+        return;
       }
-    );
+      resolve(stdout);
+    });
   });
 }
 
@@ -43,18 +38,13 @@ export function execGh(args: string[], cwd: string): Promise<string> {
     env.PATH = `/opt/homebrew/bin:/usr/local/bin:${env.PATH}`;
   }
   return new Promise((resolve, reject) => {
-    execFile(
-      "gh",
-      args,
-      { cwd, env, maxBuffer: MAX_BUFFER },
-      (err, stdout, stderr) => {
-        if (err) {
-          reject(new Error(stderr || err.message));
-          return;
-        }
-        resolve(stdout);
+    execFile("gh", args, { cwd, env, maxBuffer: MAX_BUFFER }, (err, stdout, stderr) => {
+      if (err) {
+        reject(new Error(stderr || err.message));
+        return;
       }
-    );
+      resolve(stdout);
+    });
   });
 }
 

--- a/apps/web/src/routes/workspace.$workspaceId.tsx
+++ b/apps/web/src/routes/workspace.$workspaceId.tsx
@@ -83,7 +83,7 @@ function useDiffFileCount(workspaceId: string): number {
   useEffect(() => {
     let cancelled = false;
     const fetchCount = () => {
-      trpc.workspace.getDiff
+      trpc.workspace.getDiffSummary
         .query({ workspaceId })
         .then((result) => {
           if (!cancelled) setCount(result.stats?.filesChanged ?? 0);

--- a/apps/web/src/trpc/router.ts
+++ b/apps/web/src/trpc/router.ts
@@ -562,6 +562,121 @@ const workspaceRouter = t.router({
     };
   }),
 
+  getDiffSummary: publicProcedure
+    .input(z.object({ workspaceId: z.string() }))
+    .query(async ({ input }) => {
+      const workspace = resolveWorkspace(input.workspaceId);
+      if (!workspace) {
+        throw new Error("Workspace not found");
+      }
+
+      const cwd = workspace.worktree.path;
+      const defaultBranch = workspace.project.defaultBranch;
+
+      const headBranch = (await execGit(["rev-parse", "--abbrev-ref", "HEAD"], cwd)).trim();
+
+      let mergeBase: string;
+      try {
+        mergeBase = (await execGit(["merge-base", defaultBranch, "HEAD"], cwd)).trim();
+      } catch {
+        mergeBase = (await execGit(["hash-object", "-t", "tree", "/dev/null"], cwd)).trim();
+      }
+
+      const statOutput = await execGit(["diff", "--stat", mergeBase], cwd);
+      const statLines = statOutput.trim().split("\n");
+      const summaryLine = statLines[statLines.length - 1] || "";
+
+      let filesChanged = 0;
+      let insertions = 0;
+      let deletions = 0;
+
+      const filesMatch = summaryLine.match(/(\d+)\s+files?\s+changed/);
+      const insertMatch = summaryLine.match(/(\d+)\s+insertions?\(\+\)/);
+      const deleteMatch = summaryLine.match(/(\d+)\s+deletions?\(-\)/);
+
+      if (filesMatch) filesChanged = Number.parseInt(filesMatch[1], 10);
+      if (insertMatch) insertions = Number.parseInt(insertMatch[1], 10);
+      if (deleteMatch) deletions = Number.parseInt(deleteMatch[1], 10);
+
+      const fileStatuses: Record<string, string> = {};
+      const nameStatusOutput = await execGit(["diff", "--name-status", mergeBase], cwd);
+      for (const line of nameStatusOutput.trim().split("\n").filter(Boolean)) {
+        const parts = line.split("\t");
+        const statusCode = parts[0][0];
+        if (statusCode === "R" && parts[2]) {
+          fileStatuses[parts[2]] = "R";
+        } else if (parts[1]) {
+          fileStatuses[parts[1]] = statusCode;
+        }
+      }
+
+      const untrackedOutput = await execGit(["ls-files", "--others", "--exclude-standard"], cwd);
+      const untrackedFiles = untrackedOutput.trim().split("\n").filter(Boolean);
+
+      for (const file of untrackedFiles) {
+        try {
+          const content = await readFile(join(cwd, file), "utf-8");
+          const lines = content.split("\n");
+          if (lines.length > 0 && lines[lines.length - 1] === "") {
+            lines.pop();
+          }
+          filesChanged++;
+          insertions += lines.length;
+          fileStatuses[file] = "U";
+        } catch {
+          // Skip binary or unreadable files
+        }
+      }
+
+      return {
+        stats: { filesChanged, insertions, deletions },
+        baseBranch: defaultBranch,
+        headBranch,
+        fileStatuses,
+        mergeBase,
+      };
+    }),
+
+  getFileDiff: publicProcedure
+    .input(z.object({ workspaceId: z.string(), filePath: z.string(), mergeBase: z.string() }))
+    .query(async ({ input }) => {
+      const workspace = resolveWorkspace(input.workspaceId);
+      if (!workspace) {
+        throw new Error("Workspace not found");
+      }
+
+      const cwd = workspace.worktree.path;
+
+      // Check if file is untracked
+      const untrackedOutput = await execGit(["ls-files", "--others", "--exclude-standard"], cwd);
+      const untrackedFiles = untrackedOutput.trim().split("\n").filter(Boolean);
+
+      if (untrackedFiles.includes(input.filePath)) {
+        // Synthesize diff for untracked file
+        try {
+          const content = await readFile(join(cwd, input.filePath), "utf-8");
+          const lines = content.split("\n");
+          if (lines.length > 0 && lines[lines.length - 1] === "") {
+            lines.pop();
+          }
+          let diff = `diff --git a/${input.filePath} b/${input.filePath}\n`;
+          diff += "new file mode 100644\n";
+          diff += "--- /dev/null\n";
+          diff += `+++ b/${input.filePath}\n`;
+          diff += `@@ -0,0 +1,${lines.length} @@\n`;
+          diff += lines.map((l) => `+${l}`).join("\n");
+          diff += "\n";
+          return { diff };
+        } catch {
+          return { diff: "" };
+        }
+      }
+
+      // Tracked file — get diff for this single file
+      const diff = await execGit(["diff", input.mergeBase, "--", input.filePath], cwd);
+      return { diff };
+    }),
+
   listFiles: publicProcedure
     .input(z.object({ workspaceId: z.string(), path: z.string().default("") }))
     .query(async ({ input }) => {

--- a/packages/dashboard-core/src/adapter.ts
+++ b/packages/dashboard-core/src/adapter.ts
@@ -3,12 +3,14 @@ import type {
   CliStatus,
   ContentSearchMatch,
   FileContentResult,
+  FileDiffResult,
   FileListResult,
   GitStatus,
   HooksStatus,
   ProjectInfo,
   Settings,
   WorkspaceDiff,
+  WorkspaceDiffSummary,
   WorkspaceStatus,
 } from "./types";
 
@@ -61,6 +63,8 @@ export interface DashboardAdapter {
 
   // Code browsing (optional)
   getWorkspaceDiff?(workspaceId: string): Promise<WorkspaceDiff>;
+  getWorkspaceDiffSummary?(workspaceId: string): Promise<WorkspaceDiffSummary>;
+  getFileDiff?(workspaceId: string, filePath: string, mergeBase: string): Promise<FileDiffResult>;
   listWorkspaceFiles?(workspaceId: string, path: string): Promise<FileListResult>;
   getWorkspaceFile?(workspaceId: string, path: string): Promise<FileContentResult>;
 

--- a/packages/dashboard-core/src/adapters/web.ts
+++ b/packages/dashboard-core/src/adapters/web.ts
@@ -6,12 +6,14 @@ import type {
   CliStatus,
   ContentSearchMatch,
   FileContentResult,
+  FileDiffResult,
   FileListResult,
   GitStatus,
   HooksStatus,
   ProjectInfo,
   Settings,
   WorkspaceDiff,
+  WorkspaceDiffSummary,
   WorkspaceStatus,
 } from "../types";
 
@@ -172,6 +174,24 @@ export class WebDashboardAdapter implements DashboardAdapter {
 
   async getWorkspaceDiff(workspaceId: string): Promise<WorkspaceDiff> {
     return (await this.trpc.workspace.getDiff.query({ workspaceId })) as WorkspaceDiff;
+  }
+
+  async getWorkspaceDiffSummary(workspaceId: string): Promise<WorkspaceDiffSummary> {
+    return (await this.trpc.workspace.getDiffSummary.query({
+      workspaceId,
+    })) as WorkspaceDiffSummary;
+  }
+
+  async getFileDiff(
+    workspaceId: string,
+    filePath: string,
+    mergeBase: string,
+  ): Promise<FileDiffResult> {
+    return (await this.trpc.workspace.getFileDiff.query({
+      workspaceId,
+      filePath,
+      mergeBase,
+    })) as FileDiffResult;
   }
 
   async listWorkspaceFiles(workspaceId: string, path: string): Promise<FileListResult> {

--- a/packages/dashboard-core/src/components/DiffView.tsx
+++ b/packages/dashboard-core/src/components/DiffView.tsx
@@ -1,12 +1,12 @@
 import { MergeView, unifiedMergeView } from "@codemirror/merge";
 import { EditorState, Text } from "@codemirror/state";
 import { EditorView } from "@codemirror/view";
-import { Columns2, Rows2, SquareArrowOutUpRight } from "lucide-react";
-import { useEffect, useRef, useState } from "react";
+import { Columns2, Loader2, Rows2, SquareArrowOutUpRight } from "lucide-react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useAdapter } from "../context";
 import { baseViewerExtensions, loadLanguage } from "../lib/codemirror-setup";
 import { extensionToLanguage, filenameToLanguage } from "../lib/language-map";
-import type { FileStatus, WorkspaceDiff } from "../types";
+import type { FileStatus, WorkspaceDiffSummary } from "../types";
 
 export interface DiffStats {
   filesChanged: number;
@@ -208,9 +208,145 @@ function DiffFileContent({
   return <div ref={containerRef} />;
 }
 
-export function DiffView({ workspaceId, active = true, onStatsChange, onOpenFile }: DiffViewProps) {
+// ---------------------------------------------------------------------------
+// Lazy file row — fetches diff on first expand
+// ---------------------------------------------------------------------------
+
+interface LazyFileRowProps {
+  filename: string;
+  status: FileStatus | undefined;
+  workspaceId: string;
+  mergeBase: string;
+  viewMode: ViewMode;
+  onOpenFile?: (filename: string) => void;
+}
+
+function LazyFileRow({
+  filename,
+  status,
+  workspaceId,
+  mergeBase,
+  viewMode,
+  onOpenFile,
+}: LazyFileRowProps) {
   const adapter = useAdapter();
-  const [data, setData] = useState<WorkspaceDiff | null>(null);
+  const [isOpen, setIsOpen] = useState(false);
+  const [diff, setDiff] = useState<string | null>(null);
+  const [loadingDiff, setLoadingDiff] = useState(false);
+  const [diffError, setDiffError] = useState<string | null>(null);
+  // Track which mergeBase the cached diff belongs to
+  const cachedMergeBaseRef = useRef<string | null>(null);
+
+  const toggle = useCallback(() => {
+    setIsOpen((prev) => !prev);
+  }, []);
+
+  // Fetch diff when expanded and not cached (or mergeBase changed)
+  useEffect(() => {
+    if (!isOpen) return;
+    if (diff !== null && cachedMergeBaseRef.current === mergeBase) return;
+
+    const getFileDiff = adapter.getFileDiff;
+    if (!getFileDiff) return;
+
+    let cancelled = false;
+    setLoadingDiff(true);
+    setDiffError(null);
+
+    getFileDiff
+      .call(adapter, workspaceId, filename, mergeBase)
+      .then((result) => {
+        if (!cancelled) {
+          setDiff(result.diff);
+          cachedMergeBaseRef.current = mergeBase;
+        }
+      })
+      .catch((err) => {
+        if (!cancelled) setDiffError(err instanceof Error ? err.message : "Failed to load diff");
+      })
+      .finally(() => {
+        if (!cancelled) setLoadingDiff(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [isOpen, adapter, workspaceId, filename, mergeBase, diff]);
+
+  // Invalidate cache when mergeBase changes
+  useEffect(() => {
+    if (cachedMergeBaseRef.current && cachedMergeBaseRef.current !== mergeBase) {
+      setDiff(null);
+      cachedMergeBaseRef.current = null;
+    }
+  }, [mergeBase]);
+
+  return (
+    <div id={`diff-file-${encodeURIComponent(filename)}`} className="border-b border-border/30">
+      <button
+        type="button"
+        onClick={toggle}
+        className="flex w-full items-center gap-2 px-4 py-2.5 text-left text-sm hover:bg-accent/50"
+      >
+        <span
+          className={`shrink-0 text-muted-foreground transition-transform ${isOpen ? "rotate-90" : ""}`}
+        >
+          ▶
+        </span>
+        <span className="min-w-0 flex-1 truncate font-mono">
+          {filename} <FileStatusBadge status={status} />
+        </span>
+        {onOpenFile && (
+          <span
+            title="Open in code browser"
+            onClick={(e) => {
+              e.preventDefault();
+              e.stopPropagation();
+              onOpenFile(filename);
+            }}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") {
+                e.stopPropagation();
+                onOpenFile(filename);
+              }
+            }}
+            className="shrink-0 rounded p-1 text-muted-foreground hover:bg-accent hover:text-foreground"
+          >
+            <SquareArrowOutUpRight className="size-3.5" />
+          </span>
+        )}
+      </button>
+      {isOpen && (
+        <div className="border-t border-border/20 bg-muted/30">
+          {loadingDiff && (
+            <div className="flex items-center justify-center py-6 text-sm text-muted-foreground">
+              <Loader2 className="mr-2 size-4 animate-spin" />
+              Loading diff...
+            </div>
+          )}
+          {diffError && <div className="px-4 py-4 text-sm text-destructive">{diffError}</div>}
+          {diff !== null && !loadingDiff && (
+            <DiffFileContent hunks={diff} filename={filename} viewMode={viewMode} />
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Fallback: legacy full-diff mode (when adapter lacks new methods)
+// ---------------------------------------------------------------------------
+
+function LegacyDiffView({ workspaceId, active, onStatsChange, onOpenFile }: DiffViewProps) {
+  const adapter = useAdapter();
+  const [data, setData] = useState<{
+    diff: string;
+    stats: DiffStats;
+    baseBranch: string;
+    headBranch: string;
+    fileStatuses: Record<string, FileStatus>;
+  } | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
   const [openFiles, setOpenFiles] = useState<Set<string>>(new Set());
@@ -389,6 +525,153 @@ export function DiffView({ workspaceId, active = true, onStatsChange, onOpenFile
             </div>
           );
         })}
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Main DiffView — uses lazy summary + per-file when available
+// ---------------------------------------------------------------------------
+
+export function DiffView({ workspaceId, active = true, onStatsChange, onOpenFile }: DiffViewProps) {
+  const adapter = useAdapter();
+  const [summary, setSummary] = useState<WorkspaceDiffSummary | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [viewMode, setViewMode] = useState<ViewMode>("unified");
+
+  // Fall back to legacy if adapter doesn't support new methods
+  const supportsLazy = !!(adapter.getWorkspaceDiffSummary && adapter.getFileDiff);
+
+  useEffect(() => {
+    if (!supportsLazy) return;
+
+    const getWorkspaceDiffSummary = adapter.getWorkspaceDiffSummary!;
+
+    let cancelled = false;
+    const fetchSummary = () => {
+      getWorkspaceDiffSummary
+        .call(adapter, workspaceId)
+        .then((result) => {
+          if (!cancelled) {
+            setSummary(result);
+            setError(null);
+            const hasChanges = result.stats.filesChanged > 0;
+            onStatsChange?.(hasChanges ? result.stats : null);
+          }
+        })
+        .catch((err) => {
+          if (!cancelled) setError(err instanceof Error ? err.message : "Failed to load diff");
+        })
+        .finally(() => {
+          if (!cancelled) setLoading(false);
+        });
+    };
+
+    fetchSummary();
+    const interval = active ? setInterval(fetchSummary, 15_000) : undefined;
+    return () => {
+      cancelled = true;
+      if (interval) clearInterval(interval);
+    };
+  }, [adapter, workspaceId, active, onStatsChange, supportsLazy]);
+
+  if (!supportsLazy) {
+    return (
+      <LegacyDiffView
+        workspaceId={workspaceId}
+        active={active}
+        onStatsChange={onStatsChange}
+        onOpenFile={onOpenFile}
+      />
+    );
+  }
+
+  if (loading) {
+    return (
+      <div className="flex h-full items-center justify-center text-sm text-muted-foreground">
+        Loading changes...
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="flex h-full items-center justify-center text-sm text-destructive">
+        {error}
+      </div>
+    );
+  }
+
+  if (!summary || summary.stats.filesChanged === 0) {
+    return (
+      <div className="flex h-full items-center justify-center text-sm text-muted-foreground">
+        No changes
+      </div>
+    );
+  }
+
+  const fileStatuses = summary.fileStatuses || {};
+  const filenames = Object.keys(fileStatuses);
+
+  return (
+    <div className="flex h-full flex-col overflow-hidden">
+      <div className="flex shrink-0 items-center justify-between border-b border-white/20 px-4 py-2">
+        <div>
+          <div className="text-sm text-muted-foreground">
+            <span className="font-medium text-foreground">{summary.stats.filesChanged}</span>{" "}
+            {summary.stats.filesChanged === 1 ? "file" : "files"} changed
+            {summary.stats.insertions > 0 && (
+              <span className="ml-2 text-green-400">+{summary.stats.insertions}</span>
+            )}
+            {summary.stats.deletions > 0 && (
+              <span className="ml-1 text-red-400">-{summary.stats.deletions}</span>
+            )}
+          </div>
+          <div className="mt-0.5 text-xs text-muted-foreground">
+            {summary.baseBranch} ← {summary.headBranch}
+          </div>
+        </div>
+        <div className="hidden items-center rounded-md border border-border/50 bg-muted/50 md:flex">
+          <button
+            type="button"
+            onClick={() => setViewMode("unified")}
+            className={`inline-flex items-center gap-1 rounded-l-md px-2 py-1 text-xs transition-colors ${
+              viewMode === "unified"
+                ? "bg-accent text-foreground"
+                : "text-muted-foreground hover:text-foreground"
+            }`}
+            title="Unified view"
+          >
+            <Rows2 className="size-3.5" />
+          </button>
+          <button
+            type="button"
+            onClick={() => setViewMode("split")}
+            className={`inline-flex items-center gap-1 rounded-r-md px-2 py-1 text-xs transition-colors ${
+              viewMode === "split"
+                ? "bg-accent text-foreground"
+                : "text-muted-foreground hover:text-foreground"
+            }`}
+            title="Split view"
+          >
+            <Columns2 className="size-3.5" />
+          </button>
+        </div>
+      </div>
+      <div className="min-h-0 flex-1 overflow-y-auto">
+        {filenames.map((filename) => (
+          <LazyFileRow
+            key={filename}
+            filename={filename}
+            status={fileStatuses[filename]}
+            workspaceId={workspaceId}
+            mergeBase={summary.mergeBase}
+            viewMode={viewMode}
+            onOpenFile={onOpenFile}
+          />
+        ))}
       </div>
     </div>
   );

--- a/packages/dashboard-core/src/index.ts
+++ b/packages/dashboard-core/src/index.ts
@@ -67,6 +67,7 @@ export type {
   CodingAgentType,
   ContentSearchMatch,
   FileContentResult,
+  FileDiffResult,
   FileEntry,
   FileListResult,
   FileStatus,
@@ -81,6 +82,7 @@ export type {
   SetupStatus,
   WorkspaceBranchStatus,
   WorkspaceDiff,
+  WorkspaceDiffSummary,
   WorkspaceStatus,
   WorktreeInfo,
 } from "./types";

--- a/packages/dashboard-core/src/types.ts
+++ b/packages/dashboard-core/src/types.ts
@@ -184,6 +184,18 @@ export interface FileContentResult {
   language?: string;
 }
 
+export interface WorkspaceDiffSummary {
+  stats: { filesChanged: number; insertions: number; deletions: number };
+  baseBranch: string;
+  headBranch: string;
+  fileStatuses: Record<string, FileStatus>;
+  mergeBase: string;
+}
+
+export interface FileDiffResult {
+  diff: string;
+}
+
 export interface ContentSearchMatch {
   file: string;
   line: number;


### PR DESCRIPTION
## Summary

- Split the monolithic `getDiff` endpoint into a lightweight `getDiffSummary` (file list + stats, polled every 15s) and individual `getFileDiff` requests loaded on demand when a user expands a file
- Eliminates `stdout maxBuffer length exceeded` errors on large PRs by never fetching the entire unified diff at once
- File count badge now uses the lightweight summary endpoint instead of fetching multi-MB diffs just for a number

## Test plan

- [ ] Open the changes view on a workspace with many file changes — confirm the file list loads quickly
- [ ] Expand a file — confirm the diff loads and renders correctly
- [ ] Collapse and re-expand — confirm the diff is cached (no re-fetch)
- [ ] Make a commit in the workspace — confirm the next poll cycle detects the mergeBase change and re-expanding re-fetches
- [ ] Confirm the file count badge still updates correctly
- [ ] Verify backward compatibility: adapters without new methods fall back to legacy full-diff behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)