### PR TITLE
feat: add interactive ExitPlanMode/AskUserQuestion support to CLI watch

### DIFF
--- a/apps/cli/src/main.rs
+++ b/apps/cli/src/main.rs
@@ -1110,7 +1110,6 @@ fn prompt_questions(
     questions: &[render::QuestionData],
     is_tty: bool,
 ) -> Result<HashMap<String, String>, String> {
-
     let mut answers = HashMap::new();
 
     for q in questions {
@@ -1190,7 +1189,9 @@ fn prompt_multi_select(q: &render::QuestionData) -> Result<String, String> {
         }
 
         if attempt < 2 {
-            eprintln!("  Invalid selection. Enter numbers from 1 to {num_options}, separated by commas.");
+            eprintln!(
+                "  Invalid selection. Enter numbers from 1 to {num_options}, separated by commas."
+            );
         }
     }
 

--- a/apps/cli/src/main.rs
+++ b/apps/cli/src/main.rs
@@ -5,6 +5,7 @@ mod state;
 mod validate;
 
 use clap::{Parser, Subcommand};
+use std::collections::HashMap;
 use std::fmt::Write;
 use std::io::BufRead;
 use std::process;
@@ -957,13 +958,14 @@ fn cmd_tasks_watch(
 
     let mut body = response.into_body();
     let reader = std::io::BufReader::new(body.as_reader());
-    stream_sse_events(reader, json_output, config)
+    stream_sse_events(reader, json_output, config, &client)
 }
 
 fn stream_sse_events(
     reader: impl BufRead,
     json_output: bool,
     config: render::RenderConfig,
+    client: &api::ApiClient,
 ) -> Result<bool, String> {
     let mut line_buf = String::new();
     let mut data_buf = String::new();
@@ -982,10 +984,14 @@ fn stream_sse_events(
 
         if line.is_empty() {
             if !data_buf.is_empty() {
-                let should_exit = process_sse_data(&data_buf, json_output, &mut renderer)?;
+                let action = process_sse_data(&data_buf, json_output, &mut renderer)?;
                 data_buf.clear();
-                if should_exit {
-                    return Ok(renderer.task_succeeded);
+                match action {
+                    render::RenderAction::Finish => return Ok(renderer.task_succeeded),
+                    render::RenderAction::NeedsInput(req) => {
+                        handle_interactive_input(&req, client)?;
+                    }
+                    render::RenderAction::Continue => {}
                 }
             }
             continue;
@@ -1007,17 +1013,215 @@ fn process_sse_data(
     data: &str,
     json_output: bool,
     renderer: &mut render::Renderer,
-) -> Result<bool, String> {
+) -> Result<render::RenderAction, String> {
     let chunk: serde_json::Value =
         serde_json::from_str(data).map_err(|e| format!("Invalid JSON in SSE: {e}"))?;
 
     if json_output {
         let chunk_type = chunk.get("type").and_then(|t| t.as_str()).unwrap_or("");
         println!("{}", serde_json::to_string(&chunk).unwrap_or_default());
-        Ok(chunk_type == "finish")
+        if chunk_type == "finish" {
+            Ok(render::RenderAction::Finish)
+        } else {
+            Ok(render::RenderAction::Continue)
+        }
     } else {
         Ok(renderer.render_chunk(&chunk))
     }
+}
+
+// ── Interactive input handling ──────────────────────────────────────
+
+fn handle_interactive_input(
+    req: &render::InteractiveRequest,
+    client: &api::ApiClient,
+) -> Result<(), String> {
+    use std::io::IsTerminal;
+
+    let is_tty = std::io::stdin().is_terminal();
+
+    let answers = match &req.kind {
+        render::InteractiveKind::PlanApproval => prompt_plan_approval(is_tty)?,
+        render::InteractiveKind::AskUserQuestion { questions } => {
+            prompt_questions(questions, is_tty)?
+        }
+    };
+
+    client.trpc_mutate(
+        "chat.answer",
+        &serde_json::json!({
+            "approvalId": req.approval_id,
+            "answers": answers,
+        }),
+    )?;
+
+    Ok(())
+}
+
+fn prompt_plan_approval(is_tty: bool) -> Result<HashMap<String, String>, String> {
+    use std::io::Write as _;
+
+    if !is_tty {
+        eprintln!("  (non-interactive: auto-approving plan)");
+        let mut answers = HashMap::new();
+        answers.insert("plan".to_string(), "approved".to_string());
+        return Ok(answers);
+    }
+
+    for attempt in 0..3 {
+        eprint!("  Approve plan? [y/n]: ");
+        std::io::stderr().flush().ok();
+
+        let mut input = String::new();
+        std::io::stdin()
+            .read_line(&mut input)
+            .map_err(|e| format!("Failed to read input: {e}"))?;
+
+        let trimmed = input.trim().to_lowercase();
+        match trimmed.as_str() {
+            "y" | "yes" => {
+                eprintln!("  Plan approved — agent continuing");
+                let mut answers = HashMap::new();
+                answers.insert("plan".to_string(), "approved".to_string());
+                return Ok(answers);
+            }
+            "n" | "no" => {
+                eprintln!("  Plan rejected");
+                let mut answers = HashMap::new();
+                answers.insert("plan".to_string(), "rejected".to_string());
+                return Ok(answers);
+            }
+            _ => {
+                if attempt < 2 {
+                    eprintln!("  Please enter y or n.");
+                }
+            }
+        }
+    }
+
+    // After 3 invalid attempts, default to approved.
+    eprintln!("  (defaulting to approved)");
+    let mut answers = HashMap::new();
+    answers.insert("plan".to_string(), "approved".to_string());
+    Ok(answers)
+}
+
+fn prompt_questions(
+    questions: &[render::QuestionData],
+    is_tty: bool,
+) -> Result<HashMap<String, String>, String> {
+
+    let mut answers = HashMap::new();
+
+    for q in questions {
+        if q.options.is_empty() {
+            continue;
+        }
+
+        if !is_tty {
+            let first_label = &q.options[0].label;
+            eprintln!("  (non-interactive: selecting \"{first_label}\")");
+            answers.insert(q.question.clone(), first_label.clone());
+            continue;
+        }
+
+        let selected = if q.multi_select {
+            prompt_multi_select(q)?
+        } else {
+            prompt_single_select(q)?
+        };
+
+        if !selected.is_empty() {
+            answers.insert(q.question.clone(), selected);
+        }
+    }
+
+    Ok(answers)
+}
+
+fn prompt_single_select(q: &render::QuestionData) -> Result<String, String> {
+    use std::io::Write as _;
+
+    let num_options = q.options.len();
+
+    for attempt in 0..3 {
+        eprint!("  Select option [1-{num_options}]: ");
+        std::io::stderr().flush().ok();
+
+        let mut input = String::new();
+        std::io::stdin()
+            .read_line(&mut input)
+            .map_err(|e| format!("Failed to read input: {e}"))?;
+
+        if let Some(label) = parse_single_selection(input.trim(), &q.options) {
+            eprintln!("  Selected: {label}");
+            return Ok(label);
+        }
+
+        if attempt < 2 {
+            eprintln!("  Invalid selection. Enter a number from 1 to {num_options}.");
+        }
+    }
+
+    // Default to first option after 3 failed attempts.
+    let label = q.options[0].label.clone();
+    eprintln!("  (defaulting to \"{label}\")");
+    Ok(label)
+}
+
+fn prompt_multi_select(q: &render::QuestionData) -> Result<String, String> {
+    use std::io::Write as _;
+
+    let num_options = q.options.len();
+
+    for attempt in 0..3 {
+        eprint!("  Select options (comma-separated, e.g. 1,3) [1-{num_options}]: ");
+        std::io::stderr().flush().ok();
+
+        let mut input = String::new();
+        std::io::stdin()
+            .read_line(&mut input)
+            .map_err(|e| format!("Failed to read input: {e}"))?;
+
+        let labels = parse_multi_selection(input.trim(), &q.options);
+        if !labels.is_empty() {
+            eprintln!("  Selected: {labels}");
+            return Ok(labels);
+        }
+
+        if attempt < 2 {
+            eprintln!("  Invalid selection. Enter numbers from 1 to {num_options}, separated by commas.");
+        }
+    }
+
+    // Default to first option after 3 failed attempts.
+    let label = q.options[0].label.clone();
+    eprintln!("  (defaulting to \"{label}\")");
+    Ok(label)
+}
+
+fn parse_single_selection(input: &str, options: &[render::OptionData]) -> Option<String> {
+    let num: usize = input.parse().ok()?;
+    if num >= 1 && num <= options.len() {
+        Some(options[num - 1].label.clone())
+    } else {
+        None
+    }
+}
+
+fn parse_multi_selection(input: &str, options: &[render::OptionData]) -> String {
+    let labels: Vec<&str> = input
+        .split(',')
+        .filter_map(|s| {
+            let num: usize = s.trim().parse().ok()?;
+            if num >= 1 && num <= options.len() {
+                Some(options[num - 1].label.as_str())
+            } else {
+                None
+            }
+        })
+        .collect();
+    labels.join(", ")
 }
 
 /// Resolve a task ID (tsk_*) or workspace ID to a workspace ID.

--- a/apps/cli/src/render.rs
+++ b/apps/cli/src/render.rs
@@ -47,6 +47,49 @@ impl RenderConfig {
     }
 }
 
+// ── Interactive input types ────────────────────────────────────────
+
+/// What the SSE loop should do after rendering a chunk.
+pub enum RenderAction {
+    /// Keep reading SSE events.
+    Continue,
+    /// Stream finished (received "finish" chunk).
+    Finish,
+    /// An interactive tool needs user input before continuing.
+    NeedsInput(InteractiveRequest),
+}
+
+/// A request for user input from an interactive tool.
+pub struct InteractiveRequest {
+    /// The approval ID to send back with the answer (equals toolCallId).
+    pub approval_id: String,
+    /// What kind of interactive input is needed.
+    pub kind: InteractiveKind,
+}
+
+/// The specific kind of interactive input.
+pub enum InteractiveKind {
+    /// `ExitPlanMode` — user must approve or reject the plan.
+    /// The plan content is already displayed by the renderer before this is returned.
+    PlanApproval,
+    /// `AskUserQuestion` — user must answer one or more questions.
+    AskUserQuestion { questions: Vec<QuestionData> },
+}
+
+/// A single question from `AskUserQuestion`.
+pub struct QuestionData {
+    pub question: String,
+    pub header: Option<String>,
+    pub options: Vec<OptionData>,
+    pub multi_select: bool,
+}
+
+/// A single option for a question.
+pub struct OptionData {
+    pub label: String,
+    pub description: Option<String>,
+}
+
 // ── ANSI escape helpers ────────────────────────────────────────────
 
 struct Ansi {
@@ -105,6 +148,14 @@ impl Ansi {
             ""
         }
     }
+
+    fn cyan(&self) -> &str {
+        if self.color {
+            "\x1b[36m"
+        } else {
+            ""
+        }
+    }
 }
 
 // ── Tool call tracking ─────────────────────────────────────────────
@@ -143,23 +194,27 @@ impl Renderer {
     }
 
     /// Main dispatch: render a single SSE chunk.
-    /// Returns `true` if this was a `"finish"` chunk (caller should exit).
-    pub fn render_chunk(&mut self, chunk: &serde_json::Value) -> bool {
+    /// Returns a `RenderAction` indicating what the caller should do next.
+    pub fn render_chunk(&mut self, chunk: &serde_json::Value) -> RenderAction {
         let chunk_type = chunk.get("type").and_then(|t| t.as_str()).unwrap_or("");
 
         match chunk_type {
             "text-delta" => self.on_text_delta(chunk),
             "text-end" => self.on_text_end(),
-            "tool-input-available" => self.on_tool_input(chunk),
+            "tool-input-available" => {
+                if let Some(req) = self.on_tool_input(chunk) {
+                    return RenderAction::NeedsInput(req);
+                }
+            }
             "tool-output-available" => self.on_tool_output(chunk),
             "error" => self.on_error(chunk),
             "data-result" => self.on_data_result(chunk),
-            "finish" => return true,
+            "finish" => return RenderAction::Finish,
             // text-start, data-session, data-prompt, finish-step, file — no rendering
             _ => {}
         }
 
-        false
+        RenderAction::Continue
     }
 
     // ── Chunk handlers ─────────────────────────────────────────────
@@ -176,11 +231,10 @@ impl Renderer {
         self.in_text = false;
     }
 
-    fn on_tool_input(&mut self, chunk: &serde_json::Value) {
+    /// Handle a tool-input-available chunk.
+    /// Returns `Some(InteractiveRequest)` if this is an interactive tool that needs user input.
+    fn on_tool_input(&mut self, chunk: &serde_json::Value) -> Option<InteractiveRequest> {
         let tool_display = self.config.effective_tool_display();
-        if tool_display == ToolDisplay::Off {
-            return;
-        }
 
         // If stdout cursor is mid-line, add a newline so the tool line starts fresh.
         if self.needs_newline {
@@ -198,6 +252,37 @@ impl Renderer {
             .and_then(|n| n.as_str())
             .unwrap_or("");
         let input = chunk.get("input").unwrap_or(&serde_json::Value::Null);
+
+        // Check for interactive tools first.
+        match tool_name {
+            "ExitPlanMode" => {
+                let plan = input
+                    .get("plan")
+                    .and_then(|p| p.as_str())
+                    .unwrap_or("")
+                    .to_string();
+                self.display_plan_review(&plan);
+                return Some(InteractiveRequest {
+                    approval_id: tool_call_id.to_string(),
+                    kind: InteractiveKind::PlanApproval,
+                });
+            }
+            "AskUserQuestion" => {
+                let questions = parse_questions(input);
+                self.display_questions(&questions);
+                return Some(InteractiveRequest {
+                    approval_id: tool_call_id.to_string(),
+                    kind: InteractiveKind::AskUserQuestion { questions },
+                });
+            }
+            _ => {}
+        }
+
+        // Regular tool — show normal summary.
+        if tool_display == ToolDisplay::Off {
+            return None;
+        }
+
         let summary = tool_summary(tool_name, input);
 
         // Store for later correlation with output.
@@ -229,6 +314,8 @@ impl Renderer {
                 }
             }
         }
+
+        None
     }
 
     fn on_tool_output(&mut self, chunk: &serde_json::Value) {
@@ -350,6 +437,101 @@ impl Renderer {
             eprintln!("\n{}{}Task completed.{}", a.green(), a.bold(), a.reset(),);
         }
     }
+
+    // ── Interactive display helpers ─────────────────────────────────
+
+    fn display_plan_review(&self, plan: &str) {
+        let a = &self.ansi;
+        let separator = "\u{2500}".repeat(50);
+        eprintln!(
+            "\n  {}{}{separator}{}",
+            a.cyan(),
+            a.bold(),
+            a.reset(),
+        );
+        eprintln!(
+            "  {}{}  Plan Review{}",
+            a.cyan(),
+            a.bold(),
+            a.reset(),
+        );
+        eprintln!(
+            "  {}{}{separator}{}",
+            a.cyan(),
+            a.bold(),
+            a.reset(),
+        );
+        if !plan.is_empty() {
+            eprintln!();
+            for line in plan.lines() {
+                eprintln!("  {line}");
+            }
+            eprintln!();
+        }
+        eprintln!(
+            "  {}{}{separator}{}",
+            a.cyan(),
+            a.bold(),
+            a.reset(),
+        );
+    }
+
+    fn display_questions(&self, questions: &[QuestionData]) {
+        let a = &self.ansi;
+        let separator = "\u{2500}".repeat(50);
+
+        for q in questions {
+            eprintln!(
+                "\n  {}{}{separator}{}",
+                a.cyan(),
+                a.bold(),
+                a.reset(),
+            );
+            if let Some(header) = &q.header {
+                eprintln!(
+                    "  {}{}  {header}{}",
+                    a.cyan(),
+                    a.bold(),
+                    a.reset(),
+                );
+            }
+            eprintln!(
+                "  {}{}  {}{}",
+                a.cyan(),
+                a.bold(),
+                q.question,
+                a.reset(),
+            );
+            eprintln!(
+                "  {}{}{separator}{}",
+                a.cyan(),
+                a.bold(),
+                a.reset(),
+            );
+            for (i, opt) in q.options.iter().enumerate() {
+                let num = i + 1;
+                if let Some(desc) = &opt.description {
+                    eprintln!(
+                        "  {}{}  {num}){} {} {}\u{2014} {desc}{}",
+                        a.yellow(),
+                        a.bold(),
+                        a.reset(),
+                        opt.label,
+                        a.dim(),
+                        a.reset(),
+                    );
+                } else {
+                    eprintln!(
+                        "  {}{}  {num}){} {}",
+                        a.yellow(),
+                        a.bold(),
+                        a.reset(),
+                        opt.label,
+                    );
+                }
+            }
+        }
+    }
 }
 
 // ── Helpers ────────────────────────────────────────────────────────
@@ -373,4 +555,56 @@ pub fn tool_summary(name: &str, args: &serde_json::Value) -> String {
         }
     }
     name.to_string()
+}
+
+/// Parse the `input.questions` JSON array into typed `QuestionData` structs.
+fn parse_questions(input: &serde_json::Value) -> Vec<QuestionData> {
+    let Some(questions) = input.get("questions").and_then(|q| q.as_array()) else {
+        return Vec::new();
+    };
+
+    questions
+        .iter()
+        .map(|q| {
+            let question = q
+                .get("question")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string();
+            let header = q
+                .get("header")
+                .and_then(|v| v.as_str())
+                .map(String::from);
+            let multi_select = q
+                .get("multiSelect")
+                .and_then(serde_json::Value::as_bool)
+                .unwrap_or(false);
+            let options = q
+                .get("options")
+                .and_then(|v| v.as_array())
+                .map(|opts| {
+                    opts.iter()
+                        .map(|o| OptionData {
+                            label: o
+                                .get("label")
+                                .and_then(|v| v.as_str())
+                                .unwrap_or("")
+                                .to_string(),
+                            description: o
+                                .get("description")
+                                .and_then(|v| v.as_str())
+                                .map(String::from),
+                        })
+                        .collect()
+                })
+                .unwrap_or_default();
+
+            QuestionData {
+                question,
+                header,
+                options,
+                multi_select,
+            }
+        })
+        .collect()
 }

--- a/apps/cli/src/render.rs
+++ b/apps/cli/src/render.rs
@@ -443,24 +443,9 @@ impl Renderer {
     fn display_plan_review(&self, plan: &str) {
         let a = &self.ansi;
         let separator = "\u{2500}".repeat(50);
-        eprintln!(
-            "\n  {}{}{separator}{}",
-            a.cyan(),
-            a.bold(),
-            a.reset(),
-        );
-        eprintln!(
-            "  {}{}  Plan Review{}",
-            a.cyan(),
-            a.bold(),
-            a.reset(),
-        );
-        eprintln!(
-            "  {}{}{separator}{}",
-            a.cyan(),
-            a.bold(),
-            a.reset(),
-        );
+        eprintln!("\n  {}{}{separator}{}", a.cyan(), a.bold(), a.reset(),);
+        eprintln!("  {}{}  Plan Review{}", a.cyan(), a.bold(), a.reset(),);
+        eprintln!("  {}{}{separator}{}", a.cyan(), a.bold(), a.reset(),);
         if !plan.is_empty() {
             eprintln!();
             for line in plan.lines() {
@@ -468,12 +453,7 @@ impl Renderer {
             }
             eprintln!();
         }
-        eprintln!(
-            "  {}{}{separator}{}",
-            a.cyan(),
-            a.bold(),
-            a.reset(),
-        );
+        eprintln!("  {}{}{separator}{}", a.cyan(), a.bold(), a.reset(),);
     }
 
     fn display_questions(&self, questions: &[QuestionData]) {
@@ -481,33 +461,12 @@ impl Renderer {
         let separator = "\u{2500}".repeat(50);
 
         for q in questions {
-            eprintln!(
-                "\n  {}{}{separator}{}",
-                a.cyan(),
-                a.bold(),
-                a.reset(),
-            );
+            eprintln!("\n  {}{}{separator}{}", a.cyan(), a.bold(), a.reset(),);
             if let Some(header) = &q.header {
-                eprintln!(
-                    "  {}{}  {header}{}",
-                    a.cyan(),
-                    a.bold(),
-                    a.reset(),
-                );
+                eprintln!("  {}{}  {header}{}", a.cyan(), a.bold(), a.reset(),);
             }
-            eprintln!(
-                "  {}{}  {}{}",
-                a.cyan(),
-                a.bold(),
-                q.question,
-                a.reset(),
-            );
-            eprintln!(
-                "  {}{}{separator}{}",
-                a.cyan(),
-                a.bold(),
-                a.reset(),
-            );
+            eprintln!("  {}{}  {}{}", a.cyan(), a.bold(), q.question, a.reset(),);
+            eprintln!("  {}{}{separator}{}", a.cyan(), a.bold(), a.reset(),);
             for (i, opt) in q.options.iter().enumerate() {
                 let num = i + 1;
                 if let Some(desc) = &opt.description {
@@ -571,10 +530,7 @@ fn parse_questions(input: &serde_json::Value) -> Vec<QuestionData> {
                 .and_then(|v| v.as_str())
                 .unwrap_or("")
                 .to_string();
-            let header = q
-                .get("header")
-                .and_then(|v| v.as_str())
-                .map(String::from);
+            let header = q.get("header").and_then(|v| v.as_str()).map(String::from);
             let multi_select = q
                 .get("multiSelect")
                 .and_then(serde_json::Value::as_bool)


### PR DESCRIPTION
## Summary

- When the coding agent calls `ExitPlanMode` or `AskUserQuestion` during `band tasks watch`, the CLI now detects these interactive tool calls, displays the content, and prompts for user input
- Plan approval shows the plan content in a bordered box and prompts `Approve plan? [y/n]`
- Question answering shows numbered options and prompts for selection (single or multi-select)
- User responses are sent back via the `chat.answer` tRPC endpoint, unblocking the agent
- Non-TTY mode auto-approves plans and selects first option to prevent hanging in CI/scripts

## Changes

- `render.rs`: Added `RenderAction` enum (replaces `bool` return), `InteractiveRequest`/`InteractiveKind` types, plan/question display formatting, `parse_questions` helper
- `main.rs`: Threaded `ApiClient` through SSE loop, added `handle_interactive_input`, `prompt_plan_approval`, `prompt_questions`, `prompt_single_select`, `prompt_multi_select`, `parse_single_selection`, `parse_multi_selection`

## Test plan

- [x] `cargo build` — compiles cleanly
- [x] `cargo clippy` — no warnings
- [x] All 18 existing `watch_render_*` integration tests pass
- [ ] Manual test: trigger ExitPlanMode, verify plan displayed and approve/reject works
- [ ] Manual test: trigger AskUserQuestion, verify options displayed and selection works
- [ ] Manual test: non-TTY mode (`echo "" | band tasks watch`) auto-approves

🤖 Generated with [Claude Code](https://claude.com/claude-code)