### PR TITLE
Add fuzzy scoring algorithm for Quick Open file search

### DIFF
--- a/apps/web/src/lib/fuzzy-score.ts
+++ b/apps/web/src/lib/fuzzy-score.ts
@@ -1,0 +1,209 @@
+/**
+ * Fuzzy file-path scoring algorithm, inspired by VS Code's Quick Open.
+ *
+ * Returns a numeric score (higher = better match) or null if the query
+ * does not match the target at all.
+ */
+
+// ---------------------------------------------------------------------------
+// Scoring constants
+// ---------------------------------------------------------------------------
+
+/** Base score awarded for every matched character. */
+const SCORE_MATCH = 1;
+
+/** Bonus when two matched characters are adjacent in the target. */
+const BONUS_CONSECUTIVE = 8;
+
+/** Bonus when a matched character sits at a word boundary (after / . - _ space). */
+const BONUS_WORD_START = 7;
+
+/** Bonus for a camelCase boundary (lowercase → uppercase transition). */
+const BONUS_CAMEL_CASE = 6;
+
+/** Bonus when the match starts at the very first character of the filename. */
+const BONUS_FILENAME_START = 10;
+
+/** Per-character bonus for every match that falls inside the filename portion. */
+const BONUS_FILENAME_CHAR = 3;
+
+/** Penalty applied when a match follows a gap (non-consecutive). */
+const PENALTY_GAP_START = -3;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const SEPARATOR_CODES: Set<number> = new Set([
+  47, // '/'
+  92, // '\\'
+  46, // '.'
+  45, // '-'
+  95, // '_'
+  32, // ' '
+]);
+
+function isSeparatorCode(code: number): boolean {
+  return SEPARATOR_CODES.has(code);
+}
+
+/**
+ * Compute the per-position bonus for matching at `target[j]`.
+ *
+ * Bonuses are awarded for:
+ * - Being inside the filename portion of the path
+ * - Immediately following a separator (word start)
+ * - Being the very first character of the filename
+ * - Sitting at a camelCase boundary
+ */
+function positionBonus(
+  target: string,
+  j: number,
+  filenameStart: number,
+): number {
+  let bonus = 0;
+
+  // Bonus for every match inside the filename
+  if (j >= filenameStart) {
+    bonus += BONUS_FILENAME_CHAR;
+  }
+
+  // Word-boundary / segment-start bonuses
+  if (j === 0 || isSeparatorCode(target.charCodeAt(j - 1))) {
+    bonus += j === filenameStart ? BONUS_FILENAME_START : BONUS_WORD_START;
+  } else {
+    // camelCase boundary: previous char is lowercase, current is uppercase
+    const curr = target.charCodeAt(j);
+    const prev = target.charCodeAt(j - 1);
+    if (curr >= 65 && curr <= 90 && prev >= 97 && prev <= 122) {
+      bonus += BONUS_CAMEL_CASE;
+    }
+  }
+
+  return bonus;
+}
+
+// ---------------------------------------------------------------------------
+// DP scorer
+// ---------------------------------------------------------------------------
+
+/**
+ * Find the optimal subsequence-match of `queryLower` inside `target` and
+ * return its score.  Uses a two-row DP:
+ *
+ *   M[j] = best score matching query[0..i] where query[i] IS matched at target[j]
+ *   D[j] = best score matching query[0..i] with last match at-or-before target[j]
+ *
+ * Transition (for query char i, target position j where chars match):
+ *   consecutive  = M_prev[j-1] + SCORE_MATCH + BONUS_CONSECUTIVE + posBonus
+ *   afterGap     = D_prev[j-1] + SCORE_MATCH + posBonus + PENALTY_GAP_START
+ *   M[j]         = max(consecutive, afterGap)
+ *   D[j]         = max(D[j-1], M[j])
+ */
+function dpScore(
+  queryLower: string,
+  target: string,
+  targetLower: string,
+  filenameStart: number,
+): number {
+  const n = queryLower.length;
+  const m = targetLower.length;
+
+  let M = new Array<number>(m).fill(-Infinity);
+  let D = new Array<number>(m).fill(-Infinity);
+
+  // --- first query character (i = 0) ---
+  for (let j = 0; j < m; j++) {
+    if (targetLower[j] === queryLower[0]) {
+      M[j] = SCORE_MATCH + positionBonus(target, j, filenameStart);
+    }
+    D[j] = j === 0 ? M[j] : Math.max(D[j - 1], M[j]);
+  }
+
+  // --- remaining query characters ---
+  for (let i = 1; i < n; i++) {
+    const prevM = M;
+    const prevD = D;
+    M = new Array<number>(m).fill(-Infinity);
+    D = new Array<number>(m).fill(-Infinity);
+
+    for (let j = i; j < m; j++) {
+      if (targetLower[j] === queryLower[i]) {
+        const bonus = positionBonus(target, j, filenameStart);
+
+        // Continue a consecutive run (query[i-1] matched at target[j-1])
+        const consecutive =
+          prevM[j - 1] + SCORE_MATCH + BONUS_CONSECUTIVE + bonus;
+
+        // Start a new run after a gap (penalised)
+        const afterGap =
+          prevD[j - 1] + SCORE_MATCH + bonus + PENALTY_GAP_START;
+
+        M[j] = Math.max(consecutive, afterGap);
+      }
+
+      D[j] = j > 0 ? Math.max(D[j - 1], M[j]) : M[j];
+    }
+  }
+
+  return D[m - 1];
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Compute a fuzzy-match score for `query` against `filePath`.
+ *
+ * @returns A numeric score (higher = better) or `null` when the query does
+ *          not match the path at all.  An empty query matches everything
+ *          with score 0.
+ */
+export function fuzzyScore(query: string, filePath: string): number | null {
+  if (!query) return 0;
+  if (!filePath) return null;
+
+  const queryLower = query.toLowerCase();
+  const pathLower = filePath.toLowerCase();
+  const n = queryLower.length;
+  const m = pathLower.length;
+
+  if (n > m) return null;
+
+  // Quick rejection: verify all query chars exist in order
+  let qi = 0;
+  for (let i = 0; i < m && qi < n; i++) {
+    if (pathLower[i] === queryLower[qi]) qi++;
+  }
+  if (qi < n) return null;
+
+  const filenameStart = filePath.lastIndexOf("/") + 1;
+
+  // Score against the full path
+  let score = dpScore(queryLower, filePath, pathLower, filenameStart);
+
+  // If all query chars can be found inside the filename alone, also score
+  // against just the filename.  This effectively gives a large bonus to
+  // filename-only matches because filenameStart becomes 0 and every char
+  // gets BONUS_FILENAME_START / BONUS_FILENAME_CHAR.
+  if (filenameStart > 0) {
+    const filename = filePath.slice(filenameStart);
+    const filenameLower = pathLower.slice(filenameStart);
+
+    qi = 0;
+    for (let i = 0; i < filenameLower.length && qi < n; i++) {
+      if (filenameLower[i] === queryLower[qi]) qi++;
+    }
+
+    if (qi === n) {
+      const fnScore = dpScore(queryLower, filename, filenameLower, 0);
+      score = Math.max(score, fnScore);
+    }
+  }
+
+  // Tiebreaker: among equally-scored files, prefer shorter paths (more
+  // prominent / closer to the project root).  The factor is small enough
+  // (max ~1.5 for a 150-char path) that it only affects ties.
+  return score - filePath.length * 0.01;
+}

--- a/apps/web/src/lib/fuzzy-score.ts
+++ b/apps/web/src/lib/fuzzy-score.ts
@@ -56,11 +56,7 @@ function isSeparatorCode(code: number): boolean {
  * - Being the very first character of the filename
  * - Sitting at a camelCase boundary
  */
-function positionBonus(
-  target: string,
-  j: number,
-  filenameStart: number,
-): number {
+function positionBonus(target: string, j: number, filenameStart: number): number {
   let bonus = 0;
 
   // Bonus for every match inside the filename
@@ -132,12 +128,10 @@ function dpScore(
         const bonus = positionBonus(target, j, filenameStart);
 
         // Continue a consecutive run (query[i-1] matched at target[j-1])
-        const consecutive =
-          prevM[j - 1] + SCORE_MATCH + BONUS_CONSECUTIVE + bonus;
+        const consecutive = prevM[j - 1] + SCORE_MATCH + BONUS_CONSECUTIVE + bonus;
 
         // Start a new run after a gap (penalised)
-        const afterGap =
-          prevD[j - 1] + SCORE_MATCH + bonus + PENALTY_GAP_START;
+        const afterGap = prevD[j - 1] + SCORE_MATCH + bonus + PENALTY_GAP_START;
 
         M[j] = Math.max(consecutive, afterGap);
       }

--- a/apps/web/src/trpc/router.ts
+++ b/apps/web/src/trpc/router.ts
@@ -14,6 +14,7 @@ import {
   replaceAgent,
 } from "../lib/agent-pool";
 import { checkCli, installCli } from "../lib/cli";
+import { fuzzyScore } from "../lib/fuzzy-score";
 import { reloadSchedules, stopJobsForKey } from "../lib/cronjob-scheduler";
 import {
   deleteCronjobFile,
@@ -865,9 +866,15 @@ const workspaceRouter = t.router({
       let files = output.trim().split("\n").filter(Boolean);
 
       if (input.query) {
-        const chars = input.query.split("").map((c) => c.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"));
-        const pattern = new RegExp(chars.join(".*"), "i");
-        files = files.filter((f) => pattern.test(f));
+        const scored: { file: string; score: number }[] = [];
+        for (const f of files) {
+          const score = fuzzyScore(input.query, f);
+          if (score !== null) {
+            scored.push({ file: f, score });
+          }
+        }
+        scored.sort((a, b) => b.score - a.score);
+        files = scored.map((r) => r.file);
       }
 
       return { files: files.slice(0, input.limit) };

--- a/apps/web/src/trpc/router.ts
+++ b/apps/web/src/trpc/router.ts
@@ -14,7 +14,6 @@ import {
   replaceAgent,
 } from "../lib/agent-pool";
 import { checkCli, installCli } from "../lib/cli";
-import { fuzzyScore } from "../lib/fuzzy-score";
 import { reloadSchedules, stopJobsForKey } from "../lib/cronjob-scheduler";
 import {
   deleteCronjobFile,
@@ -24,6 +23,7 @@ import {
   saveCronjobFile,
 } from "../lib/cronjob-store";
 import type { CronjobDefinition } from "../lib/cronjob-types";
+import { fuzzyScore } from "../lib/fuzzy-score";
 import { execGit, gitCmd, listWorktrees } from "../lib/git";
 import { checkHooks, installHooks } from "../lib/hooks";
 import { resolvePendingInput } from "../lib/pending-inputs";

--- a/apps/web/tests/fuzzy-score.test.ts
+++ b/apps/web/tests/fuzzy-score.test.ts
@@ -1,0 +1,182 @@
+import { describe, expect, it } from "vitest";
+import { fuzzyScore } from "../src/lib/fuzzy-score";
+
+// ---------------------------------------------------------------------------
+// Helper: given a query and a list of file paths, return them sorted by score
+// (highest first), filtering out non-matches.
+// ---------------------------------------------------------------------------
+function ranked(query: string, paths: string[]): string[] {
+  const scored: { path: string; score: number }[] = [];
+  for (const p of paths) {
+    const s = fuzzyScore(query, p);
+    if (s !== null) scored.push({ path: p, score: s });
+  }
+  scored.sort((a, b) => b.score - a.score);
+  return scored.map((r) => r.path);
+}
+
+// ---------------------------------------------------------------------------
+// Basic matching / rejection
+// ---------------------------------------------------------------------------
+describe("fuzzyScore – basic matching", () => {
+  it("returns 0 for an empty query (matches everything)", () => {
+    expect(fuzzyScore("", "src/index.ts")).toBe(0);
+    expect(fuzzyScore("", "")).toBe(0);
+  });
+
+  it("returns null when the target is empty", () => {
+    expect(fuzzyScore("a", "")).toBeNull();
+  });
+
+  it("returns null when query is longer than target", () => {
+    expect(fuzzyScore("abcdef", "abc")).toBeNull();
+  });
+
+  it("returns null when characters are not present in order", () => {
+    expect(fuzzyScore("xyz", "src/index.ts")).toBeNull();
+    expect(fuzzyScore("ba", "abc")).toBeNull();
+  });
+
+  it("returns a positive score for a valid fuzzy match", () => {
+    const score = fuzzyScore("idx", "src/index.ts");
+    expect(score).not.toBeNull();
+    expect(score!).toBeGreaterThan(0);
+  });
+
+  it("matches case-insensitively", () => {
+    expect(fuzzyScore("ABC", "abc.txt")).not.toBeNull();
+    expect(fuzzyScore("abc", "ABC.txt")).not.toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 1. Consecutive character matches score higher
+// ---------------------------------------------------------------------------
+describe("fuzzyScore – consecutive matches", () => {
+  it("exact substring beats scattered characters", () => {
+    const exact = fuzzyScore("schema", "schema.prisma")!;
+    const scattered = fuzzyScore("schema", "src/cache/help_manager_app.ts")!;
+    expect(exact).toBeGreaterThan(scattered);
+  });
+
+  it("longer consecutive run beats shorter runs", () => {
+    // "index" as 5 consecutive chars vs matched across two segments
+    const full = fuzzyScore("index", "src/index.ts")!;
+    const split = fuzzyScore("index", "src/init_dex.ts")!;
+    expect(full).toBeGreaterThan(split);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. Start-of-word / segment matches score higher
+// ---------------------------------------------------------------------------
+describe("fuzzyScore – word-start bonus", () => {
+  it("match at word boundary beats match mid-word", () => {
+    // 'r' at the start of 'router' (after /) vs 'r' buried inside 'error'
+    const wordStart = fuzzyScore("rts", "src/router.ts")!;
+    const midWord = fuzzyScore("rts", "src/errors.ts")!;
+    expect(wordStart).toBeGreaterThan(midWord);
+  });
+
+  it("camelCase boundaries count as word starts", () => {
+    const camel = fuzzyScore("QOD", "QuickOpenDialog.tsx")!;
+    const noCamel = fuzzyScore("QOD", "quod_file.tsx")!;
+    expect(camel).toBeGreaterThan(noCamel);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3. Start-of-filename matches score highest
+// ---------------------------------------------------------------------------
+describe("fuzzyScore – filename-start bonus", () => {
+  it("match at filename start beats match in directory", () => {
+    const filenameStart = fuzzyScore("router", "src/trpc/router.ts")!;
+    const dirMatch = fuzzyScore("router", "router/src/trpc.ts")!;
+    expect(filenameStart).toBeGreaterThan(dirMatch);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 4. Compact matches score higher
+// ---------------------------------------------------------------------------
+describe("fuzzyScore – compactness", () => {
+  it("adjacent matches beat distant matches", () => {
+    const compact = fuzzyScore("ab", "ab_something.ts")!;
+    const distant = fuzzyScore("ab", "a_long_path_before_b.ts")!;
+    expect(compact).toBeGreaterThan(distant);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 5. Filename matches weighted more than directory path matches
+// ---------------------------------------------------------------------------
+describe("fuzzyScore – filename vs directory weight", () => {
+  it("match in filename outscores same match in directory", () => {
+    const inFilename = fuzzyScore("schema", "src/db/schema.ts")!;
+    const inDirectory = fuzzyScore("schema", "schema/db/types.ts")!;
+    expect(inFilename).toBeGreaterThan(inDirectory);
+  });
+
+  it("full filename match beats partial directory match even for short queries", () => {
+    const filename = fuzzyScore("git", "src/lib/git.ts")!;
+    const directory = fuzzyScore("git", "git/src/lib.ts")!;
+    expect(filename).toBeGreaterThan(directory);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Real-world ranking scenarios
+// ---------------------------------------------------------------------------
+describe("fuzzyScore – real-world ranking", () => {
+  const FILES = [
+    "apps/web/src/lib/fuzzy-score.ts",
+    "apps/web/src/trpc/router.ts",
+    "apps/web/src/lib/db/schema.ts",
+    "packages/dashboard-core/src/components/QuickOpenDialog.tsx",
+    "apps/web/src/lib/state.ts",
+    "apps/web/src/lib/git.ts",
+    "apps/web/tests/trpc.test.ts",
+    "apps/web/src/lib/workspace.ts",
+    "schema.prisma",
+    "src/old/scattered_chars_hema.ts",
+  ];
+
+  it("'schema' ranks schema.prisma first", () => {
+    const result = ranked("schema", FILES);
+    expect(result[0]).toBe("schema.prisma");
+  });
+
+  it("'schema' ranks db/schema.ts above scattered matches", () => {
+    const result = ranked("schema", FILES);
+    const schemaIdx = result.indexOf("apps/web/src/lib/db/schema.ts");
+    const scatteredIdx = result.indexOf("src/old/scattered_chars_hema.ts");
+    expect(schemaIdx).toBeLessThan(scatteredIdx);
+  });
+
+  it("'router' ranks router.ts first", () => {
+    const result = ranked("router", FILES);
+    expect(result[0]).toBe("apps/web/src/trpc/router.ts");
+  });
+
+  it("'qod' ranks QuickOpenDialog.tsx first", () => {
+    const result = ranked("qod", FILES);
+    expect(result[0]).toBe(
+      "packages/dashboard-core/src/components/QuickOpenDialog.tsx",
+    );
+  });
+
+  it("'git' ranks git.ts first", () => {
+    const result = ranked("git", FILES);
+    expect(result[0]).toBe("apps/web/src/lib/git.ts");
+  });
+
+  it("'state' ranks state.ts first", () => {
+    const result = ranked("state", FILES);
+    expect(result[0]).toBe("apps/web/src/lib/state.ts");
+  });
+
+  it("'fz' ranks fuzzy-score.ts first", () => {
+    const result = ranked("fz", FILES);
+    expect(result[0]).toBe("apps/web/src/lib/fuzzy-score.ts");
+  });
+});

--- a/apps/web/tests/fuzzy-score.test.ts
+++ b/apps/web/tests/fuzzy-score.test.ts
@@ -160,9 +160,7 @@ describe("fuzzyScore – real-world ranking", () => {
 
   it("'qod' ranks QuickOpenDialog.tsx first", () => {
     const result = ranked("qod", FILES);
-    expect(result[0]).toBe(
-      "packages/dashboard-core/src/components/QuickOpenDialog.tsx",
-    );
+    expect(result[0]).toBe("packages/dashboard-core/src/components/QuickOpenDialog.tsx");
   });
 
   it("'git' ranks git.ts first", () => {


### PR DESCRIPTION
## Summary

- Replace the basic regex fuzzy match (`/s.*c.*h.*e.*m.*a/i`) in the `searchFiles` procedure with a proper DP-based scoring algorithm that ranks results by match quality
- New `fuzzyScore()` utility (`apps/web/src/lib/fuzzy-score.ts`) rewards consecutive character runs, word-boundary/camelCase matches, filename-start matches, and penalizes gaps — so typing "schema" now surfaces `schema.prisma` above scattered matches
- 21 tests covering all scoring properties: consecutive matches, word-start bonuses, filename priority, compactness, and real-world ranking scenarios

## Test plan

- [x] All 21 fuzzy-score tests pass (`vitest run tests/fuzzy-score.test.ts`)
- [ ] CI passes
- [ ] Manual QA: open Quick Open dialog and verify "schema" surfaces `schema.prisma` first

🤖 Generated with [Claude Code](https://claude.com/claude-code)