### PR TITLE
feat: clickable links and word navigation in web terminal

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -65,6 +65,7 @@
     "@types/ws": "^8.18.0",
     "@vitejs/plugin-react": "^4.3.0",
     "@xterm/addon-fit": "^0.11.0",
+    "@xterm/addon-web-links": "^0.12.0",
     "@xterm/xterm": "^6.0.0",
     "ai": "^6.0.105",
     "class-variance-authority": "^0.7.1",

--- a/apps/web/src/components/TerminalPanel.tsx
+++ b/apps/web/src/components/TerminalPanel.tsx
@@ -25,56 +25,85 @@ export function TerminalPanel({ workspaceId, visible }: TerminalPanelProps) {
       import("@xterm/addon-fit"),
       import("@xterm/addon-web-links"),
     ]).then(([{ Terminal: XTerm }, { FitAddon: XFitAddon }, { WebLinksAddon: XWebLinksAddon }]) => {
-        if (cancelled || !containerRef.current) return;
+      if (cancelled || !containerRef.current) return;
 
-        // CSS loaded on client only
-        import("@xterm/xterm/css/xterm.css");
+      // CSS loaded on client only
+      import("@xterm/xterm/css/xterm.css");
 
-        const terminal = new XTerm({
-          cursorBlink: true,
-          fontSize: 13,
-          fontFamily: "'SF Mono', Menlo, Monaco, 'Courier New', monospace",
-          macOptionIsMeta: true, // Alt+Left/Right → word navigation on macOS
-          theme: {
-            background: "#181818",
-            foreground: "#e8e8e8",
-            cursor: "#e8e8e8",
-            selectionBackground: "rgba(255, 255, 255, 0.2)",
-          },
-        });
+      const terminal = new XTerm({
+        cursorBlink: true,
+        fontSize: 13,
+        fontFamily: "'SF Mono', Menlo, Monaco, 'Courier New', monospace",
+        macOptionIsMeta: true, // Alt+Left/Right → word navigation on macOS
+        theme: {
+          background: "#181818",
+          foreground: "#e8e8e8",
+          cursor: "#e8e8e8",
+          selectionBackground: "rgba(255, 255, 255, 0.2)",
+        },
+      });
 
-        const fitAddon = new XFitAddon();
-        terminal.loadAddon(fitAddon);
-        terminal.loadAddon(new XWebLinksAddon());
-        terminal.open(containerRef.current!);
+      const fitAddon = new XFitAddon();
+      terminal.loadAddon(fitAddon);
+      terminal.loadAddon(new XWebLinksAddon());
+      terminal.open(containerRef.current!);
 
-        // Alt+Arrow → word navigation (send ESC+b / ESC+f that shells understand)
-        terminal.attachCustomKeyEventHandler((e) => {
-          if (e.type === "keydown" && e.altKey && !e.metaKey && !e.ctrlKey) {
-            if (e.key === "ArrowLeft") {
-              terminal.input("\x1bb");
-              return false;
-            }
-            if (e.key === "ArrowRight") {
-              terminal.input("\x1bf");
-              return false;
-            }
+      // Alt+Arrow → word navigation (send ESC+b / ESC+f that shells understand)
+      terminal.attachCustomKeyEventHandler((e) => {
+        if (e.type === "keydown" && e.altKey && !e.metaKey && !e.ctrlKey) {
+          if (e.key === "ArrowLeft") {
+            terminal.input("\x1bb");
+            return false;
           }
-          return true;
-        });
+          if (e.key === "ArrowRight") {
+            terminal.input("\x1bf");
+            return false;
+          }
+        }
+        return true;
+      });
 
-        terminalRef.current = terminal;
-        fitAddonRef.current = fitAddon;
+      terminalRef.current = terminal;
+      fitAddonRef.current = fitAddon;
 
-        // Connect WebSocket
-        const proto = location.protocol === "https:" ? "wss:" : "ws:";
-        const ws = new WebSocket(
-          `${proto}//${location.host}/terminal?workspaceId=${encodeURIComponent(workspaceId)}`,
+      // Connect WebSocket
+      const proto = location.protocol === "https:" ? "wss:" : "ws:";
+      const ws = new WebSocket(
+        `${proto}//${location.host}/terminal?workspaceId=${encodeURIComponent(workspaceId)}`,
+      );
+      wsRef.current = ws;
+
+      ws.onopen = () => {
+        fitAddon.fit();
+        ws.send(
+          JSON.stringify({
+            type: "resize",
+            cols: terminal.cols,
+            rows: terminal.rows,
+          }),
         );
-        wsRef.current = ws;
+      };
 
-        ws.onopen = () => {
-          fitAddon.fit();
+      ws.onmessage = (event) => {
+        terminal.write(event.data);
+      };
+
+      ws.onclose = () => {
+        terminal.write("\r\n\x1b[90m[Terminal disconnected]\x1b[0m\r\n");
+      };
+
+      terminal.onData((data) => {
+        if (ws.readyState === WebSocket.OPEN) {
+          ws.send(data);
+        }
+      });
+
+      // Auto-fit on container resize (skip zero-size to avoid killing server PTY)
+      const resizeObserver = new ResizeObserver((entries) => {
+        const entry = entries[0];
+        if (!entry || entry.contentRect.width === 0 || entry.contentRect.height === 0) return;
+        fitAddon.fit();
+        if (ws.readyState === WebSocket.OPEN && terminal.cols > 0 && terminal.rows > 0) {
           ws.send(
             JSON.stringify({
               type: "resize",
@@ -82,49 +111,19 @@ export function TerminalPanel({ workspaceId, visible }: TerminalPanelProps) {
               rows: terminal.rows,
             }),
           );
-        };
+        }
+      });
+      resizeObserver.observe(containerRef.current!);
 
-        ws.onmessage = (event) => {
-          terminal.write(event.data);
-        };
-
-        ws.onclose = () => {
-          terminal.write("\r\n\x1b[90m[Terminal disconnected]\x1b[0m\r\n");
-        };
-
-        terminal.onData((data) => {
-          if (ws.readyState === WebSocket.OPEN) {
-            ws.send(data);
-          }
-        });
-
-        // Auto-fit on container resize (skip zero-size to avoid killing server PTY)
-        const resizeObserver = new ResizeObserver((entries) => {
-          const entry = entries[0];
-          if (!entry || entry.contentRect.width === 0 || entry.contentRect.height === 0) return;
-          fitAddon.fit();
-          if (ws.readyState === WebSocket.OPEN && terminal.cols > 0 && terminal.rows > 0) {
-            ws.send(
-              JSON.stringify({
-                type: "resize",
-                cols: terminal.cols,
-                rows: terminal.rows,
-              }),
-            );
-          }
-        });
-        resizeObserver.observe(containerRef.current!);
-
-        cleanup = () => {
-          resizeObserver.disconnect();
-          ws.close();
-          terminal.dispose();
-          terminalRef.current = null;
-          fitAddonRef.current = null;
-          wsRef.current = null;
-        };
-      },
-    );
+      cleanup = () => {
+        resizeObserver.disconnect();
+        ws.close();
+        terminal.dispose();
+        terminalRef.current = null;
+        fitAddonRef.current = null;
+        wsRef.current = null;
+      };
+    });
 
     return () => {
       cancelled = true;

--- a/apps/web/src/components/TerminalPanel.tsx
+++ b/apps/web/src/components/TerminalPanel.tsx
@@ -20,8 +20,11 @@ export function TerminalPanel({ workspaceId, visible }: TerminalPanelProps) {
     let cleanup: (() => void) | undefined;
 
     // Dynamic import so @xterm (CJS) is never evaluated during SSR
-    Promise.all([import("@xterm/xterm"), import("@xterm/addon-fit")]).then(
-      ([{ Terminal: XTerm }, { FitAddon: XFitAddon }]) => {
+    Promise.all([
+      import("@xterm/xterm"),
+      import("@xterm/addon-fit"),
+      import("@xterm/addon-web-links"),
+    ]).then(([{ Terminal: XTerm }, { FitAddon: XFitAddon }, { WebLinksAddon: XWebLinksAddon }]) => {
         if (cancelled || !containerRef.current) return;
 
         // CSS loaded on client only
@@ -31,6 +34,7 @@ export function TerminalPanel({ workspaceId, visible }: TerminalPanelProps) {
           cursorBlink: true,
           fontSize: 13,
           fontFamily: "'SF Mono', Menlo, Monaco, 'Courier New', monospace",
+          macOptionIsMeta: true, // Alt+Left/Right → word navigation on macOS
           theme: {
             background: "#181818",
             foreground: "#e8e8e8",
@@ -41,7 +45,23 @@ export function TerminalPanel({ workspaceId, visible }: TerminalPanelProps) {
 
         const fitAddon = new XFitAddon();
         terminal.loadAddon(fitAddon);
+        terminal.loadAddon(new XWebLinksAddon());
         terminal.open(containerRef.current!);
+
+        // Alt+Arrow → word navigation (send ESC+b / ESC+f that shells understand)
+        terminal.attachCustomKeyEventHandler((e) => {
+          if (e.type === "keydown" && e.altKey && !e.metaKey && !e.ctrlKey) {
+            if (e.key === "ArrowLeft") {
+              terminal.input("\x1bb");
+              return false;
+            }
+            if (e.key === "ArrowRight") {
+              terminal.input("\x1bf");
+              return false;
+            }
+          }
+          return true;
+        });
 
         terminalRef.current = terminal;
         fitAddonRef.current = fitAddon;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -181,6 +181,9 @@ importers:
       '@xterm/addon-fit':
         specifier: ^0.11.0
         version: 0.11.0
+      '@xterm/addon-web-links':
+        specifier: ^0.12.0
+        version: 0.12.0
       '@xterm/xterm':
         specifier: ^6.0.0
         version: 6.0.0
@@ -3425,6 +3428,9 @@ packages:
 
   '@xterm/addon-fit@0.11.0':
     resolution: {integrity: sha512-jYcgT6xtVYhnhgxh3QgYDnnNMYTcf8ElbxxFzX0IZo+vabQqSPAjC3c1wJrKB5E19VwQei89QCiZZP86DCPF7g==}
+
+  '@xterm/addon-web-links@0.12.0':
+    resolution: {integrity: sha512-4Smom3RPyVp7ZMYOYDoC/9eGJJJqYhnPLGGqJ6wOBfB8VxPViJNSKdgRYb8NpaM6YSelEKbA2SStD7lGyqaobw==}
 
   '@xterm/xterm@6.0.0':
     resolution: {integrity: sha512-TQwDdQGtwwDt+2cgKDLn0IRaSxYu1tSUjgKarSDkUM0ZNiSRXFpjxEsvc/Zgc5kq5omJ+V0a8/kIM2WD3sMOYg==}
@@ -9350,6 +9356,8 @@ snapshots:
       tinyrainbow: 3.0.3
 
   '@xterm/addon-fit@0.11.0': {}
+
+  '@xterm/addon-web-links@0.12.0': {}
 
   '@xterm/xterm@6.0.0': {}
 


### PR DESCRIPTION
## Summary
- Load `@xterm/addon-web-links` to make URLs in terminal output clickable (opens in new tab)
- Enable `macOptionIsMeta` so Alt key works as Meta on macOS
- Map Alt+Arrow keys to ESC+b / ESC+f for word-by-word cursor navigation

## Test plan
- [ ] Open a workspace terminal, run `echo "https://github.com"` — URL should underline on hover and open on click
- [ ] Type a command, press Alt+Left/Right — cursor should jump word-by-word
- [ ] Press Alt+Backspace — should delete previous word

🤖 Generated with [Claude Code](https://claude.com/claude-code)