### PR TITLE
feat: Cmd+[/] navigates workspace history instead of cycling

### DIFF
--- a/apps/web/src/hooks/useNavigationHistory.ts
+++ b/apps/web/src/hooks/useNavigationHistory.ts
@@ -1,0 +1,95 @@
+import type { PlatformCapabilities } from "@band-app/dashboard-core";
+import { useRouterState } from "@tanstack/react-router";
+import { useCallback, useEffect, useRef } from "react";
+
+/**
+ * Browser-like workspace history for Cmd+[ (back) and Cmd+] (forward).
+ *
+ * Tracks which workspaces the user visits in a stack with a cursor.
+ * Navigating back/forward moves the cursor without pushing a new entry.
+ * Any normal workspace visit truncates the forward stack — exactly like
+ * a browser.
+ *
+ * Uses `capabilities.getWorkspaceHref()` when navigating so the user
+ * lands on the last-viewed tab inside each workspace.
+ */
+
+const WS_PREFIX = "/workspace/";
+
+/** Extract the decoded workspace ID from a pathname, or null if not on a workspace route. */
+function extractWorkspaceId(pathname: string): string | null {
+  if (!pathname.startsWith(WS_PREFIX)) return null;
+  const rest = pathname.slice(WS_PREFIX.length);
+  // The workspace ID is the first path segment (URL-encoded)
+  const slash = rest.indexOf("/");
+  const encoded = slash === -1 ? rest : rest.slice(0, slash);
+  if (!encoded) return null;
+  return decodeURIComponent(encoded);
+}
+
+export function useNavigationHistory(
+  routerNavigate: (href: string) => void,
+  capabilities: PlatformCapabilities,
+) {
+  const pathname = useRouterState({ select: (s) => s.location.pathname });
+
+  const stackRef = useRef<string[]>([]);
+  const cursorRef = useRef(-1);
+  const navigatingRef = useRef(false);
+
+  // Track workspace changes → push onto the history stack (unless we caused it).
+  useEffect(() => {
+    const wsId = extractWorkspaceId(pathname);
+    if (!wsId) return;
+
+    if (navigatingRef.current) {
+      navigatingRef.current = false;
+      return;
+    }
+
+    const stack = stackRef.current;
+    const cursor = cursorRef.current;
+
+    // Don't push if we're already looking at this workspace.
+    if (cursor >= 0 && stack[cursor] === wsId) return;
+
+    // Truncate any forward entries and push.
+    stackRef.current = [...stack.slice(0, cursor + 1), wsId];
+    cursorRef.current = stackRef.current.length - 1;
+  }, [pathname]);
+
+  const goBack = useCallback(() => {
+    if (cursorRef.current <= 0) return;
+    cursorRef.current -= 1;
+    navigatingRef.current = true;
+    const wsId = stackRef.current[cursorRef.current];
+    const href = capabilities.getWorkspaceHref?.(wsId);
+    if (href) routerNavigate(href);
+  }, [routerNavigate, capabilities]);
+
+  const goForward = useCallback(() => {
+    if (cursorRef.current >= stackRef.current.length - 1) return;
+    cursorRef.current += 1;
+    navigatingRef.current = true;
+    const wsId = stackRef.current[cursorRef.current];
+    const href = capabilities.getWorkspaceHref?.(wsId);
+    if (href) routerNavigate(href);
+  }, [routerNavigate, capabilities]);
+
+  // Global Cmd+[ / Cmd+] listener (capture phase).
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (!(e.metaKey || e.ctrlKey)) return;
+      if (e.key !== "[" && e.key !== "]") return;
+
+      e.preventDefault();
+      e.stopPropagation();
+
+      if (e.key === "[") goBack();
+      else goForward();
+    };
+
+    window.addEventListener("keydown", handler, true);
+    return () => window.removeEventListener("keydown", handler, true);
+  }, [goBack, goForward]);
+}

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -116,10 +116,7 @@ function AppShell() {
   }, [router]);
 
   // Cmd+[ / Cmd+] — back/forward through workspace history
