### PR TITLE
feat: add human-readable display titles for tool calls

### DIFF
--- a/apps/web/e2e/todo-widget.spec.ts
+++ b/apps/web/e2e/todo-widget.spec.ts
@@ -368,6 +368,7 @@ test("TodoWrite mixed with regular tool calls renders both correctly", async ({ 
           type: "tool_use",
           toolCallId: "tc2",
           toolName: "Read",
+          displayTitle: "Read(/src/app.ts)",
           input: { file_path: "/src/app.ts" },
         },
       ],

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -53,8 +53,7 @@ const ERROR_STATES = new Set<ToolPart["state"]>(["output-error", "output-denied"
 function toolPartToItem(part: ToolPart): ToolCallItem {
   const approval = "approval" in part ? (part.approval as { id?: string } | undefined) : undefined;
   const toolName = getToolName(part);
-  const displayTitle =
-    "title" in part && typeof part.title === "string" ? part.title : undefined;
+  const displayTitle = "title" in part && typeof part.title === "string" ? part.title : undefined;
   return {
     toolCallId: part.toolCallId,
     toolName,

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -53,9 +53,12 @@ const ERROR_STATES = new Set<ToolPart["state"]>(["output-error", "output-denied"
 function toolPartToItem(part: ToolPart): ToolCallItem {
   const approval = "approval" in part ? (part.approval as { id?: string } | undefined) : undefined;
   const toolName = getToolName(part);
+  const displayTitle =
+    "title" in part && typeof part.title === "string" ? part.title : undefined;
   return {
     toolCallId: part.toolCallId,
     toolName,
+    displayTitle,
     input: part.input,
     output: part.output,
     errorText: part.errorText,
@@ -150,6 +153,7 @@ function convertHistoryToUIMessages(history: HistoryMessage[]): UIMessage[] {
         } else if (block.type === "tool_use") {
           const callId = block.toolCallId ?? "";
           const toolName = block.toolName ?? "unknown";
+          const title = block.displayTitle;
           const result = toolResultMap.get(callId);
 
           if (result?.isError) {
@@ -160,6 +164,7 @@ function convertHistoryToUIMessages(history: HistoryMessage[]): UIMessage[] {
               state: "output-error",
               input: block.input,
               errorText: result.output ?? "Error",
+              ...(title ? { title } : {}),
             });
           } else if (result) {
             parts.push({
@@ -169,6 +174,7 @@ function convertHistoryToUIMessages(history: HistoryMessage[]): UIMessage[] {
               state: "output-available",
               input: block.input,
               output: result.output,
+              ...(title ? { title } : {}),
             });
           } else {
             // No result — tool is still waiting for input/completion
@@ -178,6 +184,7 @@ function convertHistoryToUIMessages(history: HistoryMessage[]): UIMessage[] {
               toolCallId: callId,
               state: "input-available",
               input: block.input,
+              ...(title ? { title } : {}),
             });
           }
         }

--- a/apps/web/src/components/ai-elements/tool-call.tsx
+++ b/apps/web/src/components/ai-elements/tool-call.tsx
@@ -19,29 +19,14 @@ function extractMarkdown(item: ToolCallItem): string | null {
 export interface ToolCallItem {
   toolCallId: string;
   toolName: string;
+  /** Server-formatted display title (e.g. "Bash(git status)"). */
+  displayTitle?: string;
   input: unknown;
   output: unknown;
   errorText?: string;
   isError: boolean;
   isInProgress: boolean;
   approvalId?: string;
-}
-
-export function formatToolTitle(name: string, input: unknown): string {
-  if (!input || typeof input !== "object") return name;
-  const record = input as Record<string, unknown>;
-  const arg =
-    record.command ??
-    record.pattern ??
-    record.query ??
-    record.file_path ??
-    record.url ??
-    record.content;
-  if (typeof arg === "string") {
-    const summary = arg.length > 80 ? `${arg.slice(0, 80)}...` : arg;
-    return `${name}(${summary})`;
-  }
-  return name;
 }
 
 function StatusDot({ isError, isInProgress }: { isError: boolean; isInProgress: boolean }) {
@@ -84,7 +69,7 @@ export function ToolCall({ item }: { item: ToolCallItem }) {
     );
   }
 
-  const title = formatToolTitle(item.toolName, item.input);
+  const title = item.displayTitle ?? item.toolName;
 
   const markdown = extractMarkdown(item);
 

--- a/apps/web/src/lib/task-runner.ts
+++ b/apps/web/src/lib/task-runner.ts
@@ -293,6 +293,7 @@ async function runTask(workspaceId: string, task: InternalTask) {
             toolCallId: event.toolCallId,
             toolName: event.toolName,
             input: event.input,
+            ...(event.displayTitle ? { title: event.displayTitle } : {}),
           });
           break;
         }

--- a/packages/coding-agent/src/adapters/claude-code.ts
+++ b/packages/coding-agent/src/adapters/claude-code.ts
@@ -26,6 +26,28 @@ const log = createLogger("coding-agent:claude-code");
 
 const ASK_USER_QUESTION_TIMEOUT_MS = 5 * 60 * 1000; // 5 minutes
 
+/**
+ * Build a human-readable display title for a Claude Code tool call.
+ *
+ * Picks the most recognisable argument from the tool input so the UI can
+ * show what the tool is doing at a glance without parsing raw JSON.
+ */
+function formatToolTitle(toolName: string, input: Record<string, unknown>): string {
+  const arg =
+    (input.command as string | undefined) ??
+    (input.pattern as string | undefined) ??
+    (input.query as string | undefined) ??
+    (input.file_path as string | undefined) ??
+    (input.url as string | undefined) ??
+    (input.content as string | undefined) ??
+    (input.description as string | undefined);
+  if (typeof arg === "string") {
+    const summary = arg.length > 80 ? `${arg.slice(0, 80)}...` : arg;
+    return `${toolName}(${summary})`;
+  }
+  return toolName;
+}
+
 function formatUserAnswer(answers: Record<string, string>): string {
   const lines = Object.entries(answers).map(([question, answer]) => `${question}: ${answer}`);
   return `The user selected:\n${lines.join("\n")}`;
@@ -304,11 +326,14 @@ function mapSessionMessage(msg: SessionMessage): SessionMessageItem {
       if (block.type === "text" && block.text) {
         content.push({ type: "text", text: block.text });
       } else if (block.type === "tool_use") {
+        const toolName = block.name ?? "unknown";
+        const input = (block.input ?? {}) as Record<string, unknown>;
         content.push({
           type: "tool_use",
           toolCallId: block.id ?? "",
-          toolName: block.name ?? "unknown",
-          input: block.input ?? {},
+          toolName,
+          displayTitle: formatToolTitle(toolName, input),
+          input,
         });
       } else if (block.type === "tool_result" && block.tool_use_id) {
         const output =
@@ -398,12 +423,14 @@ function* mapClaudeCodeEvent(
           } else if (block.type === "tool_use") {
             const toolCallId = block.id ?? crypto.randomUUID();
             const toolName = block.name ?? "unknown";
+            const input = (block.input ?? {}) as Record<string, unknown>;
             state.toolNames.set(toolCallId, toolName);
             yield {
               type: "tool-use",
               toolCallId,
               toolName,
-              input: block.input ?? {},
+              displayTitle: formatToolTitle(toolName, input),
+              input,
             };
             processedUpTo = i + 1;
           } else {

--- a/packages/coding-agent/src/events.ts
+++ b/packages/coding-agent/src/events.ts
@@ -12,6 +12,8 @@ export interface ToolUseEvent {
   type: "tool-use";
   toolCallId: string;
   toolName: string;
+  /** Human-readable display title (e.g. "Bash(git status)"). */
+  displayTitle?: string;
   input: Record<string, unknown>;
 }
 

--- a/packages/coding-agent/src/types.ts
+++ b/packages/coding-agent/src/types.ts
@@ -25,7 +25,7 @@ export interface SessionMessageItem {
   id: string;
   content: Array<
     | { type: "text"; text: string }
-    | { type: "tool_use"; toolCallId: string; toolName: string; input: unknown }
+    | { type: "tool_use"; toolCallId: string; toolName: string; displayTitle?: string; input: unknown }
     | { type: "tool_result"; toolCallId: string; output: string; isError: boolean }
   >;
 }

--- a/packages/coding-agent/src/types.ts
+++ b/packages/coding-agent/src/types.ts
@@ -25,7 +25,13 @@ export interface SessionMessageItem {
   id: string;
   content: Array<
     | { type: "text"; text: string }
-    | { type: "tool_use"; toolCallId: string; toolName: string; displayTitle?: string; input: unknown }
+    | {
+        type: "tool_use";
+        toolCallId: string;
+        toolName: string;
+        displayTitle?: string;
+        input: unknown;
+      }
     | { type: "tool_result"; toolCallId: string; output: string; isError: boolean }
   >;
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -426,8 +426,6 @@ importers:
         specifier: ^9.6.0
         version: 9.14.0
 
-  packages/shared: {}
-
   packages/ui:
     dependencies:
       class-variance-authority:


### PR DESCRIPTION
## Summary

- Move tool title formatting to the Claude Code adapter layer, producing concise titles like `Bash(git status)` or `Agent(Explore stream consumer side)` instead of raw tool names
- Add `displayTitle` field to `ToolUseEvent` and `SessionMessageItem`, flowing through the event pipeline from adapter → task-runner → broadcast → UI
- Handle both live tool events and historical session messages loaded from JSONL

## Test plan

- [ ] Start a workspace task and verify tool calls show formatted titles (e.g. `Bash(git status)`, `Read(/path/to/file)`, `Agent(description)`)
- [ ] Reload a workspace with existing session history and verify historical tool calls also show formatted titles
- [ ] Verify tools with no recognisable argument still show plain tool name

🤖 Generated with [Claude Code](https://claude.com/claude-code)