### PR TITLE
feat: full-width assistant messages in web chat

### DIFF
--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -927,7 +927,7 @@ function ModelMenu({
 
 function QueuedMessageBubble({ text, onCancel }: { text: string; onCancel: () => void }) {
   return (
-    <div className="group is-user flex w-full max-w-3xl flex-col gap-2 ml-auto justify-end opacity-60">
+    <div className="group is-user flex w-full max-w-[90%] flex-col gap-2 ml-auto justify-end opacity-60">
       <div className="flex min-w-0 max-w-full flex-col gap-2 break-words text-base ml-auto w-fit rounded-md bg-secondary px-4 py-3 text-foreground">
         <MessageResponse>{text}</MessageResponse>
         <div className="flex items-center justify-end gap-2 mt-1">

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -927,7 +927,7 @@ function ModelMenu({
 
 function QueuedMessageBubble({ text, onCancel }: { text: string; onCancel: () => void }) {
   return (
-    <div className="group is-user flex w-full max-w-[95%] flex-col gap-2 ml-auto justify-end opacity-60">
+    <div className="group is-user flex w-full max-w-3xl flex-col gap-2 ml-auto justify-end opacity-60">
       <div className="flex min-w-0 max-w-full flex-col gap-2 break-words text-base ml-auto w-fit rounded-md bg-secondary px-4 py-3 text-foreground">
         <MessageResponse>{text}</MessageResponse>
         <div className="flex items-center justify-end gap-2 mt-1">

--- a/apps/web/src/components/ai-elements/conversation.tsx
+++ b/apps/web/src/components/ai-elements/conversation.tsx
@@ -21,7 +21,7 @@ export type ConversationContentProps = ComponentProps<typeof StickToBottom.Conte
 export const ConversationContent = ({ className, ...props }: ConversationContentProps) => (
   <StickToBottom.Content
     className={cn(
-      "mx-auto flex w-full flex-col overflow-hidden px-3 py-4 lg:px-4 [&>*+*]:mt-4 [&>.is-assistant+.is-assistant]:mt-2",
+      "mx-auto flex w-full max-w-3xl flex-col overflow-hidden px-3 py-4 lg:px-4 [&>*+*]:mt-4 [&>.is-assistant+.is-assistant]:mt-2",
       className,
     )}
     {...props}

--- a/apps/web/src/components/ai-elements/conversation.tsx
+++ b/apps/web/src/components/ai-elements/conversation.tsx
@@ -21,7 +21,7 @@ export type ConversationContentProps = ComponentProps<typeof StickToBottom.Conte
 export const ConversationContent = ({ className, ...props }: ConversationContentProps) => (
   <StickToBottom.Content
     className={cn(
-      "mx-auto flex w-full max-w-3xl flex-col overflow-hidden px-3 py-4 lg:px-4 [&>*+*]:mt-4 [&>.is-assistant+.is-assistant]:mt-2",
+      "mx-auto flex w-full flex-col overflow-hidden px-3 py-4 lg:px-4 [&>*+*]:mt-4 [&>.is-assistant+.is-assistant]:mt-2",
       className,
     )}
     {...props}

--- a/apps/web/src/components/ai-elements/message.tsx
+++ b/apps/web/src/components/ai-elements/message.tsx
@@ -20,7 +20,7 @@ export const Message = ({ className, from, ...props }: MessageProps) => (
   <div
     className={cn(
       "group flex w-full min-w-0 flex-col gap-2",
-      from === "user" ? "is-user ml-auto max-w-3xl justify-end" : "is-assistant",
+      from === "user" ? "is-user ml-auto max-w-[90%] justify-end" : "is-assistant",
       className,
     )}
     {...props}

--- a/apps/web/src/components/ai-elements/message.tsx
+++ b/apps/web/src/components/ai-elements/message.tsx
@@ -19,8 +19,8 @@ export type MessageProps = HTMLAttributes<HTMLDivElement> & {
 export const Message = ({ className, from, ...props }: MessageProps) => (
   <div
     className={cn(
-      "group flex w-full min-w-0 max-w-[95%] flex-col gap-2",
-      from === "user" ? "is-user ml-auto justify-end" : "is-assistant",
+      "group flex w-full min-w-0 flex-col gap-2",
+      from === "user" ? "is-user ml-auto max-w-3xl justify-end" : "is-assistant",
       className,
     )}
     {...props}


### PR DESCRIPTION
## Summary
- Remove `max-w-3xl` constraint from conversation container so assistant messages and tool calls span the full chat width
- User messages keep `max-w-3xl` to stay compact and right-aligned
- Add `/api/uploads` middleware to Vite dev server (mirrors production start-server.ts)

## Test plan
- [ ] Open any workspace chat — assistant messages should span the full width of the chat area
- [ ] User messages should remain compact, right-aligned bubbles (max 768px)
- [ ] Tool call accordions should also be full width
- [ ] Verify `/api/uploads/<file>` serves images in dev mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)