### PR TITLE
fix: resolve hardcoded dark colors for light theme support

### DIFF
--- a/apps/web/src/components/ai-elements/message.tsx
+++ b/apps/web/src/components/ai-elements/message.tsx
@@ -34,7 +34,7 @@ export const MessageContent = ({ children, className, ...props }: MessageContent
     className={cn(
       "is-user:dark flex min-w-0 max-w-full flex-col gap-2 break-words text-base lg:text-sm",
       "group-[.is-assistant]:w-full group-[.is-user]:w-fit",
-      "group-[.is-user]:ml-auto group-[.is-user]:rounded-md group-[.is-user]:bg-white/10 group-[.is-user]:px-4 group-[.is-user]:py-3 group-[.is-user]:text-foreground",
+      "group-[.is-user]:ml-auto group-[.is-user]:rounded-md group-[.is-user]:bg-secondary group-[.is-user]:px-4 group-[.is-user]:py-3 group-[.is-user]:text-foreground",
       "group-[.is-assistant]:text-foreground",
       className,
     )}

--- a/apps/web/src/components/ai-elements/prompt-input.tsx
+++ b/apps/web/src/components/ai-elements/prompt-input.tsx
@@ -283,7 +283,7 @@ export const PromptInputAttach = ({ className, ...props }: PromptInputAttachProp
       <button
         type="button"
         className={cn(
-          "inline-flex size-8 lg:size-7 shrink-0 items-center justify-center rounded text-white/40 transition-colors hover:bg-muted hover:text-foreground",
+          "inline-flex size-8 lg:size-7 shrink-0 items-center justify-center rounded text-muted-foreground transition-colors hover:bg-muted hover:text-foreground",
           className,
         )}
         onClick={() => fileInputRef.current?.click()}
@@ -326,7 +326,7 @@ function highlightSlashCommands(text: string): ReactNode[] {
 
     // Command in blue
     segments.push(
-      <span key={commandStart} className="text-blue-400">
+      <span key={commandStart} className="text-blue-600 dark:text-blue-400">
         {commandStr}
       </span>,
     );
@@ -399,7 +399,7 @@ export const PromptInputTextarea = ({
         autoCorrect="off"
         spellCheck={false}
         className={cn(
-          "min-h-[44px] lg:min-h-[36px] max-h-48 w-full resize-none bg-transparent px-2 py-2.5 lg:py-2 text-base lg:text-sm outline-none placeholder:text-white/40 field-sizing-content",
+          "min-h-[44px] lg:min-h-[36px] max-h-48 w-full resize-none bg-transparent px-2 py-2.5 lg:py-2 text-base lg:text-sm outline-none placeholder:text-muted-foreground field-sizing-content",
           hasSlashCommand && "text-transparent caret-foreground",
           className,
         )}
@@ -481,7 +481,7 @@ export const PromptInputSubmit = ({
               ? isBusy
                 ? "bg-primary text-primary-foreground hover:bg-primary/80"
                 : "bg-foreground text-background hover:bg-foreground/80"
-              : "bg-white/15 text-white/40",
+              : "bg-muted text-muted-foreground",
             className,
           )}
           {...props}

--- a/apps/web/src/components/ai-elements/task-list-widget.tsx
+++ b/apps/web/src/components/ai-elements/task-list-widget.tsx
@@ -19,7 +19,7 @@ export function TaskListWidget({ tasks }: { tasks: TaskMap }) {
       <button
         type="button"
         onClick={() => setCollapsed(!collapsed)}
-        className="flex w-full items-center justify-between gap-2 px-2.5 py-1.5 transition-colors hover:bg-white/5"
+        className="flex w-full items-center justify-between gap-2 px-2.5 py-1.5 transition-colors hover:bg-accent/50"
       >
         <div className="flex items-center gap-1.5">
           {collapsed ? (

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -1,8 +1,4 @@
-import {
-  DashboardProvider,
-  DashboardShell,
-  useSettingsQuery,
-} from "@band-app/dashboard-core";
+import { DashboardProvider, DashboardShell, useSettingsQuery } from "@band-app/dashboard-core";
 import {
   HybridDashboardAdapter,
   NativeShellCapabilities,

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -1,4 +1,8 @@
-import { DashboardProvider, DashboardShell } from "@band-app/dashboard-core";
+import {
+  DashboardProvider,
+  DashboardShell,
+  useSettingsQuery,
+} from "@band-app/dashboard-core";
 import {
   HybridDashboardAdapter,
   NativeShellCapabilities,
@@ -55,6 +59,37 @@ function NotFound() {
   );
 }
 
+/** Syncs the "dark" class on <html> with the persisted theme setting.
+ *  Runs for ALL pages (including standalone Tauri windows like tasks/cronjobs). */
+function ThemeSync() {
+  const { settings } = useSettingsQuery();
+  const theme = settings.theme ?? "system";
+
+  useEffect(() => {
+    const root = document.documentElement;
+
+    const apply = (isDark: boolean) => {
+      if (isDark) {
+        root.classList.add("dark");
+      } else {
+        root.classList.remove("dark");
+      }
+    };
+
+    if (theme === "system") {
+      const mq = window.matchMedia("(prefers-color-scheme: dark)");
+      apply(mq.matches);
+      const handler = (e: MediaQueryListEvent) => apply(e.matches);
+      mq.addEventListener("change", handler);
+      return () => mq.removeEventListener("change", handler);
+    }
+
+    apply(theme === "dark");
+  }, [theme]);
+
+  return null;
+}
+
 function AppShell() {
   const isDesktop = useIsDesktop() && !isTauri;
   const router = useRouter();
@@ -87,12 +122,13 @@ function AppShell() {
 
 function RootLayout() {
   return (
-    <html lang="en" className="dark">
+    <html lang="en">
       <head>
         <HeadContent />
       </head>
       <body>
         <DashboardProvider adapter={adapter} capabilities={capabilities}>
+          <ThemeSync />
           <TooltipProvider>
             <AppShell />
           </TooltipProvider>

--- a/apps/web/src/routes/cronjobs.tsx
+++ b/apps/web/src/routes/cronjobs.tsx
@@ -223,7 +223,7 @@ function LastRunBadge({ status }: { status?: string }) {
   switch (status) {
     case "completed":
       return (
-        <Badge variant="secondary" className="gap-1 text-green-400">
+        <Badge variant="secondary" className="gap-1 text-green-600 dark:text-green-400">
           Completed
         </Badge>
       );
@@ -235,7 +235,7 @@ function LastRunBadge({ status }: { status?: string }) {
       );
     case "skipped":
       return (
-        <Badge variant="secondary" className="gap-1 text-yellow-400">
+        <Badge variant="secondary" className="gap-1 text-yellow-600 dark:text-yellow-400">
           Skipped
         </Badge>
       );

--- a/apps/web/src/routes/tasks.tsx
+++ b/apps/web/src/routes/tasks.tsx
@@ -246,7 +246,7 @@ function StatusBadge({ status }: { status: TaskRecord["status"] }) {
       );
     case "completed":
       return (
-        <Badge variant="secondary" className="gap-1.5 text-green-400">
+        <Badge variant="secondary" className="gap-1.5 text-green-600 dark:text-green-400">
           <CheckCircle2 className="size-3" />
           Completed
         </Badge>

--- a/apps/web/src/routes/workspace.$workspaceId.tsx
+++ b/apps/web/src/routes/workspace.$workspaceId.tsx
@@ -186,7 +186,7 @@ function DesktopDetailTabNav({
         <GitCompare className="size-4" />
         Changes
         {diffStats && diffStats.filesChanged > 0 && (
-          <span className="inline-flex h-5 min-w-5 items-center justify-center rounded-full bg-blue-500/20 text-blue-400 px-1.5 text-xs font-medium">
+          <span className="inline-flex h-5 min-w-5 items-center justify-center rounded-full bg-blue-500/20 text-blue-600 dark:text-blue-400 px-1.5 text-xs font-medium">
             {diffStats.filesChanged}
           </span>
         )}

--- a/packages/dashboard-core/src/components/CIStatusIndicator.tsx
+++ b/packages/dashboard-core/src/components/CIStatusIndicator.tsx
@@ -23,7 +23,7 @@ export function CIStatusIndicator({ ci }: Props) {
       <Tooltip>
         <TooltipTrigger asChild>
           <GitMerge
-            className={`size-3.5 shrink-0 text-violet-400 ${cursorClass}`}
+            className={`size-3.5 shrink-0 text-violet-600 dark:text-violet-400 ${cursorClass}`}
             onClick={(e) => handleOpenUrl(ci.url, e)}
           />
         </TooltipTrigger>
@@ -37,7 +37,7 @@ export function CIStatusIndicator({ ci }: Props) {
       <Tooltip>
         <TooltipTrigger asChild>
           <CircleCheck
-            className={`size-3.5 shrink-0 text-green-400 ${cursorClass}`}
+            className={`size-3.5 shrink-0 text-green-600 dark:text-green-400 ${cursorClass}`}
             onClick={(e) => handleOpenUrl(ci.url, e)}
           />
         </TooltipTrigger>
@@ -51,7 +51,7 @@ export function CIStatusIndicator({ ci }: Props) {
       <Tooltip>
         <TooltipTrigger asChild>
           <CircleAlert
-            className={`size-3.5 shrink-0 text-red-400 ${cursorClass}`}
+            className={`size-3.5 shrink-0 text-red-600 dark:text-red-400 ${cursorClass}`}
             onClick={(e) => handleOpenUrl(ci.url, e)}
           />
         </TooltipTrigger>
@@ -65,7 +65,7 @@ export function CIStatusIndicator({ ci }: Props) {
       <Tooltip>
         <TooltipTrigger asChild>
           <Loader
-            className={`size-3.5 shrink-0 text-yellow-400 animate-spin ${cursorClass}`}
+            className={`size-3.5 shrink-0 text-yellow-600 dark:text-yellow-400 animate-spin ${cursorClass}`}
             onClick={(e) => handleOpenUrl(ci.url, e)}
           />
         </TooltipTrigger>
@@ -79,7 +79,7 @@ export function CIStatusIndicator({ ci }: Props) {
       <Tooltip>
         <TooltipTrigger asChild>
           <Ban
-            className={`size-3.5 shrink-0 text-gray-400 ${cursorClass}`}
+            className={`size-3.5 shrink-0 text-gray-600 dark:text-gray-400 ${cursorClass}`}
             onClick={(e) => handleOpenUrl(ci.url, e)}
           />
         </TooltipTrigger>

--- a/packages/dashboard-core/src/components/CodeMirrorViewer.tsx
+++ b/packages/dashboard-core/src/components/CodeMirrorViewer.tsx
@@ -1,6 +1,7 @@
 import { EditorState } from "@codemirror/state";
 import { EditorView } from "@codemirror/view";
 import { useEffect, useRef } from "react";
+import { useIsDark } from "../hooks/use-is-dark";
 import { baseViewerExtensions, loadLanguage } from "../lib/codemirror-setup";
 
 interface CodeMirrorViewerProps {
@@ -21,8 +22,9 @@ export function CodeMirrorViewer({
   const viewRef = useRef<EditorView | null>(null);
   const onEditorViewRef = useRef(onEditorView);
   onEditorViewRef.current = onEditorView;
+  const isDark = useIsDark();
 
-  // Create/recreate the editor when content or language changes
+  // Create/recreate the editor when content, language, or theme changes
   useEffect(() => {
     const container = containerRef.current;
     if (!container) return;
@@ -40,7 +42,7 @@ export function CodeMirrorViewer({
         onEditorViewRef.current?.(null);
       }
 
-      const extensions = [...baseViewerExtensions()];
+      const extensions = [...baseViewerExtensions(isDark)];
       if (langSupport) {
         extensions.push(langSupport);
       }
@@ -68,7 +70,7 @@ export function CodeMirrorViewer({
         onEditorViewRef.current?.(null);
       }
     };
-  }, [content, language]);
+  }, [content, language, isDark]);
 
   return <div ref={containerRef} className={className} />;
 }

--- a/packages/dashboard-core/src/components/DashboardShell.tsx
+++ b/packages/dashboard-core/src/components/DashboardShell.tsx
@@ -16,23 +16,11 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@band-app/ui";
-import {
-  Check,
-  FolderPlus,
-  Monitor,
-  Moon,
-  Pencil,
-  Plus,
-  Settings,
-  Sun,
-  Tag,
-  X,
-} from "lucide-react";
+import { Check, FolderPlus, Pencil, Plus, Settings, Tag, X } from "lucide-react";
 import { type ReactNode, useEffect, useRef, useState } from "react";
 import { useCliSetup } from "../hooks/use-cli-setup";
 import { useHooksSetup } from "../hooks/use-hooks-setup";
 import { useProjects } from "../hooks/use-projects";
-import { useUpdateSettings } from "../hooks/use-settings-mutations";
 import { useSettingsQuery } from "../hooks/use-settings-query";
 import {
   useActiveWorkspaceWatcher,
@@ -54,7 +42,6 @@ const isTauri = typeof window !== "undefined" && "__TAURI_INTERNALS__" in window
 export function DashboardShell({ toolbarExtra }: DashboardShellProps) {
   const { projects, isLoading: loading } = useProjects();
   const { settings } = useSettingsQuery();
-  const updateSettingsMutation = useUpdateSettings();
   const labels = settings.labels ?? [];
   const error = useDashboardStore((s) => s.error);
   const clearError = useDashboardStore((s) => s.clearError);
@@ -95,54 +82,6 @@ export function DashboardShell({ toolbarExtra }: DashboardShellProps) {
     el.addEventListener("mousedown", onMouseDown);
     return () => el.removeEventListener("mousedown", onMouseDown);
   }, []);
-
-  // Sync theme class on <html> with persisted setting
-  const theme = settings.theme ?? "system";
-  useEffect(() => {
-    const root = document.documentElement;
-
-    const apply = (isDark: boolean) => {
-      if (isDark) {
-        root.classList.add("dark");
-      } else {
-        root.classList.remove("dark");
-      }
-    };
-
-    if (theme === "system") {
-      const mq = window.matchMedia("(prefers-color-scheme: dark)");
-      apply(mq.matches);
-      const handler = (e: MediaQueryListEvent) => apply(e.matches);
-      mq.addEventListener("change", handler);
-      return () => mq.removeEventListener("change", handler);
-    }
-
-    apply(theme === "dark");
-  }, [theme]);
-
-  // Resolve effective theme for icon display
-  const [resolvedDark, setResolvedDark] = useState(() =>
-    typeof window !== "undefined"
-      ? window.matchMedia("(prefers-color-scheme: dark)").matches
-      : true,
-  );
-  useEffect(() => {
-    if (theme !== "system") return;
-    const mq = window.matchMedia("(prefers-color-scheme: dark)");
-    setResolvedDark(mq.matches);
-    const handler = (e: MediaQueryListEvent) => setResolvedDark(e.matches);
-    mq.addEventListener("change", handler);
-    return () => mq.removeEventListener("change", handler);
-  }, [theme]);
-
-  const effectiveDark = theme === "dark" || (theme === "system" && resolvedDark);
-
-  const toggleTheme = () => {
-    const order = ["system", "light", "dark"] as const;
-    const idx = order.indexOf(theme as (typeof order)[number]);
-    const next = order[(idx + 1) % order.length];
-    updateSettingsMutation.mutate({ ...settings, theme: next });
-  };
 
   useStatusWatcher();
   useActiveWorkspaceWatcher();
@@ -243,26 +182,6 @@ export function DashboardShell({ toolbarExtra }: DashboardShellProps) {
               )}
             </div>
             <div className="flex items-center gap-1">
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <Button size="icon-sm" variant="ghost" onClick={toggleTheme}>
-                    {theme === "system" ? (
-                      <Monitor className="size-5" />
-                    ) : effectiveDark ? (
-                      <Sun className="size-5" />
-                    ) : (
-                      <Moon className="size-5" />
-                    )}
-                  </Button>
-                </TooltipTrigger>
-                <TooltipContent>
-                  {theme === "system"
-                    ? "Theme: System"
-                    : theme === "dark"
-                      ? "Theme: Dark"
-                      : "Theme: Light"}
-                </TooltipContent>
-              </Tooltip>
               <Tooltip>
                 <TooltipTrigger asChild>
                   <Button size="icon-sm" variant="ghost" onClick={() => setShowAddDialog(true)}>

--- a/packages/dashboard-core/src/components/DiffView.tsx
+++ b/packages/dashboard-core/src/components/DiffView.tsx
@@ -436,10 +436,14 @@ function LegacyDiffView({ workspaceId, active, onStatsChange, onOpenFile }: Diff
             <span className="font-medium text-foreground">{data.stats.filesChanged}</span>{" "}
             {data.stats.filesChanged === 1 ? "file" : "files"} changed
             {data.stats.insertions > 0 && (
-              <span className="ml-2 text-green-600 dark:text-green-400">+{data.stats.insertions}</span>
+              <span className="ml-2 text-green-600 dark:text-green-400">
+                +{data.stats.insertions}
+              </span>
             )}
             {data.stats.deletions > 0 && (
-              <span className="ml-1 text-red-600 dark:text-red-400">-{data.stats.deletions}</span>
+              <span className="ml-1 text-red-600 dark:text-red-400">
+                -{data.stats.deletions}
+              </span>
             )}
           </div>
           <div className="mt-0.5 text-xs text-muted-foreground">
@@ -625,10 +629,14 @@ export function DiffView({ workspaceId, active = true, onStatsChange, onOpenFile
             <span className="font-medium text-foreground">{summary.stats.filesChanged}</span>{" "}
             {summary.stats.filesChanged === 1 ? "file" : "files"} changed
             {summary.stats.insertions > 0 && (
-              <span className="ml-2 text-green-600 dark:text-green-400">+{summary.stats.insertions}</span>
+              <span className="ml-2 text-green-600 dark:text-green-400">
+                +{summary.stats.insertions}
+              </span>
             )}
             {summary.stats.deletions > 0 && (
-              <span className="ml-1 text-red-600 dark:text-red-400">-{summary.stats.deletions}</span>
+              <span className="ml-1 text-red-600 dark:text-red-400">
+                -{summary.stats.deletions}
+              </span>
             )}
           </div>
           <div className="mt-0.5 text-xs text-muted-foreground">

--- a/packages/dashboard-core/src/components/DiffView.tsx
+++ b/packages/dashboard-core/src/components/DiffView.tsx
@@ -441,9 +441,7 @@ function LegacyDiffView({ workspaceId, active, onStatsChange, onOpenFile }: Diff
               </span>
             )}
             {data.stats.deletions > 0 && (
-              <span className="ml-1 text-red-600 dark:text-red-400">
-                -{data.stats.deletions}
-              </span>
+              <span className="ml-1 text-red-600 dark:text-red-400">-{data.stats.deletions}</span>
             )}
           </div>
           <div className="mt-0.5 text-xs text-muted-foreground">

--- a/packages/dashboard-core/src/components/DiffView.tsx
+++ b/packages/dashboard-core/src/components/DiffView.tsx
@@ -4,6 +4,7 @@ import { EditorView } from "@codemirror/view";
 import { Columns2, Loader2, Rows2, SquareArrowOutUpRight } from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useAdapter } from "../context";
+import { useIsDark } from "../hooks/use-is-dark";
 import { baseViewerExtensions, loadLanguage } from "../lib/codemirror-setup";
 import { extensionToLanguage, filenameToLanguage } from "../lib/language-map";
 import type { FileStatus, WorkspaceDiffSummary } from "../types";
@@ -48,11 +49,11 @@ function parseDiffFiles(diff: string): ParsedFile[] {
 }
 
 const statusColors: Record<FileStatus, string> = {
-  A: "text-green-400",
-  M: "text-blue-400",
-  D: "text-red-400",
-  R: "text-purple-400",
-  U: "text-yellow-400",
+  A: "text-green-600 dark:text-green-400",
+  M: "text-blue-600 dark:text-blue-400",
+  D: "text-red-600 dark:text-red-400",
+  R: "text-purple-600 dark:text-purple-400",
+  U: "text-yellow-600 dark:text-yellow-400",
 };
 
 function FileStatusBadge({ status }: { status: FileStatus | undefined }) {
@@ -127,6 +128,7 @@ function DiffFileContent({
 }) {
   const containerRef = useRef<HTMLDivElement>(null);
   const viewRef = useRef<EditorView | MergeView | null>(null);
+  const isDark = useIsDark();
 
   useEffect(() => {
     const container = containerRef.current;
@@ -149,7 +151,7 @@ function DiffFileContent({
       const { oldText, newText } = buildOldNew(diffLines);
 
       if (viewMode === "split") {
-        const sharedExtensions = [...baseViewerExtensions(), diffTheme];
+        const sharedExtensions = [...baseViewerExtensions(isDark), diffTheme];
         if (langSupport) {
           sharedExtensions.push(langSupport);
         }
@@ -169,7 +171,7 @@ function DiffFileContent({
         });
       } else {
         const extensions = [
-          ...baseViewerExtensions(),
+          ...baseViewerExtensions(isDark),
           unifiedMergeView({
             original: Text.of(oldText.split("\n")),
             mergeControls: false,
@@ -203,7 +205,7 @@ function DiffFileContent({
         viewRef.current = null;
       }
     };
-  }, [hunks, filename, viewMode]);
+  }, [hunks, filename, viewMode, isDark]);
 
   return <div ref={containerRef} />;
 }
@@ -434,10 +436,10 @@ function LegacyDiffView({ workspaceId, active, onStatsChange, onOpenFile }: Diff
             <span className="font-medium text-foreground">{data.stats.filesChanged}</span>{" "}
             {data.stats.filesChanged === 1 ? "file" : "files"} changed
             {data.stats.insertions > 0 && (
-              <span className="ml-2 text-green-400">+{data.stats.insertions}</span>
+              <span className="ml-2 text-green-600 dark:text-green-400">+{data.stats.insertions}</span>
             )}
             {data.stats.deletions > 0 && (
-              <span className="ml-1 text-red-400">-{data.stats.deletions}</span>
+              <span className="ml-1 text-red-600 dark:text-red-400">-{data.stats.deletions}</span>
             )}
           </div>
           <div className="mt-0.5 text-xs text-muted-foreground">
@@ -623,10 +625,10 @@ export function DiffView({ workspaceId, active = true, onStatsChange, onOpenFile
             <span className="font-medium text-foreground">{summary.stats.filesChanged}</span>{" "}
             {summary.stats.filesChanged === 1 ? "file" : "files"} changed
             {summary.stats.insertions > 0 && (
-              <span className="ml-2 text-green-400">+{summary.stats.insertions}</span>
+              <span className="ml-2 text-green-600 dark:text-green-400">+{summary.stats.insertions}</span>
             )}
             {summary.stats.deletions > 0 && (
-              <span className="ml-1 text-red-400">-{summary.stats.deletions}</span>
+              <span className="ml-1 text-red-600 dark:text-red-400">-{summary.stats.deletions}</span>
             )}
           </div>
           <div className="mt-0.5 text-xs text-muted-foreground">

--- a/packages/dashboard-core/src/components/FileBrowser.tsx
+++ b/packages/dashboard-core/src/components/FileBrowser.tsx
@@ -150,7 +150,7 @@ export function FileBrowser({
                 } ${isSelected ? "bg-accent/50 text-foreground" : ""}`}
               >
                 {entry.type === "directory" ? (
-                  <Folder className={`shrink-0 text-blue-400 ${compact ? "size-4" : "size-4"}`} />
+                  <Folder className={`shrink-0 text-blue-600 dark:text-blue-400 ${compact ? "size-4" : "size-4"}`} />
                 ) : (
                   <File
                     className={`shrink-0 text-muted-foreground ${compact ? "size-4" : "size-4"}`}

--- a/packages/dashboard-core/src/components/FileBrowser.tsx
+++ b/packages/dashboard-core/src/components/FileBrowser.tsx
@@ -150,7 +150,9 @@ export function FileBrowser({
                 } ${isSelected ? "bg-accent/50 text-foreground" : ""}`}
               >
                 {entry.type === "directory" ? (
-                  <Folder className={`shrink-0 text-blue-600 dark:text-blue-400 ${compact ? "size-4" : "size-4"}`} />
+                  <Folder
+                    className={`shrink-0 text-blue-600 dark:text-blue-400 ${compact ? "size-4" : "size-4"}`}
+                  />
                 ) : (
                   <File
                     className={`shrink-0 text-muted-foreground ${compact ? "size-4" : "size-4"}`}

--- a/packages/dashboard-core/src/components/GitStatusIndicator.tsx
+++ b/packages/dashboard-core/src/components/GitStatusIndicator.tsx
@@ -11,7 +11,11 @@ export function GitStatusIndicator({ git }: Props) {
   if (git.conflict) {
     parts.push({ text: "!", color: "text-red-600 dark:text-red-400", tooltip: "Merge conflict" });
   } else if (git.dirty) {
-    parts.push({ text: "M", color: "text-yellow-600 dark:text-yellow-400", tooltip: "Uncommitted changes" });
+    parts.push({
+      text: "M",
+      color: "text-yellow-600 dark:text-yellow-400",
+      tooltip: "Uncommitted changes",
+    });
   }
 
   if (git.sync_state === "ahead") {

--- a/packages/dashboard-core/src/components/GitStatusIndicator.tsx
+++ b/packages/dashboard-core/src/components/GitStatusIndicator.tsx
@@ -9,27 +9,27 @@ export function GitStatusIndicator({ git }: Props) {
   const parts: { text: string; color: string; tooltip: string }[] = [];
 
   if (git.conflict) {
-    parts.push({ text: "!", color: "text-red-400", tooltip: "Merge conflict" });
+    parts.push({ text: "!", color: "text-red-600 dark:text-red-400", tooltip: "Merge conflict" });
   } else if (git.dirty) {
-    parts.push({ text: "M", color: "text-yellow-400", tooltip: "Uncommitted changes" });
+    parts.push({ text: "M", color: "text-yellow-600 dark:text-yellow-400", tooltip: "Uncommitted changes" });
   }
 
   if (git.sync_state === "ahead") {
     parts.push({
       text: `\u2191${git.ahead}`,
-      color: "text-blue-400",
+      color: "text-blue-600 dark:text-blue-400",
       tooltip: `${git.ahead} commit${git.ahead > 1 ? "s" : ""} ahead`,
     });
   } else if (git.sync_state === "behind") {
     parts.push({
       text: `\u2193${git.behind}`,
-      color: "text-yellow-400",
+      color: "text-yellow-600 dark:text-yellow-400",
       tooltip: `${git.behind} commit${git.behind > 1 ? "s" : ""} behind`,
     });
   } else if (git.sync_state === "diverged") {
     parts.push({
       text: `\u2191${git.ahead}\u2193${git.behind}`,
-      color: "text-orange-400",
+      color: "text-orange-600 dark:text-orange-400",
       tooltip: `Diverged: ${git.ahead} ahead, ${git.behind} behind`,
     });
   }

--- a/packages/dashboard-core/src/components/SetupStatusIndicator.tsx
+++ b/packages/dashboard-core/src/components/SetupStatusIndicator.tsx
@@ -13,7 +13,7 @@ export function SetupStatusIndicator({ setup }: Props) {
     return (
       <Tooltip>
         <TooltipTrigger asChild>
-          <Loader className="size-3.5 shrink-0 text-blue-400 animate-spin" />
+          <Loader className="size-3.5 shrink-0 text-blue-600 dark:text-blue-400 animate-spin" />
         </TooltipTrigger>
         <TooltipContent side="top">Setting up workspace...</TooltipContent>
       </Tooltip>
@@ -24,7 +24,7 @@ export function SetupStatusIndicator({ setup }: Props) {
     return (
       <Tooltip>
         <TooltipTrigger asChild>
-          <CircleAlert className="size-3.5 shrink-0 text-red-400" />
+          <CircleAlert className="size-3.5 shrink-0 text-red-600 dark:text-red-400" />
         </TooltipTrigger>
         <TooltipContent side="top">
           Setup failed{setup.error ? `: ${setup.error}` : ""}

--- a/packages/dashboard-core/src/components/WorkspaceTabNav.tsx
+++ b/packages/dashboard-core/src/components/WorkspaceTabNav.tsx
@@ -41,7 +41,7 @@ export function WorkspaceTabNav({
             <Icon className="size-4" />
             {tab.label}
             {badge && (
-              <span className="inline-flex h-5 min-w-5 items-center justify-center rounded-full bg-blue-500/20 text-blue-400 px-1.5 text-xs font-medium">
+              <span className="inline-flex h-5 min-w-5 items-center justify-center rounded-full bg-blue-500/20 text-blue-600 dark:text-blue-400 px-1.5 text-xs font-medium">
                 {diffFileCount}
               </span>
             )}

--- a/packages/dashboard-core/src/hooks/use-is-dark.ts
+++ b/packages/dashboard-core/src/hooks/use-is-dark.ts
@@ -1,0 +1,25 @@
+import { useEffect, useState } from "react";
+
+/**
+ * Returns true when the `dark` class is present on <html>.
+ * Reacts to changes via MutationObserver so CodeMirror editors
+ * (and any other consumers) re-render when the theme toggles.
+ */
+export function useIsDark(): boolean {
+  const [isDark, setIsDark] = useState(
+    () => typeof document !== "undefined" && document.documentElement.classList.contains("dark"),
+  );
+
+  useEffect(() => {
+    const root = document.documentElement;
+    setIsDark(root.classList.contains("dark"));
+
+    const observer = new MutationObserver(() => {
+      setIsDark(root.classList.contains("dark"));
+    });
+    observer.observe(root, { attributes: true, attributeFilter: ["class"] });
+    return () => observer.disconnect();
+  }, []);
+
+  return isDark;
+}

--- a/packages/dashboard-core/src/index.ts
+++ b/packages/dashboard-core/src/index.ts
@@ -23,6 +23,7 @@ export { type WorkspaceTab, WorkspaceTabNav } from "./components/WorkspaceTabNav
 // Context
 export { DashboardProvider, useAdapter, useCapabilities } from "./context";
 export { type HooksSetupState, useHooksSetup } from "./hooks/use-hooks-setup";
+export { useIsDark } from "./hooks/use-is-dark";
 export {
   useAddProject,
   useCreateWorkspace,

--- a/packages/dashboard-core/src/lib/codemirror-setup.ts
+++ b/packages/dashboard-core/src/lib/codemirror-setup.ts
@@ -124,31 +124,52 @@ export async function loadLanguage(lang: string): Promise<LanguageSupport | null
 
 /**
  * Base extensions for a read-only CodeMirror viewer.
+ * @param isDark - Whether to use dark theme colours. Defaults to true for backwards compat.
  */
-export function baseViewerExtensions(): Extension[] {
+export function baseViewerExtensions(isDark = true): Extension[] {
   return [
     EditorState.readOnly.of(true),
     EditorView.editable.of(false),
     lineNumbers(),
     bracketMatching(),
     highlightSelectionMatches(),
-    syntaxHighlighting(oneDarkHighlightStyle),
-    syntaxHighlighting(defaultHighlightStyle, { fallback: true }),
+    ...(isDark
+      ? [
+          syntaxHighlighting(oneDarkHighlightStyle),
+          syntaxHighlighting(defaultHighlightStyle, { fallback: true }),
+        ]
+      : [
+          syntaxHighlighting(defaultHighlightStyle),
+          syntaxHighlighting(oneDarkHighlightStyle, { fallback: true }),
+        ]),
     keymap.of([...defaultKeymap, ...searchKeymap]),
     EditorView.theme(
-      {
-        "&": { height: "100%", backgroundColor: "#181818" },
-        ".cm-scroller": { overflow: "auto" },
-        ".cm-gutters": { backgroundColor: "#181818", border: "none" },
-        ".cm-activeLineGutter": { backgroundColor: "transparent" },
-        ".cm-activeLine": { backgroundColor: "transparent" },
-        "&.cm-focused .cm-cursor": { borderLeftColor: "#fff" },
-        "&.cm-focused .cm-selectionBackground, .cm-selectionBackground": {
-          backgroundColor: "rgba(255, 255, 255, 0.1)",
-        },
-        ".cm-line": { color: "#abb2bf" },
-      },
-      { dark: true },
+      isDark
+        ? {
+            "&": { height: "100%", backgroundColor: "#181818" },
+            ".cm-scroller": { overflow: "auto" },
+            ".cm-gutters": { backgroundColor: "#181818", border: "none" },
+            ".cm-activeLineGutter": { backgroundColor: "transparent" },
+            ".cm-activeLine": { backgroundColor: "transparent" },
+            "&.cm-focused .cm-cursor": { borderLeftColor: "#fff" },
+            "&.cm-focused .cm-selectionBackground, .cm-selectionBackground": {
+              backgroundColor: "rgba(255, 255, 255, 0.1)",
+            },
+            ".cm-line": { color: "#abb2bf" },
+          }
+        : {
+            "&": { height: "100%", backgroundColor: "#ffffff" },
+            ".cm-scroller": { overflow: "auto" },
+            ".cm-gutters": { backgroundColor: "#f8f9fa", border: "none", color: "#6e7781" },
+            ".cm-activeLineGutter": { backgroundColor: "transparent" },
+            ".cm-activeLine": { backgroundColor: "transparent" },
+            "&.cm-focused .cm-cursor": { borderLeftColor: "#24292f" },
+            "&.cm-focused .cm-selectionBackground, .cm-selectionBackground": {
+              backgroundColor: "rgba(0, 0, 0, 0.07)",
+            },
+            ".cm-line": { color: "#24292f" },
+          },
+      { dark: isDark },
     ),
   ];
 }

--- a/packages/ui/src/components/context-menu.tsx
+++ b/packages/ui/src/components/context-menu.tsx
@@ -27,7 +27,7 @@ function ContextMenuContent({
       <ContextMenuPrimitive.Content
         data-slot="context-menu-content"
         className={cn(
-          "z-50 max-h-(--radix-context-menu-content-available-height) min-w-[8rem] origin-(--radix-context-menu-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border border-[oklch(0.4_0_0)] bg-[oklch(0.26_0_0)] p-1 text-popover-foreground shadow-md data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95",
+          "z-50 max-h-(--radix-context-menu-content-available-height) min-w-[8rem] origin-(--radix-context-menu-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border border-border bg-popover p-1 text-popover-foreground shadow-md data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95",
           className,
         )}
         {...props}
@@ -95,7 +95,7 @@ function ContextMenuSubContent({
     <ContextMenuPrimitive.SubContent
       data-slot="context-menu-sub-content"
       className={cn(
-        "z-50 min-w-[8rem] origin-(--radix-context-menu-content-transform-origin) overflow-hidden rounded-md border border-[oklch(0.4_0_0)] bg-[oklch(0.26_0_0)] p-1 text-popover-foreground shadow-lg data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95",
+        "z-50 min-w-[8rem] origin-(--radix-context-menu-content-transform-origin) overflow-hidden rounded-md border border-border bg-popover p-1 text-popover-foreground shadow-lg data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95",
         className,
       )}
       {...props}

--- a/packages/ui/src/components/dropdown-menu.tsx
+++ b/packages/ui/src/components/dropdown-menu.tsx
@@ -31,7 +31,7 @@ function DropdownMenuContent({
         data-slot="dropdown-menu-content"
         sideOffset={sideOffset}
         className={cn(
-          "z-50 max-h-(--radix-dropdown-menu-content-available-height) min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border border-[oklch(0.4_0_0)] bg-[oklch(0.26_0_0)] p-1 text-popover-foreground shadow-md data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95",
+          "z-50 max-h-(--radix-dropdown-menu-content-available-height) min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border border-border bg-popover p-1 text-popover-foreground shadow-md data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95",
           className,
         )}
         {...props}
@@ -199,7 +199,7 @@ function DropdownMenuSubContent({
     <DropdownMenuPrimitive.SubContent
       data-slot="dropdown-menu-sub-content"
       className={cn(
-        "z-50 min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-hidden rounded-md border border-[oklch(0.4_0_0)] bg-[oklch(0.26_0_0)] p-1 text-popover-foreground shadow-lg data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95",
+        "z-50 min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-hidden rounded-md border border-border bg-popover p-1 text-popover-foreground shadow-lg data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95",
         className,
       )}
       {...props}


### PR DESCRIPTION
## Summary
- Replace hardcoded oklch/white colors with theme-aware Tailwind CSS classes (bg-popover, border-border, text-muted-foreground, etc.) across dropdown menus, context menus, chat input, and message bubbles
- Move theme sync logic from DashboardShell into root layout so standalone Tauri windows (tasks/cronjobs) respect the selected theme
- Make CodeMirror viewer/diff theme-aware via a new `useIsDark` hook — editors now switch between dark and light color schemes
- Fix status indicator visibility on light backgrounds using `text-*-600 dark:text-*-400` pattern across all status components
- Remove theme toggle button from main toolbar (theme is controlled from Settings page)

## Test plan
- [ ] Toggle theme to light in Settings — verify all dashboard views render correctly
- [ ] Open a workspace and check chat input buttons, code viewer, and diff view in light mode
- [ ] Open tasks/cronjobs in separate Tauri windows — verify they follow the selected theme
- [ ] Switch to system theme and verify it tracks OS preference
- [ ] Verify dark mode still looks correct (no regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)