### PR TITLE
feat: add `band generate-skills` command

### DIFF
--- a/apps/cli/skills/band-cli.md
+++ b/apps/cli/skills/band-cli.md
@@ -1,0 +1,110 @@
+---
+name: band-cli
+version: 0.1.0
+description: Programmatic workspace management for Band. Use when the user wants to create, list, or remove Band workspaces or projects, manage tasks, manage tunnels, or check settings via the Band CLI.
+allowed-tools: Bash
+argument-hint: [command] [args...]
+---
+
+# Band CLI
+
+Thin client for the Band web server. All state, git operations, and script execution happen server-side.
+
+## Prerequisites
+
+The Band server must be running (started by the Band dashboard app). Connects to `http://localhost:3456` by default.
+
+## JSON Output
+
+All commands support `--output json` (or `BAND_OUTPUT=json` env var) for structured output.
+
+- **Success**: JSON object to stdout, exit code 0
+- **Error**: `{"error": "message"}` to stderr, exit code 1
+
+## Schema Introspection
+
+```sh
+# List all commands with parameters and types
+band schema
+
+# Show a specific command's schema
+band schema "workspaces create"
+```
+
+<!-- COMMANDS -->
+
+## Workflows
+
+### Feature branch workflow
+
+```sh
+# Create workspace, get path
+path=$(band workspaces create my-app feat/login --output json | jq -r .path)
+cd "$path"
+
+# ... do work ...
+
+# Clean up
+band workspaces remove my-app feat/login
+```
+
+### Agent task submission
+
+```sh
+band workspaces create my-app feat/auth --prompt "Add JWT authentication to the API"
+```
+
+### Enumerate workspaces
+
+```sh
+band workspaces list --output json | jq '.workspaces[] | select(.project == "my-app") | .branch'
+```
+
+### Task management
+
+```sh
+# List running tasks
+band tasks list --status running
+
+# Submit a task to a workspace
+band tasks create ws_abc123 --prompt "Fix the failing tests"
+
+# Watch task output
+band tasks watch --workspace ws_abc123
+
+# Cancel a stuck task
+band tasks cancel tsk_1234567890
+
+# Re-run a failed task
+band tasks rerun tsk_1234567890
+```
+
+### Project management
+
+```sh
+# Register a project
+band projects add /Users/me/code/my-app
+
+# List all projects
+band projects list
+
+# Remove a project
+band projects remove my-app
+```
+
+## Invariants
+
+- The CLI never modifies files directly — all operations go through the server API
+- `workspaces create` is idempotent — creating an existing workspace returns its path
+- `setup` scripts run after workspace creation, `teardown` before removal (both non-fatal)
+- Project and branch names must not contain control characters or path traversals (`../`)
+- Exit code 0 = success, 1 = error
+
+## Configuration
+
+| Setting       | Env var           | Default                      |
+| ------------- | ----------------- | ---------------------------- |
+| Server URL    | `BAND_SERVER_URL` | `http://localhost:3456`      |
+| Auth token    | `BAND_TOKEN`      | from `~/.band/settings.json` |
+| Output format | `BAND_OUTPUT`     | `text`                       |
+| Band home dir | `BAND_HOME`       | `~/.band`                    |

--- a/apps/cli/src/main.rs
+++ b/apps/cli/src/main.rs
@@ -1,6 +1,7 @@
 mod api;
 mod render;
 mod shell;
+mod skills;
 mod state;
 mod validate;
 
@@ -54,6 +55,15 @@ enum Commands {
     Schema {
         /// Command name (omit to list all commands)
         command: Option<String>,
+    },
+    /// Generate SKILL.md files from schema and registry
+    GenerateSkills {
+        /// Output directory for generated skills (default: skills/)
+        #[arg(long, default_value = "skills")]
+        output_dir: String,
+        /// Filter skills by name (substring match)
+        #[arg(long)]
+        filter: Option<String>,
     },
 }
 
