### PR TITLE
feat: show running task indicator on workspace card

### DIFF
--- a/apps/web/src/lib/task-runner.ts
+++ b/apps/web/src/lib/task-runner.ts
@@ -3,6 +3,7 @@ import type { UIMessageChunk } from "ai";
 import { getAgent, getOrCreateAgent } from "./agent-pool";
 import { createPendingInput } from "./pending-inputs";
 import { generateTaskId, markTaskFailed, saveTask } from "./task-store";
+import { emit as emitStatus } from "./watcher";
 import { resolveWorkspace } from "./workspace";
 
 const log = createLogger("task-runner");
@@ -121,6 +122,7 @@ export function submitTask(
   };
   tasks.set(workspaceId, task);
   persistTask(task);
+  emitStatus({ kind: "task-status", workspaceId, taskState: "running" });
 
   // Fire-and-forget async execution
   runTask(workspaceId, task).catch((err) => {
@@ -144,6 +146,7 @@ export function abortTask(workspaceId: string): boolean {
   task.status = "failed";
   task.completedAt = Date.now();
   persistTask(task);
+  emitStatus({ kind: "task-status", workspaceId, taskState: "failed" });
   emit(workspaceId, task, { type: "error", errorText: "Task aborted by user" });
   emit(workspaceId, task, { type: "finish" });
   scheduleExpiry(workspaceId);
@@ -164,6 +167,7 @@ export function cancelTask(taskId: string): { cancelled: boolean; workspaceId?: 
       task.status = "failed";
       task.completedAt = Date.now();
       persistTask(task);
+      emitStatus({ kind: "task-status", workspaceId, taskState: "failed" });
       emit(workspaceId, task, { type: "error", errorText: "Task cancelled" });
       emit(workspaceId, task, { type: "finish" });
       scheduleExpiry(workspaceId);
@@ -189,6 +193,7 @@ async function runTask(workspaceId: string, task: InternalTask) {
     task.status = "failed";
     task.completedAt = Date.now();
     persistTask(task);
+    emitStatus({ kind: "task-status", workspaceId, taskState: "failed" });
     emit(workspaceId, task, { type: "error", errorText: "Workspace not found" });
     scheduleExpiry(workspaceId);
     return;
@@ -290,6 +295,7 @@ async function runTask(workspaceId: string, task: InternalTask) {
             task.status = "completed";
             task.completedAt = Date.now();
             persistTask(task);
+            emitStatus({ kind: "task-status", workspaceId, taskState: "completed" });
             emit(workspaceId, task, {
               type: "data-result" as UIMessageChunk["type"],
               data: {
@@ -308,6 +314,7 @@ async function runTask(workspaceId: string, task: InternalTask) {
             task.status = "failed";
             task.completedAt = Date.now();
             persistTask(task);
+            emitStatus({ kind: "task-status", workspaceId, taskState: "failed" });
             emit(workspaceId, task, {
               type: "error",
               errorText: `Agent error: ${event.errors.join(", ") || "unknown error"}`,
@@ -335,6 +342,7 @@ async function runTask(workspaceId: string, task: InternalTask) {
         task.completedAt = Date.now();
       }
       persistTask(task);
+      emitStatus({ kind: "task-status", workspaceId, taskState: task.status });
       emit(workspaceId, task, {
         type: "error",
         errorText: "Agent session ended without producing a result",
@@ -344,6 +352,7 @@ async function runTask(workspaceId: string, task: InternalTask) {
     task.status = "failed";
     task.completedAt = Date.now();
     persistTask(task);
+    emitStatus({ kind: "task-status", workspaceId, taskState: "failed" });
     emit(workspaceId, task, {
       type: "error",
       errorText: err instanceof Error ? err.message : "Unknown error",
@@ -402,6 +411,16 @@ function toTaskInfo(task: InternalTask): TaskInfo {
     completedAt: task.completedAt,
     prompt: task.prompt,
   };
+}
+
+export function getRunningTaskWorkspaceIds(): string[] {
+  const ids: string[] = [];
+  for (const [workspaceId, task] of tasks) {
+    if (task.status === "running") {
+      ids.push(workspaceId);
+    }
+  }
+  return ids;
 }
 
 export class TaskConflictError extends Error {

--- a/apps/web/src/lib/watcher.ts
+++ b/apps/web/src/lib/watcher.ts
@@ -3,7 +3,6 @@ import { basename, extname, join } from "node:path";
 import { watch } from "chokidar";
 import { startBranchStatusPoller, stopBranchStatusPoller } from "./branch-status-poller";
 import { getRunningSetups } from "./setup-runner";
-import { getRunningTaskWorkspaceIds } from "./task-runner";
 import {
   bandHome,
   loadCurrentStatuses,
@@ -11,6 +10,7 @@ import {
   statusDir,
   type WorkspaceStatus,
 } from "./state";
+import { getRunningTaskWorkspaceIds } from "./task-runner";
 
 interface GitStatus {
   dirty: boolean;

--- a/apps/web/src/lib/watcher.ts
+++ b/apps/web/src/lib/watcher.ts
@@ -3,6 +3,7 @@ import { basename, extname, join } from "node:path";
 import { watch } from "chokidar";
 import { startBranchStatusPoller, stopBranchStatusPoller } from "./branch-status-poller";
 import { getRunningSetups } from "./setup-runner";
+import { getRunningTaskWorkspaceIds } from "./task-runner";
 import {
   bandHome,
   loadCurrentStatuses,
@@ -32,7 +33,8 @@ export interface StatusEvent {
     | "branch-status"
     | "tunnel-url"
     | "tunnel-error"
-    | "setup-status";
+    | "setup-status"
+    | "task-status";
   status?: WorkspaceStatus;
   statuses?: WorkspaceStatus[];
   workspaceId?: string;
@@ -42,6 +44,7 @@ export interface StatusEvent {
   error?: string;
   setupState?: "running" | "completed" | "failed";
   setupError?: string;
+  taskState?: "running" | "completed" | "failed";
 }
 
 type StatusListener = (event: StatusEvent) => void;
@@ -163,6 +166,11 @@ export function subscribe(listener: StatusListener): () => void {
   // Send current setup status snapshots
   for (const workspaceId of getRunningSetups()) {
     listener({ kind: "setup-status", workspaceId, setupState: "running" });
+  }
+
+  // Send current task runner status snapshots
+  for (const workspaceId of getRunningTaskWorkspaceIds()) {
+    listener({ kind: "task-status", workspaceId, taskState: "running" });
   }
 
   return () => {

--- a/packages/dashboard-core/src/components/DashboardShell.tsx
+++ b/packages/dashboard-core/src/components/DashboardShell.tsx
@@ -27,6 +27,7 @@ import {
   useBranchStatusWatcher,
   useSetupStatusWatcher,
   useStatusWatcher,
+  useTaskStatusWatcher,
 } from "../hooks/use-status";
 import { useDashboardStore } from "../stores/index";
 import { AddProjectDialog } from "./AddProjectDialog";
@@ -87,6 +88,7 @@ export function DashboardShell({ toolbarExtra }: DashboardShellProps) {
   useActiveWorkspaceWatcher();
   useBranchStatusWatcher();
   useSetupStatusWatcher();
+  useTaskStatusWatcher();
 
   return (
     <div

--- a/packages/dashboard-core/src/components/ProjectList.tsx
+++ b/packages/dashboard-core/src/components/ProjectList.tsx
@@ -57,6 +57,7 @@ import type {
   LabelDefinition,
   ProjectInfo,
   SetupStatus,
+  TaskRunnerStatus,
   WorkspaceBranchStatus,
   WorkspaceStatus,
 } from "../types";
@@ -69,6 +70,7 @@ interface SortableProjectProps {
   statuses: Map<string, WorkspaceStatus>;
   branchStatuses: Map<string, WorkspaceBranchStatus>;
   setupStatuses: Map<string, SetupStatus>;
+  taskStatuses: Map<string, TaskRunnerStatus>;
   removeProject: (name: string) => void;
   updateProjectLabel: (name: string, label: string | null) => void;
   labels: LabelDefinition[];
@@ -84,6 +86,7 @@ function SortableProject({
   statuses,
   branchStatuses,
   setupStatuses,
+  taskStatuses,
   removeProject,
   updateProjectLabel,
   labels,
@@ -222,6 +225,7 @@ function SortableProject({
                 status={statuses.get(wsId)}
                 branchStatus={branchStatuses.get(wsId)}
                 setupStatus={setupStatuses.get(wsId)}
+                taskStatus={taskStatuses.get(wsId)}
                 isFocused={currentIndex === focusedIndex}
                 onShowDeleteDialog={onShowDeleteDialog}
                 editMode={editMode}
@@ -271,6 +275,7 @@ export function ProjectList({ labelFilter, editMode }: ProjectListProps) {
   const statuses = useDashboardStore((s) => s.statuses);
   const branchStatuses = useDashboardStore((s) => s.branchStatuses);
   const setupStatuses = useDashboardStore((s) => s.setupStatuses);
+  const taskStatuses = useDashboardStore((s) => s.taskStatuses);
   const openWorkspace = useDashboardStore((s) => s.openWorkspace);
   const activeWorkspaceId = useDashboardStore((s) => s.activeWorkspaceId);
 
@@ -496,6 +501,7 @@ export function ProjectList({ labelFilter, editMode }: ProjectListProps) {
                       statuses={statuses}
                       branchStatuses={branchStatuses}
                       setupStatuses={setupStatuses}
+                      taskStatuses={taskStatuses}
                       removeProject={(name) => removeProjectMutation.mutate(name)}
                       updateProjectLabel={(name, label) =>
                         updateProjectLabelMutation.mutate({ name, label })

--- a/packages/dashboard-core/src/components/TaskRunningIndicator.tsx
+++ b/packages/dashboard-core/src/components/TaskRunningIndicator.tsx
@@ -1,0 +1,20 @@
+import { Tooltip, TooltipContent, TooltipTrigger } from "@band/ui";
+import { Loader } from "lucide-react";
+import type { TaskRunnerStatus } from "../types";
+
+interface Props {
+  taskStatus?: TaskRunnerStatus;
+}
+
+export function TaskRunningIndicator({ taskStatus }: Props) {
+  if (!taskStatus || taskStatus.state !== "running") return null;
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <Loader className="size-3.5 shrink-0 text-purple-400 animate-spin" />
+      </TooltipTrigger>
+      <TooltipContent side="top">Task running...</TooltipContent>
+    </Tooltip>
+  );
+}

--- a/packages/dashboard-core/src/components/WorkspaceCard.tsx
+++ b/packages/dashboard-core/src/components/WorkspaceCard.tsx
@@ -25,6 +25,7 @@ import { useDashboardStore } from "../stores/index";
 import type {
   DeleteDialogInfo,
   SetupStatus,
+  TaskRunnerStatus,
   WorkspaceBranchStatus,
   WorkspaceStatus,
   WorktreeInfo,
@@ -33,6 +34,7 @@ import { AgentStatusBadge } from "./AgentStatusBadge";
 import { CIStatusIndicator } from "./CIStatusIndicator";
 import { GitStatusIndicator } from "./GitStatusIndicator";
 import { SetupStatusIndicator } from "./SetupStatusIndicator";
+import { TaskRunningIndicator } from "./TaskRunningIndicator";
 
 interface Props {
   worktree: WorktreeInfo;
@@ -41,6 +43,7 @@ interface Props {
   status?: WorkspaceStatus;
   branchStatus?: WorkspaceBranchStatus;
   setupStatus?: SetupStatus;
+  taskStatus?: TaskRunnerStatus;
   isFocused?: boolean;
   onShowDeleteDialog: (info: DeleteDialogInfo) => void;
   editMode?: boolean;
@@ -53,6 +56,7 @@ export function WorkspaceCard({
   status,
   branchStatus,
   setupStatus,
+  taskStatus,
   isFocused,
   onShowDeleteDialog,
   editMode,
@@ -140,6 +144,7 @@ export function WorkspaceCard({
             </Tooltip>
             {!editMode && <AgentStatusBadge agent={status?.agent} />}
             {!editMode && <SetupStatusIndicator setup={setupStatus} />}
+            {!editMode && <TaskRunningIndicator taskStatus={taskStatus} />}
           </div>
           {!editMode && (
             <div className="flex items-center gap-2 shrink-0">

--- a/packages/dashboard-core/src/hooks/use-status.ts
+++ b/packages/dashboard-core/src/hooks/use-status.ts
@@ -103,3 +103,24 @@ export function useSetupStatusWatcher() {
     return unsubscribe;
   }, [adapter, updateSetupStatus, removeSetupStatus]);
 }
+
+export function useTaskStatusWatcher() {
+  const adapter = useAdapter();
+  const updateTaskStatus = useDashboardStore((s) => s.updateTaskStatus);
+  const removeTaskStatus = useDashboardStore((s) => s.removeTaskStatus);
+
+  useEffect(() => {
+    const unsubscribe = adapter.subscribeStatusEvents((event) => {
+      const data = event as SSEEvent;
+      if (data.kind !== "task-status" || !data.workspaceId) return;
+
+      if (data.taskState === "running") {
+        updateTaskStatus(data.workspaceId, { state: "running" });
+      } else {
+        removeTaskStatus(data.workspaceId);
+      }
+    });
+
+    return unsubscribe;
+  }, [adapter, updateTaskStatus, removeTaskStatus]);
+}

--- a/packages/dashboard-core/src/index.ts
+++ b/packages/dashboard-core/src/index.ts
@@ -18,6 +18,7 @@ export { QuickOpenDialog } from "./components/QuickOpenDialog";
 export { SearchFilesDialog } from "./components/SearchFilesDialog";
 export { SettingsPage } from "./components/SettingsPage";
 export { SetupStatusIndicator } from "./components/SetupStatusIndicator";
+export { TaskRunningIndicator } from "./components/TaskRunningIndicator";
 export { WorkspaceCard } from "./components/WorkspaceCard";
 export { type WorkspaceTab, WorkspaceTabNav } from "./components/WorkspaceTabNav";
 // Context
@@ -40,6 +41,7 @@ export {
   useBranchStatusWatcher,
   useSetupStatusWatcher,
   useStatusWatcher,
+  useTaskStatusWatcher,
 } from "./hooks/use-status";
 export { openFileSearchPanel } from "./lib/codemirror-setup";
 export { extensionToLanguage, filenameToLanguage } from "./lib/language-map";
@@ -80,6 +82,8 @@ export type {
   Settings,
   SetupState,
   SetupStatus,
+  TaskRunnerState,
+  TaskRunnerStatus,
   WorkspaceBranchStatus,
   WorkspaceDiff,
   WorkspaceDiffSummary,

--- a/packages/dashboard-core/src/lib/sse.ts
+++ b/packages/dashboard-core/src/lib/sse.ts
@@ -1,4 +1,4 @@
-import type { CIStatus, GitStatus, WorkspaceStatus } from "../types";
+import type { CIStatus, GitStatus, TaskRunnerState, WorkspaceStatus } from "../types";
 
 export type SSEEvent = {
   kind:
@@ -8,7 +8,8 @@ export type SSEEvent = {
     | "branch-status"
     | "tunnel-url"
     | "tunnel-error"
-    | "setup-status";
+    | "setup-status"
+    | "task-status";
   status?: WorkspaceStatus;
   statuses?: WorkspaceStatus[];
   workspaceId?: string;
@@ -18,4 +19,5 @@ export type SSEEvent = {
   error?: string;
   setupState?: "running" | "completed" | "failed";
   setupError?: string;
+  taskState?: TaskRunnerState;
 };

--- a/packages/dashboard-core/src/stores/dashboard-store.ts
+++ b/packages/dashboard-core/src/stores/dashboard-store.ts
@@ -4,6 +4,7 @@ import type {
   CIStatus,
   GitStatus,
   SetupStatus,
+  TaskRunnerStatus,
   WorkspaceBranchStatus,
   WorkspaceStatus,
 } from "../types";
@@ -14,6 +15,7 @@ export interface DashboardState {
   error: string | null;
   branchStatuses: Map<string, WorkspaceBranchStatus>;
   setupStatuses: Map<string, SetupStatus>;
+  taskStatuses: Map<string, TaskRunnerStatus>;
   _openingWorkspace: boolean;
 
   openWorkspace: (workspaceId: string) => void;
@@ -29,6 +31,8 @@ export interface DashboardState {
   updateCIStatus: (workspaceId: string, ci: CIStatus) => void;
   updateSetupStatus: (workspaceId: string, status: SetupStatus) => void;
   removeSetupStatus: (workspaceId: string) => void;
+  updateTaskStatus: (workspaceId: string, status: TaskRunnerStatus) => void;
+  removeTaskStatus: (workspaceId: string) => void;
 }
 
 export type DashboardStore = UseBoundStore<StoreApi<DashboardState>>;
@@ -38,6 +42,7 @@ export function createDashboardStore(adapter: DashboardAdapter): DashboardStore 
     statuses: new Map(),
     branchStatuses: new Map(),
     setupStatuses: new Map(),
+    taskStatuses: new Map(),
     activeWorkspaceId: null,
     error: null,
     _openingWorkspace: false,
@@ -164,6 +169,22 @@ export function createDashboardStore(adapter: DashboardAdapter): DashboardStore 
         const setupStatuses = new Map(state.setupStatuses);
         setupStatuses.delete(workspaceId);
         return { setupStatuses };
+      });
+    },
+
+    updateTaskStatus: (workspaceId: string, status: TaskRunnerStatus) => {
+      set((state) => {
+        const taskStatuses = new Map(state.taskStatuses);
+        taskStatuses.set(workspaceId, status);
+        return { taskStatuses };
+      });
+    },
+
+    removeTaskStatus: (workspaceId: string) => {
+      set((state) => {
+        const taskStatuses = new Map(state.taskStatuses);
+        taskStatuses.delete(workspaceId);
+        return { taskStatuses };
       });
     },
   }));

--- a/packages/dashboard-core/src/types.ts
+++ b/packages/dashboard-core/src/types.ts
@@ -67,6 +67,12 @@ export interface SetupStatus {
   error?: string;
 }
 
+export type TaskRunnerState = "running" | "completed" | "failed";
+
+export interface TaskRunnerStatus {
+  state: TaskRunnerState;
+}
+
 export type AppType = "vscode" | "zed" | "iterm" | "chrome";
 
 export interface VsCodeAppConfig {


### PR DESCRIPTION
## Summary
- Surface the task runner's running/completed/failed status on workspace cards via SSE events
- Add a spinning purple loader indicator (TaskRunningIndicator) next to the agent and setup status badges
- Wire the full data path: task-runner emits → watcher broadcasts → SSE stream → Zustand store → WorkspaceCard UI

Closes #59

## Changes

**Server (apps/web)**
- `task-runner.ts`: Emit `task-status` SSE events on task submit, complete, fail, and abort; add `getRunningTaskWorkspaceIds()` for snapshots
- `watcher.ts`: Add `task-status` to `StatusEvent` type, include running task snapshots on new subscriber connections

**Client (packages/dashboard-core)**
- `types.ts`: Add `TaskRunnerState` and `TaskRunnerStatus` types
- `sse.ts`: Add `task-status` kind and `taskState` field to `SSEEvent`
- `dashboard-store.ts`: Add `taskStatuses` Map + `updateTaskStatus`/`removeTaskStatus` actions
- `use-status.ts`: Add `useTaskStatusWatcher()` hook that filters task-status SSE events
- `DashboardShell.tsx`: Activate `useTaskStatusWatcher()`
- `ProjectList.tsx`: Read `taskStatuses` from store, pass through to `WorkspaceCard`
- `WorkspaceCard.tsx`: Accept `taskStatus` prop, render `TaskRunningIndicator`
- `TaskRunningIndicator.tsx`: New component — spinning Loader icon with tooltip when task is running

## Test plan
- [ ] Start a task on a workspace via the dashboard and verify a spinning purple indicator appears on the workspace card
- [ ] Verify the indicator disappears when the task completes or fails
- [ ] Refresh the dashboard while a task is running and verify the indicator appears immediately (snapshot support)
- [ ] Verify no indicator shows for workspaces without running tasks

🤖 Generated with [Claude Code](https://claude.com/claude-code)