### PR TITLE
feat: add selection-to-chat in file browser and diff view

### DIFF
--- a/apps/web/src/components/ai-elements/prompt-input.tsx
+++ b/apps/web/src/components/ai-elements/prompt-input.tsx
@@ -1,3 +1,4 @@
+import type { SelectionToChatDetail } from "@band-app/dashboard-core";
 import { Badge, cn } from "@band-app/ui";
 import type { ChatStatus } from "ai";
 import { ArrowUpIcon, Clock, FileIcon, Loader2, Paperclip, SquareIcon, X } from "lucide-react";
@@ -181,6 +182,41 @@ export const PromptInput = ({
     textarea.focus();
     // Move cursor to end
     textarea.selectionStart = textarea.selectionEnd = value.length;
+  }, []);
+
+  // Listen for "Add to Chat" events from CodeMirror editors
+  useEffect(() => {
+    const handler = (e: Event) => {
+      const { filePath, startLine, endLine } = (e as CustomEvent<SelectionToChatDetail>).detail;
+
+      const lineRef =
+        startLine === endLine ? `${filePath}:${startLine}` : `${filePath}:${startLine}-${endLine}`;
+
+      const reference = `\`${lineRef}\` `;
+
+      const textarea = textareaRef.current;
+      const current = textarea?.value ?? "";
+      const combined = current + reference;
+
+      // Use native setter pattern to keep React in sync
+      if (textarea) {
+        const nativeSetter = Object.getOwnPropertyDescriptor(
+          HTMLTextAreaElement.prototype,
+          "value",
+        )?.set;
+        nativeSetter?.call(textarea, combined);
+        textarea.dispatchEvent(new Event("input", { bubbles: true }));
+        // Defer focus so it happens after CodeMirror finishes its dispatch
+        // (the mousedown handler collapses the selection which re-grabs focus)
+        requestAnimationFrame(() => {
+          textarea.focus();
+          textarea.selectionStart = textarea.selectionEnd = combined.length;
+        });
+      }
+    };
+
+    window.addEventListener("band:add-to-chat", handler);
+    return () => window.removeEventListener("band:add-to-chat", handler);
   }, []);
 
   return (

--- a/packages/dashboard-core/src/components/CodeMirrorViewer.tsx
+++ b/packages/dashboard-core/src/components/CodeMirrorViewer.tsx
@@ -10,11 +10,14 @@ import {
   searchHighlightOnly,
   setHighlightLines,
 } from "../lib/codemirror-setup";
+import { selectionToChatExtension } from "../lib/selection-to-chat";
 
 interface CodeMirrorViewerProps {
   content: string;
   language: string;
   className?: string;
+  /** Workspace-relative file path — enables "Add to Chat" on text selection */
+  filePath?: string;
   /** 1-based line number to scroll to and highlight */
   line?: number;
   /** 1-based end line for range highlight (inclusive). Uses dash syntax: file:5-10 */
@@ -29,6 +32,7 @@ export function CodeMirrorViewer({
   content,
   language,
   className,
+  filePath,
   line,
   lineEnd,
   column,
@@ -71,6 +75,9 @@ export function CodeMirrorViewer({
         searchHighlightOnly(),
         ...lineHighlightExtension(isDark),
       ];
+      if (filePath) {
+        extensions.push(selectionToChatExtension(filePath));
+      }
       if (langSupport) {
         extensions.push(langSupport);
       }
@@ -103,7 +110,7 @@ export function CodeMirrorViewer({
         onEditorViewRef.current?.(null);
       }
     };
-  }, [content, language, isDark]);
+  }, [content, language, isDark, filePath]);
 
   // Handle line/lineEnd/column changes without recreating the editor
   useEffect(() => {

--- a/packages/dashboard-core/src/components/DiffView.tsx
+++ b/packages/dashboard-core/src/components/DiffView.tsx
@@ -19,6 +19,7 @@ import { useSearch } from "../hooks/use-search";
 import { baseViewerExtensions, loadLanguage, searchHighlightOnly } from "../lib/codemirror-setup";
 import { formatFileLocation } from "../lib/file-location";
 import { extensionToLanguage, filenameToLanguage } from "../lib/language-map";
+import { selectionToChatExtension } from "../lib/selection-to-chat";
 import type { DiffMode, FileStatus, WorkspaceDiffSummary } from "../types";
 import { SearchBar, type SearchOptions } from "./SearchBar";
 
@@ -203,6 +204,7 @@ function DiffFileContent({
         const sharedExtensions = [
           ...baseViewerExtensions(isDark),
           searchHighlightOnly(),
+          selectionToChatExtension(filename),
           diffTheme,
         ];
         if (langSupport) {
@@ -228,6 +230,7 @@ function DiffFileContent({
         const extensions = [
           ...baseViewerExtensions(isDark),
           searchHighlightOnly(),
+          selectionToChatExtension(filename),
           unifiedMergeView({
             original: Text.of(oldText.split("\n")),
             mergeControls: false,

--- a/packages/dashboard-core/src/components/FileViewer.tsx
+++ b/packages/dashboard-core/src/components/FileViewer.tsx
@@ -133,6 +133,7 @@ export function FileViewer({
             content={data.content}
             language={lang}
             className="h-full"
+            filePath={filePath}
             line={line}
             lineEnd={lineEnd}
             column={column}

--- a/packages/dashboard-core/src/index.ts
+++ b/packages/dashboard-core/src/index.ts
@@ -53,6 +53,7 @@ export {
 } from "./lib/codemirror-setup";
 export { type FileLocation, formatFileLocation, parseFileLocation } from "./lib/file-location";
 export { extensionToLanguage, filenameToLanguage } from "./lib/language-map";
+export type { SelectionToChatDetail } from "./lib/selection-to-chat";
 export { isServiceHealthy, type ServiceHealth } from "./lib/service-health";
 // Lib
 export { playSound, SOUNDS, type SoundId } from "./lib/sounds";

--- a/packages/dashboard-core/src/lib/selection-to-chat.ts
+++ b/packages/dashboard-core/src/lib/selection-to-chat.ts
@@ -1,0 +1,199 @@
+import { type Extension, StateEffect, StateField } from "@codemirror/state";
+import { EditorView, showTooltip, type Tooltip, ViewPlugin } from "@codemirror/view";
+
+/**
+ * Payload dispatched via the `band:add-to-chat` window CustomEvent when the
+ * user clicks "Add to Chat" on a text selection inside a CodeMirror editor.
+ */
+export interface SelectionToChatDetail {
+  filePath: string;
+  selectedText: string;
+  /** 1-based start line of the selection */
+  startLine: number;
+  /** 1-based end line of the selection */
+  endLine: number;
+}
+
+/** Minimum number of characters selected before showing the button. */
+const MIN_SELECTION_LENGTH = 1;
+
+/** Delay in ms before showing the tooltip after selection stabilises. */
+const SHOW_DELAY_MS = 500;
+
+/** Effect used by the debounce plugin to set/clear the tooltip. */
+const setSelectionTooltip = StateEffect.define<Tooltip | null>();
+
+/**
+ * CodeMirror extension that shows a floating "Add to Chat" button when the
+ * user selects text. The button appears after a short delay so it doesn't
+ * flash during casual clicking. Clicking the button dispatches a
+ * `band:add-to-chat` CustomEvent on `window` with a
+ * {@link SelectionToChatDetail} payload.
+ *
+ * @param filePath - The workspace-relative file path shown in the reference.
+ */
+export function selectionToChatExtension(filePath: string): Extension {
+  // --- StateField: holds the current tooltip (set via effect) ----------------
+
+  const tooltipField = StateField.define<Tooltip | null>({
+    create() {
+      return null;
+    },
+    update(value, tr) {
+      for (const e of tr.effects) {
+        if (e.is(setSelectionTooltip)) return e.value;
+      }
+      return value;
+    },
+    provide: (f) => showTooltip.from(f),
+  });
+
+  // --- ViewPlugin: debounces selection changes and dispatches the effect ------
+
+  const debouncePlugin = ViewPlugin.define((view) => {
+    let timer: ReturnType<typeof setTimeout> | null = null;
+
+    function clearTimer() {
+      if (timer !== null) {
+        clearTimeout(timer);
+        timer = null;
+      }
+    }
+
+    /** Build a Tooltip for the current selection, or null to hide. */
+    function buildTooltip(): Tooltip | null {
+      const sel = view.state.selection.main;
+      if (sel.empty || sel.to - sel.from < MIN_SELECTION_LENGTH) return null;
+
+      return {
+        pos: sel.head,
+        above: true,
+        strictSide: true,
+        arrow: false,
+        create(view: EditorView) {
+          const dom = document.createElement("div");
+          dom.className = "cm-add-to-chat-tooltip";
+
+          const btn = document.createElement("button");
+          btn.className = "cm-add-to-chat-btn";
+          btn.setAttribute("type", "button");
+
+          // Chat bubble icon (Lucide MessageSquare, 14×14)
+          const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+          svg.setAttribute("width", "14");
+          svg.setAttribute("height", "14");
+          svg.setAttribute("viewBox", "0 0 24 24");
+          svg.setAttribute("fill", "none");
+          svg.setAttribute("stroke", "currentColor");
+          svg.setAttribute("stroke-width", "2");
+          svg.setAttribute("stroke-linecap", "round");
+          svg.setAttribute("stroke-linejoin", "round");
+          const path = document.createElementNS("http://www.w3.org/2000/svg", "path");
+          path.setAttribute("d", "M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z");
+          svg.appendChild(path);
+          btn.appendChild(svg);
+
+          const label = document.createElement("span");
+          label.textContent = "Add to Chat";
+          btn.appendChild(label);
+
+          // Use mousedown + preventDefault so clicking the button doesn't
+          // deselect the text or blur the editor before we can read it.
+          btn.addEventListener("mousedown", (e) => {
+            e.preventDefault();
+            e.stopPropagation();
+
+            const { from, to } = view.state.selection.main;
+            if (from === to) return;
+
+            const selectedText = view.state.sliceDoc(from, to);
+            const startLine = view.state.doc.lineAt(from).number;
+            const endLine = view.state.doc.lineAt(to).number;
+
+            const detail: SelectionToChatDetail = {
+              filePath,
+              selectedText,
+              startLine,
+              endLine,
+            };
+
+            window.dispatchEvent(new CustomEvent("band:add-to-chat", { detail }));
+
+            // Collapse selection and hide tooltip
+            view.dispatch({
+              selection: { anchor: from },
+              effects: setSelectionTooltip.of(null),
+            });
+          });
+
+          dom.appendChild(btn);
+          return { dom };
+        },
+      };
+    }
+
+    /**
+     * Schedule showing or hiding the tooltip. All `view.dispatch()` calls
+     * happen inside `setTimeout` so they never run synchronously within a
+     * CodeMirror update cycle (which would be silently dropped).
+     */
+    function schedule(immediate: boolean) {
+      clearTimer();
+      timer = setTimeout(
+        () => {
+          timer = null;
+          view.dispatch({ effects: setSelectionTooltip.of(buildTooltip()) });
+        },
+        immediate ? 0 : SHOW_DELAY_MS,
+      );
+    }
+
+    return {
+      update(update) {
+        if (update.selectionSet) {
+          const sel = update.state.selection.main;
+          // Hide immediately (but still deferred via setTimeout 0) when
+          // selection is cleared; show after the full delay otherwise.
+          schedule(sel.empty || sel.to - sel.from < MIN_SELECTION_LENGTH);
+        }
+      },
+      destroy() {
+        clearTimer();
+      },
+    };
+  });
+
+  // --- Theme -----------------------------------------------------------------
+
+  const theme = EditorView.theme({
+    ".cm-tooltip.cm-add-to-chat-tooltip": {
+      backgroundColor: "transparent",
+      border: "none",
+      zIndex: "100",
+    },
+    ".cm-add-to-chat-btn": {
+      display: "inline-flex",
+      alignItems: "center",
+      gap: "4px",
+      padding: "3px 10px",
+      fontSize: "12px",
+      fontFamily: 'ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif',
+      fontWeight: "500",
+      lineHeight: "1.4",
+      color: "var(--foreground, #e4e4e7)",
+      backgroundColor: "var(--popover, #18181b)",
+      border: "1px solid var(--border, #27272a)",
+      borderRadius: "6px",
+      cursor: "pointer",
+      boxShadow: "0 2px 8px rgba(0,0,0,0.3)",
+      whiteSpace: "nowrap",
+      transition: "background-color 120ms ease, border-color 120ms ease",
+    },
+    ".cm-add-to-chat-btn:hover": {
+      backgroundColor: "var(--accent, #27272a)",
+      borderColor: "var(--ring, #3f3f46)",
+    },
+  });
+
+  return [tooltipField, debouncePlugin, theme];
+}


### PR DESCRIPTION
## Summary
- When a user selects text in a CodeMirror editor (file browser or diff/changes view), a floating "Add to Chat" button appears after a short delay
- Clicking the button inserts a file path + line range reference (e.g. `src/lib/foo.ts:5-10`) into the chat input and focuses it
- Uses CodeMirror's built-in tooltip system with a debounced ViewPlugin for proper positioning and lifecycle
- Communicates between panels via `band:add-to-chat` CustomEvent (matching existing cross-panel pattern)

## Test plan
- [ ] Open the file browser, select text in a file → verify "Add to Chat" button appears after ~500ms
- [ ] Click the button → verify a backtick-wrapped file:line reference appears in the chat input and the textarea is focused
- [ ] Open the changes/diff view, select text in a diff → verify the same behavior works in both unified and split modes
- [ ] Verify the button disappears immediately when selection is cleared
- [ ] Verify multiple selections append references (don't replace existing draft text)

🤖 Generated with [Claude Code](https://claude.com/claude-code)