### PR TITLE
feat: add load more context to diff view

### DIFF
--- a/apps/web/src/trpc/router.ts
+++ b/apps/web/src/trpc/router.ts
@@ -576,87 +576,99 @@ const LANG_MAP: Record<string, string> = {
 };
 
 const workspaceRouter = t.router({
-  getDiff: publicProcedure.input(z.object({ workspaceId: z.string() })).query(async ({ input }) => {
-    const workspace = resolveWorkspace(input.workspaceId);
-    if (!workspace) {
-      throw new Error("Workspace not found");
-    }
-
-    const cwd = workspace.worktree.path;
-    const defaultBranch = workspace.project.defaultBranch;
-
-    const headBranch = (await execGit(["rev-parse", "--abbrev-ref", "HEAD"], cwd)).trim();
-
-    let mergeBase: string;
-    try {
-      mergeBase = (await execGit(["merge-base", defaultBranch, "HEAD"], cwd)).trim();
-    } catch {
-      mergeBase = (await execGit(["hash-object", "-t", "tree", "/dev/null"], cwd)).trim();
-    }
-
-    let diff = await execGit(["diff", mergeBase], cwd);
-
-    const statOutput = await execGit(["diff", "--stat", mergeBase], cwd);
-    const statLines = statOutput.trim().split("\n");
-    const summaryLine = statLines[statLines.length - 1] || "";
-
-    let filesChanged = 0;
-    let insertions = 0;
-    let deletions = 0;
-
-    const filesMatch = summaryLine.match(/(\d+)\s+files?\s+changed/);
-    const insertMatch = summaryLine.match(/(\d+)\s+insertions?\(\+\)/);
-    const deleteMatch = summaryLine.match(/(\d+)\s+deletions?\(-\)/);
-
-    if (filesMatch) filesChanged = Number.parseInt(filesMatch[1], 10);
-    if (insertMatch) insertions = Number.parseInt(insertMatch[1], 10);
-    if (deleteMatch) deletions = Number.parseInt(deleteMatch[1], 10);
-
-    const fileStatuses: Record<string, string> = {};
-    const nameStatusOutput = await execGit(["diff", "--name-status", mergeBase], cwd);
-    for (const line of nameStatusOutput.trim().split("\n").filter(Boolean)) {
-      const parts = line.split("\t");
-      const statusCode = parts[0][0];
-      if (statusCode === "R" && parts[2]) {
-        fileStatuses[parts[2]] = "R";
-      } else if (parts[1]) {
-        fileStatuses[parts[1]] = statusCode;
+  getDiff: publicProcedure
+    .input(
+      z.object({
+        workspaceId: z.string(),
+        contextLines: z.number().int().min(0).max(99999).optional(),
+      }),
+    )
+    .query(async ({ input }) => {
+      const workspace = resolveWorkspace(input.workspaceId);
+      if (!workspace) {
+        throw new Error("Workspace not found");
       }
-    }
 
-    const untrackedOutput = await execGit(["ls-files", "--others", "--exclude-standard"], cwd);
-    const untrackedFiles = untrackedOutput.trim().split("\n").filter(Boolean);
+      const cwd = workspace.worktree.path;
+      const defaultBranch = workspace.project.defaultBranch;
 
-    for (const file of untrackedFiles) {
+      const headBranch = (await execGit(["rev-parse", "--abbrev-ref", "HEAD"], cwd)).trim();
+
+      let mergeBase: string;
       try {
-        const content = await readFile(join(cwd, file), "utf-8");
-        const lines = content.split("\n");
-        if (lines.length > 0 && lines[lines.length - 1] === "") {
-          lines.pop();
-        }
-        diff += `diff --git a/${file} b/${file}\n`;
-        diff += "new file mode 100644\n";
-        diff += "--- /dev/null\n";
-        diff += `+++ b/${file}\n`;
-        diff += `@@ -0,0 +1,${lines.length} @@\n`;
-        diff += lines.map((l) => `+${l}`).join("\n");
-        diff += "\n";
-        filesChanged++;
-        insertions += lines.length;
-        fileStatuses[file] = "U";
+        mergeBase = (await execGit(["merge-base", defaultBranch, "HEAD"], cwd)).trim();
       } catch {
-        // Skip binary or unreadable files
+        mergeBase = (await execGit(["hash-object", "-t", "tree", "/dev/null"], cwd)).trim();
       }
-    }
 
-    return {
-      diff,
-      stats: { filesChanged, insertions, deletions },
-      baseBranch: defaultBranch,
-      headBranch,
-      fileStatuses,
-    };
-  }),
+      const diffArgs = ["diff"];
+      if (input.contextLines !== undefined) {
+        diffArgs.push(`-U${input.contextLines}`);
+      }
+      diffArgs.push(mergeBase);
+      let diff = await execGit(diffArgs, cwd);
+
+      const statOutput = await execGit(["diff", "--stat", mergeBase], cwd);
+      const statLines = statOutput.trim().split("\n");
+      const summaryLine = statLines[statLines.length - 1] || "";
+
+      let filesChanged = 0;
+      let insertions = 0;
+      let deletions = 0;
+
+      const filesMatch = summaryLine.match(/(\d+)\s+files?\s+changed/);
+      const insertMatch = summaryLine.match(/(\d+)\s+insertions?\(\+\)/);
+      const deleteMatch = summaryLine.match(/(\d+)\s+deletions?\(-\)/);
+
+      if (filesMatch) filesChanged = Number.parseInt(filesMatch[1], 10);
+      if (insertMatch) insertions = Number.parseInt(insertMatch[1], 10);
+      if (deleteMatch) deletions = Number.parseInt(deleteMatch[1], 10);
+
+      const fileStatuses: Record<string, string> = {};
+      const nameStatusOutput = await execGit(["diff", "--name-status", mergeBase], cwd);
+      for (const line of nameStatusOutput.trim().split("\n").filter(Boolean)) {
+        const parts = line.split("\t");
+        const statusCode = parts[0][0];
+        if (statusCode === "R" && parts[2]) {
+          fileStatuses[parts[2]] = "R";
+        } else if (parts[1]) {
+          fileStatuses[parts[1]] = statusCode;
+        }
+      }
+
+      const untrackedOutput = await execGit(["ls-files", "--others", "--exclude-standard"], cwd);
+      const untrackedFiles = untrackedOutput.trim().split("\n").filter(Boolean);
+
+      for (const file of untrackedFiles) {
+        try {
+          const content = await readFile(join(cwd, file), "utf-8");
+          const lines = content.split("\n");
+          if (lines.length > 0 && lines[lines.length - 1] === "") {
+            lines.pop();
+          }
+          diff += `diff --git a/${file} b/${file}\n`;
+          diff += "new file mode 100644\n";
+          diff += "--- /dev/null\n";
+          diff += `+++ b/${file}\n`;
+          diff += `@@ -0,0 +1,${lines.length} @@\n`;
+          diff += lines.map((l) => `+${l}`).join("\n");
+          diff += "\n";
+          filesChanged++;
+          insertions += lines.length;
+          fileStatuses[file] = "U";
+        } catch {
+          // Skip binary or unreadable files
+        }
+      }
+
+      return {
+        diff,
+        stats: { filesChanged, insertions, deletions },
+        baseBranch: defaultBranch,
+        headBranch,
+        fileStatuses,
+      };
+    }),
 
   getDiffSummary: publicProcedure
     .input(z.object({ workspaceId: z.string() }))
@@ -734,7 +746,14 @@ const workspaceRouter = t.router({
     }),
 
   getFileDiff: publicProcedure
-    .input(z.object({ workspaceId: z.string(), filePath: z.string(), mergeBase: z.string() }))
+    .input(
+      z.object({
+        workspaceId: z.string(),
+        filePath: z.string(),
+        mergeBase: z.string(),
+        contextLines: z.number().int().min(0).max(99999).optional(),
+      }),
+    )
     .query(async ({ input }) => {
       const workspace = resolveWorkspace(input.workspaceId);
       if (!workspace) {
@@ -769,7 +788,12 @@ const workspaceRouter = t.router({
       }
 
       // Tracked file — get diff for this single file
-      const diff = await execGit(["diff", input.mergeBase, "--", input.filePath], cwd);
+      const fileDiffArgs = ["diff"];
+      if (input.contextLines !== undefined) {
+        fileDiffArgs.push(`-U${input.contextLines}`);
+      }
+      fileDiffArgs.push(input.mergeBase, "--", input.filePath);
+      const diff = await execGit(fileDiffArgs, cwd);
       return { diff };
     }),
 

--- a/packages/dashboard-core/src/adapter.ts
+++ b/packages/dashboard-core/src/adapter.ts
@@ -70,9 +70,14 @@ export interface DashboardAdapter {
   closeWorkspaceWindows(workspaceId: string): Promise<void>;
 
   // Code browsing (optional)
-  getWorkspaceDiff?(workspaceId: string): Promise<WorkspaceDiff>;
+  getWorkspaceDiff?(workspaceId: string, contextLines?: number): Promise<WorkspaceDiff>;
   getWorkspaceDiffSummary?(workspaceId: string): Promise<WorkspaceDiffSummary>;
-  getFileDiff?(workspaceId: string, filePath: string, mergeBase: string): Promise<FileDiffResult>;
+  getFileDiff?(
+    workspaceId: string,
+    filePath: string,
+    mergeBase: string,
+    contextLines?: number,
+  ): Promise<FileDiffResult>;
   listWorkspaceFiles?(workspaceId: string, path: string): Promise<FileListResult>;
   getWorkspaceFile?(workspaceId: string, path: string): Promise<FileContentResult>;
 

--- a/packages/dashboard-core/src/adapters/web.ts
+++ b/packages/dashboard-core/src/adapters/web.ts
@@ -221,8 +221,11 @@ export class WebDashboardAdapter implements DashboardAdapter {
     await this.trpc.cli.install.mutate();
   }
 
-  async getWorkspaceDiff(workspaceId: string): Promise<WorkspaceDiff> {
-    return (await this.trpc.workspace.getDiff.query({ workspaceId })) as WorkspaceDiff;
+  async getWorkspaceDiff(workspaceId: string, contextLines?: number): Promise<WorkspaceDiff> {
+    return (await this.trpc.workspace.getDiff.query({
+      workspaceId,
+      contextLines,
+    })) as WorkspaceDiff;
   }
 
   async getWorkspaceDiffSummary(workspaceId: string): Promise<WorkspaceDiffSummary> {
@@ -235,11 +238,13 @@ export class WebDashboardAdapter implements DashboardAdapter {
     workspaceId: string,
     filePath: string,
     mergeBase: string,
+    contextLines?: number,
   ): Promise<FileDiffResult> {
     return (await this.trpc.workspace.getFileDiff.query({
       workspaceId,
       filePath,
       mergeBase,
+      contextLines,
     })) as FileDiffResult;
   }
 

--- a/packages/dashboard-core/src/components/DiffView.tsx
+++ b/packages/dashboard-core/src/components/DiffView.tsx
@@ -227,6 +227,71 @@ function DiffFileContent({
 }
 
 // ---------------------------------------------------------------------------
+// Context expansion helpers
+// ---------------------------------------------------------------------------
+
+const CONTEXT_STEPS = [3, 10, 25, 100, 99999] as const;
+
+function getNextContextStep(current: number): number | null {
+  for (const step of CONTEXT_STEPS) {
+    if (step > current) return step;
+  }
+  return null;
+}
+
+function contextLabel(lines: number): string {
+  if (lines >= 99999) return "full file";
+  return `${lines} lines`;
+}
+
+function ContextToolbar({
+  contextLines,
+  onLoadMore,
+  onShowFullFile,
+}: {
+  contextLines: number;
+  onLoadMore: () => void;
+  onShowFullFile: () => void;
+}) {
+  const nextStep = getNextContextStep(contextLines);
+  if (nextStep === null) return null;
+
+  const isLastStep = nextStep >= 99999;
+
+  return (
+    <div className="flex items-center justify-center gap-2 border-b border-border/20 px-4 py-1.5">
+      {isLastStep ? (
+        <button
+          type="button"
+          onClick={onShowFullFile}
+          className="text-xs text-muted-foreground transition-colors hover:text-foreground"
+        >
+          Show full file
+        </button>
+      ) : (
+        <>
+          <button
+            type="button"
+            onClick={onLoadMore}
+            className="text-xs text-muted-foreground transition-colors hover:text-foreground"
+          >
+            Load more context
+          </button>
+          <span className="text-muted-foreground/50">|</span>
+          <button
+            type="button"
+            onClick={onShowFullFile}
+            className="text-xs text-muted-foreground transition-colors hover:text-foreground"
+          >
+            Show full file
+          </button>
+        </>
+      )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
 // Lazy file row — fetches diff on first expand
 // ---------------------------------------------------------------------------
 
@@ -252,17 +317,25 @@ function LazyFileRow({
   const [diff, setDiff] = useState<string | null>(null);
   const [loadingDiff, setLoadingDiff] = useState(false);
   const [diffError, setDiffError] = useState<string | null>(null);
-  // Track which mergeBase the cached diff belongs to
+  const [contextLines, setContextLines] = useState(3);
+  // Track which mergeBase + contextLines the cached diff belongs to
   const cachedMergeBaseRef = useRef<string | null>(null);
+  const cachedContextRef = useRef<number | null>(null);
 
   const toggle = useCallback(() => {
     setIsOpen((prev) => !prev);
   }, []);
 
-  // Fetch diff when expanded and not cached (or mergeBase changed)
+  // Fetch diff when expanded and not cached (or mergeBase/contextLines changed)
   useEffect(() => {
     if (!isOpen) return;
-    if (diff !== null && cachedMergeBaseRef.current === mergeBase) return;
+    if (
+      diff !== null &&
+      cachedMergeBaseRef.current === mergeBase &&
+      cachedContextRef.current === contextLines
+    ) {
+      return;
+    }
 
     const getFileDiff = adapter.getFileDiff;
     if (!getFileDiff) return;
@@ -272,11 +345,12 @@ function LazyFileRow({
     setDiffError(null);
 
     getFileDiff
-      .call(adapter, workspaceId, filename, mergeBase)
+      .call(adapter, workspaceId, filename, mergeBase, contextLines > 3 ? contextLines : undefined)
       .then((result) => {
         if (!cancelled) {
           setDiff(result.diff);
           cachedMergeBaseRef.current = mergeBase;
+          cachedContextRef.current = contextLines;
         }
       })
       .catch((err) => {
@@ -289,15 +363,33 @@ function LazyFileRow({
     return () => {
       cancelled = true;
     };
-  }, [isOpen, adapter, workspaceId, filename, mergeBase, diff]);
+  }, [isOpen, adapter, workspaceId, filename, mergeBase, contextLines, diff]);
 
   // Invalidate cache when mergeBase changes
   useEffect(() => {
     if (cachedMergeBaseRef.current && cachedMergeBaseRef.current !== mergeBase) {
       setDiff(null);
       cachedMergeBaseRef.current = null;
+      cachedContextRef.current = null;
+      setContextLines(3);
     }
   }, [mergeBase]);
+
+  const isUntracked = status === "U";
+  const canLoadMore = !isUntracked && getNextContextStep(contextLines) !== null;
+
+  const handleLoadMore = useCallback(() => {
+    const next = getNextContextStep(contextLines);
+    if (next !== null) {
+      setDiff(null);
+      setContextLines(next);
+    }
+  }, [contextLines]);
+
+  const handleShowFullFile = useCallback(() => {
+    setDiff(null);
+    setContextLines(99999);
+  }, []);
 
   return (
     <div id={`diff-file-${encodeURIComponent(filename)}`} className="border-b border-border/30">
@@ -344,7 +436,16 @@ function LazyFileRow({
           )}
           {diffError && <div className="px-4 py-4 text-sm text-destructive">{diffError}</div>}
           {diff !== null && !loadingDiff && (
-            <DiffFileContent hunks={diff} filename={filename} viewMode={viewMode} />
+            <>
+              {canLoadMore && (
+                <ContextToolbar
+                  contextLines={contextLines}
+                  onLoadMore={handleLoadMore}
+                  onShowFullFile={handleShowFullFile}
+                />
+              )}
+              <DiffFileContent hunks={diff} filename={filename} viewMode={viewMode} />
+            </>
           )}
         </div>
       )}
@@ -369,6 +470,7 @@ function LegacyDiffView({ workspaceId, active, onStatsChange, onOpenFile }: Diff
   const [loading, setLoading] = useState(true);
   const [openFiles, setOpenFiles] = useState<Set<string>>(new Set());
   const [viewMode, setViewModeState] = useState<ViewMode>(getStoredViewMode);
+  const [contextLines, setContextLines] = useState(3);
   const setViewMode = useCallback((mode: ViewMode) => {
     setViewModeState(mode);
     storeViewMode(mode);
@@ -385,7 +487,7 @@ function LegacyDiffView({ workspaceId, active, onStatsChange, onOpenFile }: Diff
     let cancelled = false;
     const fetchDiff = () => {
       getWorkspaceDiff
-        .call(adapter, workspaceId)
+        .call(adapter, workspaceId, contextLines > 3 ? contextLines : undefined)
         .then((result) => {
           if (!cancelled) {
             setData(result);
@@ -407,7 +509,20 @@ function LegacyDiffView({ workspaceId, active, onStatsChange, onOpenFile }: Diff
       cancelled = true;
       if (interval) clearInterval(interval);
     };
-  }, [adapter, workspaceId, active, onStatsChange]);
+  }, [adapter, workspaceId, active, onStatsChange, contextLines]);
+
+  const canLoadMore = getNextContextStep(contextLines) !== null;
+
+  const handleLoadMore = useCallback(() => {
+    const next = getNextContextStep(contextLines);
+    if (next !== null) {
+      setContextLines(next);
+    }
+  }, [contextLines]);
+
+  const handleShowFullFile = useCallback(() => {
+    setContextLines(99999);
+  }, []);
 
   if (loading) {
     return (
@@ -539,6 +654,13 @@ function LegacyDiffView({ workspaceId, active, onStatsChange, onOpenFile }: Diff
               </button>
               {isOpen && (
                 <div className="border-t border-border/20 bg-muted/30">
+                  {canLoadMore && fileStatuses[file.filename] !== "U" && (
+                    <ContextToolbar
+                      contextLines={contextLines}
+                      onLoadMore={handleLoadMore}
+                      onShowFullFile={handleShowFullFile}
+                    />
+                  )}
                   <DiffFileContent
                     hunks={file.hunks}
                     filename={file.filename}

--- a/packages/dashboard-core/src/components/DiffView.tsx
+++ b/packages/dashboard-core/src/components/DiffView.tsx
@@ -239,11 +239,6 @@ function getNextContextStep(current: number): number | null {
   return null;
 }
 
-function contextLabel(lines: number): string {
-  if (lines >= 99999) return "full file";
-  return `${lines} lines`;
-}
-
 function ContextToolbar({
   contextLines,
   onLoadMore,


### PR DESCRIPTION
## Summary
- Add progressive context expansion for file diffs with "Load more context" and "Show full file" buttons
- Context increases through steps: 3 → 10 → 25 → 100 → full file
- Works in both the lazy per-file DiffView and the LegacyDiffView
- Backend passes `-U<n>` flag to `git diff` when expanded context is requested

## Test plan
- [ ] Open a workspace with changes, expand a file diff
- [ ] Click "Load more context" — diff re-renders with more surrounding lines
- [ ] Click repeatedly to step through 10, 25, 100 context lines
- [ ] When only full file is left, button shows "Show full file" instead
- [ ] Click "Show full file" — entire file content shown in diff
- [ ] Untracked files should NOT show the context toolbar
- [ ] Test on mobile viewport — toolbar visible and tappable

🤖 Generated with [Claude Code](https://claude.com/claude-code)