### PR TITLE
fix: hide task list widget when all todos are completed

### DIFF
--- a/apps/web/e2e/todo-widget.spec.ts
+++ b/apps/web/e2e/todo-widget.spec.ts
@@ -292,6 +292,55 @@ test("multiple TodoWrite calls in same message collapse into one widget showing 
   await expect(page.getByText("Write tests")).toBeVisible();
 });
 
+test("task list is hidden when all todos are completed", async ({ page }) => {
+  const mock = createTrpcMock();
+  installSessionMock(mock, [
+    {
+      role: "user",
+      id: "m1",
+      content: [{ type: "text", text: "Finish everything" }],
+    },
+    {
+      role: "assistant",
+      id: "m2",
+      content: [
+        {
+          type: "tool_use",
+          toolCallId: "tc1",
+          toolName: "TodoWrite",
+          input: {
+            todos: [
+              { content: "Setup project", status: "completed" },
+              { content: "Write tests", status: "completed" },
+              { content: "Deploy to prod", status: "completed" },
+            ],
+          },
+        },
+      ],
+    },
+    {
+      role: "user",
+      id: "m3",
+      content: [{ type: "tool_result", toolCallId: "tc1", output: "ok", isError: false }],
+    },
+    {
+      role: "assistant",
+      id: "m4",
+      content: [{ type: "text", text: "All done!" }],
+    },
+  ]);
+  await mock.install(page);
+
+  await page.goto(`${server.url}/workspace/test-workspace?token=${TOKEN}`);
+  await loadSession(page);
+
+  // The assistant text should be visible
+  await expect(page.getByText("All done!")).toBeVisible();
+
+  // The TaskListWidget should NOT be rendered since all tasks are completed
+  await expect(page.getByText("Todos")).not.toBeVisible();
+});
+
 test("TodoWrite mixed with regular tool calls renders both correctly", async ({ page }) => {
   const mock = createTrpcMock();
   installSessionMock(mock, [

--- a/apps/web/src/components/ai-elements/task-list-widget.tsx
+++ b/apps/web/src/components/ai-elements/task-list-widget.tsx
@@ -10,6 +10,8 @@ export function TaskListWidget({ tasks }: { tasks: TaskMap }) {
   if (tasks.size === 0) return null;
 
   const taskList = Array.from(tasks.values());
+  const allDone = taskList.every((t) => t.status === "completed");
+  if (allDone) return null;
   const completedCount = taskList.filter((t) => t.status === "completed").length;
 
   return (


### PR DESCRIPTION
## Summary

- Hide the `TaskListWidget` in the chat UI when every task has `status === "completed"`, reducing visual clutter once all work is done
- Add E2E test verifying the widget is hidden when all todos are completed

## Test plan

- [x] New E2E test: `task list is hidden when all todos are completed`
- [x] All 6 existing + new todo-widget E2E tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)