### PR TITLE
fix: make diff view file path header sticky while scrolling

### DIFF
--- a/packages/dashboard-core/src/components/DiffView.tsx
+++ b/packages/dashboard-core/src/components/DiffView.tsx
@@ -390,7 +390,7 @@ function LazyFileRow({
       <button
         type="button"
         onClick={toggle}
-        className="flex w-full items-center gap-2 px-4 py-2.5 text-left text-sm hover:bg-accent/50"
+        className="sticky top-0 z-10 flex w-full items-center gap-2 bg-background px-4 py-2.5 text-left text-sm hover:bg-accent/50"
       >
         <span
           className={`shrink-0 text-muted-foreground transition-transform ${isOpen ? "rotate-90" : ""}`}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -426,8 +426,6 @@ importers:
         specifier: ^9.6.0
         version: 9.14.0
 
-  packages/shared: {}
-
   packages/ui:
     dependencies:
       class-variance-authority:


### PR DESCRIPTION
## Summary
- Add CSS sticky positioning (`sticky top-0 z-10 bg-background`) to the file path header button in `LazyFileRow` so it stays pinned at the top of the scroll viewport while reading long diffs
- Remove stale `packages/shared: {}` entry from `pnpm-lock.yaml` (package was deleted but lockfile was never updated)

## Test plan
- [ ] Open the Changes tab for a workspace with long file diffs
- [ ] Scroll down through a file's diff content — the file path header should remain visible at the top
- [ ] When scrolling past the entire file into the next file, the previous header should unstick and the new file's header should take over
- [ ] Verify the header has a solid background (no content bleeding through)
- [ ] Test in both light and dark themes

🤖 Generated with [Claude Code](https://claude.com/claude-code)