### PR TITLE
fix: add Cmd+, settings shortcut and cross-window theme sync

### DIFF
--- a/apps/dashboard/src-tauri/src/commands/window.rs
+++ b/apps/dashboard/src-tauri/src/commands/window.rs
@@ -8,7 +8,9 @@ fn secondary_window_url(app: &AppHandle, path: &str) -> Result<url::Url, String>
     let main = app
         .get_webview_window("main")
         .ok_or("Main window not found")?;
-    let mut url = main.url().map_err(|e| format!("Failed to get main window URL: {e}"))?;
+    let mut url = main
+        .url()
+        .map_err(|e| format!("Failed to get main window URL: {e}"))?;
     url.set_path(path);
     Ok(url)
 }
@@ -40,14 +42,10 @@ fn build_secondary_window(
 
     let url = secondary_window_url(app, path)?;
 
-    let builder = WebviewWindowBuilder::new(
-        app,
-        label,
-        WebviewUrl::External(url),
-    )
-    .title(title)
-    .inner_size(900.0, 700.0)
-    .center();
+    let builder = WebviewWindowBuilder::new(app, label, WebviewUrl::External(url))
+        .title(title)
+        .inner_size(900.0, 700.0)
+        .center();
 
     #[cfg(target_os = "macos")]
     let builder = builder

--- a/apps/dashboard/src-tauri/src/commands/window.rs
+++ b/apps/dashboard/src-tauri/src/commands/window.rs
@@ -1,36 +1,51 @@
 use tauri::{AppHandle, Manager, WebviewUrl, WebviewWindowBuilder};
 
-use crate::commands::webserver;
-use crate::state::load_settings;
+/// Derives a URL for a secondary window by taking the main window's origin
+/// (scheme + host + port + query params like ?token=…) and replacing the path.
+/// This ensures secondary windows always hit the same server as the main window,
+/// even when Vite auto-picks a non-default port in dev mode.
+fn secondary_window_url(app: &AppHandle, path: &str) -> Result<url::Url, String> {
+    let main = app
+        .get_webview_window("main")
+        .ok_or("Main window not found")?;
+    let mut url = main.url().map_err(|e| format!("Failed to get main window URL: {e}"))?;
+    url.set_path(path);
+    Ok(url)
+}
 
-const DEV_PORT: u16 = 3456;
+/// Apply dark background color on macOS (same as main window).
+#[cfg(target_os = "macos")]
+#[allow(deprecated)]
+fn set_dark_background(window: &tauri::WebviewWindow) {
+    use cocoa::appkit::NSColor;
+    use cocoa::appkit::NSWindow;
+    use cocoa::base::{id, nil};
+    let ns_window = window.ns_window().unwrap() as id;
+    unsafe {
+        let color = NSColor::colorWithSRGBRed_green_blue_alpha_(nil, 0.0, 0.0, 0.0, 1.0);
+        ns_window.setBackgroundColor_(color);
+    }
+}
 
-#[tauri::command]
-pub async fn open_tasks_window(app: AppHandle) -> Result<(), String> {
-    // If the tasks window already exists, just focus it
-    if let Some(existing) = app.get_webview_window("tasks") {
+fn build_secondary_window(
+    app: &AppHandle,
+    label: &str,
+    title: &str,
+    path: &str,
+) -> Result<(), String> {
+    if let Some(existing) = app.get_webview_window(label) {
         let _ = existing.set_focus();
         return Ok(());
     }
 
-    // Build the URL
-    let url = if cfg!(debug_assertions) {
-        format!("http://localhost:{DEV_PORT}/tasks")
-    } else {
-        let port = webserver::get_configured_port();
-        let settings = load_settings()?;
-        let token = settings.token_secret.ok_or_else(|| {
-            "tokenSecret not found in settings.json — start the web server first".to_string()
-        })?;
-        format!("http://localhost:{port}/tasks?token={token}")
-    };
+    let url = secondary_window_url(app, path)?;
 
     let builder = WebviewWindowBuilder::new(
-        &app,
-        "tasks",
-        WebviewUrl::External(url.parse().map_err(|e| format!("Invalid URL: {e}"))?),
+        app,
+        label,
+        WebviewUrl::External(url),
     )
-    .title("Tasks - Band")
+    .title(title)
     .inner_size(900.0, 700.0)
     .center();
 
@@ -42,129 +57,27 @@ pub async fn open_tasks_window(app: AppHandle) -> Result<(), String> {
     #[allow(unused_variables)]
     let window = builder
         .build()
-        .map_err(|e| format!("Failed to create tasks window: {e}"))?;
+        .map_err(|e| format!("Failed to create {label} window: {e}"))?;
 
-    // Set dark background color on macOS (same as main window)
     #[cfg(target_os = "macos")]
-    #[allow(deprecated)]
-    {
-        use cocoa::appkit::NSColor;
-        use cocoa::appkit::NSWindow;
-        use cocoa::base::{id, nil};
-        let ns_window = window.ns_window().unwrap() as id;
-        unsafe {
-            let color = NSColor::colorWithSRGBRed_green_blue_alpha_(nil, 0.0, 0.0, 0.0, 1.0);
-            ns_window.setBackgroundColor_(color);
-        }
-    }
+    set_dark_background(&window);
 
     Ok(())
+}
+
+#[tauri::command]
+pub async fn open_tasks_window(app: AppHandle) -> Result<(), String> {
+    build_secondary_window(&app, "tasks", "Tasks - Band", "/tasks")
 }
 
 #[tauri::command]
 pub async fn open_cronjobs_window(app: AppHandle) -> Result<(), String> {
-    if let Some(existing) = app.get_webview_window("cronjobs") {
-        let _ = existing.set_focus();
-        return Ok(());
-    }
-
-    let url = if cfg!(debug_assertions) {
-        format!("http://localhost:{DEV_PORT}/cronjobs")
-    } else {
-        let port = webserver::get_configured_port();
-        let settings = load_settings()?;
-        let token = settings.token_secret.ok_or_else(|| {
-            "tokenSecret not found in settings.json — start the web server first".to_string()
-        })?;
-        format!("http://localhost:{port}/cronjobs?token={token}")
-    };
-
-    let builder = WebviewWindowBuilder::new(
-        &app,
-        "cronjobs",
-        WebviewUrl::External(url.parse().map_err(|e| format!("Invalid URL: {e}"))?),
-    )
-    .title("Cronjobs - Band")
-    .inner_size(900.0, 700.0)
-    .center();
-
-    #[cfg(target_os = "macos")]
-    let builder = builder
-        .title_bar_style(tauri::TitleBarStyle::Overlay)
-        .hidden_title(true);
-
-    #[allow(unused_variables)]
-    let window = builder
-        .build()
-        .map_err(|e| format!("Failed to create cronjobs window: {e}"))?;
-
-    #[cfg(target_os = "macos")]
-    #[allow(deprecated)]
-    {
-        use cocoa::appkit::NSColor;
-        use cocoa::appkit::NSWindow;
-        use cocoa::base::{id, nil};
-        let ns_window = window.ns_window().unwrap() as id;
-        unsafe {
-            let color = NSColor::colorWithSRGBRed_green_blue_alpha_(nil, 0.0, 0.0, 0.0, 1.0);
-            ns_window.setBackgroundColor_(color);
-        }
-    }
-
-    Ok(())
+    build_secondary_window(&app, "cronjobs", "Cronjobs - Band", "/cronjobs")
 }
 
 #[tauri::command]
 pub async fn open_settings_window(app: AppHandle) -> Result<(), String> {
-    if let Some(existing) = app.get_webview_window("settings") {
-        let _ = existing.set_focus();
-        return Ok(());
-    }
-
-    let url = if cfg!(debug_assertions) {
-        format!("http://localhost:{DEV_PORT}/settings")
-    } else {
-        let port = webserver::get_configured_port();
-        let settings = load_settings()?;
-        let token = settings.token_secret.ok_or_else(|| {
-            "tokenSecret not found in settings.json — start the web server first".to_string()
-        })?;
-        format!("http://localhost:{port}/settings?token={token}")
-    };
-
-    let builder = WebviewWindowBuilder::new(
-        &app,
-        "settings",
-        WebviewUrl::External(url.parse().map_err(|e| format!("Invalid URL: {e}"))?),
-    )
-    .title("Settings - Band")
-    .inner_size(900.0, 700.0)
-    .center();
-
-    #[cfg(target_os = "macos")]
-    let builder = builder
-        .title_bar_style(tauri::TitleBarStyle::Overlay)
-        .hidden_title(true);
-
-    #[allow(unused_variables)]
-    let window = builder
-        .build()
-        .map_err(|e| format!("Failed to create settings window: {e}"))?;
-
-    #[cfg(target_os = "macos")]
-    #[allow(deprecated)]
-    {
-        use cocoa::appkit::NSColor;
-        use cocoa::appkit::NSWindow;
-        use cocoa::base::{id, nil};
-        let ns_window = window.ns_window().unwrap() as id;
-        unsafe {
-            let color = NSColor::colorWithSRGBRed_green_blue_alpha_(nil, 0.0, 0.0, 0.0, 1.0);
-            ns_window.setBackgroundColor_(color);
-        }
-    }
-
-    Ok(())
+    build_secondary_window(&app, "settings", "Settings - Band", "/settings")
 }
 
 #[tauri::command]

--- a/apps/dashboard/src-tauri/src/lib.rs
+++ b/apps/dashboard/src-tauri/src/lib.rs
@@ -95,8 +95,13 @@ pub fn run() {
             let reload_item = MenuItemBuilder::with_id("reload", "Reload")
                 .accelerator("CmdOrCtrl+R")
                 .build(app)?;
+            let settings_item = MenuItemBuilder::with_id("settings", "Settings...")
+                .accelerator("CmdOrCtrl+Comma")
+                .build(app)?;
             let view_menu = SubmenuBuilder::new(app, "View")
                 .item(&reload_item)
+                .separator()
+                .item(&settings_item)
                 .build()?;
 
             let menu = MenuBuilder::new(app)
@@ -105,7 +110,7 @@ pub fn run() {
                 .build()?;
             app.set_menu(menu)?;
 
-            // Handle the reload menu event on all windows.
+            // Handle menu events on all windows.
             let app_handle = app.handle().clone();
             app.on_menu_event(move |_app, event| {
                 if event.id() == "reload" {
@@ -122,6 +127,11 @@ pub fn run() {
                             let _ = win.navigate(url);
                         }
                     }
+                } else if event.id() == "settings" {
+                    let handle = app_handle.clone();
+                    tauri::async_runtime::spawn(async move {
+                        let _ = commands::window::open_settings_window(handle).await;
+                    });
                 }
             });
 

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -63,6 +63,22 @@ function NotFound() {
  *  Reads a cached theme value from localStorage (written by ThemeSync). */
 const THEME_INIT_SCRIPT = `(function(){try{var t=localStorage.getItem("band-theme")||"dark";var d=document.documentElement;if(t==="system"){if(window.matchMedia("(prefers-color-scheme:dark)").matches)d.classList.add("dark");else d.classList.remove("dark")}else if(t==="dark"){d.classList.add("dark")}else{d.classList.remove("dark")}}catch(e){document.documentElement.classList.add("dark")}})()`;
 
+/** Applies a theme value ("dark", "light", or "system") to the document root. */
+function applyTheme(theme: string) {
+  const root = document.documentElement;
+  if (theme === "system") {
+    if (window.matchMedia("(prefers-color-scheme: dark)").matches) {
+      root.classList.add("dark");
+    } else {
+      root.classList.remove("dark");
+    }
+  } else if (theme === "dark") {
+    root.classList.add("dark");
+  } else {
+    root.classList.remove("dark");
+  }
+}
+
 /** Syncs the "dark" class on <html> with the persisted theme setting.
  *  Runs for ALL pages (including standalone Tauri windows like tasks/cronjobs).
  *  Also caches the theme in localStorage so the blocking script can use it. */
@@ -71,30 +87,32 @@ function ThemeSync() {
   const theme = settings.theme ?? "dark";
 
   useEffect(() => {
-    const root = document.documentElement;
-
     try {
       localStorage.setItem("band-theme", theme);
     } catch {}
 
-    const apply = (isDark: boolean) => {
-      if (isDark) {
-        root.classList.add("dark");
-      } else {
-        root.classList.remove("dark");
-      }
-    };
+    applyTheme(theme);
 
     if (theme === "system") {
       const mq = window.matchMedia("(prefers-color-scheme: dark)");
-      apply(mq.matches);
-      const handler = (e: MediaQueryListEvent) => apply(e.matches);
+      const handler = () => applyTheme("system");
       mq.addEventListener("change", handler);
       return () => mq.removeEventListener("change", handler);
     }
-
-    apply(theme === "dark");
   }, [theme]);
+
+  // Cross-window theme sync via the storage event.
+  // When another window updates "band-theme" in localStorage,
+  // apply the change immediately to this window's DOM.
+  useEffect(() => {
+    const handleStorage = (e: StorageEvent) => {
+      if (e.key !== "band-theme" || !e.newValue) return;
+      applyTheme(e.newValue);
+    };
+
+    window.addEventListener("storage", handleStorage);
+    return () => window.removeEventListener("storage", handleStorage);
+  }, []);
 
   return null;
 }


### PR DESCRIPTION
## Summary
- Add **Cmd+,** (CmdOrCtrl+Comma) keyboard shortcut to open the Settings window from the View menu, matching standard macOS preferences behavior
- Fix **theme not propagating across Tauri windows** — when the theme is changed in the settings window, all other open windows (main, tasks, cronjobs) now update immediately without requiring a reload
- Fix **secondary windows getting 401 in dev mode** — settings, tasks, and cronjobs windows now derive their URL from the main window's origin instead of hardcoding port 3456, so they work correctly when Vite auto-picks a different port

## Details

### Cmd+, shortcut
Added a "Settings..." menu item with `CmdOrCtrl+Comma` accelerator to the View menu in the Tauri app. The menu event handler spawns the existing `open_settings_window` command via `tauri::async_runtime::spawn`, reusing the existing window creation logic with zero code duplication.

### Cross-window theme sync
**Root cause:** Each Tauri webview has its own JavaScript runtime and React Query cache. When settings are saved in the settings window, only that window's QueryClient cache is updated. Other windows never refetch because `refetchOnWindowFocus: false` and `staleTime: 30_000`.

**Fix:** Leverages the Web Storage API's `storage` event. `ThemeSync` already writes `band-theme` to localStorage when the theme changes. The `storage` event fires in all *other* same-origin windows when localStorage is modified. Added a `useEffect` listener in `ThemeSync` that applies the theme immediately when the `band-theme` key changes from another window. Also extracted an `applyTheme` helper to reduce duplication.

### Secondary window 401 fix
**Root cause:** `dev-dashboard.mjs` detects the actual Vite port and overrides `devUrl` for the main window, but `window.rs` hardcoded `DEV_PORT=3456` for all secondary windows. When port 3456 was already in use (e.g., another Band instance), secondary windows hit the wrong server and got 401.

**Fix:** Secondary windows now call `secondary_window_url()` which reads the main window's current URL and replaces just the path. `url::Url::set_path()` preserves query params, so in production the `?token=...` is carried over automatically. Also deduplicated ~130 lines of repeated window creation code into a single `build_secondary_window` helper.

## Test plan
- [ ] Press Cmd+, — settings window should open
- [ ] Press Cmd+, again — existing settings window should focus (not create duplicate)
- [ ] Open main window and settings window side by side, change theme in settings — main window should update immediately
- [ ] Test all three theme values (dark, light, system)
- [ ] Run `dev:dashboard` when port 3456 is in use — settings/tasks/cronjobs windows should load correctly on the auto-picked port
- [ ] Verify the Cmd+R reload shortcut still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)