### PR TITLE
feat: add OpenAPI spec generation and Scalar API docs

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -55,6 +55,7 @@
     "@tauri-apps/api": "^2.0.0",
     "@tauri-apps/plugin-shell": "^2.0.0",
     "@trpc/client": "^11.12.0",
+    "@trpc/openapi": "11.16.0-alpha",
     "@trpc/server": "^11.12.0",
     "@types/better-sqlite3": "^7.6.13",
     "@types/node": "^22.19.13",

--- a/apps/web/scripts/build-server.sh
+++ b/apps/web/scripts/build-server.sh
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Generate OpenAPI spec from tRPC router (static TypeScript analysis)
+mkdir -p dist
+pnpm exec trpc-openapi ./src/trpc/router.ts -o dist/openapi.json --title "Band API" --version "1.0.0"
+
 # Bundle the server entry point
 esbuild start-server.ts \
   --bundle \

--- a/apps/web/src/trpc/openapi.ts
+++ b/apps/web/src/trpc/openapi.ts
@@ -1,0 +1,24 @@
+/**
+ * Return a self-contained HTML page that loads the Scalar API reference UI
+ * from CDN and points it at the given OpenAPI spec URL.
+ */
+export function getScalarHtml(specUrl: string): string {
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <title>Band API Docs</title>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+</head>
+<body>
+  <div id="app"></div>
+  <script src="https://cdn.jsdelivr.net/npm/@scalar/api-reference"></script>
+  <script>
+    Scalar.createApiReference('#app', {
+      url: '${specUrl}',
+      theme: 'default',
+    })
+  </script>
+</body>
+</html>`;
+}

--- a/apps/web/start-server.ts
+++ b/apps/web/start-server.ts
@@ -1,4 +1,4 @@
-import { appendFileSync, createReadStream, mkdirSync, statSync } from "node:fs";
+import { appendFileSync, createReadStream, mkdirSync, readFileSync, statSync } from "node:fs";
 import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
 import { basename, extname, join } from "node:path";
 import { fetchRequestHandler } from "@trpc/server/adapters/fetch";
@@ -17,6 +17,7 @@ import { killAllTerminals } from "./src/lib/terminal-manager.ts";
 import { handleTerminalConnection } from "./src/lib/terminal-ws.ts";
 import { startTunnel, stopTunnel } from "./src/lib/tunnel.ts";
 import { createContext } from "./src/trpc/context.ts";
+import { getScalarHtml } from "./src/trpc/openapi.ts";
 import { appRouter } from "./src/trpc/router.ts";
 
 // ---------------------------------------------------------------------------
@@ -59,6 +60,13 @@ const assets = sirv(clientDir, {
   gzip: true,
   etag: true,
 });
+
+// OpenAPI spec is pre-generated at build time by @trpc/openapi CLI.
+// Add server base path so docs show correct /trpc/* URLs.
+const openApiDoc = JSON.parse(readFileSync(join(import.meta.dirname, "openapi.json"), "utf-8"));
+openApiDoc.servers = [{ url: "/trpc" }];
+const openApiSpec = JSON.stringify(openApiDoc, null, 2);
+const scalarHtml = getScalarHtml("/api/openapi.json");
 
 async function main() {
   // Run database migrations before anything else
@@ -120,6 +128,27 @@ async function main() {
         res.writeHead(404);
         res.end("Not found");
       }
+      return;
+    }
+
+    // Serve OpenAPI spec
+    if (req.url === "/api/openapi.json") {
+      res.writeHead(200, {
+        "Content-Type": "application/json",
+        "Cache-Control": "no-cache",
+        "Access-Control-Allow-Origin": "*",
+      });
+      res.end(openApiSpec);
+      return;
+    }
+
+    // Serve Scalar API docs UI
+    if (req.url === "/api/docs") {
+      res.writeHead(200, {
+        "Content-Type": "text/html",
+        "Cache-Control": "no-cache",
+      });
+      res.end(scalarHtml);
       return;
     }
 

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -2,16 +2,52 @@ import { resolve } from "node:path";
 import { createLogger } from "@band-app/logger";
 import tailwindcss from "@tailwindcss/vite";
 import { tanstackStart } from "@tanstack/react-start/plugin/vite";
+import { generateOpenAPIDocument } from "@trpc/openapi";
 import react from "@vitejs/plugin-react";
 import { defineConfig, type Plugin } from "vite";
 import { WebSocketServer } from "ws";
+import { getScalarHtml } from "./src/trpc/openapi.ts";
 
 const log = createLogger("vite-plugin");
 
 function trpcDevPlugin(): Plugin {
+  let cachedSpec: string | null = null;
+
   return {
     name: "trpc-dev-server",
     configureServer(server) {
+      // Invalidate cached spec when router or related files change
+      server.watcher.on("change", (file) => {
+        if (file.includes("/trpc/") || file.endsWith("router.ts")) {
+          cachedSpec = null;
+        }
+      });
+
+      // Serve OpenAPI spec (generated via @trpc/openapi static analysis)
+      server.middlewares.use("/api/openapi.json", async (_req, res) => {
+        if (!cachedSpec) {
+          const doc = await generateOpenAPIDocument("./src/trpc/router.ts", {
+            title: "Band API",
+            version: "1.0.0",
+          });
+          // Add server base path so Scalar shows correct URLs
+          // biome-ignore lint/suspicious/noExplicitAny: extending generated OpenAPI doc
+          (doc as any).servers = [{ url: "/trpc" }];
+          cachedSpec = JSON.stringify(doc, null, 2);
+        }
+        res.writeHead(200, {
+          "Content-Type": "application/json",
+          "Access-Control-Allow-Origin": "*",
+        });
+        res.end(cachedSpec);
+      });
+
+      // Serve Scalar API docs UI
+      server.middlewares.use("/api/docs", async (_req, res) => {
+        res.writeHead(200, { "Content-Type": "text/html" });
+        res.end(getScalarHtml("/api/openapi.json"));
+      });
+
       server.middlewares.use("/trpc", async (req, res) => {
         // Use ssrLoadModule so Vite handles TS resolution at dev time
         const [{ nodeHTTPRequestHandler }, { createContext }, { appRouter }] = (await Promise.all([

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -145,6 +145,9 @@ importers:
       '@trpc/client':
         specifier: ^11.12.0
         version: 11.12.0(@trpc/server@11.12.0(typescript@5.9.3))(typescript@5.9.3)
+      '@trpc/openapi':
+        specifier: 11.16.0-alpha
+        version: 11.16.0-alpha(@trpc/server@11.12.0(typescript@5.9.3))(typescript@5.9.3)(zod@3.25.76)
       '@trpc/server':
         specifier: ^11.12.0
         version: 11.12.0(typescript@5.9.3)
@@ -2898,6 +2901,20 @@ packages:
       '@trpc/server': 11.12.0
       typescript: '>=5.7.2'
 
+  '@trpc/openapi@11.16.0-alpha':
+    resolution: {integrity: sha512-FSJM4oplYCJ/X/YlGsBQaPPbEGvV6KgOSehEzyswFlWEmaBTuD+1obeMajrFPy2wONpHnwkVVygxfYeCIT9LHA==}
+    hasBin: true
+    peerDependencies:
+      '@hey-api/openapi-ts': '>=0.13.0'
+      '@trpc/server': 11.16.0
+      typescript: '>=5.7.2'
+      zod: '>=4.0.0'
+    peerDependenciesMeta:
+      '@hey-api/openapi-ts':
+        optional: true
+      zod:
+        optional: true
+
   '@trpc/server@11.12.0':
     resolution: {integrity: sha512-rpZnf5FUjNndE/AjGIy+FvEHR52iBd0u0wySqWCwXj67wraj3qCuBr5Opcf0Te/g67C/YztqceFkLoG0r4mp4Q==}
     peerDependencies:
@@ -4520,6 +4537,9 @@ packages:
 
   oniguruma-to-es@4.3.4:
     resolution: {integrity: sha512-3VhUGN3w2eYxnTzHn+ikMI+fp/96KoRSVK9/kMTcFqj1NRDh2IhQCKvYxDnWePKRXY/AqH+Fuiyb7VHSzBjHfA==}
+
+  openapi-types@12.1.3:
+    resolution: {integrity: sha512-N4YtSYJqghVu4iek2ZUvcN/0aqH1kRDuNqzcycDxhOUpg7GdvLa2F3DgS6yBNhInhv2r/6I0Flkn7CqL8+nIcw==}
 
   p-limit@6.2.0:
     resolution: {integrity: sha512-kuUqqHNUqoIWp/c467RI4X6mmyuojY5jGutNU0wVTmEOOfcuwLqyMVoAi9MKi2Ak+5i9+nhmrK4ufZE8069kHA==}
@@ -7938,6 +7958,14 @@ snapshots:
       '@trpc/server': 11.12.0(typescript@5.9.3)
       typescript: 5.9.3
 
+  '@trpc/openapi@11.16.0-alpha(@trpc/server@11.12.0(typescript@5.9.3))(typescript@5.9.3)(zod@3.25.76)':
+    dependencies:
+      '@trpc/server': 11.12.0(typescript@5.9.3)
+      openapi-types: 12.1.3
+      typescript: 5.9.3
+    optionalDependencies:
+      zod: 3.25.76
+
   '@trpc/server@11.12.0(typescript@5.9.3)':
     dependencies:
       typescript: 5.9.3
@@ -9994,6 +10022,8 @@ snapshots:
       oniguruma-parser: 0.12.1
       regex: 6.1.0
       regex-recursion: 6.0.2
+
+  openapi-types@12.1.3: {}
 
   p-limit@6.2.0:
     dependencies:


### PR DESCRIPTION
## Summary

- Adds automatic OpenAPI 3.1 spec generation from the tRPC router using `@trpc/openapi` (static TypeScript analysis)
- Serves interactive API documentation via [Scalar](https://github.com/scalar/scalar) at `/api/docs`
- Serves raw OpenAPI JSON at `/api/openapi.json`
- Covers all 59 non-subscription tRPC procedures with Zod-derived request schemas

## How it works

- **Dev**: `generateOpenAPIDocument()` runs on first request, cached with file-watcher invalidation when `/trpc/` files change
- **Build**: `trpc-openapi` CLI generates `openapi.json` as a build artifact in `build-server.sh`
- **Production**: pre-built spec read from disk at startup

## Test plan

- [ ] `pnpm dev` → open `http://localhost:3456/api/docs` → Scalar UI loads with all procedures grouped by namespace
- [ ] `http://localhost:3456/api/openapi.json` → valid OpenAPI 3.1 JSON with 59 paths
- [ ] Verify Zod-derived schemas appear on mutations (e.g. `tasks.submit`, `cronjobs.create`)
- [ ] Verify subscriptions (`tasks.stream`, `status.stream`, `queue.stream`) are excluded
- [ ] Build succeeds: `pnpm build` generates `dist/openapi.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)