### PR TITLE
feat: add Codex SDK adapter

### DIFF
--- a/packages/coding-agent/package.json
+++ b/packages/coding-agent/package.json
@@ -3,6 +3,9 @@
   "version": "0.1.0",
   "private": true,
   "type": "module",
+  "scripts": {
+    "test": "node --experimental-strip-types --import ./tests/register-mock-loader.mjs --test tests/**/*.test.ts"
+  },
   "main": "src/index.ts",
   "types": "src/index.ts",
   "exports": {
@@ -14,13 +17,17 @@
   },
   "peerDependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.2.62",
-    "@nothumanwork/cursor-agents-sdk": "^0.7.0"
+    "@nothumanwork/cursor-agents-sdk": "^0.7.0",
+    "@openai/codex-sdk": "^0.118.0"
   },
   "peerDependenciesMeta": {
     "@anthropic-ai/claude-agent-sdk": {
       "optional": true
     },
     "@nothumanwork/cursor-agents-sdk": {
+      "optional": true
+    },
+    "@openai/codex-sdk": {
       "optional": true
     }
   }

--- a/packages/coding-agent/src/adapters/claude-code.ts
+++ b/packages/coding-agent/src/adapters/claude-code.ts
@@ -1,3 +1,5 @@
+import { homedir } from "node:os";
+import { join } from "node:path";
 import type {
   CanUseTool,
   ModelInfo,
@@ -8,7 +10,7 @@ import { getSessionMessages, listSessions, query } from "@anthropic-ai/claude-ag
 import { createLogger } from "@band-app/logger";
 import type { ClaudeCodeConfig } from "../config.js";
 import type { AgentEvent } from "../events.js";
-import { discoverSkills } from "../skills.js";
+import { readSkillsFromDir } from "../skills.js";
 import type {
   AgentMode,
   AgentModel,
@@ -202,7 +204,7 @@ export class ClaudeCodeAdapter implements CodingAgent {
   }
 
   async listSkills(): Promise<SkillInfo[]> {
-    return discoverSkills(this.workspaceDir);
+    return discoverClaudeSkills(this.workspaceDir);
   }
 
   listModes(): AgentMode[] {
@@ -529,4 +531,22 @@ function* extractImageEvents(content: unknown): Generator<AgentEvent> {
       }
     }
   }
+}
+
+function discoverClaudeSkills(workspaceDir: string): SkillInfo[] {
+  const globalSkillsDir = join(homedir(), ".claude", "skills");
+  const projectSkillsDir = join(workspaceDir, ".claude", "skills");
+
+  const globalSkills = readSkillsFromDir(globalSkillsDir);
+  const projectSkills = readSkillsFromDir(projectSkillsDir);
+
+  const skillMap = new Map<string, SkillInfo>();
+  for (const skill of globalSkills) {
+    skillMap.set(skill.name, skill);
+  }
+  for (const skill of projectSkills) {
+    skillMap.set(skill.name, skill);
+  }
+
+  return Array.from(skillMap.values()).sort((a, b) => a.name.localeCompare(b.name));
 }

