### PR TITLE
feat: validate git repo when adding project and offer git init

### DIFF
--- a/apps/web/src/trpc/router.ts
+++ b/apps/web/src/trpc/router.ts
@@ -110,20 +110,16 @@ const projectsRouter = t.router({
     return { projects, labels: settings.labels ?? [] };
   }),
 
-  checkPath: publicProcedure
-    .input(z.object({ path: z.string() }))
-    .query(({ input }) => {
-      const resolvedPath = resolve(input.path);
-      const isGitRepo = existsSync(join(resolvedPath, ".git"));
-      return { isGitRepo };
-    }),
+  checkPath: publicProcedure.input(z.object({ path: z.string() })).query(({ input }) => {
+    const resolvedPath = resolve(input.path);
+    const isGitRepo = existsSync(join(resolvedPath, ".git"));
+    return { isGitRepo };
+  }),
 
-  gitInit: publicProcedure
-    .input(z.object({ path: z.string() }))
-    .mutation(async ({ input }) => {
-      const resolvedPath = resolve(input.path);
-      await execGit(["init"], resolvedPath);
-    }),
+  gitInit: publicProcedure.input(z.object({ path: z.string() })).mutation(async ({ input }) => {
+    const resolvedPath = resolve(input.path);
+    await execGit(["init"], resolvedPath);
+  }),
 
   add: publicProcedure
     .input(z.object({ path: z.string(), label: z.string().optional() }))

--- a/apps/web/src/trpc/router.ts
+++ b/apps/web/src/trpc/router.ts
@@ -110,6 +110,21 @@ const projectsRouter = t.router({
     return { projects, labels: settings.labels ?? [] };
   }),
 
