### PR TITLE
fix: auto-refresh changes view via WebSocket events

### DIFF
--- a/packages/dashboard-core/src/components/DiffView.tsx
+++ b/packages/dashboard-core/src/components/DiffView.tsx
@@ -20,6 +20,7 @@ import { baseViewerExtensions, loadLanguage, searchHighlightOnly } from "../lib/
 import { formatFileLocation } from "../lib/file-location";
 import { extensionToLanguage, filenameToLanguage } from "../lib/language-map";
 import { selectionToChatExtension } from "../lib/selection-to-chat";
+import type { SSEEvent } from "../lib/sse";
 import type { DiffMode, FileStatus, WorkspaceDiffSummary } from "../types";
 import { SearchBar, type SearchOptions } from "./SearchBar";
 
@@ -653,10 +654,23 @@ export function DiffView({
     };
 
     fetchSummary();
-    const interval = active ? setInterval(fetchSummary, 15_000) : undefined;
+
+    // Subscribe to branch-status events to auto-refresh when files change.
+    // The branch-status-poller emits events every ~5s with the workspace's
+    // git dirty state, so the diff view stays in sync without slow polling.
+    let unsubscribe: (() => void) | undefined;
+    if (active) {
+      unsubscribe = adapter.subscribeStatusEvents((event) => {
+        const data = event as SSEEvent;
+        if (data.kind === "branch-status" && data.workspaceId === workspaceId) {
+          fetchSummary();
+        }
+      });
+    }
+
     return () => {
       cancelled = true;
-      if (interval) clearInterval(interval);
+      unsubscribe?.();
     };
   }, [adapter, workspaceId, active, onStatsChange, diffMode]);
 


### PR DESCRIPTION
## Summary

- Replace the 15-second `setInterval` polling in `DiffView` with event-driven refetching via the existing `branch-status` WebSocket subscription
- The server's branch-status-poller already emits events every ~5s — the diff view now reacts to those instead of running its own slow timer
- Zero server-side changes needed; leverages existing real-time infrastructure

Closes #238

## Test plan

- [x] Build passes (`pnpm build:web`)
- [x] Lint passes (`biome check`)
- [x] All 303 tests pass (`pnpm --filter @band-app/server test`)
- [ ] Manual: open a workspace with the changes view visible, make a file change, and verify the diff updates within ~5 seconds without manual refresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)