### PR TITLE
fix: transition workspace to needs_attention via CLI hooks

### DIFF
--- a/apps/cli/src/main.rs
+++ b/apps/cli/src/main.rs
@@ -1435,9 +1435,7 @@ fn cmd_notify() -> Result<CommandResult, String> {
 
     let agent_status = match hook_event {
         "Stop" | "PermissionRequest" => "needs_attention",
-        "PreToolUse"
-            if tool_name == "AskUserQuestion" || tool_name == "ExitPlanMode" =>
-        {
+        "PreToolUse" if tool_name == "AskUserQuestion" || tool_name == "ExitPlanMode" => {
             "needs_attention"
         }
         _ => "working",

--- a/apps/cli/src/main.rs
+++ b/apps/cli/src/main.rs
@@ -1428,8 +1428,19 @@ fn cmd_notify() -> Result<CommandResult, String> {
         .and_then(|v| v.as_str())
         .unwrap_or("");
 
+    let tool_name = payload
+        .get("tool_name")
+        .and_then(|v| v.as_str())
+        .unwrap_or("");
+
     let agent_status = match hook_event {
         "Stop" => "needs_attention",
+        "PermissionRequest" => "needs_attention",
+        "PreToolUse"
+            if tool_name == "AskUserQuestion" || tool_name == "ExitPlanMode" =>
+        {
+            "needs_attention"
+        }
         _ => "working",
     };
 

--- a/apps/cli/src/main.rs
+++ b/apps/cli/src/main.rs
@@ -1434,8 +1434,7 @@ fn cmd_notify() -> Result<CommandResult, String> {
         .unwrap_or("");
 
     let agent_status = match hook_event {
-        "Stop" => "needs_attention",
-        "PermissionRequest" => "needs_attention",
+        "Stop" | "PermissionRequest" => "needs_attention",
         "PreToolUse"
             if tool_name == "AskUserQuestion" || tool_name == "ExitPlanMode" =>
         {

--- a/apps/cli/tests/integration.rs
+++ b/apps/cli/tests/integration.rs
@@ -336,11 +336,14 @@ fn workspaces_create_makes_worktree_and_registers_state() {
     // Worktree directory exists on disk
     assert!(Path::new(&path).exists(), "worktree dir should exist");
 
-    // State was updated
+    // State was updated (default "main" worktree + newly created one)
     let state = env.state_json();
-    let worktrees = &state["projects"][0]["worktrees"];
-    assert_eq!(worktrees.as_array().unwrap().len(), 1);
-    assert_eq!(worktrees[0]["branch"], "feat/test");
+    let worktrees = state["projects"][0]["worktrees"].as_array().unwrap();
+    assert_eq!(worktrees.len(), 2);
+    assert!(
+        worktrees.iter().any(|w| w["branch"] == "feat/test"),
+        "expected feat/test in worktrees: {worktrees:?}"
+    );
 }
 
 #[test]
@@ -439,10 +442,11 @@ fn workspaces_remove_cleans_up_worktree_and_state() {
     let output = env.band(&["workspaces", "remove", "my-project", "feat/rm"]);
     assert!(output.status.success(), "stderr: {}", stderr(&output));
 
-    // Worktree removed from state
+    // Worktree removed from state (only the seeded "main" worktree remains)
     let state = env.state_json();
-    let worktrees = &state["projects"][0]["worktrees"];
-    assert_eq!(worktrees.as_array().unwrap().len(), 0);
+    let worktrees = state["projects"][0]["worktrees"].as_array().unwrap();
+    assert_eq!(worktrees.len(), 1);
+    assert_eq!(worktrees[0]["branch"], "main");
 
     // Worktree directory removed from disk
     assert!(!Path::new(&path).exists(), "worktree dir should be gone");
@@ -665,6 +669,166 @@ fn notify_silently_succeeds_when_server_unreachable() {
         output.status.success(),
         "notify should not fail when server is down. stderr: {}",
         stderr(&output)
+    );
+}
+
+/// Helper: run `band notify` piping `payload` to stdin, using the live server
+/// from a TestEnv.
+fn band_notify(env: &TestEnv, payload: &serde_json::Value) -> std::process::Output {
+    use std::io::Write;
+    let mut child = Command::new(env!("CARGO_BIN_EXE_band"))
+        .args(["notify"])
+        .env("BAND_HOME", &env.band_dir)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("failed to spawn band notify");
+    if let Some(ref mut stdin) = child.stdin {
+        let _ = stdin.write_all(payload.to_string().as_bytes());
+    }
+    child.wait_with_output().expect("band notify failed")
+}
+
+/// Helper: query workspace status from the SQLite database.
+fn query_agent_status(band_dir: &Path, workspace_id: &str) -> Option<String> {
+    let db_path = band_dir.join("band.db");
+    let script = format!(
+        r#"
+        const Database = (await import("{bsqlite}")).default;
+        const db = new Database("{db}");
+        const row = db.prepare(
+            "SELECT agent_status FROM workspace_statuses WHERE workspace_id = ?"
+        ).get("{ws}");
+        console.log(JSON.stringify({{ status: row ? row.agent_status : null }}));
+        db.close();
+        "#,
+        bsqlite = Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("../../apps/web/node_modules/better-sqlite3/lib/index.js")
+            .to_string_lossy()
+            .replace('\\', "/"),
+        db = db_path.to_string_lossy().replace('\\', "/"),
+        ws = workspace_id,
+    );
+    let output = Command::new("node")
+        .args(["--input-type=module", "-e", &script])
+        .output()
+        .expect("query_agent_status failed");
+    assert!(
+        output.status.success(),
+        "query_agent_status failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let json: serde_json::Value =
+        serde_json::from_str(&String::from_utf8_lossy(&output.stdout)).expect("parse json");
+    json["status"].as_str().map(String::from)
+}
+
+#[test]
+fn notify_pre_tool_use_ask_user_question_sets_needs_attention() {
+    let env = TestEnv::new();
+    let payload = serde_json::json!({
+        "hook_event_name": "PreToolUse",
+        "tool_name": "AskUserQuestion",
+        "cwd": env.repo_path.to_string_lossy()
+    });
+    let output = band_notify(&env, &payload);
+    assert!(output.status.success(), "stderr: {}", stderr(&output));
+
+    let status = query_agent_status(&env.band_dir, "my-project-main");
+    assert_eq!(
+        status.as_deref(),
+        Some("needs_attention"),
+        "PreToolUse+AskUserQuestion should set needs_attention"
+    );
+}
+
+#[test]
+fn notify_pre_tool_use_exit_plan_mode_sets_needs_attention() {
+    let env = TestEnv::new();
+    let payload = serde_json::json!({
+        "hook_event_name": "PreToolUse",
+        "tool_name": "ExitPlanMode",
+        "cwd": env.repo_path.to_string_lossy()
+    });
+    let output = band_notify(&env, &payload);
+    assert!(output.status.success(), "stderr: {}", stderr(&output));
+
+    let status = query_agent_status(&env.band_dir, "my-project-main");
+    assert_eq!(
+        status.as_deref(),
+        Some("needs_attention"),
+        "PreToolUse+ExitPlanMode should set needs_attention"
+    );
+}
+
+#[test]
+fn notify_pre_tool_use_regular_tool_stays_working() {
+    let env = TestEnv::new();
+    let payload = serde_json::json!({
+        "hook_event_name": "PreToolUse",
+        "tool_name": "Read",
+        "cwd": env.repo_path.to_string_lossy()
+    });
+    let output = band_notify(&env, &payload);
+    assert!(output.status.success(), "stderr: {}", stderr(&output));
+
+    let status = query_agent_status(&env.band_dir, "my-project-main");
+    assert_eq!(
+        status.as_deref(),
+        Some("working"),
+        "PreToolUse+Read should set working, not needs_attention"
+    );
+}
+
+#[test]
+fn notify_post_tool_use_after_ask_user_restores_working() {
+    let env = TestEnv::new();
+
+    // First, AskUserQuestion triggers needs_attention
+    let payload = serde_json::json!({
+        "hook_event_name": "PreToolUse",
+        "tool_name": "AskUserQuestion",
+        "cwd": env.repo_path.to_string_lossy()
+    });
+    let output = band_notify(&env, &payload);
+    assert!(output.status.success());
+    assert_eq!(
+        query_agent_status(&env.band_dir, "my-project-main").as_deref(),
+        Some("needs_attention")
+    );
+
+    // Then PostToolUse fires after user responds → back to working
+    let payload = serde_json::json!({
+        "hook_event_name": "PostToolUse",
+        "tool_name": "AskUserQuestion",
+        "cwd": env.repo_path.to_string_lossy()
+    });
+    let output = band_notify(&env, &payload);
+    assert!(output.status.success());
+    assert_eq!(
+        query_agent_status(&env.band_dir, "my-project-main").as_deref(),
+        Some("working"),
+        "PostToolUse should restore working status"
+    );
+}
+
+#[test]
+fn notify_permission_request_sets_needs_attention() {
+    let env = TestEnv::new();
+    let payload = serde_json::json!({
+        "hook_event_name": "PermissionRequest",
+        "tool_name": "Bash",
+        "cwd": env.repo_path.to_string_lossy()
+    });
+    let output = band_notify(&env, &payload);
+    assert!(output.status.success(), "stderr: {}", stderr(&output));
+
+    let status = query_agent_status(&env.band_dir, "my-project-main");
+    assert_eq!(
+        status.as_deref(),
+        Some("needs_attention"),
+        "PermissionRequest should set needs_attention"
     );
 }
 

--- a/apps/cli/tests/seed-db.mjs
+++ b/apps/cli/tests/seed-db.mjs
@@ -71,10 +71,14 @@ for (const file of sqlFiles) {
   }
 }
 
-// Seed the test project
+// Seed the test project and its default worktree
 db.prepare(
   "INSERT INTO projects (name, path, default_branch, sort_order) VALUES (?, ?, ?, 0)"
 ).run(projectName, projectPath, defaultBranch);
+
+db.prepare(
+  "INSERT INTO worktrees (project_name, branch, path) VALUES (?, ?, ?)"
+).run(projectName, defaultBranch, projectPath);
 
 db.close();
 

--- a/apps/dashboard/src/styles/globals.css
+++ b/apps/dashboard/src/styles/globals.css
@@ -127,6 +127,20 @@ button,
   display: block;
 }
 
+@keyframes status-pulse {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.4;
+  }
+}
+
+.animate-status-pulse {
+  animation: status-pulse 1.5s ease-in-out infinite;
+}
+
 body {
   margin: 0;
   background: var(--background);

--- a/apps/web/src/lib/hooks.ts
+++ b/apps/web/src/lib/hooks.ts
@@ -3,7 +3,13 @@ import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 import { whichBinary } from "./process-utils";
 
-const HOOK_EVENTS = ["UserPromptSubmit", "PostToolUse", "Stop"];
+const HOOK_EVENTS = [
+  "PreToolUse",
+  "PermissionRequest",
+  "UserPromptSubmit",
+  "PostToolUse",
+  "Stop",
+];
 
 function claudeSettingsPath(): string {
   return join(homedir(), ".claude", "settings.json");

--- a/apps/web/src/lib/hooks.ts
+++ b/apps/web/src/lib/hooks.ts
@@ -3,13 +3,7 @@ import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 import { whichBinary } from "./process-utils";
 
-const HOOK_EVENTS = [
-  "PreToolUse",
-  "PermissionRequest",
-  "UserPromptSubmit",
-  "PostToolUse",
-  "Stop",
-];
+const HOOK_EVENTS = ["PreToolUse", "PermissionRequest", "UserPromptSubmit", "PostToolUse", "Stop"];
 
 function claudeSettingsPath(): string {
   return join(homedir(), ".claude", "settings.json");

--- a/apps/web/src/styles/globals.css
+++ b/apps/web/src/styles/globals.css
@@ -105,6 +105,20 @@ button,
   display: block;
 }
 
+@keyframes status-pulse {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.4;
+  }
+}
+
+.animate-status-pulse {
+  animation: status-pulse 1.5s ease-in-out infinite;
+}
+
 pre {
   overflow-x: auto;
 }

--- a/packages/dashboard-core/src/components/AgentStatusIndicator.tsx
+++ b/packages/dashboard-core/src/components/AgentStatusIndicator.tsx
@@ -18,12 +18,13 @@ export function AgentStatusIndicator({ agent, isActive }: Props) {
 
   const isWorking = agent.status === "working";
   const color = isWorking ? "bg-status-working" : "bg-status-needs-attention";
-  const tooltip = isWorking ? "Agent running..." : "Agent done";
+  const tooltip = isWorking ? "Agent running..." : "Needs your attention";
+  const animation = isWorking ? "" : "animate-status-pulse";
 
   return (
     <Tooltip>
       <TooltipTrigger asChild>
-        <span className={`inline-block size-2 shrink-0 rounded-full ${color}`} />
+        <span className={`inline-block size-2 shrink-0 rounded-full ${color} ${animation}`} />
       </TooltipTrigger>
       <TooltipContent side="top">{tooltip}</TooltipContent>
     </Tooltip>

--- a/packages/dashboard-core/src/components/WorkspaceCard.tsx
+++ b/packages/dashboard-core/src/components/WorkspaceCard.tsx
@@ -85,7 +85,8 @@ export const WorkspaceCard = memo(function WorkspaceCard({
     }
   };
 
-  const className = `@container group flex flex-row items-center justify-between px-3 py-2 min-w-0 overflow-hidden cursor-pointer select-none transition-colors hover:bg-accent/50 ${isActive ? "bg-accent/50 border-l-2 border-l-primary" : ""} ${isFocused ? "ring-2 ring-inset ring-ring" : ""} ${href ? "no-underline text-inherit" : ""}`;
+  const needsAttention = status?.agent?.status === "needs_attention";
+  const className = `@container group flex flex-row items-center justify-between px-3 py-2 min-w-0 overflow-hidden cursor-pointer select-none transition-colors hover:bg-accent/50 ${isActive ? "bg-accent/50 border-l-2 border-l-primary" : needsAttention ? "bg-status-needs-attention/10 border-l-2 border-l-status-needs-attention" : ""} ${isFocused ? "ring-2 ring-inset ring-ring" : ""} ${href ? "no-underline text-inherit" : ""}`;
 
   const containerProps = {
     ref: cardRef,

--- a/packages/ui/src/globals.css
+++ b/packages/ui/src/globals.css
@@ -124,6 +124,20 @@ button,
   display: block;
 }
 
+@keyframes status-pulse {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.4;
+  }
+}
+
+.animate-status-pulse {
+  animation: status-pulse 1.5s ease-in-out infinite;
+}
+
 body {
   margin: 0;
   background: var(--background);


### PR DESCRIPTION
## Summary
- Add `PreToolUse` and `PermissionRequest` to Claude Code hook events so the CLI path correctly sets `needs_attention` status when the agent calls `AskUserQuestion`, `ExitPlanMode`, or hits a permission prompt
- Previously only the web task-runner path handled this — standalone Claude Code sessions stayed stuck on "working" when blocked waiting for user input
- Add pulse animation and workspace card highlight for `needs_attention` state in the UI

## Test plan
- [x] New integration tests: `notify_pre_tool_use_ask_user_question_sets_needs_attention`, `notify_pre_tool_use_exit_plan_mode_sets_needs_attention`, `notify_permission_request_sets_needs_attention`, `notify_pre_tool_use_regular_tool_stays_working`, `notify_post_tool_use_after_ask_user_restores_working`
- [x] All 82 Rust integration tests pass
- [x] All 303 Node.js server tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)