### PR TITLE
feat: add mode and agent icons to webchat

### DIFF
--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -1,4 +1,5 @@
 import { useChat } from "@ai-sdk/react";
+import { AgentIcon } from "@band-app/dashboard-core";
 import {
   Badge,
   cn,
@@ -9,7 +10,7 @@ import {
 } from "@band-app/ui";
 import type { UIMessage } from "ai";
 import { getToolName, isToolUIPart } from "ai";
-import { Bot, ChevronDown, Clock, Loader2, X } from "lucide-react";
+import { Bot, ChevronDown, Clock, CodeXml, Loader2, ScrollText, X } from "lucide-react";
 import { Fragment, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { TaskChatTransport } from "../lib/task-chat-transport";
 import { trpc } from "../lib/trpc-client";
@@ -233,7 +234,9 @@ interface ChatViewProps {
   showSessionList: boolean;
   onShowSessionListChange: (show: boolean) => void;
   onStreamingChange?: (streaming: boolean) => void;
+  onNewSessionRef?: React.MutableRefObject<(() => void) | null>;
   chatKey?: number;
+  agentType?: string;
 }
 
 export function ChatView({
@@ -244,7 +247,9 @@ export function ChatView({
   showSessionList,
   onShowSessionListChange,
   onStreamingChange,
+  onNewSessionRef,
   chatKey = 0,
+  agentType,
 }: ChatViewProps) {
   const sessionIdRef = useRef<string | undefined>(undefined);
   const [activeSessionId, setActiveSessionId] = useState<string | undefined>(undefined);
@@ -460,6 +465,17 @@ export function ChatView({
     onShowSessionListChange(false);
   }, [setMessages, onShowSessionListChange, workspaceId]);
 
+  useEffect(() => {
+    if (onNewSessionRef) {
+      onNewSessionRef.current = handleNewSession;
+    }
+    return () => {
+      if (onNewSessionRef) {
+        onNewSessionRef.current = null;
+      }
+    };
+  }, [onNewSessionRef, handleNewSession]);
+
   const queueMessage = useCallback(
     (text: string) => {
       setQueuedMessages((prev) => [...prev, text]);
@@ -557,7 +573,6 @@ export function ChatView({
         workspaceId={workspaceId}
         activeSessionId={activeSessionId ?? sessionIdRef.current}
         onSelectSession={handleSelectSession}
-        onNewSession={handleNewSession}
       />
     );
   }
@@ -568,7 +583,13 @@ export function ChatView({
         <ConversationContent>
           {isEmpty && (
             <ConversationEmptyState
-              icon={<Bot className="size-8" />}
+              icon={
+                agentType ? (
+                  <AgentIcon type={agentType} className="size-8" />
+                ) : (
+                  <Bot className="size-8" />
+                )
+              }
               title={workspaceName}
               description="Send a message to start coding"
             />
@@ -763,7 +784,12 @@ export function ChatView({
             <div className="flex items-center gap-0.5">
               <PromptInputAttach />
               {models.length > 0 && (
-                <ModelMenu models={models} selected={selectedModel} onSelect={setSelectedModel} />
+                <ModelMenu
+                  models={models}
+                  selected={selectedModel}
+                  onSelect={setSelectedModel}
+                  agentType={agentType}
+                />
               )}
               {modes.length > 0 && (
                 <ModeMenu modes={modes} selected={selectedMode} onSelect={handleModeSelect} />
@@ -779,6 +805,17 @@ export function ChatView({
       </div>
     </div>
   );
+}
+
+function ModeIcon({ modeId, className }: { modeId: string; className?: string }) {
+  switch (modeId) {
+    case "plan":
+      return <ScrollText className={className} />;
+    case "edit":
+      return <CodeXml className={className} />;
+    default:
+      return <ChevronDown className={className} />;
+  }
 }
 
 function ModeMenu({
@@ -798,7 +835,7 @@ function ModeMenu({
           type="button"
           className="inline-flex items-center gap-1 rounded-md px-2 py-1 text-xs font-medium text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
         >
-          <ChevronDown className="size-3" />
+          <ModeIcon modeId={current?.id ?? ""} className="size-3" />
           {current?.name ?? "Mode"}
         </button>
       </DropdownMenuTrigger>
@@ -808,14 +845,17 @@ function ModeMenu({
             key={mode.id}
             onClick={() => onSelect(mode.id)}
             className={cn(
-              "flex flex-col items-start gap-0.5",
+              "flex items-start gap-2",
               mode.id === (selected ?? modes[0]?.id) ? "bg-accent" : "",
             )}
           >
-            <span className="text-sm font-medium">{mode.name}</span>
-            {mode.description && (
-              <span className="text-xs text-muted-foreground">{mode.description}</span>
-            )}
+            <ModeIcon modeId={mode.id} className="size-4 mt-0.5 shrink-0" />
+            <div className="flex flex-col gap-0.5">
+              <span className="text-sm font-medium">{mode.name}</span>
+              {mode.description && (
+                <span className="text-xs text-muted-foreground">{mode.description}</span>
+              )}
+            </div>
           </DropdownMenuItem>
         ))}
       </DropdownMenuContent>
@@ -827,10 +867,12 @@ function ModelMenu({
   models,
   selected,
   onSelect,
+  agentType,
 }: {
   models: { id: string; name: string; description?: string }[];
   selected: string | undefined;
   onSelect: (model: string | undefined) => void;
+  agentType?: string;
 }) {
   const current = models.find((m) => m.id === selected) ?? models[0];
   return (
@@ -840,7 +882,11 @@ function ModelMenu({
           type="button"
           className="inline-flex items-center gap-1 rounded-md px-2 py-1 text-xs font-medium text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
         >
-          <ChevronDown className="size-3" />
+          {agentType ? (
+            <AgentIcon type={agentType} className="size-3" />
+          ) : (
+            <ChevronDown className="size-3" />
+          )}
           {current?.name ?? "Model"}
         </button>
       </DropdownMenuTrigger>

--- a/apps/web/src/components/SessionList.tsx
+++ b/apps/web/src/components/SessionList.tsx
@@ -1,4 +1,4 @@
-import { GitBranch, Loader2, MessageSquare, Plus, RefreshCw } from "lucide-react";
+import { GitBranch, Loader2, MessageSquare, RefreshCw } from "lucide-react";
 import { useCallback, useEffect, useState } from "react";
 import { trpc } from "../lib/trpc-client";
 
@@ -14,7 +14,6 @@ interface SessionListProps {
   workspaceId: string;
   activeSessionId?: string;
   onSelectSession: (sessionId: string) => void;
-  onNewSession: () => void;
 }
 
 function relativeTime(ms: number): string {
@@ -30,12 +29,7 @@ function relativeTime(ms: number): string {
   return `${months}mo ago`;
 }
 
-export function SessionList({
-  workspaceId,
-  activeSessionId,
-  onSelectSession,
-  onNewSession,
-}: SessionListProps) {
+export function SessionList({ workspaceId, activeSessionId, onSelectSession }: SessionListProps) {
   const [sessions, setSessions] = useState<SessionItem[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -83,17 +77,6 @@ export function SessionList({
 
   return (
     <div className="mx-auto flex h-full w-full max-w-2xl flex-col">
-      <div className="shrink-0 p-3 pb-1">
-        <button
-          type="button"
-          onClick={onNewSession}
-          className="flex w-full items-center justify-center gap-2 rounded-lg bg-primary px-4 py-2.5 text-base font-medium text-primary-foreground transition-colors hover:bg-primary/90 active:bg-primary/80"
-        >
-          <Plus className="size-4" />
-          New Session
-        </button>
-      </div>
-
       {sessions.length === 0 ? (
         <div className="flex flex-1 flex-col items-center justify-center gap-3 p-8 text-center">
           <MessageSquare className="size-10 text-muted-foreground" />

--- a/apps/web/src/components/WorkspaceChatPanel.tsx
+++ b/apps/web/src/components/WorkspaceChatPanel.tsx
@@ -1,6 +1,6 @@
 import { AgentIcon } from "@band-app/dashboard-core";
-import { ChevronDown, Clock } from "lucide-react";
-import { useCallback, useEffect, useState } from "react";
+import { ChevronDown, Clock, Plus } from "lucide-react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { trpc } from "../lib/trpc-client";
 import { ChatView } from "./ChatView";
 
@@ -24,6 +24,7 @@ export function WorkspaceChatPanel({ workspaceId }: WorkspaceChatPanelProps) {
   const [taskRunning, setTaskRunning] = useState(false);
   // Incremented on agent switch to force ChatView remount
   const [chatKey, setChatKey] = useState(0);
+  const newSessionRef = useRef<(() => void) | null>(null);
 
   useEffect(() => {
     let cancelled = false;
@@ -185,13 +186,23 @@ export function WorkspaceChatPanel({ workspaceId }: WorkspaceChatPanelProps) {
           </div>
         )}
         {supportsSessionListing && (
-          <button
-            type="button"
-            onClick={handleToggleSessionList}
-            className={`inline-flex size-8 items-center justify-center rounded-md transition-colors hover:bg-accent ${showSessionList ? "bg-accent text-foreground" : "text-muted-foreground"}`}
-          >
-            <Clock className="size-4" />
-          </button>
+          <div className="flex items-center gap-0.5">
+            <button
+              type="button"
+              onClick={handleToggleSessionList}
+              className={`inline-flex size-8 items-center justify-center rounded-md transition-colors hover:bg-accent ${showSessionList ? "bg-accent text-foreground" : "text-muted-foreground"}`}
+            >
+              <Clock className="size-4" />
+            </button>
+            <button
+              type="button"
+              onClick={() => newSessionRef.current?.()}
+              className="inline-flex size-8 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+              title="New session"
+            >
+              <Plus className="size-4" />
+            </button>
+          </div>
         )}
       </header>
       <div className="flex min-h-0 flex-1 flex-col">
@@ -205,6 +216,8 @@ export function WorkspaceChatPanel({ workspaceId }: WorkspaceChatPanelProps) {
           showSessionList={showSessionList}
           onShowSessionListChange={setShowSessionList}
           onStreamingChange={setTaskRunning}
+          onNewSessionRef={newSessionRef}
+          agentType={currentAgent?.type}
         />
       </div>
     </div>

--- a/apps/web/src/hooks/useAgentSwitcherContext.ts
+++ b/apps/web/src/hooks/useAgentSwitcherContext.ts
@@ -1,8 +1,11 @@
+import type React from "react";
 import { createContext, useContext } from "react";
 
 export interface AgentSwitcherContextValue {
   chatKey: number;
   setTaskRunning: (running: boolean) => void;
+  agentType?: string;
+  newSessionRef?: React.MutableRefObject<(() => void) | null>;
 }
 
 export const AgentSwitcherContext = createContext<AgentSwitcherContextValue>({

--- a/apps/web/src/routes/workspace.$workspaceId.index.tsx
+++ b/apps/web/src/routes/workspace.$workspaceId.index.tsx
@@ -29,7 +29,7 @@ function MobileChatContent({ workspaceId }: { workspaceId: string }) {
   const [supportsSessionListing, setSupportsSessionListing] = useState(false);
   const [initialSessionId, setInitialSessionId] = useState<string | undefined>(undefined);
   const { showSessionList, setShowSessionList } = useSessionListContext();
-  const { chatKey, setTaskRunning } = useAgentSwitcherContext();
+  const { chatKey, setTaskRunning, agentType, newSessionRef } = useAgentSwitcherContext();
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: chatKey intentionally triggers reload after agent switch
   useEffect(() => {
@@ -64,6 +64,8 @@ function MobileChatContent({ workspaceId }: { workspaceId: string }) {
         showSessionList={showSessionList}
         onShowSessionListChange={setShowSessionList}
         onStreamingChange={setTaskRunning}
+        onNewSessionRef={newSessionRef}
+        agentType={agentType}
       />
     </div>
   );

--- a/apps/web/src/routes/workspace.$workspaceId.tsx
+++ b/apps/web/src/routes/workspace.$workspaceId.tsx
@@ -8,7 +8,7 @@ import {
   WorkspaceTabNav,
 } from "@band-app/dashboard-core";
 import { createFileRoute, Link, Outlet, useNavigate, useRouterState } from "@tanstack/react-router";
-import { ArrowLeft, ChevronDown, Clock, Code, GitCompare, Terminal } from "lucide-react";
+import { ArrowLeft, ChevronDown, Clock, Code, GitCompare, Plus, Terminal } from "lucide-react";
 import {
   createContext,
   useCallback,
@@ -328,6 +328,7 @@ function MobileWorkspaceLayout({
   const [showAgentMenu, setShowAgentMenu] = useState(false);
   const [taskRunning, setTaskRunning] = useState(false);
   const [chatKey, setChatKey] = useState(0);
+  const newSessionRef = useRef<(() => void) | null>(null);
 
   useEffect(() => {
     if (!isTauri) {
@@ -436,7 +437,9 @@ function MobileWorkspaceLayout({
     <SessionListContext.Provider
       value={{ showSessionList, setShowSessionList: handleSetShowSessionList }}
     >
-      <AgentSwitcherContext.Provider value={{ chatKey, setTaskRunning }}>
+      <AgentSwitcherContext.Provider
+        value={{ chatKey, setTaskRunning, agentType: currentAgent?.type, newSessionRef }}
+      >
         <div
           className="flex flex-col overflow-hidden"
           style={{
@@ -504,13 +507,23 @@ function MobileWorkspaceLayout({
               </div>
             )}
             {supportsSessionListing && activeTab === "chat" && (
-              <button
-                type="button"
-                onClick={handleToggleSessionList}
-                className={`inline-flex size-8 items-center justify-center rounded-md transition-colors hover:bg-accent ${showSessionList ? "bg-accent text-foreground" : "text-muted-foreground"}`}
-              >
-                <Clock className="size-4" />
-              </button>
+              <div className="flex items-center gap-0.5">
+                <button
+                  type="button"
+                  onClick={handleToggleSessionList}
+                  className={`inline-flex size-8 items-center justify-center rounded-md transition-colors hover:bg-accent ${showSessionList ? "bg-accent text-foreground" : "text-muted-foreground"}`}
+                >
+                  <Clock className="size-4" />
+                </button>
+                <button
+                  type="button"
+                  onClick={() => newSessionRef.current?.()}
+                  className="inline-flex size-8 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+                  title="New session"
+                >
+                  <Plus className="size-4" />
+                </button>
+              </div>
             )}
           </header>
           <WorkspaceTabNav


### PR DESCRIPTION
## Summary
- Add mode-specific icons in webchat: ScrollText for plan mode, CodeXml for edit mode
- Show coding agent icon (Claude/Codex/OpenCode) in the model selector and empty state
- Extract "New Session" button from session list panel into the header as a + icon next to history

## Test plan
- [ ] Verify plan/edit mode icons show correctly in mode dropdown
- [ ] Verify agent icon appears in model selector and empty chat state
- [ ] Verify new session + button works from header
- [ ] Verify session history panel no longer has redundant "New Session" button

🤖 Generated with [Claude Code](https://claude.com/claude-code)