@@ -234,9 +244,9 @@ enum TunnelCmd {
 
 // --- Output types ---
 
-struct CommandResult {
-    text: String,
-    json: serde_json::Value,
+pub(crate) struct CommandResult {
+    pub(crate) text: String,
+    pub(crate) json: serde_json::Value,
 }
 
 #[allow(clippy::too_many_lines)]
@@ -348,6 +358,9 @@ fn main() {
         },
         Commands::Notify => cmd_notify(),
         Commands::Schema { .. } => unreachable!(),
+        Commands::GenerateSkills { output_dir, filter } => {
+            skills::generate_skills(&output_dir, filter.as_deref())
+        }
     };
 
     match result {
@@ -1321,12 +1334,13 @@ fn format_table<const N: usize>(headers: &[&str; N], rows: &[[String; N]]) -> St
 // --- Schema ---
 
 #[allow(clippy::too_many_lines)]
-fn build_schema(command: Option<&str>) -> Result<serde_json::Value, String> {
+pub(crate) fn build_schema(command: Option<&str>) -> Result<serde_json::Value, String> {
     let commands = vec![
         serde_json::json!({
             "name": "projects list",
             "description": "List registered projects",
-            "parameters": []
+            "parameters": [],
+            "notes": "Text output: `name\\tpath\\tN worktree(s)` (tab-separated).\nJSON output: `{\"projects\": [{\"name\": \"...\", \"path\": \"...\", \"worktreeCount\": N}]}`"
         }),
         serde_json::json!({
             "name": "projects add",
@@ -1334,21 +1348,24 @@ fn build_schema(command: Option<&str>) -> Result<serde_json::Value, String> {
             "parameters": [
                 {"name": "path", "type": "string", "required": true, "positional": true, "description": "Path to the git repository"},
                 {"name": "--label", "type": "string", "required": false, "description": "Label for the project"},
-            ]
+            ],
+            "notes": "Registers an existing git repository. Detects the default branch automatically. Returns the project name."
         }),
         serde_json::json!({
             "name": "projects remove",
             "description": "Unregister a project",
             "parameters": [
                 {"name": "name", "type": "string", "required": true, "positional": true, "description": "Project name"},
-            ]
+            ],
+            "notes": "Removes the project from Band's registry (does not delete the repository)."
         }),
         serde_json::json!({
             "name": "workspaces list",
             "description": "List workspaces, optionally filtered by project",
             "parameters": [
                 {"name": "project", "type": "string", "required": false, "positional": true, "description": "Project name (optional filter)"},
-            ]
+            ],
+            "notes": "Text output: `project\\tbranch\\tpath` (tab-separated, one per line).\nJSON output: `{\"workspaces\": [{\"project\": \"...\", \"branch\": \"...\", \"path\": \"...\"}]}`"
         }),
         serde_json::json!({
             "name": "workspaces create",
@@ -1358,7 +1375,8 @@ fn build_schema(command: Option<&str>) -> Result<serde_json::Value, String> {
                 {"name": "branch", "type": "string", "required": true, "positional": true, "description": "Branch name"},
                 {"name": "--base", "type": "string", "required": false, "description": "Base branch to create from (defaults to project's default branch)"},
                 {"name": "--prompt", "type": "string", "required": false, "description": "Prompt to pass to the coding agent"},
-            ]
+            ],
+            "notes": "Returns the worktree path. Idempotent — creating an existing workspace returns its path. Runs `.band/config.json` `setup` script if present (non-fatal).\n\n**Always use `--prompt` when the user wants work to begin immediately.** This submits a task to the coding agent right after workspace creation, so the agent starts working without a separate step. Only omit `--prompt` when the user explicitly wants to create the workspace for manual/later use.\n\nWhen to use `--prompt` (most cases):\n```sh\n# User says \"create a workspace and implement X\" or \"start working on X\"\nband workspaces create my-app feat/auth --prompt \"Implement GitHub issue #42: Add JWT authentication\"\n\n# User says \"create a workspace for issue #99 and start implementing\"\nband workspaces create my-app fix/bug-99 --prompt \"Fix issue #99: login redirect loop. See https://github.com/org/repo/issues/99\"\n```\n\nWhen to omit `--prompt` (rare — user explicitly wants no task):\n```sh\n# User says \"just create a workspace, I'll work on it myself\"\nband workspaces create my-app feat/experiment\n```\n\n**Do NOT create a workspace without `--prompt` and then separately run `band tasks create`.** That is two steps for what `--prompt` does in one."
         }),
         serde_json::json!({
             "name": "workspaces remove",
@@ -1366,27 +1384,32 @@ fn build_schema(command: Option<&str>) -> Result<serde_json::Value, String> {
             "parameters": [
                 {"name": "project", "type": "string", "required": true, "positional": true, "description": "Project name"},
                 {"name": "branch", "type": "string", "required": true, "positional": true, "description": "Branch name"},
-            ]
+            ],
+            "notes": "Runs `.band/config.json` `teardown` script before removal (non-fatal). Cleans up all associated files."
         }),
         serde_json::json!({
             "name": "settings",
             "description": "Show current settings",
-            "parameters": []
+            "parameters": [],
+            "notes": "Pretty-prints the current settings as JSON. With `--output json`, outputs compact JSON."
         }),
         serde_json::json!({
             "name": "tunnel status",
             "description": "Show tunnel status",
-            "parameters": []
+            "parameters": [],
+            "notes": "Shows whether the tunnel is running and its URL."
         }),
         serde_json::json!({
             "name": "tunnel start",
             "description": "Start the remote tunnel",
-            "parameters": []
+            "parameters": [],
+            "notes": "Starts the remote tunnel. Returns the tunnel URL."
         }),
         serde_json::json!({
             "name": "tunnel stop",
             "description": "Stop the remote tunnel",
-            "parameters": []
+            "parameters": [],
+            "notes": "Stops the remote tunnel."
         }),
         serde_json::json!({
             "name": "tasks list",
@@ -1394,7 +1417,8 @@ fn build_schema(command: Option<&str>) -> Result<serde_json::Value, String> {
             "parameters": [
                 {"name": "--project", "type": "string", "required": false, "description": "Filter by project name"},
                 {"name": "--status", "type": "string", "required": false, "description": "Filter by status (running, completed, failed)"},
-            ]
+            ],
+            "notes": "Text output: `ID\\tSTATUS\\tWORKSPACE\\tPROMPT` (tab-separated table).\nJSON output: `{\"tasks\": [{\"id\": \"...\", \"status\": \"...\", \"project\": \"...\", \"branch\": \"...\", \"prompt\": \"...\"}]}`"
         }),
         serde_json::json!({
             "name": "tasks create",
@@ -1402,21 +1426,24 @@ fn build_schema(command: Option<&str>) -> Result<serde_json::Value, String> {
             "parameters": [
                 {"name": "workspace_id", "type": "string", "required": true, "positional": true, "description": "Workspace ID"},
                 {"name": "--prompt", "type": "string", "required": true, "description": "Prompt text to send to the agent"},
-            ]
+            ],
+            "notes": "Submits a new task to the coding agent. Returns the task ID.\nJSON output: `{\"id\": \"...\", \"workspaceId\": \"...\"}`"
         }),
         serde_json::json!({
             "name": "tasks cancel",
             "description": "Cancel a running task",
             "parameters": [
                 {"name": "task_id", "type": "string", "required": true, "positional": true, "description": "Task ID (e.g. tsk_1234567890)"},
-            ]
+            ],
+            "notes": "Cancels a running task.\nJSON output: `{\"cancelled\": true, \"taskId\": \"...\"}`"
         }),
         serde_json::json!({
             "name": "tasks rerun",
             "description": "Re-run a completed or failed task",
             "parameters": [
                 {"name": "task_id", "type": "string", "required": true, "positional": true, "description": "Task ID (e.g. tsk_1234567890)"},
-            ]
+            ],
+            "notes": "Re-runs a completed or failed task."
         }),
         serde_json::json!({
             "name": "tasks watch",
@@ -1424,7 +1451,8 @@ fn build_schema(command: Option<&str>) -> Result<serde_json::Value, String> {
             "parameters": [
                 {"name": "id", "type": "string", "required": false, "positional": true, "description": "Task ID (optional if --workspace is provided)"},
                 {"name": "--workspace", "type": "string", "required": false, "description": "Watch the latest task for this workspace"},
-            ]
+            ],
+            "notes": "Streams task output in real-time. Either provide a task ID or `--workspace` to watch the latest task for that workspace."
         }),
         serde_json::json!({
             "name": "cronjobs list",
@@ -1479,13 +1507,22 @@ fn build_schema(command: Option<&str>) -> Result<serde_json::Value, String> {
         serde_json::json!({
             "name": "notify",
             "description": "Receive hook notifications from Claude Code (reads JSON from stdin)",
-            "parameters": []
+            "parameters": [],
+            "notes": "Not called directly — registered as a Claude Code hook by the Band dashboard."
         }),
         serde_json::json!({
             "name": "schema",
             "description": "Show command schemas as JSON",
             "parameters": [
                 {"name": "command", "type": "string", "required": false, "positional": true, "description": "Command name (omit to list all commands)"},
+            ]
+        }),
+        serde_json::json!({
+            "name": "generate-skills",
+            "description": "Generate SKILL.md files from schema and registry",
+            "parameters": [
+                {"name": "--output-dir", "type": "string", "required": false, "description": "Output directory for generated skills (default: skills/)"},
+                {"name": "--filter", "type": "string", "required": false, "description": "Filter skills by name (substring match)"},
             ]
         }),
     ];
@@ -1502,7 +1539,7 @@ fn build_schema(command: Option<&str>) -> Result<serde_json::Value, String> {
 }
 
 /// Simple Unix timestamp without pulling in chrono crate.
-fn chrono_now() -> String {
+pub(crate) fn chrono_now() -> String {
     use std::time::{SystemTime, UNIX_EPOCH};
     let dur = SystemTime::now()
         .duration_since(UNIX_EPOCH)

--- a/apps/cli/src/skills.rs
+++ b/apps/cli/src/skills.rs
@@ -21,8 +21,7 @@ pub fn generate_skills(output_dir: &str, filter: Option<&str>) -> Result<Command
     // Generate service skill
     let svc_name =
         parse_frontmatter_field(BAND_CLI_TEMPLATE, "name").unwrap_or("band-cli".to_string());
-    let svc_desc =
-        parse_frontmatter_field(BAND_CLI_TEMPLATE, "description").unwrap_or_default();
+    let svc_desc = parse_frontmatter_field(BAND_CLI_TEMPLATE, "description").unwrap_or_default();
     if matches_filter(&svc_name, filter) {
         let content = generate_service_skill(commands);
         let dir_path = output_path.join(&svc_name);
@@ -39,7 +38,11 @@ pub fn generate_skills(output_dir: &str, filter: Option<&str>) -> Result<Command
     }
 
     let mut text = String::new();
-    let _ = writeln!(text, "Generated {} skill(s) in {output_dir}/", generated.len());
+    let _ = writeln!(
+        text,
+        "Generated {} skill(s) in {output_dir}/",
+        generated.len()
+    );
     for entry in &generated {
         let _ = writeln!(
             text,

--- a/apps/cli/src/skills.rs
+++ b/apps/cli/src/skills.rs
@@ -1,0 +1,149 @@
+use crate::CommandResult;
+use std::fmt::Write;
+use std::fs;
+use std::path::Path;
+
+/// Service skill template with `<!-- COMMANDS -->` placeholder.
+const BAND_CLI_TEMPLATE: &str = include_str!("../skills/band-cli.md");
+
+pub fn generate_skills(output_dir: &str, filter: Option<&str>) -> Result<CommandResult, String> {
+    let schema = crate::build_schema(None)?;
+    let commands = schema["commands"]
+        .as_array()
+        .ok_or("Schema has no commands array")?;
+
+    let output_path = Path::new(output_dir);
+    fs::create_dir_all(output_path)
+        .map_err(|e| format!("Failed to create output directory {output_dir}: {e}"))?;
+
+    let mut generated: Vec<serde_json::Value> = Vec::new();
+
+    // Generate service skill
+    let svc_name =
+        parse_frontmatter_field(BAND_CLI_TEMPLATE, "name").unwrap_or("band-cli".to_string());
+    let svc_desc =
+        parse_frontmatter_field(BAND_CLI_TEMPLATE, "description").unwrap_or_default();
+    if matches_filter(&svc_name, filter) {
+        let content = generate_service_skill(commands);
+        let dir_path = output_path.join(&svc_name);
+        fs::create_dir_all(&dir_path)
+            .map_err(|e| format!("Failed to create directory {}: {e}", dir_path.display()))?;
+        fs::write(dir_path.join("SKILL.md"), &content)
+            .map_err(|e| format!("Failed to write {svc_name}/SKILL.md: {e}"))?;
+        generated.push(serde_json::json!({
+            "name": svc_name,
+            "type": "service",
+            "description": svc_desc,
+            "path": format!("{svc_name}/SKILL.md"),
+        }));
+    }
+
+    let mut text = String::new();
+    let _ = writeln!(text, "Generated {} skill(s) in {output_dir}/", generated.len());
+    for entry in &generated {
+        let _ = writeln!(
+            text,
+            "  {} ({})",
+            entry["name"].as_str().unwrap_or(""),
+            entry["type"].as_str().unwrap_or("")
+        );
+    }
+
+    Ok(CommandResult {
+        text,
+        json: serde_json::json!({
+            "outputDir": output_dir,
+            "skills": generated,
+        }),
+    })
+}
+
+fn matches_filter(name: &str, filter: Option<&str>) -> bool {
+    match filter {
+        None => true,
+        Some(f) => name.to_lowercase().contains(&f.to_lowercase()),
+    }
+}
+
+/// Parse a single field from YAML frontmatter delimited by `---`.
+fn parse_frontmatter_field(content: &str, key: &str) -> Option<String> {
+    let mut in_frontmatter = false;
+    for line in content.lines() {
+        if line.trim() == "---" {
+            if in_frontmatter {
+                break;
+            }
+            in_frontmatter = true;
+            continue;
+        }
+        if in_frontmatter {
+            if let Some(rest) = line.strip_prefix(key) {
+                if let Some(value) = rest.strip_prefix(':') {
+                    return Some(value.trim().to_string());
+                }
+            }
+        }
+    }
+    None
+}
+
+const COMMANDS_PLACEHOLDER: &str = "<!-- COMMANDS -->";
+
+fn generate_service_skill(commands: &[serde_json::Value]) -> String {
+    let mut cmds = String::new();
+    let _ = writeln!(cmds, "## Commands");
+    let _ = writeln!(cmds);
+
+    for cmd in commands {
+        let desc = cmd["description"].as_str().unwrap_or("");
+        let usage = format_usage_line(cmd);
+
+        let _ = writeln!(cmds, "### {desc}");
+        let _ = writeln!(cmds);
+        let _ = writeln!(cmds, "```sh");
+        let _ = writeln!(cmds, "{usage}");
+        let _ = writeln!(cmds, "```");
+        let _ = writeln!(cmds);
+
+        if let Some(notes) = cmd.get("notes").and_then(|v| v.as_str()) {
+            let _ = writeln!(cmds, "{notes}");
+            let _ = writeln!(cmds);
+        }
+    }
+
+    BAND_CLI_TEMPLATE.replace(COMMANDS_PLACEHOLDER, cmds.trim_end())
+}
+
+fn format_usage_line(cmd: &serde_json::Value) -> String {
+    let name = cmd["name"].as_str().unwrap_or("");
+    let mut parts = vec![format!("band {name}")];
+
+    if let Some(params) = cmd["parameters"].as_array() {
+        for param in params {
+            let pname = param["name"].as_str().unwrap_or("");
+            let ptype = param["type"].as_str().unwrap_or("string");
+            let required = param["required"].as_bool().unwrap_or(false);
+            let positional = param["positional"].as_bool().unwrap_or(false);
+
+            if positional {
+                if required {
+                    parts.push(format!("<{pname}>"));
+                } else {
+                    parts.push(format!("[{pname}]"));
+                }
+            } else if ptype == "boolean" {
+                if required {
+                    parts.push(pname.to_string());
+                } else {
+                    parts.push(format!("[{pname}]"));
+                }
+            } else if required {
+                parts.push(format!("{pname} <{ptype}>"));
+            } else {
+                parts.push(format!("[{pname} <{ptype}>]"));
+            }
+        }
+    }
+
+    parts.join(" ")
+}


### PR DESCRIPTION
## Summary

- Adds `band generate-skills` command that auto-generates SKILL.md files from the CLI's own schema metadata
- Uses a markdown template (`apps/cli/skills/band-cli.md`) with a `<!-- COMMANDS -->` placeholder replaced by auto-generated command documentation
- Per-command notes (output formats, behavioral documentation) are embedded directly in the schema, serving as single source of truth
- Supports `--output-dir` and `--filter` flags for flexible generation

## Test plan

- [ ] `cargo build` compiles without errors
- [ ] `band generate-skills --output-dir /tmp/test-skills` generates `band-cli/SKILL.md`
- [ ] Generated SKILL.md matches expected format with all commands documented
- [ ] `--filter band` correctly filters output

🤖 Generated with [Claude Code](https://claude.com/claude-code)