### PR TITLE
feat: add app mode setting for Side Panel / Full Editor

### DIFF
--- a/apps/dashboard/package.json
+++ b/apps/dashboard/package.json
@@ -12,8 +12,6 @@
     "tauri:dev": "npx tauri dev"
   },
   "dependencies": {
-    "@band-app/dashboard-core": "workspace:^",
-    "@band-app/ui": "workspace:^",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "tw-animate-css": "^1.4.0"

--- a/apps/dashboard/src-tauri/src/commands/window.rs
+++ b/apps/dashboard/src-tauri/src/commands/window.rs
@@ -174,3 +174,45 @@ pub fn get_app_title() -> String {
         None => "Band".to_string(),
     }
 }
+
+const SIDE_PANEL_WIDTH: f64 = 400.0;
+
+#[tauri::command]
+pub async fn set_app_mode(app: AppHandle, mode: String) -> Result<(), String> {
+    let window = app
+        .get_webview_window("main")
+        .ok_or("Main window not found")?;
+
+    let monitor = window
+        .current_monitor()
+        .map_err(|e| format!("Failed to get monitor: {e}"))?
+        .ok_or("No monitor found")?;
+
+    let screen_size = monitor.size();
+    let scale = monitor.scale_factor();
+    let screen_w = f64::from(screen_size.width) / scale;
+    let screen_h = f64::from(screen_size.height) / scale;
+
+    if mode == "full-editor" {
+        let _ = window.set_size(tauri::Size::Logical(tauri::LogicalSize::new(
+            screen_w, screen_h,
+        )));
+        let _ = window.set_position(tauri::Position::Logical(tauri::LogicalPosition::new(
+            0.0, 0.0,
+        )));
+    } else {
+        // Side panel: narrow width, full height, left edge
+        let _ = window.set_size(tauri::Size::Logical(tauri::LogicalSize::new(
+            SIDE_PANEL_WIDTH,
+            screen_h,
+        )));
+        let _ = window.set_position(tauri::Position::Logical(tauri::LogicalPosition::new(
+            0.0, 0.0,
+        )));
+    }
+
+    // Reload the main webview so it picks up the new app mode from settings
+    let _ = window.eval("window.location.replace('/')");
+
+    Ok(())
+}

--- a/apps/dashboard/src-tauri/src/lib.rs
+++ b/apps/dashboard/src-tauri/src/lib.rs
@@ -74,6 +74,7 @@ pub fn run() {
             commands::window::open_cronjobs_window,
             commands::window::open_settings_window,
             commands::window::get_app_title,
+            commands::window::set_app_mode,
         ])
         .setup(move |app| {
             let window = app.get_webview_window("main").unwrap();
@@ -112,29 +113,48 @@ pub fn run() {
                 }
             }
 
-            // Position dashboard at left edge, full screen height (preserve current width)
+            // Read app mode from settings (defaults to "side-panel")
+            let app_mode = state::load_settings()
+                .ok()
+                .and_then(|s| s.app_mode)
+                .unwrap_or_else(|| "side-panel".to_string());
+
+            // Position and size the window based on app mode
             if let Ok(Some(monitor)) = window.current_monitor() {
                 let screen_size = monitor.size();
                 let scale_factor = monitor.scale_factor();
-                let screen_height = (f64::from(screen_size.height) / scale_factor) as u32;
-
-                let current_width = window
-                    .outer_size()
-                    .map(|s| (f64::from(s.width) / scale_factor) as u32)
-                    .unwrap_or(400);
+                let screen_width = f64::from(screen_size.width) / scale_factor;
+                let screen_height = f64::from(screen_size.height) / scale_factor;
 
                 let _ = window.set_position(tauri::Position::Logical(tauri::LogicalPosition::new(
                     0.0, 0.0,
                 )));
-                let _ = window.set_size(tauri::Size::Logical(tauri::LogicalSize::new(
-                    f64::from(current_width),
-                    f64::from(screen_height),
-                )));
+
+                if app_mode == "full-editor" {
+                    // Full editor: use entire screen
+                    let _ = window.set_size(tauri::Size::Logical(tauri::LogicalSize::new(
+                        screen_width,
+                        screen_height,
+                    )));
+                } else {
+                    // Side panel: narrow width at left edge, full height
+                    let current_width = window
+                        .outer_size()
+                        .map(|s| (f64::from(s.width) / scale_factor) as u32)
+                        .unwrap_or(400);
+
+                    let _ = window.set_size(tauri::Size::Logical(tauri::LogicalSize::new(
+                        f64::from(current_width),
+                        screen_height,
+                    )));
+                }
             }
 
-            // Poll the frontmost VS Code window to track active workspace
-            // (handles projects without the Band VS Code extension)
-            commands::ide::start_focus_polling(app.handle().clone());
+            // Poll the frontmost VS Code window to track active workspace.
+            // Only needed in side-panel mode where we manage external IDE windows.
+            if app_mode != "full-editor" {
+                commands::ide::start_focus_polling(app.handle().clone());
+            }
 
             // Kill web server and close secondary windows on app exit.
             // Uses a `cleaned_up` flag to avoid double cleanup when both
@@ -166,21 +186,24 @@ pub fn run() {
                 }
             });
 
