### PR TITLE
feat: add Xcode as an app preset

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ dist/
 band
 *.tgz
 .DS_Store
+__pycache__/
 target/
 *.vsix
 apps/dashboard/src-tauri/icons/android/

--- a/apps/dashboard/src-tauri/app-presets.json
+++ b/apps/dashboard/src-tauri/app-presets.json
@@ -34,5 +34,12 @@
     "bundleId": "com.google.Chrome",
     "displayName": "Google Chrome",
     "launchCommand": "$HOME/.band/scripts/chrome-launch.py"
+  },
+  {
+    "type": "xcode",
+    "bundleId": "com.apple.dt.Xcode",
+    "displayName": "Xcode",
+    "launchCommand": "$HOME/.band/scripts/xcode-launch.py \"{{path}}\"",
+    "titleHint": "{{folder}}"
   }
 ]

--- a/apps/dashboard/src-tauri/scripts/xcode-launch.py
+++ b/apps/dashboard/src-tauri/scripts/xcode-launch.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""Launches Xcode with the best project file found in a worktree.
+
+Usage: xcode-launch.py <worktree-path>
+
+Searches for .xcworkspace (preferred) or .xcodeproj files up to 2 levels deep,
+skipping Pods and SPM build directories. Falls back to opening the directory.
+"""
+import os
+import subprocess
+import sys
+
+
+def find_project_file(base_path):
+    """Find the best Xcode project file in the worktree.
+
+    Priority: .xcworkspace > .xcodeproj (both searched up to depth 2).
+    Skips Pods/, .build/, and xcodeproj-embedded workspaces.
+    """
+    skip_dirs = {"Pods", ".build", "DerivedData", ".swiftpm"}
+
+    for ext in (".xcworkspace", ".xcodeproj"):
+        for depth in range(3):  # 0, 1, 2 levels deep
+            if depth == 0:
+                dirs_to_check = [base_path]
+            else:
+                dirs_to_check = []
+                for root, dirs, _files in os.walk(base_path):
+                    # Calculate current depth
+                    rel = os.path.relpath(root, base_path)
+                    current_depth = 0 if rel == "." else rel.count(os.sep) + 1
+                    if current_depth >= depth:
+                        dirs.clear()
+                        continue
+                    # Prune unwanted directories
+                    dirs[:] = [
+                        d
+                        for d in dirs
+                        if d not in skip_dirs and not d.endswith(".xcodeproj")
+                    ]
+                    if current_depth == depth - 1:
+                        dirs_to_check.append(root)
+
+            for dir_path in dirs_to_check:
+                try:
+                    entries = os.listdir(dir_path)
+                except OSError:
+                    continue
+                matches = sorted(e for e in entries if e.endswith(ext))
+                for match in matches:
+                    full = os.path.join(dir_path, match)
+                    # Skip workspaces embedded inside .xcodeproj bundles
+                    if ext == ".xcworkspace" and ".xcodeproj" in dir_path:
+                        continue
+                    return full
+    return None
+
+
+def main():
+    if len(sys.argv) < 2:
+        print("Usage: xcode-launch.py <worktree-path>", file=sys.stderr)
+        sys.exit(1)
+
+    worktree_path = sys.argv[1]
+    project_file = find_project_file(worktree_path)
+    target = project_file if project_file else worktree_path
+
+    subprocess.run(["open", "-a", "Xcode", target], check=True)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Add Xcode to the app presets in `app-presets.json` (type: `xcode`, bundle ID: `com.apple.dt.Xcode`)
- Add `xcode-launch.py` script that intelligently discovers `.xcworkspace` or `.xcodeproj` files in the worktree, preferring workspaces over projects
- Skip `Pods/`, `.build/`, `DerivedData/`, `.swiftpm/` directories and workspaces embedded inside `.xcodeproj` bundles
- Add `__pycache__/` to `.gitignore`

## Test plan
- [ ] Add `{ "type": "xcode" }` to a project's `.band/config.json` apps array
- [ ] Verify Xcode launches and opens the correct project/workspace file
- [ ] Test with a worktree containing `.xcworkspace` (e.g. CocoaPods project) — should prefer workspace
- [ ] Test with a worktree containing only `.xcodeproj` — should open the project
- [ ] Test with nested project files (e.g. `ios/App.xcworkspace`) — should discover them

🤖 Generated with [Claude Code](https://claude.com/claude-code)