--- a/packages/coding-agent/src/adapters/codex.ts
+++ b/packages/coding-agent/src/adapters/codex.ts
@@ -1,0 +1,740 @@
+import { createReadStream } from "node:fs";
+import { readdir, stat } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { createInterface } from "node:readline";
+import { createLogger } from "@band-app/logger";
+import type { ThreadEvent, ThreadItem, TodoListItem } from "@openai/codex-sdk";
+import { Codex } from "@openai/codex-sdk";
+import type { CodexConfig } from "../config.js";
+import type { AgentEvent } from "../events.js";
+import { readSkillsFromDir } from "../skills.js";
+import type {
+  AgentMode,
+  AgentModel,
+  CodingAgent,
+  RunSessionOptions,
+  SessionListItem,
+  SessionMessageItem,
+  SkillInfo,
+} from "../types.js";
+
+const log = createLogger("coding-agent:codex");
+
+/**
+ * Codex adapter — uses the `@openai/codex-sdk` TypeScript SDK which wraps the
+ * Codex CLI binary and exchanges JSONL events over stdin/stdout.
+ *
+ * Feature mapping vs Claude Code adapter:
+ * ─────────────────────────────────────────────────────────
+ *  Claude Code feature        │ Codex equivalent
+ * ────────────────────────────┼────────────────────────────
+ *  Edit mode                  │ sandbox: workspace-write
+ *  Plan mode (read-only)      │ sandbox: read-only
+ *  Session resume             │ codex.resumeThread(id)
+ *  Cost tracking              │ usage tokens on turn.completed
+ *  Model selection            │ model option on constructor
+ *  Skill discovery            │ ~/.codex/skills/
+ *  Mode listing               │ edit / plan
+ *  Model listing              │ hardcoded known Codex models
+ *  Interactive tools          │ not supported by Codex SDK
+ *  Session listing            │ reads from ~/.codex/sessions/
+ * ─────────────────────────────────────────────────────────
+ */
+export class CodexAdapter implements CodingAgent {
+  readonly name = "Codex";
+  readonly supportedFeatures = {
+    costTracking: true,
+    sessionListing: true,
+  } as const;
+
+  private readonly workspaceDir: string;
+  private readonly maxTurns: number;
+  private readonly model: string | undefined;
+  private readonly executablePath: string | undefined;
+  private activeIterator: AsyncIterator<ThreadEvent> | null = null;
+
+  constructor(config: CodexConfig) {
+    this.workspaceDir = config.workspaceDir;
+    this.maxTurns = config.maxTurns;
+    this.model = config.options.model;
+    this.executablePath = config.options.executablePath;
+  }
+
+  abort(): void {
+    if (this.activeIterator) {
+      log.info("aborting active codex stream");
+      this.activeIterator.return?.(undefined);
+      this.activeIterator = null;
+    }
+  }
+
+  async *runSession(
+    prompt: string,
+    sessionId?: string,
+    options?: RunSessionOptions,
+  ): AsyncGenerator<AgentEvent> {
+    const effectiveMaxTurns = options?.maxTurns ?? this.maxTurns;
+    const effectiveModel = options?.model ?? this.model;
+    const mode = options?.mode ?? "edit";
+
+    log.info(
+      {
+        prompt: prompt.slice(0, 100),
+        sessionId,
+        model: effectiveModel,
+        cwd: this.workspaceDir,
+        maxTurns: effectiveMaxTurns,
+        mode,
+      },
+      "runSession starting",
+    );
+
+    // Build a clean environment for the codex binary, stripping Node.js/pnpm
+    // runtime vars that may leak from the vite dev server or pnpm scripts.
+    const cleanEnv: Record<string, string> = {};
+    for (const [key, value] of Object.entries(process.env)) {
+      if (value === undefined) continue;
+      // Skip Node.js/pnpm/npm internal env vars
+      if (
+        key === "NODE_PATH" ||
+        key === "NODE" ||
+        key.startsWith("npm_") ||
+        key === "INIT_CWD" ||
+        key === "PNPM_SCRIPT_SRC_DIR"
+      ) {
+        continue;
+      }
+      cleanEnv[key] = value;
+    }
+
+    const codex = new Codex({
+      ...(this.executablePath ? { codexPathOverride: this.executablePath } : {}),
+      env: cleanEnv,
+    });
+
+    // Map Band modes to Codex sandbox modes:
+    //   edit → workspace-write  (agent can read + write files, run commands)
+    //   plan → read-only        (agent can only browse, no modifications)
+    const sandboxMode = mode === "plan" ? ("read-only" as const) : ("workspace-write" as const);
+
+    const thread = sessionId
+      ? codex.resumeThread(sessionId, {
+          workingDirectory: this.workspaceDir,
+          sandboxMode,
+          model: effectiveModel,
+          approvalPolicy: "never",
+        })
+      : codex.startThread({
+          workingDirectory: this.workspaceDir,
+          sandboxMode,
+          model: effectiveModel,
+          approvalPolicy: "never",
+        });
+
+    const startMs = Date.now();
+    let turnCount = 0;
+    let totalInputTokens = 0;
+    let totalOutputTokens = 0;
+
+    let result: { events: AsyncIterable<ThreadEvent> };
+    try {
+      result = await thread.runStreamed(prompt);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      log.error({ err, cwd: this.workspaceDir, model: effectiveModel }, "codex runStreamed failed");
+      yield { type: "error", message: msg };
+      yield {
+        type: "session-result",
+        success: false,
+        sessionId: sessionId ?? "",
+        durationMs: Date.now() - startMs,
+        numTurns: 0,
+        costUsd: 0,
+        errors: [msg],
+      };
+      return;
+    }
+
+    const iterator = result.events[Symbol.asyncIterator]();
+    this.activeIterator = iterator;
+
+    // Track tool names across events so tool-result can reference the name
+    const toolNames = new Map<string, string>();
+    // Track emitted text length per item to compute deltas on item.updated
+    const emittedTextLengths = new Map<string, number>();
+
+    try {
+      for await (const event of { [Symbol.asyncIterator]: () => iterator }) {
+        log.debug({ eventType: event.type }, "codex event");
+
+        switch (event.type) {
+          // ── Session lifecycle ──────────────────────────────────────────
+          case "thread.started": {
+            yield {
+              type: "session-start",
+              sessionId: event.thread_id ?? sessionId ?? "",
+            };
+            break;
+          }
+
+          // ── Item lifecycle ────────────────────────────────────────────
+          case "item.started": {
+            yield* handleItemStarted(event.item, toolNames);
+            break;
+          }
+
+          case "item.updated": {
+            yield* handleItemUpdated(event.item, emittedTextLengths);
+            break;
+          }
+
+          case "item.completed": {
+            yield* handleItemCompleted(event.item, toolNames, emittedTextLengths);
+            break;
+          }
+
+          // ── Turn lifecycle ────────────────────────────────────────────
+          case "turn.started": {
+            turnCount++;
+            break;
+          }
+
+          case "turn.completed": {
+            totalInputTokens += event.usage.input_tokens;
+            totalOutputTokens += event.usage.output_tokens;
+            yield {
+              type: "session-result",
+              success: true,
+              sessionId: sessionId ?? "",
+              durationMs: Date.now() - startMs,
+              numTurns: turnCount,
+              costUsd: 0,
+              errors: [],
+            };
+            break;
+          }
+
+          case "turn.failed": {
+            yield {
+              type: "session-result",
+              success: false,
+              sessionId: sessionId ?? "",
+              durationMs: Date.now() - startMs,
+              numTurns: turnCount,
+              costUsd: 0,
+              errors: [event.error.message],
+            };
+            break;
+          }
+
+          // ── Errors ────────────────────────────────────────────────────
+          case "error": {
+            yield {
+              type: "error",
+              message: event.message,
+            };
+            break;
+          }
+        }
+      }
+      log.info({ turnCount, totalInputTokens, totalOutputTokens }, "codex stream done");
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      log.error({ err, cwd: this.workspaceDir }, "codex stream error");
+      yield { type: "error", message: msg };
+      yield {
+        type: "session-result",
+        success: false,
+        sessionId: sessionId ?? "",
+        durationMs: Date.now() - startMs,
+        numTurns: turnCount,
+        costUsd: 0,
+        errors: [msg],
+      };
+    } finally {
+      this.activeIterator = null;
+    }
+  }
+
+  async listSkills(): Promise<SkillInfo[]> {
+    return discoverCodexSkills(this.workspaceDir);
+  }
+
+  listModes(): AgentMode[] {
+    return [
+      { id: "edit", name: "Edit", description: "Agent can read, edit files, and run commands" },
+      { id: "plan", name: "Plan", description: "Agent browses files in read-only mode" },
+    ];
+  }
+
+  listModels(): AgentModel[] {
+    return CODEX_MODELS;
+  }
+
+  async listSessions(dir: string): Promise<SessionListItem[]> {
+    log.info({ dir }, "listSessions");
+    const sessions = await readCodexSessions();
+    return sessions.filter((s) => s.cwd === dir).sort((a, b) => b.lastModified - a.lastModified);
+  }
+
+  async getSessionMessages(
+    sessionId: string,
+    dir: string,
+    options?: { limit?: number; offset?: number },
+  ): Promise<SessionMessageItem[]> {
+    log.info({ sessionId, dir, ...options }, "getSessionMessages");
+    return readCodexSessionMessages(sessionId, options);
+  }
+}
+
+// ─── Models ─────────────────────────────────────────────────────────────────
+
+const CODEX_MODELS: AgentModel[] = [
+  { id: "gpt-5.4", name: "GPT-5.4", description: "Flagship frontier model" },
+  { id: "gpt-5.4-mini", name: "GPT-5.4 Mini", description: "Fast, efficient mini model" },
+  { id: "gpt-5.3-codex", name: "GPT-5.3 Codex", description: "Coding-optimized model" },
+  { id: "gpt-5.2-codex", name: "GPT-5.2 Codex", description: "Previous coding-optimized model" },
+];
+
+// ─── Skills ─────────────────────────────────────────────────────────────────
+
+/**
+ * Discover skills from Codex-specific directories:
+ *   - ~/.codex/skills/          (global user skills)
+ *   - ~/.codex/skills/.system/  (built-in Codex skills)
+ *   - <workspace>/.codex/skills/ (project-level skills)
+ *
+ * Project-level skills override global ones with the same name.
+ */
+function discoverCodexSkills(workspaceDir: string): SkillInfo[] {
+  const globalSkillsDir = join(CODEX_HOME, "skills");
+  const systemSkillsDir = join(CODEX_HOME, "skills", ".system");
+  const projectSkillsDir = join(workspaceDir, ".codex", "skills");
+
+  const systemSkills = readSkillsFromDir(systemSkillsDir);
+  const globalSkills = readSkillsFromDir(globalSkillsDir);
+  const projectSkills = readSkillsFromDir(projectSkillsDir);
+
+  const skillMap = new Map<string, SkillInfo>();
+  for (const skill of systemSkills) {
+    skillMap.set(skill.name, skill);
+  }
+  for (const skill of globalSkills) {
+    skillMap.set(skill.name, skill);
+  }
+  for (const skill of projectSkills) {
+    skillMap.set(skill.name, skill);
+  }
+
+  return Array.from(skillMap.values()).sort((a, b) => a.name.localeCompare(b.name));
+}
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+function parseInput(args: unknown): Record<string, unknown> {
+  if (typeof args === "string") {
+    try {
+      return JSON.parse(args);
+    } catch {
+      return { raw: args };
+    }
+  }
+  if (typeof args === "object" && args !== null) {
+    return args as Record<string, unknown>;
+  }
+  return {};
+}
+
+/**
+ * Convert Codex `todo_list` items to the `TodoWrite` format expected by the
+ * dashboard's task-state.ts parser.
+ */
+function codexTodosToTodoWrite(item: TodoListItem): { content: string; status: string }[] {
+  return item.items.map((todo) => ({
+    content: todo.text,
+    status: todo.completed ? "completed" : "in_progress",
+  }));
+}
+
+// ─── Item event handlers ────────────────────────────────────────────────────
+
+function* handleItemStarted(
+  item: ThreadItem,
+  toolNames: Map<string, string>,
+): Generator<AgentEvent> {
+  switch (item.type) {
+    case "command_execution": {
+      const name = "Bash";
+      toolNames.set(item.id, name);
+      yield {
+        type: "tool-use",
+        toolCallId: item.id,
+        toolName: name,
+        input: { command: item.command },
+      };
+      break;
+    }
+
+    case "file_change": {
+      const name = "FileEdit";
+      toolNames.set(item.id, name);
+      yield {
+        type: "tool-use",
+        toolCallId: item.id,
+        toolName: name,
+        input: { changes: item.changes },
+      };
+      break;
+    }
+
+    case "mcp_tool_call": {
+      const name = item.server ? `${item.server}:${item.tool}` : item.tool;
+      toolNames.set(item.id, name);
+      yield {
+        type: "tool-use",
+        toolCallId: item.id,
+        toolName: name,
+        input: parseInput(item.arguments),
+      };
+      break;
+    }
+
+    case "todo_list": {
+      const name = "TodoWrite";
+      toolNames.set(item.id, name);
+      yield {
+        type: "tool-use",
+        toolCallId: item.id,
+        toolName: name,
+        input: { todos: codexTodosToTodoWrite(item) },
+      };
+      break;
+    }
+
+    case "web_search": {
+      const name = "WebSearch";
+      toolNames.set(item.id, name);
+      yield {
+        type: "tool-use",
+        toolCallId: item.id,
+        toolName: name,
+        input: { query: item.query },
+      };
+      break;
+    }
+
+    case "error": {
+      yield {
+        type: "error",
+        message: item.message,
+      };
+      break;
+    }
+
+    // agent_message at item.started level is usually empty; text arrives
+    // through item.updated / item.completed events.
+  }
+}
+
+/**
+ * Map a Codex item.updated event to AgentEvent(s).
+ *
+ * The SDK sends progressive updates for agent_message items containing the
+ * accumulated text so far. We track what has been emitted and yield only the
+ * new delta.
+ */
+function* handleItemUpdated(
+  item: ThreadItem,
+  emittedTextLengths: Map<string, number>,
+): Generator<AgentEvent> {
+  if (item.type !== "agent_message") return;
+
+  const fullText = item.text;
+  if (!fullText) return;
+
+  const alreadyEmitted = emittedTextLengths.get(item.id) ?? 0;
+  if (fullText.length > alreadyEmitted) {
+    const delta = fullText.slice(alreadyEmitted);
+    emittedTextLengths.set(item.id, fullText.length);
+    yield { type: "text-delta", text: delta };
+  }
+}
+
+/**
+ * Map a Codex item.completed event to AgentEvent(s).
+ */
+function* handleItemCompleted(
+  item: ThreadItem,
+  toolNames: Map<string, string>,
+  emittedTextLengths: Map<string, number>,
+): Generator<AgentEvent> {
+  switch (item.type) {
+    case "command_execution": {
+      yield {
+        type: "tool-result",
+        toolCallId: item.id,
+        toolName: toolNames.get(item.id) ?? "Bash",
+        output: item.aggregated_output,
+        isError: item.exit_code !== undefined && item.exit_code !== 0,
+      };
+      break;
+    }
+
+    case "file_change": {
+      yield {
+        type: "tool-result",
+        toolCallId: item.id,
+        toolName: toolNames.get(item.id) ?? "FileEdit",
+        output: item.status,
+        isError: item.status === "failed",
+      };
+      break;
+    }
+
+    case "mcp_tool_call": {
+      const output = item.error ? item.error.message : JSON.stringify(item.result ?? "");
+      yield {
+        type: "tool-result",
+        toolCallId: item.id,
+        toolName: toolNames.get(item.id),
+        output,
+        isError: item.status === "failed",
+      };
+      break;
+    }
+
+    case "todo_list": {
+      yield {
+        type: "tool-use",
+        toolCallId: item.id,
+        toolName: toolNames.get(item.id) ?? "TodoWrite",
+        input: { todos: codexTodosToTodoWrite(item) },
+      };
+      yield {
+        type: "tool-result",
+        toolCallId: item.id,
+        toolName: toolNames.get(item.id) ?? "TodoWrite",
+        output: "Todos updated",
+        isError: false,
+      };
+      break;
+    }
+
+    case "web_search": {
+      yield {
+        type: "tool-result",
+        toolCallId: item.id,
+        toolName: toolNames.get(item.id) ?? "WebSearch",
+        output: "Search completed",
+        isError: false,
+      };
+      break;
+    }
+
+    case "agent_message": {
+      // Emit any remaining text that wasn't already streamed via item.updated
+      const fullText = item.text;
+      if (!fullText) break;
+      const alreadyEmitted = emittedTextLengths.get(item.id) ?? 0;
+      if (fullText.length > alreadyEmitted) {
+        yield { type: "text-delta", text: fullText.slice(alreadyEmitted) };
+        emittedTextLengths.set(item.id, fullText.length);
+      }
+      break;
+    }
+  }
+}
+
+// ─── Session history (reads from ~/.codex/sessions/) ────────────────────────
+
+const CODEX_HOME = process.env.CODEX_HOME || join(homedir(), ".codex");
+const SESSIONS_DIR = join(CODEX_HOME, "sessions");
+
+/** Recursively find all .jsonl session files under ~/.codex/sessions/ */
+async function findSessionFiles(): Promise<string[]> {
+  const results: string[] = [];
+  async function walk(dir: string): Promise<void> {
+    let entries: string[];
+    try {
+      entries = await readdir(dir);
+    } catch {
+      return;
+    }
+    for (const entry of entries) {
+      const full = join(dir, entry);
+      const s = await stat(full).catch(() => null);
+      if (!s) continue;
+      if (s.isDirectory()) {
+        await walk(full);
+      } else if (entry.endsWith(".jsonl")) {
+        results.push(full);
+      }
+    }
+  }
+  await walk(SESSIONS_DIR);
+  return results;
+}
+
+interface CodexSessionMeta {
+  id: string;
+  cwd: string;
+  timestamp: string;
+  git?: { branch?: string };
+}
+
+interface CodexSessionEntry extends SessionListItem {
+  cwd: string;
+}
+
+/** Read the first line (session_meta) from each session file. */
+async function readCodexSessions(): Promise<CodexSessionEntry[]> {
+  const files = await findSessionFiles();
+  const sessions: CodexSessionEntry[] = [];
+
+  for (const file of files) {
+    try {
+      const rl = createInterface({
+        input: createReadStream(file),
+        crlfDelay: Number.POSITIVE_INFINITY,
+      });
+      let meta: CodexSessionMeta | null = null;
+      let firstPrompt: string | undefined;
+
+      for await (const line of rl) {
+        const obj = JSON.parse(line) as { type: string; payload: Record<string, unknown> };
+
+        if (obj.type === "session_meta") {
+          meta = obj.payload as unknown as CodexSessionMeta;
+        }
+
+        // Find first user message that isn't system/developer boilerplate
+        if (!firstPrompt && obj.type === "response_item") {
+          const payload = obj.payload as {
+            role?: string;
+            content?: Array<{ type: string; text?: string }>;
+          };
+          if (payload.role === "user" && Array.isArray(payload.content)) {
+            for (const c of payload.content) {
+              if (c.type === "input_text" && c.text && !c.text.startsWith("<")) {
+                firstPrompt = c.text.slice(0, 200);
+                break;
+              }
+            }
+          }
+        }
+
+        if (meta && firstPrompt) break;
+      }
+
+      if (meta) {
+        const fileStat = await stat(file);
+        sessions.push({
+          sessionId: meta.id,
+          cwd: meta.cwd,
+          summary: firstPrompt ?? "Untitled session",
+          lastModified: fileStat.mtimeMs,
+          firstPrompt,
+          gitBranch: meta.git?.branch,
+        });
+      }
+    } catch (err) {
+      log.debug({ err, file }, "failed to parse codex session file");
+    }
+  }
+
+  return sessions;
+}
+
+/** Read messages from a specific session file. */
+async function readCodexSessionMessages(
+  sessionId: string,
+  options?: { limit?: number; offset?: number },
+): Promise<SessionMessageItem[]> {
+  const files = await findSessionFiles();
+  const targetFile = files.find((f) => f.includes(sessionId));
+  if (!targetFile) return [];
+
+  const messages: SessionMessageItem[] = [];
+  const rl = createInterface({
+    input: createReadStream(targetFile),
+    crlfDelay: Number.POSITIVE_INFINITY,
+  });
+  let msgIndex = 0;
+
+  for await (const line of rl) {
+    const obj = JSON.parse(line) as { type: string; payload: Record<string, unknown> };
+    if (obj.type !== "response_item") continue;
+
+    const payload = obj.payload as {
+      type?: string;
+      role?: string;
+      content?: Array<{
+        type: string;
+        text?: string;
+        id?: string;
+        name?: string;
+        input?: unknown;
+        tool_use_id?: string;
+        call_id?: string;
+        output?: string;
+        is_error?: boolean;
+      }>;
+    };
+
+    const role = payload.role;
+    if (role !== "user" && role !== "assistant") continue;
+
+    // Skip developer/system messages disguised as user
+    if (role === "user" && Array.isArray(payload.content)) {
+      const hasRealContent = payload.content.some(
+        (c) => c.type === "input_text" && c.text && !c.text.startsWith("<"),
+      );
+      if (!hasRealContent) continue;
+    }
+
+    const content: SessionMessageItem["content"] = [];
+    if (Array.isArray(payload.content)) {
+      for (const block of payload.content) {
+        if ((block.type === "input_text" || block.type === "output_text") && block.text) {
+          if (!block.text.startsWith("<")) {
+            content.push({ type: "text", text: block.text });
+          }
+        } else if (block.type === "tool_use") {
+          content.push({
+            type: "tool_use",
+            toolCallId: block.id ?? block.call_id ?? "",
+            toolName: block.name ?? "unknown",
+            input: block.input ?? {},
+          });
+        } else if (block.type === "tool_result" && (block.tool_use_id ?? block.call_id)) {
+          content.push({
+            type: "tool_result",
+            toolCallId: block.tool_use_id ?? block.call_id ?? "",
+            output:
+              typeof block.output === "string" ? block.output : JSON.stringify(block.output ?? ""),
+            isError: block.is_error ?? false,
+          });
+        }
+      }
+    }
+
+    if (content.length === 0) continue;
+
+    const offset = options?.offset ?? 0;
+    const limit = options?.limit ?? Number.POSITIVE_INFINITY;
+
+    if (msgIndex >= offset && msgIndex < offset + limit) {
+      messages.push({
+        role,
+        id: `codex-${sessionId}-${msgIndex}`,
+        content,
+      });
+    }
+    msgIndex++;
+
+    if (msgIndex >= offset + limit) break;
+  }
+
+  return messages;
+}

