### PR TITLE
feat: show/hide dockview workspaces instead of destroy/recreate

### DIFF
--- a/apps/dashboard/src-tauri/src/lib.rs
+++ b/apps/dashboard/src-tauri/src/lib.rs
@@ -228,7 +228,13 @@ pub fn run() {
                         let _ = settings_win.destroy();
                     }
                     web_proc.kill();
-                    webserver::kill_port_sync(webserver::get_configured_port());
+                    // Only kill by port in release builds where we spawned the
+                    // server ourselves. In dev mode the orchestrating script
+                    // (scripts/dev-dashboard.mjs) handles cleanup — blindly
+                    // killing port 3456 could hit another Band instance.
+                    if cfg!(not(debug_assertions)) {
+                        webserver::kill_port_sync(webserver::get_configured_port());
+                    }
                 }
             });
 
@@ -276,7 +282,9 @@ pub fn run() {
                 let _ = settings_win.destroy();
             }
             web_proc.kill();
-            webserver::kill_port_sync(webserver::get_configured_port());
+            if cfg!(not(debug_assertions)) {
+                webserver::kill_port_sync(webserver::get_configured_port());
+            }
         }
     });
 }

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -907,7 +907,7 @@ export function ChatView({
 
       <div className="mx-auto w-full max-w-3xl shrink-0 px-3 lg:px-4 pt-2 pb-4 standalone:pb-[env(safe-area-inset-bottom)]">
         <TaskListWidget tasks={taskMap} workspaceId={workspaceId} />
-        <PromptInput onSubmit={handleSubmit} draftKey={workspaceId}>
+        <PromptInput onSubmit={handleSubmit} draftKey={workspaceId} visible={visible}>
           <SlashCommandSuggestions skills={skills} />
           <FileMentionSuggestions workspaceId={workspaceId} />
           <PromptInputTextarea

--- a/apps/web/src/components/DockviewInstanceManager.tsx
+++ b/apps/web/src/components/DockviewInstanceManager.tsx
@@ -1,0 +1,139 @@
+import { useRouterState } from "@tanstack/react-router";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { DockviewWorkspaceLayout } from "./DockviewWorkspaceLayout";
+
+// ---------------------------------------------------------------------------
+// LRU cache for dockview workspace instances
+// ---------------------------------------------------------------------------
+
+interface CachedWorkspace {
+  workspaceId: string;
+  lastAccessed: number;
+}
+
+const MAX_CACHED_WORKSPACES = 5;
+
+function parseWorkspaceFromPath(pathname: string): string | null {
+  const match = pathname.match(/^\/workspace\/([^/]+)/);
+  if (!match) return null;
+  return decodeURIComponent(match[1]);
+}
+
+/**
+ * Manages multiple DockviewWorkspaceLayout instances with show/hide semantics.
+ *
+ * Instead of destroying and recreating dockview on workspace switch, this
+ * component keeps each visited workspace's dockview alive (hidden via CSS
+ * `display: none`) and shows the active one. An LRU strategy evicts the
+ * oldest cached instance when the cache exceeds MAX_CACHED_WORKSPACES.
+ *
+ * IMPORTANT: `activeWorkspaceId` is derived synchronously from pathname (not
+ * via useEffect) so the correct workspace is visible from the very first
+ * paint — preventing a flash of the previous workspace's content.
+ *
+ * Must be rendered inside AppShell (in __root.tsx) so it persists across
+ * route param changes.
+ */
+export function DockviewInstanceManager() {
+  const [cache, setCache] = useState<Map<string, CachedWorkspace>>(new Map());
+
+  const pathname = useRouterState({ select: (s) => s.location.pathname });
+
+  // Derive active workspace synchronously from pathname — no useEffect delay.
+  // This ensures the CSS display swap happens in the same render as the URL
+  // change, eliminating the one-frame flash of the previous workspace.
+  const activeWorkspaceId = parseWorkspaceFromPath(pathname);
+
+  // Synchronously ensure the active workspace is in the cache so it renders
+  // on the very first paint.  Calling setState during render (in response to
+  // a props/derived-value change) is the React 18 equivalent of
+  // getDerivedStateFromProps — React discards the in-progress render and
+  // immediately re-renders with the updated state.
+  if (activeWorkspaceId && !cache.has(activeWorkspaceId)) {
+    setCache((prev) => {
+      // Double-check inside updater in case of concurrent renders
+      if (prev.has(activeWorkspaceId)) return prev;
+      const next = new Map(prev);
+      next.set(activeWorkspaceId, {
+        workspaceId: activeWorkspaceId,
+        lastAccessed: Date.now(),
+      });
+
+      // LRU eviction: remove the oldest entry (excluding current)
+      if (next.size > MAX_CACHED_WORKSPACES) {
+        let oldestKey: string | null = null;
+        let oldestTime = Infinity;
+        for (const [key, entry] of next) {
+          if (key !== activeWorkspaceId && entry.lastAccessed < oldestTime) {
+            oldestTime = entry.lastAccessed;
+            oldestKey = key;
+          }
+        }
+        if (oldestKey) next.delete(oldestKey);
+      }
+
+      return next;
+    });
+  }
+
+  // Update lastAccessed timestamp in a non-blocking effect (for LRU ordering).
+  // This doesn't affect which workspace is visible — just eviction order.
+  useEffect(() => {
+    if (!activeWorkspaceId) return;
+    setCache((prev) => {
+      const existing = prev.get(activeWorkspaceId);
+      if (!existing) return prev;
+      const next = new Map(prev);
+      next.set(activeWorkspaceId, { ...existing, lastAccessed: Date.now() });
+      return next;
+    });
+  }, [activeWorkspaceId]);
+
+  // Ref so the eviction callback always reads the latest activeWorkspaceId
+  // without needing it as a useCallback dependency.  This keeps
+  // handleLayoutChange referentially stable across workspace switches,
+  // preventing unnecessary re-renders of all DockviewWorkspaceLayout
+  // instances (only the 2 whose isActive changed need to re-render).
+  const activeWorkspaceIdRef = useRef(activeWorkspaceId);
+  activeWorkspaceIdRef.current = activeWorkspaceId;
+
+  // When the active workspace's STRUCTURAL layout changes (panel move,
+  // resize, tab reorder), evict all hidden instances.  They'll recreate
+  // fresh (loading the updated layout from the global localStorage key)
+  // the next time the user navigates to them.
+  // NOT called for simple tab activation — that's per-workspace state.
+  const handleLayoutChange = useCallback(() => {
+    setCache((prev) => {
+      const awId = activeWorkspaceIdRef.current;
+      if (!awId) return prev;
+      const active = prev.get(awId);
+      if (!active) return prev;
+      if (prev.size === 1) return prev; // nothing to evict
+      const next = new Map<string, CachedWorkspace>();
+      next.set(awId, active);
+      return next;
+    });
+  }, []);
+
+  if (cache.size === 0 || activeWorkspaceId === null) return null;
+
+  return (
+    <div className="absolute inset-0">
+      {Array.from(cache.values()).map(({ workspaceId }) => (
+        <div
+          key={workspaceId}
+          className="absolute inset-0"
+          style={{
+            display: workspaceId === activeWorkspaceId ? "block" : "none",
+          }}
+        >
+          <DockviewWorkspaceLayout
+            workspaceId={workspaceId}
+            isActive={workspaceId === activeWorkspaceId}
+            onLayoutChange={handleLayoutChange}
+          />
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/apps/web/src/components/DockviewWorkspaceLayout.tsx
+++ b/apps/web/src/components/DockviewWorkspaceLayout.tsx
@@ -449,10 +449,7 @@ function saveLayout(
 
     // Always save active tab state per-workspace
     const activeState = extractActiveState(json);
-    localStorage.setItem(
-      `${ACTIVE_STATE_KEY_PREFIX}${workspaceId}`,
-      JSON.stringify(activeState),
-    );
+    localStorage.setItem(`${ACTIVE_STATE_KEY_PREFIX}${workspaceId}`, JSON.stringify(activeState));
 
     // Always save full layout to the global key
     localStorage.setItem(GLOBAL_LAYOUT_KEY, JSON.stringify(json));
@@ -477,9 +474,7 @@ function loadLayout(workspaceId: string): unknown | null {
     const layout = JSON.parse(raw);
 
     // Overlay this workspace's saved active tab state
-    const activeRaw = localStorage.getItem(
-      `${ACTIVE_STATE_KEY_PREFIX}${workspaceId}`,
-    );
+    const activeRaw = localStorage.getItem(`${ACTIVE_STATE_KEY_PREFIX}${workspaceId}`);
     if (activeRaw) {
       const activeState: ActiveTabState = JSON.parse(activeRaw);
       applyActiveState(layout, activeState);
@@ -752,6 +747,7 @@ export function DockviewWorkspaceLayout({
   );
 
   // onReady: restore or create default layout, then heal missing panels
+  // biome-ignore lint/correctness/useExhaustiveDependencies: workspaceId is constant for the lifetime of this component instance — one DockviewWorkspaceLayout per workspace. Including it would cause dockview to re-init on workspace ID change, which never happens.
   const onReady = useCallback(
     (event: DockviewReadyEvent) => {
       apiRef.current = event.api;
@@ -805,9 +801,7 @@ export function DockviewWorkspaceLayout({
       // Initialize the structural fingerprint from the just-loaded layout
       // so the first real structural change can be detected.
       {
-        const initJson = stripPanelParams(
-          event.api.toJSON() as unknown as Record<string, unknown>,
-        );
+        const initJson = stripPanelParams(event.api.toJSON() as unknown as Record<string, unknown>);
         lastStructureRef.current = getStructuralFingerprint(initJson);
       }
 
@@ -825,11 +819,7 @@ export function DockviewWorkspaceLayout({
         //  - active tab state → per-workspace key
         // It returns true when the STRUCTURAL layout changed (panels
         // moved, resized, or reordered) — NOT for simple tab clicks.
-        const structureChanged = saveLayout(
-          event.api,
-          workspaceId,
-          lastStructureRef,
-        );
+        const structureChanged = saveLayout(event.api, workspaceId, lastStructureRef);
 
         if (structureChanged) {
           onLayoutChangeRef.current?.();

--- a/apps/web/src/components/DockviewWorkspaceLayout.tsx
+++ b/apps/web/src/components/DockviewWorkspaceLayout.tsx
@@ -59,6 +59,7 @@ const SplitTerminalContainer = lazy(() =>
 
 interface ChatParams {
   workspaceId: string;
+  wsActive?: boolean;
 }
 
 interface ChangesParams {
@@ -79,6 +80,7 @@ interface FilesParams {
 
 interface TerminalParams {
   workspaceId: string;
+  wsActive?: boolean;
 }
 
 // ---------------------------------------------------------------------------
@@ -86,12 +88,12 @@ interface TerminalParams {
 // ---------------------------------------------------------------------------
 
 function ChatPanelComponent({ params, api }: IDockviewPanelProps<ChatParams>) {
-  const [visible, setVisible] = useState(api.isActive);
+  const [tabActive, setTabActive] = useState(api.isActive);
 
   useEffect(() => {
-    const d1 = api.onDidActiveChange((e) => setVisible(e.isActive));
+    const d1 = api.onDidActiveChange((e) => setTabActive(e.isActive));
     const d2 = api.onDidVisibilityChange((e) => {
-      if (e.isVisible && api.isActive) setVisible(true);
+      if (e.isVisible && api.isActive) setTabActive(true);
     });
     return () => {
       d1.dispose();
@@ -99,10 +101,19 @@ function ChatPanelComponent({ params, api }: IDockviewPanelProps<ChatParams>) {
     };
   }, [api]);
 
+  // Chat is visible only when both the workspace is active AND the tab is active
+  const visible = params.wsActive !== false && tabActive;
+
+  // Don't render until workspaceId is injected — during layout sync fromJSON
+  // recreates panels with empty params before injectParams runs a tick later.
+  // Rendering with undefined workspaceId would cause draft/session state issues.
+  if (!params.workspaceId) return null;
+
   return <WorkspaceChatPanel workspaceId={params.workspaceId} visible={visible} />;
 }
 
 function ChangesPanelComponent({ params }: IDockviewPanelProps<ChangesParams>) {
+  if (!params.workspaceId) return null;
   return (
     <DiffView
       workspaceId={params.workspaceId}
@@ -115,6 +126,7 @@ function ChangesPanelComponent({ params }: IDockviewPanelProps<ChangesParams>) {
 }
 
 function FilesPanelComponent({ params }: IDockviewPanelProps<FilesParams>) {
+  if (!params.workspaceId) return null;
   return (
     <CodeBrowserView
       workspaceId={params.workspaceId}
@@ -128,18 +140,23 @@ function FilesPanelComponent({ params }: IDockviewPanelProps<FilesParams>) {
 }
 
 function TerminalPanelComponent({ params, api }: IDockviewPanelProps<TerminalParams>) {
-  const [visible, setVisible] = useState(api.isActive);
+  const [tabActive, setTabActive] = useState(api.isActive);
 
   useEffect(() => {
-    const d1 = api.onDidActiveChange((e) => setVisible(e.isActive));
+    const d1 = api.onDidActiveChange((e) => setTabActive(e.isActive));
     const d2 = api.onDidVisibilityChange((e) => {
-      if (e.isVisible && api.isActive) setVisible(true);
+      if (e.isVisible && api.isActive) setTabActive(true);
     });
     return () => {
       d1.dispose();
       d2.dispose();
     };
   }, [api]);
+
+  // Terminal is visible only when both the workspace is active AND the tab is active
+  const visible = params.wsActive !== false && tabActive;
+
+  if (!params.workspaceId) return null;
 
   return (
     <Suspense fallback={null}>
@@ -253,9 +270,10 @@ const tabComponents: Record<string, React.FunctionComponent<IDockviewPanelHeader
 // Diff file count hook (polls every 15s)
 // ---------------------------------------------------------------------------
 
-function useDiffFileCount(workspaceId: string): number {
+function useDiffFileCount(workspaceId: string, isActive: boolean): number {
   const [count, setCount] = useState(0);
   useEffect(() => {
+    if (!isActive) return;
     let cancelled = false;
     const fetchCount = () => {
       trpc.workspace.getDiffSummary
@@ -271,7 +289,7 @@ function useDiffFileCount(workspaceId: string): number {
       cancelled = true;
       clearInterval(interval);
     };
-  }, [workspaceId]);
+  }, [workspaceId, isActive]);
   return count;
 }
 
@@ -282,18 +300,192 @@ function useDiffFileCount(workspaceId: string): number {
 /** All panels that must always be present in the layout. */
 const REQUIRED_PANEL_IDS = ["chat", "changes", "files", "terminal"] as const;
 
-const LAYOUT_KEY = "band:dockview-layout";
+// ---------------------------------------------------------------------------
+// Layout persistence: shared structure + per-workspace active tabs
+// ---------------------------------------------------------------------------
+//
+// Structural layout (panel positions, sizes, tab order) is shared across
+// ALL workspaces via a global key.  Active tab state (which tab is shown in
+// each group) is stored per-workspace so that switching workspaces doesn't
+// clobber the user's tab focus.
 
-function saveLayout(api: DockviewApi) {
-  try {
-    localStorage.setItem(LAYOUT_KEY, JSON.stringify(api.toJSON()));
-  } catch {}
+const GLOBAL_LAYOUT_KEY = "band:dockview-layout";
+const ACTIVE_STATE_KEY_PREFIX = "band:dockview-active:";
+
+/** Per-workspace active-tab state: which group is focused and which tab is
+ *  shown in each tabbed group. */
+interface ActiveTabState {
+  activeGroup?: string;
+  groups: Record<string, string>; // groupId → activeView panelId
 }
 
-function loadLayout(): unknown | null {
+// biome-ignore lint/suspicious/noExplicitAny: recursive grid JSON
+function walkGridNode(node: any, callback: (leaf: any) => void): void {
+  if (!node) return;
+  if (node.type === "leaf") {
+    callback(node);
+  } else if (node.type === "branch" && Array.isArray(node.data)) {
+    for (const child of node.data) {
+      walkGridNode(child, callback);
+    }
+  }
+}
+
+/** Extract per-workspace active tab state from serialized layout. */
+function extractActiveState(json: Record<string, unknown>): ActiveTabState {
+  const state: ActiveTabState = { groups: {} };
+  if (typeof json.activeGroup === "string") {
+    state.activeGroup = json.activeGroup;
+  }
+  // dockview v5 uses "activePanel" at the top level (the active GROUP id)
+  if (typeof json.activePanel === "string") {
+    state.activeGroup = json.activePanel;
+  }
+  const grid = json.grid as Record<string, unknown> | undefined;
+  if (grid?.root) {
+    walkGridNode(grid.root, (leaf) => {
+      const data = leaf.data;
+      if (data?.id && data?.activeView) {
+        state.groups[data.id] = data.activeView;
+      }
+    });
+  }
+  return state;
+}
+
+/** Apply per-workspace active tab state onto a layout JSON (mutates). */
+function applyActiveState(json: Record<string, unknown>, state: ActiveTabState): void {
+  if (state.activeGroup) {
+    // dockview v5 uses "activePanel" for the focused group
+    json.activePanel = state.activeGroup;
+  }
+  const grid = json.grid as Record<string, unknown> | undefined;
+  if (grid?.root) {
+    walkGridNode(grid.root, (leaf) => {
+      const data = leaf.data;
+      if (data?.id && state.groups[data.id]) {
+        data.activeView = state.groups[data.id];
+      }
+    });
+  }
+}
+
+/**
+ * Recursively sort all object keys so that JSON.stringify produces a
+ * deterministic output regardless of property insertion order.
+ */
+// biome-ignore lint/suspicious/noExplicitAny: recursive JSON normalizer
+function sortKeys(value: any): any {
+  if (Array.isArray(value)) return value.map(sortKeys);
+  if (value !== null && typeof value === "object") {
+    const sorted: Record<string, unknown> = {};
+    for (const key of Object.keys(value).sort()) {
+      sorted[key] = sortKeys(value[key]);
+    }
+    return sorted;
+  }
+  return value;
+}
+
+/**
+ * Compute a structural fingerprint of the layout that ignores active tab
+ * state and container dimensions.  Two layouts with the same panels in the
+ * same arrangement but different active tabs produce the same fingerprint.
+ *
+ * Keys are sorted before stringification so that property insertion order
+ * differences (e.g. fromJSON() vs toJSON()) don't produce false positives.
+ */
+function getStructuralFingerprint(json: Record<string, unknown>): string {
+  const clone = JSON.parse(JSON.stringify(json));
+  // Strip active-tab state
+  delete clone.activePanel;
+  delete clone.activeGroup;
+  const grid = clone.grid;
+  if (grid) {
+    delete grid.width;
+    delete grid.height;
+    walkGridNode(grid.root, (leaf) => {
+      if (leaf.data) delete leaf.data.activeView;
+    });
+  }
+  return JSON.stringify(sortKeys(clone));
+}
+
+/**
+ * Strip runtime panel params (file paths, callbacks, workspaceId) from the
+ * serialized layout so that the saved JSON only contains structural data
+ * (panel positions, sizes, groups). Each workspace re-injects its own params
+ * via injectParams() after restoring.
+ */
+function stripPanelParams(json: Record<string, unknown>): Record<string, unknown> {
+  // JSON round-trip instead of structuredClone because api.toJSON() includes
+  // panel params that may contain functions (callbacks injected via
+  // injectParams). structuredClone throws DataCloneError on functions.
+  const clone = JSON.parse(JSON.stringify(json));
+  const panels = clone.panels as Record<string, Record<string, unknown>> | undefined;
+  if (panels) {
+    for (const panel of Object.values(panels)) {
+      panel.params = {};
+    }
+  }
+  return clone;
+}
+
+/**
+ * Persist the current layout.
+ * - Full layout (structure + active tabs) → global key (shared by all ws)
+ * - Active tab state only → per-workspace key
+ *
+ * Returns true when the structural layout changed (panels moved, resized,
+ * reordered) so the caller can decide whether to evict cached workspaces.
+ */
+function saveLayout(
+  api: DockviewApi,
+  workspaceId: string,
+  lastStructureRef: React.MutableRefObject<string>,
+): boolean {
   try {
-    const raw = localStorage.getItem(LAYOUT_KEY);
-    return raw ? JSON.parse(raw) : null;
+    const json = stripPanelParams(api.toJSON() as unknown as Record<string, unknown>);
+
+    // Always save active tab state per-workspace
+    const activeState = extractActiveState(json);
+    localStorage.setItem(
+      `${ACTIVE_STATE_KEY_PREFIX}${workspaceId}`,
+      JSON.stringify(activeState),
+    );
+
+    // Always save full layout to the global key
+    localStorage.setItem(GLOBAL_LAYOUT_KEY, JSON.stringify(json));
+
+    // Detect structural changes (ignoring active tabs & container size)
+    const fingerprint = getStructuralFingerprint(json);
+    if (fingerprint !== lastStructureRef.current) {
+      lastStructureRef.current = fingerprint;
+      return true; // structural change
+    }
+    return false;
+  } catch {
+    return false;
+  }
+}
+
+/** Load layout: global structure + per-workspace active tabs merged. */
+function loadLayout(workspaceId: string): unknown | null {
+  try {
+    const raw = localStorage.getItem(GLOBAL_LAYOUT_KEY);
+    if (!raw) return null;
+    const layout = JSON.parse(raw);
+
+    // Overlay this workspace's saved active tab state
+    const activeRaw = localStorage.getItem(
+      `${ACTIVE_STATE_KEY_PREFIX}${workspaceId}`,
+    );
+    if (activeRaw) {
+      const activeState: ActiveTabState = JSON.parse(activeRaw);
+      applyActiveState(layout, activeState);
+    }
+
+    return layout;
   } catch {
     return null;
   }
@@ -305,16 +497,51 @@ function loadLayout(): unknown | null {
 
 interface DockviewWorkspaceLayoutProps {
   workspaceId: string;
-  encodedId: string;
+  isActive: boolean;
+  /** Called when the user makes a STRUCTURAL layout change (panel move,
+   *  resize, tab reorder — NOT simple tab activation).  The instance
+   *  manager uses this to evict hidden workspaces so they pick up the
+   *  new layout when re-opened. */
+  onLayoutChange?: () => void;
 }
 
-export function DockviewWorkspaceLayout({ workspaceId }: DockviewWorkspaceLayoutProps) {
+export function DockviewWorkspaceLayout({
+  workspaceId,
+  isActive,
+  onLayoutChange,
+}: DockviewWorkspaceLayoutProps) {
   const apiRef = useRef<DockviewApi | null>(null);
+
+  // Ref so the onDidLayoutChange handler always sees the latest callback
+  // without needing to re-subscribe.
+  const onLayoutChangeRef = useRef(onLayoutChange);
+  onLayoutChangeRef.current = onLayoutChange;
+
+  // Suppress saves during initial layout setup (fromJSON / buildDefaultLayout
+  // fire onDidLayoutChange events that are not user-initiated).
+  const initializedRef = useRef(false);
+
+  // Ref for injectParams so onReady doesn't need it as a dependency.
+  // Without this, onReady would be recreated on every isActive / currentFile /
+  // etc. change, causing dockview to dispose the onDidLayoutChange listener.
+  const injectParamsRef = useRef<(api: DockviewApi) => void>(() => {});
+
+  // Track active state via ref so the onDidLayoutChange handler can guard
+  // against saves from non-active workspaces. When a workspace is evicted,
+  // api.dispose() may fire layout events — without this guard the dying
+  // instance would overwrite the good layout the active workspace just saved.
+  const isActiveRef = useRef(isActive);
+  isActiveRef.current = isActive;
+
+  // Structural fingerprint for detecting real layout changes (panel move,
+  // resize, tab reorder) vs. simple tab activation changes.  Only
+  // structural changes trigger eviction of hidden workspaces.
+  const lastStructureRef = useRef("");
 
   // Cross-panel state
   const [currentFile, setCurrentFile] = useState<string | undefined>(undefined);
   const [openFilePath, setOpenFilePath] = useState<string | null>(null);
-  const diffFileCount = useDiffFileCount(workspaceId);
+  const diffFileCount = useDiffFileCount(workspaceId, isActive);
 
   // Dialog state
   const [quickOpenOpen, setQuickOpenOpen] = useState(false);
@@ -349,28 +576,10 @@ export function DockviewWorkspaceLayout({ workspaceId }: DockviewWorkspaceLayout
     setCurrentFile(filePath ?? undefined);
   }, []);
 
-  // Update Changes tab badge when diff file count changes
+  // Global keyboard shortcuts (capture phase) — only active for the visible workspace
   useEffect(() => {
-    const api = apiRef.current;
-    if (!api) return;
-    const panel = api.getPanel("changes");
-    if (panel) {
-      panel.api.updateParameters({ badge: diffFileCount });
-    }
-  }, [diffFileCount]);
+    if (!isActive) return;
 
-  // Update Files panel params when file state changes
-  useEffect(() => {
-    const api = apiRef.current;
-    if (!api) return;
-    api.getPanel("files")?.api.updateParameters({
-      file: currentFile,
-      openFilePath,
-    });
-  }, [currentFile, openFilePath]);
-
-  // Global keyboard shortcuts (capture phase)
-  useEffect(() => {
     const handler = (e: KeyboardEvent) => {
       // Shift+Tab → toggle mode (Edit/Plan)
       if (e.key === "Tab" && e.shiftKey && !e.ctrlKey && !e.metaKey) {
@@ -412,9 +621,11 @@ export function DockviewWorkspaceLayout({ workspaceId }: DockviewWorkspaceLayout
     };
     window.addEventListener("keydown", handler, true);
     return () => window.removeEventListener("keydown", handler, true);
-  }, []);
+  }, [isActive]);
 
-  // Wire callbacks into panels after layout restore (functions cannot be serialized)
+  // Wire callbacks into panels after layout restore (functions cannot be serialized).
+  // Note: wsActive is handled by a separate effect below so that workspace
+  // switches only re-render the 2 panels that care (chat, terminal), not all 4.
   const injectParams = useCallback(
     (api: DockviewApi) => {
       api.getPanel("chat")?.api.updateParameters({
@@ -451,6 +662,7 @@ export function DockviewWorkspaceLayout({ workspaceId }: DockviewWorkspaceLayout
       setFindInFile,
     ],
   );
+  injectParamsRef.current = injectParams;
 
   // Add a single missing panel back into the layout at a sensible position
   const addMissingPanel = useCallback(
@@ -546,7 +758,7 @@ export function DockviewWorkspaceLayout({ workspaceId }: DockviewWorkspaceLayout
 
       // Try to restore a saved layout
       let restored = false;
-      const saved = loadLayout();
+      const saved = loadLayout(workspaceId);
       if (saved) {
         try {
           // biome-ignore lint/suspicious/noExplicitAny: localStorage JSON shape
@@ -570,46 +782,103 @@ export function DockviewWorkspaceLayout({ workspaceId }: DockviewWorkspaceLayout
 
       // After restore, inject live callback references
       // (setTimeout ensures fromJSON completes rendering)
-      setTimeout(() => injectParams(event.api), 0);
+      setTimeout(() => injectParamsRef.current(event.api), 0);
 
       // Guard: if a required panel is removed (edge-case drag, API call, etc.)
-      // re-add it immediately so it can't be lost
-      const removeGuard = event.api.onDidRemovePanel((panel) => {
+      // re-add it immediately so it can't be lost.
+      // Note: DockviewReact ignores onReady's return value, so cleanup is
+      // handled by api.dispose() when the component unmounts — no need to
+      // store the disposable.
+      event.api.onDidRemovePanel((panel) => {
         const id = panel.id;
         if ((REQUIRED_PANEL_IDS as readonly string[]).includes(id)) {
           // Re-add on next tick so dockview finishes its removal first
           setTimeout(() => {
             if (!event.api.getPanel(id)) {
               addMissingPanel(event.api, id);
-              injectParams(event.api);
+              injectParamsRef.current(event.api);
             }
           }, 0);
         }
       });
 
-      // Persist layout on changes
-      const layoutChange = event.api.onDidLayoutChange(() => {
-        saveLayout(event.api);
+      // Initialize the structural fingerprint from the just-loaded layout
+      // so the first real structural change can be detected.
+      {
+        const initJson = stripPanelParams(
+          event.api.toJSON() as unknown as Record<string, unknown>,
+        );
+        lastStructureRef.current = getStructuralFingerprint(initJson);
+      }
+
+      // Persist layout on changes and notify the instance manager.
+      // The subscription is created AFTER fromJSON / buildDefaultLayout, so
+      // their synchronous onDidLayoutChange events are never captured.
+      // The initializedRef guard is a safety net for any edge-case async
+      // layout events during setup.
+      event.api.onDidLayoutChange(() => {
+        if (!initializedRef.current) return;
+        if (!isActiveRef.current) return;
+
+        // saveLayout writes:
+        //  - full layout → global key (shared structure)
+        //  - active tab state → per-workspace key
+        // It returns true when the STRUCTURAL layout changed (panels
+        // moved, resized, or reordered) — NOT for simple tab clicks.
+        const structureChanged = saveLayout(
+          event.api,
+          workspaceId,
+          lastStructureRef,
+        );
+
+        if (structureChanged) {
+          onLayoutChangeRef.current?.();
+        }
       });
 
-      return () => {
-        removeGuard.dispose();
-        layoutChange.dispose();
-      };
+      initializedRef.current = true;
     },
-    [buildDefaultLayout, addMissingPanel, injectParams],
+    [buildDefaultLayout, addMissingPanel],
   );
 
-  // Re-inject params when callbacks/state change
+  // Re-inject params when callbacks/state change (badge count, file
+  // state, and all callback references in one pass).
   useEffect(() => {
     const api = apiRef.current;
     if (api) injectParams(api);
   }, [injectParams]);
 
+  // Propagate workspace active state only to panels that use it (chat,
+  // terminal).  Kept separate from injectParams so that a workspace switch
+  // doesn't trigger updateParameters on all 4 panels — changes and files
+  // don't care about wsActive and would re-render for nothing.
+  useEffect(() => {
+    const api = apiRef.current;
+    if (!api) return;
+    api.getPanel("chat")?.api.updateParameters({ wsActive: isActive });
+    api.getPanel("terminal")?.api.updateParameters({ wsActive: isActive });
+  }, [isActive]);
+
+  // Force dockview to recalculate layout after becoming visible.
+  // When switching from display:none → display:block, dockview may have
+  // stale size info.  Calling layout() triggers a proper resize.
+  //
+  // No isResizingRef guard is needed here: the onDidLayoutChange handler
+  // uses a structural fingerprint comparison to detect real layout changes.
+  // A programmatic layout() with the same container dimensions produces
+  // the same fingerprint — no eviction is triggered.
+  useEffect(() => {
+    if (isActive && apiRef.current) {
+      const api = apiRef.current;
+      requestAnimationFrame(() => {
+        api.layout(api.width, api.height);
+      });
+    }
+  }, [isActive]);
+
   return (
     <>
       <DockviewReact
-        key={workspaceId}
         theme={bandTheme}
         className="h-full"
         components={components}

--- a/apps/web/src/components/ai-elements/prompt-input.tsx
+++ b/apps/web/src/components/ai-elements/prompt-input.tsx
@@ -47,6 +47,9 @@ export type PromptInputProps = Omit<HTMLAttributes<HTMLFormElement>, "onSubmit">
   onSubmit: (message: PromptInputMessage, event: FormEvent<HTMLFormElement>) => void;
   /** When set, the unsent input text is persisted to sessionStorage under this key so it survives unmounts (e.g. tab switches). */
   draftKey?: string;
+  /** Whether the prompt input is currently visible/active. Used to gate global
+   *  event handlers so hidden workspaces' textareas aren't modified. */
+  visible?: boolean;
 };
 
 function readDraft(key: string | null): string {
@@ -62,6 +65,7 @@ export const PromptInput = ({
   className,
   onSubmit,
   draftKey,
+  visible,
   children,
   ...props
 }: PromptInputProps) => {
@@ -74,23 +78,32 @@ export const PromptInput = ({
   const [inputValue, setInputValue] = useState(() => readDraft(draftStorageKey));
   const [commandHint, setCommandHint] = useState<string | null>(null);
 
-  // Restore draft into the uncontrolled textarea on mount
+  // Restore draft into the uncontrolled textarea on mount.
+  // Always set the value — even when the draft is empty — to clear any
+  // stale content the browser/WebView may have restored by field name.
   const draftRestoredRef = useRef(false);
   useEffect(() => {
     if (draftRestoredRef.current) return;
     draftRestoredRef.current = true;
     const draft = readDraft(draftStorageKey);
-    if (!draft) return;
     const textarea = textareaRef.current;
     if (!textarea) return;
+    if (!draft && !textarea.value) return;
     const nativeSetter = Object.getOwnPropertyDescriptor(
       HTMLTextAreaElement.prototype,
       "value",
     )?.set;
     nativeSetter?.call(textarea, draft);
     textarea.dispatchEvent(new Event("input", { bubbles: true }));
-    textarea.selectionStart = textarea.selectionEnd = draft.length;
+    if (draft) {
+      textarea.selectionStart = textarea.selectionEnd = draft.length;
+    }
   }, [draftStorageKey]);
+
+  // Ref for gating global event handlers — hidden workspaces must not
+  // process events that would modify their textarea.
+  const visibleRef = useRef(visible);
+  visibleRef.current = visible;
 
   const addFiles = useCallback((newFiles: FileList | File[]) => {
     const valid = Array.from(newFiles).filter((f) => f.size <= MAX_FILE_SIZE);
@@ -184,9 +197,13 @@ export const PromptInput = ({
     textarea.selectionStart = textarea.selectionEnd = value.length;
   }, []);
 
-  // Listen for "Add to Chat" events from CodeMirror editors
+  // Listen for "Add to Chat" events from CodeMirror editors.
+  // Only process the event when this prompt is visible — with workspace
+  // show/hide, multiple PromptInput instances are mounted simultaneously
+  // and we must not modify hidden workspaces' textareas.
   useEffect(() => {
     const handler = (e: Event) => {
+      if (visibleRef.current === false) return;
       const { filePath, startLine, endLine } = (e as CustomEvent<SelectionToChatDetail>).detail;
 
       const lineRef =

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -15,6 +15,7 @@ import {
   useRouterState,
 } from "@tanstack/react-router";
 import { useCallback, useEffect } from "react";
+import { DockviewInstanceManager } from "../components/DockviewInstanceManager";
 import { TauriTitleBar } from "../components/TauriTitleBar";
 import { ToolbarButtons } from "../components/ToolbarButtons";
 import { useIsDesktop } from "../hooks/useIsDesktop";
@@ -157,8 +158,9 @@ function AppShell() {
         <div className="w-80 shrink-0 border-r border-border overflow-hidden">
           <DashboardShell toolbarExtra={<ToolbarButtons />} hideTitleBar={isTauriFullEditor} />
         </div>
-        <div className="flex-1 min-w-0 overflow-hidden">
+        <div className="flex-1 min-w-0 overflow-hidden relative">
           <Outlet />
+          <DockviewInstanceManager />
         </div>
       </div>
     </div>

--- a/apps/web/src/routes/workspace.$workspaceId.tsx
+++ b/apps/web/src/routes/workspace.$workspaceId.tsx
@@ -17,7 +17,6 @@ import {
   useRef,
   useState,
 } from "react";
-import { DockviewWorkspaceLayout } from "../components/DockviewWorkspaceLayout";
 import { TauriDragRegion } from "../components/TauriTitleBar";
 import { AgentSwitcherContext } from "../hooks/useAgentSwitcherContext";
 import { useIsDesktop } from "../hooks/useIsDesktop";
@@ -181,17 +180,16 @@ function WorkspaceLayout() {
 // ---------------------------------------------------------------------------
 
 function DesktopWorkspaceLayout({
-  workspaceId,
-  encodedId,
+  workspaceId: _workspaceId,
+  encodedId: _encodedId,
 }: {
   workspaceId: string;
   encodedId: string;
 }) {
-  return (
-    <div className="h-full overflow-hidden">
-      <DockviewWorkspaceLayout workspaceId={workspaceId} encodedId={encodedId} />
-    </div>
-  );
+  // Dockview is now managed by DockviewInstanceManager in __root.tsx.
+  // Each workspace gets its own persistent DockviewReact instance that is
+  // shown/hidden via CSS rather than destroyed/recreated on workspace switch.
+  return null;
 }
 
 // ---------------------------------------------------------------------------

--- a/knip.json
+++ b/knip.json
@@ -28,7 +28,6 @@
         "class-variance-authority",
         "clsx",
         "tailwind-merge",
-        "@tauri-apps/plugin-shell",
         "@dnd-kit/core",
         "@dnd-kit/sortable",
         "@dnd-kit/utilities",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "description": "IDE-agnostic agent orchestrator — dashboard + VS Code extension",
   "type": "module",
   "scripts": {
-    "dev:dashboard": "pnpm build:cli:dev & pnpm build:extension & pnpm build:web & wait && node scripts/dev-dashboard.mjs",
+    "dev:dashboard": "pnpm build:cli:dev && pnpm build:extension && pnpm build:web && node scripts/dev-dashboard.mjs",
     "dev:web": "pnpm --filter @band-app/server dev",
     "dev:docs": "pnpm --filter @band-app/docs dev",
     "build:dashboard": "pnpm --filter @band-app/dashboard tauri build",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "description": "IDE-agnostic agent orchestrator — dashboard + VS Code extension",
   "type": "module",
   "scripts": {
-    "dev:dashboard": "pnpm build:cli:dev && pnpm build:extension && pnpm build:web && pnpm --filter @band-app/dashboard tauri:dev",
+    "dev:dashboard": "pnpm build:cli:dev & pnpm build:extension & pnpm build:web & wait && node scripts/dev-dashboard.mjs",
     "dev:web": "pnpm --filter @band-app/server dev",
     "dev:docs": "pnpm --filter @band-app/docs dev",
     "build:dashboard": "pnpm --filter @band-app/dashboard tauri build",

--- a/scripts/dev-dashboard.mjs
+++ b/scripts/dev-dashboard.mjs
@@ -1,0 +1,129 @@
+#!/usr/bin/env node
+
+/**
+ * Starts the web dev server (vite), detects the actual port it bound to,
+ * then launches the Tauri app pointed at that port.
+ *
+ * This handles the case where port 3456 is already taken (e.g. another
+ * Band instance is running) — vite auto-picks the next available port
+ * and we forward it to Tauri via --config override.
+ *
+ * The vite process is spawned in its own process group (detached) so we
+ * can reliably kill the entire tree (pnpm → node → vite) on cleanup.
+ * The tauri process is NOT detached so Node.js receives its exit event.
+ */
+
+import { spawn } from "node:child_process";
+import { createInterface } from "node:readline";
+
+/** Kill an entire process group. Falls back to single-process kill. */
+function killTree(child) {
+  if (!child || child.exitCode !== null) return;
+  if (child.detached) {
+    try {
+      // Negative PID sends the signal to the entire process group
+      process.kill(-child.pid, "SIGTERM");
+      return;
+    } catch {
+      // fall through
+    }
+  }
+  try {
+    child.kill("SIGTERM");
+  } catch {
+    // already dead
+  }
+}
+
+// ---------------------------------------------------------------------------
+// 1. Start the vite dev server in its own process group
+// ---------------------------------------------------------------------------
+
+const vite = spawn("pnpm", ["dev:web"], {
+  stdio: ["ignore", "pipe", "pipe"],
+  detached: true,
+});
+// Tag so killTree knows to use group kill
+vite.detached = true;
+
+// Forward stderr (vite warnings, HMR logs, etc.)
+vite.stderr.on("data", (chunk) => process.stderr.write(chunk));
+
+// ---------------------------------------------------------------------------
+// 2. Parse the actual port from vite's stdout
+// ---------------------------------------------------------------------------
+
+const rl = createInterface({ input: vite.stdout });
+let tauriProcess = null;
+
+rl.on("line", (line) => {
+  // Always forward vite output
+  process.stdout.write(line + "\n");
+
+  if (tauriProcess) return;
+
+  // Vite prints:  ➜  Local:   http://localhost:3456/
+  const match = line.match(/Local:\s+https?:\/\/localhost:(\d+)/);
+  if (!match) return;
+
+  const port = match[1];
+  console.log(
+    `\n[dev-dashboard] Web server ready on port ${port}, starting Tauri...\n`,
+  );
+
+  // -----------------------------------------------------------------
+  // 3. Start Tauri with the detected port, skip beforeDevCommand
+  //    (we already started vite ourselves).
+  //    NOT detached — so Node.js receives its exit event when the
+  //    Tauri window is closed.
+  // -----------------------------------------------------------------
+
+  const configOverride = JSON.stringify({
+    build: {
+      devUrl: `http://localhost:${port}`,
+      beforeDevCommand: "",
+    },
+  });
+
+  tauriProcess = spawn(
+    "pnpm",
+    [
+      "--filter",
+      "@band-app/dashboard",
+      "tauri",
+      "dev",
+      "--config",
+      configOverride,
+    ],
+    { stdio: "inherit" },
+  );
+
+  tauriProcess.on("exit", (code) => {
+    killTree(vite);
+    process.exit(code ?? 0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Cleanup
+// ---------------------------------------------------------------------------
+
+function cleanup() {
+  killTree(tauriProcess);
+  killTree(vite);
+}
+
+vite.on("exit", () => {
+  killTree(tauriProcess);
+  process.exit(0);
+});
+
+process.on("SIGINT", () => {
+  cleanup();
+  process.exit(0);
+});
+
+process.on("SIGTERM", () => {
+  cleanup();
+  process.exit(0);
+});


### PR DESCRIPTION
## Summary

- Switch dockview workspace management from destroy/recreate to show/hide with LRU cache (up to 5 instances)
- Split layout persistence: shared structural layout (panel positions, sizes, tab order) across all workspaces + per-workspace active tab state
- Use deterministic structural fingerprinting to detect real layout changes vs tab clicks, preventing unnecessary eviction of hidden workspaces
- Gate global event handlers behind visibility checks so hidden workspaces don't interfere with the active one
- Guard panel components against empty params during `fromJSON` sync and add `wsActive` prop to Chat/Terminal panels

## Test plan

- [x] Switch workspace A to Files tab, navigate to workspace B, switch B to Changes tab
- [x] Navigate back to A → Files tab still active (independent tab state)
- [x] Navigate back to B → Changes tab still active (round-trip independence)
- [x] Verify 2 dockview instances in DOM (no spurious eviction)
- [x] Tab clicks produce `structureChanged=false` — no eviction triggered
- [x] TypeScript check passes (no new errors)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)