### PR TITLE
feat: remember last active tab and file per workspace

### DIFF
--- a/apps/web/src/routes/workspace.$workspaceId.index.tsx
+++ b/apps/web/src/routes/workspace.$workspaceId.index.tsx
@@ -16,7 +16,7 @@ function WorkspaceIndex() {
   const decoded = decodeURIComponent(workspaceId);
   const isDesktop = useIsDesktop() && !isTauri;
 
-  // Desktop: chat is always visible in the right panel — redirect to changes tab
+  // Desktop: chat is always visible in the left panel — redirect to changes tab
   if (isDesktop) {
     return <Navigate to="/workspace/$workspaceId/changes" params={{ workspaceId }} replace />;
   }

--- a/apps/web/src/routes/workspace.$workspaceId.tsx
+++ b/apps/web/src/routes/workspace.$workspaceId.tsx
@@ -135,6 +135,7 @@ function WorkspaceLayout() {
   const decoded = decodeURIComponent(workspaceId);
   const isDesktop = useIsDesktop() && !isTauri;
   const [diffStats, setDiffStats] = useState<DiffStats | null>(null);
+  const pathname = useRouterState({ select: (s) => s.location.pathname });
 
   // Sync zustand active workspace from URL
   const setActiveWorkspace = useDashboardStore((s) => s.setActiveWorkspace);
@@ -148,6 +149,19 @@ function WorkspaceLayout() {
   useEffect(() => {
     clearNeedsAttention(decoded);
   }, [decoded, clearNeedsAttention]);
+
+  // Persist the full sub-path (e.g. "/code/src/index.ts") so it can be
+  // restored when navigating back — this remembers both the active tab
+  // and the specific file the user was viewing.
+  useEffect(() => {
+    const prefix = `/workspace/${workspaceId}`;
+    if (pathname.length > prefix.length && pathname.startsWith(prefix)) {
+      const subPath = pathname.slice(prefix.length); // e.g. "/code/src/index.ts"
+      try {
+        sessionStorage.setItem(`band-tab:${decoded}`, subPath);
+      } catch {}
+    }
+  }, [pathname, workspaceId, decoded]);
 
   return (
     <DiffStatsContext.Provider value={{ diffStats, setDiffStats }}>

--- a/packages/dashboard-core/src/adapters/web.ts
+++ b/packages/dashboard-core/src/adapters/web.ts
@@ -282,12 +282,22 @@ export class WebDashboardAdapter implements DashboardAdapter {
   }
 }
 
+// Valid sub-path prefixes for restoring the last workspace location
+const VALID_TAB_PREFIXES = ["/changes", "/code", "/terminal"];
+
 export class WebCapabilities implements PlatformCapabilities {
   copyPath = false;
   navigate?: (href: string) => void;
 
   getWorkspaceHref(workspaceId: string): string {
-    return `/workspace/${encodeURIComponent(workspaceId)}`;
+    const base = `/workspace/${encodeURIComponent(workspaceId)}`;
+    try {
+      const stored = sessionStorage.getItem(`band-tab:${workspaceId}`);
+      if (stored && VALID_TAB_PREFIXES.some((p) => stored.startsWith(p))) {
+        return `${base}${stored}`;
+      }
+    } catch {}
+    return base;
   }
 
   async openUrl(url: string): Promise<void> {


### PR DESCRIPTION
## Summary
- Persists the full workspace sub-path (tab + file) to `sessionStorage` on every navigation within a workspace
- Resolves the stored path in `WebCapabilities.getWorkspaceHref` so clicking a workspace card navigates directly to the last-viewed location
- Index route remains unchanged — desktop defaults to `/changes`, mobile defaults to chat

## Test plan
- [ ] Open a workspace → lands on Changes (default, no stored tab)
- [ ] Switch to Files tab, open a specific file → navigate to another workspace → navigate back → should restore the exact file
- [ ] Switch to Terminal tab → navigate away → navigate back → should restore Terminal
- [ ] On mobile: switch to Changes → go to another workspace → come back → should restore Changes
- [ ] On mobile: be on Changes → tap Chat tab → should show chat (no redirect conflict)
- [ ] Fresh browser tab (new sessionStorage) → should default to Changes on desktop, Chat on mobile

🤖 Generated with [Claude Code](https://claude.com/claude-code)