### PR TITLE
feat: add OpenCode coding agent adapter

### DIFF
--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -149,6 +149,7 @@ interface ChatViewProps {
   showSessionList: boolean;
   onShowSessionListChange: (show: boolean) => void;
   onStreamingChange?: (streaming: boolean) => void;
+  chatKey?: number;
 }
 
 export function ChatView({
@@ -159,6 +160,7 @@ export function ChatView({
   showSessionList,
   onShowSessionListChange,
   onStreamingChange,
+  chatKey = 0,
 }: ChatViewProps) {
   const sessionIdRef = useRef<string | undefined>(undefined);
   const [activeSessionId, setActiveSessionId] = useState<string | undefined>(undefined);
@@ -276,7 +278,7 @@ export function ChatView({
   }, [transport, selectedModel]);
 
   const { messages, sendMessage, status, setMessages, stop } = useChat({
-    id: workspaceId,
+    id: `${workspaceId}:${chatKey}`,
     transport,
     resume: true,
     onData: (dataPart) => {
@@ -377,21 +379,41 @@ export function ChatView({
     onShowSessionListChange(false);
   }, [setMessages, onShowSessionListChange, workspaceId]);
 
+  const queueMessage = useCallback(
+    (text: string) => {
+      setQueuedMessages((prev) => [...prev, text]);
+      trpc.queue.push.mutate({ workspaceId, text }).catch(() => {});
+    },
+    [workspaceId],
+  );
+
   const handleSubmit = useCallback(
-    (message: PromptInputMessage) => {
+    async (message: PromptInputMessage) => {
       if (!message.text.trim() && !message.files?.length) return;
 
       if (isStreaming) {
         // Agent is busy — queue the message on the backend.
         // Optimistic update for instant feedback; subscription corrects if needed.
-        setQueuedMessages((prev) => [...prev, message.text]);
-        trpc.queue.push.mutate({ workspaceId, text: message.text }).catch(() => {});
+        queueMessage(message.text);
         return;
+      }
+
+      // Check if a task is running in the background (e.g. started from CLI
+      // or another tab) that this chat doesn't know about yet.
+      try {
+        const { task } = await trpc.tasks.get.query({ workspaceId });
+        if (task) {
+          queueMessage(message.text);
+          return;
+        }
+      } catch {
+        // If the check fails, proceed with sending — the backend will
+        // reject with CONFLICT if a task is actually running.
       }
 
       doSendMessage(message);
     },
-    [doSendMessage, isStreaming, workspaceId],
+    [doSendMessage, isStreaming, workspaceId, queueMessage],
   );
 
   const handleCancelQueued = useCallback(

--- a/apps/web/src/components/WorkspaceChatPanel.tsx
+++ b/apps/web/src/components/WorkspaceChatPanel.tsx
@@ -50,6 +50,7 @@ export function WorkspaceChatPanel({ workspaceId }: WorkspaceChatPanelProps) {
   }, [workspaceId]);
 
   // Load available agents from settings and current workspace agent
+  // biome-ignore lint/correctness/useExhaustiveDependencies: chatKey intentionally triggers reload after agent switch; currentAgentId excluded to avoid infinite loop
   useEffect(() => {
     let cancelled = false;
 
@@ -196,6 +197,7 @@ export function WorkspaceChatPanel({ workspaceId }: WorkspaceChatPanelProps) {
       <div className="flex min-h-0 flex-1 flex-col">
         <ChatView
           key={chatKey}
+          chatKey={chatKey}
           workspaceId={workspaceId}
           workspaceName={workspaceId}
           supportsSessionListing={supportsSessionListing}

--- a/apps/web/src/components/ai-elements/conversation.tsx
+++ b/apps/web/src/components/ai-elements/conversation.tsx
@@ -21,7 +21,7 @@ export type ConversationContentProps = ComponentProps<typeof StickToBottom.Conte
 export const ConversationContent = ({ className, ...props }: ConversationContentProps) => (
   <StickToBottom.Content
     className={cn(
-      "mx-auto flex w-full max-w-3xl flex-col gap-2 overflow-hidden px-3 py-4 lg:px-4",
+      "mx-auto flex w-full max-w-3xl flex-col overflow-hidden px-3 py-4 lg:px-4 [&>*+*]:mt-2 [&>.is-assistant+.is-assistant]:mt-px",
       className,
     )}
     {...props}

--- a/apps/web/src/lib/task-chat-transport.ts
+++ b/apps/web/src/lib/task-chat-transport.ts
@@ -88,7 +88,22 @@ export class TaskChatTransport implements ChatTransport<UIMessage> {
         ...(this.model && { model: this.model }),
       });
     } catch (err) {
-      throw new Error(err instanceof Error ? err.message : "Submit failed");
+      const msg = err instanceof Error ? err.message : "Submit failed";
+      // If a task is already running (race condition — the pre-check in
+      // handleSubmit passed but a task started before submit), queue the
+      // message instead of failing.
+      if (msg.includes("already running") || msg.includes("CONFLICT")) {
+        await trpc.queue.push.mutate({ workspaceId: this.workspaceId, text: userText });
+        // Return an immediately-closed stream so useChat goes back to
+        // "ready" state. We don't connect to the running task's stream
+        // because it may be from a different agent.
+        return new ReadableStream<UIMessageChunk>({
+          start(controller) {
+            controller.close();
+          },
+        });
+      }
+      throw new Error(msg);
     }
 
     return subscriptionToStream(this.workspaceId, abortSignal);

--- a/apps/web/src/trpc/router.ts
+++ b/apps/web/src/trpc/router.ts
@@ -67,6 +67,13 @@ const t = initTRPC.context<Context>().create();
 
 const publicProcedure = t.procedure;
 
+/** Resolve the coding agent for a workspace, respecting the per-workspace agent selection. */
+async function getWorkspaceAgent(workspaceId: string, worktreePath: string) {
+  const wsStatus = getWorkspaceStatus(workspaceId);
+  const codingAgentId = wsStatus?.agent?.codingAgentId;
+  return getOrCreateAgent(workspaceId, worktreePath, codingAgentId);
+}
+
 // ---------------------------------------------------------------------------
 // Projects
 // ---------------------------------------------------------------------------
@@ -1220,7 +1227,7 @@ const sessionsRouter = t.router({
       throw new TRPCError({ code: "NOT_FOUND", message: "Workspace not found" });
     }
 
-    const agent = await getOrCreateAgent(input.workspaceId, workspace.worktree.path);
+    const agent = await getWorkspaceAgent(input.workspaceId, workspace.worktree.path);
 
     if (!agent.supportedFeatures.sessionListing || !agent.listSessions) {
       return { sessions: [], supported: false };
@@ -1238,7 +1245,7 @@ const sessionsRouter = t.router({
         throw new TRPCError({ code: "NOT_FOUND", message: "Workspace not found" });
       }
 
-      const agent = await getOrCreateAgent(input.workspaceId, workspace.worktree.path);
+      const agent = await getWorkspaceAgent(input.workspaceId, workspace.worktree.path);
 
       if (!agent.supportedFeatures.sessionListing || !agent.getSessionMessages) {
         throw new TRPCError({ code: "BAD_REQUEST", message: "Session listing not supported" });
@@ -1552,7 +1559,7 @@ const skillsRouter = t.router({
       return { skills: [] };
     }
 
-    const agent = await getOrCreateAgent(input.workspaceId, workspace.worktree.path);
+    const agent = await getWorkspaceAgent(input.workspaceId, workspace.worktree.path);
     if (agent.listSkills) {
       const skills = await agent.listSkills();
       return { skills };
@@ -1573,7 +1580,7 @@ const modesRouter = t.router({
       return { modes: [] };
     }
 
-    const agent = await getOrCreateAgent(input.workspaceId, workspace.worktree.path);
+    const agent = await getWorkspaceAgent(input.workspaceId, workspace.worktree.path);
     if (agent.listModes) {
       return { modes: agent.listModes() };
     }
@@ -1593,7 +1600,7 @@ const modelsRouter = t.router({
       return { models: [] };
     }
 
-    const agent = await getOrCreateAgent(input.workspaceId, workspace.worktree.path);
+    const agent = await getWorkspaceAgent(input.workspaceId, workspace.worktree.path);
     if (agent.listModels) {
       return { models: await agent.listModels() };
     }

--- a/packages/coding-agent/src/adapters/opencode.ts
+++ b/packages/coding-agent/src/adapters/opencode.ts
@@ -1,0 +1,471 @@
+import type { ChildProcess } from "node:child_process";
+import { execFile, spawn } from "node:child_process";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { createInterface } from "node:readline";
+import { createLogger } from "@band-app/logger";
+import type { OpenCodeConfig } from "../config.js";
+import type { AgentEvent } from "../events.js";
+import { readSkillsFromDir } from "../skills.js";
+import type {
+  AgentModel,
+  CodingAgent,
+  RunSessionOptions,
+  SessionListItem,
+  SessionMessageItem,
+  SkillInfo,
+} from "../types.js";
+
+const log = createLogger("coding-agent:opencode");
+
+export class OpenCodeAdapter implements CodingAgent {
+  readonly name = "OpenCode";
+  readonly supportedFeatures = {
+    costTracking: false,
+    sessionListing: true,
+  } as const;
+
+  private readonly workspaceDir: string;
+  private readonly model: string | undefined;
+  private readonly executablePath: string;
+  private activeChild: ChildProcess | null = null;
+  private cachedModels: AgentModel[] | null = null;
+
+  constructor(config: OpenCodeConfig) {
+    this.workspaceDir = config.workspaceDir;
+    this.model = config.options.model;
+    this.executablePath = config.options.executablePath ?? "opencode";
+  }
+
+  abort(): void {
+    if (this.activeChild) {
+      log.info("aborting active opencode process");
+      this.activeChild.kill();
+      this.activeChild = null;
+    }
+  }
+
+  async *runSession(
+    prompt: string,
+    sessionId?: string,
+    options?: RunSessionOptions,
+  ): AsyncGenerator<AgentEvent> {
+    const effectiveModel = options?.model ?? this.model;
+
+    log.info(
+      {
+        prompt: prompt.slice(0, 100),
+        model: effectiveModel,
+        cwd: this.workspaceDir,
+        sessionId,
+      },
+      "runSession starting",
+    );
+
+    const args = ["run", "--format", "json", "--dir", this.workspaceDir];
+    if (effectiveModel) {
+      args.push("--model", effectiveModel);
+    }
+    if (sessionId) {
+      args.push("--session", sessionId);
+    }
+    args.push(prompt);
+
+    const child = spawn(this.executablePath, args, {
+      cwd: this.workspaceDir,
+      stdio: ["ignore", "pipe", "pipe"],
+      env: { ...process.env },
+    });
+    this.activeChild = child;
+
+    const startMs = Date.now();
+    let turnCount = 0;
+    const generatedSessionId = sessionId ?? crypto.randomUUID();
+
+    yield { type: "session-start", sessionId: generatedSessionId };
+
+    const rl = createInterface({ input: child.stdout });
+
+    try {
+      for await (const line of rl) {
+        if (!line.trim()) continue;
+
+        let parsed: Record<string, unknown>;
+        try {
+          parsed = JSON.parse(line);
+        } catch {
+          log.warn({ line }, "failed to parse NDJSON line");
+          continue;
+        }
+
+        const eventType = parsed.type as string;
+        const part = parsed.part as Record<string, unknown> | undefined;
+        log.debug({ eventType }, "opencode event");
+
+        switch (eventType) {
+          case "text": {
+            const text = part?.text as string | undefined;
+            if (text) {
+              yield { type: "text-delta", text };
+            }
+            break;
+          }
+
+          case "tool_use": {
+            turnCount++;
+            const state = part?.state as Record<string, unknown> | undefined;
+            yield {
+              type: "tool-use",
+              toolCallId: String(part?.callID ?? crypto.randomUUID()),
+              toolName: String(part?.tool ?? "unknown"),
+              input: (state?.input as Record<string, unknown>) ?? {},
+            };
+            if (state?.status === "completed" || state?.status === "failed") {
+              yield {
+                type: "tool-result",
+                toolCallId: String(part?.callID ?? ""),
+                toolName: String(part?.tool ?? "unknown"),
+                output: String(state?.output ?? ""),
+                isError: state?.status === "failed",
+              };
+            }
+            break;
+          }
+
+          case "error": {
+            yield {
+              type: "error",
+              message: String(parsed.message ?? part?.text ?? "Unknown OpenCode error"),
+            };
+            break;
+          }
+
+          // step_start, step_finish — no Band equivalent, skip
+        }
+      }
+
+      const exitCode = await new Promise<number>((resolve) => {
+        child.on("close", (code) => resolve(code ?? 0));
+      });
+
+      if (exitCode !== 0) {
+        log.warn({ exitCode }, "opencode process exited with non-zero code");
+      }
+
+      yield {
+        type: "session-result",
+        success: exitCode === 0,
+        sessionId: generatedSessionId,
+        durationMs: Date.now() - startMs,
+        numTurns: turnCount,
+        costUsd: 0,
+        errors: exitCode === 0 ? [] : [`OpenCode exited with code ${exitCode}`],
+      };
+
+      log.info("opencode stream done");
+    } catch (err) {
+      log.error({ err }, "opencode error");
+      child.kill();
+      throw err;
+    } finally {
+      this.activeChild = null;
+    }
+  }
+
+  async listSkills(): Promise<SkillInfo[]> {
+    return discoverOpenCodeSkills(this.workspaceDir);
+  }
+
+  async listModels(): Promise<AgentModel[]> {
+    if (this.cachedModels) {
+      return this.cachedModels;
+    }
+
+    try {
+      const models = await fetchOpenCodeModels(this.executablePath);
+      if (models.length > 0) {
+        this.cachedModels = models;
+        return models;
+      }
+    } catch (err) {
+      log.warn({ err }, "failed to fetch models from opencode CLI, using defaults");
+    }
+
+    return DEFAULT_MODELS;
+  }
+
+  async listSessions(dir: string): Promise<SessionListItem[]> {
+    log.info({ dir }, "listSessions");
+    const sessions = await fetchOpenCodeSessions(this.executablePath);
+    return sessions
+      .filter((s) => s.directory === dir)
+      .map((s) => ({
+        sessionId: s.id,
+        summary: s.title || "Untitled session",
+        lastModified: s.updated,
+        firstPrompt: s.title,
+      }))
+      .sort((a, b) => b.lastModified - a.lastModified);
+  }
+
+  async getSessionMessages(
+    sessionId: string,
+    _dir: string,
+    options?: { limit?: number; offset?: number },
+  ): Promise<SessionMessageItem[]> {
+    log.info({ sessionId, ...options }, "getSessionMessages");
+    return fetchOpenCodeSessionMessages(this.executablePath, sessionId, options);
+  }
+}
+
+const DEFAULT_MODELS: AgentModel[] = [
+  { id: "opencode/big-pickle", name: "Big Pickle" },
+  { id: "opencode/gpt-5-nano", name: "GPT-5 Nano" },
+];
+
+function fetchOpenCodeModels(executablePath: string): Promise<AgentModel[]> {
+  return new Promise((resolve, reject) => {
+    execFile(executablePath, ["models", "--verbose"], { timeout: 10_000 }, (err, stdout) => {
+      if (err) {
+        reject(err);
+        return;
+      }
+
+      const models: AgentModel[] = [];
+      const lines = stdout.split("\n");
+      let i = 0;
+
+      while (i < lines.length) {
+        const line = lines[i]!.trim();
+        // Model IDs appear as "provider/model" lines before their JSON block
+        if (line && !line.startsWith("{") && !line.startsWith("}") && line.includes("/")) {
+          const modelId = line;
+          // Try to find the JSON block that follows
+          const jsonStart = i + 1;
+          if (jsonStart < lines.length && lines[jsonStart]!.trim().startsWith("{")) {
+            let depth = 0;
+            let jsonEnd = jsonStart;
+            for (let j = jsonStart; j < lines.length; j++) {
+              const l = lines[j]!.trim();
+              for (const ch of l) {
+                if (ch === "{") depth++;
+                if (ch === "}") depth--;
+              }
+              if (depth === 0) {
+                jsonEnd = j;
+                break;
+              }
+            }
+            const jsonStr = lines.slice(jsonStart, jsonEnd + 1).join("\n");
+            try {
+              const meta = JSON.parse(jsonStr) as { name?: string; providerID?: string };
+              models.push({
+                id: modelId,
+                name: meta.name ?? modelId,
+                description: meta.providerID,
+              });
+            } catch {
+              models.push({ id: modelId, name: modelId });
+            }
+            i = jsonEnd + 1;
+            continue;
+          }
+          models.push({ id: modelId, name: modelId });
+        }
+        i++;
+      }
+
+      resolve(models);
+    });
+  });
+}
+
+// ─── Session history ─────────────────────────────────────────────────────────
+
+interface OpenCodeSessionListEntry {
+  id: string;
+  title: string;
+  updated: number;
+  created: number;
+  projectId: string;
+  directory: string;
+}
+
+function fetchOpenCodeSessions(executablePath: string): Promise<OpenCodeSessionListEntry[]> {
+  return new Promise((resolve, reject) => {
+    execFile(
+      executablePath,
+      ["session", "list", "--format", "json"],
+      { timeout: 10_000 },
+      (err, stdout) => {
+        if (err) {
+          reject(err);
+          return;
+        }
+        try {
+          resolve(JSON.parse(stdout) as OpenCodeSessionListEntry[]);
+        } catch {
+          resolve([]);
+        }
+      },
+    );
+  });
+}
+
+interface OpenCodeExportedSession {
+  info: {
+    id: string;
+    title: string;
+    directory: string;
+  };
+  messages: OpenCodeExportedMessage[];
+}
+
+interface OpenCodeExportedMessage {
+  info: {
+    role: "user" | "assistant";
+    id: string;
+  };
+  parts: OpenCodeExportedPart[];
+}
+
+type OpenCodeExportedPart =
+  | { type: "text"; text: string }
+  | { type: "reasoning"; text: string }
+  | {
+      type: "tool";
+      callID: string;
+      tool: string;
+      state: {
+        status: string;
+        input: Record<string, unknown>;
+        output?: string;
+        title?: string;
+        metadata?: { exit?: number; output?: string };
+      };
+    }
+  | { type: "step-start" }
+  | { type: "step-finish" };
+
+async function fetchOpenCodeSessionMessages(
+  executablePath: string,
+  sessionId: string,
+  options?: { limit?: number; offset?: number },
+): Promise<SessionMessageItem[]> {
+  const raw = await new Promise<string>((resolve, reject) => {
+    execFile(
+      executablePath,
+      ["export", sessionId],
+      { timeout: 30_000, maxBuffer: 10 * 1024 * 1024 },
+      (err, stdout) => {
+        if (err) {
+          reject(err);
+          return;
+        }
+        resolve(stdout);
+      },
+    );
+  });
+
+  // `opencode export` prefixes output with "Exporting session: ..." line
+  const jsonStart = raw.indexOf("{");
+  if (jsonStart === -1) return [];
+
+  let session: OpenCodeExportedSession;
+  try {
+    session = JSON.parse(raw.slice(jsonStart)) as OpenCodeExportedSession;
+  } catch {
+    log.warn({ sessionId }, "failed to parse exported session");
+    return [];
+  }
+
+  const offset = options?.offset ?? 0;
+  const limit = options?.limit ?? Number.POSITIVE_INFINITY;
+  const messages: SessionMessageItem[] = [];
+  let msgIndex = 0;
+
+  for (const msg of session.messages) {
+    const role = msg.info.role;
+    if (role !== "user" && role !== "assistant") continue;
+
+    const content: SessionMessageItem["content"] = [];
+
+    for (const part of msg.parts) {
+      switch (part.type) {
+        case "text":
+          if (part.text) {
+            content.push({ type: "text", text: part.text });
+          }
+          break;
+
+        case "tool":
+          content.push({
+            type: "tool_use",
+            toolCallId: part.callID,
+            toolName: part.tool,
+            input: part.state.input ?? {},
+          });
+          if (part.state.status === "completed" || part.state.status === "failed") {
+            content.push({
+              type: "tool_result",
+              toolCallId: part.callID,
+              output: part.state.output ?? part.state.metadata?.output ?? "",
+              isError: part.state.status === "failed",
+            });
+          }
+          break;
+
+        // step-start, step-finish, reasoning — skip
+      }
+    }
+
+    if (content.length === 0) continue;
+
+    if (msgIndex >= offset && msgIndex < offset + limit) {
+      messages.push({
+        role,
+        id: msg.info.id,
+        content,
+      });
+    }
+    msgIndex++;
+
+    if (msgIndex >= offset + limit) break;
+  }
+
+  return messages;
+}
+
+/**
+ * Discover skills using OpenCode's 6-directory resolution order.
+ *
+ * Priority (lowest to highest — later entries override earlier ones):
+ *   6. ~/.agents/skills/
+ *   5. ~/.claude/skills/
+ *   4. ~/.config/opencode/skills/
+ *   3. <project>/.agents/skills/
+ *   2. <project>/.claude/skills/
+ *   1. <project>/.opencode/skills/
+ */
+function discoverOpenCodeSkills(workspaceDir: string): SkillInfo[] {
+  const home = homedir();
+  const dirs = [
+    // Global (lowest priority first)
+    join(home, ".agents", "skills"),
+    join(home, ".claude", "skills"),
+    join(home, ".config", "opencode", "skills"),
+    // Project-level (overrides global)
+    join(workspaceDir, ".agents", "skills"),
+    join(workspaceDir, ".claude", "skills"),
+    join(workspaceDir, ".opencode", "skills"),
+  ];
+
+  const skillMap = new Map<string, SkillInfo>();
+  for (const dir of dirs) {
+    for (const skill of readSkillsFromDir(dir)) {
+      skillMap.set(skill.name, skill);
+    }
+  }
+
+  return Array.from(skillMap.values()).sort((a, b) => a.name.localeCompare(b.name));
+}

--- a/packages/coding-agent/src/config.ts
+++ b/packages/coding-agent/src/config.ts
@@ -60,12 +60,25 @@ const geminiCliConfigSchema = z.object({
     .default({}),
 });
 
+const opencodeConfigSchema = z.object({
+  type: z.literal("opencode"),
+  workspaceDir: z.string().default(process.cwd()),
+  maxTurns: z.number().int().positive().default(3),
+  options: z
+    .object({
+      model: z.string().optional(),
+      executablePath: z.string().optional(),
+    })
+    .default({}),
+});
+
 export const codingAgentConfigSchema = z.discriminatedUnion("type", [
   claudeCodeConfigSchema,
   cursorCliConfigSchema,
   openaiCodexConfigSchema,
   codexConfigSchema,
   geminiCliConfigSchema,
+  opencodeConfigSchema,
 ]);
 
 export type CodingAgentConfig = z.infer<typeof codingAgentConfigSchema>;
@@ -75,3 +88,4 @@ export type CursorCliConfig = z.infer<typeof cursorCliConfigSchema>;
 export type OpenAICodexConfig = z.infer<typeof openaiCodexConfigSchema>;
 export type CodexConfig = z.infer<typeof codexConfigSchema>;
 export type GeminiCliConfig = z.infer<typeof geminiCliConfigSchema>;
+export type OpenCodeConfig = z.infer<typeof opencodeConfigSchema>;

--- a/packages/coding-agent/src/factory.ts
+++ b/packages/coding-agent/src/factory.ts
@@ -23,6 +23,10 @@ export async function createCodingAgent(config: CodingAgentConfig): Promise<Codi
       const { GeminiCliAdapter } = await import("./adapters/gemini-cli.js");
       return new GeminiCliAdapter(config);
     }
+    case "opencode": {
+      const { OpenCodeAdapter } = await import("./adapters/opencode.js");
+      return new OpenCodeAdapter(config);
+    }
     default:
       throw new Error(`Unknown agent type: ${(config as { type: string }).type}`);
   }

--- a/packages/coding-agent/src/index.ts
+++ b/packages/coding-agent/src/index.ts
@@ -6,6 +6,7 @@ export {
   codingAgentConfigSchema,
   type GeminiCliConfig,
   type OpenAICodexConfig,
+  type OpenCodeConfig,
 } from "./config.js";
 export type {
   AgentEvent,

--- a/packages/dashboard-core/src/components/SettingsPage.tsx
+++ b/packages/dashboard-core/src/components/SettingsPage.tsx
@@ -35,6 +35,7 @@ const KNOWN_AGENTS: { id: string; type: CodingAgentType; label: string; defaultC
   [
     { id: "claude-code", type: "claude-code", label: "Claude Code", defaultCommand: "claude" },
     { id: "codex", type: "codex", label: "Codex", defaultCommand: "codex" },
+    { id: "opencode", type: "opencode", label: "OpenCode", defaultCommand: "opencode" },
   ];
 
 const DEFAULT_DEFAULTS = {

--- a/packages/dashboard-core/src/components/agent-icons.tsx
+++ b/packages/dashboard-core/src/components/agent-icons.tsx
@@ -32,12 +32,34 @@ export function CodexIcon({ className }: IconProps) {
   );
 }
 
+export function OpenCodeIcon({ className }: IconProps) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={2}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+      role="img"
+      aria-label="OpenCode"
+    >
+      <polyline points="4 17 10 11 4 5" />
+      <line x1="12" y1="19" x2="20" y2="19" />
+    </svg>
+  );
+}
+
 export function AgentIcon({ type, className }: { type: string; className?: string }) {
   switch (type) {
     case "claude-code":
       return <ClaudeIcon className={className} />;
     case "codex":
       return <CodexIcon className={className} />;
+    case "opencode":
+      return <OpenCodeIcon className={className} />;
     default:
       return null;
   }

--- a/packages/dashboard-core/src/types.ts
+++ b/packages/dashboard-core/src/types.ts
@@ -89,7 +89,7 @@ export interface BandConfig {
   apps?: AppConfig[];
 }
 
-export type CodingAgentType = "claude-code" | "codex" | "gemini-cli" | "cursor-cli";
+export type CodingAgentType = "claude-code" | "codex" | "gemini-cli" | "cursor-cli" | "opencode";
 
 export interface CodingAgentConfig {
   type: CodingAgentType;


### PR DESCRIPTION
## Summary

- Add OpenCode (open-source AI coding CLI) as a new coding agent option with NDJSON streaming adapter, dynamic model fetching, session listing, and skill discovery
- Fix per-workspace agent selection: router endpoints now resolve the workspace's stored `codingAgentId` instead of falling back to the global default
- Collapse visual gap between consecutive assistant messages in chat
- Queue messages when a background task is already running instead of silently failing
- Include `chatKey` in `useChat` ID so agent switches get fresh chat state (no ghost messages)

## Changes

- **New**: `packages/coding-agent/src/adapters/opencode.ts` — OpenCode adapter implementing `CodingAgent` interface
- **Modified**: `packages/coding-agent/src/config.ts` — Added `opencodeConfigSchema` Zod schema
- **Modified**: `packages/coding-agent/src/factory.ts` — Added `case "opencode"` to factory switch
- **Modified**: `packages/coding-agent/src/index.ts` — Export `OpenCodeConfig` type
- **Modified**: `packages/dashboard-core/src/types.ts` — Added `"opencode"` to `CodingAgentType`
- **Modified**: `packages/dashboard-core/src/components/SettingsPage.tsx` — Added OpenCode to known agents
- **Modified**: `packages/dashboard-core/src/components/agent-icons.tsx` — Added OpenCode icon
- **Modified**: `apps/web/src/trpc/router.ts` — Added `getWorkspaceAgent()` helper; use it in sessions, skills, modes, models endpoints
- **Modified**: `apps/web/src/components/ChatView.tsx` — Pre-check for running tasks before send; `chatKey` in useChat ID
- **Modified**: `apps/web/src/components/WorkspaceChatPanel.tsx` — Pass `chatKey` prop to ChatView
- **Modified**: `apps/web/src/components/ai-elements/conversation.tsx` — Collapse gap between consecutive assistant messages
- **Modified**: `apps/web/src/lib/task-chat-transport.ts` — Handle CONFLICT by queuing message

## Test plan

- [ ] Select OpenCode in workspace settings, verify it appears in agent dropdown
- [ ] Send a message with OpenCode selected, verify streaming response
- [ ] Switch between Claude Code and OpenCode, verify correct sessions/models load
- [ ] Send a message while a background task is running, verify it gets queued
- [ ] Verify no ghost messages appear after agent switch

🤖 Generated with [Claude Code](https://claude.com/claude-code)