### PR TITLE
fix: git pull from UI shows error when pull succeeds

### DIFF
--- a/apps/web/src/trpc/router.ts
+++ b/apps/web/src/trpc/router.ts
@@ -414,7 +414,21 @@ const workspacesRouter = t.router({
         throw new Error("Workspace not found");
       }
       const cwd = workspace.worktree.path;
-      await execGit(["pull", "--rebase"], cwd);
+      try {
+        await execGit(["pull", "--rebase"], cwd);
+      } catch (e) {
+        // git pull --rebase can exit non-zero with "Cannot rebase onto multiple
+        // branches" when the fetch step already fast-forwarded the working tree.
+        // The pull effectively succeeded, so swallow this specific error.
+        const msg = String(e);
+        if (
+          msg.includes("fast-forwarding your working tree") &&
+          msg.includes("Cannot rebase onto multiple branches")
+        ) {
+          return { ok: true };
+        }
+        throw e;
+      }
       return { ok: true };
     }),
 


### PR DESCRIPTION
## Summary
- Fix git pull from Band UI showing error message even when pull actually succeeds
- `git pull --rebase` can exit non-zero with "Cannot rebase onto multiple branches" when the fetch step already fast-forwarded the working tree
- Catch this specific benign error pattern in the `gitPull` tRPC handler and treat it as success

## Test plan
- [ ] Trigger a git pull from the Band UI when the branch is behind remote
- [ ] Verify that the pull succeeds without showing an error message
- [ ] Verify that actual git pull errors (e.g., merge conflicts) still surface correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)