### PR TITLE
Use VS Code dark theme for brighter code in file and diff viewers

### DIFF
--- a/knip.json
+++ b/knip.json
@@ -52,7 +52,8 @@
     },
     "packages/dashboard-core": {
       "entry": ["src/index.ts", "src/adapters/web.ts", "src/adapters/hybrid.ts"],
-      "project": ["src/**/*.{ts,tsx}"]
+      "project": ["src/**/*.{ts,tsx}"],
+      "ignoreDependencies": ["@babel/runtime"]
     },
     "packages/coding-agent": {
       "entry": ["src/index.ts", "tests/mocks/*.mjs"],

--- a/packages/dashboard-core/package.json
+++ b/packages/dashboard-core/package.json
@@ -12,6 +12,7 @@
     "./adapters/hybrid": "./src/adapters/hybrid.ts"
   },
   "dependencies": {
+    "@babel/runtime": "^7.29.2",
     "@band-app/ui": "workspace:^",
     "@codemirror/commands": "^6.8.1",
     "@codemirror/lang-cpp": "^6.0.2",
@@ -35,7 +36,6 @@
     "@codemirror/merge": "^6.7.6",
     "@codemirror/search": "^6.5.10",
     "@codemirror/state": "^6.5.2",
-    "@codemirror/theme-one-dark": "^6.1.2",
     "@codemirror/view": "^6.36.8",
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/sortable": "^10.0.0",
@@ -43,6 +43,7 @@
     "@tanstack/react-query": "^5.90.21",
     "@trpc/client": "^11.12.0",
     "@trpc/server": "^11.12.0",
+    "@uiw/codemirror-theme-vscode": "^4.25.9",
     "lucide-react": "^0.576.0",
     "zustand": "^5.0.0"
   },

--- a/packages/dashboard-core/src/lib/codemirror-setup.ts
+++ b/packages/dashboard-core/src/lib/codemirror-setup.ts
@@ -15,7 +15,7 @@ import {
   StateEffect,
   StateField,
 } from "@codemirror/state";