-            // Raise the active workspace's app windows when dashboard gains focus
-            let active_ws_state: std::sync::Arc<std::sync::Mutex<Option<String>>> =
-                app.state::<ActiveWorkspaceState>().inner().0.clone();
-            let raise_cache = app.state::<ProjectCache>().inner().clone();
-            let window_ref = app.get_webview_window("main").unwrap();
-            window_ref.on_window_event(move |event| {
-                if let tauri::WindowEvent::Focused(true) = event {
-                    let workspace_id: Option<String> =
-                        active_ws_state.lock().ok().and_then(|guard| guard.clone());
+            // Raise the active workspace's app windows when dashboard gains focus.
+            // Only in side-panel mode where external IDE windows are managed.
+            if app_mode != "full-editor" {
+                let active_ws_state: std::sync::Arc<std::sync::Mutex<Option<String>>> =
+                    app.state::<ActiveWorkspaceState>().inner().0.clone();
+                let raise_cache = app.state::<ProjectCache>().inner().clone();
+                let window_ref = app.get_webview_window("main").unwrap();
+                window_ref.on_window_event(move |event| {
+                    if let tauri::WindowEvent::Focused(true) = event {
+                        let workspace_id: Option<String> =
+                            active_ws_state.lock().ok().and_then(|guard| guard.clone());
 
-                    if let Some(ws_id) = workspace_id {
-                        commands::ide::raise_workspace_windows(&ws_id, &raise_cache);
+                        if let Some(ws_id) = workspace_id {
+                            commands::ide::raise_workspace_windows(&ws_id, &raise_cache);
+                        }
                     }
-                }
-            });
+                });
+            }
 
             Ok(())
         })

--- a/apps/dashboard/src-tauri/src/state.rs
+++ b/apps/dashboard/src-tauri/src/state.rs
@@ -65,6 +65,8 @@ pub struct Settings {
     pub token_secret: Option<String>,
     #[serde(rename = "autoStartTunnel", skip_serializing_if = "Option::is_none")]
     pub auto_start_tunnel: Option<bool>,
+    #[serde(rename = "appMode", skip_serializing_if = "Option::is_none")]
+    pub app_mode: Option<String>,
     /// Extra fields not explicitly modeled (e.g. user-defined app definitions).
     #[serde(flatten)]
     pub extra: serde_json::Map<String, serde_json::Value>,

--- a/apps/dashboard/src/App.tsx
+++ b/apps/dashboard/src/App.tsx
@@ -1,16 +1,7 @@
-import { DashboardProvider, DashboardShell } from "@band-app/dashboard-core";
-import {
-  HybridDashboardAdapter,
-  NativeShellCapabilities,
-} from "@band-app/dashboard-core/adapters/hybrid";
-
-const adapter = new HybridDashboardAdapter();
-const capabilities = new NativeShellCapabilities();
-
+/**
+ * Placeholder component. The Tauri webview loads its UI from the
+ * web server (apps/web) — this file exists only as a Vite entry point.
+ */
 export default function App() {
-  return (
-    <DashboardProvider adapter={adapter} capabilities={capabilities}>
-      <DashboardShell />
-    </DashboardProvider>
-  );
+  return null;
 }

--- a/apps/dashboard/src/main.tsx
+++ b/apps/dashboard/src/main.tsx
@@ -1,4 +1,3 @@
-import { TooltipProvider } from "@band-app/ui";
 import React from "react";
 import ReactDOM from "react-dom/client";
 import App from "./App";
@@ -6,8 +5,6 @@ import "./styles/globals.css";
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>
-    <TooltipProvider>
-      <App />
-    </TooltipProvider>
+    <App />
   </React.StrictMode>,
 );