--- a/packages/coding-agent/src/adapters/gemini-cli.ts
+++ b/packages/coding-agent/src/adapters/gemini-cli.ts
@@ -1,10 +1,12 @@
 import type { ChildProcess } from "node:child_process";
 import { spawn } from "node:child_process";
+import { homedir } from "node:os";
+import { join } from "node:path";
 import { createInterface } from "node:readline";
 import { createLogger } from "@band-app/logger";
 import type { GeminiCliConfig } from "../config.js";
 import type { AgentEvent } from "../events.js";
-import { discoverSkills } from "../skills.js";
+import { readSkillsFromDir } from "../skills.js";
 import type { AgentModel, CodingAgent, RunSessionOptions, SkillInfo } from "../types.js";
 
 const log = createLogger("coding-agent:gemini-cli");
@@ -164,7 +166,7 @@ export class GeminiCliAdapter implements CodingAgent {
   }
 
   async listSkills(): Promise<SkillInfo[]> {
-    return discoverSkills(this.workspaceDir);
+    return discoverGeminiSkills(this.workspaceDir);
   }
 
   listModels(): AgentModel[] {
@@ -173,4 +175,22 @@ export class GeminiCliAdapter implements CodingAgent {
       { id: "gemini-2.5-flash", name: "Gemini 2.5 Flash", description: "Fast and efficient" },
     ];
   }
