### PR TITLE
feat: first-run onboarding wizard for coding agent and IDE setup

### DIFF
--- a/apps/cli/src/main.rs
+++ b/apps/cli/src/main.rs
@@ -1,4 +1,5 @@
 mod api;
+mod onboarding;
 mod render;
 mod shell;
 mod state;
@@ -41,6 +42,8 @@ enum Commands {
         #[command(subcommand)]
         cmd: CronjobsCmd,
     },
+    /// Run first-time setup wizard to configure coding agent and IDE
+    Init,
     /// Show current settings
     Settings,
     /// Manage the remote tunnel
@@ -244,6 +247,35 @@ fn main() {
     let cli = Cli::parse();
     let json_output = cli.output == "json";
 
+    // Init and Schema bypass the web server — handle before the main dispatch.
+    if let Commands::Init = cli.command {
+        if state::settings_exist() {
+            println!(
+                "Settings already exist at {}",
+                state::settings_file().display()
+            );
+            println!("To re-run setup, delete the file and run `band init` again.");
+            return;
+        }
+        match onboarding::run_onboarding() {
+            Ok(()) => return,
+            Err(e) => {
+                eprintln!("error: {e}");
+                process::exit(1);
+            }
+        }
+    }
+
+    // On first run (no settings.json), nudge the user to run `band init`.
+    if !state::settings_exist() {
+        if let Commands::Schema { .. } = cli.command {
+            // Schema is fine without settings
+        } else {
+            eprintln!("No settings found. Run `band init` to set up Band.");
+            process::exit(1);
+        }
+    }
+
     // Schema always outputs JSON, handle separately
     if let Commands::Schema { ref command } = cli.command {
         handle_schema(command.as_deref());
@@ -347,7 +379,7 @@ fn main() {
             TunnelCmd::Stop => cmd_tunnel_stop(),
         },
         Commands::Notify => cmd_notify(),
-        Commands::Schema { .. } => unreachable!(),
+        Commands::Init | Commands::Schema { .. } => unreachable!(),
     };
 
     match result {
@@ -1367,6 +1399,11 @@ fn build_schema(command: Option<&str>) -> Result<serde_json::Value, String> {
                 {"name": "project", "type": "string", "required": true, "positional": true, "description": "Project name"},
                 {"name": "branch", "type": "string", "required": true, "positional": true, "description": "Branch name"},
             ]
+        }),
+        serde_json::json!({
+            "name": "init",
+            "description": "Run first-time setup wizard to configure coding agent and IDE",
+            "parameters": []
         }),
         serde_json::json!({
             "name": "settings",

--- a/apps/cli/src/onboarding.rs
+++ b/apps/cli/src/onboarding.rs
@@ -38,10 +38,7 @@ pub fn run_onboarding() -> Result<(), String> {
     state::save_settings(&settings)?;
 
     println!();
-    println!(
-        "Settings saved to {}",
-        state::settings_file().display()
-    );
+    println!("Settings saved to {}", state::settings_file().display());
     println!("You're all set! Run `band projects add <path>` to register your first project.");
 
     Ok(())
@@ -60,7 +57,10 @@ fn prompt_coding_agent(reader: &mut impl BufRead) -> Result<CodingAgent, String>
     match choice {
         1 => Ok(CodingAgent::ClaudeCode),
         2 => {
-            let cmd = read_line_prompt(reader, "Enter the agent command (e.g. /usr/local/bin/my-agent)")?;
+            let cmd = read_line_prompt(
+                reader,
+                "Enter the agent command (e.g. /usr/local/bin/my-agent)",
+            )?;
             if cmd.is_empty() {
                 return Err("Custom command cannot be empty".to_string());
             }

--- a/apps/cli/src/onboarding.rs
+++ b/apps/cli/src/onboarding.rs
@@ -1,0 +1,287 @@
+use crate::state;
+use std::io::{self, BufRead, Write};
+
+/// Coding agent choice from the onboarding wizard.
+#[derive(Debug, Clone)]
+enum CodingAgent {
+    ClaudeCode,
+    Custom { command: String },
+}
+
+/// IDE choice from the onboarding wizard.
+#[derive(Debug, Clone)]
+enum Ide {
+    VsCode,
+    Zed,
+}
+
+/// Run the interactive onboarding wizard.
+/// Returns Ok(()) if settings were written, or Err if the user cancelled / an error occurred.
+pub fn run_onboarding() -> Result<(), String> {
+    let stdin = io::stdin();
+    let mut reader = stdin.lock();
+
+    println!();
+    println!("Welcome to Band! Let's set up your environment.");
+    println!();
+
+    // --- Step 1: Coding agent ---
+    let agent = prompt_coding_agent(&mut reader)?;
+
+    // --- Step 2: IDE ---
+    let ide = prompt_ide(&mut reader)?;
+
+    // --- Build settings ---
+    let settings = build_settings(&agent, &ide);
+
+    // --- Write ---
+    state::save_settings(&settings)?;
+
+    println!();
+    println!(
+        "Settings saved to {}",
+        state::settings_file().display()
+    );
+    println!("You're all set! Run `band projects add <path>` to register your first project.");
+
+    Ok(())
+}
+
+/// Ask which coding agent to use. Returns a `CodingAgent` variant.
+fn prompt_coding_agent(reader: &mut impl BufRead) -> Result<CodingAgent, String> {
+    println!("Which coding agent would you like to use?");
+    println!();
+    println!("  1) Claude Code");
+    println!("  2) Custom command");
+    println!();
+
+    let choice = read_choice(reader, "Choose [1-2]", 1, 2)?;
+
+    match choice {
+        1 => Ok(CodingAgent::ClaudeCode),
+        2 => {
+            let cmd = read_line_prompt(reader, "Enter the agent command (e.g. /usr/local/bin/my-agent)")?;
+            if cmd.is_empty() {
+                return Err("Custom command cannot be empty".to_string());
+            }
+            Ok(CodingAgent::Custom { command: cmd })
+        }
+        _ => unreachable!(),
+    }
+}
+
+/// Ask which IDE to use. Returns an `Ide` variant.
+fn prompt_ide(reader: &mut impl BufRead) -> Result<Ide, String> {
+    println!("Which IDE do you prefer?");
+    println!();
+    println!("  1) VS Code");
+    println!("  2) Zed");
+    println!();
+
+    let choice = read_choice(reader, "Choose [1-2]", 1, 2)?;
+
+    match choice {
+        1 => Ok(Ide::VsCode),
+        2 => Ok(Ide::Zed),
+        _ => unreachable!(),
+    }
+}
+
+/// Build a `Settings` struct from the user's choices.
+fn build_settings(agent: &CodingAgent, ide: &Ide) -> state::Settings {
+    let coding_agent = match agent {
+        CodingAgent::ClaudeCode => serde_json::json!({
+            "type": "claude-code"
+        }),
+        CodingAgent::Custom { command } => serde_json::json!({
+            "type": "claude-code",
+            "command": command
+        }),
+    };
+
+    let agent_watch_command = match agent {
+        CodingAgent::ClaudeCode => "band tasks watch && claude --continue".to_string(),
+        CodingAgent::Custom { command } => format!("band tasks watch && {command} --continue"),
+    };
+
+    let defaults = match ide {
+        Ide::VsCode => serde_json::json!({
+            "apps": [
+                {
+                    "type": "vscode",
+                    "terminals": [
+                        {
+                            "name": "agent",
+                            "command": agent_watch_command
+                        },
+                        {
+                            "name": "shell",
+                            "command": "",
+                            "split": "vertical"
+                        }
+                    ]
+                }
+            ]
+        }),
+        Ide::Zed => serde_json::json!({
+            "apps": [
+                {
+                    "type": "zed"
+                },
+                {
+                    "type": "iterm",
+                    "commands": [
+                        {
+                            "name": "agent",
+                            "command": agent_watch_command
+                        },
+                        {
+                            "name": "shell",
+                            "command": "",
+                            "split": "vertical"
+                        }
+                    ]
+                }
+            ]
+        }),
+    };
+
+    state::Settings {
+        defaults: Some(defaults),
+        coding_agent: Some(coding_agent),
+        ..state::Settings::default()
+    }
+}
+
+// ---------- Prompt helpers ----------
+
+/// Read a numeric choice from the user, retrying on invalid input.
+fn read_choice(reader: &mut impl BufRead, prompt: &str, min: u32, max: u32) -> Result<u32, String> {
+    loop {
+        print!("{prompt}: ");
+        io::stdout().flush().ok();
+
+        let line = read_line(reader)?;
+        if let Ok(n) = line.trim().parse::<u32>() {
+            if n >= min && n <= max {
+                return Ok(n);
+            }
+        }
+        println!("Please enter a number between {min} and {max}.");
+    }
+}
+
+/// Read a line of text with a prompt.
+fn read_line_prompt(reader: &mut impl BufRead, prompt: &str) -> Result<String, String> {
+    print!("{prompt}: ");
+    io::stdout().flush().ok();
+    read_line(reader)
+}
+
+/// Read a single line from the reader.
+fn read_line(reader: &mut impl BufRead) -> Result<String, String> {
+    let mut line = String::new();
+    reader
+        .read_line(&mut line)
+        .map_err(|e| format!("Failed to read input: {e}"))?;
+    if line.is_empty() {
+        return Err("Input closed (EOF)".to_string());
+    }
+    Ok(line.trim().to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn build_settings_claude_code_vscode() {
+        let settings = build_settings(&CodingAgent::ClaudeCode, &Ide::VsCode);
+
+        let agent = settings.coding_agent.unwrap();
+        assert_eq!(agent["type"], "claude-code");
+        assert!(agent.get("command").is_none());
+
+        let defaults = settings.defaults.unwrap();
+        let apps = defaults["apps"].as_array().unwrap();
+        assert_eq!(apps.len(), 1);
+        assert_eq!(apps[0]["type"], "vscode");
+
+        let terminals = apps[0]["terminals"].as_array().unwrap();
+        assert_eq!(terminals.len(), 2);
+        assert_eq!(terminals[0]["name"], "agent");
+        assert!(terminals[0]["command"]
+            .as_str()
+            .unwrap()
+            .contains("claude --continue"));
+    }
+
+    #[test]
+    fn build_settings_custom_agent_zed() {
+        let agent = CodingAgent::Custom {
+            command: "/usr/bin/my-agent".to_string(),
+        };
+        let settings = build_settings(&agent, &Ide::Zed);
+
+        let coding = settings.coding_agent.unwrap();
+        assert_eq!(coding["type"], "claude-code");
+        assert_eq!(coding["command"], "/usr/bin/my-agent");
+
+        let defaults = settings.defaults.unwrap();
+        let apps = defaults["apps"].as_array().unwrap();
+        assert_eq!(apps.len(), 2);
+        assert_eq!(apps[0]["type"], "zed");
+        assert_eq!(apps[1]["type"], "iterm");
+
+        let commands = apps[1]["commands"].as_array().unwrap();
+        assert_eq!(commands.len(), 2);
+        assert!(commands[0]["command"]
+            .as_str()
+            .unwrap()
+            .contains("/usr/bin/my-agent --continue"));
+    }
+
+    #[test]
+    fn prompt_coding_agent_claude_code() {
+        let input = b"1\n";
+        let mut cursor = io::Cursor::new(input);
+        let result = prompt_coding_agent(&mut cursor).unwrap();
+        assert!(matches!(result, CodingAgent::ClaudeCode));
+    }
+
+    #[test]
+    fn prompt_coding_agent_custom() {
+        let input = b"2\n/usr/bin/my-agent\n";
+        let mut cursor = io::Cursor::new(input);
+        let result = prompt_coding_agent(&mut cursor).unwrap();
+        match result {
+            CodingAgent::Custom { command } => assert_eq!(command, "/usr/bin/my-agent"),
+            _ => panic!("Expected Custom agent"),
+        }
+    }
+
+    #[test]
+    fn prompt_ide_vscode() {
+        let input = b"1\n";
+        let mut cursor = io::Cursor::new(input);
+        let result = prompt_ide(&mut cursor).unwrap();
+        assert!(matches!(result, Ide::VsCode));
+    }
+
+    #[test]
+    fn prompt_ide_zed() {
+        let input = b"2\n";
+        let mut cursor = io::Cursor::new(input);
+        let result = prompt_ide(&mut cursor).unwrap();
+        assert!(matches!(result, Ide::Zed));
+    }
+
+    #[test]
+    fn read_choice_retries_on_invalid() {
+        // First two lines are invalid, third is valid
+        let input = b"abc\n5\n2\n";
+        let mut cursor = io::Cursor::new(input);
+        let result = read_choice(&mut cursor, "Pick", 1, 2).unwrap();
+        assert_eq!(result, 2);
+    }
+}

--- a/apps/cli/src/state.rs
+++ b/apps/cli/src/state.rs
@@ -50,9 +50,10 @@ pub fn settings_exist() -> bool {
 
 pub fn save_settings(settings: &Settings) -> Result<(), String> {
     let home = band_home();
-    fs::create_dir_all(&home).map_err(|e| format!("Failed to create directory {}: {e}", home.display()))?;
+    fs::create_dir_all(&home)
+        .map_err(|e| format!("Failed to create directory {}: {e}", home.display()))?;
     let path = settings_file();
-    let json =
-        serde_json::to_string_pretty(settings).map_err(|e| format!("Failed to serialize settings: {e}"))?;
+    let json = serde_json::to_string_pretty(settings)
+        .map_err(|e| format!("Failed to serialize settings: {e}"))?;
     fs::write(&path, json).map_err(|e| format!("Failed to write settings: {e}"))
 }

--- a/apps/cli/src/state.rs
+++ b/apps/cli/src/state.rs
@@ -43,3 +43,16 @@ pub fn load_settings() -> Result<Settings, String> {
     let data = fs::read_to_string(&path).map_err(|e| format!("Failed to read settings: {e}"))?;
     serde_json::from_str(&data).map_err(|e| format!("Failed to parse settings: {e}"))
 }
+
+pub fn settings_exist() -> bool {
+    settings_file().exists()
+}
+
+pub fn save_settings(settings: &Settings) -> Result<(), String> {
+    let home = band_home();
+    fs::create_dir_all(&home).map_err(|e| format!("Failed to create directory {}: {e}", home.display()))?;
+    let path = settings_file();
+    let json =
+        serde_json::to_string_pretty(settings).map_err(|e| format!("Failed to serialize settings: {e}"))?;
+    fs::write(&path, json).map_err(|e| format!("Failed to write settings: {e}"))
+}

--- a/apps/cli/tests/integration.rs
+++ b/apps/cli/tests/integration.rs
@@ -341,7 +341,10 @@ fn schema_works_without_settings() {
         stderr(&output)
     );
     let out = stdout(&output);
-    assert!(out.contains("init"), "schema should list init command: {out}");
+    assert!(
+        out.contains("init"),
+        "schema should list init command: {out}"
+    );
 }
 
 // --- Projects tests ---

--- a/apps/cli/tests/integration.rs
+++ b/apps/cli/tests/integration.rs
@@ -167,6 +167,183 @@ fn stderr(output: &std::process::Output) -> String {
     String::from_utf8_lossy(&output.stderr).trim().to_string()
 }
 
+// --- Init / onboarding tests ---
+// These don't need the web server since `band init` writes directly to disk.
+
+/// Run the band binary with a custom BAND_HOME, piping `stdin_data` as stdin.
+fn band_init(band_home: &Path, args: &[&str], stdin_data: &str) -> std::process::Output {
+    let mut child = Command::new(env!("CARGO_BIN_EXE_band"))
+        .args(args)
+        .env("BAND_HOME", band_home)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("failed to execute band");
+
+    if let Some(mut stdin) = child.stdin.take() {
+        use std::io::Write;
+        stdin.write_all(stdin_data.as_bytes()).ok();
+    }
+
+    child.wait_with_output().expect("failed to wait on band")
+}
+
+/// Run band without stdin in a temp BAND_HOME (no settings.json).
+fn band_no_settings(band_home: &Path, args: &[&str]) -> std::process::Output {
+    Command::new(env!("CARGO_BIN_EXE_band"))
+        .args(args)
+        .env("BAND_HOME", band_home)
+        .output()
+        .expect("failed to execute band")
+}
+
+#[test]
+fn init_creates_settings_claude_code_vscode() {
+    let tmp = tempfile::tempdir().unwrap();
+    let band_home = tmp.path().join(".band");
+
+    // Choose: 1 (Claude Code), 1 (VS Code)
+    let output = band_init(&band_home, &["init"], "1\n1\n");
+
+    assert!(output.status.success(), "stderr: {}", stderr(&output));
+    let out = stdout(&output);
+    assert!(out.contains("Settings saved"), "stdout: {out}");
+
+    // Verify settings.json was created
+    let settings_path = band_home.join("settings.json");
+    assert!(settings_path.exists(), "settings.json should exist");
+
+    let data = fs::read_to_string(&settings_path).unwrap();
+    let settings: serde_json::Value = serde_json::from_str(&data).unwrap();
+
+    // Coding agent
+    assert_eq!(settings["codingAgent"]["type"], "claude-code");
+    assert!(
+        settings["codingAgent"].get("command").is_none(),
+        "default claude-code should not have a custom command"
+    );
+
+    // Apps defaults — VS Code with terminals
+    let apps = settings["defaults"]["apps"].as_array().unwrap();
+    assert_eq!(apps.len(), 1);
+    assert_eq!(apps[0]["type"], "vscode");
+
+    let terminals = apps[0]["terminals"].as_array().unwrap();
+    assert_eq!(terminals.len(), 2);
+    assert_eq!(terminals[0]["name"], "agent");
+    assert!(
+        terminals[0]["command"]
+            .as_str()
+            .unwrap()
+            .contains("claude --continue"),
+        "agent terminal should run claude: {}",
+        terminals[0]["command"]
+    );
+    assert_eq!(terminals[1]["name"], "shell");
+    assert_eq!(terminals[1]["split"], "vertical");
+}
+
+#[test]
+fn init_creates_settings_custom_agent_zed() {
+    let tmp = tempfile::tempdir().unwrap();
+    let band_home = tmp.path().join(".band");
+
+    // Choose: 2 (Custom), enter command, 2 (Zed)
+    let output = band_init(&band_home, &["init"], "2\n/usr/bin/my-agent\n2\n");
+
+    assert!(output.status.success(), "stderr: {}", stderr(&output));
+
+    let data = fs::read_to_string(band_home.join("settings.json")).unwrap();
+    let settings: serde_json::Value = serde_json::from_str(&data).unwrap();
+
+    // Custom agent
+    assert_eq!(settings["codingAgent"]["type"], "claude-code");
+    assert_eq!(settings["codingAgent"]["command"], "/usr/bin/my-agent");
+
+    // Apps defaults — Zed + iTerm
+    let apps = settings["defaults"]["apps"].as_array().unwrap();
+    assert_eq!(apps.len(), 2);
+    assert_eq!(apps[0]["type"], "zed");
+    assert_eq!(apps[1]["type"], "iterm");
+
+    let commands = apps[1]["commands"].as_array().unwrap();
+    assert_eq!(commands.len(), 2);
+    assert!(
+        commands[0]["command"]
+            .as_str()
+            .unwrap()
+            .contains("/usr/bin/my-agent --continue"),
+        "agent terminal should use custom command: {}",
+        commands[0]["command"]
+    );
+}
+
+#[test]
+fn init_skips_when_settings_exist() {
+    let tmp = tempfile::tempdir().unwrap();
+    let band_home = tmp.path().join(".band");
+    fs::create_dir_all(&band_home).unwrap();
+
+    // Pre-create settings.json
+    fs::write(
+        band_home.join("settings.json"),
+        r#"{"worktreesDir": "/tmp/test"}"#,
+    )
+    .unwrap();
+
+    let output = band_init(&band_home, &["init"], "1\n1\n");
+
+    assert!(output.status.success());
+    let out = stdout(&output);
+    assert!(
+        out.contains("already exist"),
+        "should say settings already exist: {out}"
+    );
+
+    // Settings should not be overwritten
+    let data = fs::read_to_string(band_home.join("settings.json")).unwrap();
+    assert!(
+        data.contains("worktreesDir"),
+        "original settings should be preserved"
+    );
+}
+
+#[test]
+fn commands_fail_without_settings() {
+    let tmp = tempfile::tempdir().unwrap();
+    let band_home = tmp.path().join(".band");
+    fs::create_dir_all(&band_home).unwrap();
+
+    // No settings.json — running any command (except init/schema) should fail with guidance
+    let output = band_no_settings(&band_home, &["projects", "list"]);
+
+    assert!(!output.status.success(), "should fail without settings");
+    let err = stderr(&output);
+    assert!(
+        err.contains("band init"),
+        "should suggest running band init: {err}"
+    );
+}
+
+#[test]
+fn schema_works_without_settings() {
+    let tmp = tempfile::tempdir().unwrap();
+    let band_home = tmp.path().join(".band");
+    fs::create_dir_all(&band_home).unwrap();
+
+    // Schema should still work without settings
+    let output = band_no_settings(&band_home, &["schema"]);
+
+    assert!(
+        output.status.success(),
+        "schema should work without settings: {}",
+        stderr(&output)
+    );
+    let out = stdout(&output);
+    assert!(out.contains("init"), "schema should list init command: {out}");
+}
+
 // --- Projects tests ---
 
 #[test]


### PR DESCRIPTION
## Summary

- Adds `band init` command — interactive wizard that asks users to choose their coding agent (Claude Code or custom) and preferred IDE (VS Code or Zed), then generates `~/.band/settings.json`
- On first run (no settings.json), all commands except `init` and `schema` now exit with a helpful message directing users to run `band init`
- Generates sensible `defaults.apps` config based on IDE choice: VS Code gets integrated terminal splits; Zed gets a separate iTerm window for the agent

Closes #93

## Test plan

- [x] 5 integration tests: verifies settings generation for both agent/IDE combos, skip-when-exists, first-run blocking, schema bypass
- [x] 7 unit tests: build_settings output, prompt parsing, retry on invalid input
- [ ] Manual: run `band init` interactively, verify settings.json content

🤖 Generated with [Claude Code](https://claude.com/claude-code)