### PR TITLE
fix: clear needs_attention status when workspace is selected

### DIFF
--- a/apps/web/src/routes/workspace.$workspaceId.tsx
+++ b/apps/web/src/routes/workspace.$workspaceId.tsx
@@ -126,6 +126,15 @@ function WorkspaceLayout() {
     return () => setActiveWorkspace(null);
   }, [decoded, setActiveWorkspace]);
 
+  // Clear needs_attention status when viewing this workspace
+  const agentStatus = useDashboardStore((s) => s.statuses.get(decoded)?.agent?.status);
+  useEffect(() => {
+    if (agentStatus !== "needs_attention") return;
+    trpc.statuses.update
+      .mutate({ workspaceId: decoded, agent: { status: "waiting" } })
+      .catch(() => {});
+  }, [decoded, agentStatus]);
+
   return (
     <DiffStatsContext.Provider value={{ diffStats, setDiffStats }}>
       {isDesktop ? (


### PR DESCRIPTION
## Summary
- When a workspace route is opened in the dashboard, automatically clears the `needs_attention` agent status by calling `statuses.update` to set it to `waiting`
- Only fires when the status is actually `needs_attention` to avoid unnecessary API calls
- Implemented as a `useEffect` in the workspace route component, which has direct access to the tRPC client and the Zustand store

## Test plan
- [ ] Open a workspace that has `needs_attention` status → verify the indicator clears automatically
- [ ] Open a workspace with `working` or `waiting` status → verify no unnecessary mutation is fired
- [ ] Let an agent stop while already viewing that workspace → verify the `needs_attention` status is cleared immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)