### PR TITLE
feat: add line-level navigation to code browser and search

### DIFF
--- a/apps/web/src/components/CodeBrowserView.tsx
+++ b/apps/web/src/components/CodeBrowserView.tsx
@@ -1,4 +1,9 @@
-import { FileBrowser, FileViewer, openFileSearchPanel } from "@band-app/dashboard-core";
+import {
+  FileBrowser,
+  FileViewer,
+  openFileSearchPanel,
+  parseFileLocation,
+} from "@band-app/dashboard-core";
 import { File } from "lucide-react";
 import { useCallback, useEffect, useState } from "react";
 import { useIsDesktop } from "../hooks/useIsDesktop";
@@ -31,24 +36,51 @@ export function CodeBrowserView({
   onFindInFile,
 }: CodeBrowserViewProps) {
   const isDesktop = useIsDesktop();
-  const [currentPath, setCurrentPath] = useState(() => (file ? directoryOf(file) : ""));
-  const [viewFilePath, setViewFilePath] = useState(file ?? "");
+  const [currentPath, setCurrentPath] = useState(() => {
+    if (!file) return "";
+    const loc = parseFileLocation(file);
+    return directoryOf(loc.filePath);
+  });
+  const [viewFilePath, setViewFilePath] = useState(() => {
+    if (!file) return "";
+    return parseFileLocation(file).filePath;
+  });
+  const [viewLine, setViewLine] = useState<number | undefined>(() => {
+    if (!file) return undefined;
+    return parseFileLocation(file).line;
+  });
+  const [viewLineEnd, setViewLineEnd] = useState<number | undefined>(() => {
+    if (!file) return undefined;
+    return parseFileLocation(file).lineEnd;
+  });
+  const [viewColumn, setViewColumn] = useState<number | undefined>(() => {
+    if (!file) return undefined;
+    return parseFileLocation(file).column;
+  });
 
   // Sync when the file prop changes (e.g. navigating from diff view)
   useEffect(() => {
     if (file) {
-      setViewFilePath(file);
-      setCurrentPath(directoryOf(file));
+      const loc = parseFileLocation(file);
+      setViewFilePath(loc.filePath);
+      setCurrentPath(directoryOf(loc.filePath));
+      setViewLine(loc.line);
+      setViewLineEnd(loc.lineEnd);
+      setViewColumn(loc.column);
     }
   }, [file]);
 
   // Handle externally triggered file open
   useEffect(() => {
     if (openFilePath) {
-      setViewFilePath(openFilePath);
+      const loc = parseFileLocation(openFilePath);
+      setViewFilePath(loc.filePath);
+      setViewLine(loc.line);
+      setViewLineEnd(loc.lineEnd);
+      setViewColumn(loc.column);
       // Navigate the file browser to the file's parent directory
-      const lastSlash = openFilePath.lastIndexOf("/");
-      setCurrentPath(lastSlash > 0 ? openFilePath.slice(0, lastSlash) : "");
+      const lastSlash = loc.filePath.lastIndexOf("/");
+      setCurrentPath(lastSlash > 0 ? loc.filePath.slice(0, lastSlash) : "");
       onFileOpened?.();
     }
   }, [openFilePath, onFileOpened]);
@@ -76,6 +108,9 @@ export function CodeBrowserView({
   const handleSelectFile = useCallback(
     (filePath: string) => {
       setViewFilePath(filePath);
+      setViewLine(undefined);
+      setViewLineEnd(undefined);
+      setViewColumn(undefined);
       onSelectFile?.(filePath);
     },
     [onSelectFile],
@@ -83,13 +118,25 @@ export function CodeBrowserView({
 
   const handleBack = useCallback(() => {
     setViewFilePath("");
+    setViewLine(undefined);
+    setViewLineEnd(undefined);
+    setViewColumn(undefined);
     onSelectFile?.(null);
   }, [onSelectFile]);
 
   // Mobile: toggle between browse and view
   if (!isDesktop) {
     if (viewFilePath) {
-      return <FileViewer workspaceId={workspaceId} filePath={viewFilePath} onBack={handleBack} />;
+      return (
+        <FileViewer
+          workspaceId={workspaceId}
+          filePath={viewFilePath}
+          line={viewLine}
+          lineEnd={viewLineEnd}
+          column={viewColumn}
+          onBack={handleBack}
+        />
+      );
     }
     return (
       <FileBrowser
@@ -122,6 +169,9 @@ export function CodeBrowserView({
           <FileViewer
             workspaceId={workspaceId}
             filePath={viewFilePath}
+            line={viewLine}
+            lineEnd={viewLineEnd}
+            column={viewColumn}
             onEditorView={handleEditorView}
           />
         ) : (

--- a/packages/dashboard-core/src/components/CodeMirrorViewer.tsx
+++ b/packages/dashboard-core/src/components/CodeMirrorViewer.tsx
@@ -2,12 +2,24 @@ import { EditorState } from "@codemirror/state";
 import { EditorView } from "@codemirror/view";
 import { useEffect, useRef } from "react";
 import { useIsDark } from "../hooks/use-is-dark";
-import { baseViewerExtensions, loadLanguage } from "../lib/codemirror-setup";
+import {
+  baseViewerExtensions,
+  lineHighlightExtension,
+  loadLanguage,
+  scrollToLine,
+  setHighlightLines,
+} from "../lib/codemirror-setup";
 
 interface CodeMirrorViewerProps {
   content: string;
   language: string;
   className?: string;
+  /** 1-based line number to scroll to and highlight */
+  line?: number;
+  /** 1-based end line for range highlight (inclusive). Uses dash syntax: file:5-10 */
+  lineEnd?: number;
+  /** 1-based column number for cursor positioning. Uses colon syntax: file:5:10 */
+  column?: number;
   /** Called when the EditorView is created or destroyed */
   onEditorView?: (view: EditorView | null) => void;
 }
@@ -16,6 +28,9 @@ export function CodeMirrorViewer({
   content,
   language,
   className,
+  line,
+  lineEnd,
+  column,
   onEditorView,
 }: CodeMirrorViewerProps) {
   const containerRef = useRef<HTMLDivElement>(null);
@@ -23,6 +38,14 @@ export function CodeMirrorViewer({
   const onEditorViewRef = useRef(onEditorView);
   onEditorViewRef.current = onEditorView;
   const isDark = useIsDark();
+
+  // Store line props in refs so the creation effect can read them without re-running
+  const lineRef = useRef(line);
+  const lineEndRef = useRef(lineEnd);
+  const columnRef = useRef(column);
+  lineRef.current = line;
+  lineEndRef.current = lineEnd;
+  columnRef.current = column;
 
   // Create/recreate the editor when content, language, or theme changes
   useEffect(() => {
@@ -42,7 +65,7 @@ export function CodeMirrorViewer({
         onEditorViewRef.current?.(null);
       }
 
-      const extensions = [...baseViewerExtensions(isDark)];
+      const extensions = [...baseViewerExtensions(isDark), ...lineHighlightExtension(isDark)];
       if (langSupport) {
         extensions.push(langSupport);
       }
@@ -56,6 +79,11 @@ export function CodeMirrorViewer({
         state,
         parent: container,
       });
+
+      // Scroll to line after creation
+      if (lineRef.current) {
+        scrollToLine(viewRef.current, lineRef.current, lineEndRef.current, columnRef.current);
+      }
 
       onEditorViewRef.current?.(viewRef.current);
     };
@@ -71,6 +99,19 @@ export function CodeMirrorViewer({
       }
     };
   }, [content, language, isDark]);
+
+  // Handle line/lineEnd/column changes without recreating the editor
+  useEffect(() => {
+    if (!viewRef.current) return;
+    if (line) {
+      scrollToLine(viewRef.current, line, lineEnd, column);
+    } else {
+      // Clear highlight when line is removed
+      viewRef.current.dispatch({
+        effects: setHighlightLines.of(null),
+      });
+    }
+  }, [line, lineEnd, column]);
 
   return <div ref={containerRef} className={className} />;
 }

--- a/packages/dashboard-core/src/components/DiffView.tsx
+++ b/packages/dashboard-core/src/components/DiffView.tsx
@@ -6,6 +6,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { useAdapter } from "../context";
 import { useIsDark } from "../hooks/use-is-dark";
 import { baseViewerExtensions, loadLanguage } from "../lib/codemirror-setup";
+import { formatFileLocation } from "../lib/file-location";
 import { extensionToLanguage, filenameToLanguage } from "../lib/language-map";
 import type { FileStatus, WorkspaceDiffSummary } from "../types";
 
@@ -43,6 +44,12 @@ interface DiffViewProps {
 interface ParsedFile {
   filename: string;
   hunks: string;
+}
+
+/** Extracts the start line of the first hunk in a diff (new-file side). */
+function firstChangeLine(hunks: string): number | undefined {
+  const match = hunks.match(/@@ [^ ]+ \+(\d+)/);
+  return match ? parseInt(match[1], 10) : undefined;
 }
 
 function parseDiffFiles(diff: string): ParsedFile[] {
@@ -407,12 +414,14 @@ function LazyFileRow({
             onClick={(e) => {
               e.preventDefault();
               e.stopPropagation();
-              onOpenFile(filename);
+              const line = diff ? firstChangeLine(diff) : undefined;
+              onOpenFile(formatFileLocation(filename, line));
             }}
             onKeyDown={(e) => {
               if (e.key === "Enter") {
                 e.stopPropagation();
-                onOpenFile(filename);
+                const line = diff ? firstChangeLine(diff) : undefined;
+                onOpenFile(formatFileLocation(filename, line));
               }
             }}
             className="shrink-0 rounded p-1 text-muted-foreground hover:bg-accent hover:text-foreground"
@@ -633,12 +642,14 @@ function LegacyDiffView({ workspaceId, active, onStatsChange, onOpenFile }: Diff
                     onClick={(e) => {
                       e.preventDefault();
                       e.stopPropagation();
-                      onOpenFile(file.filename);
+                      const line = firstChangeLine(file.hunks);
+                      onOpenFile(formatFileLocation(file.filename, line));
                     }}
                     onKeyDown={(e) => {
                       if (e.key === "Enter") {
                         e.stopPropagation();
-                        onOpenFile(file.filename);
+                        const line = firstChangeLine(file.hunks);
+                        onOpenFile(formatFileLocation(file.filename, line));
                       }
                     }}
                     className="shrink-0 rounded p-1 text-muted-foreground hover:bg-accent hover:text-foreground"

--- a/packages/dashboard-core/src/components/FileViewer.tsx
+++ b/packages/dashboard-core/src/components/FileViewer.tsx
@@ -10,6 +10,12 @@ interface FileViewerProps {
   workspaceId: string;
   filePath: string;
   onBack?: () => void;
+  /** 1-based line number to scroll to and highlight */
+  line?: number;
+  /** 1-based end line for range highlight (inclusive) */
+  lineEnd?: number;
+  /** 1-based column number for cursor positioning */
+  column?: number;
   /** Called when the CodeMirror EditorView is created or destroyed */
   onEditorView?: (view: EditorView | null) => void;
 }
@@ -33,7 +39,15 @@ function detectLanguage(filePath: string, serverHint?: string): string {
   return fromName || "plaintext";
 }
 
-export function FileViewer({ workspaceId, filePath, onBack, onEditorView }: FileViewerProps) {
+export function FileViewer({
+  workspaceId,
+  filePath,
+  onBack,
+  line,
+  lineEnd,
+  column,
+  onEditorView,
+}: FileViewerProps) {
   const adapter = useAdapter();
   const [data, setData] = useState<FileContentResult | null>(null);
   const [loading, setLoading] = useState(true);
@@ -114,6 +128,9 @@ export function FileViewer({ workspaceId, filePath, onBack, onEditorView }: File
             content={data.content}
             language={lang}
             className="h-full"
+            line={line}
+            lineEnd={lineEnd}
+            column={column}
             onEditorView={onEditorView}
           />
         )}

--- a/packages/dashboard-core/src/components/SearchFilesDialog.tsx
+++ b/packages/dashboard-core/src/components/SearchFilesDialog.tsx
@@ -14,6 +14,7 @@ import { CaseSensitive, SearchIcon } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useAdapter } from "../context";
 import { getFileIcon } from "../lib/file-icon";
+import { formatFileLocation } from "../lib/file-location";
 import type { ContentSearchMatch } from "../types";
 
 interface SearchFilesDialogProps {
@@ -89,8 +90,8 @@ export function SearchFilesDialog({
   }, [results]);
 
   const handleSelect = useCallback(
-    (filePath: string) => {
-      onOpenFile(filePath);
+    (filePath: string, line: number) => {
+      onOpenFile(formatFileLocation(filePath, line));
       onOpenChange(false);
     },
     [onOpenFile, onOpenChange],
@@ -152,7 +153,7 @@ export function SearchFilesDialog({
                     <CommandItem
                       key={`${file}:${match.line}:${match.content}`}
                       value={`${file}:${match.line}:${match.content}`}
-                      onSelect={() => handleSelect(file)}
+                      onSelect={() => handleSelect(file, match.line)}
                     >
                       <span className="w-8 shrink-0 text-right font-mono text-xs text-muted-foreground">
                         {match.line}

--- a/packages/dashboard-core/src/index.ts
+++ b/packages/dashboard-core/src/index.ts
@@ -44,6 +44,7 @@ export {
   useStatusWatcher,
 } from "./hooks/use-status";
 export { openFileSearchPanel } from "./lib/codemirror-setup";
+export { type FileLocation, formatFileLocation, parseFileLocation } from "./lib/file-location";
 export { extensionToLanguage, filenameToLanguage } from "./lib/language-map";
 export { isServiceHealthy, type ServiceHealth } from "./lib/service-health";
 // Lib

--- a/packages/dashboard-core/src/lib/codemirror-setup.ts
+++ b/packages/dashboard-core/src/lib/codemirror-setup.ts
@@ -7,9 +7,15 @@ import {
   syntaxHighlighting,
 } from "@codemirror/language";
 import { highlightSelectionMatches, openSearchPanel, searchKeymap } from "@codemirror/search";
-import { EditorState, type Extension } from "@codemirror/state";
+import {
+  EditorState,
+  type Extension,
+  type Range,
+  StateEffect,
+  StateField,
+} from "@codemirror/state";
 import { oneDarkHighlightStyle } from "@codemirror/theme-one-dark";
-import { EditorView, keymap, lineNumbers } from "@codemirror/view";
+import { Decoration, type DecorationSet, EditorView, keymap, lineNumbers } from "@codemirror/view";
 
 /**
  * Lazy-loads a CodeMirror LanguageSupport for the given language name.
@@ -181,4 +187,84 @@ export function baseViewerExtensions(isDark = true): Extension[] {
 // biome-ignore lint/suspicious/noExplicitAny: EditorView type from @codemirror/view — kept untyped for cross-package use
 export function openFileSearchPanel(view: any): boolean {
   return openSearchPanel(view as EditorView);
+}
+
+// ---------------------------------------------------------------------------
+// Line highlight extension
+// ---------------------------------------------------------------------------
+
+/** Effect to set or clear the highlighted line range. */
+export const setHighlightLines = StateEffect.define<{
+  from: number;
+  to: number;
+} | null>();
+
+const highlightLineDeco = Decoration.line({ class: "cm-highlighted-line" });
+
+const highlightLineField = StateField.define<DecorationSet>({
+  create() {
+    return Decoration.none;
+  },
+  update(decos, tr) {
+    for (const e of tr.effects) {
+      if (e.is(setHighlightLines)) {
+        if (!e.value) return Decoration.none;
+        const { from, to } = e.value;
+        const doc = tr.state.doc;
+        const decorations: Range<Decoration>[] = [];
+        for (let line = from; line <= to && line <= doc.lines; line++) {
+          decorations.push(highlightLineDeco.range(doc.line(line).from));
+        }
+        return Decoration.set(decorations);
+      }
+    }
+    return decos;
+  },
+  provide: (f) => EditorView.decorations.from(f),
+});
+
+/**
+ * Extension that enables line highlighting via the setHighlightLines effect.
+ * Include this in the editor's extensions to support scroll-to-line + highlight.
+ */
+export function lineHighlightExtension(isDark = true): Extension[] {
+  return [
+    highlightLineField,
+    EditorView.theme(
+      {
+        ".cm-highlighted-line": {
+          backgroundColor: isDark ? "rgba(255, 213, 79, 0.12)" : "rgba(255, 213, 79, 0.25)",
+        },
+      },
+      { dark: isDark },
+    ),
+  ];
+}
+
+/**
+ * Scrolls the editor to the given 1-based line and highlights the range.
+ * Optionally positions cursor at a specific column.
+ */
+export function scrollToLine(
+  view: EditorView,
+  line: number,
+  lineEnd?: number,
+  column?: number,
+): void {
+  const doc = view.state.doc;
+  const clampedLine = Math.max(1, Math.min(line, doc.lines));
+  const clampedEnd = lineEnd ? Math.max(clampedLine, Math.min(lineEnd, doc.lines)) : clampedLine;
+
+  // Set highlight decorations
+  view.dispatch({
+    effects: setHighlightLines.of({ from: clampedLine, to: clampedEnd }),
+  });
+
+  // Scroll the target line into view (centered)
+  const lineObj = doc.line(clampedLine);
+  const scrollPos = column != null ? Math.min(lineObj.from + column - 1, lineObj.to) : lineObj.from;
+
+  view.dispatch({
+    effects: EditorView.scrollIntoView(scrollPos, { y: "center" }),
+  });
 }

--- a/packages/dashboard-core/src/lib/file-location.ts
+++ b/packages/dashboard-core/src/lib/file-location.ts
@@ -1,0 +1,79 @@
+/** Parsed file location with optional line, line range, or column. */
+export interface FileLocation {
+  /** The file path without line/column suffix. */
+  filePath: string;
+  /** Line number (1-based). */
+  line?: number;
+  /** End of line range (1-based, inclusive). Only set for range syntax `file:5-10`. */
+  lineEnd?: number;
+  /** Column number (1-based). Only set for column syntax `file:5:10`. */
+  column?: number;
+}
+
+/**
+ * Parses a file path that may include a line suffix.
+ *
+ * Supported formats:
+ *   "src/main.ts"        -> { filePath: "src/main.ts" }
+ *   "src/main.ts:89"     -> { filePath: "src/main.ts", line: 89 }
+ *   "src/main.ts:5-10"   -> { filePath: "src/main.ts", line: 5, lineEnd: 10 }
+ *   "src/main.ts:5:10"   -> { filePath: "src/main.ts", line: 5, column: 10 }
+ */
+export function parseFileLocation(raw: string): FileLocation {
+  // Try :line-lineEnd (range with dash)
+  const rangeMatch = raw.match(/:(\d+)-(\d+)$/);
+  if (rangeMatch) {
+    const line = parseInt(rangeMatch[1], 10);
+    const lineEnd = parseInt(rangeMatch[2], 10);
+    if (line > 0 && lineEnd > 0) {
+      return {
+        filePath: raw.slice(0, raw.length - rangeMatch[0].length),
+        line,
+        lineEnd,
+      };
+    }
+  }
+
+  // Try :line:column (two colon-separated numbers)
+  const colMatch = raw.match(/:(\d+):(\d+)$/);
+  if (colMatch) {
+    const line = parseInt(colMatch[1], 10);
+    const column = parseInt(colMatch[2], 10);
+    if (line > 0 && column > 0) {
+      return {
+        filePath: raw.slice(0, raw.length - colMatch[0].length),
+        line,
+        column,
+      };
+    }
+  }
+
+  // Try :line (single number)
+  const lineMatch = raw.match(/:(\d+)$/);
+  if (lineMatch) {
+    const line = parseInt(lineMatch[1], 10);
+    if (line > 0) {
+      return {
+        filePath: raw.slice(0, raw.length - lineMatch[0].length),
+        line,
+      };
+    }
+  }
+
+  return { filePath: raw };
+}
+
+/**
+ * Formats a file path with optional line/range/column information.
+ * Inverse of parseFileLocation.
+ */
+export function formatFileLocation(
+  filePath: string,
+  line?: number,
+  options?: { lineEnd?: number; column?: number },
+): string {
+  if (line != null && options?.lineEnd != null) return `${filePath}:${line}-${options.lineEnd}`;
+  if (line != null && options?.column != null) return `${filePath}:${line}:${options.column}`;
+  if (line != null) return `${filePath}:${line}`;
+  return filePath;
+}


### PR DESCRIPTION
## Summary

- Adds line number support in code browser URLs: `file.ts:89` (single line), `file.ts:5-10` (range), `file.ts:5:10` (line + column)
- Search results now navigate to the exact match line with highlighting
- DiffView "Open in code browser" jumps to the first changed line

## Changes

- New `file-location.ts` utility for parsing/formatting `file:line` paths
- CodeMirror line highlight extension with scroll-to-line + yellow background decoration
- `CodeMirrorViewer`, `FileViewer` accept `line`/`lineEnd`/`column` props
- `CodeBrowserView` parses line info from URL splat and `openFilePath`
- `SearchFilesDialog` encodes match line in `onOpenFile` callback
- `DiffView` includes first hunk line in "Open in code browser" action

## Test plan

- [ ] Navigate to `/workspace/{id}/code/src/some-file.ts:10` — scrolls to line 10 with highlight
- [ ] Navigate to `/workspace/{id}/code/src/some-file.ts:5-15` — highlights lines 5-15
- [ ] Use Search Files (Cmd+Shift+F), click a result — opens file scrolled to match line
- [ ] Click "Open in code browser" from diff view — jumps to first changed line
- [ ] Click a different file in sidebar — highlight clears

🤖 Generated with [Claude Code](https://claude.com/claude-code)