### PR TITLE
fix: preserve scroll position when selecting a workspace

### DIFF
--- a/packages/dashboard-core/src/components/DashboardShell.tsx
+++ b/packages/dashboard-core/src/components/DashboardShell.tsx
@@ -195,11 +195,11 @@ export function DashboardShell({ toolbarExtra }: DashboardShellProps) {
             className="flex-1 overflow-hidden"
             onClick={(e: React.MouseEvent<HTMLDivElement>) => {
               const target = e.target as HTMLElement;
-              if (target.closest("button, a, input, select, textarea")) return;
+              if (target.closest("button, a, input, select, textarea, [tabindex]")) return;
               const list = (e.currentTarget as HTMLElement).querySelector<HTMLElement>(
-                '[tabindex="0"]',
+                '[tabindex="-1"]',
               );
-              list?.focus();
+              list?.focus({ preventScroll: true });
             }}
           >
             <main className="px-2 py-2 overflow-hidden">

--- a/packages/dashboard-core/src/components/ProjectList.tsx
+++ b/packages/dashboard-core/src/components/ProjectList.tsx
@@ -360,7 +360,7 @@ export function ProjectList({ labelFilter, editMode }: ProjectListProps) {
   const hasProjects = projects.length > 0;
   useEffect(() => {
     if (hasProjects) {
-      containerRef.current?.focus();
+      containerRef.current?.focus({ preventScroll: true });
     }
   }, [hasProjects]);
 
@@ -397,13 +397,13 @@ export function ProjectList({ labelFilter, editMode }: ProjectListProps) {
       setFocusedIndex((prev) => (prev < allWorkspaceIds.length - 1 ? prev + 1 : prev));
       // Keep DOM focus on the container so Enter fires here, not on a child card.
       // See block comment above — removing this breaks keyboard Enter navigation.
-      containerRef.current?.focus();
+      containerRef.current?.focus({ preventScroll: true });
     } else if (e.key === "ArrowUp") {
       e.preventDefault();
       keyboardNavRef.current = true;
       setFocusedIndex((prev) => (prev > 0 ? prev - 1 : prev));
       // Keep DOM focus on the container — same reasoning as ArrowDown above.
-      containerRef.current?.focus();
+      containerRef.current?.focus({ preventScroll: true });
     } else if (e.key === "Enter") {
       e.preventDefault();
       if (focusedIndex >= 0 && focusedIndex < allWorkspaceIds.length) {

--- a/packages/dashboard-core/src/components/WorkspaceCard.tsx
+++ b/packages/dashboard-core/src/components/WorkspaceCard.tsx
@@ -17,7 +17,7 @@ import {
   Square,
   Trash2,
 } from "lucide-react";
-import { useEffect, useRef } from "react";
+import { memo, useEffect, useRef } from "react";
 import { useCapabilities } from "../context";
 import { useRemoveWorkspace } from "../hooks/use-project-mutations";
 import { toWorkspaceId } from "../lib/workspace-id";
@@ -46,7 +46,7 @@ interface Props {
   editMode?: boolean;
 }
 
-export function WorkspaceCard({
+export const WorkspaceCard = memo(function WorkspaceCard({
   worktree,
   projectName,
   defaultBranch,
@@ -70,11 +70,10 @@ export function WorkspaceCard({
   const runScript = useDashboardStore((s) => s.runScript);
   const gitPull = useDashboardStore((s) => s.gitPull);
   const gitPush = useDashboardStore((s) => s.gitPush);
-  const activeWorkspaceId = useDashboardStore((s) => s.activeWorkspaceId);
   const removeWorkspaceMutation = useRemoveWorkspace();
 
   const workspaceId = toWorkspaceId(projectName, worktree.branch);
-  const isActive = activeWorkspaceId === workspaceId;
+  const isActive = useDashboardStore((s) => s.activeWorkspaceId === workspaceId);
   const href = capabilities.getWorkspaceHref?.(workspaceId);
 
   const handleClick = () => {
@@ -91,7 +90,10 @@ export function WorkspaceCard({
     ref: cardRef,
     className,
     tabIndex: 0,
-    onClick: handleClick,
+    onClick: (e: React.MouseEvent) => {
+      e.stopPropagation();
+      handleClick();
+    },
     onKeyDown: (e: React.KeyboardEvent) => {
       if (e.key === "Enter" || e.key === " ") {
         e.stopPropagation();
@@ -191,4 +193,4 @@ export function WorkspaceCard({
       </ContextMenuContent>
     </ContextMenu>
   );
-}
+});


### PR DESCRIPTION
## Summary

- Fix scroll jumping to top when clicking a workspace in the project list
- The ScrollArea's onClick handler was calling `focus()` on the first WorkspaceCard (found via `querySelector('[tabindex="0"]')`), causing the browser to scroll the viewport to that element
- Stop click propagation from WorkspaceCard, harden the ScrollArea handler to skip focusable elements and use `preventScroll`, and add `preventScroll` to all programmatic focus calls in keyboard navigation
- Optimise re-renders: derive `isActive` as a boolean Zustand selector (only 2 cards re-render on selection instead of all) and wrap WorkspaceCard with `React.memo`

## Test plan

- [ ] Scroll down in the project list, click a workspace → scroll position stays the same
- [ ] Arrow key navigation still works without scroll jumps
- [ ] Clicking empty space in the scroll area still enables keyboard navigation
- [ ] Context menu (right-click) on workspace cards still works
- [ ] Drag-and-drop reorder still works in edit mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)