### PR TITLE
feat: add Windows compatibility (Phase 1 & 2)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,6 +95,73 @@ jobs:
       - name: Build frontend
         run: pnpm --filter @band/dashboard build
 
+  # ── Windows build & test ──────────────────────────────────────────────────
+  check-windows:
+    name: Windows Build & Test
+    runs-on: windows-latest
+    env:
+      NODE_OPTIONS: "--max-old-space-size=6144"
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - name: Cache pnpm store
+        uses: actions/cache@v4
+        with:
+          path: ~/AppData/Local/pnpm/store
+          key: pnpm-windows-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: pnpm-windows-
+
+      - name: Cache Cargo registry
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+          key: cargo-registry-windows-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: cargo-registry-windows-
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build CLI
+        run: cargo build --release --manifest-path apps/cli/Cargo.toml
+
+      - name: Lint (cargo clippy - CLI)
+        run: cargo clippy --manifest-path apps/cli/Cargo.toml -- -D warnings
+
+      - name: Lint (cargo clippy - Dashboard)
+        shell: bash
+        run: |
+          mkdir -p apps/web/dist apps/dashboard/src-tauri/binaries
+          touch apps/web/dist/start-server.mjs
+          TARGET=$(rustc -vV | sed -n 's/host: //p')
+          cp "apps/cli/target/release/band.exe" "apps/dashboard/src-tauri/binaries/band-${TARGET}.exe"
+          cargo clippy --manifest-path apps/dashboard/src-tauri/Cargo.toml -- -D warnings
+
+      - name: Build web
+        run: pnpm build:web
+
+      - name: Test (CLI)
+        run: cargo test --manifest-path apps/cli/Cargo.toml
+
+      - name: Test (Dashboard)
+        run: cargo test --manifest-path apps/dashboard/src-tauri/Cargo.toml
+
   delete-runner:
     name: Delete Runner
     needs: [create-runner, check]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -155,7 +155,16 @@ jobs:
         run: cargo clippy --manifest-path apps/cli/Cargo.toml -- -D warnings
 
       - name: Build CLI
-        run: pnpm build:cli
+        shell: bash
+        run: |
+          pnpm --filter @band/cli build
+          mkdir -p apps/dashboard/src-tauri/binaries
+          TARGET=$(rustc -vV | sed -n 's/host: //p')
+          EXT=""
+          if [[ "$RUNNER_OS" == "Windows" ]]; then
+            EXT=".exe"
+          fi
+          cp "apps/cli/target/release/band${EXT}" "apps/dashboard/src-tauri/binaries/band-${TARGET}${EXT}"
 
       - name: Lint (cargo clippy — Dashboard)
         shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,9 +22,68 @@ permissions:
   contents: write
 
 jobs:
-  release:
-    name: Release
+  # ── Determine version ────────────────────────────────────────────────────
+  version:
+    name: Determine Version
     runs-on: macos-latest
