### PR TITLE
feat: support line references in quick open dialog

### DIFF
--- a/apps/web/tests/file-location.test.ts
+++ b/apps/web/tests/file-location.test.ts
@@ -1,0 +1,148 @@
+import { formatFileLocation, parseFileLocation } from "@band-app/dashboard-core";
+import { describe, expect, it } from "vitest";
+
+// ---------------------------------------------------------------------------
+// parseFileLocation
+// ---------------------------------------------------------------------------
+describe("parseFileLocation", () => {
+  it("returns bare path when there is no line suffix", () => {
+    expect(parseFileLocation("src/main.ts")).toEqual({ filePath: "src/main.ts" });
+  });
+
+  it("returns bare path for an empty string", () => {
+    expect(parseFileLocation("")).toEqual({ filePath: "" });
+  });
+
+  it("parses file:line format", () => {
+    expect(parseFileLocation("src/main.rs:42")).toEqual({
+      filePath: "src/main.rs",
+      line: 42,
+    });
+  });
+
+  it("parses file:line:col format", () => {
+    expect(parseFileLocation("app.tsx:100:15")).toEqual({
+      filePath: "app.tsx",
+      line: 100,
+      column: 15,
+    });
+  });
+
+  it("parses file:line-lineEnd range format", () => {
+    expect(parseFileLocation("src/lib.rs:5-10")).toEqual({
+      filePath: "src/lib.rs",
+      line: 5,
+      lineEnd: 10,
+    });
+  });
+
+  it("handles deeply nested paths with line reference", () => {
+    expect(
+      parseFileLocation("packages/dashboard-core/src/components/QuickOpenDialog.tsx:77"),
+    ).toEqual({
+      filePath: "packages/dashboard-core/src/components/QuickOpenDialog.tsx",
+      line: 77,
+    });
+  });
+
+  it("treats :0 as invalid and returns the raw string as path", () => {
+    // Line numbers are 1-based, so :0 should not be treated as a line ref
+    expect(parseFileLocation("file.ts:0")).toEqual({ filePath: "file.ts:0" });
+  });
+
+  it("treats :0:0 as invalid and returns raw string as path", () => {
+    expect(parseFileLocation("file.ts:0:0")).toEqual({ filePath: "file.ts:0:0" });
+  });
+
+  it("handles file paths that already contain colons (Windows-style drive letters)", () => {
+    // "C:" prefix should not be confused with a line suffix
+    // The regex anchors to the end, so only the last `:N` is parsed
+    const result = parseFileLocation("C:/Users/src/main.ts:10");
+    expect(result).toEqual({ filePath: "C:/Users/src/main.ts", line: 10 });
+  });
+
+  it("handles very large line numbers", () => {
+    expect(parseFileLocation("app.tsx:999999")).toEqual({
+      filePath: "app.tsx",
+      line: 999999,
+    });
+  });
+
+  it("does not match a trailing colon without a number", () => {
+    expect(parseFileLocation("file.ts:")).toEqual({ filePath: "file.ts:" });
+  });
+
+  it("does not match non-numeric suffix after colon", () => {
+    expect(parseFileLocation("file.ts:abc")).toEqual({ filePath: "file.ts:abc" });
+  });
+
+  // Stack trace / compiler error formats that users paste directly
+  it("handles grep-style output (file:line)", () => {
+    expect(parseFileLocation("src/index.ts:23")).toEqual({
+      filePath: "src/index.ts",
+      line: 23,
+    });
+  });
+
+  it("handles compiler error style (file:line:col)", () => {
+    expect(parseFileLocation("src/app.tsx:45:12")).toEqual({
+      filePath: "src/app.tsx",
+      line: 45,
+      column: 12,
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// formatFileLocation
+// ---------------------------------------------------------------------------
+describe("formatFileLocation", () => {
+  it("returns bare path when no line is given", () => {
+    expect(formatFileLocation("src/main.ts")).toBe("src/main.ts");
+  });
+
+  it("returns bare path when line is undefined", () => {
+    expect(formatFileLocation("src/main.ts", undefined)).toBe("src/main.ts");
+  });
+
+  it("formats file:line", () => {
+    expect(formatFileLocation("src/main.rs", 42)).toBe("src/main.rs:42");
+  });
+
+  it("formats file:line:col", () => {
+    expect(formatFileLocation("app.tsx", 100, { column: 15 })).toBe("app.tsx:100:15");
+  });
+
+  it("formats file:line-lineEnd", () => {
+    expect(formatFileLocation("src/lib.rs", 5, { lineEnd: 10 })).toBe("src/lib.rs:5-10");
+  });
+
+  it("lineEnd takes precedence over column", () => {
+    // formatFileLocation checks lineEnd before column
+    expect(formatFileLocation("file.ts", 5, { lineEnd: 10, column: 3 })).toBe("file.ts:5-10");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Round-trip: parse ↔ format
+// ---------------------------------------------------------------------------
+describe("parseFileLocation ↔ formatFileLocation round-trip", () => {
+  const cases = [
+    "src/main.ts",
+    "src/main.rs:42",
+    "app.tsx:100:15",
+    "src/lib.rs:5-10",
+    "packages/core/src/index.ts:1",
+  ];
+
+  for (const input of cases) {
+    it(`round-trips "${input}"`, () => {
+      const parsed = parseFileLocation(input);
+      const formatted = formatFileLocation(parsed.filePath, parsed.line, {
+        lineEnd: parsed.lineEnd,
+        column: parsed.column,
+      });
+      expect(formatted).toBe(input);
+    });
+  }
+});

--- a/packages/dashboard-core/src/components/QuickOpenDialog.tsx
+++ b/packages/dashboard-core/src/components/QuickOpenDialog.tsx
@@ -11,9 +11,10 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@band-app/ui";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useAdapter } from "../context";
 import { getFileIcon } from "../lib/file-icon";
+import { formatFileLocation, parseFileLocation } from "../lib/file-location";
 
 interface QuickOpenDialogProps {
   workspaceId: string;
@@ -34,6 +35,10 @@ export function QuickOpenDialog({
   const [loading, setLoading] = useState(false);
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
+  // Parse line/column reference from the query (e.g. "src/main.rs:42" -> line 42)
+  const parsedQuery = useMemo(() => parseFileLocation(query), [query]);
+  const searchQuery = parsedQuery.filePath;
+
   useEffect(() => {
     if (!open || !adapter.searchWorkspaceFiles) return;
 
@@ -42,9 +47,9 @@ export function QuickOpenDialog({
 
     if (debounceRef.current) clearTimeout(debounceRef.current);
 
-    const delay = query ? 150 : 0;
+    const delay = searchQuery ? 150 : 0;
     debounceRef.current = setTimeout(() => {
-      adapter.searchWorkspaceFiles!(workspaceId, query, 50)
+      adapter.searchWorkspaceFiles!(workspaceId, searchQuery, 50)
         .then((result) => {
           if (!cancelled) setFiles(result.files);
         })
@@ -58,7 +63,7 @@ export function QuickOpenDialog({
       cancelled = true;
       if (debounceRef.current) clearTimeout(debounceRef.current);
     };
-  }, [adapter, workspaceId, query, open]);
+  }, [adapter, workspaceId, searchQuery, open]);
 
   // Reset on close
   useEffect(() => {
@@ -70,10 +75,14 @@ export function QuickOpenDialog({
 
   const handleSelect = useCallback(
     (filePath: string) => {
-      onOpenFile(filePath);
+      const location = formatFileLocation(filePath, parsedQuery.line, {
+        lineEnd: parsedQuery.lineEnd,
+        column: parsedQuery.column,
+      });
+      onOpenFile(location);
       onOpenChange(false);
     },
-    [onOpenFile, onOpenChange],
+    [onOpenFile, onOpenChange, parsedQuery],
   );
 
   return (
@@ -89,6 +98,13 @@ export function QuickOpenDialog({
             value={query}
             onValueChange={setQuery}
           />
+          {parsedQuery.line != null && (
+            <div className="border-b px-3 py-1.5 text-xs text-muted-foreground">
+              Go to line {parsedQuery.line}
+              {parsedQuery.lineEnd != null && `-${parsedQuery.lineEnd}`}
+              {parsedQuery.column != null && `, column ${parsedQuery.column}`}
+            </div>
+          )}
           <CommandList className="max-h-[360px]">
             <CommandEmpty>{loading ? "Searching..." : "No files found."}</CommandEmpty>
             <CommandGroup>


### PR DESCRIPTION
## Summary

- Parse line/column suffixes (`file:line`, `file:line:col`, `file:line-lineEnd`) from the quick open query so users can paste stack traces, compiler errors, or grep output directly and jump to the referenced location
- Strip line reference from the search query so fuzzy matching works on the file path alone
- Reattach line reference when a file is selected, leveraging the existing `CodeBrowserView` → `FileViewer` → `CodeMirrorViewer` pipeline for scroll + highlight
- Show a "Go to line N" indicator when a line reference is detected

Closes #243

## Test plan

- [x] Added 25 tests covering `parseFileLocation` and `formatFileLocation` round-trips, edge cases (`:0`, trailing colon, non-numeric suffixes, deeply nested paths), and all supported formats
- [x] All 46 tests pass (25 new + 21 existing fuzzy-score)
- [x] TypeScript type-check passes
- [x] Biome lint/format passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)