### PR TITLE
fix: set agent to needs_attention when waiting for user input

### DIFF
--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -481,7 +481,15 @@ export function ChatView({
             return messages.map((message, messageIndex) => {
               const isLastMessage = messageIndex === messages.length - 1;
               const isLastAssistant = message.role === "assistant" && isLastMessage;
-              const showThinking = isLastAssistant && isStreaming;
+              const hasPendingInteractiveTool =
+                isLastAssistant &&
+                message.parts.some(
+                  (p) =>
+                    isToolUIPart(p) &&
+                    IN_PROGRESS_STATES.has(p.state) &&
+                    (getToolName(p) === "AskUserQuestion" || getToolName(p) === "ExitPlanMode"),
+                );
+              const showThinking = isLastAssistant && isStreaming && !hasPendingInteractiveTool;
 
               if (message.role !== "assistant") {
                 // User messages render normally

--- a/apps/web/src/lib/task-runner.ts
+++ b/apps/web/src/lib/task-runner.ts
@@ -3,7 +3,9 @@ import type { UIMessageChunk } from "ai";
 import { getAgent, getOrCreateAgent } from "./agent-pool";
 import { createPendingInput } from "./pending-inputs";
 import { shiftQueuedMessage } from "./queued-message-store";
+import { upsertWorkspaceStatus } from "./state";
 import { generateTaskId, markTaskFailed, saveTask } from "./task-store";
+import { emit as emitStatusEvent } from "./watcher";
 import { resolveWorkspace } from "./workspace";
 
 const log = createLogger("task-runner");
@@ -210,7 +212,17 @@ async function runTask(workspaceId: string, task: InternalTask) {
   const agent = await getOrCreateAgent(workspaceId, workspace.worktree.path);
 
   agent.onUserInputNeeded = async (request) => {
-    return createPendingInput(request.approvalId);
+    // Set status to needs_attention while waiting for user input
+    const needsAttention = upsertWorkspaceStatus(workspaceId, { status: "needs_attention" });
+    emitStatusEvent({ kind: "update", status: needsAttention });
+
+    const answers = await createPendingInput(request.approvalId);
+
+    // Restore working status after user responds
+    const restored = upsertWorkspaceStatus(workspaceId, { status: "working" });
+    emitStatusEvent({ kind: "update", status: restored });
+
+    return answers;
   };
 
   let textPartId = "";


### PR DESCRIPTION
## Summary

- When the agent emits `AskUserQuestion` or `ExitPlanMode`, update workspace status to `needs_attention` so the dashboard shows the user they need to act. Status restores to `working` after the user responds.
- Hide the "Thinking..." indicator in the chat UI while an interactive tool is pending — previously it kept spinning even though the agent was blocked on the user.

## Test plan

- [x] All 244 existing integration tests pass
- [ ] Manual: trigger `AskUserQuestion` or `ExitPlanMode` → verify status badge changes to `needs_attention` and notification sound plays
- [ ] Manual: answer the question → verify status returns to `working` and thinking indicator reappears

🤖 Generated with [Claude Code](https://claude.com/claude-code)