+    outputs:
+      new_version: ${{ steps.version.outputs.new_version }}
+      bump_args: ${{ steps.version.outputs.bump_args }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Determine version
+        id: version
+        run: |
+          if [ -n "${{ inputs.version }}" ]; then
+            BUMP_ARGS="--version ${{ inputs.version }}"
+          elif [ -n "${{ inputs.bump }}" ]; then
+            BUMP_ARGS="--bump ${{ inputs.bump }}"
+          else
+            BUMP_ARGS="--from-commits"
+          fi
+          NEW_VERSION=$(node scripts/bump-version.mjs $BUMP_ARGS --dry-run 2>&1 | grep "^Version:" | sed 's/Version: .* → //')
+          echo "new_version=$NEW_VERSION" >> "$GITHUB_OUTPUT"
+          echo "bump_args=$BUMP_ARGS" >> "$GITHUB_OUTPUT"
+          echo "Will release version: $NEW_VERSION"
+
+      - name: Verify tag does not exist
+        run: |
+          if git rev-parse "v${{ steps.version.outputs.new_version }}" >/dev/null 2>&1; then
+            echo "Error: Tag v${{ steps.version.outputs.new_version }} already exists"
+            exit 1
+          fi
+
+  # ── Build matrix (macOS + Windows) ───────────────────────────────────────
+  build:
+    name: Build (${{ matrix.os }})
+    needs: version
+    strategy:
+      matrix:
+        include:
+          - os: macos-latest
+            bundle_target: dmg
+            artifact_glob: "apps/dashboard/src-tauri/target/release/bundle/dmg/*.dmg"
+          - os: windows-latest
+            bundle_target: nsis
+            artifact_glob: "apps/dashboard/src-tauri/target/release/bundle/nsis/*.exe"
+    runs-on: ${{ matrix.os }}
 
     steps:
       - name: Checkout
@@ -80,48 +139,33 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Determine version
-        id: version
-        run: |
-          if [ -n "${{ inputs.version }}" ]; then
-            BUMP_ARGS="--version ${{ inputs.version }}"
-          elif [ -n "${{ inputs.bump }}" ]; then
-            BUMP_ARGS="--bump ${{ inputs.bump }}"
-          else
-            BUMP_ARGS="--from-commits"
-          fi
-          NEW_VERSION=$(node scripts/bump-version.mjs $BUMP_ARGS --dry-run 2>&1 | grep "^Version:" | sed 's/Version: .* → //')
-          echo "new_version=$NEW_VERSION" >> "$GITHUB_OUTPUT"
-          echo "bump_args=$BUMP_ARGS" >> "$GITHUB_OUTPUT"
-          echo "Will release version: $NEW_VERSION"
-
-      - name: Verify tag does not exist
-        run: |
-          if git rev-parse "v${{ steps.version.outputs.new_version }}" >/dev/null 2>&1; then
-            echo "Error: Tag v${{ steps.version.outputs.new_version }} already exists"
-            exit 1
-          fi
-
       - name: Bump versions
-        run: node scripts/bump-version.mjs ${{ steps.version.outputs.bump_args }}
+        run: node scripts/bump-version.mjs ${{ needs.version.outputs.bump_args }}
 
-      - name: Lint
+      - name: Lint (Biome)
+        run: pnpm exec biome check .
+
+      - name: Lint (cargo fmt)
+        shell: bash
         run: |
-          pnpm exec biome check .
           cargo fmt --manifest-path apps/cli/Cargo.toml -- --check
           cargo fmt --manifest-path apps/dashboard/src-tauri/Cargo.toml -- --check
-          cargo clippy --manifest-path apps/cli/Cargo.toml -- -D warnings
+
+      - name: Lint (cargo clippy — CLI)
+        run: cargo clippy --manifest-path apps/cli/Cargo.toml -- -D warnings
 
       - name: Build CLI
         run: pnpm build:cli
 
       - name: Lint (cargo clippy — Dashboard)
+        shell: bash
         run: |
           mkdir -p apps/web/dist
           touch apps/web/dist/start-server.mjs
           cargo clippy --manifest-path apps/dashboard/src-tauri/Cargo.toml -- -D warnings
 
       - name: Test
+        shell: bash
         run: |
           pnpm --filter @band/web test
           cargo test --manifest-path apps/cli/Cargo.toml
@@ -135,16 +179,53 @@ jobs:
           pnpm build:web
           pnpm --filter @band/dashboard build
 
-      - name: Build DMG
-        run: pnpm --filter @band/dashboard tauri build --ci --config '{"build":{"beforeBuildCommand":""}}'
+      - name: Build installer
+        shell: bash
+        run: |
+          pnpm --filter @band/dashboard tauri build --ci \
+            --bundles ${{ matrix.bundle_target }} \
+            --config '{"build":{"beforeBuildCommand":""}}'
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-${{ runner.os }}
+          path: ${{ matrix.artifact_glob }}
+
+  # ── Release (runs after all builds succeed) ──────────────────────────────
+  release:
+    name: Create Release
+    needs: [version, build]
+    runs-on: macos-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Bump versions
+        run: node scripts/bump-version.mjs ${{ needs.version.outputs.bump_args }}
 
       - name: Commit and tag
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add -A
-          git commit -m "chore: release v${{ steps.version.outputs.new_version }}"
-          git tag "v${{ steps.version.outputs.new_version }}"
+          git commit -m "chore: release v${{ needs.version.outputs.new_version }}"
+          git tag "v${{ needs.version.outputs.new_version }}"
           git push origin main --follow-tags
 
       - name: Generate changelog
@@ -152,9 +233,9 @@ jobs:
         run: |
           LAST_TAG=$(git describe --tags --abbrev=0 HEAD^ 2>/dev/null || echo "")
           if [ -n "$LAST_TAG" ]; then
-            RANGE="${LAST_TAG}..v${{ steps.version.outputs.new_version }}"
+            RANGE="${LAST_TAG}..v${{ needs.version.outputs.new_version }}"
           else
-            RANGE="v${{ steps.version.outputs.new_version }}"
+            RANGE="v${{ needs.version.outputs.new_version }}"
           fi
           CHANGELOG=$(git log $RANGE --pretty=format:"- %s" --no-merges | grep -v "^- chore: release" || true)
           {
@@ -163,10 +244,16 @@ jobs:
             echo "EOF"
           } >> "$GITHUB_OUTPUT"
 
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: release-artifacts
+          merge-multiple: true
+
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: v${{ steps.version.outputs.new_version }}
-          name: v${{ steps.version.outputs.new_version }}
+          tag_name: v${{ needs.version.outputs.new_version }}
+          name: v${{ needs.version.outputs.new_version }}
           body: ${{ steps.changelog.outputs.changelog }}
-          files: apps/dashboard/src-tauri/target/release/bundle/dmg/*.dmg
+          files: release-artifacts/*

--- a/apps/cli/bin/band.cmd
+++ b/apps/cli/bin/band.cmd
@@ -1,0 +1,18 @@
+@echo off
+rem Wrapper script for the band CLI binary on Windows.
+rem Looks for the Cargo-built binary relative to this script's location.
+
+set "SCRIPT_DIR=%~dp0.."
+
+if exist "%SCRIPT_DIR%\target\release\band.exe" (
+  "%SCRIPT_DIR%\target\release\band.exe" %*
+  exit /b %ERRORLEVEL%
+)
+
+if exist "%SCRIPT_DIR%\target\debug\band.exe" (
+  "%SCRIPT_DIR%\target\debug\band.exe" %*
+  exit /b %ERRORLEVEL%
+)
+
+echo error: band binary not found. Run 'pnpm --filter @band/cli build' first. >&2
+exit /b 1

--- a/apps/cli/src/main.rs
+++ b/apps/cli/src/main.rs
@@ -394,20 +394,26 @@ fn open_configured_editor(worktree_path: &str) {
         return;
     };
 
-    // Try macOS `open -g` first (opens without stealing focus), fall back to CLI
-    let opened = std::process::Command::new("open")
-        .args(["-g", "-a", app_name, "--args", worktree_path])
-        .output()
-        .map(|o| o.status.success())
-        .unwrap_or(false);
-    if !opened {
-        let open_result = std::process::Command::new(cli_name)
-            .arg(worktree_path)
-            .env("PATH", shell::shell_path())
-            .output();
-        if let Err(e) = open_result {
-            eprintln!("Warning: failed to open {app_name}: {e}");
+    // macOS: try `open -g` first (opens without stealing focus), fall back to CLI
+    // Windows/Linux: use the CLI command directly
+    #[cfg(target_os = "macos")]
+    {
+        let opened = std::process::Command::new("open")
+            .args(["-g", "-a", app_name, "--args", worktree_path])
+            .output()
+            .map(|o| o.status.success())
+            .unwrap_or(false);
+        if opened {
+            return;
         }
+    }
+
+    let open_result = std::process::Command::new(cli_name)
+        .arg(worktree_path)
+        .env("PATH", shell::shell_path())
+        .output();
+    if let Err(e) = open_result {
+        eprintln!("Warning: failed to open {app_name}: {e}");
     }
 }
 

--- a/apps/cli/src/shell.rs
+++ b/apps/cli/src/shell.rs
@@ -6,21 +6,29 @@ use std::sync::OnceLock;
 pub fn shell_path() -> &'static str {
     static PATH: OnceLock<String> = OnceLock::new();
     PATH.get_or_init(|| {
-        let shell = std::env::var("SHELL").unwrap_or_else(|_| "/bin/zsh".to_string());
-        if let Ok(output) = Command::new(&shell)
-            .args(["-li", "-c", "echo $PATH"])
-            .stdout(Stdio::piped())
-            .stderr(Stdio::null())
-            .output()
+        #[cfg(unix)]
         {
-            let path = String::from_utf8_lossy(&output.stdout).trim().to_string();
-            if !path.is_empty() {
-                return path;
+            let shell = std::env::var("SHELL").unwrap_or_else(|_| "/bin/zsh".to_string());
+            if let Ok(output) = Command::new(&shell)
+                .args(["-li", "-c", "echo $PATH"])
+                .stdout(Stdio::piped())
+                .stderr(Stdio::null())
+                .output()
+            {
+                let path = String::from_utf8_lossy(&output.stdout).trim().to_string();
+                if !path.is_empty() {
+                    return path;
+                }
             }
+            format!(
+                "/opt/homebrew/bin:/usr/local/bin:{}",
+                std::env::var("PATH").unwrap_or_default()
+            )
         }
-        format!(
-            "/opt/homebrew/bin:/usr/local/bin:{}",
+        #[cfg(windows)]
+        {
+            // On Windows, PATH is always available in the environment — no login shell probe needed
             std::env::var("PATH").unwrap_or_default()
-        )
+        }
     })
 }

--- a/apps/cli/src/shell.rs
+++ b/apps/cli/src/shell.rs
@@ -1,4 +1,3 @@
-use std::process::{Command, Stdio};
 use std::sync::OnceLock;
 
 /// Resolve the user's full shell PATH once (includes nvm/volta/homebrew paths).
@@ -8,6 +7,7 @@ pub fn shell_path() -> &'static str {
     PATH.get_or_init(|| {
         #[cfg(unix)]
         {
+            use std::process::{Command, Stdio};
             let shell = std::env::var("SHELL").unwrap_or_else(|_| "/bin/zsh".to_string());
             if let Ok(output) = Command::new(&shell)
                 .args(["-li", "-c", "echo $PATH"])

--- a/apps/cli/tests/integration.rs
+++ b/apps/cli/tests/integration.rs
@@ -21,9 +21,9 @@ struct TestEnv {
 impl TestEnv {
     fn new() -> Self {
         let tmp = tempfile::tempdir().expect("create tempdir");
-        // home_dir is the fake HOME — server computes band_home as HOME/.band
+        // home_dir is the fake HOME parent directory
         let home_dir = tmp.path().to_path_buf();
-        // band_dir is HOME/.band — used as BAND_HOME for the CLI
+        // band_dir is HOME/.band — passed as BAND_HOME to both CLI and server
         let band_dir = home_dir.join(".band");
         let repo_path = tmp.path().join("my-project");
         let token = "test-token-12345";
@@ -81,6 +81,7 @@ impl TestEnv {
         let mut child = Command::new("node")
             .arg(&web_dist)
             .env("HOME", &home_dir)
+            .env("BAND_HOME", &band_dir)
             .env("PORT", port.to_string())
             .env("NODE_ENV", "production")
             .stdout(Stdio::piped())
@@ -396,11 +397,12 @@ fn setup_script_runs_on_create() {
 
     let band_dir = env.repo_path.join(".band");
     fs::create_dir_all(&band_dir).unwrap();
-    fs::write(
-        band_dir.join("config.json"),
-        r#"{ "setup": "touch setup-ran.txt" }"#,
-    )
-    .unwrap();
+    let setup_cmd = if cfg!(windows) {
+        r#"{ "setup": "type nul > setup-ran.txt" }"#
+    } else {
+        r#"{ "setup": "touch setup-ran.txt" }"#
+    };
+    fs::write(band_dir.join("config.json"), setup_cmd).unwrap();
     git(&env.repo_path, &["add", ".band/config.json"]);
     git(&env.repo_path, &["commit", "-m", "add config"]);
 
@@ -408,10 +410,17 @@ fn setup_script_runs_on_create() {
     assert!(output.status.success(), "stderr: {}", stderr(&output));
 
     let path = stdout(&output);
-    assert!(
-        Path::new(&path).join("setup-ran.txt").exists(),
-        "setup script should have created setup-ran.txt"
-    );
+    let marker = Path::new(&path).join("setup-ran.txt");
+    // Setup runs asynchronously on the server — poll until the marker file appears
+    let mut found = false;
+    for _ in 0..50 {
+        if marker.exists() {
+            found = true;
+            break;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(100));
+    }
+    assert!(found, "setup script should have created setup-ran.txt");
 }
 
 #[test]
@@ -421,8 +430,13 @@ fn teardown_script_runs_on_remove() {
     let band_dir = env.repo_path.join(".band");
     fs::create_dir_all(&band_dir).unwrap();
     let marker_path = env.band_dir.join("teardown-ran.txt");
+    let teardown_cmd = if cfg!(windows) {
+        format!(r#"type nul > "{}""#, marker_path.to_string_lossy())
+    } else {
+        format!("touch '{}'", marker_path.to_string_lossy())
+    };
     let config = serde_json::json!({
-        "teardown": format!("touch '{}'", marker_path.to_string_lossy())
+        "teardown": teardown_cmd
     });
     fs::write(
         band_dir.join("config.json"),

--- a/apps/dashboard/src-tauri/Cargo.toml
+++ b/apps/dashboard/src-tauri/Cargo.toml
@@ -23,11 +23,13 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 chrono = "0.4"
 dirs = "6"
-libc = "0.2"
 tokio = { version = "1", features = ["process", "time", "net"] }
 url = "2"
 wry = "0.54.3"
 ureq = { version = "3", features = ["json"] }
+
+[target.'cfg(unix)'.dependencies]
+libc = "0.2"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 cocoa = "0.26"

--- a/apps/dashboard/src-tauri/scripts/notify.ps1
+++ b/apps/dashboard/src-tauri/scripts/notify.ps1
@@ -6,8 +6,8 @@ $ErrorActionPreference = "Stop"
 
 # Read hook input from stdin (Claude Code passes JSON with hook_event_name)
 try {
-    $input = $input | Out-String
-    $parsed = $input | ConvertFrom-Json
+    $stdinText = @($input) -join "`n"
+    $parsed = $stdinText | ConvertFrom-Json
     $hookEvent = $parsed.hook_event_name
 } catch {
     exit 0

--- a/apps/dashboard/src-tauri/scripts/notify.ps1
+++ b/apps/dashboard/src-tauri/scripts/notify.ps1
@@ -1,0 +1,99 @@
+# Band hook for Claude Code on Windows - reports agent status changes
+# This script is called by Claude Code lifecycle hooks.
+# It looks up workspace identity from ~/.band/state.json and writes status to ~/.band/status/
+
+$ErrorActionPreference = "Stop"
+
+# Read hook input from stdin (Claude Code passes JSON with hook_event_name)
+try {
+    $input = $input | Out-String
+    $parsed = $input | ConvertFrom-Json
+    $hookEvent = $parsed.hook_event_name
+} catch {
+    exit 0
+}
+
+if (-not $hookEvent) {
+    exit 0
+}
+
+$stateFile = Join-Path $env:USERPROFILE ".band" "state.json"
+$currentDir = (Get-Location).Path
+
+# Look up project and branch from state.json (single source of truth)
+$project = $null
+$branch = $null
+$worktreePath = $null
+
+if (Test-Path $stateFile) {
+    try {
+        $state = Get-Content $stateFile -Raw | ConvertFrom-Json
+        $resolvedCwd = (Resolve-Path $currentDir).Path.TrimEnd('\')
+        foreach ($proj in $state.projects) {
+            foreach ($wt in $proj.worktrees) {
+                $wtPath = (Resolve-Path $wt.path -ErrorAction SilentlyContinue).Path.TrimEnd('\')
+                if ($wtPath -and ($resolvedCwd -eq $wtPath -or $resolvedCwd.StartsWith("$wtPath\"))) {
+                    $project = $proj.name
+                    $branch = $wt.branch
+                    $worktreePath = $wt.path
+                    break
+                }
+            }
+            if ($project) { break }
+        }
+    } catch {
+        # Ignore parse errors
+    }
+}
+
+if (-not $project -or -not $branch) {
+    exit 0
+}
+
+$workspaceId = "$project-$($branch -replace '/', '-')"
+$statusDir = Join-Path $env:USERPROFILE ".band" "status"
+$statusFile = Join-Path $statusDir "$workspaceId.json"
+
+# Map hook event to agent status
+switch ($hookEvent) {
+    "UserPromptSubmit"    { $status = "working" }
+    "PostToolUse"         { $status = "working" }
+    "PostToolUseFailure"  { $status = "working" }
+    "Stop"                { $status = "needs_attention" }
+    "PermissionRequest"   { $status = "needs_attention" }
+    default               { exit 0 }
+}
+
+$now = (Get-Date).ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ")
+
+if (-not (Test-Path $statusDir)) {
+    New-Item -ItemType Directory -Path $statusDir -Force | Out-Null
+}
+
+if (Test-Path $statusFile) {
+    # Atomic update: read, modify, write to temp, then move
+    try {
+        $existing = Get-Content $statusFile -Raw | ConvertFrom-Json
+        $existing.agent.status = $status
+        $existing.agent.lastActivity = $now
+        $tmpFile = Join-Path $statusDir ".tmp.$([System.IO.Path]::GetRandomFileName())"
+        $existing | ConvertTo-Json -Depth 10 | Set-Content $tmpFile -Encoding UTF8
+        Move-Item -Path $tmpFile -Destination $statusFile -Force
+    } catch {
+        # Ignore update errors
+    }
+} else {
+    $statusObj = @{
+        workspaceId = $workspaceId
+        project = $project
+        branch = $branch
+        worktreePath = $worktreePath
+        ide = "vscode"
+        agent = @{
+            name = "claude-code"
+            status = $status
+            lastActivity = $now
+        }
+    }
+    $statusObj | ConvertTo-Json -Depth 10 | Set-Content $statusFile -Encoding UTF8
+}

--- a/apps/dashboard/src-tauri/src/api.rs
+++ b/apps/dashboard/src-tauri/src/api.rs
@@ -1,3 +1,5 @@
+#![allow(dead_code)]
+
 use crate::state;
 use ureq::http;
 use ureq::Body;

--- a/apps/dashboard/src-tauri/src/commands/ide_stub.rs
+++ b/apps/dashboard/src-tauri/src/commands/ide_stub.rs
@@ -1,5 +1,6 @@
 //! Stub implementations of the IDE commands for non-macOS platforms.
 //! The real implementation lives in `ide.rs` and uses macOS-specific APIs.
+//! On Windows, `pick_folder` and `reveal_in_finder` use native commands.
 
 use crate::state::{ActiveWorkspaceState, ProjectCache};
 
@@ -41,10 +42,60 @@ pub fn detect_active_workspace(
 
 #[tauri::command]
 pub fn pick_folder() -> Result<Option<String>, String> {
-    Err("Not supported on this platform".to_string())
+    // Use the Tauri dialog plugin via rfd (native file dialog) on non-macOS.
+    // Since we can't use the async Tauri dialog API in a synchronous command,
+    // fall back to a native command approach.
+    #[cfg(target_os = "windows")]
+    {
+        // Use PowerShell to show a native folder picker dialog
+        let output = std::process::Command::new("powershell")
+            .args([
+                "-NoProfile",
+                "-Command",
+                "Add-Type -AssemblyName System.Windows.Forms; $d = New-Object System.Windows.Forms.FolderBrowserDialog; $d.ShowNewFolderButton = $true; if ($d.ShowDialog() -eq 'OK') { $d.SelectedPath } else { '' }",
+            ])
+            .output()
+            .map_err(|e| format!("Failed to open folder dialog: {e}"))?;
+
+        let path = String::from_utf8_lossy(&output.stdout).trim().to_string();
+        if path.is_empty() {
+            Ok(None)
+        } else {
+            Ok(Some(path))
+        }
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    {
+        Err("Not supported on this platform".to_string())
+    }
 }
 
 #[tauri::command]
-pub fn reveal_in_finder(_path: String) -> Result<(), String> {
-    Err("Not supported on this platform".to_string())
+pub fn reveal_in_finder(path: String) -> Result<(), String> {
+    #[cfg(target_os = "windows")]
+    {
+        // Use explorer.exe to open the folder
+        std::process::Command::new("explorer")
+            .arg(&path)
+            .spawn()
+            .map_err(|e| format!("Failed to open Explorer: {e}"))?;
+        Ok(())
+    }
+
+    #[cfg(target_os = "linux")]
+    {
+        // Use xdg-open to open the folder
+        std::process::Command::new("xdg-open")
+            .arg(&path)
+            .spawn()
+            .map_err(|e| format!("Failed to open file manager: {e}"))?;
+        Ok(())
+    }
+
+    #[cfg(not(any(target_os = "windows", target_os = "linux")))]
+    {
+        let _ = path;
+        Err("Not supported on this platform".to_string())
+    }
 }

--- a/apps/dashboard/src-tauri/src/commands/webserver.rs
+++ b/apps/dashboard/src-tauri/src/commands/webserver.rs
@@ -153,7 +153,7 @@ fn set_process_group(cmd: &mut Command) -> &mut Command {
         use std::os::windows::process::CommandExt;
         // CREATE_NEW_PROCESS_GROUP (0x00000200) — allows the child tree to be
         // killed as a group via taskkill /T.
-        cmd.creation_flags(0x00000200)
+        cmd.creation_flags(0x0000_0200)
     }
 }
 

--- a/apps/dashboard/src-tauri/src/commands/webserver.rs
+++ b/apps/dashboard/src-tauri/src/commands/webserver.rs
@@ -1,4 +1,5 @@
 use std::fs::OpenOptions;
+#[cfg(unix)]
 use std::os::unix::process::CommandExt;
 use std::process::{Child, Command, Stdio};
 use std::sync::{Arc, Mutex, OnceLock};
@@ -14,7 +15,7 @@ const DEFAULT_WEB_SERVER_PORT: u16 = 3456;
 
 fn resolve_web_dir() -> Result<std::path::PathBuf, String> {
     // 1. Dev only: CARGO_MANIFEST_DIR (compile-time).
-    //    In release builds this is skipped so the DMG never accidentally
+    //    In release builds this is skipped so the installer never accidentally
     //    picks up the source repo's dist/ folder.
     #[cfg(debug_assertions)]
     {
@@ -29,11 +30,36 @@ fn resolve_web_dir() -> Result<std::path::PathBuf, String> {
 
     // 2. Production: relative to current executable
     if let Ok(exe) = std::env::current_exe() {
-        // macOS bundle: .app/Contents/MacOS/band-dashboard → .app/Contents/Resources/web
-        if let Some(macos_dir) = exe.parent() {
-            let resources = macos_dir.join("../Resources/web");
-            if resources.join("dist/server/server.js").exists() {
-                return Ok(resources);
+        if let Some(exe_dir) = exe.parent() {
+            // macOS bundle: .app/Contents/MacOS/band-dashboard → .app/Contents/Resources/web
+            #[cfg(target_os = "macos")]
+            {
+                let resources = exe_dir.join("../Resources/web");
+                if resources.join("dist/server/server.js").exists() {
+                    return Ok(resources);
+                }
+            }
+
+            // Windows NSIS installer: places web/ next to the executable
+            #[cfg(target_os = "windows")]
+            {
+                let web = exe_dir.join("web");
+                if web.join("dist/server/server.js").exists() {
+                    return Ok(web);
+                }
+            }
+
+            // Linux / generic fallback: try ../Resources/web and ./web
+            #[cfg(not(any(target_os = "macos", target_os = "windows")))]
+            {
+                let resources = exe_dir.join("../Resources/web");
+                if resources.join("dist/server/server.js").exists() {
+                    return Ok(resources);
+                }
+                let web = exe_dir.join("web");
+                if web.join("dist/server/server.js").exists() {
+                    return Ok(web);
+                }
             }
         }
     }
@@ -52,22 +78,30 @@ pub(crate) fn get_configured_port() -> u16 {
 pub(crate) fn shell_path() -> &'static str {
     static PATH: OnceLock<String> = OnceLock::new();
     PATH.get_or_init(|| {
-        let shell = std::env::var("SHELL").unwrap_or_else(|_| "/bin/zsh".to_string());
-        if let Ok(output) = Command::new(&shell)
-            .args(["-li", "-c", "echo $PATH"])
-            .stdout(Stdio::piped())
-            .stderr(Stdio::null())
-            .output()
+        #[cfg(unix)]
         {
-            let path = String::from_utf8_lossy(&output.stdout).trim().to_string();
-            if !path.is_empty() {
-                return path;
+            let shell = std::env::var("SHELL").unwrap_or_else(|_| "/bin/zsh".to_string());
+            if let Ok(output) = Command::new(&shell)
+                .args(["-li", "-c", "echo $PATH"])
+                .stdout(Stdio::piped())
+                .stderr(Stdio::null())
+                .output()
+            {
+                let path = String::from_utf8_lossy(&output.stdout).trim().to_string();
+                if !path.is_empty() {
+                    return path;
+                }
             }
+            format!(
+                "/opt/homebrew/bin:/usr/local/bin:{}",
+                std::env::var("PATH").unwrap_or_default()
+            )
         }
-        format!(
-            "/opt/homebrew/bin:/usr/local/bin:{}",
+        #[cfg(windows)]
+        {
+            // On Windows, PATH is already fully resolved in the environment
             std::env::var("PATH").unwrap_or_default()
-        )
+        }
     })
 }
 
@@ -79,27 +113,47 @@ pub(crate) fn get_token() -> Result<String, String> {
     })
 }
 
-/// Send SIGTERM to the entire process group, then fall back to SIGKILL.
+/// Kill a child process and its descendants.
 fn kill_process_tree(child: &mut Child) {
-    let pid = child.id() as libc::pid_t;
-    // Kill the process group (negative pid)
-    unsafe {
-        libc::kill(-pid, libc::SIGTERM);
+    #[cfg(unix)]
+    {
+        let pid = child.id() as libc::pid_t;
+        // Kill the process group (negative pid)
+        unsafe {
+            libc::kill(-pid, libc::SIGTERM);
+        }
+        // Give the process time to run shutdown hooks (e.g. tunnel cleanup)
+        std::thread::sleep(std::time::Duration::from_millis(3000));
     }
-    // Give the process time to run shutdown hooks (e.g. tunnel cleanup)
-    std::thread::sleep(std::time::Duration::from_millis(3000));
+    #[cfg(windows)]
+    {
+        // Use taskkill /T to terminate the process tree
+        let pid = child.id();
+        let _ = Command::new("taskkill")
+            .args(["/PID", &pid.to_string(), "/T", "/F"])
+            .output();
+        std::thread::sleep(std::time::Duration::from_millis(1000));
+    }
     // Fallback: force-kill the child itself if still alive
     let _ = child.kill();
     let _ = child.wait();
 }
 
-/// Set the spawned process to be a new session leader so we can kill the tree.
+/// Configure the spawned process for clean process-group management.
 fn set_process_group(cmd: &mut Command) -> &mut Command {
+    #[cfg(unix)]
     unsafe {
         cmd.pre_exec(|| {
             libc::setsid();
             Ok(())
         })
+    }
+    #[cfg(windows)]
+    {
+        use std::os::windows::process::CommandExt;
+        // CREATE_NEW_PROCESS_GROUP (0x00000200) — allows the child tree to be
+        // killed as a group via taskkill /T.
+        cmd.creation_flags(0x00000200)
     }
 }
 
@@ -193,50 +247,74 @@ fn parse_local_health(body: &str) -> bool {
     }
 }
 
-/// Check the local web server health endpoint.
-pub(crate) async fn check_local_health(port: u16, token: &str) -> bool {
-    let output = tokio::process::Command::new("curl")
-        .args([
-            "-s",
-            "-f",
-            "--max-time",
-            "2",
-            &format!("http://127.0.0.1:{port}/api/health?token={token}"),
-        ])
-        .output()
-        .await;
-    match output {
-        Ok(o) if o.status.success() => parse_local_health(&String::from_utf8_lossy(&o.stdout)),
-        _ => false,
-    }
+/// Create a ureq agent with a 2-second timeout for health checks.
+fn health_check_agent() -> ureq::Agent {
+    ureq::Agent::new_with_config(
+        ureq::config::Config::builder()
+            .timeout_global(Some(std::time::Duration::from_secs(2)))
+            .http_status_as_error(false)
+            .build(),
+    )
 }
 
-/// Check the local health endpoint synchronously using a blocking curl call.
+/// Check the local web server health endpoint.
+#[allow(clippy::unused_async)] // called from async Tauri command handler
+pub(crate) async fn check_local_health(port: u16, token: &str) -> bool {
+    check_local_health_sync(port, token)
+}
+
+/// Check the local health endpoint synchronously using a blocking HTTP call.
 fn check_local_health_sync(port: u16, token: &str) -> bool {
     let url = format!("http://127.0.0.1:{port}/api/health?token={token}");
-    let output = Command::new("curl")
-        .args(["-s", "-f", "--max-time", "2", &url])
-        .output();
-    match output {
-        Ok(o) if o.status.success() => parse_local_health(&String::from_utf8_lossy(&o.stdout)),
-        _ => false,
+    let agent = health_check_agent();
+    match agent.get(&url).call() {
+        Ok(mut response) => {
+            let body = response.body_mut().read_to_string().unwrap_or_default();
+            parse_local_health(&body)
+        }
+        Err(_) => false,
     }
 }
 
 /// Kill any process listening on the given port.
 pub(crate) fn kill_port_sync(port: u16) {
-    if let Ok(output) = Command::new("lsof").args([&format!("-ti:{port}")]).output() {
-        if output.status.success() {
-            let pids = String::from_utf8_lossy(&output.stdout);
-            for pid in pids.split_whitespace() {
-                if let Ok(pid_num) = pid.parse::<i32>() {
-                    unsafe {
-                        libc::kill(pid_num, libc::SIGTERM);
+    #[cfg(unix)]
+    {
+        if let Ok(output) = Command::new("lsof").args([&format!("-ti:{port}")]).output() {
+            if output.status.success() {
+                let pids = String::from_utf8_lossy(&output.stdout);
+                for pid in pids.split_whitespace() {
+                    if let Ok(pid_num) = pid.parse::<i32>() {
+                        unsafe {
+                            libc::kill(pid_num, libc::SIGTERM);
+                        }
                     }
                 }
+                // Give processes a moment to exit
+                std::thread::sleep(std::time::Duration::from_millis(500));
             }
-            // Give processes a moment to exit
-            std::thread::sleep(std::time::Duration::from_millis(500));
+        }
+    }
+    #[cfg(windows)]
+    {
+        // Use netstat to find the PID, then taskkill
+        if let Ok(output) = Command::new("netstat").args(["-ano", "-p", "TCP"]).output() {
+            if output.status.success() {
+                let text = String::from_utf8_lossy(&output.stdout);
+                let port_str = format!(":{port}");
+                for line in text.lines() {
+                    if line.contains(&port_str) && line.contains("LISTENING") {
+                        if let Some(pid) = line.split_whitespace().last() {
+                            if pid != "0" {
+                                let _ = Command::new("taskkill")
+                                    .args(["/PID", pid, "/T", "/F"])
+                                    .output();
+                            }
+                        }
+                    }
+                }
+                std::thread::sleep(std::time::Duration::from_millis(500));
+            }
         }
     }
 }
@@ -345,22 +423,7 @@ pub async fn webserver_stop(state: State<'_, WebServerState>) -> Result<(), Stri
 
     // Kill any process listening on the port (handles externally-started servers)
     let port = get_configured_port();
-    if let Ok(output) = tokio::process::Command::new("lsof")
-        .args([&format!("-ti:{port}")])
-        .output()
-        .await
-    {
-        if output.status.success() {
-            let pids = String::from_utf8_lossy(&output.stdout);
-            for pid in pids.split_whitespace() {
-                if let Ok(pid_num) = pid.parse::<i32>() {
-                    unsafe {
-                        libc::kill(pid_num, libc::SIGTERM);
-                    }
-                }
-            }
-        }
-    }
+    kill_port_sync(port);
 
     Ok(())
 }
@@ -384,10 +447,16 @@ mod tests {
     #[test]
     fn managed_process_tracks_child() {
         let mp = ManagedProcess::new();
+        #[cfg(unix)]
         let child = Command::new("sleep")
             .arg("60")
             .spawn()
             .expect("failed to spawn sleep");
+        #[cfg(windows)]
+        let child = Command::new("timeout")
+            .args(["/T", "60", "/NOBREAK"])
+            .spawn()
+            .expect("failed to spawn timeout");
         mp.set(child);
         assert!(mp.is_running());
         mp.kill();

--- a/apps/dashboard/src-tauri/src/git.rs
+++ b/apps/dashboard/src-tauri/src/git.rs
@@ -1,13 +1,17 @@
 use std::process::Command;
 
 fn git_cmd() -> Command {
-    let mut cmd = Command::new("git");
+    let cmd = Command::new("git");
     // On Unix, prepend Homebrew paths to find git installed via Homebrew.
     // On Windows, PATH is already correct — no extra dirs needed.
     #[cfg(unix)]
-    if let Ok(path) = std::env::var("PATH") {
-        cmd.env("PATH", format!("/opt/homebrew/bin:/usr/local/bin:{path}"));
-    }
+    let cmd = {
+        let mut c = cmd;
+        if let Ok(path) = std::env::var("PATH") {
+            c.env("PATH", format!("/opt/homebrew/bin:/usr/local/bin:{path}"));
+        }
+        c
+    };
     cmd
 }
 

--- a/apps/dashboard/src-tauri/src/git.rs
+++ b/apps/dashboard/src-tauri/src/git.rs
@@ -2,7 +2,9 @@ use std::process::Command;
 
 fn git_cmd() -> Command {
     let mut cmd = Command::new("git");
-    // Ensure git is found via Homebrew on macOS
+    // On Unix, prepend Homebrew paths to find git installed via Homebrew.
+    // On Windows, PATH is already correct — no extra dirs needed.
+    #[cfg(unix)]
     if let Ok(path) = std::env::var("PATH") {
         cmd.env("PATH", format!("/opt/homebrew/bin:/usr/local/bin:{path}"));
     }

--- a/apps/dashboard/src-tauri/src/lib.rs
+++ b/apps/dashboard/src-tauri/src/lib.rs
@@ -1,4 +1,3 @@
-#[cfg(target_os = "macos")]
 mod api;
 mod commands;
 mod git;

--- a/apps/dashboard/src-tauri/tauri.conf.json
+++ b/apps/dashboard/src-tauri/tauri.conf.json
@@ -31,7 +31,7 @@
   },
   "bundle": {
     "active": true,
-    "targets": ["dmg"],
+    "targets": ["dmg", "nsis"],
     "externalBin": ["binaries/band"],
     "icon": [
       "icons/32x32.png",
@@ -42,6 +42,11 @@
     ],
     "resources": {
       "../../web/dist/": "web/dist/"
+    },
+    "windows": {
+      "nsis": {
+        "installMode": "currentUser"
+      }
     }
   },
   "plugins": {}

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -5,14 +5,14 @@
   "type": "module",
   "scripts": {
     "dev": "vite dev --port 3456 --host 0.0.0.0",
-    "build": "vite build && ./scripts/build-server.sh",
+    "build": "vite build && node scripts/build-server.mjs",
     "start": "node dist/start-server.mjs",
     "build:test-server": "esbuild test-server.ts --bundle --platform=node --format=esm --outfile=dist/test-server.mjs --banner:js=\"import{createRequire}from'module';import{fileURLToPath as __fu}from'url';import{dirname as __dn}from'path';const require=createRequire(import.meta.url);const __filename=__fu(import.meta.url);const __dirname=__dn(__filename);\"",
     "pretest": "pnpm build",
     "test": "vitest run",
     "test:e2e": "playwright test",
     "test:e2e:ui": "playwright test --ui",
-    "postinstall": "chmod +x node_modules/node-pty/prebuilds/*/spawn-helper 2>/dev/null || true"
+    "postinstall": "node -e \"if(process.platform!=='win32'){require('child_process').execSync('chmod +x node_modules/node-pty/prebuilds/*/spawn-helper 2>/dev/null || true')}\""
   },
   "dependencies": {
     "@ai-sdk/react": "^3.0.0",

--- a/apps/web/scripts/build-server.mjs
+++ b/apps/web/scripts/build-server.mjs
@@ -1,0 +1,146 @@
+#!/usr/bin/env node
+
+/**
+ * Cross-platform build script for the Band web server.
+ * Replaces build-server.sh so the build works on macOS, Linux, and Windows.
+ */
+
+import { execSync } from "node:child_process";
+import {
+  copyFileSync,
+  cpSync,
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  readlinkSync,
+  realpathSync,
+  rmSync,
+  statSync,
+} from "node:fs";
+import { basename, join, resolve } from "node:path";
+import { platform } from "node:os";
+
+// ── 1. Bundle the server entry point ────────────────────────────────────────
+execSync(
+  [
+    "esbuild",
+    "start-server.ts",
+    "--bundle",
+    "--platform=node",
+    "--format=esm",
+    `--outfile=dist/start-server.mjs`,
+    "--external:./server/server.js",
+    "--external:node-pty",
+    "--external:better-sqlite3",
+    `--banner:js="import{createRequire}from'module';import{fileURLToPath as __fu}from'url';import{dirname as __dn}from'path';const require=createRequire(import.meta.url);const __filename=__fu(import.meta.url);const __dirname=__dn(__filename);"`,
+  ].join(" "),
+  { stdio: "inherit" },
+);
+
+// ── 2. Copy node-pty native module (only current platform prebuilds) ────────
+const ptyDest = "dist/node_modules/node-pty";
+mkdirSync(join(ptyDest, "prebuilds"), { recursive: true });
+
+// Resolve symlinks to get real node-pty path (for hoisted node_modules)
+const ptyPkg = resolve("node_modules/node-pty");
+copyFileSync(join(ptyPkg, "package.json"), join(ptyDest, "package.json"));
+cpSync(join(ptyPkg, "lib"), join(ptyDest, "lib"), { recursive: true, dereference: true });
+
+// Detect platform for prebuild filtering
+const os = platform();
+let prebuildGlob;
+switch (os) {
+  case "darwin":
+    prebuildGlob = "darwin-";
+    break;
+  case "linux":
+    prebuildGlob = "linux-";
+    break;
+  case "win32":
+    prebuildGlob = "win32-";
+    break;
+  default:
+    prebuildGlob = "";
+    break;
+}
+
+const prebuildsDir = join(ptyPkg, "prebuilds");
+if (existsSync(prebuildsDir)) {
+  for (const entry of readdirSync(prebuildsDir)) {
+    if (prebuildGlob && !entry.startsWith(prebuildGlob)) continue;
+    const srcDir = join(prebuildsDir, entry);
+    if (!statSync(srcDir).isDirectory()) continue;
+
+    const destDir = join(ptyDest, "prebuilds", entry);
+    mkdirSync(destDir, { recursive: true });
+
+    for (const file of readdirSync(srcDir)) {
+      // Skip debug symbol files
+      if (file.endsWith(".pdb")) continue;
+      const srcFile = join(srcDir, file);
+      if (statSync(srcFile).isFile()) {
+        copyFileSync(srcFile, join(destDir, file));
+      }
+    }
+  }
+}
+
+// On Unix, make spawn-helper executable
+if (os !== "win32") {
+  try {
+    const spawnHelpers = join(ptyDest, "prebuilds");
+    for (const dir of readdirSync(spawnHelpers)) {
+      const helper = join(spawnHelpers, dir, "spawn-helper");
+      if (existsSync(helper)) {
+        execSync(`chmod +x "${helper}"`);
+      }
+    }
+  } catch {
+    // Non-fatal
+  }
+}
+
+// ── 3. Copy better-sqlite3 native module and its dependencies ───────────────
+const sqliteDest = "dist/node_modules/better-sqlite3";
+mkdirSync(join(sqliteDest, "build", "Release"), { recursive: true });
+
+const sqlitePkg = resolve("node_modules/better-sqlite3");
+copyFileSync(join(sqlitePkg, "package.json"), join(sqliteDest, "package.json"));
+cpSync(join(sqlitePkg, "lib"), join(sqliteDest, "lib"), { recursive: true });
+
+const nativeModule = join(sqlitePkg, "build", "Release", "better_sqlite3.node");
+copyFileSync(nativeModule, join(sqliteDest, "build", "Release", "better_sqlite3.node"));
+
+// better-sqlite3 uses 'bindings' (+ file-uri-to-path) to locate .node at runtime.
+// In pnpm, these are peers of better-sqlite3 inside the .pnpm store, not directly
+// in node_modules/. Resolve from the real better-sqlite3 path's parent directory.
+const sqliteRealDir = realpathSync(resolve("node_modules/better-sqlite3"));
+const sqlitePeers = join(sqliteRealDir, "..");
+
+function resolvePeerPkg(name) {
+  const peerDir = join(sqlitePeers, name);
+  if (existsSync(peerDir)) return realpathSync(peerDir);
+  // Fallback: try local node_modules
+  const localDir = resolve("node_modules", name);
+  if (existsSync(localDir)) return realpathSync(localDir);
+  throw new Error(`Cannot find package '${name}' as peer of better-sqlite3 or in node_modules`);
+}
+
+const bindingsReal = resolvePeerPkg("bindings");
+mkdirSync("dist/node_modules/bindings", { recursive: true });
+cpSync(bindingsReal, "dist/node_modules/bindings", { recursive: true, dereference: true });
+
+// file-uri-to-path is a dep of bindings; resolve from bindings' peers
+const bindingsPeers = join(realpathSync(join(sqlitePeers, "bindings")), "..");
+const fileUriDir = join(bindingsPeers, "file-uri-to-path");
+const fileUriReal = existsSync(fileUriDir) ? realpathSync(fileUriDir) : resolvePeerPkg("file-uri-to-path");
+mkdirSync("dist/node_modules/file-uri-to-path", { recursive: true });
+cpSync(fileUriReal, "dist/node_modules/file-uri-to-path", { recursive: true, dereference: true });
+
+// ── 4. Copy Drizzle migrations ──────────────────────────────────────────────
+if (existsSync("dist/migrations")) {
+  rmSync("dist/migrations", { recursive: true });
+}
+cpSync("src/lib/db/migrations", "dist/migrations", { recursive: true });
+
+console.log("✓ Server build complete");

--- a/apps/web/src/lib/cli.ts
+++ b/apps/web/src/lib/cli.ts
@@ -1,5 +1,16 @@
-import { accessSync, constants, lstatSync, realpathSync, symlinkSync, unlinkSync } from "node:fs";
+import {
+  accessSync,
+  constants,
+  copyFileSync,
+  lstatSync,
+  mkdirSync,
+  realpathSync,
+  symlinkSync,
+  unlinkSync,
+} from "node:fs";
 import { dirname, join, resolve } from "node:path";
+
+import { cliInstallDir, cliInstallPath, executableExtension, isWindows } from "./platform";
 
 export type CliStatus =
   | "Installed"
@@ -8,10 +19,11 @@ export type CliStatus =
   | "DirNotFound"
   | "NotWritable";
 
-const SYMLINK_PATH = "/usr/local/bin/band";
+const INSTALL_PATH = cliInstallPath();
 
 /** Find the CLI binary by trying multiple resolution strategies. */
 function findCliBinary(): string | null {
+  const binaryName = `band${executableExtension}`;
   const strategies = [
     // cwd = apps/web/ (Vite dev and production server)
     resolve(process.cwd(), ".."),
@@ -23,7 +35,7 @@ function findCliBinary(): string | null {
 
   for (const appsDir of strategies) {
     for (const profile of ["release", "debug"]) {
-      const p = join(appsDir, "cli", "target", profile, "band");
+      const p = join(appsDir, "cli", "target", profile, binaryName);
       try {
         lstatSync(p);
         return p;
@@ -37,12 +49,19 @@ function findCliBinary(): string | null {
 
 export async function checkCli(): Promise<CliStatus> {
   try {
-    const stat = lstatSync(SYMLINK_PATH);
-    if (!stat.isSymbolicLink()) {
+    const s = lstatSync(INSTALL_PATH);
+    if (isWindows) {
+      // On Windows we copy the binary — just check it's a file
+      if (!s.isFile()) {
+        return "ConflictingBinary";
+      }
+      return "Installed";
+    }
+    if (!s.isSymbolicLink()) {
       return "ConflictingBinary";
     }
     // Check if the symlink points to our CLI binary
-    const target = realpathSync(SYMLINK_PATH);
+    const target = realpathSync(INSTALL_PATH);
     if (!target.includes(join("apps", "cli", "target"))) {
       return "ConflictingBinary";
     }
@@ -50,9 +69,10 @@ export async function checkCli(): Promise<CliStatus> {
   } catch (err) {
     const code = (err as NodeJS.ErrnoException).code;
     if (code === "ENOENT") {
-      // Check if /usr/local/bin exists
+      // Check if install directory exists
+      const dir = cliInstallDir();
       try {
-        lstatSync("/usr/local/bin");
+        lstatSync(dir);
         return "NotInstalled";
       } catch {
         return "DirNotFound";
@@ -83,19 +103,37 @@ export async function installCli(): Promise<void> {
     );
   }
 
-  const dir = dirname(SYMLINK_PATH);
+  const dir = dirname(INSTALL_PATH);
 
+  if (isWindows) {
+    // On Windows: create the directory and copy the binary
+    try {
+      mkdirSync(dir, { recursive: true });
+    } catch {
+      // Directory may already exist
+    }
+    if (isDirWritable(dir)) {
+      copyFileSync(binaryPath, INSTALL_PATH);
+    } else {
+      throw new Error(
+        `Cannot write to ${dir}. Copy manually: copy "${binaryPath}" "${INSTALL_PATH}"`,
+      );
+    }
+    return;
+  }
+
+  // Unix: use symlinks
   if (isDirWritable(dir)) {
     // Directory is writable — do it directly
     try {
-      lstatSync(SYMLINK_PATH);
-      unlinkSync(SYMLINK_PATH);
+      lstatSync(INSTALL_PATH);
+      unlinkSync(INSTALL_PATH);
     } catch (err) {
       const code = (err as NodeJS.ErrnoException).code;
       if (code !== "ENOENT") throw err;
     }
-    symlinkSync(binaryPath, SYMLINK_PATH);
+    symlinkSync(binaryPath, INSTALL_PATH);
   } else {
-    throw new Error(`Run: sudo ln -sf "${binaryPath}" "${SYMLINK_PATH}"`);
+    throw new Error(`Run: sudo ln -sf "${binaryPath}" "${INSTALL_PATH}"`);
   }
 }

--- a/apps/web/src/lib/git.ts
+++ b/apps/web/src/lib/git.ts
@@ -2,6 +2,8 @@ import { execFile } from "node:child_process";
 import { readFile, stat } from "node:fs/promises";
 import { join } from "node:path";
 
+import { enrichedEnv } from "./platform";
+
 export interface WorktreeInfo {
   branch: string;
   path: string;
@@ -46,11 +48,7 @@ export async function getRepoInfo(worktreePath: string): Promise<RepoInfo | null
 }
 
 export function gitCmd(): { command: string; env: NodeJS.ProcessEnv } {
-  const env = { ...process.env };
-  if (env.PATH) {
-    env.PATH = `/opt/homebrew/bin:/usr/local/bin:${env.PATH}`;
-  }
-  return { command: "git", env };
+  return { command: "git", env: enrichedEnv() };
 }
 
 const MAX_BUFFER = 50 * 1024 * 1024; // 50 MB
@@ -69,10 +67,7 @@ export function execGit(args: string[], cwd: string): Promise<string> {
 }
 
 export function execGh(args: string[], cwd: string): Promise<string> {
-  const env = { ...process.env };
-  if (env.PATH) {
-    env.PATH = `/opt/homebrew/bin:/usr/local/bin:${env.PATH}`;
-  }
+  const env = enrichedEnv();
   return new Promise((resolve, reject) => {
     execFile("gh", args, { cwd, env, maxBuffer: MAX_BUFFER }, (err, stdout, stderr) => {
       if (err) {

--- a/apps/web/src/lib/hooks.ts
+++ b/apps/web/src/lib/hooks.ts
@@ -105,9 +105,9 @@ export async function installHooks(): Promise<void> {
       return !e.hooks.some((h) => h.type === "command" && h.command && isBandHook(h.command));
     });
 
-    // Add fresh band hook
+    // Add fresh band hook (quote path for Windows paths that may contain spaces)
     filtered.push({
-      hooks: [{ type: "command", command: `${bandPath} notify` }],
+      hooks: [{ type: "command", command: `"${bandPath}" notify` }],
     });
 
     hooks[event] = filtered;

--- a/apps/web/src/lib/hooks.ts
+++ b/apps/web/src/lib/hooks.ts
@@ -1,6 +1,7 @@
-import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { dirname, join } from "node:path";
+import { cliInstallPath } from "./platform";
 import { whichBinary } from "./process-utils";
 
 const HOOK_EVENTS = ["UserPromptSubmit", "PostToolUse", "Stop"];
@@ -60,13 +61,11 @@ export async function checkHooks(): Promise<{
 }
 
 export async function installHooks(): Promise<void> {
-  // Find band binary
+  // Find band binary — check platform-specific install path first, then PATH
   let bandPath: string | null = null;
-  try {
-    const stat = await import("node:fs/promises").then((m) => m.stat("/usr/local/bin/band"));
-    if (stat) bandPath = "/usr/local/bin/band";
-  } catch {
-    // Try which
+  const platformPath = cliInstallPath();
+  if (existsSync(platformPath)) {
+    bandPath = platformPath;
   }
   if (!bandPath) {
     bandPath = await whichBinary("band");

--- a/apps/web/src/lib/platform.ts
+++ b/apps/web/src/lib/platform.ts
@@ -1,0 +1,130 @@
+/**
+ * Central platform utilities for cross-platform compatibility.
+ * All platform-specific logic should go through these helpers.
+ */
+
+export const isWindows = process.platform === "win32";
+
+/**
+ * The platform's null device path.
+ * - Unix: /dev/null
+ * - Windows: NUL
+ */
+export const nullDevice = isWindows ? "NUL" : "/dev/null";
+
+/**
+ * Returns the default shell for the current platform.
+ * - Unix: $SHELL or /bin/zsh
+ * - Windows: $COMSPEC or cmd.exe
+ */
+export function defaultShell(): string {
+  if (isWindows) {
+    return process.env.COMSPEC || "cmd.exe";
+  }
+  return process.env.SHELL || "/bin/zsh";
+}
+
+/**
+ * Returns the arguments needed to execute a command string in the platform shell.
+ * - Unix: ["-c", command]
+ * - Windows cmd.exe: ["/c", command]
+ * - Windows PowerShell: ["-Command", command]
+ */
+export function shellExecArgs(command: string): [string, string[]] {
+  if (isWindows) {
+    const shell = defaultShell();
+    if (shell.toLowerCase().includes("powershell") || shell.toLowerCase().includes("pwsh")) {
+      return [shell, ["-Command", command]];
+    }
+    return [shell, ["/c", command]];
+  }
+  const shell = defaultShell();
+  return [shell, ["-c", command]];
+}
+
+/**
+ * Returns the shell arguments for an interactive login shell PATH probe.
+ * - Unix: ["-li", "-c", "echo $PATH"]
+ * - Windows: not needed (PATH is already available in the environment)
+ */
+export function shellPathProbeArgs(): [string, string[]] | null {
+  if (isWindows) {
+    // Windows doesn't need a login shell to resolve PATH
+    return null;
+  }
+  const shell = defaultShell();
+  return [shell, ["-li", "-c", "echo $PATH"]];
+}
+
+/**
+ * Extra directories to prepend to PATH on Unix to pick up Homebrew, etc.
+ * Returns empty array on Windows where these paths don't exist.
+ */
+export function extraPathDirs(): string[] {
+  if (isWindows) {
+    return [];
+  }
+  return ["/opt/homebrew/bin", "/usr/local/bin"];
+}
+
+/**
+ * Build an enriched PATH string by prepending platform-specific directories.
+ */
+export function enrichPath(basePath?: string): string {
+  const dirs = extraPathDirs();
+  const base = basePath || process.env.PATH || "";
+  if (dirs.length === 0) return base;
+  return [...dirs, base].join(pathSeparator);
+}
+
+/**
+ * Build an enriched env object with platform-specific PATH.
+ */
+export function enrichedEnv(base?: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
+  const env = { ...(base || process.env) };
+  if (env.PATH) {
+    env.PATH = enrichPath(env.PATH);
+  }
+  return env;
+}
+
+/**
+ * The name of the "which" command for finding binaries.
+ * - Unix: "which"
+ * - Windows: "where"
+ */
+export const whichCommand = isWindows ? "where" : "which";
+
+/**
+ * The default CLI install path.
+ * - Unix: /usr/local/bin/band
+ * - Windows: %LOCALAPPDATA%\Band\band.exe (user-writable, no admin needed)
+ */
+export function cliInstallDir(): string {
+  if (isWindows) {
+    return `${process.env.LOCALAPPDATA || "C:\\Users\\Default\\AppData\\Local"}\\Band`;
+  }
+  return "/usr/local/bin";
+}
+
+/**
+ * The full path to the installed CLI binary.
+ */
+export function cliInstallPath(): string {
+  if (isWindows) {
+    return `${cliInstallDir()}\\band.exe`;
+  }
+  return "/usr/local/bin/band";
+}
+
+/**
+ * The binary extension for executables on the current platform.
+ */
+export const executableExtension = isWindows ? ".exe" : "";
+
+/**
+ * PATH separator for the current platform.
+ * - Unix: ":"
+ * - Windows: ";"
+ */
+export const pathSeparator = isWindows ? ";" : ":";

--- a/apps/web/src/lib/process-utils.ts
+++ b/apps/web/src/lib/process-utils.ts
@@ -1,30 +1,35 @@
 import { execFile } from "node:child_process";
 
+import { enrichPath, shellPathProbeArgs, whichCommand } from "./platform";
+
 let cachedShellPath: string | null = null;
 
 export async function shellPath(): Promise<string> {
   if (cachedShellPath) return cachedShellPath;
 
-  const shell = process.env.SHELL || "/bin/zsh";
-  try {
-    const result = await new Promise<string>((resolve, reject) => {
-      execFile(shell, ["-li", "-c", "echo $PATH"], { timeout: 5000 }, (err, stdout) => {
-        if (err) {
-          reject(err);
-          return;
-        }
-        resolve(stdout.trim());
+  const probeArgs = shellPathProbeArgs();
+  if (probeArgs) {
+    const [shell, args] = probeArgs;
+    try {
+      const result = await new Promise<string>((resolve, reject) => {
+        execFile(shell, args, { timeout: 5000 }, (err, stdout) => {
+          if (err) {
+            reject(err);
+            return;
+          }
+          resolve(stdout.trim());
+        });
       });
-    });
-    if (result) {
-      cachedShellPath = result;
-      return result;
+      if (result) {
+        cachedShellPath = result;
+        return result;
+      }
+    } catch {
+      // Fall through to default
     }
-  } catch {
-    // Fall through to default
   }
 
-  const fallback = `/opt/homebrew/bin:/usr/local/bin:${process.env.PATH || ""}`;
+  const fallback = enrichPath();
   cachedShellPath = fallback;
   return fallback;
 }
@@ -33,15 +38,22 @@ export async function whichBinary(name: string): Promise<string | null> {
   const resolvedPath = await shellPath();
   try {
     const result = await new Promise<string>((resolve, reject) => {
-      execFile("which", [name], { env: { ...process.env, PATH: resolvedPath } }, (err, stdout) => {
-        if (err) {
-          reject(err);
-          return;
-        }
-        resolve(stdout.trim());
-      });
+      execFile(
+        whichCommand,
+        [name],
+        { env: { ...process.env, PATH: resolvedPath } },
+        (err, stdout) => {
+          if (err) {
+            reject(err);
+            return;
+          }
+          resolve(stdout.trim());
+        },
+      );
     });
-    return result || null;
+    // On Windows, `where` may return multiple lines — take the first
+    const firstLine = result.split("\n")[0]?.trim() || null;
+    return firstLine || null;
   } catch {
     return null;
   }

--- a/apps/web/src/lib/setup-runner.ts
+++ b/apps/web/src/lib/setup-runner.ts
@@ -1,6 +1,7 @@
 import { type ChildProcess, spawn } from "node:child_process";
 import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
+import { enrichPath, shellExecArgs } from "./platform";
 import { emit } from "./watcher";
 
 interface SetupInfo {
@@ -39,11 +40,12 @@ export function runSetup(workspaceId: string, worktreePath: string, onComplete?:
     return;
   }
 
-  const child = spawn("bash", ["-c", setupCommand], {
+  const [shell, args] = shellExecArgs(setupCommand);
+  const child = spawn(shell, args, {
     cwd: worktreePath,
     env: {
       ...process.env,
-      PATH: `/opt/homebrew/bin:/usr/local/bin:${process.env.PATH}`,
+      PATH: enrichPath(),
     },
     stdio: ["ignore", "pipe", "pipe"],
   });

--- a/apps/web/src/lib/terminal-manager.ts
+++ b/apps/web/src/lib/terminal-manager.ts
@@ -1,6 +1,7 @@
 import { existsSync } from "node:fs";
 import { createLogger } from "@band/logger";
 import type { IPty } from "node-pty";
+import { defaultShell, isWindows } from "./platform";
 import { shellPath } from "./process-utils";
 import { resolveWorkspace } from "./workspace";
 
@@ -29,7 +30,7 @@ export async function getOrSpawnTerminal(workspaceId: string): Promise<TerminalS
     throw new Error(`Workspace not found: ${workspaceId}`);
   }
 
-  const shell = process.env.SHELL || "/bin/zsh";
+  const shell = defaultShell();
   const resolvedPath = await shellPath();
 
   // Filter env to only string values — posix_spawnp fails on undefined/null
@@ -40,13 +41,16 @@ export async function getOrSpawnTerminal(workspaceId: string): Promise<TerminalS
     }
   }
   env.PATH = resolvedPath;
-  env.TERM = "xterm-256color";
+  if (!isWindows) {
+    env.TERM = "xterm-256color";
+  }
 
   const cwd = workspace.worktree.path;
   if (!existsSync(cwd)) {
     throw new Error(`Workspace directory does not exist: ${cwd}`);
   }
-  if (!existsSync(shell)) {
+  // On Windows, shell may be "cmd.exe" (resolved via PATH, not an absolute path)
+  if (!isWindows && !existsSync(shell)) {
     throw new Error(`Shell not found: ${shell}`);
   }
 

--- a/apps/web/src/lib/tunnel.ts
+++ b/apps/web/src/lib/tunnel.ts
@@ -1,6 +1,7 @@
 import { type ChildProcess, spawn } from "node:child_process";
 import { createLogger } from "@band/logger";
 import { getToken } from "./auth-token";
+import { nullDevice } from "./platform";
 import { shellPath } from "./process-utils";
 import { emit } from "./watcher";
 
@@ -30,7 +31,7 @@ function appendToken(baseUrl: string, token: string): string {
 }
 
 function spawnTunnel(options: { port: number }, resolvedPath: string): Promise<void> {
-  const args = ["tunnel", "--config", "/dev/null", "--url", `http://localhost:${options.port}`];
+  const args = ["tunnel", "--config", nullDevice, "--url", `http://localhost:${options.port}`];
 
   log.debug("spawning cloudflared %s", args.join(" "));
 

--- a/apps/web/src/trpc/router.ts
+++ b/apps/web/src/trpc/router.ts
@@ -400,7 +400,10 @@ const workspacesRouter = t.router({
         throw new Error(`Script "${input.scriptType}" not found`);
       }
 
-      const [shell, args] = shellExecArgs(scriptPath);
+      // On Unix, run via bash (reads the file); on Windows, run via the shell's exec flag.
+      const [shell, args]: [string, string[]] = isWindows
+        ? shellExecArgs(scriptPath)
+        : ["bash", [scriptPath]];
       return new Promise<{ ok: true }>((resolve, reject) => {
         execFile(shell, args, { cwd: input.path }, (err) => {
           if (err) {

--- a/apps/web/src/trpc/router.ts
+++ b/apps/web/src/trpc/router.ts
@@ -28,6 +28,7 @@ import type { CronjobDefinition } from "../lib/cronjob-types";
 import { execGit, gitCmd, listWorktrees } from "../lib/git";
 import { checkHooks, installHooks } from "../lib/hooks";
 import { resolvePendingInput } from "../lib/pending-inputs";
+import { enrichedEnv, enrichPath, isWindows, nullDevice, shellExecArgs } from "../lib/platform";
 import { checkPrereqs, shellPath } from "../lib/process-utils";
 import { runSetup } from "../lib/setup-runner";
 import {
@@ -122,10 +123,7 @@ const projectsRouter = t.router({
 
       let defaultBranch = "main";
       try {
-        const env = { ...process.env };
-        if (env.PATH) {
-          env.PATH = `/opt/homebrew/bin:/usr/local/bin:${env.PATH}`;
-        }
+        const env = enrichedEnv();
         const output = execFileSync("git", ["symbolic-ref", "--short", "HEAD"], {
           cwd: input.path,
           env,
@@ -304,11 +302,12 @@ const workspacesRouter = t.router({
               if (existsSync(configPath)) {
                 const config = JSON.parse(readFileSync(configPath, "utf-8"));
                 if (config.teardown) {
-                  execFileSync("bash", ["-c", config.teardown], {
+                  const [teardownShell, teardownArgs] = shellExecArgs(config.teardown);
+                  execFileSync(teardownShell, teardownArgs, {
                     cwd: worktreePath,
                     env: {
                       ...process.env,
-                      PATH: `/opt/homebrew/bin:/usr/local/bin:${process.env.PATH}`,
+                      PATH: enrichPath(),
                     },
                     encoding: "utf-8",
                     timeout: 60_000,
@@ -401,8 +400,9 @@ const workspacesRouter = t.router({
         throw new Error(`Script "${input.scriptType}" not found`);
       }
 
+      const [shell, args] = shellExecArgs(scriptPath);
       return new Promise<{ ok: true }>((resolve, reject) => {
-        execFile("bash", [scriptPath], { cwd: input.path }, (err) => {
+        execFile(shell, args, { cwd: input.path }, (err) => {
           if (err) {
             reject(new Error(err.message));
           } else {
@@ -526,7 +526,7 @@ const workspaceRouter = t.router({
     try {
       mergeBase = (await execGit(["merge-base", defaultBranch, "HEAD"], cwd)).trim();
     } catch {
-      mergeBase = (await execGit(["hash-object", "-t", "tree", "/dev/null"], cwd)).trim();
+      mergeBase = (await execGit(["hash-object", "-t", "tree", nullDevice], cwd)).trim();
     }
 
     let diff = await execGit(["diff", mergeBase], cwd);
@@ -610,7 +610,7 @@ const workspaceRouter = t.router({
       try {
         mergeBase = (await execGit(["merge-base", defaultBranch, "HEAD"], cwd)).trim();
       } catch {
-        mergeBase = (await execGit(["hash-object", "-t", "tree", "/dev/null"], cwd)).trim();
+        mergeBase = (await execGit(["hash-object", "-t", "tree", nullDevice], cwd)).trim();
       }
 
       const statOutput = await execGit(["diff", "--stat", mergeBase], cwd);
@@ -903,10 +903,13 @@ const prereqsRouter = t.router({
 
   installTunnel: publicProcedure.mutation(async () => {
     const resolvedPath = await shellPath();
+    const [cmd, args]: [string, string[]] = isWindows
+      ? ["winget", ["install", "--id", "Cloudflare.cloudflared", "--accept-source-agreements"]]
+      : ["brew", ["install", "cloudflared"]];
     await new Promise<void>((resolve, reject) => {
       execFile(
-        "brew",
-        ["install", "cloudflared"],
+        cmd,
+        args,
         { env: { ...process.env, PATH: resolvedPath }, timeout: 120_000 },
         (err, _stdout, stderr) => {
           if (err) {

--- a/packages/dashboard-core/src/hooks/use-cli-setup.ts
+++ b/packages/dashboard-core/src/hooks/use-cli-setup.ts
@@ -41,13 +41,17 @@ export function useCliSetup() {
           case "DirNotFound":
             setState({
               status: "manual",
-              reason: "/usr/local/bin does not exist",
+              reason: navigator.platform?.startsWith("Win")
+                ? "%LOCALAPPDATA%\\Band does not exist"
+                : "/usr/local/bin does not exist",
             });
             break;
           case "NotWritable":
             setState({
               status: "manual",
-              reason: "/usr/local/bin is not writable",
+              reason: navigator.platform?.startsWith("Win")
+                ? "%LOCALAPPDATA%\\Band is not writable"
+                : "/usr/local/bin is not writable",
             });
             break;
         }

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -38,5 +38,16 @@ export interface DashboardState {
 
 export const BAND_DIR = ".band";
 export const STATUS_DIR = "status";
-export const BAND_HOME = "~/.band";
+
+/**
+ * Display-friendly BAND_HOME path.
+ * On Windows, Band data lives under %USERPROFILE%\.band.
+ * On Unix, it lives under ~/.band.
+ * Actual path resolution is done by the web server's state.ts using os.homedir().
+ */
+export const BAND_HOME =
+  typeof navigator !== "undefined" && navigator.platform?.startsWith("Win")
+    ? "%USERPROFILE%\\.band"
+    : "~/.band";
+
 export const STATUS_HOME = `${BAND_HOME}/${STATUS_DIR}`;


### PR DESCRIPTION
## Summary

Enables Band to build and run on Windows through the Node.js web server, CLI, and Tauri desktop app.

### Phase 1 — Node.js Web Server + CLI
- Create `platform.ts` central abstraction (shell, PATH, null device, install paths)
- Fix all shell/PATH hardcoding in process-utils, git, terminal-manager, setup-runner, tunnel, cli, hooks, and router to use platform helpers
- Replace `bash` invocations with cross-platform `shellExecArgs()`
- Replace `/dev/null` with `nullDevice` constant
- Replace Homebrew PATH with `enrichPath()`/`enrichedEnv()`
- Add Windows CLI install via file copy to `%LOCALAPPDATA%\Band`
- Add `band.cmd` Windows wrapper script
- Replace `build-server.sh` with cross-platform `build-server.mjs`
- Fix pnpm postinstall to skip `chmod` on Windows
- Quote band CLI path in hook commands for Windows paths with spaces

### Phase 2 — Tauri Desktop App
- Add Windows process management (`CREATE_NEW_PROCESS_GROUP` + `taskkill /T`)
- Add Windows NSIS web directory resolution
- Add Windows port killing via `netstat` + `taskkill`
- Add Windows folder picker (PowerShell `FolderBrowserDialog`)
- Add Windows `reveal_in_finder` (`explorer.exe`)
- Gate macOS Cocoa/Accessibility code with `cfg(target_os)`
- Add NSIS installer target and configuration
- Conditional Cargo dependencies (unix/macos only)

### Phase 3 — Shared + Dashboard Core
- Windows-aware `BAND_HOME` display path
- Windows-aware CLI setup error messages

### Phase 4 — CI/Build Pipeline
- Add `check-windows` job to CI (Windows build, clippy, tests)
- Add Windows matrix build to release workflow (NSIS installer)
- Replace `pnpm build:cli` with cross-platform bash commands in release workflow
- Add `notify.ps1` PowerShell hook script for Claude Code on Windows

Closes #150

## Test plan
- [x] TypeScript compilation (`pnpm build:web`) succeeds
- [x] Rust compilation and clippy pass for both CLI and dashboard crates
- [x] Biome lint + cargo fmt checks pass
- [x] All 212 web tests pass
- [x] All 9 dashboard Rust tests pass
- [x] 76/77 CLI Rust tests pass (1 pre-existing failure on main)
- [ ] Windows CI job verifies cross-compilation and Windows-specific builds

🤖 Generated with [Claude Code](https://claude.com/claude-code)