### PR TITLE
fix: improve find-in-file search and code browser

### DIFF
--- a/apps/web/src/components/CodeBrowserView.tsx
+++ b/apps/web/src/components/CodeBrowserView.tsx
@@ -58,19 +58,16 @@ export function CodeBrowserView({
   const onFindInFileRef = useRef(onFindInFile);
   onFindInFileRef.current = onFindInFile;
 
-  const handleEditorView = useCallback(
-    (view: { focus: () => void } | null) => {
-      if (view) {
-        onFindInFileRef.current?.(() => {
-          view.focus();
-          openFileSearchPanel(view);
-        });
-      } else {
-        onFindInFileRef.current?.(null);
-      }
-    },
-    [],
-  );
+  const handleEditorView = useCallback((view: { focus: () => void } | null) => {
+    if (view) {
+      onFindInFileRef.current?.(() => {
+        view.focus();
+        openFileSearchPanel(view);
+      });
+    } else {
+      onFindInFileRef.current?.(null);
+    }
+  }, []);
 
   // Clean up on unmount
   useEffect(() => {

--- a/apps/web/src/components/CodeBrowserView.tsx
+++ b/apps/web/src/components/CodeBrowserView.tsx
@@ -1,6 +1,6 @@
 import { FileBrowser, FileViewer, openFileSearchPanel } from "@band-app/dashboard-core";
 import { File } from "lucide-react";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useIsDesktop } from "../hooks/useIsDesktop";
 
 interface CodeBrowserViewProps {
@@ -53,19 +53,23 @@ export function CodeBrowserView({
     }
   }, [openFilePath, onFileOpened]);
 
+  // Use a ref for onFindInFile so the handleEditorView callback doesn't
+  // need to be recreated when onFindInFile changes identity.
+  const onFindInFileRef = useRef(onFindInFile);
+  onFindInFileRef.current = onFindInFile;
+
   const handleEditorView = useCallback(
-    // EditorView type from @codemirror/view — kept untyped to avoid cross-package dependency
     (view: { focus: () => void } | null) => {
       if (view) {
-        onFindInFile?.(() => {
+        onFindInFileRef.current?.(() => {
           view.focus();
           openFileSearchPanel(view);
         });
       } else {
-        onFindInFile?.(null);
+        onFindInFileRef.current?.(null);
       }
     },
-    [onFindInFile],
+    [],
   );
 
   // Clean up on unmount

--- a/apps/web/src/components/ai-elements/prompt-input.tsx
+++ b/apps/web/src/components/ai-elements/prompt-input.tsx
@@ -450,7 +450,7 @@ export const PromptInputTextarea = ({
         autoCorrect="off"
         spellCheck={false}
         className={cn(
-          "min-h-[44px] lg:min-h-[36px] max-h-48 w-full resize-none bg-transparent px-2 py-2.5 lg:py-2 text-base lg:text-sm outline-none placeholder:text-muted-foreground field-sizing-content",
+          "min-h-[44px] lg:min-h-[36px] max-h-48 w-full resize-none overflow-y-auto bg-transparent px-2 py-2.5 lg:py-2 text-base lg:text-sm outline-none placeholder:text-muted-foreground field-sizing-content",
           hasSlashCommand && "text-transparent caret-foreground",
           className,
         )}

--- a/apps/web/src/routes/workspace.$workspaceId.code.index.tsx
+++ b/apps/web/src/routes/workspace.$workspaceId.code.index.tsx
@@ -1,6 +1,7 @@
 import { createFileRoute, useNavigate } from "@tanstack/react-router";
 import { useCallback } from "react";
 import { CodeBrowserView } from "../components/CodeBrowserView";
+import { useFindInFileContext } from "./workspace.$workspaceId";
 
 export const Route = createFileRoute("/workspace/$workspaceId/code/")({
   component: CodeIndex,
@@ -9,6 +10,7 @@ export const Route = createFileRoute("/workspace/$workspaceId/code/")({
 function CodeIndex() {
   const { workspaceId } = Route.useParams();
   const navigate = useNavigate();
+  const { setFindInFile } = useFindInFileContext();
 
   const handleSelectFile = useCallback(
     (filePath: string | null) => {
@@ -26,6 +28,7 @@ function CodeIndex() {
     <CodeBrowserView
       workspaceId={decodeURIComponent(workspaceId)}
       onSelectFile={handleSelectFile}
+      onFindInFile={setFindInFile}
     />
   );
 }

--- a/apps/web/src/routes/workspace.$workspaceId.tsx
+++ b/apps/web/src/routes/workspace.$workspaceId.tsx
@@ -260,9 +260,11 @@ function DesktopWorkspaceLayout({
         e.preventDefault();
         setSearchFilesOpen(true);
       } else if (key === "f" && !e.shiftKey) {
+        e.preventDefault();
         if (findInFileRef.current) {
-          e.preventDefault();
           findInFileRef.current();
+        } else {
+          window.dispatchEvent(new CustomEvent("band:find-in-file"));
         }
       }
     };

--- a/packages/dashboard-core/src/components/CodeMirrorViewer.tsx
+++ b/packages/dashboard-core/src/components/CodeMirrorViewer.tsx
@@ -2,7 +2,7 @@ import { EditorState } from "@codemirror/state";
 import { EditorView } from "@codemirror/view";
 import { useEffect, useRef } from "react";
 import { useIsDark } from "../hooks/use-is-dark";
-import { baseViewerExtensions, loadLanguage } from "../lib/codemirror-setup";
+import { baseViewerExtensions, loadLanguage, openFileSearchPanel } from "../lib/codemirror-setup";
 
 interface CodeMirrorViewerProps {
   content: string;
@@ -71,6 +71,21 @@ export function CodeMirrorViewer({
       }
     };
   }, [content, language, isDark]);
+
+  // Listen for find-in-file custom event dispatched by the workspace layout
+  useEffect(() => {
+    const handler = () => {
+      const view = viewRef.current;
+      console.log("[band:find-in-file] handler fired, view:", !!view);
+      if (view) {
+        view.focus();
+        const result = openFileSearchPanel(view);
+        console.log("[band:find-in-file] openSearchPanel result:", result);
+      }
+    };
+    window.addEventListener("band:find-in-file", handler);
+    return () => window.removeEventListener("band:find-in-file", handler);
+  }, []);
 
   return <div ref={containerRef} className={className} />;
 }

--- a/packages/dashboard-core/src/lib/codemirror-setup.ts
+++ b/packages/dashboard-core/src/lib/codemirror-setup.ts
@@ -6,7 +6,12 @@ import {
   StreamLanguage,
   syntaxHighlighting,
 } from "@codemirror/language";
-import { highlightSelectionMatches, openSearchPanel, searchKeymap } from "@codemirror/search";
+import {
+  highlightSelectionMatches,
+  openSearchPanel,
+  search,
+  searchKeymap,
+} from "@codemirror/search";
 import { EditorState, type Extension } from "@codemirror/state";
 import { oneDarkHighlightStyle } from "@codemirror/theme-one-dark";
 import { EditorView, keymap, lineNumbers } from "@codemirror/view";
@@ -142,6 +147,7 @@ export function baseViewerExtensions(isDark = true): Extension[] {
           syntaxHighlighting(defaultHighlightStyle),
           syntaxHighlighting(oneDarkHighlightStyle, { fallback: true }),
         ]),
+    search(),
     keymap.of([...defaultKeymap, ...searchKeymap]),
     EditorView.theme(
       isDark


### PR DESCRIPTION
## Summary
- Always prevent browser default on Cmd+F so the browser find dialog never appears in the app
- Fall back to `band:find-in-file` custom event when the ref-based callback is unavailable, fixing the shortcut not working in some states
- Add CodeMirror `search()` extension and `searchKeymap` to the code viewer for find-in-file support
- Wire up `FindInFileContext` in the code index route so find-in-file works when browsing files
- Add `overflow-y-auto` to the prompt textarea to prevent content overflow

## Test plan
- [ ] Open a file in the code browser, press Cmd+F — search panel should appear
- [ ] Press Cmd+F without a file open — browser find should NOT appear
- [ ] Cmd+Shift+F and Cmd+P shortcuts still work as before
- [ ] Long text in prompt textarea scrolls instead of overflowing

🤖 Generated with [Claude Code](https://claude.com/claude-code)