### PR TITLE
feat: add app presets for Android Studio, browsers, terminals, and editors

### DIFF
--- a/apps/dashboard/src-tauri/app-presets.json
+++ b/apps/dashboard/src-tauri/app-presets.json
@@ -105,5 +105,56 @@
     "launchCommand": "open -a \"PhpStorm\" \"{{path}}\"",
     "titleHint": "{{folder}}",
     "waitTimeout": 30000
+  },
+  {
+    "type": "android-studio",
+    "bundleId": "com.google.android.studio",
+    "displayName": "Android Studio",
+    "launchCommand": "open -a \"Android Studio\" \"{{path}}\"",
+    "titleHint": "{{folder}}",
+    "waitTimeout": 30000
+  },
+  {
+    "type": "safari",
+    "bundleId": "com.apple.Safari",
+    "displayName": "Safari",
+    "launchCommand": "$HOME/.band/scripts/safari-launch.py"
+  },
+  {
+    "type": "firefox",
+    "bundleId": "org.mozilla.firefox",
+    "displayName": "Firefox",
+    "launchCommand": "$HOME/.band/scripts/firefox-launch.py"
+  },
+  {
+    "type": "ghostty",
+    "bundleId": "com.mitchellh.ghostty",
+    "displayName": "Ghostty",
+    "launchCommand": "open -a \"Ghostty\"",
+    "newWindowCommand": "osascript -e 'tell application \"Ghostty\"' -e 'set cfg to new surface configuration' -e 'new window with configuration cfg' -e 'end tell'",
+    "setupCommand": "$HOME/.band/scripts/ghostty-setup.py \"{{path}}\" \"{{folder}}\"",
+    "titleHint": "band:{{folder}}"
+  },
+  {
+    "type": "windsurf",
+    "bundleId": "com.exafunction.windsurf",
+    "displayName": "Windsurf",
+    "launchCommand": "open -a \"Windsurf\" \"{{path}}\"",
+    "titleHint": "{{folder}}"
+  },
+  {
+    "type": "warp",
+    "bundleId": "dev.warp.Warp-Stable",
+    "displayName": "Warp",
+    "launchCommand": "open -a \"Warp\"",
+    "setupCommand": "$HOME/.band/scripts/warp-setup.py \"{{path}}\" \"{{folder}}\"",
+    "titleHint": "band:{{folder}}"
+  },
+  {
+    "type": "kiro",
+    "bundleId": "dev.kiro.desktop",
+    "displayName": "Kiro",
+    "launchCommand": "open -a \"Kiro\" \"{{path}}\"",
+    "titleHint": "{{folder}}"
   }
 ]