--- a/apps/web/src/components/DashboardView.tsx
+++ b/apps/web/src/components/DashboardView.tsx
@@ -1,11 +1,14 @@
-import { DashboardShell } from "@band-app/dashboard-core";
+import { DashboardShell, useSettingsQuery } from "@band-app/dashboard-core";
 import { useIsDesktop } from "../hooks/useIsDesktop";
 import { isTauri } from "../lib/is-tauri";
 import { DesktopLayout } from "./DesktopLayout";
 import { ToolbarButtons } from "./ToolbarButtons";
 
 export function DashboardView() {
-  const isDesktop = useIsDesktop() && !isTauri;
+  const { settings } = useSettingsQuery();
+  const appMode = settings.appMode ?? "side-panel";
+  const isWideScreen = useIsDesktop();
+  const isDesktop = (isWideScreen && !isTauri) || (isTauri && appMode === "full-editor");
 
   if (isDesktop) {
     return <DesktopLayout toolbarExtra={<ToolbarButtons />} />;

--- a/apps/web/src/components/TauriTitleBar.tsx
+++ b/apps/web/src/components/TauriTitleBar.tsx
@@ -1,0 +1,62 @@
+import { type RefObject, useEffect, useRef, useState } from "react";
+
+/** Attaches a native mousedown → startDragging listener to a ref. */
+function useTauriDrag(ref: RefObject<HTMLElement | null>) {
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+
+    let appWindow: { startDragging: () => Promise<void> } | null = null;
+    import("@tauri-apps/api/window").then(({ getCurrentWindow }) => {
+      appWindow = getCurrentWindow();
+    });
+
+    const onMouseDown = (e: MouseEvent) => {
+      if (e.buttons === 1 && appWindow) {
+        appWindow.startDragging();
+      }
+    };
+    el.addEventListener("mousedown", onMouseDown);
+    return () => el.removeEventListener("mousedown", onMouseDown);
+  }, [ref]);
+}
+
+interface TauriTitleBarProps {
+  /** Static title. If omitted, fetches the app title from Tauri. */
+  title?: string;
+}
+
+/** Draggable Tauri title bar that works with external-URL webviews. */
+export function TauriTitleBar({ title }: TauriTitleBarProps) {
+  const [appTitle, setAppTitle] = useState(title ?? "Band");
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (title) return;
+    import("@tauri-apps/api/core").then(({ invoke }) => {
+      invoke<string>("get_app_title").then(setAppTitle);
+    });
+  }, [title]);
+
+  useTauriDrag(ref);
+
+  return (
+    <div
+      ref={ref}
+      data-tauri-drag-region
+      className="h-[28px] shrink-0 flex items-center justify-center"
+    >
+      <span className="text-xs font-medium text-muted-foreground select-none pointer-events-none">
+        {appTitle}
+      </span>
+    </div>
+  );
+}
+
+/** Invisible draggable region for Tauri windows (no title text). */
+export function TauriDragRegion() {
+  const ref = useRef<HTMLDivElement>(null);
+  useTauriDrag(ref);
+
+  return <div ref={ref} data-tauri-drag-region className="h-[28px] shrink-0" />;
+}

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -15,6 +15,7 @@ import {
   useRouterState,
 } from "@tanstack/react-router";
 import { useCallback, useEffect } from "react";
+import { TauriTitleBar } from "../components/TauriTitleBar";
 import { ToolbarButtons } from "../components/ToolbarButtons";
 import { useIsDesktop } from "../hooks/useIsDesktop";
 import { useNavigationHistory } from "../hooks/useNavigationHistory";