+}
+
+function discoverGeminiSkills(workspaceDir: string): SkillInfo[] {
+  const globalSkillsDir = join(homedir(), ".gemini", "skills");
+  const projectSkillsDir = join(workspaceDir, ".gemini", "skills");
+
+  const globalSkills = readSkillsFromDir(globalSkillsDir);
+  const projectSkills = readSkillsFromDir(projectSkillsDir);
+
+  const skillMap = new Map<string, SkillInfo>();
+  for (const skill of globalSkills) {
+    skillMap.set(skill.name, skill);
+  }
+  for (const skill of projectSkills) {
+    skillMap.set(skill.name, skill);
+  }
+
+  return Array.from(skillMap.values()).sort((a, b) => a.name.localeCompare(b.name));
 }

--- a/packages/coding-agent/src/adapters/openai-codex.ts
+++ b/packages/coding-agent/src/adapters/openai-codex.ts
@@ -1,7 +1,9 @@
+import { homedir } from "node:os";
+import { join } from "node:path";
 import { createLogger } from "@band-app/logger";
 import type { OpenAICodexConfig } from "../config.js";
 import type { AgentEvent } from "../events.js";
-import { discoverSkills } from "../skills.js";
+import { readSkillsFromDir } from "../skills.js";
 import type { AgentModel, CodingAgent, RunSessionOptions, SkillInfo } from "../types.js";
 
 const log = createLogger("coding-agent:openai-codex");
@@ -165,7 +167,7 @@ export class OpenAICodexAdapter implements CodingAgent {
   }
 
   async listSkills(): Promise<SkillInfo[]> {
-    return discoverSkills(this.workspaceDir);
+    return discoverCodexSkills(this.workspaceDir);
   }
 
   listModels(): AgentModel[] {
@@ -185,6 +187,31 @@ interface CodexThread {
       sandbox?: string;
     },
   ): AsyncIterable<Record<string, unknown>>;
