### PR TITLE
fix: persist plan/edit mode and task list state across navigation

### DIFF
--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -175,13 +175,44 @@ export function ChatView({
   }, [workspaceId]);
 
   const [modes, setModes] = useState<{ id: string; name: string; description?: string }[]>([]);
-  const [selectedMode, setSelectedMode] = useState<string | undefined>(undefined);
+  const modeStorageKey = `band-mode:${workspaceId}`;
+  const [selectedMode, setSelectedMode] = useState<string | undefined>(() => {
+    try {
+      return sessionStorage.getItem(modeStorageKey) ?? undefined;
+    } catch {
+      return undefined;
+    }
+  });
+  const handleModeSelect = useCallback(
+    (mode: string | undefined) => {
+      setSelectedMode(mode);
+      try {
+        if (mode) {
+          sessionStorage.setItem(modeStorageKey, mode);
+        } else {
+          sessionStorage.removeItem(modeStorageKey);
+        }
+      } catch {
+        // ignore storage errors
+      }
+    },
+    [modeStorageKey],
+  );
   useEffect(() => {
     trpc.modes.list
       .query({ workspaceId })
       .then((data) => setModes(data.modes as { id: string; name: string; description?: string }[]))
       .catch(() => setModes([]));
-  }, [workspaceId]);
+    // Derive mode from active task (e.g. reconnecting to a running plan-mode task)
+    trpc.tasks.get
+      .query({ workspaceId })
+      .then((data) => {
+        if (data.task?.mode && data.task.status === "running") {
+          handleModeSelect(data.task.mode);
+        }
+      })
+      .catch(() => {});
+  }, [workspaceId, handleModeSelect]);
 
   const [queuedMessages, setQueuedMessages] = useState<string[]>([]);
 
@@ -648,7 +679,7 @@ export function ChatView({
       </Conversation>
 
       <div className="mx-auto w-full max-w-3xl shrink-0 px-3 lg:px-4 pt-2 pb-4 standalone:pb-[env(safe-area-inset-bottom)]">
-        <TaskListWidget tasks={displayTaskMap} />
+        <TaskListWidget tasks={displayTaskMap} workspaceId={workspaceId} />
         <PromptInput onSubmit={handleSubmit} draftKey={workspaceId}>
           <SlashCommandSuggestions skills={skills} />
           <PromptInputTextarea
@@ -660,7 +691,7 @@ export function ChatView({
             <div className="flex items-center gap-0.5">
               <PromptInputAttach />
               {modes.length > 0 && (
-                <ModeMenu modes={modes} selected={selectedMode} onSelect={setSelectedMode} />
+                <ModeMenu modes={modes} selected={selectedMode} onSelect={handleModeSelect} />
               )}
             </div>
             <PromptInputSubmit

--- a/apps/web/src/components/ai-elements/task-list-widget.tsx
+++ b/apps/web/src/components/ai-elements/task-list-widget.tsx
@@ -12,13 +12,7 @@ function readCollapsed(workspaceId: string): boolean {
   }
 }
 
-export function TaskListWidget({
-  tasks,
-  workspaceId,
-}: {
-  tasks: TaskMap;
-  workspaceId: string;
-}) {
+export function TaskListWidget({ tasks, workspaceId }: { tasks: TaskMap; workspaceId: string }) {
   const [collapsed, setCollapsed] = useState(() => readCollapsed(workspaceId));
   const toggleCollapsed = useCallback(() => {
     setCollapsed((prev) => {

--- a/apps/web/src/components/ai-elements/task-list-widget.tsx
+++ b/apps/web/src/components/ai-elements/task-list-widget.tsx
@@ -1,11 +1,40 @@
 import { cn } from "@band-app/ui";
 import { CheckCircle2, ChevronDown, ChevronRight, Circle, Loader2 } from "lucide-react";
-import { useState } from "react";
+import { useCallback, useState } from "react";
 
 import type { TaskMap } from "./task-state";
 
-export function TaskListWidget({ tasks }: { tasks: TaskMap }) {
-  const [collapsed, setCollapsed] = useState(false);
+function readCollapsed(workspaceId: string): boolean {
+  try {
+    return sessionStorage.getItem(`band-tasks-collapsed:${workspaceId}`) === "true";
+  } catch {
+    return false;
+  }
+}
+
+export function TaskListWidget({
+  tasks,
+  workspaceId,
+}: {
+  tasks: TaskMap;
+  workspaceId: string;
+}) {
+  const [collapsed, setCollapsed] = useState(() => readCollapsed(workspaceId));
+  const toggleCollapsed = useCallback(() => {
+    setCollapsed((prev) => {
+      const next = !prev;
+      try {
+        if (next) {
+          sessionStorage.setItem(`band-tasks-collapsed:${workspaceId}`, "true");
+        } else {
+          sessionStorage.removeItem(`band-tasks-collapsed:${workspaceId}`);
+        }
+      } catch {
+        // ignore storage errors
+      }
+      return next;
+    });
+  }, [workspaceId]);
 
   if (tasks.size === 0) return null;
 
@@ -18,7 +47,7 @@ export function TaskListWidget({ tasks }: { tasks: TaskMap }) {
     <div className="not-prose mb-2 w-full rounded border border-border/50">
       <button
         type="button"
-        onClick={() => setCollapsed(!collapsed)}
+        onClick={toggleCollapsed}
         className="flex w-full items-center justify-between gap-2 px-2.5 py-1.5 transition-colors hover:bg-accent/50"
       >
         <div className="flex items-center gap-1.5">


### PR DESCRIPTION
## Summary
- Store the selected mode (plan/edit) in `sessionStorage` per workspace so it survives navigation away and back
- On reconnect, derive the mode from the active running task if one exists
- Persist the task list widget expanded/collapsed state in `sessionStorage` per workspace

Closes #188

## Test plan
- [ ] Select "plan" mode, navigate away from workspace, return — mode should still be "plan"
- [ ] Start a task in plan mode, navigate away, return — mode selector should show "plan"
- [ ] Collapse the todo list, navigate away, return — list should still be collapsed
- [ ] Expand the todo list, navigate away, return — list should still be expanded
- [ ] Verify mode persists independently per workspace

🤖 Generated with [Claude Code](https://claude.com/claude-code)