### PR TITLE
feat: add keyboard shortcuts and tooltips to web dashboard

### DIFF
--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -7,6 +7,9 @@ import {
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuTrigger,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
 } from "@band-app/ui";
 import type { UIMessage } from "ai";
 import { getToolName, isToolUIPart } from "ai";
@@ -297,6 +300,18 @@ export function ChatView({
       })
       .catch(() => {});
   }, [workspaceId, codingAgentId, handleModeSelect]);
+
+  // Listen for Shift+Tab mode toggle dispatched from the workspace layout
+  useEffect(() => {
+    const handler = () => {
+      if (modes.length < 2) return;
+      const currentIndex = modes.findIndex((m) => m.id === selectedMode);
+      const nextIndex = currentIndex === -1 ? 1 : (currentIndex + 1) % modes.length;
+      handleModeSelect(modes[nextIndex].id);
+    };
+    window.addEventListener("band:toggle-mode", handler);
+    return () => window.removeEventListener("band:toggle-mode", handler);
+  }, [modes, selectedMode, handleModeSelect]);
 
   const [models, setModels] = useState<{ id: string; name: string; description?: string }[]>([]);
   const [selectedModel, setSelectedModel] = useState<string | undefined>(() => {
@@ -824,15 +839,20 @@ function ModeMenu({
   const current = modes.find((m) => m.id === selected) ?? modes[0];
   return (
     <DropdownMenu>
-      <DropdownMenuTrigger asChild>
-        <button
-          type="button"
-          className="inline-flex items-center gap-1 rounded-md px-2 py-1 text-xs font-medium text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
-        >
-          <ModeIcon modeId={current?.id ?? ""} className="size-3" />
-          {current?.name ?? "Mode"}
-        </button>
-      </DropdownMenuTrigger>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <DropdownMenuTrigger asChild>
+            <button
+              type="button"
+              className="inline-flex items-center gap-1 rounded-md px-2 py-1 text-xs font-medium text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+            >
+              <ModeIcon modeId={current?.id ?? ""} className="size-3" />
+              {current?.name ?? "Mode"}
+            </button>
+          </DropdownMenuTrigger>
+        </TooltipTrigger>
+        <TooltipContent>⇧Tab</TooltipContent>
+      </Tooltip>
       <DropdownMenuContent align="start" className="min-w-[140px]">
         {modes.map((mode) => (
           <DropdownMenuItem

--- a/apps/web/src/routes/workspace.$workspaceId.tsx
+++ b/apps/web/src/routes/workspace.$workspaceId.tsx
@@ -7,6 +7,7 @@ import {
   type WorkspaceTab,
   WorkspaceTabNav,
 } from "@band-app/dashboard-core";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@band-app/ui";
 import { createFileRoute, Link, Outlet, useNavigate, useRouterState } from "@tanstack/react-router";
 import {
   ArrowLeft,
@@ -212,31 +213,50 @@ function DesktopDetailTabNav({ workspaceId }: { workspaceId: string }) {
 
   return (
     <div className="flex h-12 shrink-0 items-center border-b border-border">
-      <Link
-        to="/workspace/$workspaceId/changes"
-        params={{ workspaceId }}
-        className={tabClass(isChanges)}
-      >
-        <GitCompare className="size-4" />
-        Changes
-        {diffFileCount > 0 && (
-          <span className="inline-flex h-5 min-w-5 items-center justify-center rounded-full bg-blue-500/20 text-blue-600 dark:text-blue-400 px-1.5 text-xs font-medium">
-            {diffFileCount}
-          </span>
-        )}
-      </Link>
-      <Link to="/workspace/$workspaceId/code" params={{ workspaceId }} className={tabClass(isCode)}>
-        <FolderOpen className="size-4" />
-        Files
-      </Link>
-      <Link
-        to="/workspace/$workspaceId/terminal"
-        params={{ workspaceId }}
-        className={tabClass(isTerminal)}
-      >
-        <Terminal className="size-4" />
-        Terminal
-      </Link>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Link
+            to="/workspace/$workspaceId/changes"
+            params={{ workspaceId }}
+            className={tabClass(isChanges)}
+          >
+            <GitCompare className="size-4" />
+            Changes
+            {diffFileCount > 0 && (
+              <span className="inline-flex h-5 min-w-5 items-center justify-center rounded-full bg-blue-500/20 text-blue-600 dark:text-blue-400 px-1.5 text-xs font-medium">
+                {diffFileCount}
+              </span>
+            )}
+          </Link>
+        </TooltipTrigger>
+        <TooltipContent>⌘E</TooltipContent>
+      </Tooltip>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Link
+            to="/workspace/$workspaceId/code"
+            params={{ workspaceId }}
+            className={tabClass(isCode)}
+          >
+            <FolderOpen className="size-4" />
+            Files
+          </Link>
+        </TooltipTrigger>
+        <TooltipContent>⌘G</TooltipContent>
+      </Tooltip>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Link
+            to="/workspace/$workspaceId/terminal"
+            params={{ workspaceId }}
+            className={tabClass(isTerminal)}
+          >
+            <Terminal className="size-4" />
+            Terminal
+          </Link>
+        </TooltipTrigger>
+        <TooltipContent>⌘J</TooltipContent>
+      </Tooltip>
     </div>
   );
 }
@@ -263,6 +283,14 @@ function DesktopWorkspaceLayout({
   // Global keyboard shortcuts (capture phase to beat browser defaults)
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
+      // Shift+Tab (no Ctrl/Cmd) → toggle mode between Edit and Plan
+      if (e.key === "Tab" && e.shiftKey && !e.ctrlKey && !e.metaKey) {
+        e.preventDefault();
+        e.stopPropagation();
+        window.dispatchEvent(new CustomEvent("band:toggle-mode"));
+        return;
+      }
+
       const mod = e.metaKey || e.ctrlKey;
       if (!mod) return;
 
@@ -280,11 +308,29 @@ function DesktopWorkspaceLayout({
         } else {
           window.dispatchEvent(new CustomEvent("band:find-in-file"));
         }
+      } else if (key === "e" && !e.shiftKey) {
+        e.preventDefault();
+        navigate({
+          to: "/workspace/$workspaceId/changes",
+          params: { workspaceId: encodedId },
+        });
+      } else if (key === "j" && !e.shiftKey) {
+        e.preventDefault();
+        navigate({
+          to: "/workspace/$workspaceId/terminal",
+          params: { workspaceId: encodedId },
+        });
+      } else if (key === "g" && !e.shiftKey) {
+        e.preventDefault();
+        navigate({
+          to: "/workspace/$workspaceId/code",
+          params: { workspaceId: encodedId },
+        });
       }
     };
     window.addEventListener("keydown", handler, true);
     return () => window.removeEventListener("keydown", handler, true);
-  }, []);
+  }, [encodedId, navigate]);
 
   // Resizable panel width
   const [panelPct, setPanelPct] = useState(getStoredPanelWidth);

--- a/packages/dashboard-core/src/components/ProjectList.tsx
+++ b/packages/dashboard-core/src/components/ProjectList.tsx
@@ -40,7 +40,7 @@ import {
   Tag,
   Trash2,
 } from "lucide-react";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useCapabilities } from "../context";
 import {
   useRemoveProject,
@@ -364,6 +364,8 @@ export function ProjectList({ labelFilter, editMode }: ProjectListProps) {
     }
   }, [hasProjects]);
 
+  const capabilities = useCapabilities();
+
   // ──────────────────────────────────────────────────────────────────────────
   // KEYBOARD NAVIGATION — READ BEFORE MODIFYING
   //
@@ -388,6 +390,18 @@ export function ProjectList({ labelFilter, editMode }: ProjectListProps) {
   // pressing Enter after arrow-key navigation opens the wrong workspace (or
   // no workspace at all, depending on the platform).
   // ──────────────────────────────────────────────────────────────────────────
+  const selectWorkspace = useCallback(
+    (wsId: string) => {
+      const href = capabilities.getWorkspaceHref?.(wsId);
+      if (href && capabilities.navigate) {
+        capabilities.navigate(href);
+      } else {
+        openWorkspace(wsId);
+      }
+    },
+    [capabilities, openWorkspace],
+  );
+
   function handleKeyDown(e: React.KeyboardEvent) {
     if (allWorkspaceIds.length === 0) return;
 
@@ -408,7 +422,7 @@ export function ProjectList({ labelFilter, editMode }: ProjectListProps) {
       e.preventDefault();
       if (focusedIndex >= 0 && focusedIndex < allWorkspaceIds.length) {
         keyboardNavRef.current = false;
-        openWorkspace(allWorkspaceIds[focusedIndex]);
+        selectWorkspace(allWorkspaceIds[focusedIndex]);
       }
     }
   }
@@ -421,8 +435,6 @@ export function ProjectList({ labelFilter, editMode }: ProjectListProps) {
   // as WorkspaceCard: web uses capabilities.navigate(href), Tauri uses
   // openWorkspace() which triggers IPC.
   // ──────────────────────────────────────────────────────────────────────────
-  const capabilities = useCapabilities();
-
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
       if (!(e.metaKey || e.ctrlKey)) return;
@@ -440,18 +452,11 @@ export function ProjectList({ labelFilter, editMode }: ProjectListProps) {
 
       const delta = key === "[" ? -1 : 1;
       const nextIndex = (currentIndex + delta + allWorkspaceIds.length) % allWorkspaceIds.length;
-      const nextId = allWorkspaceIds[nextIndex];
-
-      const href = capabilities.getWorkspaceHref?.(nextId);
-      if (href && capabilities.navigate) {
-        capabilities.navigate(href);
-      } else {
-        openWorkspace(nextId);
-      }
+      selectWorkspace(allWorkspaceIds[nextIndex]);
     };
     window.addEventListener("keydown", handler, true);
     return () => window.removeEventListener("keydown", handler, true);
-  }, [allWorkspaceIds, activeWorkspaceId, openWorkspace, capabilities]);
+  }, [allWorkspaceIds, activeWorkspaceId, selectWorkspace]);
 
   const allProjectNames = useMemo(
     () => visibleGroups.flatMap((g) => g.projects.map((p) => p.name)),

--- a/packages/dashboard-core/src/components/ProjectList.tsx
+++ b/packages/dashboard-core/src/components/ProjectList.tsx
@@ -413,6 +413,46 @@ export function ProjectList({ labelFilter, editMode }: ProjectListProps) {
     }
   }
 
+  // ──────────────────────────────────────────────────────────────────────────
+  // Cmd+[ / Cmd+] — cycle to previous / next workspace
+  //
+  // This is a global (window-level, capture-phase) shortcut so it fires
+  // regardless of which element has focus.  It follows the same dual-path
+  // as WorkspaceCard: web uses capabilities.navigate(href), Tauri uses
+  // openWorkspace() which triggers IPC.
+  // ──────────────────────────────────────────────────────────────────────────
+  const capabilities = useCapabilities();
+
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (!(e.metaKey || e.ctrlKey)) return;
+      const key = e.key;
+      if (key !== "[" && key !== "]") return;
+
+      e.preventDefault();
+      e.stopPropagation();
+      if (allWorkspaceIds.length <= 1) return;
+
+      const currentId = activeWorkspaceId;
+      if (!currentId) return;
+      const currentIndex = allWorkspaceIds.indexOf(currentId);
+      if (currentIndex === -1) return;
+
+      const delta = key === "[" ? -1 : 1;
+      const nextIndex = (currentIndex + delta + allWorkspaceIds.length) % allWorkspaceIds.length;
+      const nextId = allWorkspaceIds[nextIndex];
+
+      const href = capabilities.getWorkspaceHref?.(nextId);
+      if (href && capabilities.navigate) {
+        capabilities.navigate(href);
+      } else {
+        openWorkspace(nextId);
+      }
+    };
+    window.addEventListener("keydown", handler, true);
+    return () => window.removeEventListener("keydown", handler, true);
+  }, [allWorkspaceIds, activeWorkspaceId, openWorkspace, capabilities]);
+
   const allProjectNames = useMemo(
     () => visibleGroups.flatMap((g) => g.projects.map((p) => p.name)),
     [visibleGroups],


### PR DESCRIPTION
## Summary
- **⌘E / ⌘J / ⌘G**: switch to Changes / Terminal / Files tab (with tooltips)
- **⌘[ / ⌘]**: cycle to previous / next workspace (shared `dashboard-core`, works in both web and Tauri)
- **⇧Tab**: toggle mode between Edit and Plan (with tooltip on mode menu)
- Arrow keys navigate the project list without selection; Enter and ⌘[/] open workspaces using the same dual-path as WorkspaceCard (web: `capabilities.navigate`, Tauri: `openWorkspace` IPC)

## Test plan
- [ ] Open a workspace in browser, verify ⌘E/⌘J/⌘G switch tabs
- [ ] Hover tab buttons and mode toggle to see shortcut tooltips
- [ ] With multiple workspaces, verify ⌘[/⌘] cycles between them
- [ ] Verify ⇧Tab toggles mode between Edit and Plan
- [ ] Verify arrow keys in project list move focus without opening workspace

🤖 Generated with [Claude Code](https://claude.com/claude-code)