+}
+
+const CODEX_HOME = process.env.CODEX_HOME || join(homedir(), ".codex");
+
+function discoverCodexSkills(workspaceDir: string): SkillInfo[] {
+  const globalSkillsDir = join(CODEX_HOME, "skills");
+  const systemSkillsDir = join(CODEX_HOME, "skills", ".system");
+  const projectSkillsDir = join(workspaceDir, ".codex", "skills");
+
+  const systemSkills = readSkillsFromDir(systemSkillsDir);
+  const globalSkills = readSkillsFromDir(globalSkillsDir);
+  const projectSkills = readSkillsFromDir(projectSkillsDir);
+
+  const skillMap = new Map<string, SkillInfo>();
+  for (const skill of systemSkills) {
+    skillMap.set(skill.name, skill);
+  }
+  for (const skill of globalSkills) {
+    skillMap.set(skill.name, skill);
+  }
+  for (const skill of projectSkills) {
+    skillMap.set(skill.name, skill);
+  }
+
+  return Array.from(skillMap.values()).sort((a, b) => a.name.localeCompare(b.name));
 }
 
 function parseInput(args: unknown): Record<string, unknown> {

--- a/packages/coding-agent/src/config.ts
+++ b/packages/coding-agent/src/config.ts
@@ -36,6 +36,18 @@ const openaiCodexConfigSchema = z.object({
     .default({}),
 });
 
+const codexConfigSchema = z.object({
+  type: z.literal("codex"),
+  workspaceDir: z.string().default(process.cwd()),
+  maxTurns: z.number().int().positive().default(3),
+  options: z
+    .object({
+      model: z.string().optional(),
+      executablePath: z.string().optional(),
+    })
+    .default({}),
+});
+
 const geminiCliConfigSchema = z.object({
   type: z.literal("gemini-cli"),
   workspaceDir: z.string().default(process.cwd()),
@@ -52,6 +64,7 @@ export const codingAgentConfigSchema = z.discriminatedUnion("type", [
   claudeCodeConfigSchema,
   cursorCliConfigSchema,
   openaiCodexConfigSchema,
+  codexConfigSchema,
   geminiCliConfigSchema,
 ]);
 
@@ -60,4 +73,5 @@ export type CodingAgentConfig = z.infer<typeof codingAgentConfigSchema>;
 export type ClaudeCodeConfig = z.infer<typeof claudeCodeConfigSchema>;
 export type CursorCliConfig = z.infer<typeof cursorCliConfigSchema>;
 export type OpenAICodexConfig = z.infer<typeof openaiCodexConfigSchema>;
+export type CodexConfig = z.infer<typeof codexConfigSchema>;
 export type GeminiCliConfig = z.infer<typeof geminiCliConfigSchema>;

--- a/packages/coding-agent/src/factory.ts
+++ b/packages/coding-agent/src/factory.ts
@@ -15,6 +15,10 @@ export async function createCodingAgent(config: CodingAgentConfig): Promise<Codi
       const { OpenAICodexAdapter } = await import("./adapters/openai-codex.js");
       return new OpenAICodexAdapter(config);
     }
+    case "codex": {
+      const { CodexAdapter } = await import("./adapters/codex.js");
+      return new CodexAdapter(config);
+    }
     case "gemini-cli": {
       const { GeminiCliAdapter } = await import("./adapters/gemini-cli.js");
       return new GeminiCliAdapter(config);

--- a/packages/coding-agent/src/index.ts
+++ b/packages/coding-agent/src/index.ts
@@ -1,5 +1,6 @@
 export {
   type ClaudeCodeConfig,
+  type CodexConfig,
   type CodingAgentConfig,
   type CursorCliConfig,
   codingAgentConfigSchema,

--- a/packages/coding-agent/src/skills.ts
+++ b/packages/coding-agent/src/skills.ts
@@ -1,5 +1,4 @@
 import { readdirSync, readFileSync, statSync } from "node:fs";
-import { homedir } from "node:os";
 import { join } from "node:path";
 import { createLogger } from "@band-app/logger";
 import type { SkillInfo } from "./types.js";
@@ -26,7 +25,14 @@ function parseFrontmatter(content: string): Record<string, string> {
     if (colonIndex === -1) continue;
 
     const key = line.slice(0, colonIndex).trim();
-    const value = line.slice(colonIndex + 1).trim();
+    let value = line.slice(colonIndex + 1).trim();
+    // Strip surrounding YAML quotes
+    if (
+      (value.startsWith('"') && value.endsWith('"')) ||
+      (value.startsWith("'") && value.endsWith("'"))
+    ) {
+      value = value.slice(1, -1);
+    }
     if (key && value) {
       result[key] = value;
     }
@@ -79,30 +85,4 @@ export function readSkillsFromDir(skillsDir: string): SkillInfo[] {
   }
 
   return skills;
-}
-
-/**
- * Discover skills from both global (~/.claude/skills/) and project-level
- * (<workspaceDir>/.claude/skills/) directories.
- *
- * Project-level skills override global skills with the same name.
- * This is agent-agnostic — any adapter with a workspaceDir can use it.
- */
-export function discoverSkills(workspaceDir: string): SkillInfo[] {
-  const globalSkillsDir = join(homedir(), ".claude", "skills");
-  const projectSkillsDir = join(workspaceDir, ".claude", "skills");
-
-  const globalSkills = readSkillsFromDir(globalSkillsDir);
-  const projectSkills = readSkillsFromDir(projectSkillsDir);
-
-  // Merge: project-level skills override global ones with the same name
-  const skillMap = new Map<string, SkillInfo>();
-  for (const skill of globalSkills) {
-    skillMap.set(skill.name, skill);
-  }
-  for (const skill of projectSkills) {
-    skillMap.set(skill.name, skill);
-  }
-
-  return Array.from(skillMap.values()).sort((a, b) => a.name.localeCompare(b.name));
 }

--- a/packages/coding-agent/tests/codex-adapter.test.ts
+++ b/packages/coding-agent/tests/codex-adapter.test.ts
@@ -1,0 +1,760 @@
+/**
+ * Integration tests for the Codex adapter.
+ *
+ * Run with:
+ *   node --experimental-strip-types \
+ *        --import ./tests/register-mock-loader.mjs \
+ *        --test tests/codex-adapter.test.ts
+ *
+ * The custom loader in register-mock-loader.mjs redirects the
+ * `import { Codex } from "@openai/codex-sdk"` inside the adapter to
+ * tests/mocks/codex-sdk.mjs so the real SDK binary isn't needed.
+ */
+
+import assert from "node:assert/strict";
+import { beforeEach, describe, it } from "node:test";
+
+// The mock SDK is loaded via our custom loader.
+// Import the test-control object to configure events & inspect calls.
+import { _test } from "@openai/codex-sdk";
+
+// Import the adapter (which will import @openai/codex-sdk → our mock)
+import { CodexAdapter } from "../src/adapters/codex.ts";
+import { codingAgentConfigSchema } from "../src/config.ts";
+import { createCodingAgent } from "../src/factory.ts";
+
+type AgentEvent = import("../src/events.ts").AgentEvent;
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+async function collectEvents(gen: AsyncGenerator<AgentEvent>): Promise<AgentEvent[]> {
+  const events: AgentEvent[] = [];
+  for await (const event of gen) {
+    events.push(event);
+  }
+  return events;
+}
+
+function makeConfig(overrides?: Record<string, unknown>) {
+  return {
+    type: "codex" as const,
+    workspaceDir: "/tmp/test-workspace",
+    maxTurns: 5,
+    options: { model: "codex-mini", ...overrides },
+  };
+}
+
+// ─── Tests ──────────────────────────────────────────────────────────────────
+
+describe("CodexAdapter", () => {
+  beforeEach(() => {
+    _test.reset();
+  });
+
+  // ── Static properties ───────────────────────────────────────────────────
+
+  it("has correct name", () => {
+    const adapter = new CodexAdapter(makeConfig());
+    assert.equal(adapter.name, "Codex");
+  });
+
+  it("supports cost tracking", () => {
+    const adapter = new CodexAdapter(makeConfig());
+    assert.equal(adapter.supportedFeatures.costTracking, true);
+  });
+
+  it("supports session listing", () => {
+    const adapter = new CodexAdapter(makeConfig());
+    assert.equal(adapter.supportedFeatures.sessionListing, true);
+  });
+
+  // ── Modes ─────────────────────────────────────────────────────────────
+
+  it("lists edit and plan modes", () => {
+    const adapter = new CodexAdapter(makeConfig());
+    const modes = adapter.listModes();
+    assert.equal(modes.length, 2);
+    assert.equal(modes[0].id, "edit");
+    assert.equal(modes[1].id, "plan");
+  });
+
+  // ── Constructor passes options to SDK ──────────────────────────────────
+
+  it("passes model via startThread, not constructor config", async () => {
+    _test.setEvents([{ type: "thread.started", thread_id: "t1" }]);
+    const adapter = new CodexAdapter(makeConfig({ model: "gpt-5-codex" }));
+    await collectEvents(adapter.runSession("hello"));
+    assert.equal(_test.constructorCalls.length, 1);
+    // Model is no longer passed via constructor config (avoids double-passing)
+    assert.equal(_test.constructorCalls[0].config, undefined);
+    // Model is passed via startThread options instead
+    assert.equal(_test.startThreadCalls[0].opts?.model, "gpt-5-codex");
+  });
+
+  it("passes executablePath as codexPathOverride", async () => {
+    _test.setEvents([{ type: "thread.started", thread_id: "t1" }]);
+    const adapter = new CodexAdapter(
+      makeConfig({ model: "codex-mini", executablePath: "/usr/local/bin/codex" }),
+    );
+    await collectEvents(adapter.runSession("hello"));
+    assert.equal(_test.constructorCalls[0].codexPathOverride, "/usr/local/bin/codex");
+  });
+
+  it("passes env override to Codex constructor", async () => {
+    _test.setEvents([{ type: "thread.started", thread_id: "t1" }]);
+    const adapter = new CodexAdapter({
+      type: "codex" as const,
+      workspaceDir: "/tmp/test",
+      maxTurns: 5,
+      options: {},
+    });
+    await collectEvents(adapter.runSession("hello"));
+    // Constructor should receive env override (clean env without Node.js internals)
+    assert.ok(_test.constructorCalls[0].env, "env override should be set");
+  });
+
+  // ── Session start ─────────────────────────────────────────────────────
+
+  it("maps thread.started to session-start", async () => {
+    _test.setEvents([{ type: "thread.started", thread_id: "thread-abc" }]);
+    const adapter = new CodexAdapter(makeConfig());
+    const events = await collectEvents(adapter.runSession("hello"));
+
+    assert.equal(events.length, 1);
+    assert.equal(events[0].type, "session-start");
+    assert.equal((events[0] as { sessionId: string }).sessionId, "thread-abc");
+  });
+
+  // ── Streaming text deltas via item.updated ────────────────────────────
+
+  it("computes text deltas from item.updated agent_message", async () => {
+    _test.setEvents([
+      { type: "item.updated", item: { type: "agent_message", id: "msg-1", text: "Hello" } },
+      {
+        type: "item.updated",
+        item: { type: "agent_message", id: "msg-1", text: "Hello, world!" },
+      },
+      {
+        type: "item.completed",
+        item: { type: "agent_message", id: "msg-1", text: "Hello, world!" },
+      },
+    ]);
+    const adapter = new CodexAdapter(makeConfig());
+    const events = await collectEvents(adapter.runSession("hello"));
+
+    // First updated: "Hello" (5 chars, 0 previously emitted → delta: "Hello")
+    // Second updated: "Hello, world!" (13 chars, 5 previously emitted → delta: ", world!")
+    // Completed: "Hello, world!" (13 chars, 13 previously emitted → no delta)
+    const textEvents = events.filter((e) => e.type === "text-delta") as { text: string }[];
+    assert.equal(textEvents.length, 2);
+    assert.equal(textEvents[0].text, "Hello");
+    assert.equal(textEvents[1].text, ", world!");
+  });
+
+  it("emits remaining text on item.completed if not fully streamed", async () => {
+    _test.setEvents([
+      { type: "item.updated", item: { type: "agent_message", id: "msg-1", text: "Hi" } },
+      {
+        type: "item.completed",
+        item: { type: "agent_message", id: "msg-1", text: "Hi there!" },
+      },
+    ]);
+    const adapter = new CodexAdapter(makeConfig());
+    const events = await collectEvents(adapter.runSession("hello"));
+
+    const textEvents = events.filter((e) => e.type === "text-delta") as { text: string }[];
+    assert.equal(textEvents.length, 2);
+    assert.equal(textEvents[0].text, "Hi");
+    assert.equal(textEvents[1].text, " there!");
+  });
+
+  // ── Command execution (Bash) ──────────────────────────────────────────
+
+  it("maps command_execution item.started to tool-use with Bash name", async () => {
+    _test.setEvents([
+      {
+        type: "item.started",
+        item: {
+          type: "command_execution",
+          id: "cmd-1",
+          command: "ls -la",
+          aggregated_output: "",
+          status: "in_progress",
+        },
+      },
+    ]);
+    const adapter = new CodexAdapter(makeConfig());
+    const events = await collectEvents(adapter.runSession("list files"));
+
+    assert.equal(events.length, 1);
+    assert.equal(events[0].type, "tool-use");
+    const e = events[0] as { toolCallId: string; toolName: string; input: Record<string, unknown> };
+    assert.equal(e.toolName, "Bash");
+    assert.deepEqual(e.input, { command: "ls -la" });
+  });
+
+  it("maps command_execution item.completed to tool-result", async () => {
+    _test.setEvents([
+      {
+        type: "item.started",
+        item: {
+          type: "command_execution",
+          id: "cmd-1",
+          command: "echo hi",
+          aggregated_output: "",
+          status: "in_progress",
+        },
+      },
+      {
+        type: "item.completed",
+        item: {
+          type: "command_execution",
+          id: "cmd-1",
+          command: "echo hi",
+          aggregated_output: "hi\n",
+          exit_code: 0,
+          status: "completed",
+        },
+      },
+    ]);
+    const adapter = new CodexAdapter(makeConfig());
+    const events = await collectEvents(adapter.runSession("echo"));
+
+    assert.equal(events[1].type, "tool-result");
+    const result = events[1] as { output: string; isError: boolean; toolName: string };
+    assert.equal(result.output, "hi\n");
+    assert.equal(result.isError, false);
+    assert.equal(result.toolName, "Bash");
+  });
+
+  it("marks command_execution with non-zero exit code as error", async () => {
+    _test.setEvents([
+      {
+        type: "item.started",
+        item: {
+          type: "command_execution",
+          id: "cmd-2",
+          command: "false",
+          aggregated_output: "",
+          status: "in_progress",
+        },
+      },
+      {
+        type: "item.completed",
+        item: {
+          type: "command_execution",
+          id: "cmd-2",
+          command: "false",
+          aggregated_output: "",
+          exit_code: 1,
+          status: "failed",
+        },
+      },
+    ]);
+    const adapter = new CodexAdapter(makeConfig());
+    const events = await collectEvents(adapter.runSession("fail"));
+
+    const result = events[1] as { isError: boolean };
+    assert.equal(result.isError, true);
+  });
+
+  // ── File change ───────────────────────────────────────────────────────
+
+  it("maps file_change item.started to tool-use with FileEdit name", async () => {
+    _test.setEvents([
+      {
+        type: "item.started",
+        item: {
+          type: "file_change",
+          id: "fc-1",
+          changes: [{ kind: "add", path: "src/new.ts" }],
+          status: "completed",
+        },
+      },
+    ]);
+    const adapter = new CodexAdapter(makeConfig());
+    const events = await collectEvents(adapter.runSession("create file"));
+
+    assert.equal(events[0].type, "tool-use");
+    const e = events[0] as { toolName: string; input: Record<string, unknown> };
+    assert.equal(e.toolName, "FileEdit");
+    assert.deepEqual(e.input, { changes: [{ kind: "add", path: "src/new.ts" }] });
+  });
+
+  it("maps file_change item.completed to tool-result", async () => {
+    _test.setEvents([
+      {
+        type: "item.started",
+        item: { type: "file_change", id: "fc-1", changes: [], status: "completed" },
+      },
+      {
+        type: "item.completed",
+        item: { type: "file_change", id: "fc-1", changes: [], status: "completed" },
+      },
+    ]);
+    const adapter = new CodexAdapter(makeConfig());
+    const events = await collectEvents(adapter.runSession("edit"));
+
+    assert.equal(events[1].type, "tool-result");
+    const result = events[1] as { output: string; isError: boolean };
+    assert.equal(result.output, "completed");
+    assert.equal(result.isError, false);
+  });
+
+  // ── MCP tool call ─────────────────────────────────────────────────────
+
+  it("maps mcp_tool_call to tool-use with server:tool name", async () => {
+    _test.setEvents([
+      {
+        type: "item.started",
+        item: {
+          type: "mcp_tool_call",
+          id: "mcp-1",
+          server: "github",
+          tool: "create_issue",
+          arguments: { title: "Bug" },
+          status: "in_progress",
+        },
+      },
+    ]);
+    const adapter = new CodexAdapter(makeConfig());
+    const events = await collectEvents(adapter.runSession("create issue"));
+
+    assert.equal(events[0].type, "tool-use");
+    const e = events[0] as { toolName: string; input: Record<string, unknown> };
+    assert.equal(e.toolName, "github:create_issue");
+    assert.deepEqual(e.input, { title: "Bug" });
+  });
+
+  it("maps mcp_tool_call completed to tool-result", async () => {
+    _test.setEvents([
+      {
+        type: "item.started",
+        item: {
+          type: "mcp_tool_call",
+          id: "mcp-1",
+          server: "s",
+          tool: "t",
+          arguments: {},
+          status: "in_progress",
+        },
+      },
+      {
+        type: "item.completed",
+        item: {
+          type: "mcp_tool_call",
+          id: "mcp-1",
+          server: "s",
+          tool: "t",
+          arguments: {},
+          result: { content: [], structured_content: { url: "https://gh.io/1" } },
+          status: "completed",
+        },
+      },
+    ]);
+    const adapter = new CodexAdapter(makeConfig());
+    const events = await collectEvents(adapter.runSession("mcp"));
+
+    assert.equal(events[1].type, "tool-result");
+    const result = events[1] as { output: string };
+    assert.ok(result.output.includes("gh.io"));
+  });
+
+  it("marks failed mcp_tool_call as error", async () => {
+    _test.setEvents([
+      {
+        type: "item.completed",
+        item: {
+          type: "mcp_tool_call",
+          id: "mcp-2",
+          server: "s",
+          tool: "t",
+          arguments: {},
+          status: "failed",
+          error: { message: "auth error" },
+        },
+      },
+    ]);
+    const adapter = new CodexAdapter(makeConfig());
+    const events = await collectEvents(adapter.runSession("mcp fail"));
+
+    const result = events[0] as { isError: boolean; output: string };
+    assert.equal(result.isError, true);
+    assert.equal(result.output, "auth error");
+  });
+
+  // ── Todo list (maps to TodoWrite) ─────────────────────────────────────
+
+  it("maps todo_list item.started to TodoWrite tool-use", async () => {
+    _test.setEvents([
+      {
+        type: "item.started",
+        item: {
+          type: "todo_list",
+          id: "todo-1",
+          items: [
+            { text: "Read the file", completed: false },
+            { text: "Fix the bug", completed: true },
+          ],
+        },
+      },
+    ]);
+    const adapter = new CodexAdapter(makeConfig());
+    const events = await collectEvents(adapter.runSession("plan"));
+
+    assert.equal(events.length, 1);
+    assert.equal(events[0].type, "tool-use");
+    const e = events[0] as { toolName: string; input: Record<string, unknown> };
+    assert.equal(e.toolName, "TodoWrite");
+    assert.deepEqual(e.input, {
+      todos: [
+        { content: "Read the file", status: "in_progress" },
+        { content: "Fix the bug", status: "completed" },
+      ],
+    });
+  });
+
+  it("maps todo_list item.completed to TodoWrite tool-use + tool-result", async () => {
+    _test.setEvents([
+      {
+        type: "item.completed",
+        item: {
+          type: "todo_list",
+          id: "todo-2",
+          items: [
+            { text: "Step 1", completed: true },
+            { text: "Step 2", completed: false },
+          ],
+        },
+      },
+    ]);
+    const adapter = new CodexAdapter(makeConfig());
+    const events = await collectEvents(adapter.runSession("work"));
+
+    assert.equal(events.length, 2);
+    assert.equal(events[0].type, "tool-use");
+    assert.equal((events[0] as { toolName: string }).toolName, "TodoWrite");
+    assert.equal(events[1].type, "tool-result");
+    assert.equal((events[1] as { isError: boolean }).isError, false);
+  });
+
+  // ── Web search ────────────────────────────────────────────────────────
+
+  it("maps web_search item.started to tool-use", async () => {
+    _test.setEvents([
+      {
+        type: "item.started",
+        item: { type: "web_search", id: "ws-1", query: "node.js streams" },
+      },
+    ]);
+    const adapter = new CodexAdapter(makeConfig());
+    const events = await collectEvents(adapter.runSession("search"));
+
+    assert.equal(events[0].type, "tool-use");
+    const e = events[0] as { toolName: string; input: Record<string, unknown> };
+    assert.equal(e.toolName, "WebSearch");
+    assert.deepEqual(e.input, { query: "node.js streams" });
+  });
+
+  // ── Turn lifecycle ────────────────────────────────────────────────────
+
+  it("maps turn.completed to session-result", async () => {
+    _test.setEvents([
+      { type: "thread.started", thread_id: "t1" },
+      { type: "turn.started" },
+      {
+        type: "turn.completed",
+        usage: { input_tokens: 1000, cached_input_tokens: 200, output_tokens: 500 },
+      },
+    ]);
+    const adapter = new CodexAdapter(makeConfig());
+    const events = await collectEvents(adapter.runSession("plan"));
+
+    const result = events.find((e) => e.type === "session-result") as {
+      success: boolean;
+      numTurns: number;
+    };
+    assert.ok(result);
+    assert.equal(result.success, true);
+    assert.equal(result.numTurns, 1);
+  });
+
+  it("maps turn.failed to session-result with error", async () => {
+    _test.setEvents([
+      { type: "thread.started", thread_id: "t2" },
+      { type: "turn.started" },
+      {
+        type: "turn.failed",
+        error: { message: "Rate limit exceeded" },
+      },
+    ]);
+    const adapter = new CodexAdapter(makeConfig());
+    const events = await collectEvents(adapter.runSession("fail"));
+
+    const result = events.find((e) => e.type === "session-result") as {
+      success: boolean;
+      errors: string[];
+    };
+    assert.ok(result);
+    assert.equal(result.success, false);
+    assert.deepEqual(result.errors, ["Rate limit exceeded"]);
+  });
+
+  // ── Error events ──────────────────────────────────────────────────────
+
+  it("maps error event to error", async () => {
+    _test.setEvents([{ type: "error", message: "Connection failed" }]);
+    const adapter = new CodexAdapter(makeConfig());
+    const events = await collectEvents(adapter.runSession("err"));
+
+    assert.equal(events.length, 1);
+    assert.equal(events[0].type, "error");
+    assert.equal((events[0] as { message: string }).message, "Connection failed");
+  });
+
+  // ── Mode mapping to sandbox ───────────────────────────────────────────
+
+  it("uses workspace-write sandbox for edit mode", async () => {
+    _test.setEvents([{ type: "thread.started", thread_id: "t1" }]);
+    const adapter = new CodexAdapter(makeConfig());
+    await collectEvents(adapter.runSession("hello", undefined, { mode: "edit" }));
+
+    assert.equal(_test.startThreadCalls.length, 1);
+    assert.equal(_test.startThreadCalls[0].opts?.sandboxMode, "workspace-write");
+  });
+
+  it("uses read-only sandbox for plan mode", async () => {
+    _test.setEvents([{ type: "thread.started", thread_id: "t1" }]);
+    const adapter = new CodexAdapter(makeConfig());
+    await collectEvents(adapter.runSession("plan this", undefined, { mode: "plan" }));
+
+    assert.equal(_test.startThreadCalls.length, 1);
+    assert.equal(_test.startThreadCalls[0].opts?.sandboxMode, "read-only");
+  });
+
+  it("defaults to edit mode (workspace-write sandbox)", async () => {
+    _test.setEvents([{ type: "thread.started", thread_id: "t1" }]);
+    const adapter = new CodexAdapter(makeConfig());
+    await collectEvents(adapter.runSession("hello"));
+
+    assert.equal(_test.startThreadCalls[0].opts?.sandboxMode, "workspace-write");
+  });
+
+  // ── Session resume ────────────────────────────────────────────────────
+
+  it("resumes existing session when sessionId is provided", async () => {
+    _test.setEvents([{ type: "thread.started", thread_id: "existing-session" }]);
+    const adapter = new CodexAdapter(makeConfig());
+    await collectEvents(adapter.runSession("continue", "existing-session"));
+
+    assert.equal(_test.resumeThreadCalls.length, 1);
+    assert.equal(_test.resumeThreadCalls[0].id, "existing-session");
+    assert.equal(_test.startThreadCalls.length, 0);
+  });
+
+  it("starts new thread when no sessionId", async () => {
+    _test.setEvents([{ type: "thread.started", thread_id: "new" }]);
+    const adapter = new CodexAdapter(makeConfig());
+    await collectEvents(adapter.runSession("hello"));
+
+    assert.equal(_test.startThreadCalls.length, 1);
+    assert.equal(_test.resumeThreadCalls.length, 0);
+  });
+
+  // ── Abort ─────────────────────────────────────────────────────────────
+
+  it("abort() can be called safely when no session is active", () => {
+    const adapter = new CodexAdapter(makeConfig());
+    // Should not throw
+    adapter.abort();
+  });
+
+  // ── Error item ────────────────────────────────────────────────────────
+
+  it("maps error item.started to error event", async () => {
+    _test.setEvents([
+      {
+        type: "item.started",
+        item: { type: "error", id: "err-1", message: "Something went wrong" },
+      },
+    ]);
+    const adapter = new CodexAdapter(makeConfig());
+    const events = await collectEvents(adapter.runSession("err"));
+
+    assert.equal(events.length, 1);
+    assert.equal(events[0].type, "error");
+    assert.equal((events[0] as { message: string }).message, "Something went wrong");
+  });
+
+  // ── runStreamed failure ────────────────────────────────────────────
+
+  it("yields error + session-result when runStreamed throws", async () => {
+    _test.setRunStreamedError(
+      new Error("Codex Exec exited with code 1: Reading prompt from stdin..."),
+    );
+    const adapter = new CodexAdapter(makeConfig());
+    const events = await collectEvents(adapter.runSession("fail"));
+
+    assert.equal(events.length, 2);
+    assert.equal(events[0].type, "error");
+    assert.ok((events[0] as { message: string }).message.includes("Codex Exec exited with code 1"));
+    assert.equal(events[1].type, "session-result");
+    assert.equal((events[1] as { success: boolean }).success, false);
+    assert.ok(
+      (events[1] as { errors: string[] }).errors[0].includes("Codex Exec exited with code 1"),
+    );
+  });
+
+  // ── Complete event sequence ───────────────────────────────────────────
+
+  it("handles a realistic full session flow", async () => {
+    _test.setEvents([
+      { type: "thread.started", thread_id: "session-123" },
+      {
+        type: "item.updated",
+        item: { type: "agent_message", id: "msg-1", text: "I'll read the file for you." },
+      },
+      {
+        type: "item.completed",
+        item: { type: "agent_message", id: "msg-1", text: "I'll read the file for you." },
+      },
+      {
+        type: "item.started",
+        item: {
+          type: "command_execution",
+          id: "cmd-1",
+          command: "cat README.md",
+          aggregated_output: "",
+          status: "in_progress",
+        },
+      },
+      {
+        type: "item.completed",
+        item: {
+          type: "command_execution",
+          id: "cmd-1",
+          command: "cat README.md",
+          aggregated_output: "# My Project\nHello world",
+          exit_code: 0,
+          status: "completed",
+        },
+      },
+      {
+        type: "item.updated",
+        item: { type: "agent_message", id: "msg-2", text: "Here's the content." },
+      },
+      {
+        type: "item.completed",
+        item: { type: "agent_message", id: "msg-2", text: "Here's the content." },
+      },
+      { type: "turn.started" },
+      {
+        type: "turn.completed",
+        usage: { input_tokens: 500, cached_input_tokens: 0, output_tokens: 200 },
+      },
+    ]);
+
+    const adapter = new CodexAdapter(makeConfig());
+    const events = await collectEvents(adapter.runSession("read README.md"));
+
+    const types = events.map((e) => e.type);
+    assert.deepEqual(types, [
+      "session-start",
+      "text-delta",
+      // item.completed for agent_message emits no delta (already fully streamed)
+      "tool-use",
+      "tool-result",
+      "text-delta",
+      // item.completed for agent_message emits no delta (already fully streamed)
+      "session-result",
+    ]);
+
+    // Verify session-start
+    assert.equal((events[0] as { sessionId: string }).sessionId, "session-123");
+
+    // Verify tool-use
+    const toolUse = events[2] as { toolName: string };
+    assert.equal(toolUse.toolName, "Bash");
+
+    // Verify tool-result
+    const toolResult = events[3] as { output: string };
+    assert.equal(toolResult.output, "# My Project\nHello world");
+
+    // Verify session-result
+    const sessionResult = events[5] as {
+      success: boolean;
+      numTurns: number;
+    };
+    assert.equal(sessionResult.success, true);
+    assert.equal(sessionResult.numTurns, 1);
+  });
+});
+
+// ─── Config schema tests ──────────────────────────────────────────────────
+
+describe("codex config schema", () => {
+  it("parses minimal codex config with defaults", () => {
+    const result = codingAgentConfigSchema.parse({
+      type: "codex",
+    });
+    assert.equal(result.type, "codex");
+    assert.equal(result.maxTurns, 3);
+    assert.deepEqual(result.options, {});
+  });
+
+  it("parses codex config with model and executablePath", () => {
+    const result = codingAgentConfigSchema.parse({
+      type: "codex",
+      maxTurns: 10,
+      options: {
+        model: "gpt-5-codex",
+        executablePath: "/opt/codex/bin/codex",
+      },
+    });
+    assert.equal(result.type, "codex");
+    assert.equal(result.maxTurns, 10);
+    assert.equal((result.options as { model: string }).model, "gpt-5-codex");
+    assert.equal(
+      (result.options as { executablePath: string }).executablePath,
+      "/opt/codex/bin/codex",
+    );
+  });
+
+  it("rejects invalid codex config options", () => {
+    assert.throws(() => {
+      codingAgentConfigSchema.parse({
+        type: "codex",
+        maxTurns: -1,
+      });
+    });
+  });
+});
+
+// ─── Factory tests ────────────────────────────────────────────────────────
+
+describe("createCodingAgent with codex type", () => {
+  it("creates a CodexAdapter", async () => {
+    const agent = await createCodingAgent({
+      type: "codex",
+      workspaceDir: "/tmp/test",
+      maxTurns: 3,
+      options: {},
+    });
+    assert.equal(agent.name, "Codex");
+    assert.equal(agent.supportedFeatures.costTracking, true);
+    assert.equal(agent.supportedFeatures.sessionListing, true);
+  });
+
+  it("factory-created agent has listModes", async () => {
+    const agent = await createCodingAgent({
+      type: "codex",
+      workspaceDir: "/tmp/test",
+      maxTurns: 3,
+      options: {},
+    });
+    const modes = agent.listModes!();
+    assert.equal(modes.length, 2);
+    assert.equal(modes[0].id, "edit");
+    assert.equal(modes[1].id, "plan");
+  });
+});

--- a/packages/coding-agent/tests/mock-codex-loader.mjs
+++ b/packages/coding-agent/tests/mock-codex-loader.mjs
@@ -1,0 +1,44 @@
+/**
+ * Custom Node.js module loader hook for tests.
+ *
+ * 1. Redirects `@openai/codex-sdk` imports to the local mock module.
+ * 2. Rewrites `.js` extensions to `.ts` so TypeScript sources resolve
+ *    correctly when using --experimental-strip-types.
+ */
+
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { dirname, join } from "node:path";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const mockUrl = pathToFileURL(join(__dirname, "mocks", "codex-sdk.mjs")).href;
+
+/**
+ * @param {string} specifier
+ * @param {object} context
+ * @param {Function} nextResolve
+ */
+export function resolve(specifier, context, nextResolve) {
+  // 1. Intercept @openai/codex-sdk
+  if (specifier === "@openai/codex-sdk" || specifier.endsWith("codex-sdk")) {
+    return { url: mockUrl, shortCircuit: true };
+  }
+
+  // 2. Rewrite .js → .ts for relative imports within our source tree only.
+  //    Skip anything inside node_modules.
+  const parentUrl = context.parentURL || "";
+  const inOurSource = parentUrl.includes("/packages/coding-agent/") && !parentUrl.includes("node_modules");
+  if (
+    inOurSource &&
+    specifier.endsWith(".js") &&
+    (specifier.startsWith("./") || specifier.startsWith("../"))
+  ) {
+    const tsSpecifier = specifier.replace(/\.js$/, ".ts");
+    try {
+      return nextResolve(tsSpecifier, context);
+    } catch {
+      // Fall through to original resolution
+    }
+  }
+
+  return nextResolve(specifier, context);
+}

--- a/packages/coding-agent/tests/mocks/codex-sdk.mjs
+++ b/packages/coding-agent/tests/mocks/codex-sdk.mjs
@@ -1,0 +1,94 @@
+/**
+ * Fake @openai/codex-sdk module for testing.
+ *
+ * Exposes a FakeCodex class that records constructor, startThread,
+ * resumeThread calls and yields configurable events.
+ *
+ * Tests configure behaviour via the exported `_test` control object.
+ */
+
+/** @type {Record<string, unknown>[]} */
+let _fakeEvents = [];
+
+/** @type {Error | null} */
+let _runStreamedError = null;
+
+/** @type {Array<{opts?: Record<string, unknown>}>} */
+let _startThreadCalls = [];
+
+/** @type {Array<{id: string, opts?: Record<string, unknown>}>} */
+let _resumeThreadCalls = [];
+
+/** @type {Array<{input: string}>} */
+let _runStreamedCalls = [];
+
+/** @type {Record<string, unknown>[]} */
+let _constructorCalls = [];
+
+class FakeCodexThread {
+  /**
+   * Returns Promise<{ events: AsyncGenerator<ThreadEvent> }> matching the real SDK API.
+   * @param {string} input
+   */
+  async runStreamed(input) {
+    _runStreamedCalls.push({ input });
+    if (_runStreamedError) {
+      throw _runStreamedError;
+    }
+    const events = _fakeEvents;
+    return {
+      events: (async function* () {
+        for (const event of events) {
+          yield event;
+        }
+      })(),
+    };
+  }
+}
+
+export class Codex {
+  /** @param {Record<string, unknown>} [opts] */
+  constructor(opts) {
+    _constructorCalls.push(opts ?? {});
+  }
+
+  /** @param {Record<string, unknown>} [opts] */
+  startThread(opts) {
+    _startThreadCalls.push({ opts });
+    return new FakeCodexThread();
+  }
+
+  /**
+   * @param {string} id
+   * @param {Record<string, unknown>} [opts]
+   */
+  resumeThread(id, opts) {
+    _resumeThreadCalls.push({ id, opts });
+    return new FakeCodexThread();
+  }
+}
+
+/**
+ * Test control object — lets tests configure fake events and inspect calls.
+ */
+export const _test = {
+  get startThreadCalls() { return _startThreadCalls; },
+  get resumeThreadCalls() { return _resumeThreadCalls; },
+  get runStreamedCalls() { return _runStreamedCalls; },
+  get constructorCalls() { return _constructorCalls; },
+
+  /** @param {Record<string, unknown>[]} events */
+  setEvents(events) { _fakeEvents = events; },
+
+  /** @param {Error} err */
+  setRunStreamedError(err) { _runStreamedError = err; },
+
+  reset() {
+    _fakeEvents = [];
+    _runStreamedError = null;
+    _startThreadCalls = [];
+    _resumeThreadCalls = [];
+    _runStreamedCalls = [];
+    _constructorCalls = [];
+  },
+};

--- a/packages/coding-agent/tests/register-mock-loader.mjs
+++ b/packages/coding-agent/tests/register-mock-loader.mjs
@@ -1,0 +1,6 @@
+/**
+ * Registration script for the custom module loader.
+ * Passed via `node --import ./tests/register-mock-loader.mjs`.
+ */
+import { register } from "node:module";
+register("./mock-codex-loader.mjs", import.meta.url);

--- a/packages/dashboard-core/src/components/SettingsPage.tsx
+++ b/packages/dashboard-core/src/components/SettingsPage.tsx
@@ -32,10 +32,17 @@ import type { CodingAgentConfig, CodingAgentType, LabelDefinition, Theme } from 
 
 const AGENT_TYPES: { value: CodingAgentType; label: string }[] = [
   { value: "claude-code", label: "Claude Code" },
+  { value: "codex", label: "Codex" },
+  { value: "gemini-cli", label: "Gemini CLI" },
+  { value: "cursor-cli", label: "Cursor CLI" },
 ];
 
 const AGENT_LABEL: Record<string, string> = {
   "claude-code": "Claude Code",
+  codex: "Codex",
+  "openai-codex": "OpenAI Codex (SDK)",
+  "gemini-cli": "Gemini CLI",
+  "cursor-cli": "Cursor CLI",
 };
 
 const DEFAULT_DEFAULTS = {

--- a/packages/dashboard-core/src/types.ts
+++ b/packages/dashboard-core/src/types.ts
@@ -88,7 +88,12 @@ export interface BandConfig {
   apps?: AppConfig[];
 }
 
-export type CodingAgentType = "claude-code";
+export type CodingAgentType =
+  | "claude-code"
+  | "codex"
+  | "openai-codex"
+  | "gemini-cli"
+  | "cursor-cli";
 
 export interface CodingAgentConfig {
   type: CodingAgentType;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -283,6 +283,9 @@ importers:
       '@nothumanwork/cursor-agents-sdk':
         specifier: ^0.7.0
         version: 0.7.0(typescript@5.9.3)
+      '@openai/codex-sdk':
+        specifier: ^0.118.0
+        version: 0.118.0
       zod:
         specifier: ^3.25.67
         version: 3.25.76
@@ -1675,6 +1678,51 @@ packages:
   '@oozcitak/util@10.0.0':
     resolution: {integrity: sha512-hAX0pT/73190NLqBPPWSdBVGtbY6VOhWYK3qqHqtXQ1gK7kS2yz4+ivsN07hpJ6I3aeMtKP6J6npsEKOAzuTLA==}
     engines: {node: '>=20.0'}
+
+  '@openai/codex-sdk@0.118.0':
+    resolution: {integrity: sha512-cMisxx4CGQL44yv2USqdgcPhxPOhv227+CJiF9snn2X7nL+6wary4g38OknornjlrPob7LyzdIFB7dXqjkXKxg==}
+    engines: {node: '>=18'}
+
+  '@openai/codex@0.118.0':
+    resolution: {integrity: sha512-oJhNOsP/Vu7DBUhodpP15z60cCZv3sKORqUn1+pepleqSTmc0zXJZSjz6fQOLzny9Ra6sRcvprFFKmQ3Q6+E6w==}
+    engines: {node: '>=16'}
+    hasBin: true
+
+  '@openai/codex@0.118.0-darwin-arm64':
+    resolution: {integrity: sha512-sxq7Q2q9YiJN1wNrzvFRCC5oQKXPVUvu9Ejg6SI/CvyyI9YdtyLTO633wQJALGB7XQfT+3tyM5nNBivnSzLA3Q==}
+    engines: {node: '>=16'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@openai/codex@0.118.0-darwin-x64':
+    resolution: {integrity: sha512-iIvrqzsh1iJmVfqyYwLZBiuh0MkN1Suqniz9hBfmRmE6txMWhRVfigb9SMBiOkfCW1C4sjBwLCsCSzg11rvppQ==}
+    engines: {node: '>=16'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@openai/codex@0.118.0-linux-arm64':
+    resolution: {integrity: sha512-YKWmIqLBu9mmBhN3JHQNkLzk0BtAtV6LBPvhnL5eeHkNrChvA6PKrhsjy0O7wvRkiByZY/1dD14qVdAUfxcbiA==}
+    engines: {node: '>=16'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@openai/codex@0.118.0-linux-x64':
+    resolution: {integrity: sha512-vzU2d/gwAmZbf/DnwVzfQiNN3Ri04XpaZiJkHElIvGoqFbdrxRQFYTtslGDISYIO3o+POADZcFZIfamFsZj9yQ==}
+    engines: {node: '>=16'}
+    cpu: [x64]
+    os: [linux]
+
+  '@openai/codex@0.118.0-win32-arm64':
+    resolution: {integrity: sha512-AU7GPVFqd0Ml3P2OXfy6K6TONcxfCZLUh1zjYkkoPGWJ4A3BVMkOmMP9CAdSiQsnU/RQfdV/9IGqo1xwUQDdjA==}
+    engines: {node: '>=16'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@openai/codex@0.118.0-win32-x64':
+    resolution: {integrity: sha512-9vKW1ANQxIUsLpiY0VsOM+1avZjqxDZgqgxKABJHWRlLMuaSykwXexf8Hqq+BnYFfmn0d6MjxTuE1UtVvg9caw==}
+    engines: {node: '>=16'}
+    cpu: [x64]
+    os: [win32]
 
   '@opentelemetry/api@1.9.0':
     resolution: {integrity: sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==}
@@ -6623,6 +6671,37 @@ snapshots:
       '@oozcitak/util': 10.0.0
 
   '@oozcitak/util@10.0.0': {}
+
+  '@openai/codex-sdk@0.118.0':
+    dependencies:
+      '@openai/codex': 0.118.0
+
+  '@openai/codex@0.118.0':
+    optionalDependencies:
+      '@openai/codex-darwin-arm64': '@openai/codex@0.118.0-darwin-arm64'
+      '@openai/codex-darwin-x64': '@openai/codex@0.118.0-darwin-x64'
+      '@openai/codex-linux-arm64': '@openai/codex@0.118.0-linux-arm64'
+      '@openai/codex-linux-x64': '@openai/codex@0.118.0-linux-x64'
+      '@openai/codex-win32-arm64': '@openai/codex@0.118.0-win32-arm64'
+      '@openai/codex-win32-x64': '@openai/codex@0.118.0-win32-x64'
+
+  '@openai/codex@0.118.0-darwin-arm64':
+    optional: true
+
+  '@openai/codex@0.118.0-darwin-x64':
+    optional: true
+
+  '@openai/codex@0.118.0-linux-arm64':
+    optional: true
+
+  '@openai/codex@0.118.0-linux-x64':
+    optional: true
+
+  '@openai/codex@0.118.0-win32-arm64':
+    optional: true
+
+  '@openai/codex@0.118.0-win32-x64':
+    optional: true
 
   '@opentelemetry/api@1.9.0': {}
 


### PR DESCRIPTION
## Summary
- Add new `CodexAdapter` using the `@openai/codex-sdk` TypeScript SDK as a coding agent backend
- Support model listing, session history, skills discovery from `~/.codex/skills`, and streaming events
- Clean environment filtering to strip pnpm/vite variables that cause the codex binary to fail when spawned from the dev server
- Fix YAML frontmatter parser to strip surrounding quotes from skill names
- Add Codex option to the dashboard settings page
- Integration tests with 38 test cases covering the adapter

## Test plan
- [x] All 38 integration tests pass (`node --test packages/coding-agent/tests/codex-adapter.test.ts`)
- [x] Biome lint/format passes
- [ ] CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)