### PR TITLE
feat: fall back to main repo for .band/config.json

### DIFF
--- a/apps/dashboard/src-tauri/src/commands/apps/mod.rs
+++ b/apps/dashboard/src-tauri/src/commands/apps/mod.rs
@@ -361,17 +361,20 @@ pub fn compute_layout(
 
 // --- Config loading ---
 
-pub fn load_apps_config(worktree_path: &str) -> Vec<AppConfig> {
-    // Try project .band/config.json first
-    let project_config_path = std::path::PathBuf::from(worktree_path)
-        .join(".band")
-        .join("config.json");
+pub fn load_apps_config(worktree_path: &str, project_path: &str) -> Vec<AppConfig> {
+    // Try .band/config.json — worktree first, then project root (fallback for
+    // .gitignored configs that don't appear in new worktrees).
+    for base in [worktree_path, project_path] {
+        let config_path = std::path::PathBuf::from(base)
+            .join(".band")
+            .join("config.json");
 
-    if let Ok(data) = std::fs::read_to_string(&project_config_path) {
-        if let Ok(config) = serde_json::from_str::<BandAppsConfig>(&data) {
-            if let Some(apps) = config.apps {
-                if !apps.is_empty() {
-                    return apps;
+        if let Ok(data) = std::fs::read_to_string(&config_path) {
+            if let Ok(config) = serde_json::from_str::<BandAppsConfig>(&data) {
+                if let Some(apps) = config.apps {
+                    if !apps.is_empty() {
+                        return apps;
+                    }
                 }
             }
         }

--- a/apps/dashboard/src-tauri/src/commands/ide.rs
+++ b/apps/dashboard/src-tauri/src/commands/ide.rs
@@ -188,7 +188,7 @@ fn is_dashboard_frontmost() -> bool {
 }
 
 /// Look up the worktree path and folder name for a given workspace ID.
-fn workspace_info(workspace_id: &str, app_state: &state::AppState) -> Option<(String, String)> {
+fn workspace_info(workspace_id: &str, app_state: &state::AppState) -> Option<(String, String, String)> {
     for proj in &app_state.projects {
         for wt in &proj.worktrees {
             let ws_id = to_workspace_id(&proj.name, &wt.branch);
@@ -198,7 +198,7 @@ fn workspace_info(workspace_id: &str, app_state: &state::AppState) -> Option<(St
                     .and_then(|n| n.to_str())
                     .unwrap_or("")
                     .to_string();
-                return Some((wt.path.clone(), folder_name));
+                return Some((wt.path.clone(), folder_name, proj.path.clone()));
             }
         }
     }
@@ -381,11 +381,11 @@ pub fn raise_workspace_windows(workspace_id: &str, cache: &ProjectCache) {
     let Some(app_state) = cache.get() else {
         return;
     };
-    let Some((worktree_path, _folder_name)) = workspace_info(workspace_id, &app_state) else {
+    let Some((worktree_path, _folder_name, proj_path)) = workspace_info(workspace_id, &app_state) else {
         return;
     };
 
-    let app_configs = apps::load_apps_config(&worktree_path);
+    let app_configs = apps::load_apps_config(&worktree_path, &proj_path);
 
     if app_configs.is_empty() {
         return;
@@ -519,13 +519,13 @@ pub fn workspace_focus(
         .or_else(|| refresh_project_cache(&project_cache))
         .ok_or("Project state not available yet")?;
 
-    let (wt_path, ws_id) = if let Some((_proj, wt)) = find_workspace(&workspace_id, &app_state) {
-        (wt.path.clone(), workspace_id.clone())
+    let (wt_path, proj_path, ws_id) = if let Some((proj, wt)) = find_workspace(&workspace_id, &app_state) {
+        (wt.path.clone(), proj.path.clone(), workspace_id.clone())
     } else {
         let fresh = refresh_project_cache(&project_cache)
             .ok_or(format!("Workspace '{workspace_id}' not found"))?;
-        if let Some((_proj, wt)) = find_workspace(&workspace_id, &fresh) {
-            (wt.path.clone(), workspace_id.clone())
+        if let Some((proj, wt)) = find_workspace(&workspace_id, &fresh) {
+            (wt.path.clone(), proj.path.clone(), workspace_id.clone())
         } else {
             return Err(format!("Workspace '{workspace_id}' not found"));
         }
@@ -538,7 +538,7 @@ pub fn workspace_focus(
         .to_string();
 
     // Load apps config for this workspace
-    let app_configs = apps::load_apps_config(&wt_path);
+    let app_configs = apps::load_apps_config(&wt_path, &proj_path);
 
     if app_configs.is_empty() {
         return Err("IDE not configured: no apps defined in config".to_string());

--- a/apps/dashboard/src-tauri/src/commands/ide.rs
+++ b/apps/dashboard/src-tauri/src/commands/ide.rs
@@ -188,7 +188,10 @@ fn is_dashboard_frontmost() -> bool {
 }
 
 /// Look up the worktree path and folder name for a given workspace ID.
-fn workspace_info(workspace_id: &str, app_state: &state::AppState) -> Option<(String, String, String)> {
+fn workspace_info(
+    workspace_id: &str,
+    app_state: &state::AppState,
+) -> Option<(String, String, String)> {
     for proj in &app_state.projects {
         for wt in &proj.worktrees {
             let ws_id = to_workspace_id(&proj.name, &wt.branch);
@@ -381,7 +384,8 @@ pub fn raise_workspace_windows(workspace_id: &str, cache: &ProjectCache) {
     let Some(app_state) = cache.get() else {
         return;
     };
-    let Some((worktree_path, _folder_name, proj_path)) = workspace_info(workspace_id, &app_state) else {
+    let Some((worktree_path, _folder_name, proj_path)) = workspace_info(workspace_id, &app_state)
+    else {
         return;
     };
 
@@ -519,17 +523,18 @@ pub fn workspace_focus(
         .or_else(|| refresh_project_cache(&project_cache))
         .ok_or("Project state not available yet")?;
 
-    let (wt_path, proj_path, ws_id) = if let Some((proj, wt)) = find_workspace(&workspace_id, &app_state) {
-        (wt.path.clone(), proj.path.clone(), workspace_id.clone())
-    } else {
-        let fresh = refresh_project_cache(&project_cache)
-            .ok_or(format!("Workspace '{workspace_id}' not found"))?;
-        if let Some((proj, wt)) = find_workspace(&workspace_id, &fresh) {
+    let (wt_path, proj_path, ws_id) =
+        if let Some((proj, wt)) = find_workspace(&workspace_id, &app_state) {
             (wt.path.clone(), proj.path.clone(), workspace_id.clone())
         } else {
-            return Err(format!("Workspace '{workspace_id}' not found"));
-        }
-    };
+            let fresh = refresh_project_cache(&project_cache)
+                .ok_or(format!("Workspace '{workspace_id}' not found"))?;
+            if let Some((proj, wt)) = find_workspace(&workspace_id, &fresh) {
+                (wt.path.clone(), proj.path.clone(), workspace_id.clone())
+            } else {
+                return Err(format!("Workspace '{workspace_id}' not found"));
+            }
+        };
 
     let folder_name = Path::new(&wt_path)
         .file_name()

--- a/apps/web/src/lib/project-config.ts
+++ b/apps/web/src/lib/project-config.ts
@@ -1,0 +1,25 @@
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+/**
+ * Load .band/config.json, trying the worktree path first, then falling back
+ * to the project's main repo path.  This handles the common case where the
+ * config file lives on the main branch but is .gitignored, so new worktrees
+ * don't contain it.
+ */
+export function loadProjectConfig(
+  worktreePath: string,
+  projectPath: string,
+): Record<string, unknown> | null {
+  for (const base of [worktreePath, projectPath]) {
+    const configPath = join(base, ".band", "config.json");
+    if (existsSync(configPath)) {
+      try {
+        return JSON.parse(readFileSync(configPath, "utf-8"));
+      } catch {
+        // Malformed JSON – skip and try next location
+      }
+    }
+  }
+  return null;
+}

--- a/apps/web/src/lib/setup-runner.ts
+++ b/apps/web/src/lib/setup-runner.ts
@@ -14,7 +14,12 @@ export function getRunningSetups(): string[] {
   return Array.from(setups.keys());
 }
 
-export function runSetup(workspaceId: string, worktreePath: string, projectPath: string, onComplete?: () => void): void {
+export function runSetup(
+  workspaceId: string,
+  worktreePath: string,
+  projectPath: string,
+  onComplete?: () => void,
+): void {
   // Guard against concurrent setups on same workspace
   if (setups.has(workspaceId)) return;
 

--- a/apps/web/src/lib/setup-runner.ts
+++ b/apps/web/src/lib/setup-runner.ts
@@ -1,6 +1,5 @@
 import { type ChildProcess, spawn } from "node:child_process";
-import { existsSync, readFileSync } from "node:fs";
-import { join } from "node:path";
+import { loadProjectConfig } from "./project-config";
 import { emit } from "./watcher";
 
 interface SetupInfo {
@@ -15,24 +14,12 @@ export function getRunningSetups(): string[] {
   return Array.from(setups.keys());
 }
 
-export function runSetup(workspaceId: string, worktreePath: string, onComplete?: () => void): void {
+export function runSetup(workspaceId: string, worktreePath: string, projectPath: string, onComplete?: () => void): void {
   // Guard against concurrent setups on same workspace
   if (setups.has(workspaceId)) return;
 
-  const configPath = join(worktreePath, ".band", "config.json");
-  if (!existsSync(configPath)) {
-    onComplete?.();
-    return;
-  }
-
-  let setupCommand: string | undefined;
-  try {
-    const config = JSON.parse(readFileSync(configPath, "utf-8"));
-    setupCommand = config.setup;
-  } catch {
-    onComplete?.();
-    return;
-  }
+  const config = loadProjectConfig(worktreePath, projectPath);
+  const setupCommand = typeof config?.setup === "string" ? config.setup : undefined;
 
   if (!setupCommand) {
     onComplete?.();

--- a/apps/web/src/trpc/router.ts
+++ b/apps/web/src/trpc/router.ts
@@ -1,5 +1,5 @@
 import { execFile, execFileSync } from "node:child_process";
-import { existsSync, mkdirSync, readFileSync, rmSync, unlinkSync } from "node:fs";
+import { existsSync, mkdirSync, rmSync, unlinkSync } from "node:fs";
 import { mkdir, readdir, readFile, stat, writeFile } from "node:fs/promises";
 import { basename, extname, join, resolve } from "node:path";
 import { toWorkspaceId } from "@band/dashboard-core";
@@ -31,6 +31,7 @@ import {
   shiftQueuedMessage,
   subscribeQueue,
 } from "../lib/queued-message-store";
+import { loadProjectConfig } from "../lib/project-config";
 import { runSetup } from "../lib/setup-runner";
 import {
   bandHome,
@@ -283,7 +284,7 @@ const workspacesRouter = t.router({
         ? () => submitTask(workspaceId, input.prompt!)
         : undefined;
 
-      runSetup(workspaceId, worktreePath, onSetupComplete);
+      runSetup(workspaceId, worktreePath, proj.path, onSetupComplete);
 
       // If there's no setup command, runSetup calls onComplete synchronously,
       // so the task is submitted immediately. If there IS a setup command,
@@ -324,21 +325,18 @@ const workspacesRouter = t.router({
             const worktreePath = currentPath;
 
             // Run teardown script before removing worktree so it can access project files
-            const configPath = join(worktreePath, ".band", "config.json");
             try {
-              if (existsSync(configPath)) {
-                const config = JSON.parse(readFileSync(configPath, "utf-8"));
-                if (config.teardown) {
-                  execFileSync("bash", ["-c", config.teardown], {
-                    cwd: worktreePath,
-                    env: {
-                      ...process.env,
-                      PATH: `/opt/homebrew/bin:/usr/local/bin:${process.env.PATH}`,
-                    },
-                    encoding: "utf-8",
-                    timeout: 60_000,
-                  });
-                }
+              const config = loadProjectConfig(worktreePath, proj.path);
+              if (config?.teardown && typeof config.teardown === "string") {
+                execFileSync("bash", ["-c", config.teardown], {
+                  cwd: worktreePath,
+                  env: {
+                    ...process.env,
+                    PATH: `/opt/homebrew/bin:/usr/local/bin:${process.env.PATH}`,
+                  },
+                  encoding: "utf-8",
+                  timeout: 60_000,
+                });
               }
             } catch {
               // Teardown script failure is non-fatal

--- a/apps/web/src/trpc/router.ts
+++ b/apps/web/src/trpc/router.ts
@@ -22,6 +22,7 @@ import { execGit, gitCmd, listWorktrees } from "../lib/git";
 import { checkHooks, installHooks } from "../lib/hooks";
 import { resolvePendingInput } from "../lib/pending-inputs";
 import { checkPrereqs, shellPath } from "../lib/process-utils";
+import { loadProjectConfig } from "../lib/project-config";
 import {
   clearQueuedMessages,
   getQueuedMessages,
@@ -31,7 +32,6 @@ import {
   shiftQueuedMessage,
   subscribeQueue,
 } from "../lib/queued-message-store";
-import { loadProjectConfig } from "../lib/project-config";
 import { runSetup } from "../lib/setup-runner";
 import {
   bandHome,

--- a/extensions/vscode/src/config.ts
+++ b/extensions/vscode/src/config.ts
@@ -1,3 +1,4 @@
+import { execFile } from "node:child_process";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
@@ -79,8 +80,16 @@ export function mergeConfigs(
   };
 }
 
-export async function loadEffectiveConfig(workspacePath: string): Promise<BandConfig | null> {
-  const projectConfig = await loadConfig(workspacePath);
+export async function loadEffectiveConfig(
+  workspacePath: string,
+  projectPath?: string,
+): Promise<BandConfig | null> {
+  let projectConfig = await loadConfig(workspacePath);
+  // Fall back to the main repo path when the worktree has no config
+  // (e.g. .band/config.json is .gitignored so new worktrees don't contain it)
+  if (!projectConfig && projectPath && projectPath !== workspacePath) {
+    projectConfig = await loadConfig(projectPath);
+  }
   const defaults = await loadUserDefaults();
   return mergeConfigs(defaults, projectConfig);
 }
@@ -89,6 +98,7 @@ export interface WorkspaceIdentity {
   project: string;
   branch: string;
   workspaceId: string;
+  projectPath: string;
 }
 
 export async function getBandWorktreeIdentity(
@@ -110,6 +120,7 @@ export async function getBandWorktreeIdentity(
                 project: project.name,
                 branch: wt.branch,
                 workspaceId: `${project.name}-${wt.branch.replaceAll("/", "-")}`,
+                projectPath: project.path,
               };
             }
           }
@@ -120,6 +131,32 @@ export async function getBandWorktreeIdentity(
     return null;
   } catch (err) {
     console.log(`[Band] Failed to read state.json:`, err);
+    return null;
+  }
+}
+
+/**
+ * Use git to find the main worktree (project root) for the given workspace.
+ * Returns null if the workspace is not inside a git repo or is itself the main worktree.
+ */
+export async function getGitMainWorktreePath(workspacePath: string): Promise<string | null> {
+  try {
+    const gitCommonDir = await new Promise<string>((resolve, reject) => {
+      execFile(
+        "git",
+        ["rev-parse", "--path-format=absolute", "--git-common-dir"],
+        { cwd: workspacePath, encoding: "utf-8" },
+        (err, stdout) => (err ? reject(err) : resolve(stdout.trim())),
+      );
+    });
+
+    // git-common-dir returns <main-repo>/.git for both main and worktrees
+    const mainRepo = path.dirname(gitCommonDir);
+    if (mainRepo === workspacePath) {
+      return null; // already the main worktree
+    }
+    return mainRepo;
+  } catch {
     return null;
   }
 }

--- a/extensions/vscode/src/extension.ts
+++ b/extensions/vscode/src/extension.ts
@@ -1,5 +1,10 @@
 import * as vscode from "vscode";
-import { getBandWorktreeIdentity, loadConfig, loadEffectiveConfig } from "./config";
+import {
+  getBandWorktreeIdentity,
+  getGitMainWorktreePath,
+  loadConfig,
+  loadEffectiveConfig,
+} from "./config";
 import { setupWorkspace } from "./workspace-setup";
 
 let log: vscode.OutputChannel;
@@ -22,8 +27,11 @@ export async function activate(context: vscode.ExtensionContext) {
     const hasProjectConfig = (await loadConfig(workspacePath)) !== null;
     const identity = await getBandWorktreeIdentity(workspacePath);
 
-    if (hasProjectConfig || identity) {
-      const effective = await loadEffectiveConfig(workspacePath);
+    // Resolve the project root: from Band state, or by asking git for the main worktree
+    const projectPath = identity?.projectPath ?? (await getGitMainWorktreePath(workspacePath));
+
+    if (hasProjectConfig || identity || projectPath) {
+      const effective = await loadEffectiveConfig(workspacePath, projectPath ?? undefined);
       if (effective) {
         log.appendLine("Effective config loaded, setting up workspace...");
         await setupWorkspace(effective);
@@ -50,32 +58,18 @@ async function runSetup() {
     return;
   }
 
-  for (const folder of workspaceFolders) {
-    const config = await loadConfig(folder.uri.fsPath);
-    if (config) {
-      const effective = await loadEffectiveConfig(folder.uri.fsPath);
-      if (effective) {
-        await setupWorkspace(effective);
-        vscode.window.showInformationMessage("Band workspace setup complete");
-      }
-      return;
-    }
-  }
-
-  // No project config found — try user defaults if it's a Band worktree
   const workspacePath = workspaceFolders[0].uri.fsPath;
   const identity = await getBandWorktreeIdentity(workspacePath);
-  if (identity) {
-    const effective = await loadEffectiveConfig(workspacePath);
-    if (effective) {
-      await setupWorkspace(effective);
-      vscode.window.showInformationMessage("Band workspace setup complete");
-      return;
-    }
+  const projectPath = identity?.projectPath ?? (await getGitMainWorktreePath(workspacePath));
+  const effective = await loadEffectiveConfig(workspacePath, projectPath ?? undefined);
+  if (effective) {
+    await setupWorkspace(effective);
+    vscode.window.showInformationMessage("Band workspace setup complete");
+    return;
   }
 
   vscode.window.showErrorMessage(
-    `No .band/config.json found. Checked: ${workspacePath}/.band/config.json`,
+    `No .band/config.json found. Checked: ${workspacePath}/.band/config.json${projectPath ? ` and ${projectPath}/.band/config.json` : ""}`,
   );
 }
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "description": "IDE-agnostic agent orchestrator — dashboard + VS Code extension",
   "type": "module",
   "scripts": {
-    "dev:dashboard": "pnpm build:cli:dev && pnpm build:web && pnpm --filter @band/dashboard tauri:dev",
+    "dev:dashboard": "pnpm build:cli:dev && pnpm build:extension && pnpm build:web && pnpm --filter @band/dashboard tauri:dev",
     "dev:web": "pnpm --filter @band/web dev",
     "build:dashboard": "pnpm --filter @band/dashboard tauri build",
     "build:web": "pnpm --filter @band/web build",


### PR DESCRIPTION
## Summary

When `.band/config.json` is `.gitignored`, new git worktrees don't contain it — so setup/teardown commands and app configs are silently skipped. This PR adds fallback logic across all config loading paths: try the worktree path first, then the project's main repo path.

- **New shared helper** (`apps/web/src/lib/project-config.ts`): `loadProjectConfig(worktreePath, projectPath)` tries worktree first, falls back to project root
- **setup-runner.ts**: Uses `loadProjectConfig` instead of direct file read; accepts `projectPath` parameter
- **router.ts**: Passes `proj.path` to `runSetup` and uses `loadProjectConfig` for teardown
- **Rust `load_apps_config`**: Accepts `project_path` parameter, loops over both paths
- **Rust `ide.rs`**: Extracts project path from `find_workspace`/`workspace_info` and passes it through
- **VS Code extension**: Discovers the main repo via `git rev-parse --git-common-dir` when the worktree has no config and isn't in Band state — enables config loading even for worktrees not managed by Band
- **dev:dashboard script**: Adds `build:extension` step so Tauri build finds the VS Code extension artifact

## Test plan

- [ ] Create a test project with `.band/config.json` containing `{"setup": "echo setup-ran"}` in main, add `.band/` to `.gitignore`
- [ ] Create a workspace — verify setup command runs (config found via project root fallback)
- [ ] Remove the workspace — verify teardown runs if configured
- [ ] Open a worktree in VS Code — verify extension loads terminal preset from main repo config
- [ ] Verify `pnpm dev:dashboard` builds successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)