@@ -99,8 +100,32 @@ function ThemeSync() {
 
 const STANDALONE_ROUTES = ["/tasks", "/cronjobs", "/settings"];
 
+/**
+ * Syncs the appMode setting into the HybridDashboardAdapter and
+ * NativeShellCapabilities so they behave correctly for the active mode.
+ */
+function ModeSync() {
+  const { settings } = useSettingsQuery();
+  const appMode = settings.appMode ?? "side-panel";
+
+  useEffect(() => {
+    if (isTauri) {
+      (adapter as HybridDashboardAdapter).setAppMode(appMode);
+      (capabilities as NativeShellCapabilities).setAppMode(appMode);
+    }
+  }, [appMode]);
+
+  return null;
+}
+
 function AppShell() {
-  const isDesktop = useIsDesktop() && !isTauri;
+  const { settings } = useSettingsQuery();
+  const appMode = settings.appMode ?? "side-panel";
+  // Show desktop split layout when:
+  // - In a regular browser on a wide screen, OR
+  // - In Tauri with "full-editor" mode
+  const isWideScreen = useIsDesktop();
+  const isDesktop = (isWideScreen && !isTauri) || (isTauri && appMode === "full-editor");
   const router = useRouter();
   const pathname = useRouterState({ select: (s) => s.location.pathname });
   const isStandalone = STANDALONE_ROUTES.includes(pathname);
@@ -123,13 +148,18 @@ function AppShell() {
     return <Outlet />;
   }
 
+  const isTauriFullEditor = isTauri && appMode === "full-editor";
+
   return (
-    <div className="flex h-dvh w-full overflow-hidden bg-background text-foreground">
-      <div className="w-80 shrink-0 border-r border-border overflow-hidden">
-        <DashboardShell toolbarExtra={<ToolbarButtons />} />
-      </div>
-      <div className="flex-1 min-w-0 overflow-hidden">
-        <Outlet />
+    <div className="flex flex-col h-dvh w-full overflow-hidden bg-background text-foreground">
+      {isTauriFullEditor && <TauriTitleBar />}
+      <div className="flex flex-1 min-h-0 overflow-hidden">
+        <div className="w-80 shrink-0 border-r border-border overflow-hidden">
+          <DashboardShell toolbarExtra={<ToolbarButtons />} hideTitleBar={isTauriFullEditor} />
+        </div>
+        <div className="flex-1 min-w-0 overflow-hidden">
+          <Outlet />
+        </div>
       </div>
     </div>
   );
@@ -146,6 +176,7 @@ function RootLayout() {
       <body>
         <DashboardProvider adapter={adapter} capabilities={capabilities}>
           <ThemeSync />
+          <ModeSync />
           <TooltipProvider>
             <AppShell />
           </TooltipProvider>

--- a/apps/web/src/routes/cronjobs.tsx
+++ b/apps/web/src/routes/cronjobs.tsx
@@ -1,5 +1,6 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { CronjobsPageContent } from "../components/CronjobsPageContent";
+import { TauriTitleBar } from "../components/TauriTitleBar";
 import { isTauri } from "../lib/is-tauri";
 
 export const Route = createFileRoute("/cronjobs")({
@@ -9,13 +10,7 @@ export const Route = createFileRoute("/cronjobs")({
 function CronjobsPage() {
   return (
     <div className="flex h-dvh flex-col overflow-hidden pb-[env(safe-area-inset-bottom)]">
-      {isTauri && (
-        <div data-tauri-drag-region className="h-[28px] shrink-0 flex items-center justify-center">
-          <span className="text-xs font-medium text-muted-foreground select-none pointer-events-none">
-            Cronjobs
-          </span>
-        </div>
-      )}
+      {isTauri && <TauriTitleBar title="Cronjobs" />}
       <CronjobsPageContent />
     </div>
   );

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -1,3 +1,4 @@
+import { useSettingsQuery } from "@band-app/dashboard-core";
 import { createFileRoute } from "@tanstack/react-router";
 import { MessageSquare } from "lucide-react";
 import { DashboardView } from "../components/DashboardView";
@@ -9,7 +10,11 @@ export const Route = createFileRoute("/")({
 });
 
 function DashboardPage() {
-  const isDesktop = useIsDesktop() && !isTauri;
+  const { settings } = useSettingsQuery();
+  const appMode = settings.appMode ?? "side-panel";
+  const isWideScreen = useIsDesktop();
+  // Desktop split layout is active in browser on wide screens, or in Tauri full-editor mode
+  const isDesktop = (isWideScreen && !isTauri) || (isTauri && appMode === "full-editor");
 
   // Desktop: sidebar is rendered by root layout, just show empty state
   if (isDesktop) {
@@ -23,7 +28,7 @@ function DashboardPage() {
     );
   }
 
-  // Mobile: full-screen dashboard shell
+  // Mobile / Tauri side-panel: full-screen dashboard shell
   return (
     <div className="h-dvh pb-4 standalone:pb-[env(safe-area-inset-bottom)]">
       <DashboardView />

--- a/apps/web/src/routes/settings.tsx
+++ b/apps/web/src/routes/settings.tsx
@@ -1,6 +1,7 @@
 import { SettingsPage } from "@band-app/dashboard-core";
 import { ScrollArea } from "@band-app/ui";
 import { createFileRoute } from "@tanstack/react-router";
+import { TauriTitleBar } from "../components/TauriTitleBar";
 import { isTauri } from "../lib/is-tauri";
 
 export const Route = createFileRoute("/settings")({
@@ -10,13 +11,7 @@ export const Route = createFileRoute("/settings")({
 function SettingsRoute() {
   return (
     <div className="flex h-dvh flex-col overflow-hidden pb-[env(safe-area-inset-bottom)]">
-      {isTauri && (
-        <div data-tauri-drag-region className="h-[28px] shrink-0 flex items-center justify-center">
-          <span className="text-xs font-medium text-muted-foreground select-none pointer-events-none">
-            Settings
-          </span>
-        </div>
-      )}
+      {isTauri && <TauriTitleBar title="Settings" />}
       <ScrollArea className="flex-1 overflow-hidden">
         <div className="px-2 py-2">
           <SettingsPage hideTitle />

--- a/apps/web/src/routes/tasks.tsx
+++ b/apps/web/src/routes/tasks.tsx
@@ -1,5 +1,6 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { TasksPageContent } from "../components/TasksPageContent";
+import { TauriTitleBar } from "../components/TauriTitleBar";
 import { isTauri } from "../lib/is-tauri";
 
 export const Route = createFileRoute("/tasks")({
@@ -9,13 +10,7 @@ export const Route = createFileRoute("/tasks")({
 function TasksPage() {
   return (
     <div className="flex h-dvh flex-col overflow-hidden pb-[env(safe-area-inset-bottom)]">
-      {isTauri && (
-        <div data-tauri-drag-region className="h-[28px] shrink-0 flex items-center justify-center">
-          <span className="text-xs font-medium text-muted-foreground select-none pointer-events-none">
-            Tasks
-          </span>
-        </div>
-      )}
+      {isTauri && <TauriTitleBar title="Tasks" />}
       <TasksPageContent />
     </div>
   );

--- a/apps/web/src/routes/workspace.$workspaceId.index.tsx
+++ b/apps/web/src/routes/workspace.$workspaceId.index.tsx
@@ -1,3 +1,4 @@
+import { useSettingsQuery } from "@band-app/dashboard-core";
 import { createFileRoute, Navigate } from "@tanstack/react-router";
 import { useEffect, useState } from "react";
 import { ChatView } from "../components/ChatView";
@@ -14,7 +15,10 @@ export const Route = createFileRoute("/workspace/$workspaceId/")({
 function WorkspaceIndex() {
   const { workspaceId } = Route.useParams();
   const decoded = decodeURIComponent(workspaceId);
-  const isDesktop = useIsDesktop() && !isTauri;
+  const { settings } = useSettingsQuery();
+  const appMode = settings.appMode ?? "side-panel";
+  const isWideScreen = useIsDesktop();
+  const isDesktop = (isWideScreen && !isTauri) || (isTauri && appMode === "full-editor");
 
   // Desktop: chat is always visible in the left panel — redirect to changes tab
   if (isDesktop) {

--- a/apps/web/src/routes/workspace.$workspaceId.tsx
+++ b/apps/web/src/routes/workspace.$workspaceId.tsx
@@ -4,6 +4,7 @@ import {
   QuickOpenDialog,
   SearchFilesDialog,
   useDashboardStore,
+  useSettingsQuery,
   type WorkspaceTab,
   WorkspaceTabNav,
 } from "@band-app/dashboard-core";
@@ -28,6 +29,7 @@ import {
   useState,
 } from "react";
 import { PanelResizer } from "../components/PanelResizer";
+import { TauriDragRegion } from "../components/TauriTitleBar";
 import { WorkspaceChatPanel } from "../components/WorkspaceChatPanel";
 import { AgentSwitcherContext } from "../hooks/useAgentSwitcherContext";
 import { useIsDesktop } from "../hooks/useIsDesktop";
@@ -134,7 +136,10 @@ function useDiffFileCount(workspaceId: string): number {
 function WorkspaceLayout() {
   const { workspaceId } = Route.useParams();
   const decoded = decodeURIComponent(workspaceId);
-  const isDesktop = useIsDesktop() && !isTauri;
+  const { settings } = useSettingsQuery();
+  const appMode = settings.appMode ?? "side-panel";
+  const isWideScreen = useIsDesktop();
+  const isDesktop = (isWideScreen && !isTauri) || (isTauri && appMode === "full-editor");
   const [diffStats, setDiffStats] = useState<DiffStats | null>(null);
   const pathname = useRouterState({ select: (s) => s.location.pathname });
 
@@ -540,7 +545,7 @@ function MobileWorkspaceLayout({
             transform: appOffsetTop ? `translateY(${appOffsetTop}px)` : undefined,
           }}
         >
-          {isTauri && <div data-tauri-drag-region className="h-[28px] shrink-0" />}
+          {isTauri && <TauriDragRegion />}
           <header className="flex shrink-0 items-center gap-3 border-b border-border/50 px-4 py-3 pt-[max(0.75rem,env(safe-area-inset-top))]">
             <button
               type="button"

--- a/packages/dashboard-core/src/adapters/hybrid.ts
+++ b/packages/dashboard-core/src/adapters/hybrid.ts
@@ -1,5 +1,6 @@
 import type { PlatformCapabilities, Unsubscribe } from "../adapter";
 import { toWorkspaceId } from "../lib/workspace-id";
+import type { AppMode } from "../types";
 import { WebCapabilities, WebDashboardAdapter } from "./web";
 
 function isTauri(): boolean {
@@ -19,11 +20,24 @@ async function tauriListen<T>(event: string, handler: (payload: T) => void): Pro
 /**
  * Hybrid adapter: data operations go through HTTP (WebDashboardAdapter),
  * but workspace open and active-workspace tracking use Tauri IPC when
- * running inside the Tauri webview.
+ * running inside the Tauri webview in side-panel mode.
+ *
+ * In full-editor mode, workspace clicks navigate to in-app routes instead
+ * of opening external IDE windows.
  */
 export class HybridDashboardAdapter extends WebDashboardAdapter {
+  private _appMode: AppMode = "side-panel";
+
+  setAppMode(mode: AppMode) {
+    this._appMode = mode;
+  }
+
+  get appMode(): AppMode {
+    return this._appMode;
+  }
+
   async removeWorkspace(project: string, branch: string): Promise<void> {
-    if (isTauri()) {
+    if (isTauri() && this._appMode === "side-panel") {
       const workspaceId = toWorkspaceId(project, branch);
       await tauriInvoke("workspace_close", { workspaceId });
     }
@@ -31,13 +45,13 @@ export class HybridDashboardAdapter extends WebDashboardAdapter {
   }
 
   async closeWorkspaceWindows(workspaceId: string): Promise<void> {
-    if (isTauri()) {
+    if (isTauri() && this._appMode === "side-panel") {
       await tauriInvoke("workspace_close", { workspaceId });
     }
   }
 
   async openWorkspace(workspaceId: string): Promise<void> {
-    if (isTauri()) {
+    if (isTauri() && this._appMode === "side-panel") {
       await tauriInvoke("workspace_focus", { workspaceId });
       return;
     }
@@ -45,7 +59,7 @@ export class HybridDashboardAdapter extends WebDashboardAdapter {
   }
 
   subscribeActiveWorkspace(onChange: (workspaceId: string | null) => void): Unsubscribe {
-    if (!isTauri()) {
+    if (!isTauri() || this._appMode === "full-editor") {
       return super.subscribeActiveWorkspace(onChange);
     }
 
@@ -74,18 +88,32 @@ export class HybridDashboardAdapter extends WebDashboardAdapter {
  * Native shell capabilities: Tauri IPC for native OS features
  * (copy path, reveal in finder, pick folder, open URL).
  * Tunnel and web server management are handled via HTTP endpoints.
+ *
+ * Mode-aware: in side-panel mode, workspace clicks focus IDE windows.
+ * In full-editor mode, workspace clicks navigate to in-app routes.
  */
 export class NativeShellCapabilities implements PlatformCapabilities {
   private web = new WebCapabilities();
+  private _appMode: AppMode = "side-panel";
+  navigate?: (href: string) => void;
+
+  setAppMode(mode: AppMode) {
+    this._appMode = mode;
+  }
+
+  get appMode(): AppMode {
+    return this._appMode;
+  }
 
   get copyPath(): boolean {
     return isTauri();
   }
 
   getWorkspaceHref(workspaceId: string): string | undefined {
-    // Inside Tauri, clicking a workspace should focus the IDE window
-    // via openWorkspace (Tauri IPC), not navigate to the chat page.
-    if (isTauri()) return undefined;
+    // In side-panel mode inside Tauri, clicking a workspace should focus
+    // the IDE window via openWorkspace (Tauri IPC), not navigate.
+    // In full-editor mode, navigate to the workspace page in-app.
+    if (isTauri() && this._appMode === "side-panel") return undefined;
     return this.web.getWorkspaceHref(workspaceId);
   }
 

--- a/packages/dashboard-core/src/components/DashboardShell.tsx
+++ b/packages/dashboard-core/src/components/DashboardShell.tsx
@@ -35,11 +35,13 @@ import { SettingsPage } from "./SettingsPage";
 
 interface DashboardShellProps {
   toolbarExtra?: ReactNode;
+  /** Hide the Tauri title bar (e.g. when the parent renders a full-width one). */
+  hideTitleBar?: boolean;
 }
 
 const isTauri = typeof window !== "undefined" && "__TAURI_INTERNALS__" in window;
 
-export function DashboardShell({ toolbarExtra }: DashboardShellProps) {
+export function DashboardShell({ toolbarExtra, hideTitleBar }: DashboardShellProps) {
   const { projects, isLoading: loading } = useProjects();
   const { settings } = useSettingsQuery();
   const labels = settings.labels ?? [];
@@ -101,7 +103,7 @@ export function DashboardShell({ toolbarExtra }: DashboardShellProps) {
     <div
       className={`h-dvh w-full overflow-hidden flex flex-col bg-background text-foreground p-0 ${isTauri ? "" : "pt-[env(safe-area-inset-top)]"}`}
     >
-      {isTauri && (
+      {isTauri && !hideTitleBar && (
         <div
           ref={titleBarRef}
           data-tauri-drag-region

--- a/packages/dashboard-core/src/components/SettingsPage.tsx
+++ b/packages/dashboard-core/src/components/SettingsPage.tsx
@@ -28,7 +28,13 @@ import { useCapabilities } from "../context";
 import { useUpdateSettings } from "../hooks/use-settings-mutations";
 import { useSettingsQuery } from "../hooks/use-settings-query";
 import { playSound, SOUNDS, type SoundId } from "../lib/sounds";
-import type { CodingAgentDefinition, CodingAgentType, LabelDefinition, Theme } from "../types";
+import type {
+  AppMode,
+  CodingAgentDefinition,
+  CodingAgentType,
+  LabelDefinition,
+  Theme,
+} from "../types";
 import { AgentIcon } from "./agent-icons";
 
 const KNOWN_AGENTS: { id: string; type: CodingAgentType; label: string; defaultCommand: string }[] =
@@ -52,6 +58,7 @@ const DEFAULT_DEFAULTS = {
 
 type Section =
   | "menu"
+  | "app-mode"
   | "appearance"
   | "general"
   | "coding-agent"
@@ -61,6 +68,7 @@ type Section =
   | "labels";
 
 const SECTION_TITLES: Record<Exclude<Section, "menu">, string> = {
+  "app-mode": "App Mode",
   appearance: "Appearance",
   general: "General",
   labels: "Labels",
@@ -107,7 +115,7 @@ export function SettingsPage({ onClose, hideTitle }: Props) {
   const capabilities = useCapabilities();
   const [section, setSection] = useState<Section>(() => {
     if (typeof window !== "undefined" && window.matchMedia("(min-width: 1024px)").matches) {
-      return "appearance";
+      return "app-mode";
     }
     return "menu";
   });
@@ -128,6 +136,9 @@ export function SettingsPage({ onClose, hideTitle }: Props) {
   const [labels, setLabels] = useState<LabelDefinition[]>(settings.labels ?? []);
   const [autoStartTunnel, setAutoStartTunnel] = useState(settings.autoStartTunnel ?? false);
   const [selectedTheme, setSelectedTheme] = useState<Theme>(settings.theme ?? "system");
+  const [appMode, setAppMode] = useState<AppMode>(settings.appMode ?? "side-panel");
+
+  const isTauriApp = typeof window !== "undefined" && "__TAURI_INTERNALS__" in window;
 
   const isDirty = useMemo(() => {
     if (worktreesDir !== (settings.worktreesDir ?? "")) return true;
@@ -146,6 +157,7 @@ export function SettingsPage({ onClose, hideTitle }: Props) {
     if (JSON.stringify(labels) !== JSON.stringify(settings.labels ?? [])) return true;
     if (autoStartTunnel !== (settings.autoStartTunnel ?? false)) return true;
     if (selectedTheme !== (settings.theme ?? "system")) return true;
+    if (appMode !== (settings.appMode ?? "side-panel")) return true;
     return false;
   }, [
     worktreesDir,
@@ -158,6 +170,7 @@ export function SettingsPage({ onClose, hideTitle }: Props) {
     labels,
     autoStartTunnel,
     selectedTheme,
+    appMode,
     settings,
   ]);
 
@@ -172,6 +185,7 @@ export function SettingsPage({ onClose, hideTitle }: Props) {
     setLabels(settings.labels ?? []);
     setAutoStartTunnel(settings.autoStartTunnel ?? false);
     setSelectedTheme(settings.theme ?? "system");
+    setAppMode(settings.appMode ?? "side-panel");
   }, [
     settings.worktreesDir,
     settings.defaults,
@@ -182,6 +196,7 @@ export function SettingsPage({ onClose, hideTitle }: Props) {
     settings.labels,
     settings.autoStartTunnel,
     settings.theme,
+    settings.appMode,
   ]);
 
   const handleBrowse = async () => {
@@ -240,9 +255,21 @@ export function SettingsPage({ onClose, hideTitle }: Props) {
       tokenSecret: settings.tokenSecret,
       autoStartTunnel: autoStartTunnel || undefined,
       theme: selectedTheme,
+      appMode,
     });
+
+    // If running in Tauri and the app mode changed, resize the window
+    if (isTauriApp && appMode !== (settings.appMode ?? "side-panel")) {
+      try {
+        const { invoke } = await import("@tauri-apps/api/core");
+        await invoke("set_app_mode", { mode: appMode });
+      } catch {
+        // Tauri command not available; mode will apply on next restart
+      }
+    }
   };
 
+  const appModePreview = appMode === "full-editor" ? "Full Editor" : "Side Panel";
   const worktreesDirPreview = worktreesDir || "Default";
   const agentPreview =
     codingAgents.length > 0
@@ -264,6 +291,70 @@ export function SettingsPage({ onClose, hideTitle }: Props) {
 
   const sectionContent = activeSection && (
     <>
+      {activeSection === "app-mode" && (
+        <div className="space-y-4 px-1">
+          <div className="space-y-3">
+            <Label>App Mode</Label>
+            <div className="space-y-2">
+              <button
+                type="button"
+                onClick={() => setAppMode("side-panel")}
+                className={`flex w-full items-start gap-3 rounded-md border p-3 text-left transition-colors ${
+                  appMode === "side-panel"
+                    ? "border-primary bg-primary/5"
+                    : "border-border hover:border-muted-foreground/50"
+                }`}
+              >
+                <div
+                  className={`mt-0.5 size-4 shrink-0 rounded-full border-2 flex items-center justify-center ${
+                    appMode === "side-panel" ? "border-primary" : "border-muted-foreground/40"
+                  }`}
+                >
+                  {appMode === "side-panel" && <div className="size-2 rounded-full bg-primary" />}
+                </div>
+                <div className="flex-1 min-w-0">
+                  <div className="text-sm font-medium">Side Panel</div>
+                  <p className="text-xs text-muted-foreground mt-0.5">
+                    Compact sidebar alongside your IDE. Clicking a workspace opens it in an external
+                    editor window.
+                  </p>
+                </div>
+              </button>
+              <button
+                type="button"
+                onClick={() => setAppMode("full-editor")}
+                className={`flex w-full items-start gap-3 rounded-md border p-3 text-left transition-colors ${
+                  appMode === "full-editor"
+                    ? "border-primary bg-primary/5"
+                    : "border-border hover:border-muted-foreground/50"
+                }`}
+              >
+                <div
+                  className={`mt-0.5 size-4 shrink-0 rounded-full border-2 flex items-center justify-center ${
+                    appMode === "full-editor" ? "border-primary" : "border-muted-foreground/40"
+                  }`}
+                >
+                  {appMode === "full-editor" && <div className="size-2 rounded-full bg-primary" />}
+                </div>
+                <div className="flex-1 min-w-0">
+                  <div className="text-sm font-medium">Full Editor</div>
+                  <p className="text-xs text-muted-foreground mt-0.5">
+                    Full-width editor with built-in file browser, changes view, chat, and terminal.
+                    No external IDE windows needed.
+                  </p>
+                </div>
+              </button>
+            </div>
+            <p className="text-xs text-muted-foreground">
+              Choose how Band appears on your desktop.{" "}
+              {isTauriApp
+                ? "The window will resize immediately after saving."
+                : "This setting applies to the desktop app."}
+            </p>
+          </div>
+        </div>
+      )}
+
       {activeSection === "appearance" && (
         <div className="space-y-4 px-1">
           <div className="space-y-2">
@@ -595,6 +686,13 @@ export function SettingsPage({ onClose, hideTitle }: Props) {
 
   const menuItems = (
     <div className="flex flex-col gap-px">
+      <SettingsRow
+        label="App Mode"
+        value={appModePreview}
+        active={activeSection === "app-mode"}
+        onClick={() => setSection("app-mode")}
+      />
+      <Separator />
       <SettingsRow
         label="Appearance"
         value={themePreview}

--- a/packages/dashboard-core/src/index.ts
+++ b/packages/dashboard-core/src/index.ts
@@ -70,6 +70,7 @@ export {
 export type {
   AgentInfo,
   AgentStatusType,
+  AppMode,
   BandConfig,
   CIState,
   CIStatus,

--- a/packages/dashboard-core/src/types.ts
+++ b/packages/dashboard-core/src/types.ts
@@ -116,6 +116,8 @@ export interface LabelDefinition {
 
 export type Theme = "system" | "light" | "dark";
 
+export type AppMode = "side-panel" | "full-editor";
+
 export interface Settings {
   worktreesDir: string | null;
   defaults?: BandConfig;
@@ -129,6 +131,7 @@ export interface Settings {
   tokenSecret?: string;
   autoStartTunnel?: boolean;
   theme?: Theme;
+  appMode?: AppMode;
 }
 
 export interface HooksStatus {


### PR DESCRIPTION
## Summary

- Adds a persistent **App Mode** setting (stored in `~/.band/settings.json`) that lets users choose between **Side Panel** (compact sidebar alongside IDE) and **Full Editor** (full-width editor with file browser, changes view, chat, and terminal)
- Mode controls window sizing, layout rendering, workspace click behavior (IPC vs in-app navigation), and focus polling on the Tauri desktop app
- Switching modes from Settings resizes the main window and reloads the webview so the layout fully transitions
- Removes unused `dashboard-core` dependency from the Tauri app package
- Adds a shared `TauriTitleBar` component using the `startDragging()` JS API for reliable window dragging in external-URL webviews

## Changes

- `packages/dashboard-core/src/types.ts` — new `AppMode` type
- `packages/dashboard-core/src/components/SettingsPage.tsx` — App Mode section with radio-style cards
- `packages/dashboard-core/src/adapters/hybrid.ts` — mode-aware adapter and capabilities
- `packages/dashboard-core/src/components/DashboardShell.tsx` — `hideTitleBar` prop
- `apps/dashboard/src-tauri/src/commands/window.rs` — `set_app_mode` Tauri command (resize + reload)
- `apps/dashboard/src-tauri/src/lib.rs` — reads mode on startup for window sizing and focus polling
- `apps/dashboard/src-tauri/src/state.rs` — `app_mode` field in Rust Settings struct
- `apps/web/src/routes/__root.tsx` — `ModeSync` component and mode-aware `AppShell` layout
- `apps/web/src/components/TauriTitleBar.tsx` — shared drag-region component
- `apps/web/src/routes/settings.tsx`, `tasks.tsx`, `cronjobs.tsx`, `workspace.$workspaceId.tsx` — use `TauriTitleBar`
- `apps/web/src/routes/index.tsx`, `workspace.$workspaceId.index.tsx`, `DashboardView.tsx` — mode-aware desktop detection

## Test plan

- [ ] Open Tauri app in default Side Panel mode — verify narrow sidebar layout
- [ ] Go to Settings → App Mode → select Full Editor → Save — verify window expands to full screen and layout switches to split view with sidebar + content area
- [ ] Switch back to Side Panel → Save — verify window shrinks and layout returns to sidebar-only
- [ ] Verify workspace clicks: Side Panel mode opens external IDE, Full Editor mode navigates in-app
- [ ] Verify window dragging works in Settings, Tasks, and Cronjobs standalone windows
- [ ] Verify the title bar spans full width in Full Editor mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)