-import { oneDarkHighlightStyle } from "@codemirror/theme-one-dark";
+import { vscodeDarkInit } from "@uiw/codemirror-theme-vscode";
 import { Decoration, type DecorationSet, EditorView, keymap, lineNumbers } from "@codemirror/view";
 
 /**
@@ -142,27 +142,26 @@ export function baseViewerExtensions(isDark = true): Extension[] {
     highlightSelectionMatches(),
     ...(isDark
       ? [
-          syntaxHighlighting(oneDarkHighlightStyle),
+          vscodeDarkInit({
+            settings: {
+              background: "var(--background)",
+              gutterBackground: "var(--background)",
+              lineHighlight: "transparent",
+            },
+          }),
           syntaxHighlighting(defaultHighlightStyle, { fallback: true }),
         ]
       : [
           syntaxHighlighting(defaultHighlightStyle),
-          syntaxHighlighting(oneDarkHighlightStyle, { fallback: true }),
         ]),
     keymap.of([...defaultKeymap]),
+    // Viewer-specific overrides
     EditorView.theme(
       isDark
         ? {
-            "&": { height: "100%", backgroundColor: "#181818" },
+            "&": { height: "100%", fontSize: "13px" },
             ".cm-scroller": { overflow: "auto" },
-            ".cm-gutters": { backgroundColor: "#181818", border: "none" },
             ".cm-activeLineGutter": { backgroundColor: "transparent" },
-            ".cm-activeLine": { backgroundColor: "transparent" },
-            "&.cm-focused .cm-cursor": { borderLeftColor: "#fff" },
-            "&.cm-focused .cm-selectionBackground, .cm-selectionBackground": {
-              backgroundColor: "rgba(255, 255, 255, 0.1)",
-            },
-            ".cm-line": { color: "#abb2bf" },
             ".cm-searchMatch": {
               backgroundColor: "rgba(255, 213, 0, 0.35)",
               borderRadius: "2px",
@@ -172,9 +171,9 @@ export function baseViewerExtensions(isDark = true): Extension[] {
             },
           }
         : {
-            "&": { height: "100%", backgroundColor: "#ffffff" },
+            "&": { height: "100%", fontSize: "13px", backgroundColor: "var(--background)" },
             ".cm-scroller": { overflow: "auto" },
-            ".cm-gutters": { backgroundColor: "#f8f9fa", border: "none", color: "#6e7781" },
+            ".cm-gutters": { backgroundColor: "var(--background)", border: "none", color: "#6e7781" },
             ".cm-activeLineGutter": { backgroundColor: "transparent" },
             ".cm-activeLine": { backgroundColor: "transparent" },
             "&.cm-focused .cm-cursor": { borderLeftColor: "#24292f" },

--- a/packages/dashboard-core/src/lib/codemirror-setup.ts
+++ b/packages/dashboard-core/src/lib/codemirror-setup.ts
@@ -15,8 +15,8 @@ import {
   StateEffect,
   StateField,
 } from "@codemirror/state";
-import { vscodeDarkInit } from "@uiw/codemirror-theme-vscode";
 import { Decoration, type DecorationSet, EditorView, keymap, lineNumbers } from "@codemirror/view";
+import { vscodeDarkInit } from "@uiw/codemirror-theme-vscode";
 
 /**
  * Lazy-loads a CodeMirror LanguageSupport for the given language name.
@@ -151,9 +151,7 @@ export function baseViewerExtensions(isDark = true): Extension[] {
           }),
           syntaxHighlighting(defaultHighlightStyle, { fallback: true }),
         ]
-      : [
-          syntaxHighlighting(defaultHighlightStyle),
-        ]),
+      : [syntaxHighlighting(defaultHighlightStyle)]),
     keymap.of([...defaultKeymap]),
     // Viewer-specific overrides
     EditorView.theme(
@@ -173,7 +171,11 @@ export function baseViewerExtensions(isDark = true): Extension[] {
         : {
             "&": { height: "100%", fontSize: "13px", backgroundColor: "var(--background)" },
             ".cm-scroller": { overflow: "auto" },
-            ".cm-gutters": { backgroundColor: "var(--background)", border: "none", color: "#6e7781" },
+            ".cm-gutters": {
+              backgroundColor: "var(--background)",
+              border: "none",
+              color: "#6e7781",
+            },
             ".cm-activeLineGutter": { backgroundColor: "transparent" },
             ".cm-activeLine": { backgroundColor: "transparent" },
             "&.cm-focused .cm-cursor": { borderLeftColor: "#24292f" },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -307,6 +307,9 @@ importers:
 
   packages/dashboard-core:
     dependencies:
+      '@babel/runtime':
+        specifier: ^7.29.2
+        version: 7.29.2
       '@band-app/ui':
         specifier: workspace:^
         version: link:../ui
@@ -376,9 +379,6 @@ importers:
       '@codemirror/state':
         specifier: ^6.5.2
         version: 6.6.0
-      '@codemirror/theme-one-dark':
-        specifier: ^6.1.2
-        version: 6.1.3
       '@codemirror/view':
         specifier: ^6.36.8
         version: 6.40.0
@@ -400,6 +400,9 @@ importers:
       '@trpc/server':
         specifier: ^11.12.0
         version: 11.12.0(typescript@5.9.3)
+      '@uiw/codemirror-theme-vscode':
+        specifier: ^4.25.9
+        version: 4.25.9(@codemirror/language@6.12.2)(@codemirror/state@6.6.0)(@codemirror/view@6.40.0)
       lucide-react:
         specifier: ^0.576.0
         version: 0.576.0(react@19.2.4)
@@ -612,6 +615,10 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
+  '@babel/runtime@7.29.2':
+    resolution: {integrity: sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/template@7.28.6':
     resolution: {integrity: sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==}
     engines: {node: '>=6.9.0'}
@@ -770,9 +777,6 @@ packages:
 
   '@codemirror/state@6.6.0':
     resolution: {integrity: sha512-4nbvra5R5EtiCzr9BTHiTLc+MLXK2QGiAVYMyi8PkQd3SR+6ixar/Q/01Fa21TBIDOZXgeWV4WppsQolSreAPQ==}
-
-  '@codemirror/theme-one-dark@6.1.3':
-    resolution: {integrity: sha512-NzBdIvEJmx6fjeremiGp3t/okrLPYT0d9orIc7AFun8oZcRk58aejkqhv6spnz4MLAevrKNPMQYXEWMg4s+sKA==}
 
   '@codemirror/view@6.40.0':
     resolution: {integrity: sha512-WA0zdU7xfF10+5I3HhUUq3kqOx3KjqmtQ9lqZjfK7jtYk4G72YW9rezcSywpaUMCWOMlq+6E0pO1IWg1TNIhtg==}
@@ -3383,6 +3387,16 @@ packages:
 
   '@types/ws@8.18.1':
     resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
+
+  '@uiw/codemirror-theme-vscode@4.25.9':
+    resolution: {integrity: sha512-9KTnScHTSk97yGnyNYvDm6QZuBCdbO1OzMQ5bHtoBSPSVtH0LjY3bS6CXsBagb22v8OLPx/XwrBYOjKFp409CQ==}
+
+  '@uiw/codemirror-themes@4.25.9':
+    resolution: {integrity: sha512-DAHKb/L9ELwjY4nCf/MP/mIllHOn4GQe7RR4x8AMJuNeh9nGRRoo1uPxrxMmUL/bKqe6kDmDbIZ2AlhlqyIJuw==}
+    peerDependencies:
+      '@codemirror/language': '>=6.0.0'
+      '@codemirror/state': '>=6.0.0'
+      '@codemirror/view': '>=6.0.0'
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
@@ -6669,6 +6683,8 @@ snapshots:
       '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
 
+  '@babel/runtime@7.29.2': {}
+
   '@babel/template@7.28.6':
     dependencies:
       '@babel/code-frame': 7.29.0
@@ -6928,13 +6944,6 @@ snapshots:
   '@codemirror/state@6.6.0':
     dependencies:
       '@marijn/find-cluster-break': 1.0.2
-
-  '@codemirror/theme-one-dark@6.1.3':
-    dependencies:
-      '@codemirror/language': 6.12.2
-      '@codemirror/state': 6.6.0
-      '@codemirror/view': 6.40.0
-      '@lezer/highlight': 1.2.3
 
   '@codemirror/view@6.40.0':
     dependencies:
@@ -9287,6 +9296,20 @@ snapshots:
   '@types/ws@8.18.1':
     dependencies:
       '@types/node': 22.19.13
+
+  '@uiw/codemirror-theme-vscode@4.25.9(@codemirror/language@6.12.2)(@codemirror/state@6.6.0)(@codemirror/view@6.40.0)':
+    dependencies:
+      '@uiw/codemirror-themes': 4.25.9(@codemirror/language@6.12.2)(@codemirror/state@6.6.0)(@codemirror/view@6.40.0)
+    transitivePeerDependencies:
+      - '@codemirror/language'
+      - '@codemirror/state'
+      - '@codemirror/view'
+
+  '@uiw/codemirror-themes@4.25.9(@codemirror/language@6.12.2)(@codemirror/state@6.6.0)(@codemirror/view@6.40.0)':
+    dependencies:
+      '@codemirror/language': 6.12.2
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.40.0
 
   '@ungap/structured-clone@1.3.0': {}
 


### PR DESCRIPTION
## Summary
- Replace the One Dark syntax highlighting theme with `@uiw/codemirror-theme-vscode` for brighter, more readable code text in both the file viewer and diff viewer
- Set font size to 13px for better readability
- Use `var(--background)` CSS variable so the editor background always matches the app

## Test plan
- [ ] Open a workspace → Files tab → click a file → verify syntax highlighting uses VS Code dark colors and text is bright/readable
- [ ] Open a workspace → Changes tab → expand a diff → verify syntax highlighting in the diff view matches
- [ ] Verify the editor background blends seamlessly with the surrounding app background
- [ ] Verify font size is comfortable (13px)

🤖 Generated with [Claude Code](https://claude.com/claude-code)