### PR TITLE
feat: add multi-terminal splits with persistent layout

### DIFF
--- a/apps/cli/src/main.rs
+++ b/apps/cli/src/main.rs
@@ -1434,7 +1434,7 @@ fn cmd_notify() -> Result<CommandResult, String> {
         .unwrap_or("");
 
     let agent_status = match hook_event {
-        "Stop" => "needs_attention",
+        "Stop" | "PermissionRequest" => "needs_attention",
         "PreToolUse" if tool_name == "AskUserQuestion" || tool_name == "ExitPlanMode" => {
             "needs_attention"
         }

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -32,7 +32,8 @@
   },
   "dependencies": {
     "better-sqlite3": "^12.8.0",
-    "node-pty": "^1.1.0"
+    "node-pty": "^1.1.0",
+    "react-resizable-panels": "^4.9.0"
   },
   "devDependencies": {
     "@ai-sdk/react": "^3.0.0",

--- a/apps/web/src/components/DockviewWorkspaceLayout.tsx
+++ b/apps/web/src/components/DockviewWorkspaceLayout.tsx
@@ -46,11 +46,11 @@ const PANEL_SHORTCUTS: Record<string, string> = {
 };
 
 // ---------------------------------------------------------------------------
-// Lazy-loaded terminal (avoid importing @xterm CJS during SSR)
+// Lazy-loaded split terminal container (avoid importing @xterm CJS during SSR)
 // ---------------------------------------------------------------------------
 
-const TerminalPanel = lazy(() =>
-  import("./TerminalPanel").then((m) => ({ default: m.TerminalPanel })),
+const SplitTerminalContainer = lazy(() =>
+  import("./SplitTerminalContainer").then((m) => ({ default: m.SplitTerminalContainer })),
 );
 
 // ---------------------------------------------------------------------------
@@ -143,7 +143,7 @@ function TerminalPanelComponent({ params, api }: IDockviewPanelProps<TerminalPar
 
   return (
     <Suspense fallback={null}>
-      <TerminalPanel workspaceId={params.workspaceId} visible={visible} />
+      <SplitTerminalContainer workspaceId={params.workspaceId} visible={visible} />
     </Suspense>
   );
 }

--- a/apps/web/src/components/SplitTerminalContainer.tsx
+++ b/apps/web/src/components/SplitTerminalContainer.tsx
@@ -7,8 +7,8 @@ import {
   type LeafNode,
   loadTree,
   removeLeaf,
-  saveTree,
   type SplitNode,
+  saveTree,
   splitLeaf,
   type TreeNode,
   updateNodeSizes,
@@ -101,7 +101,14 @@ interface RenderNodeProps {
   totalLeaves: number;
 }
 
-function RenderNode({ node, workspaceId, visible, onSplit, onClose, totalLeaves }: RenderNodeProps) {
+function RenderNode({
+  node,
+  workspaceId,
+  visible,
+  onSplit,
+  onClose,
+  totalLeaves,
+}: RenderNodeProps) {
   if (node.type === "leaf") {
     return (
       <LeafPane
@@ -175,7 +182,11 @@ function SplitPane({ node, workspaceId, visible, onSplit, onClose, totalLeaves }
   );
 
   return (
-    <Group orientation={orientation} defaultLayout={defaultLayout} onLayoutChanged={handleLayoutChanged}>
+    <Group
+      orientation={orientation}
+      defaultLayout={defaultLayout}
+      onLayoutChanged={handleLayoutChanged}
+    >
       <Panel id="left" minSize={10}>
         <RenderNode
           node={node.children[0]}
@@ -186,11 +197,13 @@ function SplitPane({ node, workspaceId, visible, onSplit, onClose, totalLeaves }
           totalLeaves={totalLeaves}
         />
       </Panel>
-      <Separator className={
-        orientation === "horizontal"
-          ? "w-1 bg-neutral-700/50 hover:bg-blue-500/50 transition-colors"
-          : "h-1 bg-neutral-700/50 hover:bg-blue-500/50 transition-colors"
-      } />
+      <Separator
+        className={
+          orientation === "horizontal"
+            ? "w-1 bg-neutral-700/50 hover:bg-blue-500/50 transition-colors"
+            : "h-1 bg-neutral-700/50 hover:bg-blue-500/50 transition-colors"
+        }
+      />
       <Panel id="right" minSize={10}>
         <RenderNode
           node={node.children[1]}
@@ -229,17 +242,11 @@ function LeafPane({ node, workspaceId, visible, onSplit, onClose, showClose }: L
         >
           <Columns2 className="size-3.5" />
         </ToolbarButton>
-        <ToolbarButton
-          title="Split Vertical"
-          onClick={() => onSplit(node.terminalId, "vertical")}
-        >
+        <ToolbarButton title="Split Vertical" onClick={() => onSplit(node.terminalId, "vertical")}>
           <Rows2 className="size-3.5" />
         </ToolbarButton>
         {showClose && (
-          <ToolbarButton
-            title="Close Terminal"
-            onClick={() => onClose(node.terminalId)}
-          >
+          <ToolbarButton title="Close Terminal" onClick={() => onClose(node.terminalId)}>
             <X className="size-3.5" />
           </ToolbarButton>
         )}
@@ -247,11 +254,7 @@ function LeafPane({ node, workspaceId, visible, onSplit, onClose, showClose }: L
       {/* Terminal */}
       <div className="min-h-0 flex-1">
         <Suspense fallback={null}>
-          <TerminalPanel
-            workspaceId={workspaceId}
-            terminalId={node.terminalId}
-            visible={visible}
-          />
+          <TerminalPanel workspaceId={workspaceId} terminalId={node.terminalId} visible={visible} />
         </Suspense>
       </div>
     </div>

--- a/apps/web/src/components/SplitTerminalContainer.tsx
+++ b/apps/web/src/components/SplitTerminalContainer.tsx
@@ -1,0 +1,300 @@
+import { Columns2, Rows2, X } from "lucide-react";
+import { lazy, Suspense, useCallback, useEffect, useRef, useState } from "react";
+import { Group, Panel, Separator } from "react-resizable-panels";
+import {
+  countLeaves,
+  createLeaf,
+  type LeafNode,
+  loadTree,
+  removeLeaf,
+  saveTree,
+  type SplitNode,
+  splitLeaf,
+  type TreeNode,
+  updateNodeSizes,
+} from "../lib/terminal-split-tree";
+
+// Lazy-load TerminalPanel to avoid importing @xterm CJS during SSR
+const TerminalPanel = lazy(() =>
+  import("./TerminalPanel").then((m) => ({ default: m.TerminalPanel })),
+);
+
+interface SplitTerminalContainerProps {
+  workspaceId: string;
+  visible: boolean;
+}
+
+export function SplitTerminalContainer({ workspaceId, visible }: SplitTerminalContainerProps) {
+  const [tree, setTree] = useState<TreeNode>(() => {
+    const stored = loadTree(workspaceId);
+    if (stored) return stored;
+    const fresh = createLeaf();
+    saveTree(workspaceId, fresh);
+    return fresh;
+  });
+
+  // Reload tree when workspace changes
+  useEffect(() => {
+    const stored = loadTree(workspaceId);
+    if (stored) {
+      setTree(stored);
+    } else {
+      const fresh = createLeaf();
+      saveTree(workspaceId, fresh);
+      setTree(fresh);
+    }
+  }, [workspaceId]);
+
+  const handleSplit = useCallback(
+    (terminalId: string, direction: "horizontal" | "vertical") => {
+      setTree((prev) => {
+        const next = splitLeaf(prev, terminalId, direction);
+        saveTree(workspaceId, next);
+        return next;
+      });
+    },
+    [workspaceId],
+  );
+
+  const handleClose = useCallback(
+    (terminalId: string) => {
+      // Kill the PTY on the backend via a one-shot WebSocket close message.
+      // TerminalPanel unmount does NOT kill PTYs (so they survive workspace
+      // switches). Only an explicit user close action kills them.
+      killTerminalRemotely(workspaceId, terminalId);
+
+      setTree((prev) => {
+        const next = removeLeaf(prev, terminalId) ?? createLeaf();
+        saveTree(workspaceId, next);
+        return next;
+      });
+    },
+    [workspaceId],
+  );
+
+  const totalLeaves = countLeaves(tree);
+
+  return (
+    <div className="h-full w-full">
+      <RenderNode
+        node={tree}
+        workspaceId={workspaceId}
+        visible={visible}
+        onSplit={handleSplit}
+        onClose={handleClose}
+        totalLeaves={totalLeaves}
+      />
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Recursive tree renderer
+// ---------------------------------------------------------------------------
+
+interface RenderNodeProps {
+  node: TreeNode;
+  workspaceId: string;
+  visible: boolean;
+  onSplit: (terminalId: string, direction: "horizontal" | "vertical") => void;
+  onClose: (terminalId: string) => void;
+  totalLeaves: number;
+}
+
+function RenderNode({ node, workspaceId, visible, onSplit, onClose, totalLeaves }: RenderNodeProps) {
+  if (node.type === "leaf") {
+    return (
+      <LeafPane
+        node={node}
+        workspaceId={workspaceId}
+        visible={visible}
+        onSplit={onSplit}
+        onClose={onClose}
+        showClose={totalLeaves > 1}
+      />
+    );
+  }
+
+  // SplitNode — render a Group with two children separated by a Separator
+  return (
+    <SplitPane
+      node={node}
+      workspaceId={workspaceId}
+      visible={visible}
+      onSplit={onSplit}
+      onClose={onClose}
+      totalLeaves={totalLeaves}
+    />
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Split pane: Group with two panels and persistent sizes
+// ---------------------------------------------------------------------------
+
+interface SplitPaneProps {
+  node: SplitNode;
+  workspaceId: string;
+  visible: boolean;
+  onSplit: (terminalId: string, direction: "horizontal" | "vertical") => void;
+  onClose: (terminalId: string) => void;
+  totalLeaves: number;
+}
+
+function SplitPane({ node, workspaceId, visible, onSplit, onClose, totalLeaves }: SplitPaneProps) {
+  const orientation = node.direction === "horizontal" ? "horizontal" : "vertical";
+
+  const defaultLayout = node.sizes
+    ? { left: node.sizes[0], right: node.sizes[1] }
+    : { left: 50, right: 50 };
+
+  // Skip the first onLayoutChanged callback — react-resizable-panels fires it
+  // on initial mount with a computed layout that may differ from defaultLayout
+  // (e.g. before the container has its final CSS dimensions). Saving those
+  // values would overwrite the correct stored sizes.
+  const skipNextCallback = useRef(true);
+
+  // Persist sizes directly to localStorage on resize — no React state update.
+  // This avoids re-renders that fight with the Group's internal layout state.
+  const handleLayoutChanged = useCallback(
+    (layout: Record<string, number>) => {
+      if (skipNextCallback.current) {
+        skipNextCallback.current = false;
+        return;
+      }
+      const left = layout.left;
+      const right = layout.right;
+      if (left != null && right != null) {
+        const stored = loadTree(workspaceId);
+        if (stored) {
+          saveTree(workspaceId, updateNodeSizes(stored, node.nodeId, [left, right]));
+        }
+      }
+    },
+    [node.nodeId, workspaceId],
+  );
+
+  return (
+    <Group orientation={orientation} defaultLayout={defaultLayout} onLayoutChanged={handleLayoutChanged}>
+      <Panel id="left" minSize={10}>
+        <RenderNode
+          node={node.children[0]}
+          workspaceId={workspaceId}
+          visible={visible}
+          onSplit={onSplit}
+          onClose={onClose}
+          totalLeaves={totalLeaves}
+        />
+      </Panel>
+      <Separator className={
+        orientation === "horizontal"
+          ? "w-1 bg-neutral-700/50 hover:bg-blue-500/50 transition-colors"
+          : "h-1 bg-neutral-700/50 hover:bg-blue-500/50 transition-colors"
+      } />
+      <Panel id="right" minSize={10}>
+        <RenderNode
+          node={node.children[1]}
+          workspaceId={workspaceId}
+          visible={visible}
+          onSplit={onSplit}
+          onClose={onClose}
+          totalLeaves={totalLeaves}
+        />
+      </Panel>
+    </Group>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Leaf pane: toolbar + terminal
+// ---------------------------------------------------------------------------
+
+interface LeafPaneProps {
+  node: LeafNode;
+  workspaceId: string;
+  visible: boolean;
+  onSplit: (terminalId: string, direction: "horizontal" | "vertical") => void;
+  onClose: (terminalId: string) => void;
+  showClose: boolean;
+}
+
+function LeafPane({ node, workspaceId, visible, onSplit, onClose, showClose }: LeafPaneProps) {
+  return (
+    <div className="flex h-full w-full flex-col">
+      {/* Compact toolbar */}
+      <div className="flex h-7 shrink-0 items-center justify-end gap-0.5 border-b border-neutral-700/50 px-1">
+        <ToolbarButton
+          title="Split Horizontal"
+          onClick={() => onSplit(node.terminalId, "horizontal")}
+        >
+          <Columns2 className="size-3.5" />
+        </ToolbarButton>
+        <ToolbarButton
+          title="Split Vertical"
+          onClick={() => onSplit(node.terminalId, "vertical")}
+        >
+          <Rows2 className="size-3.5" />
+        </ToolbarButton>
+        {showClose && (
+          <ToolbarButton
+            title="Close Terminal"
+            onClick={() => onClose(node.terminalId)}
+          >
+            <X className="size-3.5" />
+          </ToolbarButton>
+        )}
+      </div>
+      {/* Terminal */}
+      <div className="min-h-0 flex-1">
+        <Suspense fallback={null}>
+          <TerminalPanel
+            workspaceId={workspaceId}
+            terminalId={node.terminalId}
+            visible={visible}
+          />
+        </Suspense>
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Toolbar button
+// ---------------------------------------------------------------------------
+
+function ToolbarButton({
+  title,
+  onClick,
+  children,
+}: {
+  title: string;
+  onClick: () => void;
+  children: React.ReactNode;
+}) {
+  return (
+    <button
+      type="button"
+      title={title}
+      onClick={onClick}
+      className="flex items-center justify-center rounded p-1 text-neutral-400 hover:bg-neutral-700/50 hover:text-neutral-200 transition-colors"
+    >
+      {children}
+    </button>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Helper: kill a PTY on the backend via a one-shot WebSocket
+// ---------------------------------------------------------------------------
+
+function killTerminalRemotely(workspaceId: string, terminalId: string): void {
+  const proto = location.protocol === "https:" ? "wss:" : "ws:";
+  const ws = new WebSocket(
+    `${proto}//${location.host}/terminal?workspaceId=${encodeURIComponent(workspaceId)}&terminalId=${encodeURIComponent(terminalId)}`,
+  );
+  ws.onopen = () => {
+    ws.send(JSON.stringify({ type: "close" }));
+    ws.close();
+  };
+  ws.onerror = () => ws.close();
+}

--- a/apps/web/src/components/TerminalPanel.tsx
+++ b/apps/web/src/components/TerminalPanel.tsx
@@ -5,10 +5,11 @@ import { isTauri } from "../lib/is-tauri";
 
 interface TerminalPanelProps {
   workspaceId: string;
+  terminalId: string;
   visible: boolean;
 }
 
-export function TerminalPanel({ workspaceId, visible }: TerminalPanelProps) {
+export function TerminalPanel({ workspaceId, terminalId, visible }: TerminalPanelProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const terminalRef = useRef<Terminal | null>(null);
   const fitAddonRef = useRef<FitAddon | null>(null);
@@ -82,7 +83,7 @@ export function TerminalPanel({ workspaceId, visible }: TerminalPanelProps) {
       // Connect WebSocket
       const proto = location.protocol === "https:" ? "wss:" : "ws:";
       const ws = new WebSocket(
-        `${proto}//${location.host}/terminal?workspaceId=${encodeURIComponent(workspaceId)}`,
+        `${proto}//${location.host}/terminal?workspaceId=${encodeURIComponent(workspaceId)}&terminalId=${encodeURIComponent(terminalId)}`,
       );
       wsRef.current = ws;
 
@@ -142,7 +143,7 @@ export function TerminalPanel({ workspaceId, visible }: TerminalPanelProps) {
       cancelled = true;
       cleanup?.();
     };
-  }, [workspaceId]);
+  }, [terminalId, workspaceId]);
 
   // Refit when visibility changes and notify server of new size
   useEffect(() => {
@@ -160,7 +161,7 @@ export function TerminalPanel({ workspaceId, visible }: TerminalPanelProps) {
 
   return (
     <div className="relative h-full w-full">
-      <div ref={containerRef} className="absolute inset-3 overflow-hidden" />
+      <div ref={containerRef} className="absolute inset-1 overflow-hidden" />
     </div>
   );
 }

--- a/apps/web/src/lib/terminal-manager.ts
+++ b/apps/web/src/lib/terminal-manager.ts
@@ -11,19 +11,20 @@ const MAX_SCROLLBACK_SIZE = 100_000;
 interface TerminalSession {
   pty: IPty;
   scrollback: string;
+  workspaceId: string;
 }
 
+/** terminalId -> session */
 const terminals = new Map<string, TerminalSession>();
 
-/**
- * Returns an existing terminal session for the workspace, or spawns a new one.
- */
-export async function getOrSpawnTerminal(workspaceId: string): Promise<TerminalSession> {
-  const existing = terminals.get(workspaceId);
-  if (existing) {
-    return existing;
-  }
+/** workspaceId -> Set<terminalId> (reverse index for workspace-level cleanup) */
+const workspaceTerminals = new Map<string, Set<string>>();
 
+/**
+ * Spawns a new terminal session for the given workspace and terminalId.
+ * Always creates a new PTY (each split pane gets its own shell).
+ */
+export async function spawnTerminal(workspaceId: string, terminalId: string): Promise<TerminalSession> {
   const workspace = resolveWorkspace(workspaceId);
   if (!workspace) {
     throw new Error(`Workspace not found: ${workspaceId}`);
@@ -52,7 +53,7 @@ export async function getOrSpawnTerminal(workspaceId: string): Promise<TerminalS
     throw new Error(`Shell not found: ${shell}`);
   }
 
-  log.debug("Spawning shell %s in %s (PATH=%s)", shell, cwd, resolvedPath.slice(0, 200));
+  log.debug("Spawning shell %s in %s for terminal %s (PATH=%s)", shell, cwd, terminalId, resolvedPath.slice(0, 200));
 
   const nodePty = (await import("node-pty")).default;
   let ptyProcess: IPty;
@@ -70,8 +71,16 @@ export async function getOrSpawnTerminal(workspaceId: string): Promise<TerminalS
     throw err;
   }
 
-  const session: TerminalSession = { pty: ptyProcess, scrollback: "" };
-  terminals.set(workspaceId, session);
+  const session: TerminalSession = { pty: ptyProcess, scrollback: "", workspaceId };
+  terminals.set(terminalId, session);
+
+  // Register in reverse index
+  let ids = workspaceTerminals.get(workspaceId);
+  if (!ids) {
+    ids = new Set();
+    workspaceTerminals.set(workspaceId, ids);
+  }
+  ids.add(terminalId);
 
   // Buffer all PTY output for replay on reconnect
   ptyProcess.onData((data: string) => {
@@ -82,30 +91,66 @@ export async function getOrSpawnTerminal(workspaceId: string): Promise<TerminalS
   });
 
   ptyProcess.onExit(() => {
-    log.debug("Terminal exited for workspace %s", workspaceId);
-    terminals.delete(workspaceId);
+    log.debug("Terminal exited: %s (workspace %s)", terminalId, workspaceId);
+    terminals.delete(terminalId);
+    const set = workspaceTerminals.get(workspaceId);
+    if (set) {
+      set.delete(terminalId);
+      if (set.size === 0) {
+        workspaceTerminals.delete(workspaceId);
+      }
+    }
   });
 
   return session;
 }
 
-export function getTerminal(workspaceId: string): TerminalSession | undefined {
-  return terminals.get(workspaceId);
+/**
+ * Returns an existing terminal session by terminalId, or undefined.
+ */
+export function getTerminalSession(terminalId: string): TerminalSession | undefined {
+  return terminals.get(terminalId);
 }
 
-export function resizeTerminal(workspaceId: string, cols: number, rows: number): void {
-  const session = terminals.get(workspaceId);
+export function resizeTerminal(terminalId: string, cols: number, rows: number): void {
+  const session = terminals.get(terminalId);
   if (session) {
     session.pty.resize(cols, rows);
   }
 }
 
-export function killTerminal(workspaceId: string): void {
-  const session = terminals.get(workspaceId);
+/**
+ * Kill a single terminal by terminalId.
+ */
+export function killTerminal(terminalId: string): void {
+  const session = terminals.get(terminalId);
   if (session) {
     session.pty.kill();
-    terminals.delete(workspaceId);
+    terminals.delete(terminalId);
+    const set = workspaceTerminals.get(session.workspaceId);
+    if (set) {
+      set.delete(terminalId);
+      if (set.size === 0) {
+        workspaceTerminals.delete(session.workspaceId);
+      }
+    }
   }
+}
+
+/**
+ * Kill all terminals for a workspace.
+ */
+export function killWorkspaceTerminals(workspaceId: string): void {
+  const ids = workspaceTerminals.get(workspaceId);
+  if (!ids) return;
+  for (const terminalId of ids) {
+    const session = terminals.get(terminalId);
+    if (session) {
+      session.pty.kill();
+      terminals.delete(terminalId);
+    }
+  }
+  workspaceTerminals.delete(workspaceId);
 }
 
 export function killAllTerminals(): void {
@@ -113,4 +158,5 @@ export function killAllTerminals(): void {
     session.pty.kill();
   }
   terminals.clear();
+  workspaceTerminals.clear();
 }

--- a/apps/web/src/lib/terminal-manager.ts
+++ b/apps/web/src/lib/terminal-manager.ts
@@ -24,7 +24,10 @@ const workspaceTerminals = new Map<string, Set<string>>();
  * Spawns a new terminal session for the given workspace and terminalId.
  * Always creates a new PTY (each split pane gets its own shell).
  */
-export async function spawnTerminal(workspaceId: string, terminalId: string): Promise<TerminalSession> {
+export async function spawnTerminal(
+  workspaceId: string,
+  terminalId: string,
+): Promise<TerminalSession> {
   const workspace = resolveWorkspace(workspaceId);
   if (!workspace) {
     throw new Error(`Workspace not found: ${workspaceId}`);
@@ -53,7 +56,13 @@ export async function spawnTerminal(workspaceId: string, terminalId: string): Pr
     throw new Error(`Shell not found: ${shell}`);
   }
 
-  log.debug("Spawning shell %s in %s for terminal %s (PATH=%s)", shell, cwd, terminalId, resolvedPath.slice(0, 200));
+  log.debug(
+    "Spawning shell %s in %s for terminal %s (PATH=%s)",
+    shell,
+    cwd,
+    terminalId,
+    resolvedPath.slice(0, 200),
+  );
 
   const nodePty = (await import("node-pty")).default;
   let ptyProcess: IPty;

--- a/apps/web/src/lib/terminal-split-tree.ts
+++ b/apps/web/src/lib/terminal-split-tree.ts
@@ -1,0 +1,156 @@
+// Pure functions + types for the binary split tree used by terminal splits.
+
+export type SplitDirection = "horizontal" | "vertical";
+
+export interface SplitNode {
+  type: "split";
+  nodeId: string;
+  direction: SplitDirection;
+  children: [TreeNode, TreeNode];
+  sizes?: [number, number]; // percentage of each child, e.g. [50, 50]
+}
+
+export interface LeafNode {
+  type: "leaf";
+  terminalId: string;
+}
+
+export type TreeNode = SplitNode | LeafNode;
+
+/**
+ * Create a new leaf node with a random terminalId.
+ */
+export function createLeaf(): LeafNode {
+  return { type: "leaf", terminalId: crypto.randomUUID() };
+}
+
+/**
+ * Replace the leaf identified by `targetId` with a split containing
+ * the original leaf and a new leaf in the given direction.
+ * Returns a new tree (immutable).
+ */
+export function splitLeaf(tree: TreeNode, targetId: string, direction: SplitDirection): TreeNode {
+  if (tree.type === "leaf") {
+    if (tree.terminalId === targetId) {
+      return {
+        type: "split",
+        nodeId: crypto.randomUUID(),
+        direction,
+        children: [tree, createLeaf()],
+        sizes: [50, 50],
+      };
+    }
+    return tree;
+  }
+
+  // SplitNode — recurse into children
+  const [left, right] = tree.children;
+  const newLeft = splitLeaf(left, targetId, direction);
+  const newRight = splitLeaf(right, targetId, direction);
+
+  if (newLeft === left && newRight === right) {
+    return tree; // nothing changed
+  }
+
+  return { ...tree, children: [newLeft, newRight] };
+}
+
+/**
+ * Remove the leaf identified by `targetId`.
+ * The sibling is promoted to replace the parent split.
+ * Returns `null` if the last leaf is removed (tree is now empty).
+ */
+export function removeLeaf(tree: TreeNode, targetId: string): TreeNode | null {
+  if (tree.type === "leaf") {
+    return tree.terminalId === targetId ? null : tree;
+  }
+
+  const [left, right] = tree.children;
+
+  // Check if target is a direct child
+  if (left.type === "leaf" && left.terminalId === targetId) {
+    return right; // promote sibling
+  }
+  if (right.type === "leaf" && right.terminalId === targetId) {
+    return left; // promote sibling
+  }
+
+  // Recurse into children
+  const newLeft = removeLeaf(left, targetId);
+  const newRight = removeLeaf(right, targetId);
+
+  if (newLeft === null) return newRight;
+  if (newRight === null) return newLeft;
+
+  if (newLeft === left && newRight === right) {
+    return tree; // nothing changed
+  }
+
+  return { ...tree, children: [newLeft, newRight] };
+}
+
+/**
+ * Collect all terminal IDs from the tree (all leaf nodes).
+ */
+export function getAllTerminalIds(tree: TreeNode): string[] {
+  if (tree.type === "leaf") {
+    return [tree.terminalId];
+  }
+  return [...getAllTerminalIds(tree.children[0]), ...getAllTerminalIds(tree.children[1])];
+}
+
+/**
+ * Count the total number of leaves in the tree.
+ */
+export function countLeaves(tree: TreeNode): number {
+  if (tree.type === "leaf") return 1;
+  return countLeaves(tree.children[0]) + countLeaves(tree.children[1]);
+}
+
+/**
+ * Update the sizes of a specific split node identified by nodeId.
+ * Returns a new tree (immutable).
+ */
+export function updateNodeSizes(tree: TreeNode, nodeId: string, sizes: [number, number]): TreeNode {
+  if (tree.type === "leaf") return tree;
+
+  if (tree.nodeId === nodeId) {
+    return { ...tree, sizes };
+  }
+
+  const [left, right] = tree.children;
+  const newLeft = updateNodeSizes(left, nodeId, sizes);
+  const newRight = updateNodeSizes(right, nodeId, sizes);
+
+  if (newLeft === left && newRight === right) {
+    return tree; // nothing changed
+  }
+
+  return { ...tree, children: [newLeft, newRight] };
+}
+
+const STORAGE_PREFIX = "band:terminal-splits:";
+
+/**
+ * Persist the split tree for a workspace to localStorage.
+ */
+export function saveTree(workspaceId: string, tree: TreeNode): void {
+  try {
+    localStorage.setItem(`${STORAGE_PREFIX}${workspaceId}`, JSON.stringify(tree));
+  } catch {
+    // localStorage may be full or unavailable
+  }
+}
+
+/**
+ * Load the persisted split tree for a workspace from localStorage.
+ * Returns `null` if nothing is stored or the data is corrupt.
+ */
+export function loadTree(workspaceId: string): TreeNode | null {
+  try {
+    const raw = localStorage.getItem(`${STORAGE_PREFIX}${workspaceId}`);
+    return raw ? (JSON.parse(raw) as TreeNode) : null;
+  } catch {
+    return null;
+  }
+}

--- a/apps/web/src/lib/terminal-ws.ts
+++ b/apps/web/src/lib/terminal-ws.ts
@@ -1,7 +1,12 @@
 import type { IncomingMessage } from "node:http";
 import { createLogger } from "@band-app/logger";
 import type { WebSocket } from "ws";
-import { getTerminalSession, killTerminal, resizeTerminal, spawnTerminal } from "./terminal-manager";
+import {
+  getTerminalSession,
+  killTerminal,
+  resizeTerminal,
+  spawnTerminal,
+} from "./terminal-manager";
 
 const log = createLogger("terminal-ws");
 
@@ -22,7 +27,12 @@ export async function handleTerminalConnection(ws: WebSocket, req: IncomingMessa
       session = await spawnTerminal(workspaceId, terminalId);
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
-      log.error("Failed to spawn terminal %s for workspace %s: %s", terminalId, workspaceId, message);
+      log.error(
+        "Failed to spawn terminal %s for workspace %s: %s",
+        terminalId,
+        workspaceId,
+        message,
+      );
       ws.close(4001, message);
       return;
     }
@@ -96,6 +106,6 @@ export async function handleTerminalConnection(ws: WebSocket, req: IncomingMessa
  *  \x1b[=c   — Tertiary Device Attributes (DA3)
  */
 function stripTerminalQueries(data: string): string {
-  // eslint-disable-next-line no-control-regex
+  // biome-ignore lint/suspicious/noControlCharactersInRegex: intentional — matching real ESC sequences in terminal output
   return data.replace(/\x1b\[\??[0-9]*[nc]|\x1b\[>[0-9]*c|\x1b\[=[0-9]*c/g, "");
 }

--- a/apps/web/src/lib/terminal-ws.ts
+++ b/apps/web/src/lib/terminal-ws.ts
@@ -1,34 +1,40 @@
 import type { IncomingMessage } from "node:http";
 import { createLogger } from "@band-app/logger";
 import type { WebSocket } from "ws";
-import { getOrSpawnTerminal, resizeTerminal } from "./terminal-manager";
+import { getTerminalSession, killTerminal, resizeTerminal, spawnTerminal } from "./terminal-manager";
 
 const log = createLogger("terminal-ws");
 
 export async function handleTerminalConnection(ws: WebSocket, req: IncomingMessage): Promise<void> {
   const url = new URL(req.url!, `http://${req.headers.host}`);
   const workspaceId = url.searchParams.get("workspaceId");
+  const terminalId = url.searchParams.get("terminalId");
 
-  if (!workspaceId) {
-    ws.close(4000, "Missing workspaceId");
+  if (!workspaceId || !terminalId) {
+    ws.close(4000, "Missing workspaceId or terminalId");
     return;
   }
 
-  let session: Awaited<ReturnType<typeof getOrSpawnTerminal>>;
-  try {
-    session = await getOrSpawnTerminal(workspaceId);
-  } catch (err) {
-    const message = err instanceof Error ? err.message : String(err);
-    log.error("Failed to spawn terminal for workspace %s: %s", workspaceId, message);
-    ws.close(4001, message);
-    return;
+  // Try reconnection first, otherwise spawn a new terminal
+  let session = getTerminalSession(terminalId);
+  if (!session) {
+    try {
+      session = await spawnTerminal(workspaceId, terminalId);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      log.error("Failed to spawn terminal %s for workspace %s: %s", terminalId, workspaceId, message);
+      ws.close(4001, message);
+      return;
+    }
   }
 
-  log.debug("Terminal connected for workspace %s", workspaceId);
+  log.debug("Terminal connected: %s (workspace %s)", terminalId, workspaceId);
 
-  // Replay buffered scrollback so the client sees previous output
+  // Replay buffered scrollback so the client sees previous output.
+  // Strip terminal query sequences (e.g. cursor position request \x1b[6n)
+  // that would cause xterm.js to send spurious responses back to the PTY.
   if (session.scrollback.length > 0) {
-    ws.send(session.scrollback);
+    ws.send(stripTerminalQueries(session.scrollback));
   }
 
   // PTY output -> WebSocket
@@ -40,7 +46,7 @@ export async function handleTerminalConnection(ws: WebSocket, req: IncomingMessa
 
   // PTY exit -> close WebSocket
   const exitDisposable = session.pty.onExit(({ exitCode }) => {
-    log.debug("PTY exited with code %d for workspace %s", exitCode, workspaceId);
+    log.debug("PTY exited with code %d for terminal %s", exitCode, terminalId);
     if (ws.readyState === ws.OPEN) {
       ws.close(1000, "Terminal exited");
     }
@@ -49,12 +55,17 @@ export async function handleTerminalConnection(ws: WebSocket, req: IncomingMessa
   // WebSocket input -> PTY
   ws.on("message", (data: Buffer | string) => {
     const message = data.toString();
-    // Check for resize command
-    if (message.startsWith('{"type":"resize"')) {
+    // Check for JSON commands
+    if (message.startsWith("{")) {
       try {
         const parsed = JSON.parse(message);
         if (parsed.type === "resize" && parsed.cols && parsed.rows) {
-          resizeTerminal(workspaceId, parsed.cols, parsed.rows);
+          resizeTerminal(terminalId, parsed.cols, parsed.rows);
+          return;
+        }
+        if (parsed.type === "close") {
+          killTerminal(terminalId);
+          ws.close(1000, "Terminal closed by client");
           return;
         }
       } catch {
@@ -68,6 +79,23 @@ export async function handleTerminalConnection(ws: WebSocket, req: IncomingMessa
   ws.on("close", () => {
     dataDisposable.dispose();
     exitDisposable.dispose();
-    log.debug("Terminal disconnected for workspace %s (PTY kept alive)", workspaceId);
+    log.debug("Terminal disconnected: %s (PTY kept alive)", terminalId);
   });
+}
+
+/**
+ * Strip terminal query/request escape sequences from scrollback so
+ * replaying them doesn't cause xterm.js to emit spurious responses.
+ *
+ * Covers:
+ *  \x1b[6n   — Cursor Position Report (DSR CPR)
+ *  \x1b[?6n  — Extended CPR
+ *  \x1b[5n   — Device Status Report
+ *  \x1b[c    — Primary Device Attributes (DA1)
+ *  \x1b[>c   — Secondary Device Attributes (DA2)
+ *  \x1b[=c   — Tertiary Device Attributes (DA3)
+ */
+function stripTerminalQueries(data: string): string {
+  // eslint-disable-next-line no-control-regex
+  return data.replace(/\x1b\[\??[0-9]*[nc]|\x1b\[>[0-9]*c|\x1b\[=[0-9]*c/g, "");
 }

--- a/apps/web/src/routes/workspace.$workspaceId.terminal.tsx
+++ b/apps/web/src/routes/workspace.$workspaceId.terminal.tsx
@@ -2,9 +2,9 @@ import { createFileRoute } from "@tanstack/react-router";
 import { lazy, Suspense } from "react";
 
 // Lazy-load to avoid importing @xterm/xterm (CJS) in SSR context
-const TerminalPanel = lazy(() =>
-  import("../components/TerminalPanel").then((m) => ({
-    default: m.TerminalPanel,
+const SplitTerminalContainer = lazy(() =>
+  import("../components/SplitTerminalContainer").then((m) => ({
+    default: m.SplitTerminalContainer,
   })),
 );
 
@@ -16,7 +16,7 @@ function WorkspaceTerminal() {
   const { workspaceId } = Route.useParams();
   return (
     <Suspense fallback={null}>
-      <TerminalPanel workspaceId={decodeURIComponent(workspaceId)} visible={true} />
+      <SplitTerminalContainer workspaceId={decodeURIComponent(workspaceId)} visible={true} />
     </Suspense>
   );
 }

--- a/apps/web/src/trpc/router.ts
+++ b/apps/web/src/trpc/router.ts
@@ -68,7 +68,7 @@ import {
   TaskConflictError,
 } from "../lib/task-runner";
 import { listTasks, loadTask } from "../lib/task-store";
-import { killTerminal } from "../lib/terminal-manager";
+import { killWorkspaceTerminals } from "../lib/terminal-manager";
 import { getTunnelStatus, startTunnel, stopTunnel } from "../lib/tunnel";
 import { emit, subscribe as subscribeStatus } from "../lib/watcher";
 import { resolveWorkspace } from "../lib/workspace";
@@ -414,8 +414,8 @@ const workspacesRouter = t.router({
             // Clean up cached agent from pool
             removeAgent(workspaceId);
 
-            // Kill any running terminal PTY session
-            killTerminal(workspaceId);
+            // Kill any running terminal PTY sessions
+            killWorkspaceTerminals(workspaceId);
 
             // Clean up workspace-scoped cronjobs
             stopJobsForKey(workspaceId);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -84,6 +84,9 @@ importers:
       node-pty:
         specifier: ^1.1.0
         version: 1.1.0
+      react-resizable-panels:
+        specifier: ^4.9.0
+        version: 4.9.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
     devDependencies:
       '@ai-sdk/react':
         specifier: ^3.0.0
@@ -5483,6 +5486,12 @@ packages:
     peerDependenciesMeta:
       '@types/react':
         optional: true
+
+  react-resizable-panels@4.9.0:
+    resolution: {integrity: sha512-sEl+hA6y9/kxa0aPlrUC+G1lcShAf/PiIjoeC8kWXxa53RfAVplVCIxEl01Nwa4L2iRa5JXBXq1/mI8ch6qOZQ==}
+    peerDependencies:
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
 
   react-style-singleton@2.2.3:
     resolution: {integrity: sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==}
@@ -11993,6 +12002,11 @@ snapshots:
       use-sidecar: 1.1.3(@types/react@19.2.14)(react@19.2.4)
     optionalDependencies:
       '@types/react': 19.2.14
+
+  react-resizable-panels@4.9.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+    dependencies:
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
 
   react-style-singleton@2.2.3(@types/react@19.2.14)(react@19.2.4):
     dependencies:


### PR DESCRIPTION
## Summary
- Add VS Code-style terminal splits using a binary tree data structure and `react-resizable-panels`
- Re-key terminal manager from workspaceId to terminalId, enabling multiple independent PTYs per workspace
- Persist split layout and panel sizes per workspace in localStorage
- Strip terminal query sequences from scrollback replay to prevent xterm.js cursor position noise

## Test plan
- [ ] Open a workspace, split the terminal horizontally and vertically
- [ ] Resize split panes, reload the page — sizes should persist
- [ ] Switch between workspaces — each should have its own independent terminal layout
- [ ] Close a split pane — PTY should be killed and sibling promoted
- [ ] Verify scrollback is replayed without `[2;1R` noise on workspace switch

🤖 Generated with [Claude Code](https://claude.com/claude-code)