+  checkPath: publicProcedure
+    .input(z.object({ path: z.string() }))
+    .query(({ input }) => {
+      const resolvedPath = resolve(input.path);
+      const isGitRepo = existsSync(join(resolvedPath, ".git"));
+      return { isGitRepo };
+    }),
+
+  gitInit: publicProcedure
+    .input(z.object({ path: z.string() }))
+    .mutation(async ({ input }) => {
+      const resolvedPath = resolve(input.path);
+      await execGit(["init"], resolvedPath);
+    }),
+
   add: publicProcedure
     .input(z.object({ path: z.string(), label: z.string().optional() }))
     .mutation(async ({ input }) => {

--- a/apps/web/tests/trpc.test.ts
+++ b/apps/web/tests/trpc.test.ts
@@ -305,6 +305,69 @@ describe("tRPC — projects CRUD", () => {
 });
 
 // ---------------------------------------------------------------------------
+// Git init project validation
+// ---------------------------------------------------------------------------
+
+describe("tRPC — git init project validation", () => {
+  let server: ServerHandle;
+  let tmpHome: string;
+  let gitRepoPath: string;
+  let plainDirPath: string;
+
+  beforeAll(async () => {
+    tmpHome = createTmpHome();
+    gitRepoPath = createGitRepo(tmpHome, "existing-repo");
+
+    // Create a plain directory (not a git repo)
+    plainDirPath = join(tmpHome, "plain-dir");
+    mkdirSync(plainDirPath, { recursive: true });
+
+    seedState(tmpHome, { projects: [] });
+    seedSettings(tmpHome, { tokenSecret: DEFAULT_TOKEN });
+    server = await startServer({ tmpHome });
+  });
+
+  afterAll(async () => {
+    await server.close();
+    rmSync(tmpHome, { recursive: true, force: true });
+  });
+
+  it("projects.checkPath returns isGitRepo true for a git repo", async () => {
+    const res = await trpcQuery(server.url, "projects.checkPath", { path: gitRepoPath });
+    expect(res.status).toBe(200);
+    const data = await trpcData<{ isGitRepo: boolean }>(res);
+    expect(data.isGitRepo).toBe(true);
+  });
+
+  it("projects.checkPath returns isGitRepo false for a plain directory", async () => {
+    const res = await trpcQuery(server.url, "projects.checkPath", { path: plainDirPath });
+    expect(res.status).toBe(200);
+    const data = await trpcData<{ isGitRepo: boolean }>(res);
+    expect(data.isGitRepo).toBe(false);
+  });
+
+  it("projects.gitInit initializes a git repo in a plain directory", async () => {
+    const res = await trpcMutate(server.url, "projects.gitInit", { path: plainDirPath });
+    expect(res.status).toBe(200);
+  });
+
+  it("projects.checkPath returns isGitRepo true after gitInit", async () => {
+    const res = await trpcQuery(server.url, "projects.checkPath", { path: plainDirPath });
+    expect(res.status).toBe(200);
+    const data = await trpcData<{ isGitRepo: boolean }>(res);
+    expect(data.isGitRepo).toBe(true);
+  });
+
+  it("projects.add succeeds after gitInit on a previously plain directory", async () => {
+    const res = await trpcMutate(server.url, "projects.add", { path: plainDirPath });
+    expect(res.status).toBe(200);
+    const data = await trpcData<{ name: string; path: string; defaultBranch: string }>(res);
+    expect(data.name).toBe("plain-dir");
+    expect(data.path).toBe(plainDirPath);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Settings CRUD
 // ---------------------------------------------------------------------------
 

--- a/packages/dashboard-core/src/adapter.ts
+++ b/packages/dashboard-core/src/adapter.ts
@@ -23,6 +23,8 @@ export interface DashboardAdapter {
   removeProject(name: string): Promise<void>;
   reorderProjects(names: string[]): Promise<void>;
   updateProjectLabel(name: string, label: string | null): Promise<void>;
+  checkPath(path: string): Promise<{ isGitRepo: boolean }>;
+  gitInit(path: string): Promise<void>;
 
   // Workspaces
   createWorkspace(project: string, branch: string, base?: string, prompt?: string): Promise<void>;

--- a/packages/dashboard-core/src/adapters/web.ts
+++ b/packages/dashboard-core/src/adapters/web.ts
@@ -59,6 +59,14 @@ export class WebDashboardAdapter implements DashboardAdapter {
     await this.trpc.projects.updateLabel.mutate({ name, label });
   }
 
+  async checkPath(path: string): Promise<{ isGitRepo: boolean }> {
+    return await this.trpc.projects.checkPath.query({ path });
+  }
+
+  async gitInit(path: string): Promise<void> {
+    await this.trpc.projects.gitInit.mutate({ path });
+  }
+
   async createWorkspace(
     project: string,
     branch: string,

--- a/packages/dashboard-core/src/components/AddProjectDialog.tsx
+++ b/packages/dashboard-core/src/components/AddProjectDialog.tsx
@@ -9,10 +9,10 @@ import {
   Input,
   Label,
 } from "@band/ui";
-import { FolderOpen } from "lucide-react";
+import { AlertTriangle, FolderOpen } from "lucide-react";
 import { useState } from "react";
-import { useCapabilities } from "../context";
-import { useAddProject } from "../hooks/use-project-mutations";
+import { useAdapter, useCapabilities } from "../context";
+import { useAddProject, useGitInit } from "../hooks/use-project-mutations";
 
 interface Props {
   open: boolean;
@@ -22,29 +22,87 @@ interface Props {
 
 export function AddProjectDialog({ open, onOpenChange, defaultLabel }: Props) {
   const [path, setPath] = useState("");
+  const [needsGitInit, setNeedsGitInit] = useState(false);
+  const [isChecking, setIsChecking] = useState(false);
   const addProjectMutation = useAddProject();
+  const gitInitMutation = useGitInit();
+  const adapter = useAdapter();
   const capabilities = useCapabilities();
+
+  const resetAndClose = () => {
+    setPath("");
+    setNeedsGitInit(false);
+    setIsChecking(false);
+    onOpenChange(false);
+  };
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     if (!path.trim()) return;
-    await addProjectMutation.mutateAsync({ path: path.trim(), label: defaultLabel ?? undefined });
-    setPath("");
-    onOpenChange(false);
+
+    const trimmedPath = path.trim();
+
+    if (needsGitInit) {
+      await gitInitMutation.mutateAsync(trimmedPath);
+      await addProjectMutation.mutateAsync({
+        path: trimmedPath,
+        label: defaultLabel ?? undefined,
+      });
+      resetAndClose();
+      return;
+    }
+
+    setIsChecking(true);
+    try {
+      const { isGitRepo } = await adapter.checkPath(trimmedPath);
+      if (!isGitRepo) {
+        setNeedsGitInit(true);
+        setIsChecking(false);
+        return;
+      }
+    } catch {
+      // If check fails, proceed anyway — add will fail with a clear error
+    }
+    setIsChecking(false);
+
+    await addProjectMutation.mutateAsync({
+      path: trimmedPath,
+      label: defaultLabel ?? undefined,
+    });
+    resetAndClose();
+  };
+
+  const handleOpenChange = (open: boolean) => {
+    if (!open) {
+      setPath("");
+      setNeedsGitInit(false);
+      setIsChecking(false);
+    }
+    onOpenChange(open);
+  };
+
+  const handlePathChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setPath(e.target.value);
+    setNeedsGitInit(false);
   };
 
   const handleBrowse = async () => {
     if (!capabilities.pickFolder) return;
     try {
       const selected = await capabilities.pickFolder();
-      if (selected) setPath(selected);
+      if (selected) {
+        setPath(selected);
+        setNeedsGitInit(false);
+      }
     } catch {
       // Dialog cancelled
     }
   };
 
+  const isBusy = isChecking || addProjectMutation.isPending || gitInitMutation.isPending;
+
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
+    <Dialog open={open} onOpenChange={handleOpenChange}>
       <DialogContent className="sm:max-w-[425px]">
         <form onSubmit={handleSubmit}>
           <DialogHeader>
@@ -58,7 +116,7 @@ export function AddProjectDialog({ open, onOpenChange, defaultLabel }: Props) {
                 id="project-path"
                 placeholder="Path to git repository"
                 value={path}
-                onChange={(e: React.ChangeEvent<HTMLInputElement>) => setPath(e.target.value)}
+                onChange={handlePathChange}
                 autoFocus
               />
               {capabilities.pickFolder && (
@@ -67,12 +125,24 @@ export function AddProjectDialog({ open, onOpenChange, defaultLabel }: Props) {
                 </Button>
               )}
             </div>
+            {needsGitInit && (
+              <div className="flex items-start gap-2 rounded-md border border-yellow-500/30 bg-yellow-500/10 p-3 text-sm">
+                <AlertTriangle className="size-4 shrink-0 text-yellow-500 mt-0.5" />
+                <span>
+                  This folder is not a git repository. Initialize it with{" "}
+                  <code className="rounded bg-muted px-1 py-0.5 font-mono text-xs">git init</code>
+                  ?
+                </span>
+              </div>
+            )}
           </div>
           <DialogFooter>
-            <Button type="button" variant="ghost" onClick={() => onOpenChange(false)}>
+            <Button type="button" variant="ghost" onClick={resetAndClose}>
               Cancel
             </Button>
-            <Button type="submit">Add Project</Button>
+            <Button type="submit" disabled={isBusy}>
+              {needsGitInit ? "Initialize & Add" : "Add Project"}
+            </Button>
           </DialogFooter>
         </form>
       </DialogContent>

--- a/packages/dashboard-core/src/components/AddProjectDialog.tsx
+++ b/packages/dashboard-core/src/components/AddProjectDialog.tsx
@@ -130,8 +130,7 @@ export function AddProjectDialog({ open, onOpenChange, defaultLabel }: Props) {
                 <AlertTriangle className="size-4 shrink-0 text-yellow-500 mt-0.5" />
                 <span>
                   This folder is not a git repository. Initialize it with{" "}
-                  <code className="rounded bg-muted px-1 py-0.5 font-mono text-xs">git init</code>
-                  ?
+                  <code className="rounded bg-muted px-1 py-0.5 font-mono text-xs">git init</code>?
                 </span>
               </div>
             )}

--- a/packages/dashboard-core/src/hooks/use-project-mutations.ts
+++ b/packages/dashboard-core/src/hooks/use-project-mutations.ts
@@ -85,6 +85,18 @@ export function useUpdateProjectLabel() {
   });
 }
 
+export function useGitInit() {
+  const adapter = useAdapter();
+  const setError = useDashboardStore((s) => s.setError);
+
+  return useMutation({
+    mutationFn: (path: string) => adapter.gitInit(path),
+    onError: (err) => {
+      setError(String(err));
+    },
+  });
+}
+
 export function useCreateWorkspace() {
   const adapter = useAdapter();
   const queryClient = useQueryClient();


### PR DESCRIPTION
## Summary

- When adding a project, checks if the folder is a git repository before proceeding
- If not a git repo, shows an inline warning asking the user if they want to run `git init`
- If confirmed, initializes the repo and adds the project; if cancelled, aborts
- Adds `checkPath` query and `gitInit` mutation to the backend tRPC router
- Updates the `DashboardAdapter` interface and `WebDashboardAdapter` with the new methods
- Implements a two-phase submit flow in `AddProjectDialog` with a yellow warning banner

## Test plan

- [x] Integration tests for `projects.checkPath` (git repo returns true, plain dir returns false)
- [x] Integration test for `projects.gitInit` (initializes repo in plain directory)
- [x] Integration test for full flow: gitInit → checkPath → add project
- [ ] Manual: open dashboard, click "+", enter a non-git folder, see warning, click "Initialize & Add", verify project appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)