-  const routerNavigate = useCallback(
-    (href: string) => router.navigate({ to: href }),
-    [router],
-  );
+  const routerNavigate = useCallback((href: string) => router.navigate({ to: href }), [router]);
   useNavigationHistory(routerNavigate, capabilities);
 
   if (!isDesktop || isStandalone) {

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -14,9 +14,10 @@ import {
   useRouter,
   useRouterState,
 } from "@tanstack/react-router";
-import { useEffect } from "react";
+import { useCallback, useEffect } from "react";
 import { ToolbarButtons } from "../components/ToolbarButtons";
 import { useIsDesktop } from "../hooks/useIsDesktop";
+import { useNavigationHistory } from "../hooks/useNavigationHistory";
 import { isTauri } from "../lib/is-tauri";
 import "../styles/globals.css";
 
@@ -113,6 +114,13 @@ function AppShell() {
       router.navigate({ to: href });
     };
   }, [router]);
+
+  // Cmd+[ / Cmd+] — back/forward through workspace history
+  const routerNavigate = useCallback(
+    (href: string) => router.navigate({ to: href }),
+    [router],
+  );
+  useNavigationHistory(routerNavigate, capabilities);
 
   if (!isDesktop || isStandalone) {
     return <Outlet />;

--- a/packages/dashboard-core/src/components/ProjectList.tsx
+++ b/packages/dashboard-core/src/components/ProjectList.tsx
@@ -427,37 +427,6 @@ export function ProjectList({ labelFilter, editMode }: ProjectListProps) {
     }
   }
 
-  // ──────────────────────────────────────────────────────────────────────────
-  // Cmd+[ / Cmd+] — cycle to previous / next workspace
-  //
-  // This is a global (window-level, capture-phase) shortcut so it fires
-  // regardless of which element has focus.  It follows the same dual-path
-  // as WorkspaceCard: web uses capabilities.navigate(href), Tauri uses
-  // openWorkspace() which triggers IPC.
-  // ──────────────────────────────────────────────────────────────────────────
-  useEffect(() => {
-    const handler = (e: KeyboardEvent) => {
-      if (!(e.metaKey || e.ctrlKey)) return;
-      const key = e.key;
-      if (key !== "[" && key !== "]") return;
-
-      e.preventDefault();
-      e.stopPropagation();
-      if (allWorkspaceIds.length <= 1) return;
-
-      const currentId = activeWorkspaceId;
-      if (!currentId) return;
-      const currentIndex = allWorkspaceIds.indexOf(currentId);
-      if (currentIndex === -1) return;
-
-      const delta = key === "[" ? -1 : 1;
-      const nextIndex = (currentIndex + delta + allWorkspaceIds.length) % allWorkspaceIds.length;
-      selectWorkspace(allWorkspaceIds[nextIndex]);
-    };
-    window.addEventListener("keydown", handler, true);
-    return () => window.removeEventListener("keydown", handler, true);
-  }, [allWorkspaceIds, activeWorkspaceId, selectWorkspace]);
-
   const allProjectNames = useMemo(
     () => visibleGroups.flatMap((g) => g.projects.map((p) => p.name)),
     [visibleGroups],


### PR DESCRIPTION
## Summary
- **Replaced** Cmd+[ / Cmd+] workspace cycling (prev/next in list) with browser-style back/forward navigation through visited workspaces
- **Added** `useNavigationHistory` hook that tracks workspace IDs in a history stack with a cursor
- **Leverages** existing `getWorkspaceHref()` tab restoration so navigating back lands on the last-viewed tab

## Test plan
- [ ] Open workspace A, then workspace B, then workspace C
- [ ] Press Cmd+[ — should navigate back to B (with last tab restored)
- [ ] Press Cmd+[ again — should navigate back to A
- [ ] Press Cmd+] — should navigate forward to B
- [ ] Click workspace D after going back — forward history (C) should be cleared
- [ ] Switching tabs within a workspace should NOT create history entries
- [ ] Landing on a workspace URL that auto-redirects (e.g. `/workspace/foo` → `/workspace/foo/changes`) should not cause a back-loop

🤖 Generated with [Claude Code](https://claude.com/claude-code)