### PR TITLE
feat: add find-in-file search to changes and file browser views

### DIFF
--- a/apps/web/src/components/CodeBrowserView.tsx
+++ b/apps/web/src/components/CodeBrowserView.tsx
@@ -92,10 +92,7 @@ export function CodeBrowserView({
   // biome-ignore lint/suspicious/noExplicitAny: EditorView type from @codemirror/view — kept untyped to avoid cross-package dependency
   const editorViewRef = useRef<any>(null);
 
-  const getViews = useCallback(
-    () => (editorViewRef.current ? [editorViewRef.current] : []),
-    [],
-  );
+  const getViews = useCallback(() => (editorViewRef.current ? [editorViewRef.current] : []), []);
 
   const search = useSearch({ getViews, onFindInFile });
 

--- a/apps/web/src/components/CodeBrowserView.tsx
+++ b/apps/web/src/components/CodeBrowserView.tsx
@@ -1,8 +1,9 @@
 import {
   FileBrowser,
   FileViewer,
-  openFileSearchPanel,
   parseFileLocation,
+  SearchBar,
+  useSearch,
 } from "@band-app/dashboard-core";
 import { File } from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
@@ -85,26 +86,35 @@ export function CodeBrowserView({
     }
   }, [openFilePath, onFileOpened]);
 
-  // Use a ref for onFindInFile so the handleEditorView callback doesn't
-  // need to be recreated when onFindInFile changes identity.
-  const onFindInFileRef = useRef(onFindInFile);
-  onFindInFileRef.current = onFindInFile;
+  // -------------------------------------------------------------------------
+  // Find-in-file state
+  // -------------------------------------------------------------------------
+  // biome-ignore lint/suspicious/noExplicitAny: EditorView type from @codemirror/view — kept untyped to avoid cross-package dependency
+  const editorViewRef = useRef<any>(null);
 
-  const handleEditorView = useCallback((view: { focus: () => void } | null) => {
-    if (view) {
-      onFindInFileRef.current?.(() => {
-        view.focus();
-        openFileSearchPanel(view);
-      });
-    } else {
-      onFindInFileRef.current?.(null);
-    }
-  }, []);
+  const getViews = useCallback(
+    () => (editorViewRef.current ? [editorViewRef.current] : []),
+    [],
+  );
 
-  // Clean up on unmount
+  const search = useSearch({ getViews, onFindInFile });
+
+  const handleEditorView = useCallback(
+    // biome-ignore lint/suspicious/noExplicitAny: EditorView from @codemirror/view — kept untyped to avoid cross-package dependency
+    (view: any) => {
+      editorViewRef.current = view;
+      if (view) {
+        search.dispatchToViews([view]);
+      }
+    },
+    [search.dispatchToViews],
+  );
+
+  // Close search when file changes
+  // biome-ignore lint/correctness/useExhaustiveDependencies: viewFilePath intentionally triggers reset when user navigates to a different file
   useEffect(() => {
-    return () => onFindInFile?.(null);
-  }, [onFindInFile]);
+    search.handleCloseSearch();
+  }, [viewFilePath]);
 
   const handleSelectFile = useCallback(
     (filePath: string) => {
@@ -153,7 +163,7 @@ export function CodeBrowserView({
   return (
     <div className="flex h-full overflow-hidden">
       {/* Left sidebar - file tree */}
-      <div className="w-60 shrink-0 border-r border-border overflow-hidden">
+      <div className="w-60 shrink-0 overflow-hidden border-r border-border">
         <FileBrowser
           workspaceId={workspaceId}
           currentPath={currentPath}
@@ -165,7 +175,7 @@ export function CodeBrowserView({
       </div>
 
       {/* Right panel - file content */}
-      <div className="flex-1 min-w-0 overflow-hidden">
+      <div className="min-w-0 flex-1 overflow-hidden">
         {viewFilePath ? (
           <FileViewer
             workspaceId={workspaceId}
@@ -174,10 +184,26 @@ export function CodeBrowserView({
             lineEnd={viewLineEnd}
             column={viewColumn}
             onEditorView={handleEditorView}
+            toolbar={
+              search.searchOpen ? (
+                <SearchBar
+                  ref={search.searchBarRef}
+                  query={search.searchQuery}
+                  onQueryChange={search.setSearchQuery}
+                  options={search.searchOptions}
+                  onOptionsChange={search.setSearchOptions}
+                  placeholder="Find in file..."
+                  matchInfo={search.matchInfo}
+                  onNext={search.handleNext}
+                  onPrevious={search.handlePrevious}
+                  onClose={search.handleCloseSearch}
+                />
+              ) : undefined
+            }
           />
         ) : (
           <div className="flex h-full items-center justify-center">
-            <div className="flex flex-col items-center gap-3 text-center px-8">
+            <div className="flex flex-col items-center gap-3 px-8 text-center">
               <File className="size-8 text-muted-foreground/30" />
               <p className="text-sm text-muted-foreground">Select a file to view</p>
             </div>

--- a/apps/web/src/routes/workspace.$workspaceId.changes.tsx
+++ b/apps/web/src/routes/workspace.$workspaceId.changes.tsx
@@ -1,7 +1,7 @@
 import { DiffView } from "@band-app/dashboard-core";
 import { createFileRoute, useNavigate } from "@tanstack/react-router";
 import { useCallback } from "react";
-import { useDiffStatsContext } from "./workspace.$workspaceId";
+import { useDiffStatsContext, useFindInFileContext } from "./workspace.$workspaceId";
 
 export const Route = createFileRoute("/workspace/$workspaceId/changes")({
   component: ChangesTab,
@@ -12,6 +12,7 @@ function ChangesTab() {
   const decoded = decodeURIComponent(workspaceId);
   const navigate = useNavigate();
   const { setDiffStats } = useDiffStatsContext();
+  const { setFindInFile } = useFindInFileContext();
 
   const handleOpenFile = useCallback(
     (filename: string) => {
@@ -29,6 +30,7 @@ function ChangesTab() {
       active
       onStatsChange={setDiffStats}
       onOpenFile={handleOpenFile}
+      onFindInFile={setFindInFile}
     />
   );
 }

--- a/apps/web/src/trpc/router.ts
+++ b/apps/web/src/trpc/router.ts
@@ -928,6 +928,8 @@ const workspaceRouter = t.router({
         workspaceId: z.string(),
         query: z.string().min(1),
         caseSensitive: z.boolean().default(false),
+        wholeWord: z.boolean().default(false),
+        regex: z.boolean().default(false),
         limit: z.number().default(100),
       }),
     )
@@ -938,8 +940,14 @@ const workspaceRouter = t.router({
       }
 
       const cwd = workspace.worktree.path;
-      const args = ["grep", "-n", "--no-color", "-I", "-F"];
+      const args = ["grep", "-n", "--no-color", "-I"];
+      if (input.regex) {
+        args.push("-E");
+      } else {
+        args.push("-F");
+      }
       if (!input.caseSensitive) args.push("-i");
+      if (input.wholeWord) args.push("-w");
       args.push("--", input.query);
 
       let output: string;

--- a/packages/dashboard-core/src/adapter.ts
+++ b/packages/dashboard-core/src/adapter.ts
@@ -95,7 +95,7 @@ export interface DashboardAdapter {
   searchWorkspaceContent?(
     workspaceId: string,
     query: string,
-    options?: { caseSensitive?: boolean; limit?: number },
+    options?: { caseSensitive?: boolean; wholeWord?: boolean; regex?: boolean; limit?: number },
   ): Promise<{ results: ContentSearchMatch[] }>;
 }
 

--- a/packages/dashboard-core/src/adapters/web.ts
+++ b/packages/dashboard-core/src/adapters/web.ts
@@ -281,12 +281,14 @@ export class WebDashboardAdapter implements DashboardAdapter {
   async searchWorkspaceContent(
     workspaceId: string,
     query: string,
-    options?: { caseSensitive?: boolean; limit?: number },
+    options?: { caseSensitive?: boolean; wholeWord?: boolean; regex?: boolean; limit?: number },
   ): Promise<{ results: ContentSearchMatch[] }> {
     return (await this.trpc.workspace.searchContent.query({
       workspaceId,
       query,
       caseSensitive: options?.caseSensitive,
+      wholeWord: options?.wholeWord,
+      regex: options?.regex,
       limit: options?.limit,
     })) as { results: ContentSearchMatch[] };
   }

--- a/packages/dashboard-core/src/components/CodeMirrorViewer.tsx
+++ b/packages/dashboard-core/src/components/CodeMirrorViewer.tsx
@@ -6,8 +6,8 @@ import {
   baseViewerExtensions,
   lineHighlightExtension,
   loadLanguage,
-  openFileSearchPanel,
   scrollToLine,
+  searchHighlightOnly,
   setHighlightLines,
 } from "../lib/codemirror-setup";
 
@@ -66,7 +66,11 @@ export function CodeMirrorViewer({
         onEditorViewRef.current?.(null);
       }
 
-      const extensions = [...baseViewerExtensions(isDark), ...lineHighlightExtension(isDark)];
+      const extensions = [
+        ...baseViewerExtensions(isDark),
+        searchHighlightOnly(),
+        ...lineHighlightExtension(isDark),
+      ];
       if (langSupport) {
         extensions.push(langSupport);
       }
@@ -113,19 +117,6 @@ export function CodeMirrorViewer({
       });
     }
   }, [line, lineEnd, column]);
-
-  // Listen for find-in-file custom event dispatched by the workspace layout
-  useEffect(() => {
-    const handler = () => {
-      const view = viewRef.current;
-      if (view) {
-        view.focus();
-        openFileSearchPanel(view);
-      }
-    };
-    window.addEventListener("band:find-in-file", handler);
-    return () => window.removeEventListener("band:find-in-file", handler);
-  }, []);
 
   return <div ref={containerRef} className={className} />;
 }

--- a/packages/dashboard-core/src/components/DiffView.tsx
+++ b/packages/dashboard-core/src/components/DiffView.tsx
@@ -16,11 +16,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { useAdapter } from "../context";
 import { useIsDark } from "../hooks/use-is-dark";
 import { useSearch } from "../hooks/use-search";
-import {
-  baseViewerExtensions,
-  loadLanguage,
-  searchHighlightOnly,
-} from "../lib/codemirror-setup";
+import { baseViewerExtensions, loadLanguage, searchHighlightOnly } from "../lib/codemirror-setup";
 import { formatFileLocation } from "../lib/file-location";
 import { extensionToLanguage, filenameToLanguage } from "../lib/language-map";
 import type { DiffMode, FileStatus, WorkspaceDiffSummary } from "../types";
@@ -598,10 +594,7 @@ export function DiffView({
   // Track filenames in a ref for stable access in navigation callbacks
   const filenamesRef = useRef<string[]>([]);
 
-  const getViews = useCallback(
-    () => Array.from(editorViewsRef.current.values()).flat(),
-    [],
-  );
+  const getViews = useCallback(() => Array.from(editorViewsRef.current.values()).flat(), []);
 
   const collectMatches = useCallback(
     (query: string, opts: SearchOptions) =>

--- a/packages/dashboard-core/src/components/DiffView.tsx
+++ b/packages/dashboard-core/src/components/DiffView.tsx
@@ -1,5 +1,6 @@
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@band-app/ui";
 import { MergeView, unifiedMergeView } from "@codemirror/merge";
+import { SearchQuery } from "@codemirror/search";
 import { EditorState, Text } from "@codemirror/state";
 import { EditorView } from "@codemirror/view";
 import {
@@ -8,15 +9,22 @@ import {
   Columns2,
   Loader2,
   Rows2,
+  Search,
   SquareArrowOutUpRight,
 } from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useAdapter } from "../context";
 import { useIsDark } from "../hooks/use-is-dark";
-import { baseViewerExtensions, loadLanguage } from "../lib/codemirror-setup";
+import { useSearch } from "../hooks/use-search";
+import {
+  baseViewerExtensions,
+  loadLanguage,
+  searchHighlightOnly,
+} from "../lib/codemirror-setup";
 import { formatFileLocation } from "../lib/file-location";
 import { extensionToLanguage, filenameToLanguage } from "../lib/language-map";
 import type { DiffMode, FileStatus, WorkspaceDiffSummary } from "../types";
+import { SearchBar, type SearchOptions } from "./SearchBar";
 
 export interface DiffStats {
   filesChanged: number;
@@ -78,6 +86,7 @@ interface DiffViewProps {
   active?: boolean;
   onStatsChange?: (stats: DiffStats | null) => void;
   onOpenFile?: (filename: string) => void;
+  onFindInFile?: (fn: (() => void) | null) => void;
 }
 
 /** Extracts the start line of the first hunk in a diff (new-file side). */
@@ -159,14 +168,20 @@ function DiffFileContent({
   hunks,
   filename,
   viewMode,
+  onEditorViews,
 }: {
   hunks: string;
   filename: string;
   viewMode: ViewMode;
+  onEditorViews?: (views: EditorView[]) => void;
 }) {
   const containerRef = useRef<HTMLDivElement>(null);
   const viewRef = useRef<EditorView | MergeView | null>(null);
   const isDark = useIsDark();
+
+  // Use ref pattern so callback identity changes don't re-run the setup effect
+  const onEditorViewsRef = useRef(onEditorViews);
+  onEditorViewsRef.current = onEditorViews;
 
   useEffect(() => {
     const container = containerRef.current;
@@ -189,7 +204,11 @@ function DiffFileContent({
       const { oldText, newText } = buildOldNew(diffLines);
 
       if (viewMode === "split") {
-        const sharedExtensions = [...baseViewerExtensions(isDark), diffTheme];
+        const sharedExtensions = [
+          ...baseViewerExtensions(isDark),
+          searchHighlightOnly(),
+          diffTheme,
+        ];
         if (langSupport) {
           sharedExtensions.push(langSupport);
         }
@@ -207,9 +226,12 @@ function DiffFileContent({
           highlightChanges: false,
           gutter: true,
         });
+
+        onEditorViewsRef.current?.([viewRef.current.a, viewRef.current.b]);
       } else {
         const extensions = [
           ...baseViewerExtensions(isDark),
+          searchHighlightOnly(),
           unifiedMergeView({
             original: Text.of(oldText.split("\n")),
             mergeControls: false,
@@ -231,6 +253,8 @@ function DiffFileContent({
           state,
           parent: container,
         });
+
+        onEditorViewsRef.current?.([viewRef.current]);
       }
     };
 
@@ -242,6 +266,7 @@ function DiffFileContent({
         viewRef.current.destroy();
         viewRef.current = null;
       }
+      onEditorViewsRef.current?.([]);
     };
   }, [hunks, filename, viewMode, isDark]);
 
@@ -320,6 +345,7 @@ interface LazyFileRowProps {
   viewMode: ViewMode;
   expandAll: boolean;
   onOpenFile?: (filename: string) => void;
+  onEditorViews?: (filename: string, views: EditorView[]) => void;
 }
 
 function LazyFileRow({
@@ -330,6 +356,7 @@ function LazyFileRow({
   viewMode,
   expandAll,
   onOpenFile,
+  onEditorViews,
 }: LazyFileRowProps) {
   const adapter = useAdapter();
   const [isOpen, setIsOpen] = useState(expandAll);
@@ -340,6 +367,20 @@ function LazyFileRow({
   // Track which mergeBase + contextLines the cached diff belongs to
   const cachedMergeBaseRef = useRef<string | null>(null);
   const cachedContextRef = useRef<number | null>(null);
+
+  const handleEditorViews = useCallback(
+    (views: EditorView[]) => {
+      onEditorViews?.(filename, views);
+    },
+    [filename, onEditorViews],
+  );
+
+  // Clear editor views when collapsing
+  useEffect(() => {
+    if (!isOpen) {
+      onEditorViews?.(filename, []);
+    }
+  }, [isOpen, filename, onEditorViews]);
 
   const toggle = useCallback(() => {
     setIsOpen((prev) => !prev);
@@ -470,7 +511,12 @@ function LazyFileRow({
                   onShowFullFile={handleShowFullFile}
                 />
               )}
-              <DiffFileContent hunks={diff} filename={filename} viewMode={viewMode} />
+              <DiffFileContent
+                hunks={diff}
+                filename={filename}
+                viewMode={viewMode}
+                onEditorViews={handleEditorViews}
+              />
             </>
           )}
         </div>
@@ -480,10 +526,50 @@ function LazyFileRow({
 }
 
 // ---------------------------------------------------------------------------
+// Search helpers
+// ---------------------------------------------------------------------------
+
+function collectAllMatches(
+  editorViewsMap: Map<string, EditorView[]>,
+  filenames: string[],
+  query: string,
+  opts?: SearchOptions,
+): Array<{ view: EditorView; from: number; to: number }> {
+  if (!query) return [];
+  const cmQuery = new SearchQuery({
+    search: query,
+    caseSensitive: opts?.caseSensitive ?? false,
+    literal: !opts?.regex,
+    regexp: opts?.regex ?? false,
+    wholeWord: opts?.wholeWord ?? false,
+  });
+  const matches: Array<{ view: EditorView; from: number; to: number }> = [];
+
+  for (const filename of filenames) {
+    const views = editorViewsMap.get(filename) || [];
+    for (const view of views) {
+      const cursor = cmQuery.getCursor(view.state);
+      let result = cursor.next();
+      while (!result.done) {
+        matches.push({ view, from: result.value.from, to: result.value.to });
+        result = cursor.next();
+      }
+    }
+  }
+  return matches;
+}
+
+// ---------------------------------------------------------------------------
 // Main DiffView
 // ---------------------------------------------------------------------------
 
-export function DiffView({ workspaceId, active = true, onStatsChange, onOpenFile }: DiffViewProps) {
+export function DiffView({
+  workspaceId,
+  active = true,
+  onStatsChange,
+  onOpenFile,
+  onFindInFile,
+}: DiffViewProps) {
   const adapter = useAdapter();
   const [summary, setSummary] = useState<WorkspaceDiffSummary | null>(null);
   const [baseBranch, setBaseBranch] = useState<string | null>(null);
@@ -504,6 +590,43 @@ export function DiffView({ workspaceId, active = true, onStatsChange, onOpenFile
     setExpandAllState(v);
     storeExpandAll(v);
   }, []);
+
+  // -------------------------------------------------------------------------
+  // Find-in-diff state
+  // -------------------------------------------------------------------------
+  const editorViewsRef = useRef<Map<string, EditorView[]>>(new Map());
+  // Track filenames in a ref for stable access in navigation callbacks
+  const filenamesRef = useRef<string[]>([]);
+
+  const getViews = useCallback(
+    () => Array.from(editorViewsRef.current.values()).flat(),
+    [],
+  );
+
+  const collectMatches = useCallback(
+    (query: string, opts: SearchOptions) =>
+      collectAllMatches(editorViewsRef.current, filenamesRef.current, query, opts),
+    [],
+  );
+
+  const search = useSearch({ getViews, collectMatches, onFindInFile });
+
+  // Editor views registry — also dispatches active search to newly registered views
+  const handleEditorViews = useCallback(
+    (filename: string, views: EditorView[]) => {
+      if (views.length === 0) {
+        editorViewsRef.current.delete(filename);
+      } else {
+        editorViewsRef.current.set(filename, views);
+        search.dispatchToViews(views);
+      }
+    },
+    [search.dispatchToViews],
+  );
+
+  // -------------------------------------------------------------------------
+  // Fetch diff summary
+  // -------------------------------------------------------------------------
 
   useEffect(() => {
     const getWorkspaceDiffSummary = adapter.getWorkspaceDiffSummary;
@@ -580,6 +703,7 @@ export function DiffView({ workspaceId, active = true, onStatsChange, onOpenFile
 
   const fileStatuses = summary.fileStatuses || {};
   const filenames = Object.keys(fileStatuses);
+  filenamesRef.current = filenames;
 
   return (
     <div className="flex h-full flex-col overflow-hidden">
@@ -606,6 +730,14 @@ export function DiffView({ workspaceId, active = true, onStatsChange, onOpenFile
           </div>
         </div>
         <div className="flex items-center gap-2">
+          <button
+            type="button"
+            onClick={search.handleOpenSearch}
+            className="inline-flex items-center rounded-md border border-border/50 bg-muted/50 px-2 py-1 text-xs text-muted-foreground transition-colors hover:text-foreground"
+            title="Find in changes (⌘F)"
+          >
+            <Search className="size-3.5" />
+          </button>
           <button
             type="button"
             onClick={() => setExpandAll(!expandAll)}
@@ -659,6 +791,20 @@ export function DiffView({ workspaceId, active = true, onStatsChange, onOpenFile
           </div>
         </div>
       </div>
+      {search.searchOpen && (
+        <SearchBar
+          ref={search.searchBarRef}
+          query={search.searchQuery}
+          onQueryChange={search.setSearchQuery}
+          options={search.searchOptions}
+          onOptionsChange={search.setSearchOptions}
+          placeholder="Find in changes..."
+          matchInfo={search.matchInfo}
+          onNext={search.handleNext}
+          onPrevious={search.handlePrevious}
+          onClose={search.handleCloseSearch}
+        />
+      )}
       <div className="min-h-0 flex-1 overflow-y-auto">
         {filenames.map((filename) => (
           <LazyFileRow
@@ -670,6 +816,7 @@ export function DiffView({ workspaceId, active = true, onStatsChange, onOpenFile
             viewMode={viewMode}
             expandAll={expandAll}
             onOpenFile={onOpenFile}
+            onEditorViews={handleEditorViews}
           />
         ))}
       </div>

--- a/packages/dashboard-core/src/components/FileViewer.tsx
+++ b/packages/dashboard-core/src/components/FileViewer.tsx
@@ -18,6 +18,8 @@ interface FileViewerProps {
   column?: number;
   /** Called when the CodeMirror EditorView is created or destroyed */
   onEditorView?: (view: EditorView | null) => void;
+  /** Optional toolbar rendered between the title bar and the content area */
+  toolbar?: React.ReactNode;
 }
 
 function getFilename(path: string): string {
@@ -47,6 +49,7 @@ export function FileViewer({
   lineEnd,
   column,
   onEditorView,
+  toolbar,
 }: FileViewerProps) {
   const adapter = useAdapter();
   const [data, setData] = useState<FileContentResult | null>(null);
@@ -99,6 +102,8 @@ export function FileViewer({
           <span className="shrink-0 text-xs text-muted-foreground">{formatSize(data.size)}</span>
         )}
       </div>
+
+      {toolbar}
 
       <div className="min-h-0 flex-1 overflow-hidden">
         {loading && (

--- a/packages/dashboard-core/src/components/QuickOpenDialog.tsx
+++ b/packages/dashboard-core/src/components/QuickOpenDialog.tsx
@@ -78,7 +78,7 @@ export function QuickOpenDialog({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="overflow-hidden p-0 sm:max-w-[520px]">
+      <DialogContent className="overflow-hidden p-0 sm:max-w-[520px]" showCloseButton={false}>
         <DialogHeader className="sr-only">
           <DialogTitle>Quick Open</DialogTitle>
           <DialogDescription>Search for files by name</DialogDescription>

--- a/packages/dashboard-core/src/components/SearchBar.tsx
+++ b/packages/dashboard-core/src/components/SearchBar.tsx
@@ -1,0 +1,168 @@
+import { CaseSensitive, ChevronDown, ChevronUp, Regex, Search, WholeWord, X } from "lucide-react";
+import { forwardRef, useCallback, useImperativeHandle, useRef } from "react";
+
+export interface SearchOptions {
+  caseSensitive: boolean;
+  wholeWord: boolean;
+  regex: boolean;
+}
+
+export interface SearchBarProps {
+  /** Current search query text */
+  query: string;
+  /** Called when the query text changes */
+  onQueryChange: (query: string) => void;
+  /** Current search option toggles */
+  options: SearchOptions;
+  /** Called when any search option toggle changes */
+  onOptionsChange: (options: SearchOptions) => void;
+  /** Input placeholder text */
+  placeholder?: string;
+  /** Match info to display (e.g. "3 of 12") — omit to hide */
+  matchInfo?: { total: number; current: number };
+  /** Called when user requests next match (Enter / down arrow button) */
+  onNext?: () => void;
+  /** Called when user requests previous match (Shift+Enter / up arrow button) */
+  onPrevious?: () => void;
+  /** Called when user closes the search bar (Escape / X button) — omit to hide close button */
+  onClose?: () => void;
+  /** Extra class names for the root container */
+  className?: string;
+}
+
+export interface SearchBarHandle {
+  focus: () => void;
+  select: () => void;
+}
+
+function ToggleButton({
+  active,
+  onClick,
+  title,
+  children,
+}: {
+  active: boolean;
+  onClick: () => void;
+  title: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={`inline-flex size-6 items-center justify-center rounded-sm transition-colors ${
+        active ? "bg-accent text-accent-foreground" : "text-muted-foreground hover:text-foreground"
+      }`}
+      title={title}
+    >
+      {children}
+    </button>
+  );
+}
+
+export const SearchBar = forwardRef<SearchBarHandle, SearchBarProps>(function SearchBar(
+  {
+    query,
+    onQueryChange,
+    options,
+    onOptionsChange,
+    placeholder = "Find...",
+    matchInfo,
+    onNext,
+    onPrevious,
+    onClose,
+    className,
+  },
+  ref,
+) {
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useImperativeHandle(ref, () => ({
+    focus: () => inputRef.current?.focus(),
+    select: () => inputRef.current?.select(),
+  }));
+
+  const toggleCase = useCallback(() => {
+    onOptionsChange({ ...options, caseSensitive: !options.caseSensitive });
+  }, [options, onOptionsChange]);
+
+  const toggleWholeWord = useCallback(() => {
+    onOptionsChange({ ...options, wholeWord: !options.wholeWord });
+  }, [options, onOptionsChange]);
+
+  const toggleRegex = useCallback(() => {
+    onOptionsChange({ ...options, regex: !options.regex });
+  }, [options, onOptionsChange]);
+
+  return (
+    <div
+      className={`flex shrink-0 items-center gap-1.5 border-b border-border bg-muted/30 px-3 py-1.5 ${className ?? ""}`}
+    >
+      <Search className="size-3.5 shrink-0 text-muted-foreground" />
+      <input
+        ref={inputRef}
+        className="min-w-0 flex-1 bg-transparent text-sm outline-none placeholder:text-muted-foreground"
+        placeholder={placeholder}
+        value={query}
+        onChange={(e) => onQueryChange(e.target.value)}
+        onKeyDown={(e) => {
+          if (e.key === "Enter") {
+            e.preventDefault();
+            if (e.shiftKey) onPrevious?.();
+            else onNext?.();
+          }
+          if (e.key === "Escape" && onClose) {
+            e.preventDefault();
+            onClose();
+          }
+        }}
+      />
+      <ToggleButton active={options.caseSensitive} onClick={toggleCase} title="Match Case">
+        <CaseSensitive className="size-4" />
+      </ToggleButton>
+      <ToggleButton active={options.wholeWord} onClick={toggleWholeWord} title="Match Whole Word">
+        <WholeWord className="size-4" />
+      </ToggleButton>
+      <ToggleButton active={options.regex} onClick={toggleRegex} title="Use Regular Expression">
+        <Regex className="size-4" />
+      </ToggleButton>
+      {matchInfo && query && (
+        <span className="shrink-0 text-xs text-muted-foreground tabular-nums">
+          {matchInfo.total > 0 ? `${matchInfo.current} of ${matchInfo.total}` : "No results"}
+        </span>
+      )}
+      {onPrevious && (
+        <button
+          type="button"
+          onClick={onPrevious}
+          disabled={!matchInfo || matchInfo.total === 0}
+          className="inline-flex size-6 items-center justify-center rounded text-muted-foreground hover:text-foreground disabled:opacity-30"
+          title="Previous match (Shift+Enter)"
+        >
+          <ChevronUp className="size-3.5" />
+        </button>
+      )}
+      {onNext && (
+        <button
+          type="button"
+          onClick={onNext}
+          disabled={!matchInfo || matchInfo.total === 0}
+          className="inline-flex size-6 items-center justify-center rounded text-muted-foreground hover:text-foreground disabled:opacity-30"
+          title="Next match (Enter)"
+        >
+          <ChevronDown className="size-3.5" />
+        </button>
+      )}
+      {onClose && (
+        <button
+          type="button"
+          onClick={onClose}
+          className="inline-flex size-6 items-center justify-center rounded text-muted-foreground hover:text-foreground"
+          title="Close (Escape)"
+        >
+          <X className="size-3.5" />
+        </button>
+      )}
+    </div>
+  );
+});

--- a/packages/dashboard-core/src/components/SearchFilesDialog.tsx
+++ b/packages/dashboard-core/src/components/SearchFilesDialog.tsx
@@ -10,12 +10,12 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@band-app/ui";
-import { CaseSensitive, SearchIcon } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useAdapter } from "../context";
 import { getFileIcon } from "../lib/file-icon";
 import { formatFileLocation } from "../lib/file-location";
 import type { ContentSearchMatch } from "../types";
+import { SearchBar, type SearchBarHandle, type SearchOptions } from "./SearchBar";
 
 interface SearchFilesDialogProps {
   workspaceId: string;
@@ -32,10 +32,15 @@ export function SearchFilesDialog({
 }: SearchFilesDialogProps) {
   const adapter = useAdapter();
   const [query, setQuery] = useState("");
-  const [caseSensitive, setCaseSensitive] = useState(false);
+  const [searchOptions, setSearchOptions] = useState<SearchOptions>({
+    caseSensitive: false,
+    wholeWord: false,
+    regex: false,
+  });
   const [results, setResults] = useState<ContentSearchMatch[]>([]);
   const [loading, setLoading] = useState(false);
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const searchBarRef = useRef<SearchBarHandle>(null);
 
   useEffect(() => {
     if (!open || !adapter.searchWorkspaceContent || query.length < 2) {
@@ -50,7 +55,9 @@ export function SearchFilesDialog({
 
     debounceRef.current = setTimeout(() => {
       adapter.searchWorkspaceContent!(workspaceId, query, {
-        caseSensitive,
+        caseSensitive: searchOptions.caseSensitive,
+        wholeWord: searchOptions.wholeWord,
+        regex: searchOptions.regex,
         limit: 100,
       })
         .then((result) => {
@@ -68,13 +75,15 @@ export function SearchFilesDialog({
       cancelled = true;
       if (debounceRef.current) clearTimeout(debounceRef.current);
     };
-  }, [adapter, workspaceId, query, caseSensitive, open]);
+  }, [adapter, workspaceId, query, searchOptions, open]);
 
-  // Reset on close
+  // Reset on close, auto-focus on open
   useEffect(() => {
     if (!open) {
       setQuery("");
       setResults([]);
+    } else {
+      requestAnimationFrame(() => searchBarRef.current?.focus());
     }
   }, [open]);
 
@@ -101,34 +110,20 @@ export function SearchFilesDialog({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="overflow-hidden p-0 sm:max-w-[640px]">
+      <DialogContent className="overflow-hidden p-0 sm:max-w-[640px]" showCloseButton={false}>
         <DialogHeader className="sr-only">
           <DialogTitle>Search in Files</DialogTitle>
           <DialogDescription>Text search across workspace files</DialogDescription>
         </DialogHeader>
         <Command shouldFilter={false}>
-          <div className="flex items-center border-b px-3" cmdk-input-wrapper="">
-            <SearchIcon className="mr-2 size-4 shrink-0 opacity-50" />
-            <input
-              className="flex h-10 w-full bg-transparent py-3 text-sm outline-none placeholder:text-muted-foreground"
-              placeholder="Search in files..."
-              value={query}
-              onChange={(e) => setQuery(e.target.value)}
-              autoFocus
-            />
-            <button
-              type="button"
-              onClick={() => setCaseSensitive((v) => !v)}
-              className={`ml-2 inline-flex size-7 shrink-0 items-center justify-center rounded-sm transition-colors ${
-                caseSensitive
-                  ? "bg-accent text-accent-foreground"
-                  : "text-muted-foreground hover:text-foreground"
-              }`}
-              title="Match Case"
-            >
-              <CaseSensitive className="size-4" />
-            </button>
-          </div>
+          <SearchBar
+            ref={searchBarRef}
+            query={query}
+            onQueryChange={setQuery}
+            options={searchOptions}
+            onOptionsChange={setSearchOptions}
+            placeholder="Search in files..."
+          />
           <CommandList className="max-h-[400px]">
             <CommandEmpty>
               {loading

--- a/packages/dashboard-core/src/hooks/use-search.ts
+++ b/packages/dashboard-core/src/hooks/use-search.ts
@@ -1,7 +1,12 @@
 import type { EditorView } from "@codemirror/view";
 import { useCallback, useEffect, useRef, useState } from "react";
-import { clearSearch, collectSearchMatches, dispatchSearch, scrollToSearchMatch } from "../lib/codemirror-setup";
 import type { SearchBarHandle, SearchOptions } from "../components/SearchBar";
+import {
+  clearSearch,
+  collectSearchMatches,
+  dispatchSearch,
+  scrollToSearchMatch,
+} from "../lib/codemirror-setup";
 
 type SearchMatch = { view: EditorView; from: number; to: number };
 
@@ -53,7 +58,11 @@ export interface UseSearchReturn {
   dispatchToViews: (views: EditorView[]) => void;
 }
 
-export function useSearch({ getViews, collectMatches, onFindInFile }: UseSearchOptions): UseSearchReturn {
+export function useSearch({
+  getViews,
+  collectMatches,
+  onFindInFile,
+}: UseSearchOptions): UseSearchReturn {
   const [searchOpen, setSearchOpen] = useState(false);
   const [searchQuery, setSearchQueryText] = useState("");
   const [searchOptions, setSearchOptions] = useState<SearchOptions>(DEFAULT_SEARCH_OPTIONS);

--- a/packages/dashboard-core/src/hooks/use-search.ts
+++ b/packages/dashboard-core/src/hooks/use-search.ts
@@ -1,0 +1,193 @@
+import type { EditorView } from "@codemirror/view";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { clearSearch, collectSearchMatches, dispatchSearch, scrollToSearchMatch } from "../lib/codemirror-setup";
+import type { SearchBarHandle, SearchOptions } from "../components/SearchBar";
+
+type SearchMatch = { view: EditorView; from: number; to: number };
+
+const DEFAULT_SEARCH_OPTIONS: SearchOptions = {
+  caseSensitive: false,
+  wholeWord: false,
+  regex: false,
+};
+
+interface UseSearchOptions {
+  /** Return the current set of editor views to search in. */
+  getViews: () => EditorView[];
+  /**
+   * Optional custom match collector (e.g. for cross-file ordering in DiffView).
+   * When omitted the default `collectSearchMatches` is used.
+   */
+  collectMatches?: (query: string, opts: SearchOptions) => SearchMatch[];
+  /** Called when the find-in-file open callback changes (for Cmd+F integration). */
+  onFindInFile?: ((fn: (() => void) | null) => void) | null;
+}
+
+export interface UseSearchReturn {
+  /** Whether the search bar is open. */
+  searchOpen: boolean;
+  /** Current search query text. */
+  searchQuery: string;
+  /** Current search option toggles. */
+  searchOptions: SearchOptions;
+  /** Match counter info for the SearchBar. */
+  matchInfo: { total: number; current: number };
+  /** Ref to attach to the SearchBar component. */
+  searchBarRef: React.RefObject<SearchBarHandle | null>;
+  /** Open the search bar and focus it. */
+  handleOpenSearch: () => void;
+  /** Close the search bar and clear all highlights. */
+  handleCloseSearch: () => void;
+  /** Navigate to the next match. */
+  handleNext: () => void;
+  /** Navigate to the previous match. */
+  handlePrevious: () => void;
+  /** Update the query text (pass as `onQueryChange` to SearchBar). */
+  setSearchQuery: (q: string) => void;
+  /** Update the option toggles (pass as `onOptionsChange` to SearchBar). */
+  setSearchOptions: (opts: SearchOptions) => void;
+  /**
+   * Dispatch the current search query to specific views.
+   * Call this when new editor views are registered after the search is already active.
+   */
+  dispatchToViews: (views: EditorView[]) => void;
+}
+
+export function useSearch({ getViews, collectMatches, onFindInFile }: UseSearchOptions): UseSearchReturn {
+  const [searchOpen, setSearchOpen] = useState(false);
+  const [searchQuery, setSearchQueryText] = useState("");
+  const [searchOptions, setSearchOptions] = useState<SearchOptions>(DEFAULT_SEARCH_OPTIONS);
+  const searchQueryRef = useRef("");
+  const searchOptionsRef = useRef<SearchOptions>(DEFAULT_SEARCH_OPTIONS);
+  const [matchInfo, setMatchInfo] = useState<{ total: number; current: number }>({
+    total: 0,
+    current: 0,
+  });
+  const currentMatchIndexRef = useRef(0);
+  const searchBarRef = useRef<SearchBarHandle>(null);
+
+  // Keep refs in sync with state so callbacks always read the latest value.
+  useEffect(() => {
+    searchQueryRef.current = searchQuery;
+  }, [searchQuery]);
+  useEffect(() => {
+    searchOptionsRef.current = searchOptions;
+  }, [searchOptions]);
+
+  // Stable ref for getViews / collectMatches so callbacks don't re-create.
+  const getViewsRef = useRef(getViews);
+  getViewsRef.current = getViews;
+  const collectMatchesRef = useRef(collectMatches);
+  collectMatchesRef.current = collectMatches;
+
+  const getMatches = useCallback((query: string, opts: SearchOptions): SearchMatch[] => {
+    if (collectMatchesRef.current) return collectMatchesRef.current(query, opts);
+    return collectSearchMatches(getViewsRef.current(), query, opts);
+  }, []);
+
+  // ---------------------------------------------------------------------------
+  // Handlers
+  // ---------------------------------------------------------------------------
+
+  const handleOpenSearch = useCallback(() => {
+    setSearchOpen(true);
+    requestAnimationFrame(() => {
+      searchBarRef.current?.focus();
+      searchBarRef.current?.select();
+    });
+  }, []);
+
+  const handleCloseSearch = useCallback(() => {
+    setSearchOpen(false);
+    setSearchQueryText("");
+    currentMatchIndexRef.current = 0;
+    clearSearch(getViewsRef.current());
+  }, []);
+
+  const handleNext = useCallback(() => {
+    const matches = getMatches(searchQueryRef.current, searchOptionsRef.current);
+    if (matches.length === 0) return;
+    currentMatchIndexRef.current = (currentMatchIndexRef.current + 1) % matches.length;
+    const match = matches[currentMatchIndexRef.current];
+    scrollToSearchMatch(match);
+    match.view.dom.scrollIntoView({ block: "nearest" });
+    setMatchInfo({ total: matches.length, current: currentMatchIndexRef.current + 1 });
+  }, [getMatches]);
+
+  const handlePrevious = useCallback(() => {
+    const matches = getMatches(searchQueryRef.current, searchOptionsRef.current);
+    if (matches.length === 0) return;
+    currentMatchIndexRef.current =
+      (currentMatchIndexRef.current - 1 + matches.length) % matches.length;
+    const match = matches[currentMatchIndexRef.current];
+    scrollToSearchMatch(match);
+    match.view.dom.scrollIntoView({ block: "nearest" });
+    setMatchInfo({ total: matches.length, current: currentMatchIndexRef.current + 1 });
+  }, [getMatches]);
+
+  const setSearchQuery = useCallback((q: string) => {
+    setSearchQueryText(q);
+    currentMatchIndexRef.current = 0;
+  }, []);
+
+  const dispatchToViews = useCallback((views: EditorView[]) => {
+    if (searchQueryRef.current) {
+      dispatchSearch(views, searchQueryRef.current, searchOptionsRef.current);
+    }
+  }, []);
+
+  // ---------------------------------------------------------------------------
+  // Effects
+  // ---------------------------------------------------------------------------
+
+  // Dispatch search to all editors and count matches when query or options change.
+  useEffect(() => {
+    const views = getViewsRef.current();
+    dispatchSearch(views, searchQuery, searchOptions);
+
+    if (!searchQuery) {
+      setMatchInfo({ total: 0, current: 0 });
+      currentMatchIndexRef.current = 0;
+      return;
+    }
+
+    const matches = getMatches(searchQuery, searchOptions);
+    currentMatchIndexRef.current = 0;
+    setMatchInfo({ total: matches.length, current: matches.length > 0 ? 1 : 0 });
+  }, [searchQuery, searchOptions, getMatches]);
+
+  // Report find-in-file callback to parent (for Cmd+F integration).
+  useEffect(() => {
+    onFindInFile?.(handleOpenSearch);
+    return () => onFindInFile?.(null);
+  }, [onFindInFile, handleOpenSearch]);
+
+  // Direct Cmd+F / Ctrl+F handler so the search works even when
+  // the parent layout does not provide a FindInFileContext (e.g. Tauri / mobile).
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      const mod = e.metaKey || e.ctrlKey;
+      if (mod && e.key.toLowerCase() === "f" && !e.shiftKey) {
+        e.preventDefault();
+        handleOpenSearch();
+      }
+    };
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, [handleOpenSearch]);
+
+  return {
+    searchOpen,
+    searchQuery,
+    searchOptions,
+    matchInfo,
+    searchBarRef,
+    handleOpenSearch,
+    handleCloseSearch,
+    handleNext,
+    handlePrevious,
+    setSearchQuery,
+    setSearchOptions,
+    dispatchToViews,
+  };
+}

--- a/packages/dashboard-core/src/index.ts
+++ b/packages/dashboard-core/src/index.ts
@@ -16,6 +16,7 @@ export { GitStatusIndicator } from "./components/GitStatusIndicator";
 export { NewWorkspaceDialog } from "./components/NewWorkspaceForm";
 export { ProjectList } from "./components/ProjectList";
 export { QuickOpenDialog } from "./components/QuickOpenDialog";
+export { SearchBar, type SearchBarHandle, type SearchOptions } from "./components/SearchBar";
 export { SearchFilesDialog } from "./components/SearchFilesDialog";
 export { SettingsPage } from "./components/SettingsPage";
 export { SetupStatusIndicator } from "./components/SetupStatusIndicator";
@@ -25,6 +26,7 @@ export { type WorkspaceTab, WorkspaceTabNav } from "./components/WorkspaceTabNav
 export { DashboardProvider, useAdapter, useCapabilities } from "./context";
 export { type HooksSetupState, useHooksSetup } from "./hooks/use-hooks-setup";
 export { useIsDark } from "./hooks/use-is-dark";
+export { useSearch, type UseSearchReturn } from "./hooks/use-search";
 export {
   useAddProject,
   useCreateWorkspace,
@@ -43,7 +45,12 @@ export {
   useSetupStatusWatcher,
   useStatusWatcher,
 } from "./hooks/use-status";
-export { openFileSearchPanel } from "./lib/codemirror-setup";
+export {
+  clearSearch,
+  collectSearchMatches,
+  dispatchSearch,
+  scrollToSearchMatch,
+} from "./lib/codemirror-setup";
 export { type FileLocation, formatFileLocation, parseFileLocation } from "./lib/file-location";
 export { extensionToLanguage, filenameToLanguage } from "./lib/language-map";
 export { isServiceHealthy, type ServiceHealth } from "./lib/service-health";

--- a/packages/dashboard-core/src/index.ts
+++ b/packages/dashboard-core/src/index.ts
@@ -26,7 +26,6 @@ export { type WorkspaceTab, WorkspaceTabNav } from "./components/WorkspaceTabNav
 export { DashboardProvider, useAdapter, useCapabilities } from "./context";
 export { type HooksSetupState, useHooksSetup } from "./hooks/use-hooks-setup";
 export { useIsDark } from "./hooks/use-is-dark";
-export { useSearch, type UseSearchReturn } from "./hooks/use-search";
 export {
   useAddProject,
   useCreateWorkspace,
@@ -36,6 +35,7 @@ export {
   useUpdateProjectLabel,
 } from "./hooks/use-project-mutations";
 export { useProjects } from "./hooks/use-projects";
+export { type UseSearchReturn, useSearch } from "./hooks/use-search";
 export { useUpdateSettings } from "./hooks/use-settings-mutations";
 export { useSettingsQuery } from "./hooks/use-settings-query";
 // Hooks

--- a/packages/dashboard-core/src/lib/codemirror-setup.ts
+++ b/packages/dashboard-core/src/lib/codemirror-setup.ts
@@ -6,16 +6,12 @@ import {
   StreamLanguage,
   syntaxHighlighting,
 } from "@codemirror/language";
-import {
-  highlightSelectionMatches,
-  openSearchPanel,
-  search,
-  searchKeymap,
-} from "@codemirror/search";
+import { highlightSelectionMatches, SearchQuery } from "@codemirror/search";
 import {
   EditorState,
   type Extension,
   type Range,
+  RangeSetBuilder,
   StateEffect,
   StateField,
 } from "@codemirror/state";
@@ -153,8 +149,7 @@ export function baseViewerExtensions(isDark = true): Extension[] {
           syntaxHighlighting(defaultHighlightStyle),
           syntaxHighlighting(oneDarkHighlightStyle, { fallback: true }),
         ]),
-    search(),
-    keymap.of([...defaultKeymap, ...searchKeymap]),
+    keymap.of([...defaultKeymap]),
     EditorView.theme(
       isDark
         ? {
@@ -168,6 +163,13 @@ export function baseViewerExtensions(isDark = true): Extension[] {
               backgroundColor: "rgba(255, 255, 255, 0.1)",
             },
             ".cm-line": { color: "#abb2bf" },
+            ".cm-searchMatch": {
+              backgroundColor: "rgba(255, 213, 0, 0.35)",
+              borderRadius: "2px",
+            },
+            ".cm-searchMatch-selected": {
+              backgroundColor: "rgba(255, 150, 50, 0.5)",
+            },
           }
         : {
             "&": { height: "100%", backgroundColor: "#ffffff" },
@@ -180,19 +182,133 @@ export function baseViewerExtensions(isDark = true): Extension[] {
               backgroundColor: "rgba(0, 0, 0, 0.07)",
             },
             ".cm-line": { color: "#24292f" },
+            ".cm-searchMatch": {
+              backgroundColor: "rgba(255, 213, 0, 0.4)",
+              borderRadius: "2px",
+            },
+            ".cm-searchMatch-selected": {
+              backgroundColor: "rgba(255, 150, 50, 0.55)",
+            },
           },
       { dark: isDark },
     ),
   ];
 }
 
+// ---------------------------------------------------------------------------
+// Search highlight extension (custom — replaces @codemirror/search's built-in
+// searchHighlighter to avoid module-identity issues with setSearchQuery)
+// ---------------------------------------------------------------------------
+
+/** Effect that replaces the current search-match decorations. */
+const setSearchDecorations = StateEffect.define<DecorationSet>();
+
+const searchMatchMark = Decoration.mark({ class: "cm-searchMatch" });
+
+/** StateField that holds search-match decorations. */
+const searchHighlightField = StateField.define<DecorationSet>({
+  create() {
+    return Decoration.none;
+  },
+  update(value, tr) {
+    for (const effect of tr.effects) {
+      if (effect.is(setSearchDecorations)) return effect.value;
+    }
+    // Map existing decorations through document changes so positions stay correct.
+    return value.map(tr.changes);
+  },
+  provide: (f) => EditorView.decorations.from(f),
+});
+
 /**
- * Opens the CodeMirror search panel for find-in-file.
- * Accepts a loose type so consumers don't need a direct @codemirror dependency.
+ * Extension that enables search-match highlighting via `dispatchSearch`.
+ * Include this in editor extensions to support find-in-file highlighting.
  */
-// biome-ignore lint/suspicious/noExplicitAny: EditorView type from @codemirror/view — kept untyped for cross-package use
-export function openFileSearchPanel(view: any): boolean {
-  return openSearchPanel(view as EditorView);
+export function searchHighlightOnly(): Extension {
+  return searchHighlightField;
+}
+
+/** Build a sorted DecorationSet for the given query against a view. */
+function buildSearchDecorations(view: EditorView, query: string, opts?: SearchOpts): DecorationSet {
+  if (!query) return Decoration.none;
+  const cmQuery = makeSearchQuery(query, opts);
+  const builder = new RangeSetBuilder<Decoration>();
+  const cursor = cmQuery.getCursor(view.state);
+  let result = cursor.next();
+  while (!result.done) {
+    builder.add(result.value.from, result.value.to, searchMatchMark);
+    result = cursor.next();
+  }
+  return builder.finish();
+}
+
+type SearchOpts = { caseSensitive?: boolean; wholeWord?: boolean; regex?: boolean };
+
+function makeSearchQuery(query: string, opts?: SearchOpts): SearchQuery {
+  return new SearchQuery({
+    search: query,
+    caseSensitive: opts?.caseSensitive ?? false,
+    literal: !opts?.regex,
+    regexp: opts?.regex ?? false,
+    wholeWord: opts?.wholeWord ?? false,
+  });
+}
+
+/**
+ * Dispatches a search query to one or more CodeMirror `EditorView` instances.
+ * Highlights matches inside each editor.
+ */
+export function dispatchSearch(views: EditorView[], query: string, opts?: SearchOpts): void {
+  for (const view of views) {
+    view.dispatch({
+      effects: setSearchDecorations.of(buildSearchDecorations(view, query, opts)),
+    });
+  }
+}
+
+/**
+ * Counts all matches in the given editor views and returns them as an ordered
+ * list of `{ view, from, to }` objects suitable for next/prev navigation.
+ */
+export function collectSearchMatches(
+  views: EditorView[],
+  query: string,
+  opts?: SearchOpts,
+): Array<{ view: EditorView; from: number; to: number }> {
+  if (!query) return [];
+  const cmQuery = makeSearchQuery(query, opts);
+  const matches: Array<{ view: EditorView; from: number; to: number }> = [];
+  for (const view of views) {
+    const cursor = cmQuery.getCursor(view.state);
+    let result = cursor.next();
+    while (!result.done) {
+      matches.push({ view, from: result.value.from, to: result.value.to });
+      result = cursor.next();
+    }
+  }
+  return matches;
+}
+
+/**
+ * Selects the given match range and scrolls it into view (centered).
+ */
+export function scrollToSearchMatch(match: { view: EditorView; from: number; to: number }): void {
+  match.view.dispatch({
+    selection: { anchor: match.from, head: match.to },
+    effects: EditorView.scrollIntoView(match.from, { y: "center" }),
+  });
+}
+
+/**
+ * Clears search highlights and collapses the selection in all given views.
+ */
+export function clearSearch(views: EditorView[]): void {
+  for (const view of views) {
+    view.dispatch({
+      effects: setSearchDecorations.of(Decoration.none),
+      selection: { anchor: view.state.selection.main.head },
+    });
+  }
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Add Cmd+F find-in-file search to the Changes (diff) view with cross-file match navigation
- Replace native CodeMirror search panel in the Code Browser with a custom SearchBar component
- Extract shared `useSearch` hook and `SearchBar` component to eliminate ~130 lines of duplicated search logic per consumer
- Custom CodeMirror `StateField`-based search decorations for reliable cross-editor highlighting

## Changes
- **`use-search.ts`** — new shared hook encapsulating search state, match navigation, keyboard shortcuts, and editor view dispatching
- **`SearchBar.tsx`** — new shared search bar component with VS Code-style toggles (case sensitive, whole word, regex)
- **`codemirror-setup.ts`** — replaced `@codemirror/search` extension with custom `StateField<DecorationSet>` for reliable highlighting across multiple editor instances
- **`DiffView.tsx`** — added search support with cross-file ordered match navigation
- **`CodeBrowserView.tsx`** — replaced native CodeMirror search with custom SearchBar rendered via FileViewer's toolbar prop
- **`FileViewer.tsx`** — added `toolbar` prop for injecting content between title bar and code
- **`CodeMirrorViewer.tsx`** — removed native search panel, added `searchHighlightOnly()` extension
- **`SearchFilesDialog.tsx`** — uses shared SearchBar, hides dialog close button
- **`QuickOpenDialog.tsx`** — hides dialog close button to prevent icon overlap
- **`adapter.ts` / `web.ts` / `router.ts`** — added `wholeWord` and `regex` options to content search

## Test plan
- [ ] Open a workspace with changes, press Cmd+F — search bar appears in changes view
- [ ] Type a query — matches highlight across all expanded diffs
- [ ] Press Enter / Shift+Enter — cycles through matches, scrolling to each
- [ ] Expand a collapsed file while search is active — new file shows highlights
- [ ] Toggle unified/split view — highlights persist
- [ ] Press Escape or click X — search bar closes, highlights clear
- [ ] Code browser: Cmd+F opens search bar below file title (not spanning sidebar)
- [ ] Search files dialog: no overlapping close button

🤖 Generated with [Claude Code](https://claude.com/claude-code)