### PR TITLE
feat: persist chat queue with proper message boundaries

### DIFF
--- a/apps/web/e2e/helpers/trpc-mock.ts
+++ b/apps/web/e2e/helpers/trpc-mock.ts
@@ -113,5 +113,12 @@ export function createTrpcMock() {
     });
   }
 
-  return { query, install };
+  // mutation is the same internally — both queries and mutations go through
+  // the same handler map keyed by procedure path. This alias exists for
+  // clarity and correct typing at call sites.
+  function mutation<P extends ProcedurePath>(path: P, handler: Handler<P>): void {
+    query(path, handler);
+  }
+
+  return { query, mutation, install };
 }

--- a/apps/web/e2e/queue-ui.spec.ts
+++ b/apps/web/e2e/queue-ui.spec.ts
@@ -1,0 +1,135 @@
+import { rmSync } from "node:fs";
+import { expect, test } from "@playwright/test";
+import {
+  createTmpHome,
+  type ServerHandle,
+  seedSettings,
+  seedState,
+  startServer,
+} from "./helpers/server";
+import { createTrpcMock } from "./helpers/trpc-mock";
+
+const TOKEN = "e2e-queue-test-token";
+
+let server: ServerHandle;
+let tmpHome: string;
+
+test.beforeAll(async () => {
+  tmpHome = createTmpHome();
+  seedState(tmpHome, { projects: [] });
+  seedSettings(tmpHome, { tokenSecret: TOKEN });
+  server = await startServer({ tmpHome });
+});
+
+test.afterAll(async () => {
+  await server.close();
+  rmSync(tmpHome, { recursive: true, force: true });
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+test("queued messages render with text, Queued badge, and Cancel button", async ({ page }) => {
+  const mock = createTrpcMock();
+  mock.query("queue.get", { messages: ["fix the bug", "add tests"] });
+  await mock.install(page);
+
+  await page.goto(`${server.url}/workspace/test-workspace?token=${TOKEN}`);
+
+  // Both queued message texts should be visible
+  await expect(page.getByText("fix the bug")).toBeVisible();
+  await expect(page.getByText("add tests")).toBeVisible();
+
+  // Both should show the "Queued" badge
+  const queuedBadges = page.getByText("Queued");
+  await expect(queuedBadges).toHaveCount(2);
+
+  // Both should have a Cancel button
+  const cancelButtons = page.getByRole("button", { name: "Cancel" });
+  await expect(cancelButtons).toHaveCount(2);
+});
+
+test("empty queue renders no queued message bubbles", async ({ page }) => {
+  const mock = createTrpcMock();
+  mock.query("queue.get", { messages: [] });
+  await mock.install(page);
+
+  await page.goto(`${server.url}/workspace/test-workspace?token=${TOKEN}`);
+
+  // Wait for the page to load — the prompt input should be visible
+  await expect(page.getByPlaceholder("Type a message")).toBeVisible();
+
+  // No "Queued" badge should appear
+  await expect(page.getByText("Queued")).not.toBeVisible();
+});
+
+test("cancel button calls queue.remove and bubble disappears", async ({ page }) => {
+  const removedTexts: string[] = [];
+  const queue = ["first message", "second message"];
+
+  const mock = createTrpcMock();
+
+  mock.query("queue.get", () => ({ messages: [...queue] }));
+
+  mock.mutation("queue.remove", (input) => {
+    const { text } = input as { workspaceId: string; text: string };
+    removedTexts.push(text);
+    const idx = queue.indexOf(text);
+    if (idx !== -1) queue.splice(idx, 1);
+    return { ok: true as const, messages: [...queue] };
+  });
+
+  await mock.install(page);
+
+  await page.goto(`${server.url}/workspace/test-workspace?token=${TOKEN}`);
+
+  // Both messages should be visible initially
+  await expect(page.getByText("first message")).toBeVisible();
+  await expect(page.getByText("second message")).toBeVisible();
+
+  // Click Cancel on the first message
+  const cancelButtons = page.getByRole("button", { name: "Cancel" });
+  await cancelButtons.first().click();
+
+  // After cancel, the first message should disappear
+  await expect(page.getByText("first message")).not.toBeVisible();
+
+  // Second message should still be visible
+  await expect(page.getByText("second message")).toBeVisible();
+
+  // Only one "Queued" badge should remain
+  await expect(page.getByText("Queued")).toHaveCount(1);
+
+  // The queue.remove mutation should have been called with the correct text
+  expect(removedTexts).toContain("first message");
+});
+
+test("multiple queued messages render in array order", async ({ page }) => {
+  const mock = createTrpcMock();
+  mock.query("queue.get", { messages: ["alpha", "beta", "gamma"] });
+  await mock.install(page);
+
+  await page.goto(`${server.url}/workspace/test-workspace?token=${TOKEN}`);
+
+  // All three messages should be visible
+  await expect(page.getByText("alpha")).toBeVisible();
+  await expect(page.getByText("beta")).toBeVisible();
+  await expect(page.getByText("gamma")).toBeVisible();
+
+  // Three "Queued" badges
+  await expect(page.getByText("Queued")).toHaveCount(3);
+
+  // Verify DOM order: alpha should come before beta, beta before gamma
+  const bubbleTexts = await page
+    .locator("[class*='is-user']")
+    .filter({ has: page.getByText("Queued") })
+    .allTextContents();
+
+  const alphaIdx = bubbleTexts.findIndex((t) => t.includes("alpha"));
+  const betaIdx = bubbleTexts.findIndex((t) => t.includes("beta"));
+  const gammaIdx = bubbleTexts.findIndex((t) => t.includes("gamma"));
+
+  expect(alphaIdx).toBeLessThan(betaIdx);
+  expect(betaIdx).toBeLessThan(gammaIdx);
+});

--- a/apps/web/e2e/queue-ui.spec.ts
+++ b/apps/web/e2e/queue-ui.spec.ts
@@ -7,7 +7,6 @@ import {
   seedState,
   startServer,
 } from "./helpers/server";
-import { createTrpcMock } from "./helpers/trpc-mock";
 
 const TOKEN = "e2e-queue-test-token";
 
@@ -27,15 +26,39 @@ test.afterAll(async () => {
 });
 
 // ---------------------------------------------------------------------------
+// Helpers — call the real server's queue store via tRPC HTTP API
+// ---------------------------------------------------------------------------
+
+async function trpcMutate(procedure: string, input: unknown): Promise<void> {
+  const res = await fetch(`${server.url}/trpc/${procedure}?token=${TOKEN}`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(input),
+  });
+  if (!res.ok) {
+    const text = await res.text().catch(() => "");
+    throw new Error(`trpcMutate(${procedure}) failed: ${res.status} ${text}`);
+  }
+}
+
+async function pushQueue(workspaceId: string, text: string): Promise<void> {
+  await trpcMutate("queue.push", { workspaceId, text });
+}
+
+async function clearQueue(workspaceId: string): Promise<void> {
+  await trpcMutate("queue.clear", { workspaceId });
+}
+
+// ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
 
 test("queued messages render with text, Queued badge, and Cancel button", async ({ page }) => {
-  const mock = createTrpcMock();
-  mock.query("queue.get", { messages: ["fix the bug", "add tests"] });
-  await mock.install(page);
+  const wsId = "test-ws-render";
+  await pushQueue(wsId, "fix the bug");
+  await pushQueue(wsId, "add tests");
 
-  await page.goto(`${server.url}/workspace/test-workspace?token=${TOKEN}`);
+  await page.goto(`${server.url}/workspace/${wsId}?token=${TOKEN}`);
 
   // Both queued message texts should be visible
   await expect(page.getByText("fix the bug")).toBeVisible();
@@ -48,14 +71,14 @@ test("queued messages render with text, Queued badge, and Cancel button", async 
   // Both should have a Cancel button
   const cancelButtons = page.getByRole("button", { name: "Cancel" });
   await expect(cancelButtons).toHaveCount(2);
+
+  await clearQueue(wsId);
 });
 
 test("empty queue renders no queued message bubbles", async ({ page }) => {
-  const mock = createTrpcMock();
-  mock.query("queue.get", { messages: [] });
-  await mock.install(page);
+  const wsId = "test-ws-empty";
 
-  await page.goto(`${server.url}/workspace/test-workspace?token=${TOKEN}`);
+  await page.goto(`${server.url}/workspace/${wsId}?token=${TOKEN}`);
 
   // Wait for the page to load — the prompt input should be visible
   await expect(page.getByPlaceholder("Type a message")).toBeVisible();
@@ -65,24 +88,11 @@ test("empty queue renders no queued message bubbles", async ({ page }) => {
 });
 
 test("cancel button calls queue.remove and bubble disappears", async ({ page }) => {
-  const removedTexts: string[] = [];
-  const queue = ["first message", "second message"];
+  const wsId = "test-ws-cancel";
+  await pushQueue(wsId, "first message");
+  await pushQueue(wsId, "second message");
 
-  const mock = createTrpcMock();
-
-  mock.query("queue.get", () => ({ messages: [...queue] }));
-
-  mock.mutation("queue.remove", (input) => {
-    const { text } = input as { workspaceId: string; text: string };
-    removedTexts.push(text);
-    const idx = queue.indexOf(text);
-    if (idx !== -1) queue.splice(idx, 1);
-    return { ok: true as const, messages: [...queue] };
-  });
-
-  await mock.install(page);
-
-  await page.goto(`${server.url}/workspace/test-workspace?token=${TOKEN}`);
+  await page.goto(`${server.url}/workspace/${wsId}?token=${TOKEN}`);
 
   // Both messages should be visible initially
   await expect(page.getByText("first message")).toBeVisible();
@@ -101,16 +111,16 @@ test("cancel button calls queue.remove and bubble disappears", async ({ page }) 
   // Only one "Queued" badge should remain
   await expect(page.getByText("Queued")).toHaveCount(1);
 
-  // The queue.remove mutation should have been called with the correct text
-  expect(removedTexts).toContain("first message");
+  await clearQueue(wsId);
 });
 
 test("multiple queued messages render in array order", async ({ page }) => {
-  const mock = createTrpcMock();
-  mock.query("queue.get", { messages: ["alpha", "beta", "gamma"] });
-  await mock.install(page);
+  const wsId = "test-ws-order";
+  await pushQueue(wsId, "alpha");
+  await pushQueue(wsId, "beta");
+  await pushQueue(wsId, "gamma");
 
-  await page.goto(`${server.url}/workspace/test-workspace?token=${TOKEN}`);
+  await page.goto(`${server.url}/workspace/${wsId}?token=${TOKEN}`);
 
   // All three messages should be visible
   await expect(page.getByText("alpha")).toBeVisible();
@@ -132,4 +142,6 @@ test("multiple queued messages render in array order", async ({ page }) => {
 
   expect(alphaIdx).toBeLessThan(betaIdx);
   expect(betaIdx).toBeLessThan(gammaIdx);
+
+  await clearQueue(wsId);
 });

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -2,7 +2,7 @@ import { useChat } from "@ai-sdk/react";
 import { Badge } from "@band/ui";
 import { getToolName, isToolUIPart } from "ai";
 import { Bot, Clock, Loader2, X } from "lucide-react";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { Fragment, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { TaskChatTransport } from "../lib/task-chat-transport";
 import { trpc } from "../lib/trpc-client";
 import {
@@ -81,10 +81,53 @@ interface HistoryMessage {
   content: HistoryMessageContent[];
 }
 
-interface QueuedMessage {
-  id: string;
-  message: PromptInputMessage;
-  queuedAt: number;
+type UIMessageParts = ReturnType<
+  typeof import("@ai-sdk/react").useChat
+>["messages"][number]["parts"];
+
+type QueueSegment = {
+  userPrompt: string | null;
+  parts: UIMessageParts;
+};
+
+/**
+ * Splits an assistant message's parts at `data-prompt` boundaries so each
+ * queued task renders as a separate user→assistant pair.
+ *
+ * When `skipFirstPrompt` is true, the first `data-prompt` is not turned into
+ * a user bubble (because a real user message already precedes the assistant
+ * message in the messages array).
+ */
+function splitMessageAtQueueBoundaries(
+  parts: UIMessageParts,
+  skipFirstPrompt: boolean,
+): QueueSegment[] {
+  const segments: QueueSegment[] = [];
+  let current: QueueSegment = { userPrompt: null, parts: [] };
+  let seenFirst = false;
+
+  for (const part of parts) {
+    if (part.type === "data-prompt") {
+      if (!seenFirst) {
+        seenFirst = true;
+        if (skipFirstPrompt) continue; // user message already in messages array
+      }
+      // Finish current segment and start a new one
+      if (current.parts.length > 0 || segments.length > 0 || !skipFirstPrompt) {
+        segments.push(current);
+      }
+      current = {
+        userPrompt: (part as { type: string; data: { text: string } }).data.text,
+        parts: [],
+      };
+      continue;
+    }
+    // Skip other data-* parts (data-result, data-session) from rendering
+    if (typeof part.type === "string" && part.type.startsWith("data-")) continue;
+    current.parts.push(part);
+  }
+  segments.push(current);
+  return segments;
 }
 
 interface ChatViewProps {
@@ -105,7 +148,6 @@ export function ChatView({
   onShowSessionListChange,
 }: ChatViewProps) {
   const sessionIdRef = useRef<string | undefined>(undefined);
-  const [reconnectedPrompt, setReconnectedPrompt] = useState<string | undefined>(undefined);
   const [activeSessionId, setActiveSessionId] = useState<string | undefined>(undefined);
   const [historicalMessages, setHistoricalMessages] = useState<HistoryMessage[]>([]);
   const [loadingHistory, setLoadingHistory] = useState(false);
@@ -119,6 +161,24 @@ export function ChatView({
       .query({ workspaceId })
       .then((data) => setSkills(data.skills))
       .catch(() => setSkills([]));
+  }, [workspaceId]);
+
+  const [queuedMessages, setQueuedMessages] = useState<string[]>([]);
+
+  // Subscribe to queue state changes via a dedicated tRPC subscription.
+  // The backend pushes the full queue array on every change (push, shift,
+  // remove, clear) so the frontend always has the authoritative state.
+  useEffect(() => {
+    const subscription = trpc.queue.stream.subscribe(
+      { workspaceId },
+      {
+        onData(data: { messages: string[] }) {
+          console.log("subscribe", data.messages);
+          setQueuedMessages(data.messages);
+        },
+      },
+    );
+    return () => subscription.unsubscribe();
   }, [workspaceId]);
 
   const transport = useMemo(
@@ -138,15 +198,6 @@ export function ChatView({
         "sessionId" in (dataPart.data as Record<string, unknown>)
       ) {
         sessionIdRef.current = (dataPart.data as { sessionId: string }).sessionId;
-      }
-      // Store reconnected prompt for rendering (don't inject into useChat state)
-      if (
-        dataPart.type === "data-prompt" &&
-        dataPart.data != null &&
-        typeof dataPart.data === "object" &&
-        "text" in (dataPart.data as Record<string, unknown>)
-      ) {
-        setReconnectedPrompt((dataPart.data as { text: string }).text);
       }
     },
   });
@@ -169,9 +220,6 @@ export function ChatView({
     }
   }, [isStreaming, handleStop]);
 
-  const [queuedMessages, setQueuedMessages] = useState<QueuedMessage[]>([]);
-  const sendingQueuedRef = useRef(false);
-
   const doSendMessage = useCallback(
     (message: PromptInputMessage) => {
       if (message.files?.length) {
@@ -191,7 +239,10 @@ export function ChatView({
     async (sessionId: string) => {
       setLoadingHistory(true);
       try {
-        const data = await trpc.sessions.messages.query({ workspaceId, sessionId });
+        const data = await trpc.sessions.messages.query({
+          workspaceId,
+          sessionId,
+        });
         setHistoricalMessages(data.messages as HistoryMessage[]);
       } finally {
         setLoadingHistory(false);
@@ -212,67 +263,60 @@ export function ChatView({
   const handleSelectSession = useCallback(
     async (sessionId: string) => {
       sessionIdRef.current = sessionId;
-      setReconnectedPrompt(undefined);
       setActiveSessionId(sessionId);
       setMessages([]);
       setHistoricalMessages([]);
       setQueuedMessages([]);
+      trpc.queue.clear.mutate({ workspaceId }).catch(() => {});
       onShowSessionListChange(false);
       await loadMessages(sessionId);
     },
-    [loadMessages, setMessages, onShowSessionListChange],
+    [loadMessages, setMessages, onShowSessionListChange, workspaceId],
   );
 
   const handleNewSession = useCallback(() => {
     sessionIdRef.current = undefined;
-    setReconnectedPrompt(undefined);
     setActiveSessionId(undefined);
     setHistoricalMessages([]);
     setMessages([]);
     setQueuedMessages([]);
+    trpc.queue.clear.mutate({ workspaceId }).catch(() => {});
     onShowSessionListChange(false);
-  }, [setMessages, onShowSessionListChange]);
+  }, [setMessages, onShowSessionListChange, workspaceId]);
 
   const handleSubmit = useCallback(
     (message: PromptInputMessage) => {
       if (!message.text.trim() && !message.files?.length) return;
 
       if (isStreaming) {
-        // Agent is busy — queue the message instead of sending
-        setQueuedMessages((prev) => [
-          ...prev,
-          {
-            id: crypto.randomUUID(),
-            message,
-            queuedAt: Date.now(),
-          },
-        ]);
+        // Agent is busy — queue the message on the backend.
+        // Optimistic update for instant feedback; subscription corrects if needed.
+        setQueuedMessages((prev) => [...prev, message.text]);
+        trpc.queue.push.mutate({ workspaceId, text: message.text }).catch(() => {});
         return;
       }
 
       doSendMessage(message);
     },
-    [doSendMessage, isStreaming],
+    [doSendMessage, isStreaming, workspaceId],
   );
 
-  // Auto-send queued messages when the agent becomes idle
-  useEffect(() => {
-    if (isStreaming) {
-      sendingQueuedRef.current = false;
-      return;
-    }
-    if (sendingQueuedRef.current) return;
-    if (queuedMessages.length === 0) return;
+  const handleCancelQueued = useCallback(
+    (text: string) => {
+      // Optimistic update for instant feedback; subscription corrects if needed.
+      setQueuedMessages((prev) => {
+        const idx = prev.indexOf(text);
+        if (idx === -1) return prev;
+        const messages = [...prev.slice(0, idx), ...prev.slice(idx + 1)];
 
-    sendingQueuedRef.current = true;
-    const [next, ...rest] = queuedMessages;
-    setQueuedMessages(rest);
-    doSendMessage(next.message);
-  }, [isStreaming, queuedMessages, doSendMessage]);
+        console.log("cancel", text, messages);
 
-  const handleCancelQueued = useCallback((id: string) => {
-    setQueuedMessages((prev) => prev.filter((m) => m.id !== id));
-  }, []);
+        return messages;
+      });
+      trpc.queue.remove.mutate({ workspaceId, text }).catch(() => {});
+    },
+    [workspaceId],
+  );
 
   const liveTaskMap: TaskMap = useMemo(() => {
     let map: TaskMap = new Map();
@@ -293,10 +337,15 @@ export function ChatView({
   // task's content which overlaps with the tail of the session history.
   // Strip the overlapping turn from history so each message appears once.
   const filteredHistoricalMessages = useMemo(() => {
-    if (!reconnectedPrompt || historicalMessages.length === 0) {
-      return historicalMessages;
-    }
-    const promptText = reconnectedPrompt.trim();
+    if (historicalMessages.length === 0) return historicalMessages;
+    // Find current prompt from data-prompt parts in the last assistant message
+    const lastAssistant = [...messages].reverse().find((m) => m.role === "assistant");
+    const dataPromptPart = lastAssistant?.parts.find((p) => p.type === "data-prompt");
+    const currentPrompt = dataPromptPart
+      ? (dataPromptPart as { type: string; data: { text: string } }).data.text.trim()
+      : undefined;
+    if (!currentPrompt) return historicalMessages;
+    // Strip overlapping turn from history
     for (let i = historicalMessages.length - 1; i >= 0; i--) {
       if (historicalMessages[i].role === "user") {
         const text = historicalMessages[i].content
@@ -304,14 +353,12 @@ export function ChatView({
           .map((b) => b.text)
           .join("\n")
           .trim();
-        if (text === promptText) {
-          return historicalMessages.slice(0, i);
-        }
+        if (text === currentPrompt) return historicalMessages.slice(0, i);
         break;
       }
     }
     return historicalMessages;
-  }, [historicalMessages, reconnectedPrompt]);
+  }, [historicalMessages, messages]);
 
   const historyToolResultMap = useMemo(
     () => buildToolResultMap(filteredHistoricalMessages),
@@ -325,7 +372,7 @@ export function ChatView({
   const displayTaskMap = liveTaskMap.size > 0 ? liveTaskMap : historyTaskMap;
 
   const getLastUserMessage = useCallback((): string | undefined => {
-    // Check live messages first (most recent)
+    // Check live messages: user messages first, then data-prompt parts in assistant messages
     for (let i = messages.length - 1; i >= 0; i--) {
       if (messages[i].role === "user") {
         const text = messages[i].parts
@@ -335,9 +382,13 @@ export function ChatView({
           .trim();
         if (text) return text;
       }
+      if (messages[i].role === "assistant") {
+        // Find the last data-prompt in this message
+        const prompts = messages[i].parts.filter((p) => p.type === "data-prompt");
+        const last = prompts[prompts.length - 1];
+        if (last) return (last as { type: string; data: { text: string } }).data.text;
+      }
     }
-    // Fall back to reconnected prompt
-    if (reconnectedPrompt) return reconnectedPrompt;
     // Fall back to historical messages
     for (let i = filteredHistoricalMessages.length - 1; i >= 0; i--) {
       if (filteredHistoricalMessages[i].role === "user") {
@@ -350,14 +401,16 @@ export function ChatView({
       }
     }
     return undefined;
-  }, [messages, reconnectedPrompt, filteredHistoricalMessages]);
+  }, [messages, filteredHistoricalMessages]);
 
   const hasHistory = filteredHistoricalMessages.length > 0;
   const hasLiveMessages = messages.length > 0;
-  // Show the reconnected prompt as a user message when the stream is
-  // providing the current task (no user message in live stream).
-  const showReconnectedPrompt = reconnectedPrompt && !messages.some((m) => m.role === "user");
-  const isEmpty = !hasHistory && !hasLiveMessages && !showReconnectedPrompt;
+  // Detect reconnected/queued prompt: assistant message has data-prompt parts
+  // but no user message exists in the live messages array.
+  const hasReconnectedPrompt =
+    messages.some((m) => m.role === "assistant" && m.parts.some((p) => p.type === "data-prompt")) &&
+    !messages.some((m) => m.role === "user");
+  const isEmpty = !hasHistory && !hasLiveMessages && !hasReconnectedPrompt;
 
   if (supportsSessionListing && showSessionList) {
     return (
@@ -392,20 +445,12 @@ export function ChatView({
             <HistoryMessages messages={filteredHistoricalMessages} />
           )}
 
-          {hasHistory && (hasLiveMessages || showReconnectedPrompt) && (
+          {hasHistory && (hasLiveMessages || hasReconnectedPrompt) && (
             <div className="flex items-center gap-3 py-2">
               <div className="h-px flex-1 bg-border/50" />
               <span className="text-sm text-muted-foreground">new messages</span>
               <div className="h-px flex-1 bg-border/50" />
             </div>
-          )}
-
-          {showReconnectedPrompt && (
-            <Message from="user">
-              <MessageContent>
-                <MessageResponse>{reconnectedPrompt}</MessageResponse>
-              </MessageContent>
-            </Message>
           )}
 
           {(() => {
@@ -414,47 +459,145 @@ export function ChatView({
               const isLastAssistant = message.role === "assistant" && isLastMessage;
               const showThinking = isLastAssistant && isStreaming;
 
-              const visibleParts = message.parts.filter(
-                (p) => (p.type === "text" && p.text.trim()) || p.type === "file" || isToolUIPart(p),
-              );
-              if (message.role === "assistant" && visibleParts.length === 0 && !showThinking) {
-                return null;
-              }
-              return (
-                <Message key={message.id} from={message.role}>
-                  <MessageContent>
-                    {groupMessageParts(message.parts).map((segment) => {
-                      if (segment.type === "text") {
-                        const { part, partIndex } = segment;
-                        if (part.type === "text" && part.text.trim()) {
+              if (message.role !== "assistant") {
+                // User messages render normally
+                const userParts = groupMessageParts(message.parts);
+                if (userParts.length === 0) return null;
+                return (
+                  <Message key={message.id} from="user">
+                    <MessageContent>
+                      {userParts.map((segment) => {
+                        if (
+                          segment.type === "text" &&
+                          segment.part.type === "text" &&
+                          segment.part.text.trim()
+                        ) {
                           return (
-                            <MessageResponse key={`${message.id}-text-${partIndex}`}>
-                              {part.text}
+                            <MessageResponse key={`${message.id}-text-${segment.partIndex}`}>
+                              {segment.part.text}
                             </MessageResponse>
                           );
                         }
+                        if (segment.type === "file") {
+                          return (
+                            <MessageFilePart
+                              key={`${message.id}-file-${segment.partIndex}`}
+                              part={segment.part}
+                            />
+                          );
+                        }
                         return null;
-                      }
-                      if (segment.type === "file") {
+                      })}
+                    </MessageContent>
+                  </Message>
+                );
+              }
+
+              // Assistant message
+              const hasPrecedingUserMsg =
+                messageIndex > 0 && messages[messageIndex - 1]?.role === "user";
+              const hasDataPrompts = message.parts.some((p) => p.type === "data-prompt");
+
+              if (!hasDataPrompts) {
+                // No queue boundaries — render as before
+                const visibleParts = message.parts.filter(
+                  (p) =>
+                    (p.type === "text" && p.text.trim()) || p.type === "file" || isToolUIPart(p),
+                );
+                if (visibleParts.length === 0 && !showThinking) return null;
+                return (
+                  <Message key={message.id} from="assistant">
+                    <MessageContent>
+                      {groupMessageParts(message.parts).map((segment) => {
+                        if (segment.type === "text") {
+                          const { part, partIndex } = segment;
+                          if (part.type === "text" && part.text.trim()) {
+                            return (
+                              <MessageResponse key={`${message.id}-text-${partIndex}`}>
+                                {part.text}
+                              </MessageResponse>
+                            );
+                          }
+                          return null;
+                        }
+                        if (segment.type === "file") {
+                          return (
+                            <MessageFilePart
+                              key={`${message.id}-file-${segment.partIndex}`}
+                              part={segment.part}
+                            />
+                          );
+                        }
+                        const item = toolPartToItem(segment.part);
+                        if (isTaskTool(item.toolName)) return null;
                         return (
-                          <MessageFilePart
-                            key={`${message.id}-file-${segment.partIndex}`}
-                            part={segment.part}
-                          />
+                          <ToolCall key={`${message.id}-tool-${segment.partIndex}`} item={item} />
                         );
-                      }
-                      const item = toolPartToItem(segment.part);
-                      if (isTaskTool(item.toolName)) {
-                        return null;
-                      }
-                      return (
-                        <ToolCall key={`${message.id}-tool-${segment.partIndex}`} item={item} />
-                      );
-                    })}
-                    {showThinking && <ThinkingIndicator />}
-                  </MessageContent>
-                </Message>
-              );
+                      })}
+                      {showThinking && <ThinkingIndicator />}
+                    </MessageContent>
+                  </Message>
+                );
+              }
+
+              // Split at data-prompt boundaries
+              const segments = splitMessageAtQueueBoundaries(message.parts, hasPrecedingUserMsg);
+
+              return segments.map((segment, segIdx) => {
+                const visibleParts = groupMessageParts(segment.parts);
+                const isLastSegment = segIdx === segments.length - 1;
+                const segKey = segment.userPrompt ?? "initial";
+
+                return (
+                  <Fragment key={`${message.id}-seg-${segKey}`}>
+                    {segment.userPrompt && (
+                      <Message from="user">
+                        <MessageContent>
+                          <MessageResponse>{segment.userPrompt}</MessageResponse>
+                        </MessageContent>
+                      </Message>
+                    )}
+                    {(visibleParts.length > 0 || (isLastSegment && showThinking)) && (
+                      <Message from="assistant">
+                        <MessageContent>
+                          {visibleParts.map((seg) => {
+                            if (seg.type === "text") {
+                              const { part, partIndex } = seg;
+                              if (part.type === "text" && part.text.trim()) {
+                                return (
+                                  <MessageResponse
+                                    key={`${message.id}-${segKey}-text-${partIndex}`}
+                                  >
+                                    {part.text}
+                                  </MessageResponse>
+                                );
+                              }
+                              return null;
+                            }
+                            if (seg.type === "file") {
+                              return (
+                                <MessageFilePart
+                                  key={`${message.id}-${segKey}-file-${seg.partIndex}`}
+                                  part={seg.part}
+                                />
+                              );
+                            }
+                            const item = toolPartToItem(seg.part);
+                            if (isTaskTool(item.toolName)) return null;
+                            return (
+                              <ToolCall
+                                key={`${message.id}-${segKey}-tool-${seg.partIndex}`}
+                                item={item}
+                              />
+                            );
+                          })}
+                          {isLastSegment && showThinking && <ThinkingIndicator />}
+                        </MessageContent>
+                      </Message>
+                    )}
+                  </Fragment>
+                );
+              });
             });
           })()}
           {isStreaming && (!messages.length || messages[messages.length - 1].role === "user") && (
@@ -465,12 +608,8 @@ export function ChatView({
             </Message>
           )}
 
-          {queuedMessages.map((qm) => (
-            <QueuedMessageBubble
-              key={qm.id}
-              queuedMessage={qm}
-              onCancel={() => handleCancelQueued(qm.id)}
-            />
+          {queuedMessages.map((text) => (
+            <QueuedMessageBubble key={text} text={text} onCancel={() => handleCancelQueued(text)} />
           ))}
         </ConversationContent>
         <ConversationScrollButton />
@@ -499,17 +638,11 @@ export function ChatView({
   );
 }
 
-function QueuedMessageBubble({
-  queuedMessage,
-  onCancel,
-}: {
-  queuedMessage: QueuedMessage;
-  onCancel: () => void;
-}) {
+function QueuedMessageBubble({ text, onCancel }: { text: string; onCancel: () => void }) {
   return (
     <div className="group is-user flex w-full max-w-[95%] flex-col gap-2 ml-auto justify-end opacity-60">
       <div className="flex min-w-0 max-w-full flex-col gap-2 break-words text-base ml-auto w-fit rounded-md bg-secondary px-4 py-3 text-foreground">
-        <MessageResponse>{queuedMessage.message.text}</MessageResponse>
+        <MessageResponse>{text}</MessageResponse>
         <div className="flex items-center justify-end gap-2 mt-1">
           <Badge variant="outline" className="text-xs text-muted-foreground">
             <Clock className="size-3" />

--- a/apps/web/src/lib/queued-message-store.ts
+++ b/apps/web/src/lib/queued-message-store.ts
@@ -1,0 +1,102 @@
+/**
+ * In-memory store for queued chat messages, keyed by workspaceId.
+ *
+ * When a user sends a message while the agent is busy, the frontend
+ * persists it here so it survives page navigation. When a task
+ * completes, the task-runner pops the next message and auto-starts
+ * a new task. The frontend only pushes to and renders the queue.
+ *
+ * Uses the globalThis Symbol pattern (same as task-runner.ts) to
+ * ensure a single shared map across multiple bundles.
+ */
+
+const QUEUED_KEY = Symbol.for("band.queued-messages");
+const LISTENERS_KEY = Symbol.for("band.queued-messages.listeners");
+
+const g = globalThis as unknown as Record<symbol, unknown>;
+if (!g[QUEUED_KEY]) g[QUEUED_KEY] = new Map<string, string[]>();
+if (!g[LISTENERS_KEY]) g[LISTENERS_KEY] = new Set<QueueListener>();
+
+const store = g[QUEUED_KEY] as Map<string, string[]>;
+const queueListeners = g[LISTENERS_KEY] as Set<QueueListener>;
+
+type QueueListener = (workspaceId: string, messages: string[]) => void;
+
+function notify(workspaceId: string): void {
+  const messages = [...(store.get(workspaceId) ?? [])];
+  for (const listener of queueListeners) {
+    try {
+      listener(workspaceId, messages);
+    } catch {
+      // listener may have been removed
+    }
+  }
+}
+
+/** Subscribe to queue state changes. Returns an unsubscribe function. */
+export function subscribeQueue(listener: QueueListener): () => void {
+  queueListeners.add(listener);
+  return () => {
+    queueListeners.delete(listener);
+  };
+}
+
+/** Append a queued message for a workspace. */
+export function pushQueuedMessage(workspaceId: string, text: string): void {
+  const msgs = store.get(workspaceId);
+  if (msgs) {
+    msgs.push(text);
+  } else {
+    store.set(workspaceId, [text]);
+  }
+  notify(workspaceId);
+}
+
+/** Replace the entire queue for a workspace. */
+export function setQueuedMessages(workspaceId: string, texts: string[]): void {
+  if (texts.length === 0) {
+    store.delete(workspaceId);
+  } else {
+    store.set(workspaceId, [...texts]);
+  }
+  notify(workspaceId);
+}
+
+/** Retrieve all queued messages for a workspace (empty array if none). */
+export function getQueuedMessages(workspaceId: string): string[] {
+  return store.get(workspaceId) ?? [];
+}
+
+/**
+ * Remove and return the first queued message for a workspace, or null
+ * if the queue is empty.
+ */
+export function shiftQueuedMessage(workspaceId: string): string | null {
+  const msgs = store.get(workspaceId);
+  if (!msgs || msgs.length === 0) return null;
+  const first = msgs.shift()!;
+  if (msgs.length === 0) store.delete(workspaceId);
+  notify(workspaceId);
+  return first;
+}
+
+/**
+ * Remove the first occurrence of a message matching `text` from the queue.
+ * Returns true if a message was removed.
+ */
+export function removeQueuedMessage(workspaceId: string, text: string): boolean {
+  const msgs = store.get(workspaceId);
+  if (!msgs) return false;
+  const idx = msgs.indexOf(text);
+  if (idx === -1) return false;
+  msgs.splice(idx, 1);
+  if (msgs.length === 0) store.delete(workspaceId);
+  notify(workspaceId);
+  return true;
+}
+
+/** Remove all queued messages for a workspace. */
+export function clearQueuedMessages(workspaceId: string): void {
+  store.delete(workspaceId);
+  notify(workspaceId);
+}

--- a/apps/web/src/lib/task-runner.ts
+++ b/apps/web/src/lib/task-runner.ts
@@ -2,6 +2,7 @@ import { createLogger } from "@band/logger";
 import type { UIMessageChunk } from "ai";
 import { getAgent, getOrCreateAgent } from "./agent-pool";
 import { createPendingInput } from "./pending-inputs";
+import { shiftQueuedMessage } from "./queued-message-store";
 import { generateTaskId, markTaskFailed, saveTask } from "./task-store";
 import { resolveWorkspace } from "./workspace";
 
@@ -121,6 +122,10 @@ export function submitTask(
   };
   tasks.set(workspaceId, task);
   persistTask(task);
+
+  // Broadcast to any live subscribers (auto-started tasks).
+  // For the initial task this is a no-op — no subscribers exist yet.
+  broadcast(workspaceId, task.chunks[0]);
 
   // Fire-and-forget async execution
   runTask(workspaceId, task).catch((err) => {
@@ -351,6 +356,18 @@ async function runTask(workspaceId: string, task: InternalTask) {
   }
 
   scheduleExpiry(workspaceId);
+
+  // Auto-start a new task if there's a queued message and the task succeeded
+  if (task.status === "completed") {
+    const queued = shiftQueuedMessage(workspaceId);
+    if (queued) {
+      try {
+        submitTask(workspaceId, queued, task.sessionId);
+      } catch (err) {
+        log.warn({ workspaceId, err }, "failed to auto-start queued task");
+      }
+    }
+  }
 }
 
 function scheduleExpiry(workspaceId: string) {

--- a/apps/web/src/trpc/router.ts
+++ b/apps/web/src/trpc/router.ts
@@ -29,6 +29,15 @@ import { execGit, gitCmd, listWorktrees } from "../lib/git";
 import { checkHooks, installHooks } from "../lib/hooks";
 import { resolvePendingInput } from "../lib/pending-inputs";
 import { checkPrereqs, shellPath } from "../lib/process-utils";
+import {
+  clearQueuedMessages,
+  getQueuedMessages,
+  pushQueuedMessage,
+  removeQueuedMessage,
+  setQueuedMessages,
+  shiftQueuedMessage,
+  subscribeQueue,
+} from "../lib/queued-message-store";
 import { runSetup } from "../lib/setup-runner";
 import {
   bandHome,
@@ -1082,13 +1091,9 @@ const tasksRouter = t.router({
       type Chunk = Parameters<Parameters<typeof subscribeTask>[1]>[0];
       const queue: Chunk[] = [];
       let resolve: (() => void) | null = null;
-      let done = false;
 
       const unsubscribe = subscribeTask(workspaceId, (chunk) => {
         queue.push(chunk);
-        if (chunk.type === "finish") {
-          done = true;
-        }
         resolve?.();
       });
 
@@ -1113,9 +1118,16 @@ const tasksRouter = t.router({
       try {
         while (!opts.signal.aborted) {
           while (queue.length > 0) {
-            yield queue.shift()!;
+            const chunk = queue.shift()!;
+            yield chunk;
+            // When a task finishes and no queued follow-ups remain,
+            // end the subscription. Otherwise keep it alive — the
+            // backend auto-starts the next queued task and its events
+            // flow through the same listener.
+            if (chunk.type === "finish" && getQueuedMessages(workspaceId).length === 0) {
+              return;
+            }
           }
-          if (done) return;
           await new Promise<void>((r) => {
             resolve = r;
           });
@@ -1507,6 +1519,90 @@ const skillsRouter = t.router({
 });
 
 // ---------------------------------------------------------------------------
+// Queue (persisted queued messages)
+// ---------------------------------------------------------------------------
+
+const queueRouter = t.router({
+  push: publicProcedure
+    .input(z.object({ workspaceId: z.string(), text: z.string() }))
+    .mutation(({ input }) => {
+      pushQueuedMessage(input.workspaceId, input.text);
+      return { ok: true, messages: getQueuedMessages(input.workspaceId) };
+    }),
+
+  set: publicProcedure
+    .input(z.object({ workspaceId: z.string(), messages: z.array(z.string()) }))
+    .mutation(({ input }) => {
+      setQueuedMessages(input.workspaceId, input.messages);
+      return { ok: true };
+    }),
+
+  get: publicProcedure.input(z.object({ workspaceId: z.string() })).query(({ input }) => {
+    const messages = getQueuedMessages(input.workspaceId);
+    return { messages };
+  }),
+
+  remove: publicProcedure
+    .input(z.object({ workspaceId: z.string(), text: z.string() }))
+    .mutation(({ input }) => {
+      removeQueuedMessage(input.workspaceId, input.text);
+      return { ok: true, messages: getQueuedMessages(input.workspaceId) };
+    }),
+
+  shift: publicProcedure.input(z.object({ workspaceId: z.string() })).mutation(({ input }) => {
+    const text = shiftQueuedMessage(input.workspaceId);
+    return { text };
+  }),
+
+  clear: publicProcedure.input(z.object({ workspaceId: z.string() })).mutation(({ input }) => {
+    clearQueuedMessages(input.workspaceId);
+    return { ok: true };
+  }),
+
+  stream: publicProcedure
+    .input(z.object({ workspaceId: z.string() }))
+    .subscription(async function* (opts) {
+      const { workspaceId } = opts.input;
+
+      type Update = { messages: string[] };
+      const queue: Update[] = [];
+      let resolve: (() => void) | null = null;
+
+      const unsubscribe = subscribeQueue((wsId, messages) => {
+        if (wsId !== workspaceId) return;
+        queue.push({ messages });
+        resolve?.();
+      });
+
+      opts.signal?.addEventListener("abort", () => {
+        unsubscribe();
+        resolve?.();
+      });
+
+      // Emit current state immediately so the client is in sync
+      yield { messages: getQueuedMessages(workspaceId) };
+
+      // Discard notifications that arrived between listener registration
+      // and the initial yield — the initial yield already covers them.
+      queue.length = 0;
+
+      try {
+        while (!opts.signal?.aborted) {
+          while (queue.length > 0) {
+            yield queue.shift()!;
+          }
+          await new Promise<void>((r) => {
+            resolve = r;
+          });
+          resolve = null;
+        }
+      } finally {
+        unsubscribe();
+      }
+    }),
+});
+
+// ---------------------------------------------------------------------------
 // App Router
 // ---------------------------------------------------------------------------
 
@@ -1527,6 +1623,7 @@ export const appRouter = t.router({
   status: statusRouter,
   cronjobs: cronjobsRouter,
   skills: skillsRouter,
+  queue: queueRouter,
 });
 
 export type AppRouter = typeof appRouter;

--- a/apps/web/tests/queue-drain.test.ts
+++ b/apps/web/tests/queue-drain.test.ts
@@ -1,0 +1,797 @@
+import { spawn } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { createServer } from "node:net";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { WebSocket } from "ws";
+
+const PROJECT_ROOT = join(import.meta.dirname, "..");
+const FAKE_AGENT_PATH = join(import.meta.dirname, "fake-agent.mjs");
+const DEFAULT_TOKEN = "queue-drain-test-token";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+interface ServerHandle {
+  url: string;
+  home: string;
+  close: () => Promise<void>;
+}
+
+function createTmpHome(): string {
+  const tmp = mkdtempSync(join(tmpdir(), "band-qdrain-test-"));
+  const bandDir = join(tmp, ".band");
+  mkdirSync(bandDir, { recursive: true });
+  mkdirSync(join(bandDir, "status"), { recursive: true });
+  return tmp;
+}
+
+function seedState(tmpHome: string, state: object): void {
+  writeFileSync(join(tmpHome, ".band", "state.json"), JSON.stringify(state));
+}
+
+function seedSettings(tmpHome: string, settings: object): void {
+  writeFileSync(join(tmpHome, ".band", "settings.json"), JSON.stringify(settings));
+}
+
+function writeScenario(tmpHome: string, events: object[]): string {
+  const scenarioPath = join(tmpHome, "scenario.json");
+  writeFileSync(scenarioPath, JSON.stringify(events));
+  return scenarioPath;
+}
+
+function createDefaultState(tmpHome: string) {
+  const repoDir = join(tmpHome, "repo");
+  mkdirSync(repoDir, { recursive: true });
+  return {
+    projects: [
+      {
+        name: "testproject",
+        path: repoDir,
+        defaultBranch: "main",
+        worktrees: [{ branch: "main", path: repoDir }],
+      },
+    ],
+  };
+}
+
+function defaultSettings() {
+  return {
+    tokenSecret: DEFAULT_TOKEN,
+    codingAgent: {
+      type: "claude-code",
+      command: FAKE_AGENT_PATH,
+    },
+  };
+}
+
+function getRandomPort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const srv = createServer();
+    srv.listen(0, "127.0.0.1", () => {
+      const { port } = srv.address() as { port: number };
+      srv.close(() => resolve(port));
+    });
+    srv.on("error", reject);
+  });
+}
+
+async function startServer(
+  opts: { tmpHome?: string; scenarioPath?: string; env?: Record<string, string> } = {},
+): Promise<ServerHandle> {
+  const home = opts.tmpHome || createTmpHome();
+  const port = await getRandomPort();
+
+  return new Promise((resolve, reject) => {
+    const child = spawn("node", ["dist/start-server.mjs"], {
+      cwd: PROJECT_ROOT,
+      env: {
+        ...process.env,
+        HOME: home,
+        PORT: String(port),
+        NODE_ENV: "production",
+        FAKE_AGENT_SCENARIO: opts.scenarioPath || "",
+        ...opts.env,
+      },
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+
+    let stderr = "";
+    let settled = false;
+
+    child.stderr!.on("data", (chunk: Buffer) => {
+      stderr += chunk.toString();
+    });
+
+    child.stdout!.on("data", (chunk: Buffer) => {
+      const text = chunk.toString();
+      if (text.includes("listening") && !settled) {
+        settled = true;
+        resolve({
+          url: `http://127.0.0.1:${port}`,
+          home,
+          close: () =>
+            new Promise<void>((r) => {
+              child.on("exit", () => r());
+              child.kill("SIGTERM");
+            }),
+        });
+      }
+    });
+
+    child.on("error", (err) => {
+      if (!settled) {
+        settled = true;
+        reject(err);
+      }
+    });
+
+    child.on("exit", (code) => {
+      if (!settled) {
+        settled = true;
+        reject(new Error(`Server exited with code ${code} before listening.\nstderr: ${stderr}`));
+      }
+    });
+
+    setTimeout(() => {
+      if (!settled) {
+        settled = true;
+        child.kill("SIGTERM");
+        reject(new Error(`Server did not start within 15 s.\nstderr: ${stderr}`));
+      }
+    }, 15_000);
+  });
+}
+
+// ---------------------------------------------------------------------------
+// tRPC HTTP helpers
+// ---------------------------------------------------------------------------
+
+const defaultHeaders = { Cookie: `band_token=${DEFAULT_TOKEN}` };
+
+async function trpcQuery(serverUrl: string, procedure: string, input?: unknown) {
+  const url =
+    input !== undefined
+      ? `${serverUrl}/trpc/${procedure}?input=${encodeURIComponent(JSON.stringify(input))}`
+      : `${serverUrl}/trpc/${procedure}`;
+  return fetch(url, { headers: defaultHeaders });
+}
+
+async function trpcMutate(serverUrl: string, procedure: string, input?: unknown) {
+  return fetch(`${serverUrl}/trpc/${procedure}`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", ...defaultHeaders },
+    body: input !== undefined ? JSON.stringify(input) : "{}",
+  });
+}
+
+async function trpcData<T>(res: Response): Promise<T> {
+  const body = (await res.json()) as { result: { data: T } };
+  return body.result.data;
+}
+
+// ---------------------------------------------------------------------------
+// WebSocket helpers (tRPC JSON-RPC over WebSocket)
+// ---------------------------------------------------------------------------
+
+interface WSMessage {
+  id: number;
+  jsonrpc: string;
+  result?: { type: string; data?: unknown };
+  error?: unknown;
+}
+
+interface SSEEvent {
+  event: string | null;
+  data: unknown;
+}
+
+/**
+ * Subscribe to a tRPC procedure over WebSocket and collect data messages.
+ * Returns collected data events once the subscription completes or times out.
+ */
+function wsSubscribe(
+  serverUrl: string,
+  procedure: string,
+  input: unknown,
+  opts?: { headers?: Record<string, string>; timeoutMs?: number },
+): Promise<{ messages: WSMessage[]; events: SSEEvent[] }> {
+  const wsUrl = `${serverUrl.replace(/^http/, "ws")}/trpc`;
+  const timeout = opts?.timeoutMs ?? 10_000;
+
+  return new Promise((resolve) => {
+    const ws = new WebSocket(wsUrl, { headers: opts?.headers ?? defaultHeaders });
+    const messages: WSMessage[] = [];
+    const events: SSEEvent[] = [];
+    let timer: ReturnType<typeof setTimeout>;
+
+    function finish() {
+      clearTimeout(timer);
+      ws.close();
+      resolve({ messages, events });
+    }
+
+    ws.on("open", () => {
+      ws.send(
+        JSON.stringify({
+          id: 1,
+          jsonrpc: "2.0",
+          method: "subscription",
+          params: { path: procedure, input },
+        }),
+      );
+    });
+
+    ws.on("message", (raw: Buffer) => {
+      const msg = JSON.parse(raw.toString()) as WSMessage;
+      messages.push(msg);
+
+      if (msg.result?.type === "data" && msg.result.data !== undefined) {
+        const data = msg.result.data;
+        const event =
+          typeof data === "object" && data !== null
+            ? ((data as Record<string, unknown>).type as string)
+            : null;
+        if (event) {
+          events.push({ event, data });
+        }
+      }
+
+      // "stopped" means the subscription completed server-side
+      if (msg.result?.type === "stopped") {
+        finish();
+      }
+    });
+
+    ws.on("error", () => finish());
+    ws.on("close", () => finish());
+    timer = setTimeout(finish, timeout);
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Polling helper
+// ---------------------------------------------------------------------------
+
+async function waitFor(
+  fn: () => Promise<boolean>,
+  { timeout = 10_000, interval = 100 } = {},
+): Promise<void> {
+  const start = Date.now();
+  while (Date.now() - start < timeout) {
+    try {
+      if (await fn()) return;
+    } catch {
+      // ignore and retry
+    }
+    await new Promise((r) => setTimeout(r, interval));
+  }
+  throw new Error(`waitFor timed out after ${timeout}ms`);
+}
+
+// ---------------------------------------------------------------------------
+// A simple scenario that completes quickly
+// ---------------------------------------------------------------------------
+
+function quickSuccessScenario() {
+  return [
+    {
+      type: "system",
+      subtype: "init",
+      session_id: "session-1",
+    },
+    {
+      type: "assistant",
+      message: {
+        content: [{ type: "text", text: "Done!" }],
+      },
+    },
+    {
+      type: "result",
+      subtype: "success",
+      session_id: "session-1",
+      duration_ms: 100,
+      num_turns: 1,
+      total_cost_usd: 0.01,
+    },
+  ];
+}
+
+function failureScenario() {
+  return [
+    {
+      type: "system",
+      subtype: "init",
+      session_id: "fail-session",
+    },
+    {
+      type: "result",
+      subtype: "failure",
+      session_id: "fail-session",
+      duration_ms: 50,
+      num_turns: 0,
+      total_cost_usd: 0,
+      errors: ["Something went wrong"],
+    },
+  ];
+}
+
+// ---------------------------------------------------------------------------
+// Queue auto-drain — single queued message
+// ---------------------------------------------------------------------------
+
+describe("queue auto-drain — single queued message", () => {
+  let server: ServerHandle;
+  let tmpHome: string;
+
+  beforeAll(async () => {
+    tmpHome = createTmpHome();
+    seedState(tmpHome, createDefaultState(tmpHome));
+
+    const scenarioPath = writeScenario(tmpHome, quickSuccessScenario());
+    seedSettings(tmpHome, defaultSettings());
+
+    server = await startServer({ tmpHome, scenarioPath });
+  });
+
+  afterAll(async () => {
+    await server.close();
+    rmSync(tmpHome, { recursive: true, force: true });
+  });
+
+  it("auto-starts the queued message after the first task completes", async () => {
+    const workspaceId = "testproject-main";
+
+    // 1. Submit the first task
+    const submitRes = await trpcMutate(server.url, "tasks.submit", {
+      workspaceId,
+      prompt: "first task",
+    });
+    expect(submitRes.status).toBe(200);
+
+    // 2. While the task is running, push a message to the queue
+    await trpcMutate(server.url, "queue.push", {
+      workspaceId,
+      text: "second task from queue",
+    });
+
+    // 3. Wait for the first task to complete AND the auto-started second task to complete
+    await waitFor(async () => {
+      const res = await trpcQuery(server.url, "tasks.get", { workspaceId });
+      const data = await trpcData<{ task?: { status: string; prompt: string } }>(res);
+      // The auto-started task should eventually finish too
+      return data.task?.status !== "running";
+    });
+
+    // 4. Verify the queue is now empty (message was consumed)
+    const queueRes = await trpcQuery(server.url, "queue.get", { workspaceId });
+    const queueData = await trpcData<{ messages: string[] }>(queueRes);
+    expect(queueData.messages).toEqual([]);
+
+    // 5. Verify the last task that ran was the queued one
+    const taskRes = await trpcQuery(server.url, "tasks.get", { workspaceId });
+    const taskData = await trpcData<{ task?: { prompt: string; status: string } }>(taskRes);
+    expect(taskData.task?.prompt).toBe("second task from queue");
+    expect(taskData.task?.status).toBe("completed");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Queue auto-drain — multiple queued messages
+// ---------------------------------------------------------------------------
+
+describe("queue auto-drain — multiple queued messages", () => {
+  let server: ServerHandle;
+  let tmpHome: string;
+
+  beforeAll(async () => {
+    tmpHome = createTmpHome();
+    seedState(tmpHome, createDefaultState(tmpHome));
+
+    const scenarioPath = writeScenario(tmpHome, quickSuccessScenario());
+    seedSettings(tmpHome, defaultSettings());
+
+    server = await startServer({ tmpHome, scenarioPath });
+  });
+
+  afterAll(async () => {
+    await server.close();
+    rmSync(tmpHome, { recursive: true, force: true });
+  });
+
+  it("drains all queued messages sequentially", async () => {
+    const workspaceId = "testproject-main";
+
+    // 1. Submit the first task
+    const submitRes = await trpcMutate(server.url, "tasks.submit", {
+      workspaceId,
+      prompt: "task 1",
+    });
+    expect(submitRes.status).toBe(200);
+
+    // 2. Queue up two more messages while it's running
+    await trpcMutate(server.url, "queue.push", { workspaceId, text: "task 2" });
+    await trpcMutate(server.url, "queue.push", { workspaceId, text: "task 3" });
+
+    // 3. Wait for all tasks to drain (the last prompt should be "task 3")
+    await waitFor(
+      async () => {
+        const res = await trpcQuery(server.url, "tasks.get", { workspaceId });
+        const data = await trpcData<{ task?: { status: string; prompt: string } }>(res);
+        return data.task?.prompt === "task 3" && data.task?.status !== "running";
+      },
+      { timeout: 15_000 },
+    );
+
+    // 4. Verify queue is empty
+    const queueRes = await trpcQuery(server.url, "queue.get", { workspaceId });
+    const queueData = await trpcData<{ messages: string[] }>(queueRes);
+    expect(queueData.messages).toEqual([]);
+
+    // 5. Verify all three tasks were recorded
+    const listRes = await trpcQuery(server.url, "tasks.list", { workspaceId });
+    const listData = await trpcData<{ tasks: Array<{ prompt: string; status: string }> }>(listRes);
+    const prompts = listData.tasks.map((t) => t.prompt);
+    expect(prompts).toContain("task 1");
+    expect(prompts).toContain("task 2");
+    expect(prompts).toContain("task 3");
+
+    // All should be completed
+    for (const task of listData.tasks) {
+      expect(task.status).toBe("completed");
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Queue auto-drain — failed task does NOT drain queue
+// ---------------------------------------------------------------------------
+
+describe("queue auto-drain — failed task does not drain queue", () => {
+  let server: ServerHandle;
+  let tmpHome: string;
+
+  beforeAll(async () => {
+    tmpHome = createTmpHome();
+    seedState(tmpHome, createDefaultState(tmpHome));
+
+    const scenarioPath = writeScenario(tmpHome, failureScenario());
+    seedSettings(tmpHome, defaultSettings());
+
+    server = await startServer({ tmpHome, scenarioPath });
+  });
+
+  afterAll(async () => {
+    await server.close();
+    rmSync(tmpHome, { recursive: true, force: true });
+  });
+
+  it("does not auto-start queued messages when a task fails", async () => {
+    const workspaceId = "testproject-main";
+
+    // 1. Submit a task that will fail
+    const submitRes = await trpcMutate(server.url, "tasks.submit", {
+      workspaceId,
+      prompt: "this will fail",
+    });
+    expect(submitRes.status).toBe(200);
+
+    // 2. Queue a message while it's running
+    await trpcMutate(server.url, "queue.push", { workspaceId, text: "should stay queued" });
+
+    // 3. Wait for the task to fail
+    await waitFor(async () => {
+      const res = await trpcQuery(server.url, "tasks.get", { workspaceId });
+      const data = await trpcData<{ task?: { status: string } }>(res);
+      return data.task?.status === "failed";
+    });
+
+    // 4. Give a short moment to ensure no auto-start happens
+    await new Promise((r) => setTimeout(r, 500));
+
+    // 5. Verify queue still has the message (it was NOT consumed)
+    const queueRes = await trpcQuery(server.url, "queue.get", { workspaceId });
+    const queueData = await trpcData<{ messages: string[] }>(queueRes);
+    expect(queueData.messages).toEqual(["should stay queued"]);
+
+    // Cleanup
+    await trpcMutate(server.url, "queue.clear", { workspaceId });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Stream subscription stays alive across auto-drained tasks (WebSocket)
+// ---------------------------------------------------------------------------
+
+describe("stream stays alive across auto-drained tasks (WebSocket)", () => {
+  let server: ServerHandle;
+  let tmpHome: string;
+
+  beforeAll(async () => {
+    tmpHome = createTmpHome();
+    seedState(tmpHome, createDefaultState(tmpHome));
+
+    const scenarioPath = writeScenario(tmpHome, quickSuccessScenario());
+    seedSettings(tmpHome, defaultSettings());
+
+    server = await startServer({ tmpHome, scenarioPath });
+  });
+
+  afterAll(async () => {
+    await server.close();
+    rmSync(tmpHome, { recursive: true, force: true });
+  });
+
+  it("reconnecting client receives the auto-started task's buffered events", async () => {
+    const workspaceId = "testproject-main";
+
+    // 1. Pre-load the queue BEFORE submitting the first task
+    await trpcMutate(server.url, "queue.push", { workspaceId, text: "task B" });
+
+    // 2. Submit the first task
+    const submitRes = await trpcMutate(server.url, "tasks.submit", {
+      workspaceId,
+      prompt: "task A",
+    });
+    expect(submitRes.status).toBe(200);
+
+    // 3. Wait for both tasks to drain completely
+    await waitFor(
+      async () => {
+        const res = await trpcQuery(server.url, "tasks.get", { workspaceId });
+        const data = await trpcData<{ task?: { prompt: string; status: string } }>(res);
+        return data.task?.prompt === "task B" && data.task?.status !== "running";
+      },
+      { timeout: 15_000 },
+    );
+
+    // 4. Subscribe via WebSocket — simulates a reconnecting client.
+    //    The stream buffer should contain the auto-started task's events.
+    const { events } = await wsSubscribe(
+      server.url,
+      "tasks.stream",
+      { workspaceId },
+      { timeoutMs: 5_000 },
+    );
+
+    // 5. Should have task B's data-prompt in the buffer
+    const dataPromptEvents = events.filter((e) => e.event === "data-prompt");
+    expect(dataPromptEvents.length).toBeGreaterThanOrEqual(1);
+
+    const prompts = dataPromptEvents.map(
+      (e) => ((e.data as Record<string, unknown>).data as { text: string }).text,
+    );
+    expect(prompts).toContain("task B");
+
+    // 6. Should have finish and result events
+    const finishEvents = events.filter((e) => e.event === "finish");
+    expect(finishEvents.length).toBeGreaterThanOrEqual(1);
+
+    const resultEvents = events.filter((e) => e.event === "data-result");
+    expect(resultEvents.length).toBeGreaterThanOrEqual(1);
+
+    // 7. Queue should be empty
+    const queueRes = await trpcQuery(server.url, "queue.get", { workspaceId });
+    const queueData = await trpcData<{ messages: string[] }>(queueRes);
+    expect(queueData.messages).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Stream closes after last task when queue is empty
+// ---------------------------------------------------------------------------
+
+describe("stream closes after last task when queue is empty", () => {
+  let server: ServerHandle;
+  let tmpHome: string;
+
+  beforeAll(async () => {
+    tmpHome = createTmpHome();
+    seedState(tmpHome, createDefaultState(tmpHome));
+
+    const scenarioPath = writeScenario(tmpHome, quickSuccessScenario());
+    seedSettings(tmpHome, defaultSettings());
+
+    server = await startServer({ tmpHome, scenarioPath });
+  });
+
+  afterAll(async () => {
+    await server.close();
+    rmSync(tmpHome, { recursive: true, force: true });
+  });
+
+  it("closes the subscription after task finishes with empty queue", async () => {
+    const workspaceId = "testproject-main";
+
+    // Submit a task with no queue
+    const submitRes = await trpcMutate(server.url, "tasks.submit", {
+      workspaceId,
+      prompt: "only task",
+    });
+    expect(submitRes.status).toBe(200);
+
+    await new Promise((r) => setTimeout(r, 100));
+
+    // Subscribe and wait for completion
+    const startTime = Date.now();
+    const { events } = await wsSubscribe(
+      server.url,
+      "tasks.stream",
+      { workspaceId },
+      { timeoutMs: 10_000 },
+    );
+    const elapsed = Date.now() - startTime;
+
+    // Should have completed (not timed out at 10s)
+    expect(elapsed).toBeLessThan(9_000);
+
+    // Should have exactly one finish event
+    const finishEvents = events.filter((e) => e.event === "finish");
+    expect(finishEvents.length).toBe(1);
+
+    // Should have exactly one data-prompt
+    const dataPromptEvents = events.filter((e) => e.event === "data-prompt");
+    expect(dataPromptEvents.length).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// queue.shift — backend shift endpoint
+// ---------------------------------------------------------------------------
+
+describe("queue.shift — pops the first message", () => {
+  let server: ServerHandle;
+  let tmpHome: string;
+
+  beforeAll(async () => {
+    tmpHome = createTmpHome();
+    seedState(tmpHome, createDefaultState(tmpHome));
+    seedSettings(tmpHome, defaultSettings());
+
+    server = await startServer({ tmpHome });
+  });
+
+  afterAll(async () => {
+    await server.close();
+    rmSync(tmpHome, { recursive: true, force: true });
+  });
+
+  it("returns null when queue is empty", async () => {
+    const res = await trpcMutate(server.url, "queue.shift", { workspaceId: "testproject-main" });
+    expect(res.status).toBe(200);
+    const data = await trpcData<{ text: string | null }>(res);
+    expect(data.text).toBeNull();
+  });
+
+  it("pops the first message and leaves the rest", async () => {
+    const workspaceId = "testproject-main";
+
+    // Seed the queue
+    await trpcMutate(server.url, "queue.push", { workspaceId, text: "first" });
+    await trpcMutate(server.url, "queue.push", { workspaceId, text: "second" });
+    await trpcMutate(server.url, "queue.push", { workspaceId, text: "third" });
+
+    // Shift the first
+    const shiftRes = await trpcMutate(server.url, "queue.shift", { workspaceId });
+    const shiftData = await trpcData<{ text: string | null }>(shiftRes);
+    expect(shiftData.text).toBe("first");
+
+    // Verify remaining
+    const getRes = await trpcQuery(server.url, "queue.get", { workspaceId });
+    const getData = await trpcData<{ messages: string[] }>(getRes);
+    expect(getData.messages).toEqual(["second", "third"]);
+
+    // Cleanup
+    await trpcMutate(server.url, "queue.clear", { workspaceId });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Queue auto-drain — session continuity
+// ---------------------------------------------------------------------------
+
+describe("queue auto-drain — session continuity", () => {
+  let server: ServerHandle;
+  let tmpHome: string;
+
+  beforeAll(async () => {
+    tmpHome = createTmpHome();
+    seedState(tmpHome, createDefaultState(tmpHome));
+
+    const scenarioPath = writeScenario(tmpHome, quickSuccessScenario());
+    seedSettings(tmpHome, defaultSettings());
+
+    server = await startServer({ tmpHome, scenarioPath });
+  });
+
+  afterAll(async () => {
+    await server.close();
+    rmSync(tmpHome, { recursive: true, force: true });
+  });
+
+  it("auto-started task inherits the session ID from the completed task", async () => {
+    const workspaceId = "testproject-main";
+
+    // 1. Submit the first task
+    await trpcMutate(server.url, "tasks.submit", { workspaceId, prompt: "initial task" });
+
+    // 2. Queue a follow-up
+    await trpcMutate(server.url, "queue.push", { workspaceId, text: "follow-up" });
+
+    // 3. Wait for both tasks to drain
+    await waitFor(
+      async () => {
+        const res = await trpcQuery(server.url, "tasks.get", { workspaceId });
+        const data = await trpcData<{ task?: { status: string; prompt: string } }>(res);
+        return data.task?.prompt === "follow-up" && data.task?.status !== "running";
+      },
+      { timeout: 15_000 },
+    );
+
+    // 4. Both tasks should have a session ID (the second inherits from the first)
+    const listRes = await trpcQuery(server.url, "tasks.list", { workspaceId });
+    const listData = await trpcData<{
+      tasks: Array<{ prompt: string; sessionId: string | null }>;
+    }>(listRes);
+
+    const initialTask = listData.tasks.find((t) => t.prompt === "initial task");
+    const followUpTask = listData.tasks.find((t) => t.prompt === "follow-up");
+
+    expect(initialTask).toBeDefined();
+    expect(followUpTask).toBeDefined();
+    expect(initialTask!.sessionId).toBeDefined();
+    // The follow-up should have the same session ID (session continuity)
+    expect(followUpTask!.sessionId).toBe(initialTask!.sessionId);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Queue auto-drain — queue pushed after task starts but before it finishes
+// ---------------------------------------------------------------------------
+
+describe("queue auto-drain — late queue push", () => {
+  let server: ServerHandle;
+  let tmpHome: string;
+
+  beforeAll(async () => {
+    tmpHome = createTmpHome();
+    seedState(tmpHome, createDefaultState(tmpHome));
+
+    const scenarioPath = writeScenario(tmpHome, quickSuccessScenario());
+    seedSettings(tmpHome, defaultSettings());
+
+    server = await startServer({ tmpHome, scenarioPath });
+  });
+
+  afterAll(async () => {
+    await server.close();
+    rmSync(tmpHome, { recursive: true, force: true });
+  });
+
+  it("drains a message pushed while the task is still running", async () => {
+    const workspaceId = "testproject-main";
+
+    // 1. Submit the first task
+    await trpcMutate(server.url, "tasks.submit", { workspaceId, prompt: "main task" });
+
+    // 2. Immediately push to queue (task is still running or just finishing)
+    await trpcMutate(server.url, "queue.push", { workspaceId, text: "queued while running" });
+
+    // 3. Wait for the queued task to complete
+    await waitFor(
+      async () => {
+        const res = await trpcQuery(server.url, "tasks.get", { workspaceId });
+        const data = await trpcData<{ task?: { prompt: string; status: string } }>(res);
+        return data.task?.prompt === "queued while running" && data.task?.status !== "running";
+      },
+      { timeout: 15_000 },
+    );
+
+    // 4. Queue is drained
+    const queueRes = await trpcQuery(server.url, "queue.get", { workspaceId });
+    const queueData = await trpcData<{ messages: string[] }>(queueRes);
+    expect(queueData.messages).toEqual([]);
+  });
+});

--- a/apps/web/tests/queue-drain.test.ts
+++ b/apps/web/tests/queue-drain.test.ts
@@ -357,12 +357,11 @@ describe("queue auto-drain — single queued message", () => {
       text: "second task from queue",
     });
 
-    // 3. Wait for the first task to complete AND the auto-started second task to complete
+    // 3. Wait for the auto-started second task to complete
     await waitFor(async () => {
       const res = await trpcQuery(server.url, "tasks.get", { workspaceId });
       const data = await trpcData<{ task?: { status: string; prompt: string } }>(res);
-      // The auto-started task should eventually finish too
-      return data.task?.status !== "running";
+      return data.task?.prompt === "second task from queue" && data.task?.status === "completed";
     });
 
     // 4. Verify the queue is now empty (message was consumed)

--- a/apps/web/tests/queue.test.ts
+++ b/apps/web/tests/queue.test.ts
@@ -1,0 +1,405 @@
+import { execFileSync, spawn } from "node:child_process";
+import { mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from "node:fs";
+import { createServer } from "node:net";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+const PROJECT_ROOT = join(import.meta.dirname, "..");
+const DEFAULT_TOKEN = "queue-test-token";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+interface ServerHandle {
+  url: string;
+  home: string;
+  close: () => Promise<void>;
+}
+
+function createTmpHome(): string {
+  const tmp = realpathSync(mkdtempSync(join(tmpdir(), "band-queue-test-")));
+  const bandDir = join(tmp, ".band");
+  mkdirSync(bandDir, { recursive: true });
+  mkdirSync(join(bandDir, "status"), { recursive: true });
+  return tmp;
+}
+
+function seedState(tmpHome: string, state: object): void {
+  writeFileSync(join(tmpHome, ".band", "state.json"), JSON.stringify(state));
+}
+
+function seedSettings(tmpHome: string, settings: object): void {
+  writeFileSync(join(tmpHome, ".band", "settings.json"), JSON.stringify(settings));
+}
+
+function getRandomPort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const srv = createServer();
+    srv.listen(0, "127.0.0.1", () => {
+      const { port } = srv.address() as { port: number };
+      srv.close(() => resolve(port));
+    });
+    srv.on("error", reject);
+  });
+}
+
+async function startServer(
+  opts: { tmpHome?: string; env?: Record<string, string> } = {},
+): Promise<ServerHandle> {
+  const home = opts.tmpHome || createTmpHome();
+  const port = await getRandomPort();
+
+  return new Promise((resolve, reject) => {
+    const child = spawn("node", ["dist/start-server.mjs"], {
+      cwd: PROJECT_ROOT,
+      env: {
+        ...process.env,
+        HOME: home,
+        PORT: String(port),
+        NODE_ENV: "production",
+        ...opts.env,
+      },
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+
+    let stderr = "";
+    let settled = false;
+
+    child.stderr!.on("data", (chunk: Buffer) => {
+      stderr += chunk.toString();
+    });
+
+    child.stdout!.on("data", (chunk: Buffer) => {
+      const text = chunk.toString();
+      if (text.includes("listening") && !settled) {
+        settled = true;
+        resolve({
+          url: `http://127.0.0.1:${port}`,
+          home,
+          close: () =>
+            new Promise<void>((r) => {
+              child.on("exit", () => r());
+              child.kill("SIGTERM");
+            }),
+        });
+      }
+    });
+
+    child.on("error", (err) => {
+      if (!settled) {
+        settled = true;
+        reject(err);
+      }
+    });
+
+    child.on("exit", (code) => {
+      if (!settled) {
+        settled = true;
+        reject(new Error(`Server exited with code ${code} before listening.\nstderr: ${stderr}`));
+      }
+    });
+
+    setTimeout(() => {
+      if (!settled) {
+        settled = true;
+        child.kill("SIGTERM");
+        reject(new Error(`Server did not start within 15 s.\nstderr: ${stderr}`));
+      }
+    }, 15_000);
+  });
+}
+
+// ---------------------------------------------------------------------------
+// tRPC HTTP helpers
+// ---------------------------------------------------------------------------
+
+const defaultHeaders = { Cookie: `band_token=${DEFAULT_TOKEN}` };
+
+async function trpcQuery(serverUrl: string, procedure: string, input?: unknown) {
+  const url =
+    input !== undefined
+      ? `${serverUrl}/trpc/${procedure}?input=${encodeURIComponent(JSON.stringify(input))}`
+      : `${serverUrl}/trpc/${procedure}`;
+  return fetch(url, { headers: defaultHeaders });
+}
+
+async function trpcMutate(serverUrl: string, procedure: string, input?: unknown) {
+  return fetch(`${serverUrl}/trpc/${procedure}`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", ...defaultHeaders },
+    body: input !== undefined ? JSON.stringify(input) : "{}",
+  });
+}
+
+async function trpcData<T>(res: Response): Promise<T> {
+  const body = (await res.json()) as { result: { data: T } };
+  return body.result.data;
+}
+
+// ---------------------------------------------------------------------------
+// Git helpers
+// ---------------------------------------------------------------------------
+
+const gitEnv = {
+  ...process.env,
+  GIT_AUTHOR_NAME: "Test",
+  GIT_AUTHOR_EMAIL: "test@test.com",
+  GIT_COMMITTER_NAME: "Test",
+  GIT_COMMITTER_EMAIL: "test@test.com",
+};
+
+function git(cwd: string, args: string[]): string {
+  return execFileSync("git", args, { cwd, env: gitEnv, encoding: "utf-8" });
+}
+
+function createGitRepo(parentDir: string, name: string): string {
+  const repoPath = join(parentDir, name);
+  mkdirSync(repoPath, { recursive: true });
+  git(repoPath, ["init", "-b", "main"]);
+  writeFileSync(join(repoPath, "README.md"), "# Test\n");
+  git(repoPath, ["add", "."]);
+  git(repoPath, ["commit", "-m", "init"]);
+  return repoPath;
+}
+
+// ---------------------------------------------------------------------------
+// queue.push / queue.set / queue.get / queue.clear — CRUD
+// ---------------------------------------------------------------------------
+
+describe("tRPC — queue CRUD", () => {
+  let server: ServerHandle;
+  let tmpHome: string;
+
+  beforeAll(async () => {
+    tmpHome = createTmpHome();
+    const repo = createGitRepo(tmpHome, "proj");
+
+    seedState(tmpHome, {
+      projects: [
+        {
+          name: "proj",
+          path: repo,
+          defaultBranch: "main",
+          worktrees: [{ branch: "main", path: repo }],
+        },
+      ],
+    });
+    seedSettings(tmpHome, { tokenSecret: DEFAULT_TOKEN });
+
+    server = await startServer({ tmpHome });
+  });
+
+  afterAll(async () => {
+    await server.close();
+    rmSync(tmpHome, { recursive: true, force: true });
+  });
+
+  it("returns empty array when no queued messages exist", async () => {
+    const res = await trpcQuery(server.url, "queue.get", { workspaceId: "proj-main" });
+    expect(res.status).toBe(200);
+    const data = await trpcData<{ messages: string[] }>(res);
+    expect(data.messages).toEqual([]);
+  });
+
+  it("pushes a single queued message via queue.push", async () => {
+    const res = await trpcMutate(server.url, "queue.push", {
+      workspaceId: "proj-main",
+      text: "fix the bug",
+    });
+    expect(res.status).toBe(200);
+    const data = await trpcData<{ ok: boolean }>(res);
+    expect(data.ok).toBe(true);
+
+    const getRes = await trpcQuery(server.url, "queue.get", { workspaceId: "proj-main" });
+    const getData = await trpcData<{ messages: string[] }>(getRes);
+    expect(getData.messages).toEqual(["fix the bug"]);
+  });
+
+  it("pushes multiple messages and preserves order", async () => {
+    await trpcMutate(server.url, "queue.push", {
+      workspaceId: "proj-main",
+      text: "add tests",
+    });
+    await trpcMutate(server.url, "queue.push", {
+      workspaceId: "proj-main",
+      text: "update docs",
+    });
+
+    const res = await trpcQuery(server.url, "queue.get", { workspaceId: "proj-main" });
+    const data = await trpcData<{ messages: string[] }>(res);
+    expect(data.messages).toEqual(["fix the bug", "add tests", "update docs"]);
+  });
+
+  it("replaces the entire queue via queue.set", async () => {
+    const res = await trpcMutate(server.url, "queue.set", {
+      workspaceId: "proj-main",
+      messages: ["new first", "new second"],
+    });
+    expect(res.status).toBe(200);
+
+    const getRes = await trpcQuery(server.url, "queue.get", { workspaceId: "proj-main" });
+    const getData = await trpcData<{ messages: string[] }>(getRes);
+    expect(getData.messages).toEqual(["new first", "new second"]);
+  });
+
+  it("queue.set with empty array clears the queue", async () => {
+    await trpcMutate(server.url, "queue.set", {
+      workspaceId: "proj-main",
+      messages: [],
+    });
+
+    const res = await trpcQuery(server.url, "queue.get", { workspaceId: "proj-main" });
+    const data = await trpcData<{ messages: string[] }>(res);
+    expect(data.messages).toEqual([]);
+  });
+
+  it("removes a single message by value via queue.remove", async () => {
+    // Seed: a, b, c
+    await trpcMutate(server.url, "queue.clear", { workspaceId: "proj-main" });
+    await trpcMutate(server.url, "queue.push", { workspaceId: "proj-main", text: "a" });
+    await trpcMutate(server.url, "queue.push", { workspaceId: "proj-main", text: "b" });
+    await trpcMutate(server.url, "queue.push", { workspaceId: "proj-main", text: "c" });
+
+    const res = await trpcMutate(server.url, "queue.remove", {
+      workspaceId: "proj-main",
+      text: "b",
+    });
+    expect(res.status).toBe(200);
+
+    const getRes = await trpcQuery(server.url, "queue.get", { workspaceId: "proj-main" });
+    const getData = await trpcData<{ messages: string[] }>(getRes);
+    expect(getData.messages).toEqual(["a", "c"]);
+
+    // cleanup
+    await trpcMutate(server.url, "queue.clear", { workspaceId: "proj-main" });
+  });
+
+  it("queue.remove only removes the first occurrence of a duplicate", async () => {
+    await trpcMutate(server.url, "queue.push", { workspaceId: "proj-main", text: "dup" });
+    await trpcMutate(server.url, "queue.push", { workspaceId: "proj-main", text: "dup" });
+
+    await trpcMutate(server.url, "queue.remove", { workspaceId: "proj-main", text: "dup" });
+
+    const getRes = await trpcQuery(server.url, "queue.get", { workspaceId: "proj-main" });
+    const getData = await trpcData<{ messages: string[] }>(getRes);
+    expect(getData.messages).toEqual(["dup"]);
+
+    // cleanup
+    await trpcMutate(server.url, "queue.clear", { workspaceId: "proj-main" });
+  });
+
+  it("clears all queued messages via queue.clear", async () => {
+    // Seed some messages first
+    await trpcMutate(server.url, "queue.push", { workspaceId: "proj-main", text: "a" });
+    await trpcMutate(server.url, "queue.push", { workspaceId: "proj-main", text: "b" });
+
+    const clearRes = await trpcMutate(server.url, "queue.clear", { workspaceId: "proj-main" });
+    expect(clearRes.status).toBe(200);
+    const clearData = await trpcData<{ ok: boolean }>(clearRes);
+    expect(clearData.ok).toBe(true);
+
+    const getRes = await trpcQuery(server.url, "queue.get", { workspaceId: "proj-main" });
+    const getData = await trpcData<{ messages: string[] }>(getRes);
+    expect(getData.messages).toEqual([]);
+  });
+
+  it("clearing a non-existent queue is a no-op", async () => {
+    const res = await trpcMutate(server.url, "queue.clear", { workspaceId: "nonexistent-ws" });
+    expect(res.status).toBe(200);
+    const data = await trpcData<{ ok: boolean }>(res);
+    expect(data.ok).toBe(true);
+  });
+
+  it("queued messages are isolated per workspace", async () => {
+    await trpcMutate(server.url, "queue.push", { workspaceId: "ws-a", text: "msg-a1" });
+    await trpcMutate(server.url, "queue.push", { workspaceId: "ws-a", text: "msg-a2" });
+    await trpcMutate(server.url, "queue.push", { workspaceId: "ws-b", text: "msg-b1" });
+
+    const resA = await trpcQuery(server.url, "queue.get", { workspaceId: "ws-a" });
+    const dataA = await trpcData<{ messages: string[] }>(resA);
+    expect(dataA.messages).toEqual(["msg-a1", "msg-a2"]);
+
+    const resB = await trpcQuery(server.url, "queue.get", { workspaceId: "ws-b" });
+    const dataB = await trpcData<{ messages: string[] }>(resB);
+    expect(dataB.messages).toEqual(["msg-b1"]);
+
+    // Clearing one doesn't affect the other
+    await trpcMutate(server.url, "queue.clear", { workspaceId: "ws-a" });
+
+    const resA2 = await trpcQuery(server.url, "queue.get", { workspaceId: "ws-a" });
+    const dataA2 = await trpcData<{ messages: string[] }>(resA2);
+    expect(dataA2.messages).toEqual([]);
+
+    const resB2 = await trpcQuery(server.url, "queue.get", { workspaceId: "ws-b" });
+    const dataB2 = await trpcData<{ messages: string[] }>(resB2);
+    expect(dataB2.messages).toEqual(["msg-b1"]);
+
+    // cleanup
+    await trpcMutate(server.url, "queue.clear", { workspaceId: "ws-b" });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Input validation
+// ---------------------------------------------------------------------------
+
+describe("tRPC — queue input validation", () => {
+  let server: ServerHandle;
+  let tmpHome: string;
+
+  beforeAll(async () => {
+    tmpHome = createTmpHome();
+    const repo = createGitRepo(tmpHome, "proj");
+
+    seedState(tmpHome, {
+      projects: [
+        {
+          name: "proj",
+          path: repo,
+          defaultBranch: "main",
+          worktrees: [{ branch: "main", path: repo }],
+        },
+      ],
+    });
+    seedSettings(tmpHome, { tokenSecret: DEFAULT_TOKEN });
+
+    server = await startServer({ tmpHome });
+  });
+
+  afterAll(async () => {
+    await server.close();
+    rmSync(tmpHome, { recursive: true, force: true });
+  });
+
+  it("queue.push fails when workspaceId is missing", async () => {
+    const res = await trpcMutate(server.url, "queue.push", { text: "hello" });
+    expect(res.ok).toBe(false);
+  });
+
+  it("queue.push fails when text is missing", async () => {
+    const res = await trpcMutate(server.url, "queue.push", { workspaceId: "proj-main" });
+    expect(res.ok).toBe(false);
+  });
+
+  it("queue.set fails when workspaceId is missing", async () => {
+    const res = await trpcMutate(server.url, "queue.set", { messages: ["hello"] });
+    expect(res.ok).toBe(false);
+  });
+
+  it("queue.set fails when messages is missing", async () => {
+    const res = await trpcMutate(server.url, "queue.set", { workspaceId: "proj-main" });
+    expect(res.ok).toBe(false);
+  });
+
+  it("queue.get fails when workspaceId is missing", async () => {
+    const res = await trpcQuery(server.url, "queue.get", {});
+    expect(res.ok).toBe(false);
+  });
+
+  it("queue.clear fails when workspaceId is missing", async () => {
+    const res = await trpcMutate(server.url, "queue.clear", {});
+    expect(res.ok).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- When multiple messages are queued while the agent is busy, each now renders as a separate user→assistant pair instead of being concatenated into a single bubble
- Queue state syncs in real-time via a dedicated tRPC subscription backed by an in-memory pub/sub store (`queued-message-store.ts`)
- Broadcasts `data-prompt` chunks to existing stream subscribers when auto-starting queued tasks, and splits assistant messages at these boundaries for segmented rendering

## Test plan
- [x] `pnpm --filter @band/web build` passes
- [x] `pnpm --filter @band/web test` — 237 tests pass (including 16 queue tests)
- [ ] Manual: send "say 1", queue "say 2", "say 3", "say 4" — verify each appears as separate user→assistant pairs, badges disappear progressively
- [ ] Manual: queue messages, navigate away and back — verify processing continues and display is correct
- [ ] Manual: cancel a queued message — verify it disappears immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)