### PR TITLE
feat: add light/dark/system theme toggle to dashboard

### DIFF
--- a/apps/dashboard/index.html
+++ b/apps/dashboard/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html lang="en" class="dark">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />

--- a/apps/dashboard/src/styles/globals.css
+++ b/apps/dashboard/src/styles/globals.css
@@ -48,6 +48,40 @@
 
 :root {
   --radius: 0.625rem;
+  --background: oklch(1 0 0);
+  --foreground: oklch(0.145 0 0);
+  --card: oklch(1 0 0);
+  --card-foreground: oklch(0.145 0 0);
+  --popover: oklch(1 0 0);
+  --popover-foreground: oklch(0.145 0 0);
+  --primary: oklch(0.205 0 0);
+  --primary-foreground: oklch(0.985 0 0);
+  --secondary: oklch(0.965 0 0);
+  --secondary-foreground: oklch(0.205 0 0);
+  --muted: oklch(0.965 0 0);
+  --muted-foreground: oklch(0.556 0 0);
+  --accent: oklch(0.965 0 0);
+  --accent-foreground: oklch(0.205 0 0);
+  --destructive: oklch(0.577 0.245 27.325);
+  --border: oklch(0.922 0 0);
+  --input: oklch(0.922 0 0);
+  --ring: oklch(0.708 0 0);
+  --chart-1: oklch(0.646 0.222 41.116);
+  --chart-2: oklch(0.6 0.118 184.714);
+  --chart-3: oklch(0.398 0 0);
+  --chart-4: oklch(0.828 0.189 84.429);
+  --chart-5: oklch(0.769 0.188 70.08);
+  --sidebar: oklch(0.985 0 0);
+  --sidebar-foreground: oklch(0.145 0 0);
+  --sidebar-primary: oklch(0.205 0 0);
+  --sidebar-primary-foreground: oklch(0.985 0 0);
+  --sidebar-accent: oklch(0.965 0 0);
+  --sidebar-accent-foreground: oklch(0.205 0 0);
+  --sidebar-border: oklch(0.922 0 0);
+  --sidebar-ring: oklch(0.708 0 0);
+}
+
+.dark {
   --background: #181818;
   --foreground: oklch(0.922 0 0);
   --card: oklch(0.17 0 0);

--- a/apps/web/src/components/CodeBrowserView.tsx
+++ b/apps/web/src/components/CodeBrowserView.tsx
@@ -105,7 +105,7 @@ export function CodeBrowserView({
   return (
     <div className="flex h-full overflow-hidden">
       {/* Left sidebar - file tree */}
-      <div className="w-60 shrink-0 border-r border-white/20 overflow-hidden">
+      <div className="w-60 shrink-0 border-r border-border overflow-hidden">
         <FileBrowser
           workspaceId={workspaceId}
           currentPath={currentPath}

--- a/apps/web/src/components/DesktopLayout.tsx
+++ b/apps/web/src/components/DesktopLayout.tsx
@@ -10,7 +10,7 @@ export function DesktopLayout({ toolbarExtra }: DesktopLayoutProps) {
   return (
     <div className="flex h-dvh w-full overflow-hidden bg-background text-foreground">
       {/* Left Panel — Project List */}
-      <div className="w-80 shrink-0 border-r border-white/20 overflow-hidden">
+      <div className="w-80 shrink-0 border-r border-border overflow-hidden">
         <DashboardShell toolbarExtra={toolbarExtra} />
       </div>
 

--- a/apps/web/src/components/WorkspaceChatPanel.tsx
+++ b/apps/web/src/components/WorkspaceChatPanel.tsx
@@ -42,7 +42,7 @@ export function WorkspaceChatPanel({ workspaceId }: WorkspaceChatPanelProps) {
 
   return (
     <div className="flex h-full flex-col overflow-hidden">
-      <header className="flex h-12 shrink-0 items-center gap-3 border-b border-white/20 px-4">
+      <header className="flex h-12 shrink-0 items-center gap-3 border-b border-border px-4">
         <div className="min-w-0 flex-1">
           <h1 className="truncate text-sm font-semibold">{workspaceId}</h1>
         </div>

--- a/apps/web/src/components/ai-elements/prompt-input.tsx
+++ b/apps/web/src/components/ai-elements/prompt-input.tsx
@@ -140,7 +140,7 @@ export const PromptInput = ({ className, onSubmit, children, ...props }: PromptI
   return (
     <form
       className={cn(
-        "relative flex w-full flex-col rounded-md border border-white/15 bg-white/5 p-2 shadow-[0_0_20px_rgba(255,255,255,0.06)]",
+        "relative flex w-full flex-col rounded-md border border-border bg-muted/50 p-2 shadow-sm",
         isDragging && "border-primary/50 bg-primary/5",
         className,
       )}

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -75,7 +75,7 @@ function AppShell() {
 
   return (
     <div className="flex h-dvh w-full overflow-hidden bg-background text-foreground">
-      <div className="w-80 shrink-0 border-r border-white/20 overflow-hidden">
+      <div className="w-80 shrink-0 border-r border-border overflow-hidden">
         <DashboardShell toolbarExtra={<ToolbarButtons />} />
       </div>
       <div className="flex-1 min-w-0 overflow-hidden">

--- a/apps/web/src/routes/workspace.$workspaceId.tsx
+++ b/apps/web/src/routes/workspace.$workspaceId.tsx
@@ -177,7 +177,7 @@ function DesktopDetailTabNav({
     }`;
 
   return (
-    <div className="flex h-12 shrink-0 items-center border-b border-white/20">
+    <div className="flex h-12 shrink-0 items-center border-b border-border">
       <Link
         to="/workspace/$workspaceId/changes"
         params={{ workspaceId }}
@@ -265,7 +265,7 @@ function DesktopWorkspaceLayout({
   return (
     <div className="flex h-full overflow-hidden">
       {/* Middle Panel — Changes / Code / Terminal */}
-      <div className="flex-1 min-w-0 border-r border-white/20 overflow-hidden">
+      <div className="flex-1 min-w-0 border-r border-border overflow-hidden">
         <div className="flex h-full flex-col overflow-hidden">
           <DesktopDetailTabNav workspaceId={encodedId} diffStats={diffStats} />
           <div className="min-h-0 flex-1 overflow-hidden">

--- a/apps/web/src/styles/globals.css
+++ b/apps/web/src/styles/globals.css
@@ -41,6 +41,32 @@
 
 :root {
   --radius: 0.625rem;
+  --background: oklch(1 0 0);
+  --foreground: oklch(0.145 0 0);
+  --card: oklch(1 0 0);
+  --card-foreground: oklch(0.145 0 0);
+  --popover: oklch(1 0 0);
+  --popover-foreground: oklch(0.145 0 0);
+  --primary: oklch(0.205 0 0);
+  --primary-foreground: oklch(0.985 0 0);
+  --secondary: oklch(0.965 0 0);
+  --secondary-foreground: oklch(0.205 0 0);
+  --muted: oklch(0.965 0 0);
+  --muted-foreground: oklch(0.556 0 0);
+  --accent: oklch(0.965 0 0);
+  --accent-foreground: oklch(0.205 0 0);
+  --destructive: oklch(0.577 0.245 27.325);
+  --border: oklch(0.922 0 0);
+  --input: oklch(0.922 0 0);
+  --ring: oklch(0.708 0 0);
+  --chart-1: oklch(0.646 0.222 41.116);
+  --chart-2: oklch(0.6 0.118 184.714);
+  --chart-3: oklch(0.398 0 0);
+  --chart-4: oklch(0.828 0.189 84.429);
+  --chart-5: oklch(0.769 0.188 70.08);
+}
+
+.dark {
   --background: #181818;
   --foreground: oklch(0.922 0 0);
   --card: oklch(0.17 0 0);

--- a/packages/dashboard-core/src/components/DashboardShell.tsx
+++ b/packages/dashboard-core/src/components/DashboardShell.tsx
@@ -16,11 +16,23 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@band-app/ui";
-import { Check, FolderPlus, Pencil, Plus, Settings, Tag, X } from "lucide-react";
+import {
+  Check,
+  FolderPlus,
+  Monitor,
+  Moon,
+  Pencil,
+  Plus,
+  Settings,
+  Sun,
+  Tag,
+  X,
+} from "lucide-react";
 import { type ReactNode, useEffect, useRef, useState } from "react";
 import { useCliSetup } from "../hooks/use-cli-setup";
 import { useHooksSetup } from "../hooks/use-hooks-setup";
 import { useProjects } from "../hooks/use-projects";
+import { useUpdateSettings } from "../hooks/use-settings-mutations";
 import { useSettingsQuery } from "../hooks/use-settings-query";
 import {
   useActiveWorkspaceWatcher,
@@ -42,6 +54,7 @@ const isTauri = typeof window !== "undefined" && "__TAURI_INTERNALS__" in window
 export function DashboardShell({ toolbarExtra }: DashboardShellProps) {
   const { projects, isLoading: loading } = useProjects();
   const { settings } = useSettingsQuery();
+  const updateSettingsMutation = useUpdateSettings();
   const labels = settings.labels ?? [];
   const error = useDashboardStore((s) => s.error);
   const clearError = useDashboardStore((s) => s.clearError);
@@ -83,6 +96,54 @@ export function DashboardShell({ toolbarExtra }: DashboardShellProps) {
     return () => el.removeEventListener("mousedown", onMouseDown);
   }, []);
 
+  // Sync theme class on <html> with persisted setting
+  const theme = settings.theme ?? "system";
+  useEffect(() => {
+    const root = document.documentElement;
+
+    const apply = (isDark: boolean) => {
+      if (isDark) {
+        root.classList.add("dark");
+      } else {
+        root.classList.remove("dark");
+      }
+    };
+
+    if (theme === "system") {
+      const mq = window.matchMedia("(prefers-color-scheme: dark)");
+      apply(mq.matches);
+      const handler = (e: MediaQueryListEvent) => apply(e.matches);
+      mq.addEventListener("change", handler);
+      return () => mq.removeEventListener("change", handler);
+    }
+
+    apply(theme === "dark");
+  }, [theme]);
+
+  // Resolve effective theme for icon display
+  const [resolvedDark, setResolvedDark] = useState(() =>
+    typeof window !== "undefined"
+      ? window.matchMedia("(prefers-color-scheme: dark)").matches
+      : true,
+  );
+  useEffect(() => {
+    if (theme !== "system") return;
+    const mq = window.matchMedia("(prefers-color-scheme: dark)");
+    setResolvedDark(mq.matches);
+    const handler = (e: MediaQueryListEvent) => setResolvedDark(e.matches);
+    mq.addEventListener("change", handler);
+    return () => mq.removeEventListener("change", handler);
+  }, [theme]);
+
+  const effectiveDark = theme === "dark" || (theme === "system" && resolvedDark);
+
+  const toggleTheme = () => {
+    const order = ["system", "light", "dark"] as const;
+    const idx = order.indexOf(theme as (typeof order)[number]);
+    const next = order[(idx + 1) % order.length];
+    updateSettingsMutation.mutate({ ...settings, theme: next });
+  };
+
   useStatusWatcher();
   useActiveWorkspaceWatcher();
   useBranchStatusWatcher();
@@ -111,7 +172,7 @@ export function DashboardShell({ toolbarExtra }: DashboardShellProps) {
         </ScrollArea>
       ) : (
         <>
-          <div className="flex h-12 shrink-0 items-center justify-between border-b border-white/20 px-4">
+          <div className="flex h-12 shrink-0 items-center justify-between border-b border-border px-4">
             <div className="flex items-center gap-1">
               <DropdownMenu>
                 <Tooltip>
@@ -181,14 +242,36 @@ export function DashboardShell({ toolbarExtra }: DashboardShellProps) {
                 </DropdownMenu>
               )}
             </div>
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <Button size="icon-sm" variant="ghost" onClick={() => setShowAddDialog(true)}>
-                  <Plus className="size-5" />
-                </Button>
-              </TooltipTrigger>
-              <TooltipContent>Add project</TooltipContent>
-            </Tooltip>
+            <div className="flex items-center gap-1">
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button size="icon-sm" variant="ghost" onClick={toggleTheme}>
+                    {theme === "system" ? (
+                      <Monitor className="size-5" />
+                    ) : effectiveDark ? (
+                      <Sun className="size-5" />
+                    ) : (
+                      <Moon className="size-5" />
+                    )}
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent>
+                  {theme === "system"
+                    ? "Theme: System"
+                    : theme === "dark"
+                      ? "Theme: Dark"
+                      : "Theme: Light"}
+                </TooltipContent>
+              </Tooltip>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button size="icon-sm" variant="ghost" onClick={() => setShowAddDialog(true)}>
+                    <Plus className="size-5" />
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent>Add project</TooltipContent>
+              </Tooltip>
+            </div>
           </div>
 
           <ScrollArea
@@ -229,7 +312,7 @@ export function DashboardShell({ toolbarExtra }: DashboardShellProps) {
 
           {(cliState.status === "manual" || cliState.status === "conflict") && (
             <div className="mx-4 mb-2 px-4 py-2 bg-blue-500/10 border border-blue-500/30 rounded-lg text-sm flex items-center justify-between gap-2">
-              <span className="text-blue-200">
+              <span className="text-blue-700 dark:text-blue-200">
                 {cliState.status === "conflict"
                   ? "A different `band` binary exists — replace it to use the bundled CLI"
                   : `Install \`band\` CLI to /usr/local/bin (${cliState.reason})`}
@@ -242,7 +325,7 @@ export function DashboardShell({ toolbarExtra }: DashboardShellProps) {
 
           {hooksState.status === "needs_install" && (
             <div className="mx-4 mb-2 px-4 py-2 bg-blue-500/10 border border-blue-500/30 rounded-lg text-sm flex items-center justify-between gap-2">
-              <span className="text-blue-200">
+              <span className="text-blue-700 dark:text-blue-200">
                 Install Claude Code hooks for agent status detection
               </span>
               <Button

--- a/packages/dashboard-core/src/components/DiffView.tsx
+++ b/packages/dashboard-core/src/components/DiffView.tsx
@@ -428,7 +428,7 @@ function LegacyDiffView({ workspaceId, active, onStatsChange, onOpenFile }: Diff
 
   return (
     <div className="flex h-full flex-col overflow-hidden">
-      <div className="flex shrink-0 items-center justify-between border-b border-white/20 px-4 py-2">
+      <div className="flex shrink-0 items-center justify-between border-b border-border px-4 py-2">
         <div>
           <div className="text-sm text-muted-foreground">
             <span className="font-medium text-foreground">{data.stats.filesChanged}</span>{" "}
@@ -617,7 +617,7 @@ export function DiffView({ workspaceId, active = true, onStatsChange, onOpenFile
 
   return (
     <div className="flex h-full flex-col overflow-hidden">
-      <div className="flex shrink-0 items-center justify-between border-b border-white/20 px-4 py-2">
+      <div className="flex shrink-0 items-center justify-between border-b border-border px-4 py-2">
         <div>
           <div className="text-sm text-muted-foreground">
             <span className="font-medium text-foreground">{summary.stats.filesChanged}</span>{" "}

--- a/packages/dashboard-core/src/components/SettingsPage.tsx
+++ b/packages/dashboard-core/src/components/SettingsPage.tsx
@@ -28,7 +28,7 @@ import { useCapabilities } from "../context";
 import { useUpdateSettings } from "../hooks/use-settings-mutations";
 import { useSettingsQuery } from "../hooks/use-settings-query";
 import { playSound, SOUNDS, type SoundId } from "../lib/sounds";
-import type { CodingAgentConfig, CodingAgentType, LabelDefinition } from "../types";
+import type { CodingAgentConfig, CodingAgentType, LabelDefinition, Theme } from "../types";
 
 const AGENT_TYPES: { value: CodingAgentType; label: string }[] = [
   { value: "claude-code", label: "Claude Code" },
@@ -52,6 +52,7 @@ const DEFAULT_DEFAULTS = {
 
 type Section =
   | "menu"
+  | "appearance"
   | "general"
   | "coding-agent"
   | "defaults"
@@ -108,6 +109,7 @@ export function SettingsPage({ onClose }: Props) {
   );
   const [labels, setLabels] = useState<LabelDefinition[]>(settings.labels ?? []);
   const [autoStartTunnel, setAutoStartTunnel] = useState(settings.autoStartTunnel ?? false);
+  const [selectedTheme, setSelectedTheme] = useState<Theme>(settings.theme ?? "system");
 
   const isDirty = useMemo(() => {
     if (worktreesDir !== (settings.worktreesDir ?? "")) return true;
@@ -121,6 +123,7 @@ export function SettingsPage({ onClose }: Props) {
     if (selectedSound !== ((settings.notifications?.sound as SoundId) ?? "chime")) return true;
     if (JSON.stringify(labels) !== JSON.stringify(settings.labels ?? [])) return true;
     if (autoStartTunnel !== (settings.autoStartTunnel ?? false)) return true;
+    if (selectedTheme !== (settings.theme ?? "system")) return true;
     return false;
   }, [
     worktreesDir,
@@ -132,6 +135,7 @@ export function SettingsPage({ onClose }: Props) {
     selectedSound,
     labels,
     autoStartTunnel,
+    selectedTheme,
     settings,
   ]);
 
@@ -145,6 +149,7 @@ export function SettingsPage({ onClose }: Props) {
     setSelectedSound((settings.notifications?.sound as SoundId) ?? "chime");
     setLabels(settings.labels ?? []);
     setAutoStartTunnel(settings.autoStartTunnel ?? false);
+    setSelectedTheme(settings.theme ?? "system");
   }, [
     settings.worktreesDir,
     settings.defaults,
@@ -153,6 +158,7 @@ export function SettingsPage({ onClose }: Props) {
     settings.notifications,
     settings.labels,
     settings.autoStartTunnel,
+    settings.theme,
   ]);
 
   const handleBrowse = async () => {
@@ -216,6 +222,7 @@ export function SettingsPage({ onClose }: Props) {
       labels: labels.length > 0 ? labels : undefined,
       tokenSecret: settings.tokenSecret,
       autoStartTunnel: autoStartTunnel || undefined,
+      theme: selectedTheme,
     });
   };
 
@@ -225,6 +232,8 @@ export function SettingsPage({ onClose }: Props) {
   const portPreview = webServerPort || "3456";
   const labelsPreview =
     labels.length > 0 ? `${labels.length} label${labels.length === 1 ? "" : "s"}` : "None";
+  const themePreview =
+    selectedTheme === "system" ? "System" : selectedTheme === "dark" ? "Dark" : "Light";
   const notificationsPreview = soundOnNeedsAttention
     ? (SOUNDS.find((s) => s.id === selectedSound)?.label ?? "On")
     : "Off";
@@ -237,6 +246,7 @@ export function SettingsPage({ onClose }: Props) {
             <ChevronLeft className="size-5" />
           </Button>
           <h2 className="text-base font-semibold flex-1">
+            {section === "appearance" && "Appearance"}
             {section === "general" && "General"}
             {section === "labels" && "Labels"}
             {section === "coding-agent" && "Coding Agent"}
@@ -263,6 +273,47 @@ export function SettingsPage({ onClose }: Props) {
           </Tooltip>
         </div>
         <Separator className="mb-3" />
+
+        {section === "appearance" && (
+          <div className="space-y-4 px-1">
+            <div className="space-y-2">
+              <Label>Theme</Label>
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    className="w-full justify-between font-normal h-7 text-xs px-2"
+                  >
+                    {selectedTheme === "system"
+                      ? "System"
+                      : selectedTheme === "dark"
+                        ? "Dark"
+                        : "Light"}
+                    <ChevronDown className="size-3 opacity-50" />
+                  </Button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent
+                  align="start"
+                  className="w-[--radix-dropdown-menu-trigger-width]"
+                >
+                  <DropdownMenuRadioGroup
+                    value={selectedTheme}
+                    onValueChange={(v: string) => setSelectedTheme(v as Theme)}
+                  >
+                    <DropdownMenuRadioItem value="system">System</DropdownMenuRadioItem>
+                    <DropdownMenuRadioItem value="light">Light</DropdownMenuRadioItem>
+                    <DropdownMenuRadioItem value="dark">Dark</DropdownMenuRadioItem>
+                  </DropdownMenuRadioGroup>
+                </DropdownMenuContent>
+              </DropdownMenu>
+              <p className="text-xs text-muted-foreground">
+                Choose between system default, light, and dark mode. System follows your OS
+                preference. You can also cycle through themes using the toolbar button.
+              </p>
+            </div>
+          </div>
+        )}
 
         {section === "general" && (
           <div className="space-y-4 px-1">
@@ -544,6 +595,12 @@ export function SettingsPage({ onClose }: Props) {
       </div>
       <Separator />
       <div className="flex flex-col gap-px">
+        <SettingsRow
+          label="Appearance"
+          value={themePreview}
+          onClick={() => setSection("appearance")}
+        />
+        <Separator />
         <SettingsRow
           label="General"
           value={worktreesDirPreview}

--- a/packages/dashboard-core/src/types.ts
+++ b/packages/dashboard-core/src/types.ts
@@ -106,6 +106,8 @@ export interface LabelDefinition {
   color: string;
 }
 
+export type Theme = "system" | "light" | "dark";
+
 export interface Settings {
   worktreesDir: string | null;
   defaults?: BandConfig;
@@ -115,6 +117,7 @@ export interface Settings {
   labels?: LabelDefinition[];
   tokenSecret?: string;
   autoStartTunnel?: boolean;
+  theme?: Theme;
 }
 
 export interface HooksStatus {

--- a/packages/ui/src/globals.css
+++ b/packages/ui/src/globals.css
@@ -45,6 +45,40 @@
 
 :root {
   --radius: 0.625rem;
+  --background: oklch(1 0 0);
+  --foreground: oklch(0.145 0 0);
+  --card: oklch(1 0 0);
+  --card-foreground: oklch(0.145 0 0);
+  --popover: oklch(1 0 0);
+  --popover-foreground: oklch(0.145 0 0);
+  --primary: oklch(0.205 0 0);
+  --primary-foreground: oklch(0.985 0 0);
+  --secondary: oklch(0.965 0 0);
+  --secondary-foreground: oklch(0.205 0 0);
+  --muted: oklch(0.965 0 0);
+  --muted-foreground: oklch(0.556 0 0);
+  --accent: oklch(0.965 0 0);
+  --accent-foreground: oklch(0.205 0 0);
+  --destructive: oklch(0.577 0.245 27.325);
+  --border: oklch(0.922 0 0);
+  --input: oklch(0.922 0 0);
+  --ring: oklch(0.708 0 0);
+  --chart-1: oklch(0.646 0.222 41.116);
+  --chart-2: oklch(0.6 0.118 184.714);
+  --chart-3: oklch(0.398 0 0);
+  --chart-4: oklch(0.828 0.189 84.429);
+  --chart-5: oklch(0.769 0.188 70.08);
+  --sidebar: oklch(0.985 0 0);
+  --sidebar-foreground: oklch(0.145 0 0);
+  --sidebar-primary: oklch(0.205 0 0);
+  --sidebar-primary-foreground: oklch(0.985 0 0);
+  --sidebar-accent: oklch(0.965 0 0);
+  --sidebar-accent-foreground: oklch(0.205 0 0);
+  --sidebar-border: oklch(0.922 0 0);
+  --sidebar-ring: oklch(0.708 0 0);
+}
+
+.dark {
   --background: #181818;
   --foreground: oklch(0.922 0 0);
   --card: oklch(0.17 0 0);


### PR DESCRIPTION
## Summary

- Adds theme support with three modes: **System** (follows OS preference), **Light**, and **Dark**
- System is the new default — the app automatically adapts to the user's OS color scheme
- Theme can be toggled via a toolbar button (cycles System → Light → Dark) or the new **Appearance** section in Settings
- Preference is persisted in the settings database

## Changes

- Restructured CSS variables across all 3 `globals.css` files: light values in `:root`, dark overrides in `.dark`
- Added `theme` field (`"system" | "light" | "dark"`) to the `Settings` type
- Added Sun/Moon/Monitor toggle button to DashboardShell toolbar with `useEffect` to sync `<html>` class
- Added Appearance section to SettingsPage with System/Light/Dark dropdown
- Fixed hardcoded `border-white/20` → `border-border` and `text-blue-200` → `text-blue-700 dark:text-blue-200` for proper light mode support
- Added `class="dark"` to Tauri `index.html` so the desktop app defaults to dark correctly after CSS restructuring

## Test plan

- [ ] Verify dashboard loads in dark mode by default (OS dark) or light mode (OS light) with System theme
- [ ] Toggle to Light — all backgrounds white, text dark, borders visible
- [ ] Toggle to Dark — matches previous look exactly
- [ ] Toggle to System — follows OS preference, reacts to OS theme changes in real-time
- [ ] Refresh page — verify theme persists
- [ ] Settings → Appearance dropdown shows all 3 options and saves correctly
- [ ] Tauri desktop app defaults to dark mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)