### PR TITLE
feat: add configurable maxTurns for agent tasks

### DIFF
--- a/apps/cli/SKILL.md
+++ b/apps/cli/SKILL.md
@@ -70,7 +70,7 @@ JSON output: `{"workspaces": [{"project": "...", "branch": "...", "path": "..."}
 ### Create a workspace
 
 ```sh
-band workspaces create <project> <branch> [--base <branch>] [--prompt <text>]
+band workspaces create <project> <branch> [--base <branch>] [--prompt <text>] [--max-turns <N>]
 ```
 
 Returns the worktree path. Idempotent — creating an existing workspace returns its path. Runs `.band/config.json` `setup` script if present (non-fatal).
@@ -146,10 +146,10 @@ JSON output: `{"tasks": [{"id": "...", "status": "...", "project": "...", "branc
 ### Create a task
 
 ```sh
-band tasks create <workspace_id> --prompt <text>
+band tasks create <workspace_id> --prompt <text> [--max-turns <N>]
 ```
 
-Submits a new task to the coding agent. Returns the task ID.
+Submits a new task to the coding agent. `--max-turns` sets the maximum number of agentic turns (default: 100). Returns the task ID.
 JSON output: `{"id": "...", "workspaceId": "..."}`
 
 ### Cancel a task

--- a/apps/cli/src/main.rs
+++ b/apps/cli/src/main.rs
@@ -104,6 +104,9 @@ enum WorkspacesCmd {
         /// Prompt to pass to the coding agent
         #[arg(long)]
         prompt: Option<String>,
+        /// Maximum number of agentic turns
+        #[arg(long)]
+        max_turns: Option<u32>,
     },
     /// Remove a workspace (git worktree + state cleanup)
     Remove {
@@ -132,6 +135,9 @@ enum TasksCmd {
         /// Prompt text to send to the agent
         #[arg(long)]
         prompt: String,
+        /// Maximum number of agentic turns
+        #[arg(long)]
+        max_turns: Option<u32>,
     },
     /// Cancel a running task
     Cancel {
@@ -293,7 +299,14 @@ fn main() {
                 branch,
                 base,
                 prompt,
-            } => cmd_workspaces_create(&project, &branch, base.as_deref(), prompt.as_deref()),
+                max_turns,
+            } => cmd_workspaces_create(
+                &project,
+                &branch,
+                base.as_deref(),
+                prompt.as_deref(),
+                max_turns,
+            ),
             WorkspacesCmd::Remove { project, branch } => cmd_workspaces_remove(&project, &branch),
         },
         Commands::Tasks { cmd } => match cmd {
@@ -303,7 +316,8 @@ fn main() {
             TasksCmd::Create {
                 workspace_id,
                 prompt,
-            } => cmd_tasks_create(&workspace_id, &prompt),
+                max_turns,
+            } => cmd_tasks_create(&workspace_id, &prompt, max_turns),
             TasksCmd::Cancel { task_id } => cmd_tasks_cancel(&task_id),
             TasksCmd::Rerun { task_id } => cmd_tasks_rerun(&task_id),
             TasksCmd::Watch { .. } => unreachable!(),
@@ -536,6 +550,7 @@ fn cmd_workspaces_create(
     branch: &str,
     base: Option<&str>,
     prompt: Option<&str>,
+    max_turns: Option<u32>,
 ) -> Result<CommandResult, String> {
     validate::validate_name(project, "Project name")?;
     validate::validate_name(branch, "Branch name")?;
@@ -553,6 +568,9 @@ fn cmd_workspaces_create(
     }
     if let Some(prompt) = prompt {
         input["prompt"] = serde_json::json!(prompt);
+    }
+    if let Some(max_turns) = max_turns {
+        input["maxTurns"] = serde_json::json!(max_turns);
     }
     let data = client.trpc_mutate("workspaces.create", &input)?;
     let path = data.get("path").and_then(|p| p.as_str()).unwrap_or("");
@@ -635,15 +653,20 @@ fn cmd_tasks_list(project: Option<&str>, status: Option<&str>) -> Result<Command
     })
 }
 
-fn cmd_tasks_create(workspace_id: &str, prompt: &str) -> Result<CommandResult, String> {
+fn cmd_tasks_create(
+    workspace_id: &str,
+    prompt: &str,
+    max_turns: Option<u32>,
+) -> Result<CommandResult, String> {
     let client = api::ApiClient::from_settings()?;
-    let data = client.trpc_mutate(
-        "tasks.submit",
-        &serde_json::json!({
-            "workspaceId": workspace_id,
-            "prompt": prompt,
-        }),
-    )?;
+    let mut input = serde_json::json!({
+        "workspaceId": workspace_id,
+        "prompt": prompt,
+    });
+    if let Some(max_turns) = max_turns {
+        input["maxTurns"] = serde_json::json!(max_turns);
+    }
+    let data = client.trpc_mutate("tasks.submit", &input)?;
 
     let id = data.get("id").and_then(|i| i.as_str()).unwrap_or("");
     let ws = data

--- a/apps/web/src/lib/agent-pool.ts
+++ b/apps/web/src/lib/agent-pool.ts
@@ -22,7 +22,7 @@ function getAgentConfig(worktreePath: string): CodingAgentConfig {
   return {
     type: agentType,
     workspaceDir: worktreePath,
-    maxTurns: 50,
+    maxTurns: 100,
     additionalDirectories: [join(bandHome(), "uploads")],
     options: {
       executablePath: settings.codingAgent?.command,

--- a/apps/web/src/lib/db/migrations/0005_daffy_clint_barton.sql
+++ b/apps/web/src/lib/db/migrations/0005_daffy_clint_barton.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `tasks` ADD `max_turns` integer;

--- a/apps/web/src/lib/db/migrations/meta/0005_snapshot.json
+++ b/apps/web/src/lib/db/migrations/meta/0005_snapshot.json
@@ -1,0 +1,465 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "6c3a87b7-8c05-45f0-ad5d-57af3fa485f4",
+  "prevId": "48b5b98b-b10b-43df-be36-49d9c746d790",
+  "tables": {
+    "branch_statuses": {
+      "name": "branch_statuses",
+      "columns": {
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "git_dirty": {
+          "name": "git_dirty",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "git_conflict": {
+          "name": "git_conflict",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "git_ahead": {
+          "name": "git_ahead",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "git_behind": {
+          "name": "git_behind",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "git_sync_state": {
+          "name": "git_sync_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ci_state": {
+          "name": "ci_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ci_url": {
+          "name": "ci_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "cronjobs": {
+      "name": "cronjobs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "file_key": {
+          "name": "file_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cron_expression": {
+          "name": "cron_expression",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_run_at": {
+          "name": "last_run_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_run_status": {
+          "name": "last_run_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "projects": {
+      "name": "projects",
+      "columns": {
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "default_branch": {
+          "name": "default_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "settings": {
+      "name": "settings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "data": {
+          "name": "data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{}'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tasks": {
+      "name": "tasks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project": {
+          "name": "project",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "branch": {
+          "name": "branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "max_turns": {
+          "name": "max_turns",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "workspace_statuses": {
+      "name": "workspace_statuses",
+      "columns": {
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project": {
+          "name": "project",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "branch": {
+          "name": "branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "worktree_path": {
+          "name": "worktree_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ide": {
+          "name": "ide",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_name": {
+          "name": "agent_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "agent_status": {
+          "name": "agent_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "agent_last_activity": {
+          "name": "agent_last_activity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "agent_summary": {
+          "name": "agent_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "worktrees": {
+      "name": "worktrees",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "project_name": {
+          "name": "project_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "branch": {
+          "name": "branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "head": {
+          "name": "head",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "worktrees_project_name_projects_name_fk": {
+          "name": "worktrees_project_name_projects_name_fk",
+          "tableFrom": "worktrees",
+          "tableTo": "projects",
+          "columnsFrom": ["project_name"],
+          "columnsTo": ["name"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/apps/web/src/lib/db/migrations/meta/_journal.json
+++ b/apps/web/src/lib/db/migrations/meta/_journal.json
@@ -36,6 +36,13 @@
       "when": 1774340938871,
       "tag": "0004_handy_ricochet",
       "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "6",
+      "when": 1774511963227,
+      "tag": "0005_daffy_clint_barton",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/web/src/lib/db/schema.ts
+++ b/apps/web/src/lib/db/schema.ts
@@ -53,6 +53,7 @@ export const tasks = sqliteTable("tasks", {
   sessionId: text("session_id"),
   startedAt: integer("started_at").notNull(),
   completedAt: integer("completed_at"),
+  maxTurns: integer("max_turns"),
 });
 
 export const settings = sqliteTable("settings", {

--- a/apps/web/src/lib/task-runner.ts
+++ b/apps/web/src/lib/task-runner.ts
@@ -25,6 +25,7 @@ export interface TaskInfo {
   startedAt: number;
   completedAt?: number;
   prompt: string;
+  maxTurns?: number;
 }
 
 type Listener = (chunk: UIMessageChunk) => void;
@@ -63,6 +64,7 @@ function persistTask(task: InternalTask): void {
       sessionId: task.sessionId,
       startedAt: task.startedAt,
       completedAt: task.completedAt,
+      maxTurns: task.maxTurns,
     });
   } catch (err) {
     log.warn({ err, taskId: task.taskRecordId }, "failed to persist task");
@@ -91,6 +93,7 @@ export function submitTask(
   prompt: string,
   sessionId?: string,
   agentPrompt?: string,
+  maxTurns?: number,
 ): TaskInfo {
   const workspace = resolveWorkspace(workspaceId);
   if (!workspace) {
@@ -115,6 +118,7 @@ export function submitTask(
     prompt,
     taskRecordId: generateTaskId(),
     agentPrompt: agentPrompt ?? prompt,
+    maxTurns,
     chunks: [
       // Emit user-facing prompt so reconnecting clients can reconstruct the user message
       { type: "data-prompt", data: { text: prompt } } as UIMessageChunk,
@@ -218,7 +222,8 @@ async function runTask(workspaceId: string, task: InternalTask) {
   }
 
   try {
-    for await (const event of agent.runSession(task.agentPrompt, task.sessionId)) {
+    const sessionOptions = task.maxTurns ? { maxTurns: task.maxTurns } : undefined;
+    for await (const event of agent.runSession(task.agentPrompt, task.sessionId, sessionOptions)) {
       log.info({ workspaceId, eventType: event.type }, "task event");
 
       switch (event.type) {
@@ -418,6 +423,7 @@ function toTaskInfo(task: InternalTask): TaskInfo {
     startedAt: task.startedAt,
     completedAt: task.completedAt,
     prompt: task.prompt,
+    maxTurns: task.maxTurns,
   };
 }
 

--- a/apps/web/src/lib/task-store.ts
+++ b/apps/web/src/lib/task-store.ts
@@ -17,6 +17,7 @@ export interface TaskRecord {
   sessionId?: string;
   startedAt: number;
   completedAt?: number;
+  maxTurns?: number;
 }
 
 export interface TaskFilters {
@@ -42,6 +43,7 @@ export function saveTask(task: TaskRecord): void {
       sessionId: task.sessionId ?? null,
       startedAt: task.startedAt,
       completedAt: task.completedAt ?? null,
+      maxTurns: task.maxTurns ?? null,
     })
     .onConflictDoUpdate({
       target: tasks.id,
@@ -54,6 +56,7 @@ export function saveTask(task: TaskRecord): void {
         sessionId: task.sessionId ?? null,
         startedAt: task.startedAt,
         completedAt: task.completedAt ?? null,
+        maxTurns: task.maxTurns ?? null,
       },
     })
     .run();
@@ -140,5 +143,6 @@ function rowToRecord(row: typeof tasks.$inferSelect): TaskRecord {
     sessionId: row.sessionId ?? undefined,
     startedAt: row.startedAt,
     completedAt: row.completedAt ?? undefined,
+    maxTurns: row.maxTurns ?? undefined,
   };
 }

--- a/apps/web/src/trpc/router.ts
+++ b/apps/web/src/trpc/router.ts
@@ -240,6 +240,7 @@ const workspacesRouter = t.router({
         branch: z.string(),
         base: z.string().optional(),
         prompt: z.string().optional(),
+        maxTurns: z.number().int().positive().optional(),
       }),
     )
     .mutation(({ input }) => {
@@ -281,7 +282,7 @@ const workspacesRouter = t.router({
       // If a prompt is provided, defer task submission until setup completes
       // so the agent has dependencies installed.
       const onSetupComplete = input.prompt
-        ? () => submitTask(workspaceId, input.prompt!)
+        ? () => submitTask(workspaceId, input.prompt!, undefined, undefined, input.maxTurns)
         : undefined;
 
       runSetup(workspaceId, worktreePath, proj.path, onSetupComplete);
@@ -1002,6 +1003,7 @@ const tasksRouter = t.router({
         workspaceId: z.string(),
         prompt: z.string(),
         sessionId: z.string().optional(),
+        maxTurns: z.number().int().positive().optional(),
         files: z
           .array(
             z.object({
@@ -1024,7 +1026,13 @@ const tasksRouter = t.router({
       }
 
       try {
-        const task = submitTask(input.workspaceId, input.prompt, input.sessionId, agentPrompt);
+        const task = submitTask(
+          input.workspaceId,
+          input.prompt,
+          input.sessionId,
+          agentPrompt,
+          input.maxTurns,
+        );
         return { id: task.id, workspaceId: task.workspaceId, sessionId: task.sessionId };
       } catch (err) {
         if (err instanceof TaskConflictError) {
@@ -1074,7 +1082,13 @@ const tasksRouter = t.router({
     }
 
     try {
-      const task = submitTask(record.workspaceId, record.prompt);
+      const task = submitTask(
+        record.workspaceId,
+        record.prompt,
+        undefined,
+        undefined,
+        record.maxTurns,
+      );
       return { workspaceId: task.workspaceId, sessionId: task.sessionId };
     } catch (err) {
       if (err instanceof TaskConflictError) {

--- a/packages/coding-agent/src/adapters/claude-code.ts
+++ b/packages/coding-agent/src/adapters/claude-code.ts
@@ -6,6 +6,7 @@ import type { AgentEvent } from "../events.js";
 import { discoverSkills } from "../skills.js";
 import type {
   CodingAgent,
+  RunSessionOptions,
   SessionListItem,
   SessionMessageItem,
   SkillInfo,
@@ -53,7 +54,12 @@ export class ClaudeCodeAdapter implements CodingAgent {
     }
   }
 
-  async *runSession(prompt: string, sessionId?: string): AsyncGenerator<AgentEvent> {
+  async *runSession(
+    prompt: string,
+    sessionId?: string,
+    options?: RunSessionOptions,
+  ): AsyncGenerator<AgentEvent> {
+    const effectiveMaxTurns = options?.maxTurns ?? this.maxTurns;
     const env = { ...process.env };
     env.CLAUDECODE = undefined;
     env.CLAUDE_CODE_ENTRYPOINT = undefined;
@@ -65,7 +71,7 @@ export class ClaudeCodeAdapter implements CodingAgent {
         sessionId,
         model: this.model,
         cwd: this.workspaceDir,
-        maxTurns: this.maxTurns,
+        maxTurns: effectiveMaxTurns,
         claudeCodePath: this.executablePath || "(default)",
       },
       "runSession starting",
@@ -107,7 +113,7 @@ export class ClaudeCodeAdapter implements CodingAgent {
       options: {
         cwd: this.workspaceDir,
         model: this.model,
-        maxTurns: this.maxTurns,
+        maxTurns: effectiveMaxTurns,
         resume: sessionId,
         canUseTool,
         env,

--- a/packages/coding-agent/src/adapters/cursor-cli.ts
+++ b/packages/coding-agent/src/adapters/cursor-cli.ts
@@ -2,7 +2,7 @@ import { createLogger } from "@band-app/logger";
 import { CursorAgent } from "@nothumanwork/cursor-agents-sdk";
 import type { CursorCliConfig } from "../config.js";
 import type { AgentEvent } from "../events.js";
-import type { CodingAgent } from "../types.js";
+import type { CodingAgent, RunSessionOptions } from "../types.js";
 
 const log = createLogger("coding-agent:cursor-cli");
 
@@ -72,7 +72,11 @@ export class CursorCliAdapter implements CodingAgent {
     }
   }
 
-  async *runSession(prompt: string, sessionId?: string): AsyncGenerator<AgentEvent> {
+  async *runSession(
+    prompt: string,
+    sessionId?: string,
+    _options?: RunSessionOptions,
+  ): AsyncGenerator<AgentEvent> {
     log.info(
       {
         prompt: prompt.slice(0, 100),

--- a/packages/coding-agent/src/adapters/gemini-cli.ts
+++ b/packages/coding-agent/src/adapters/gemini-cli.ts
@@ -5,7 +5,7 @@ import { createLogger } from "@band-app/logger";
 import type { GeminiCliConfig } from "../config.js";
 import type { AgentEvent } from "../events.js";
 import { discoverSkills } from "../skills.js";
-import type { CodingAgent, SkillInfo } from "../types.js";
+import type { CodingAgent, RunSessionOptions, SkillInfo } from "../types.js";
 
 const log = createLogger("coding-agent:gemini-cli");
 
@@ -37,13 +37,18 @@ export class GeminiCliAdapter implements CodingAgent {
     }
   }
 
-  async *runSession(prompt: string, _sessionId?: string): AsyncGenerator<AgentEvent> {
+  async *runSession(
+    prompt: string,
+    _sessionId?: string,
+    options?: RunSessionOptions,
+  ): AsyncGenerator<AgentEvent> {
+    const effectiveMaxTurns = options?.maxTurns ?? this.maxTurns;
     log.info(
       {
         prompt: prompt.slice(0, 100),
         model: this.model,
         cwd: this.workspaceDir,
-        maxTurns: this.maxTurns,
+        maxTurns: effectiveMaxTurns,
       },
       "runSession starting",
     );

--- a/packages/coding-agent/src/adapters/openai-codex.ts
+++ b/packages/coding-agent/src/adapters/openai-codex.ts
@@ -2,7 +2,7 @@ import { createLogger } from "@band-app/logger";
 import type { OpenAICodexConfig } from "../config.js";
 import type { AgentEvent } from "../events.js";
 import { discoverSkills } from "../skills.js";
-import type { CodingAgent, SkillInfo } from "../types.js";
+import type { CodingAgent, RunSessionOptions, SkillInfo } from "../types.js";
 
 const log = createLogger("coding-agent:openai-codex");
 
@@ -34,14 +34,19 @@ export class OpenAICodexAdapter implements CodingAgent {
     }
   }
 
-  async *runSession(prompt: string, sessionId?: string): AsyncGenerator<AgentEvent> {
+  async *runSession(
+    prompt: string,
+    sessionId?: string,
+    options?: RunSessionOptions,
+  ): AsyncGenerator<AgentEvent> {
+    const effectiveMaxTurns = options?.maxTurns ?? this.maxTurns;
     log.info(
       {
         prompt: prompt.slice(0, 100),
         sessionId,
         model: this.model,
         cwd: this.workspaceDir,
-        maxTurns: this.maxTurns,
+        maxTurns: effectiveMaxTurns,
       },
       "runSession starting",
     );
@@ -65,7 +70,7 @@ export class OpenAICodexAdapter implements CodingAgent {
 
     const stream = thread.runStreamed(prompt, {
       cwd: this.workspaceDir,
-      maxTurns: this.maxTurns,
+      maxTurns: effectiveMaxTurns,
       sandbox: this.sandboxMode,
     });
 

--- a/packages/coding-agent/src/index.ts
+++ b/packages/coding-agent/src/index.ts
@@ -19,6 +19,7 @@ export { createCodingAgent } from "./factory.js";
 export type {
   CodingAgent,
   CodingAgentFeatures,
+  RunSessionOptions,
   SessionListItem,
   SessionMessageItem,
   SkillInfo,

--- a/packages/coding-agent/src/types.ts
+++ b/packages/coding-agent/src/types.ts
@@ -36,11 +36,19 @@ export interface SkillInfo {
   argumentHint?: string;
 }
 
+export interface RunSessionOptions {
+  maxTurns?: number;
+}
+
 export interface CodingAgent {
   readonly name: string;
   readonly supportedFeatures: CodingAgentFeatures;
   onUserInputNeeded?: (request: UserInputRequest) => Promise<Record<string, string>>;
-  runSession(prompt: string, sessionId?: string): AsyncGenerator<AgentEvent>;
+  runSession(
+    prompt: string,
+    sessionId?: string,
+    options?: RunSessionOptions,
+  ): AsyncGenerator<AgentEvent>;
   abort?(): void;
   listSessions?(dir: string): Promise<SessionListItem[]>;
   getSessionMessages?(


### PR DESCRIPTION
## Summary
- Change default agent max turns from 50 to 100
- Add `maxTurns` option to task submission API (`tasks.submit` and `workspaces.create` tRPC mutations)
- Store `max_turns` in the tasks database table (new migration)
- Add `--max-turns` CLI flag to `band tasks create` and `band workspaces create`
- Thread `maxTurns` through the full stack: CLI → tRPC → task-runner → `CodingAgent.runSession()` → SDK `query()` call
- Preserve `maxTurns` on task reruns

## Test plan
- [ ] Verify `band tasks create <ws> --prompt "..." --max-turns 50` passes maxTurns through the API
- [ ] Verify `band workspaces create <proj> <branch> --prompt "..." --max-turns 200` forwards maxTurns
- [ ] Verify default behavior (no --max-turns flag) uses the 100-turn default
- [ ] Verify task rerun preserves the original maxTurns setting
- [ ] Verify DB migration adds `max_turns` column to tasks table

🤖 Generated with [Claude Code](https://claude.com/claude-code)