### PR TITLE
fix: hide workspace status indicators at narrow sidebar widths

### DIFF
--- a/packages/dashboard-core/src/components/WorkspaceCard.tsx
+++ b/packages/dashboard-core/src/components/WorkspaceCard.tsx
@@ -83,7 +83,7 @@ export const WorkspaceCard = memo(function WorkspaceCard({
     }
   };
 
-  const className = `flex flex-row items-center justify-between px-3 py-2.5 min-w-0 overflow-hidden cursor-pointer select-none transition-colors hover:bg-accent/50 ${isActive ? "bg-accent/50 border-l-2 border-l-primary" : ""} ${isFocused ? "ring-2 ring-inset ring-ring" : ""} ${href ? "no-underline text-inherit" : ""}`;
+  const className = `@container group flex flex-row items-center justify-between px-3 py-2.5 min-w-0 overflow-hidden cursor-pointer select-none transition-colors hover:bg-accent/50 ${isActive ? "bg-accent/50 border-l-2 border-l-primary" : ""} ${isFocused ? "ring-2 ring-inset ring-ring" : ""} ${href ? "no-underline text-inherit" : ""}`;
 
   const containerProps = {
     ref: cardRef,
@@ -139,7 +139,7 @@ export const WorkspaceCard = memo(function WorkspaceCard({
             <TooltipContent side="top">{worktree.branch}</TooltipContent>
           </Tooltip>
           {!editMode && (
-            <div className="flex items-center gap-2 shrink-0 ml-auto pl-2">
+            <div className="hidden @[12rem]:flex group-hover:flex items-center gap-2 shrink-0 ml-auto pl-2">
               <SetupStatusIndicator setup={setupStatus} />
               {branchStatus && <GitStatusIndicator git={branchStatus.git} />}
               {branchStatus && <CIStatusIndicator ci={branchStatus.ci} />}


### PR DESCRIPTION
## Summary

- Use CSS container queries (`@container` + `@[12rem]:flex`) to hide setup/git/CI status indicators when the workspace card is narrower than 12rem
- Add `group-hover:flex` so indicators reappear on hover for discoverability
- Branch name now gets full space at minimum sidebar width instead of being cut off

Fixes #191

🤖 Generated with [Claude Code](https://claude.com/claude-code)