--- a/apps/dashboard/src-tauri/scripts/firefox-launch.py
+++ b/apps/dashboard/src-tauri/scripts/firefox-launch.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python3
+"""Launches Firefox with a URL.
+
+Usage: firefox-launch.py
+
+Reads BAND_CONFIG env var (JSON) to extract url (defaults to about:blank).
+"""
+import json
+import os
+import subprocess
+
+
+def main():
+    config = json.loads(os.environ.get("BAND_CONFIG", "{}"))
+    url = config.get("url", "about:blank") or "about:blank"
+
+    subprocess.run(
+        ["open", "-na", "Firefox", "--args", url],
+        check=True,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/apps/dashboard/src-tauri/scripts/ghostty-setup.py
+++ b/apps/dashboard/src-tauri/scripts/ghostty-setup.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+"""Configures a Ghostty window with a working directory and commands.
+
+Usage: ghostty-setup.py <worktree_path> <folder_name>
+
+Reads BAND_CONFIG env var (JSON) to extract commands[].command.
+Uses Ghostty's AppleScript API to send keystrokes to the terminal.
+"""
+import json
+import os
+import subprocess
+import sys
+
+
+def as_escape(s):
+    """Escape a value for use inside an AppleScript double-quoted string."""
+    return s.replace("\\", "\\\\").replace('"', '\\"')
+
+
+def main():
+    worktree_path = sys.argv[1]
+    folder_name = sys.argv[2]
+
+    config = json.loads(os.environ.get("BAND_CONFIG", "{}"))
+    raw_commands = [
+        c for c in config.get("commands", [])
+        if isinstance(c, dict) and "command" in c
+    ]
+    commands = [c["command"] for c in raw_commands]
+
+    window_name = f"band:{folder_name}"
+
+    lines = [
+        'tell application "Ghostty"',
+        "    set term to focused terminal of selected tab of front window",
+        # Set terminal title via OSC escape sequence
+        f"    input text \"printf '\\\\033]0;{as_escape(window_name)}\\\\007'\" to term",
+        '    send key "enter" to term',
+        # cd into worktree
+        f"    input text \"cd {as_escape(worktree_path)}\" to term",
+        '    send key "enter" to term',
+    ]
+
+    for cmd in commands:
+        lines.append(f"    input text \"{as_escape(cmd)}\" to term")
+        lines.append('    send key "enter" to term')
+
+    lines.append("end tell")
+
+    script = "\n".join(lines)
+    subprocess.run(["osascript", "-e", script], check=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/apps/dashboard/src-tauri/scripts/safari-launch.py
+++ b/apps/dashboard/src-tauri/scripts/safari-launch.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python3
+"""Launches Safari with a URL.
+
+Usage: safari-launch.py
+
+Reads BAND_CONFIG env var (JSON) to extract url (defaults to about:blank).
+"""
+import json
+import os
+import subprocess
+
+
+def main():
+    config = json.loads(os.environ.get("BAND_CONFIG", "{}"))
+    url = config.get("url", "about:blank") or "about:blank"
+
+    subprocess.run(
+        ["open", "-a", "Safari", url],
+        check=True,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/apps/dashboard/src-tauri/scripts/warp-setup.py
+++ b/apps/dashboard/src-tauri/scripts/warp-setup.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+"""Configures a Warp terminal window with a working directory and commands.
+
+Usage: warp-setup.py <worktree_path> <folder_name>
+
+Reads BAND_CONFIG env var (JSON) to extract commands[].command.
+Uses System Events keystrokes to drive the Warp terminal since
+Warp does not expose an app-specific AppleScript API.
+"""
+import json
+import os
+import subprocess
+import sys
+import time
+
+
+def as_escape(s):
+    """Escape a value for use inside an AppleScript double-quoted string."""
+    return s.replace("\\", "\\\\").replace('"', '\\"')
+
+
+def keystroke_lines(text):
+    """Generate AppleScript lines to type text and press Enter via System Events."""
+    return [
+        f'        keystroke "{as_escape(text)}"',
+        '        key code 36',  # Return key
+    ]
+
+
+def main():
+    worktree_path = sys.argv[1]
+    folder_name = sys.argv[2]
+
+    config = json.loads(os.environ.get("BAND_CONFIG", "{}"))
+    raw_commands = [
+        c for c in config.get("commands", [])
+        if isinstance(c, dict) and "command" in c
+    ]
+    commands = [c["command"] for c in raw_commands]
+
+    window_name = f"band:{folder_name}"
+
+    # Small delay to let the window finish appearing
+    time.sleep(0.3)
+
+    lines = [
+        'tell application "System Events"',
+        '    tell process "Warp"',
+        '        set frontmost to true',
+    ]
+
+    # Set terminal title via OSC escape sequence
+    lines.extend(keystroke_lines(f"printf '\\033]0;{window_name}\\007'"))
+    # cd into worktree
+    lines.extend(keystroke_lines(f"cd {worktree_path}"))
+
+    # Run commands
+    for cmd in commands:
+        lines.extend(keystroke_lines(cmd))
+
+    lines.append("    end tell")
+    lines.append("end tell")
+
+    script = "\n".join(lines)
+    subprocess.run(["osascript", "-e", script], check=True)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- Add **Android Studio** preset (JetBrains IDE pattern with 30s wait timeout)
- Add **Safari** and **Firefox** browser presets with launch scripts (read `url` from config, like Chrome)
- Add **Ghostty** terminal preset with AppleScript setup via its native scripting API
- Add **Warp** terminal preset with System Events keystroke-based setup
- Add **Windsurf** and **Kiro** editor presets (VS Code-fork pattern)

Total presets: 14 → 21

## Test plan

- [ ] Verify `app-presets.json` parses correctly (validated via Python JSON loader)
- [ ] Verify all new Python scripts are syntactically valid (validated via `py_compile`)
- [ ] Test each preset on macOS with the respective app installed

🤖 Generated with [Claude Code](https://claude.com/claude-code)