### PR TITLE
feat: add file type icons to file browser and search dialogs

### DIFF
--- a/packages/dashboard-core/src/components/FileBrowser.tsx
+++ b/packages/dashboard-core/src/components/FileBrowser.tsx
@@ -1,6 +1,7 @@
-import { ChevronRight, File, Folder } from "lucide-react";
+import { ChevronRight, Folder } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import { useAdapter } from "../context";
+import { getFileIcon } from "../lib/file-icon";
 import type { FileEntry } from "../types";
 
 interface FileBrowserProps {
@@ -154,9 +155,14 @@ export function FileBrowser({
                     className={`shrink-0 text-blue-600 dark:text-blue-400 ${compact ? "size-4" : "size-4"}`}
                   />
                 ) : (
-                  <File
-                    className={`shrink-0 text-muted-foreground ${compact ? "size-4" : "size-4"}`}
-                  />
+                  (() => {
+                    const FileIcon = getFileIcon(entry.name);
+                    return (
+                      <FileIcon
+                        className={`shrink-0 text-muted-foreground ${compact ? "size-4" : "size-4"}`}
+                      />
+                    );
+                  })()
                 )}
                 <span className="min-w-0 flex-1 truncate">{entry.name}</span>
                 {!compact && entry.type === "directory" && (

--- a/packages/dashboard-core/src/components/QuickOpenDialog.tsx
+++ b/packages/dashboard-core/src/components/QuickOpenDialog.tsx
@@ -11,9 +11,9 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@band-app/ui";
-import { File } from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useAdapter } from "../context";
+import { getFileIcon } from "../lib/file-icon";
 
 interface QuickOpenDialogProps {
   workspaceId: string;
@@ -94,9 +94,10 @@ export function QuickOpenDialog({
             <CommandGroup>
               {files.map((file) => {
                 const fileName = file.split("/").pop() || file;
+                const Icon = getFileIcon(fileName);
                 return (
                   <CommandItem key={file} value={file} onSelect={() => handleSelect(file)}>
-                    <File className="size-4 shrink-0 text-muted-foreground" />
+                    <Icon className="size-4 shrink-0 text-muted-foreground" />
                     <div className="flex min-w-0 flex-1 items-baseline gap-2">
                       <span className="shrink-0 text-sm font-medium">{fileName}</span>
                       <span className="min-w-0 truncate text-xs text-muted-foreground">{file}</span>

--- a/packages/dashboard-core/src/components/SearchFilesDialog.tsx
+++ b/packages/dashboard-core/src/components/SearchFilesDialog.tsx
@@ -10,9 +10,10 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@band-app/ui";
-import { CaseSensitive, File, SearchIcon } from "lucide-react";
+import { CaseSensitive, SearchIcon } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useAdapter } from "../context";
+import { getFileIcon } from "../lib/file-icon";
 import type { ContentSearchMatch } from "../types";
 
 interface SearchFilesDialogProps {
@@ -135,12 +136,14 @@ export function SearchFilesDialog({
                   ? "Type at least 2 characters to search."
                   : "No results found."}
             </CommandEmpty>
-            {grouped.map(([file, matches]) => (
+            {grouped.map(([file, matches]) => {
+              const FileIcon = getFileIcon(file);
+              return (
               <CommandGroup
                 key={file}
                 heading={
                   <span className="inline-flex items-center gap-1.5">
-                    <File className="size-3" />
+                    <FileIcon className="size-3" />
                     {file}
                   </span>
                 }
@@ -158,7 +161,8 @@ export function SearchFilesDialog({
                   </CommandItem>
                 ))}
               </CommandGroup>
-            ))}
+              );
+            })}
           </CommandList>
           {totalMatches > 0 && (
             <div className="border-t px-3 py-1.5 text-xs text-muted-foreground">

--- a/packages/dashboard-core/src/components/SearchFilesDialog.tsx
+++ b/packages/dashboard-core/src/components/SearchFilesDialog.tsx
@@ -139,28 +139,28 @@ export function SearchFilesDialog({
             {grouped.map(([file, matches]) => {
               const FileIcon = getFileIcon(file);
               return (
-              <CommandGroup
-                key={file}
-                heading={
-                  <span className="inline-flex items-center gap-1.5">
-                    <FileIcon className="size-3" />
-                    {file}
-                  </span>
-                }
-              >
-                {matches.map((match) => (
-                  <CommandItem
-                    key={`${file}:${match.line}:${match.content}`}
-                    value={`${file}:${match.line}:${match.content}`}
-                    onSelect={() => handleSelect(file)}
-                  >
-                    <span className="w-8 shrink-0 text-right font-mono text-xs text-muted-foreground">
-                      {match.line}
+                <CommandGroup
+                  key={file}
+                  heading={
+                    <span className="inline-flex items-center gap-1.5">
+                      <FileIcon className="size-3" />
+                      {file}
                     </span>
-                    <span className="min-w-0 truncate font-mono text-xs">{match.content}</span>
-                  </CommandItem>
-                ))}
-              </CommandGroup>
+                  }
+                >
+                  {matches.map((match) => (
+                    <CommandItem
+                      key={`${file}:${match.line}:${match.content}`}
+                      value={`${file}:${match.line}:${match.content}`}
+                      onSelect={() => handleSelect(file)}
+                    >
+                      <span className="w-8 shrink-0 text-right font-mono text-xs text-muted-foreground">
+                        {match.line}
+                      </span>
+                      <span className="min-w-0 truncate font-mono text-xs">{match.content}</span>
+                    </CommandItem>
+                  ))}
+                </CommandGroup>
               );
             })}
           </CommandList>

--- a/packages/dashboard-core/src/lib/file-icon.ts
+++ b/packages/dashboard-core/src/lib/file-icon.ts
@@ -1,0 +1,177 @@
+import type { LucideIcon } from "lucide-react";
+import {
+  Braces,
+  Database,
+  File,
+  FileCode2,
+  FileJson,
+  FileText,
+  Globe,
+  Image,
+  Lock,
+  Music,
+  Package,
+  Settings,
+  Terminal,
+  Video,
+} from "lucide-react";
+
+const extensionIconMap: Record<string, LucideIcon> = {
+  // Code files
+  ts: FileCode2,
+  tsx: FileCode2,
+  js: FileCode2,
+  jsx: FileCode2,
+  mjs: FileCode2,
+  cjs: FileCode2,
+  py: FileCode2,
+  rb: FileCode2,
+  go: FileCode2,
+  rs: FileCode2,
+  java: FileCode2,
+  kt: FileCode2,
+  swift: FileCode2,
+  c: FileCode2,
+  cpp: FileCode2,
+  h: FileCode2,
+  hpp: FileCode2,
+  cs: FileCode2,
+  php: FileCode2,
+  r: FileCode2,
+  lua: FileCode2,
+  zig: FileCode2,
+
+  // Web / markup
+  html: Globe,
+  htm: Globe,
+  css: Braces,
+  scss: Braces,
+  less: Braces,
+  sass: Braces,
+  vue: FileCode2,
+  svelte: FileCode2,
+
+  // Data / config
+  json: FileJson,
+  jsonc: FileJson,
+  json5: FileJson,
+  yaml: FileText,
+  yml: FileText,
+  toml: FileText,
+  ini: FileText,
+  xml: FileText,
+  csv: FileText,
+
+  // Text / docs
+  md: FileText,
+  mdx: FileText,
+  txt: FileText,
+  rst: FileText,
+  tex: FileText,
+  log: FileText,
+
+  // Shell / scripts
+  sh: Terminal,
+  bash: Terminal,
+  zsh: Terminal,
+  fish: Terminal,
+  ps1: Terminal,
+  bat: Terminal,
+  cmd: Terminal,
+
+  // Images
+  png: Image,
+  jpg: Image,
+  jpeg: Image,
+  gif: Image,
+  svg: Image,
+  webp: Image,
+  ico: Image,
+  bmp: Image,
+  avif: Image,
+
+  // Audio
+  mp3: Music,
+  wav: Music,
+  ogg: Music,
+  flac: Music,
+  aac: Music,
+
+  // Video
+  mp4: Video,
+  webm: Video,
+  mov: Video,
+  avi: Video,
+  mkv: Video,
+
+  // Database
+  sql: Database,
+  sqlite: Database,
+  db: Database,
+
+  // Config / dotfiles
+  env: Settings,
+  editorconfig: Settings,
+  prettierrc: Settings,
+  eslintrc: Settings,
+
+  // Lock files
+  lock: Lock,
+
+  // Package / archive
+  zip: Package,
+  tar: Package,
+  gz: Package,
+  tgz: Package,
+  bz2: Package,
+  xz: Package,
+  "7z": Package,
+  rar: Package,
+  wasm: Package,
+};
+
+/** Well-known filenames that map to a specific icon regardless of extension */
+const filenameIconMap: Record<string, LucideIcon> = {
+  dockerfile: Settings,
+  "docker-compose.yml": Settings,
+  "docker-compose.yaml": Settings,
+  makefile: Terminal,
+  rakefile: Terminal,
+  procfile: Terminal,
+  ".gitignore": Settings,
+  ".gitattributes": Settings,
+  ".npmrc": Settings,
+  ".nvmrc": Settings,
+  ".prettierrc": Settings,
+  ".eslintrc": Settings,
+  ".editorconfig": Settings,
+  ".env": Settings,
+  ".env.local": Settings,
+  ".env.development": Settings,
+  ".env.production": Settings,
+};
+
+/**
+ * Returns the appropriate lucide-react icon component for a given filename.
+ * Falls back to the generic File icon for unrecognized extensions.
+ */
+export function getFileIcon(filename: string): LucideIcon {
+  const lower = filename.toLowerCase();
+
+  // Check full filename first (e.g. Dockerfile, Makefile)
+  const basename = lower.split("/").pop() ?? lower;
+  if (filenameIconMap[basename]) {
+    return filenameIconMap[basename];
+  }
+
+  // Check extension
+  const dotIndex = basename.lastIndexOf(".");
+  if (dotIndex !== -1) {
+    const ext = basename.slice(dotIndex + 1);
+    if (extensionIconMap[ext]) {
+      return extensionIconMap[ext];
+    }
+  }
+
+  return File;
+}


### PR DESCRIPTION
## Summary
- Create a shared `getFileIcon` utility in `packages/dashboard-core/src/lib/file-icon.ts` that maps file extensions and well-known filenames to lucide-react icon components
- Replace generic `File` icons with type-specific icons (FileCode2 for code, FileJson for JSON, FileText for markdown/text, Image for images, Terminal for shell scripts, etc.) across:
  - **FileBrowser** — file/folder tree in the code browser
  - **SearchFilesDialog** — content search results grouped by file
  - **QuickOpenDialog** — file search results list
- Falls back to generic `File` icon for unrecognized extensions

## Test plan
- [ ] Open the code browser and verify files show type-specific icons (e.g. `.ts` files show code icon, `.json` shows JSON icon, folders still show folder icon)
- [ ] Open Quick Open dialog (Cmd+P) and verify file results show appropriate icons
- [ ] Open Search in Files dialog and verify file group headings show appropriate icons
- [ ] Verify unrecognized file extensions fall back to generic file icon

🤖 Generated with [Claude Code](https://claude.com/claude-code)