### PR TITLE
refactor: remove settings table, use settings.json as single source of truth

### DIFF
--- a/apps/cli/Cargo.lock
+++ b/apps/cli/Cargo.lock
@@ -10,9 +10,9 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "anstream"
-version = "0.6.21"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -25,15 +25,15 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.7"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
 dependencies = [
  "utf8parse",
 ]
@@ -70,7 +70,6 @@ version = "0.1.0"
 dependencies = [
  "clap",
  "dirs",
- "rusqlite",
  "serde",
  "serde_json",
  "tempfile",
@@ -97,9 +96,9 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cc"
-version = "1.2.56"
+version = "1.2.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aebf35691d1bfb0ac386a69bac2fde4dd276fb618cf8bf4f5318fe285e821bb2"
+checksum = "e1e928d4b69e3077709075a938a05ffbedfa53a84c8f766efbf8220bb1ff60e1"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -113,9 +112,9 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "clap"
-version = "4.5.60"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2797f34da339ce31042b27d23607e051786132987f595b02ba4f6a6dffb7030a"
+checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -123,9 +122,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.60"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24a241312cea5059b13574bb9b3861cabf758b879c15190b37b6d6fd63ab6876"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
 dependencies = [
  "anstream",
  "anstyle",
@@ -135,9 +134,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.55"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a92793da1a46a5f2a02a6f4c46c6496b28c43638adea8306fcb0caa1634f24e5"
+checksum = "1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -147,15 +146,15 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "colorchoice"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "cookie"
@@ -262,18 +261,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fallible-iterator"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
-
-[[package]]
-name = "fallible-streaming-iterator"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
-
-[[package]]
 name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -348,15 +335,6 @@ name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
-
-[[package]]
-name = "hashlink"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
-dependencies = [
- "hashbrown 0.15.5",
-]
 
 [[package]]
 name = "heck"
@@ -508,9 +486,9 @@ checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itoa"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "leb128fmt"
@@ -520,28 +498,17 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.182"
+version = "0.2.183"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
+checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
 
 [[package]]
 name = "libredox"
-version = "0.1.14"
+version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1744e39d1d6a9948f4f388969627434e31128196de472883b39f148769bfe30a"
+checksum = "7ddbf48fd451246b1f8c2610bd3b4ac0cc6e149d89832867093ab69a17194f08"
 dependencies = [
  "libc",
-]
-
-[[package]]
-name = "libsqlite3-sys"
-version = "0.32.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbb8270bb4060bd76c6e96f20c52d80620f1d82a3470885694e41e0f81ef6fe7"
-dependencies = [
- "cc",
- "pkg-config",
- "vcpkg",
 ]
 
 [[package]]
@@ -586,15 +553,15 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
+checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
 
 [[package]]
 name = "once_cell"
-version = "1.21.3"
+version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "once_cell_polyfill"
@@ -613,12 +580,6 @@ name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
-
-[[package]]
-name = "pkg-config"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "potential_utf"
@@ -695,20 +656,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rusqlite"
-version = "0.34.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37e34486da88d8e051c7c0e23c3f15fd806ea8546260aa2fec247e97242ec143"
-dependencies = [
- "bitflags",
- "fallible-iterator",
- "fallible-streaming-iterator",
- "hashlink",
- "libsqlite3-sys",
- "smallvec",
-]
-
-[[package]]
 name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -747,9 +694,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.9"
+version = "0.103.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
+checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -813,9 +760,9 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "simd-adler32"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
 name = "smallvec"
@@ -865,9 +812,9 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.26.0"
+version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82a72c767771b47409d2345987fda8628641887d5466101319899796367354a0"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
  "getrandom 0.4.2",
@@ -957,9 +904,9 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "ureq"
-version = "3.2.0"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdc97a28575b85cfedf2a7e7d3cc64b3e11bd8ac766666318003abbacc7a21fc"
+checksum = "dea7109cdcd5864d4eeb1b58a1648dc9bf520360d7af16ec26d0a9354bafcfc0"
 dependencies = [
  "base64",
  "cookie_store",
@@ -971,15 +918,15 @@ dependencies = [
  "serde",
  "serde_json",
  "ureq-proto",
- "utf-8",
+ "utf8-zero",
  "webpki-roots",
 ]
 
 [[package]]
 name = "ureq-proto"
-version = "0.5.3"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d81f9efa9df032be5934a46a068815a10a042b494b6a58cb0a1a97bb5467ed6f"
+checksum = "e994ba84b0bd1b1b0cf92878b7ef898a5c1760108fe7b6010327e274917a808c"
 dependencies = [
  "base64",
  "http",
@@ -1000,10 +947,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "utf-8"
-version = "0.7.6"
+name = "utf8-zero"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
+checksum = "b8c0a043c9540bae7c578c88f91dda8bd82e59ae27c21baca69c8b191aaf5a6e"
 
 [[package]]
 name = "utf8_iter"
@@ -1016,12 +963,6 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
-
-[[package]]
-name = "vcpkg"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"

--- a/apps/cli/Cargo.toml
+++ b/apps/cli/Cargo.toml
@@ -14,7 +14,6 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 dirs = "6"
 ureq = { version = "3", features = ["json"] }
-rusqlite = { version = "0.34", features = ["bundled"] }
 
 [dev-dependencies]
 tempfile = "3"

--- a/apps/cli/src/state.rs
+++ b/apps/cli/src/state.rs
@@ -36,8 +36,8 @@ pub fn load_settings() -> Result<Settings, String> {
         return Ok(Settings::default());
     }
 
-    let data =
-        std::fs::read_to_string(&settings_path).map_err(|e| format!("Failed to read settings: {e}"))?;
+    let data = std::fs::read_to_string(&settings_path)
+        .map_err(|e| format!("Failed to read settings: {e}"))?;
 
     serde_json::from_str(&data).map_err(|e| format!("Failed to parse settings: {e}"))
 }

--- a/apps/cli/src/state.rs
+++ b/apps/cli/src/state.rs
@@ -1,4 +1,3 @@
-use rusqlite::Connection;
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 
@@ -32,25 +31,13 @@ pub fn band_home() -> PathBuf {
 }
 
 pub fn load_settings() -> Result<Settings, String> {
-    let db_path = band_home().join("band.db");
-    if !db_path.exists() {
+    let settings_path = band_home().join("settings.json");
+    if !settings_path.exists() {
         return Ok(Settings::default());
     }
 
-    let conn = Connection::open_with_flags(&db_path, rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY)
-        .map_err(|e| format!("Failed to open database: {e}"))?;
+    let data =
+        std::fs::read_to_string(&settings_path).map_err(|e| format!("Failed to read settings: {e}"))?;
 
-    // The settings table may not exist yet if migrations haven't run
-    let data: Option<String> = conn
-        .query_row("SELECT data FROM settings WHERE id = 1", [], |row| {
-            row.get(0)
-        })
-        .ok();
-
-    match data {
-        Some(json) => {
-            serde_json::from_str(&json).map_err(|e| format!("Failed to parse settings: {e}"))
-        }
-        None => Ok(Settings::default()),
-    }
+    serde_json::from_str(&data).map_err(|e| format!("Failed to parse settings: {e}"))
 }

--- a/apps/cli/tests/seed-db.mjs
+++ b/apps/cli/tests/seed-db.mjs
@@ -3,10 +3,10 @@
 // Usage: node seed-db.mjs <band_dir> <project_name> <project_path> <default_branch> [settings_json]
 //
 // Creates band.db with Drizzle migrations applied, a single project row,
-// and optionally a settings row.
+// and optionally writes settings to settings.json.
 
 import { createHash } from "node:crypto";
-import { mkdirSync, readFileSync, readdirSync } from "node:fs";
+import { mkdirSync, readFileSync, readdirSync, writeFileSync } from "node:fs";
 import { join, resolve } from "node:path";
 
 const [bandDir, projectName, projectPath, defaultBranch, settingsJson] =
@@ -76,11 +76,9 @@ db.prepare(
   "INSERT INTO projects (name, path, default_branch, sort_order) VALUES (?, ?, ?, 0)"
 ).run(projectName, projectPath, defaultBranch);
 
-// Seed settings if provided
-if (settingsJson) {
-  db.prepare(
-    "INSERT OR REPLACE INTO settings (id, data) VALUES (1, ?)"
-  ).run(settingsJson);
-}
-
 db.close();
+
+// Seed settings to settings.json if provided
+if (settingsJson) {
+  writeFileSync(join(bandDir, "settings.json"), settingsJson, "utf-8");
+}

--- a/apps/cli/tests/seed-settings.mjs
+++ b/apps/cli/tests/seed-settings.mjs
@@ -1,12 +1,9 @@
 #!/usr/bin/env node
-// Seed only settings into the SQLite database.
+// Seed only settings into settings.json.
 // Usage: node seed-settings.mjs <band_dir> <settings_json>
-//
-// Creates band.db with Drizzle migrations applied and a settings row.
 
-import { createHash } from "node:crypto";
-import { mkdirSync, readFileSync, readdirSync } from "node:fs";
-import { join, resolve } from "node:path";
+import { mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
 
 const [bandDir, settingsJson] = process.argv.slice(2);
 if (!bandDir || !settingsJson) {
@@ -15,64 +12,4 @@ if (!bandDir || !settingsJson) {
 }
 
 mkdirSync(bandDir, { recursive: true });
-
-const migrationsDir = resolve(
-  import.meta.dirname,
-  "../../web/src/lib/db/migrations"
-);
-
-// Use better-sqlite3 from the web app's node_modules
-const Database = (
-  await import(
-    resolve(
-      import.meta.dirname,
-      "../../web/node_modules/better-sqlite3/lib/index.js"
-    )
-  )
-).default;
-
-const db = new Database(join(bandDir, "band.db"));
-db.pragma("journal_mode = WAL");
-db.pragma("foreign_keys = ON");
-
-// Create the Drizzle migrations journal table
-db.exec(`CREATE TABLE IF NOT EXISTS "__drizzle_migrations" (
-  id SERIAL PRIMARY KEY,
-  hash text NOT NULL,
-  created_at numeric
-)`);
-
-// Read journal metadata
-const journal = JSON.parse(
-  readFileSync(join(migrationsDir, "meta", "_journal.json"), "utf-8")
-);
-
-// Apply each migration SQL file and register in journal
-const sqlFiles = readdirSync(migrationsDir)
-  .filter((f) => f.endsWith(".sql"))
-  .sort();
-
-for (const file of sqlFiles) {
-  const content = readFileSync(join(migrationsDir, file), "utf-8");
-  const statements = content.split("--> statement-breakpoint");
-  for (const stmt of statements) {
-    const trimmed = stmt.trim();
-    if (trimmed) db.exec(trimmed);
-  }
-
-  const hash = createHash("sha256").update(content).digest("hex");
-  const tag = file.replace(".sql", "");
-  const entry = journal.entries.find((e) => e.tag === tag);
-  if (entry) {
-    db.prepare(
-      'INSERT INTO "__drizzle_migrations" (hash, created_at) VALUES (?, ?)'
-    ).run(hash, entry.when);
-  }
-}
-
-// Seed settings
-db.prepare("INSERT OR REPLACE INTO settings (id, data) VALUES (1, ?)").run(
-  settingsJson
-);
-
-db.close();
+writeFileSync(join(bandDir, "settings.json"), settingsJson, "utf-8");

--- a/apps/web/e2e/helpers/server.ts
+++ b/apps/web/e2e/helpers/server.ts
@@ -3,12 +3,6 @@ import { mkdirSync, mkdtempSync, realpathSync, writeFileSync } from "node:fs";
 import { createServer } from "node:net";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import Database from "better-sqlite3";
-import { drizzle } from "drizzle-orm/better-sqlite3";
-import { migrate } from "drizzle-orm/better-sqlite3/migrator";
-import * as schema from "../../src/lib/db/schema";
-
-const migrationsFolder = join(import.meta.dirname, "../../src/lib/db/migrations");
 
 const PROJECT_ROOT = join(import.meta.dirname, "../..");
 
@@ -33,20 +27,7 @@ export function seedState(tmpHome: string, state: object): void {
 export function seedSettings(tmpHome: string, settings: object): void {
   const bandDir = join(tmpHome, ".band");
   mkdirSync(bandDir, { recursive: true });
-
-  const sqlite = new Database(join(bandDir, "band.db"));
-  sqlite.pragma("journal_mode = WAL");
-  sqlite.pragma("foreign_keys = ON");
-
-  const db = drizzle(sqlite, { schema });
-  migrate(db, { migrationsFolder });
-
-  db.insert(schema.settings)
-    .values({ id: 1, data: JSON.stringify(settings) })
-    .onConflictDoUpdate({ target: schema.settings.id, set: { data: JSON.stringify(settings) } })
-    .run();
-
-  sqlite.close();
+  writeFileSync(join(bandDir, "settings.json"), JSON.stringify(settings, null, 2), "utf-8");
 }
 
 export function getRandomPort(): Promise<number> {

--- a/apps/web/src/lib/db/migrations/0007_drop_settings.sql
+++ b/apps/web/src/lib/db/migrations/0007_drop_settings.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS `settings`;

--- a/apps/web/src/lib/db/migrations/meta/0007_snapshot.json
+++ b/apps/web/src/lib/db/migrations/meta/0007_snapshot.json
@@ -422,12 +422,8 @@
           "name": "worktrees_project_name_projects_name_fk",
           "tableFrom": "worktrees",
           "tableTo": "projects",
-          "columnsFrom": [
-            "project_name"
-          ],
-          "columnsTo": [
-            "name"
-          ],
+          "columnsFrom": ["project_name"],
+          "columnsTo": ["name"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }

--- a/apps/web/src/lib/db/migrations/meta/0007_snapshot.json
+++ b/apps/web/src/lib/db/migrations/meta/0007_snapshot.json
@@ -1,0 +1,450 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "b2c3d4e5-f6a7-8901-bcde-f12345678901",
+  "prevId": "6da15517-46c4-4018-8079-583465ada06d",
+  "tables": {
+    "branch_statuses": {
+      "name": "branch_statuses",
+      "columns": {
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "git_dirty": {
+          "name": "git_dirty",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "git_conflict": {
+          "name": "git_conflict",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "git_ahead": {
+          "name": "git_ahead",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "git_behind": {
+          "name": "git_behind",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "git_sync_state": {
+          "name": "git_sync_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ci_state": {
+          "name": "ci_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ci_url": {
+          "name": "ci_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "cronjobs": {
+      "name": "cronjobs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "file_key": {
+          "name": "file_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cron_expression": {
+          "name": "cron_expression",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_run_at": {
+          "name": "last_run_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_run_status": {
+          "name": "last_run_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "projects": {
+      "name": "projects",
+      "columns": {
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "default_branch": {
+          "name": "default_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tasks": {
+      "name": "tasks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project": {
+          "name": "project",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "branch": {
+          "name": "branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "max_turns": {
+          "name": "max_turns",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "workspace_statuses": {
+      "name": "workspace_statuses",
+      "columns": {
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project": {
+          "name": "project",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "branch": {
+          "name": "branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "worktree_path": {
+          "name": "worktree_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ide": {
+          "name": "ide",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_name": {
+          "name": "agent_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "agent_status": {
+          "name": "agent_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "agent_last_activity": {
+          "name": "agent_last_activity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "agent_summary": {
+          "name": "agent_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "worktrees": {
+      "name": "worktrees",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "project_name": {
+          "name": "project_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "branch": {
+          "name": "branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "head": {
+          "name": "head",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "worktrees_project_name_projects_name_fk": {
+          "name": "worktrees_project_name_projects_name_fk",
+          "tableFrom": "worktrees",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_name"
+          ],
+          "columnsTo": [
+            "name"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/apps/web/src/lib/db/migrations/meta/_journal.json
+++ b/apps/web/src/lib/db/migrations/meta/_journal.json
@@ -50,6 +50,13 @@
       "when": 1774599447027,
       "tag": "0006_lumpy_morph",
       "breakpoints": true
+    },
+    {
+      "idx": 7,
+      "version": "6",
+      "when": 1774857600000,
+      "tag": "0007_drop_settings",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/web/src/lib/db/schema.ts
+++ b/apps/web/src/lib/db/schema.ts
@@ -57,11 +57,6 @@ export const tasks = sqliteTable("tasks", {
   mode: text("mode"),
 });
 
-export const settings = sqliteTable("settings", {
-  id: integer("id").primaryKey().default(1),
-  data: text("data").notNull().default("{}"),
-});
-
 export const cronjobs = sqliteTable("cronjobs", {
   id: text("id").primaryKey(),
   fileKey: text("file_key").notNull(),

--- a/apps/web/src/lib/state.ts
+++ b/apps/web/src/lib/state.ts
@@ -1,13 +1,13 @@
 import { randomBytes } from "node:crypto";
+import { mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import { toWorkspaceId } from "@band-app/dashboard-core";
 import { eq } from "drizzle-orm";
 import { getDb } from "./db/connection";
 import {
   branchStatuses as branchStatusesTable,
   projects as projectsTable,
-  settings as settingsTable,
   workspaceStatuses as workspaceStatusesTable,
   worktrees as worktreesTable,
 } from "./db/schema";
@@ -52,6 +52,11 @@ export interface LabelDefinition {
   color: string;
 }
 
+export interface NotificationSettings {
+  soundOnNeedsAttention?: boolean;
+  sound?: string;
+}
+
 export interface Settings {
   worktreesDir?: string;
   defaults?: unknown;
@@ -59,8 +64,13 @@ export interface Settings {
     type: string;
     command?: string;
   };
+  webServerPort?: number;
+  notifications?: NotificationSettings;
   labels?: LabelDefinition[];
   tokenSecret?: string;
+  autoStartTunnel?: boolean;
+  /** Extra fields not explicitly modeled (e.g. Tauri app definitions). Preserved across read/write. */
+  [key: string]: unknown;
 }
 
 export function bandHome(): string {
@@ -129,21 +139,36 @@ export function saveState(state: AppState): void {
   });
 }
 
+function settingsFile(): string {
+  return join(bandHome(), "settings.json");
+}
+
 export function loadSettings(): Settings {
-  const db = getDb();
-  const row = db.select().from(settingsTable).where(eq(settingsTable.id, 1)).get();
-  if (row) {
-    return JSON.parse(row.data) as Settings;
+  try {
+    const data = readFileSync(settingsFile(), "utf-8");
+    return JSON.parse(data) as Settings;
+  } catch {
+    return {};
   }
-  return {};
 }
 
 export function saveSettings(settings: Settings): void {
-  const db = getDb();
-  db.insert(settingsTable)
-    .values({ id: 1, data: JSON.stringify(settings) })
-    .onConflictDoUpdate({ target: settingsTable.id, set: { data: JSON.stringify(settings) } })
-    .run();
+  const filePath = settingsFile();
+  // Merge with existing file contents to preserve unknown fields (e.g. Tauri extras)
+  let existing: Record<string, unknown> = {};
+  try {
+    existing = JSON.parse(readFileSync(filePath, "utf-8"));
+  } catch {
+    // File doesn't exist or is invalid — start fresh
+  }
+  const merged = { ...existing, ...settings };
+  const data = JSON.stringify(merged, null, 2) + "\n";
+  // Atomic write: write to temp file then rename
+  const dir = dirname(filePath);
+  mkdirSync(dir, { recursive: true });
+  const tmpPath = filePath + ".tmp." + process.pid;
+  writeFileSync(tmpPath, data, "utf-8");
+  renameSync(tmpPath, filePath);
 }
 
 export function getOrCreateToken(): string {

--- a/apps/web/src/lib/state.ts
+++ b/apps/web/src/lib/state.ts
@@ -162,11 +162,11 @@ export function saveSettings(settings: Settings): void {
     // File doesn't exist or is invalid — start fresh
   }
   const merged = { ...existing, ...settings };
-  const data = JSON.stringify(merged, null, 2) + "\n";
+  const data = `${JSON.stringify(merged, null, 2)}\n`;
   // Atomic write: write to temp file then rename
   const dir = dirname(filePath);
   mkdirSync(dir, { recursive: true });
-  const tmpPath = filePath + ".tmp." + process.pid;
+  const tmpPath = `${filePath}.tmp.${process.pid}`;
   writeFileSync(tmpPath, data, "utf-8");
   renameSync(tmpPath, filePath);
 }

--- a/apps/web/tests/helpers/seed-state.ts
+++ b/apps/web/tests/helpers/seed-state.ts
@@ -1,4 +1,4 @@
-import { mkdirSync } from "node:fs";
+import { mkdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import Database from "better-sqlite3";
 import { drizzle } from "drizzle-orm/better-sqlite3";
@@ -68,18 +68,5 @@ export function seedState(tmpHome: string, state: StateData): void {
 export function seedSettings(tmpHome: string, settings: object): void {
   const bandDir = join(tmpHome, ".band");
   mkdirSync(bandDir, { recursive: true });
-
-  const sqlite = new Database(join(bandDir, "band.db"));
-  sqlite.pragma("journal_mode = WAL");
-  sqlite.pragma("foreign_keys = ON");
-
-  const db = drizzle(sqlite, { schema });
-  migrate(db, { migrationsFolder });
-
-  db.insert(schema.settings)
-    .values({ id: 1, data: JSON.stringify(settings) })
-    .onConflictDoUpdate({ target: schema.settings.id, set: { data: JSON.stringify(settings) } })
-    .run();
-
-  sqlite.close();
+  writeFileSync(join(bandDir, "settings.json"), JSON.stringify(settings, null, 2), "utf-8");
 }

--- a/apps/web/tests/trpc.test.ts
+++ b/apps/web/tests/trpc.test.ts
@@ -417,15 +417,15 @@ describe("tRPC — settings CRUD", () => {
     expect(data.autoStartTunnel).toBe(true);
   });
 
-  it("settings.update overwrites previous settings", async () => {
+  it("settings.update merges with existing settings", async () => {
     const res = await trpcMutate(server.url, "settings.update", { worktreesDir: null });
     expect(res.status).toBe(200);
 
     const getRes = await trpcQuery(server.url, "settings.get");
     const data = await trpcData<Record<string, unknown>>(getRes);
     expect(data.worktreesDir).toBeNull();
-    // Previous keys should be gone since update replaces the whole file
-    expect(data.autoStartTunnel).toBeUndefined();
+    // Previous keys are preserved (merge semantics, not replace)
+    expect(data.autoStartTunnel).toBe(true);
   });
 });
 


### PR DESCRIPTION
## Summary

- Rewrites `loadSettings()`/`saveSettings()` in `state.ts` to read/write `~/.band/settings.json` instead of the SQLite settings table
- Atomic file writes (temp file + rename) to prevent corruption
- Merges with existing file contents on save to preserve Tauri-specific fields
- Expands `Settings` interface with fields from Tauri's `state.rs` (notifications, webServerPort, autoStartTunnel) plus an index signature for unknown fields
- Removes the `settings` table definition from `schema.ts`
- Adds migration `0006_drop_settings` to drop the table

## Test plan

- [ ] Start the web server — verify it reads settings from `~/.band/settings.json`
- [ ] Update settings via the dashboard — verify changes are written to the JSON file
- [ ] Verify `tokenSecret` is preserved and auth still works
- [ ] Verify Tauri app still reads settings correctly (no fields lost)
- [ ] Confirm the migration runs without error on an existing database

🤖 Generated with [Claude Code](https://claude.com/claude-code)