### PR TITLE
feat: add browser tab with native Tauri webview

### DIFF
--- a/apps/dashboard/src-tauri/Cargo.toml
+++ b/apps/dashboard/src-tauri/Cargo.toml
@@ -15,7 +15,7 @@ path = "src/main.rs"
 tauri-build = { version = "2", features = [] }
 
 [dependencies]
-tauri = { version = "2", features = [] }
+tauri = { version = "2", features = ["unstable"] }
 tauri-plugin-fs = "2"
 tauri-plugin-shell = "2"
 tauri-plugin-dialog = "2"

--- a/apps/dashboard/src-tauri/capabilities/default.json
+++ b/apps/dashboard/src-tauri/capabilities/default.json
@@ -7,6 +7,7 @@
   },
   "permissions": [
     "core:default",
+    "core:webview:default",
     "fs:default",
     "fs:allow-read-file",
     "fs:allow-write-file",

--- a/apps/dashboard/src-tauri/src/commands/browser.rs
+++ b/apps/dashboard/src-tauri/src/commands/browser.rs
@@ -105,21 +105,20 @@ pub async fn browser_create(
 
     let app_handle = app.clone();
     let ws_id = workspace_id.clone();
-    let builder =
-        tauri::webview::WebviewBuilder::new(&label, WebviewUrl::External(parsed_url))
-            .on_page_load(move |webview, payload| {
-                let loading = matches!(payload.event(), PageLoadEvent::Started);
-                if let Ok(current_url) = webview.url() {
-                    let _ = app_handle.emit(
-                        "browser-url-changed",
-                        BrowserUrlChanged {
-                            url: current_url.to_string(),
-                            workspace_id: ws_id.clone(),
-                            loading,
-                        },
-                    );
-                }
-            });
+    let builder = tauri::webview::WebviewBuilder::new(&label, WebviewUrl::External(parsed_url))
+        .on_page_load(move |webview, payload| {
+            let loading = matches!(payload.event(), PageLoadEvent::Started);
+            if let Ok(current_url) = webview.url() {
+                let _ = app_handle.emit(
+                    "browser-url-changed",
+                    BrowserUrlChanged {
+                        url: current_url.to_string(),
+                        workspace_id: ws_id.clone(),
+                        loading,
+                    },
+                );
+            }
+        });
 
     window
         .add_child(
@@ -150,9 +149,7 @@ pub async fn browser_navigate(
 pub async fn browser_go_back(app: AppHandle, workspace_id: String) -> Result<(), String> {
     let label = webview_label(&workspace_id);
     let webview = app.get_webview(&label).ok_or("Browser webview not found")?;
-    webview
-        .eval("history.back()")
-        .map_err(|e| format!("{e}"))
+    webview.eval("history.back()").map_err(|e| format!("{e}"))
 }
 
 /// Go forward in the browser history.

--- a/apps/dashboard/src-tauri/src/commands/browser.rs
+++ b/apps/dashboard/src-tauri/src/commands/browser.rs
@@ -69,6 +69,7 @@ fn enforce_lru(app: &AppHandle, state: &BrowserState, new_workspace_id: &str) {
 /// If a webview for this workspace already exists it is shown and repositioned.
 /// Otherwise a new child webview is created inside the main window.
 #[tauri::command]
+#[allow(clippy::too_many_arguments)]
 pub async fn browser_create(
     app: AppHandle,
     state: tauri::State<'_, BrowserState>,

--- a/apps/dashboard/src-tauri/src/commands/browser.rs
+++ b/apps/dashboard/src-tauri/src/commands/browser.rs
@@ -1,0 +1,240 @@
+use std::sync::Mutex;
+
+use serde::Serialize;
+use tauri::webview::PageLoadEvent;
+use tauri::{AppHandle, Emitter, Manager, WebviewUrl};
+
+/// Maximum number of browser webviews kept alive simultaneously.
+/// When exceeded the least-recently-used webview is closed.
+const MAX_BROWSER_WEBVIEWS: usize = 5;
+
+/// Managed state that tracks browser webview creation order for LRU eviction.
+pub struct BrowserState {
+    /// Workspace IDs whose browser webviews are currently alive, ordered from
+    /// oldest (front) to newest (back).
+    pub order: Mutex<Vec<String>>,
+}
+
+impl BrowserState {
+    pub fn new() -> Self {
+        Self {
+            order: Mutex::new(Vec::new()),
+        }
+    }
+}
+
+/// Payload emitted to the frontend when a browser webview navigates.
+#[derive(Clone, Serialize)]
+struct BrowserUrlChanged {
+    url: String,
+    workspace_id: String,
+    /// `true` while the page is still loading, `false` when finished.
+    loading: bool,
+}
+
+/// Build the webview label for a given workspace.
+fn webview_label(workspace_id: &str) -> String {
+    format!("browser-{workspace_id}")
+}
+
+/// Enforce the LRU cap by closing the oldest browser webview(s).
+fn enforce_lru(app: &AppHandle, state: &BrowserState, new_workspace_id: &str) {
+    let mut order = state.order.lock().unwrap();
+
+    // If this workspace already has a webview, bump it to the end (most recent).
+    if let Some(pos) = order.iter().position(|id| id == new_workspace_id) {
+        order.remove(pos);
+    }
+
+    // Evict oldest until we're under the cap (leaving room for the new one).
+    while order.len() >= MAX_BROWSER_WEBVIEWS {
+        if let Some(oldest_id) = order.first().cloned() {
+            order.remove(0);
+            let label = webview_label(&oldest_id);
+            if let Some(wv) = app.get_webview(&label) {
+                let _ = wv.close();
+            }
+        }
+    }
+
+    order.push(new_workspace_id.to_string());
+}
+
+// ---------------------------------------------------------------------------
+// Commands
+// ---------------------------------------------------------------------------
+
+/// Create (or show) a child webview for the given workspace's browser panel.
+///
+/// If a webview for this workspace already exists it is shown and repositioned.
+/// Otherwise a new child webview is created inside the main window.
+#[tauri::command]
+pub async fn browser_create(
+    app: AppHandle,
+    state: tauri::State<'_, BrowserState>,
+    workspace_id: String,
+    x: f64,
+    y: f64,
+    width: f64,
+    height: f64,
+    url: String,
+) -> Result<(), String> {
+    let label = webview_label(&workspace_id);
+
+    // If the webview already exists, just show + reposition it.
+    if let Some(existing) = app.get_webview(&label) {
+        let _ = existing.show();
+        let _ = existing.set_position(tauri::LogicalPosition::new(x, y));
+        let _ = existing.set_size(tauri::LogicalSize::new(width, height));
+        // Bump to most-recent in LRU order.
+        {
+            let mut order = state.order.lock().unwrap();
+            if let Some(pos) = order.iter().position(|id| id == &workspace_id) {
+                order.remove(pos);
+                order.push(workspace_id);
+            }
+        }
+        return Ok(());
+    }
+
+    // Enforce LRU cap before creating a new webview.
+    enforce_lru(&app, &state, &workspace_id);
+
+    let window = app.get_window("main").ok_or("Main window not found")?;
+    let parsed_url: url::Url = url.parse().map_err(|e| format!("Invalid URL: {e}"))?;
+
+    let app_handle = app.clone();
+    let ws_id = workspace_id.clone();
+    let builder =
+        tauri::webview::WebviewBuilder::new(&label, WebviewUrl::External(parsed_url))
+            .on_page_load(move |webview, payload| {
+                let loading = matches!(payload.event(), PageLoadEvent::Started);
+                if let Ok(current_url) = webview.url() {
+                    let _ = app_handle.emit(
+                        "browser-url-changed",
+                        BrowserUrlChanged {
+                            url: current_url.to_string(),
+                            workspace_id: ws_id.clone(),
+                            loading,
+                        },
+                    );
+                }
+            });
+
+    window
+        .add_child(
+            builder,
+            tauri::LogicalPosition::new(x, y),
+            tauri::LogicalSize::new(width, height),
+        )
+        .map_err(|e| format!("Failed to create browser webview: {e}"))?;
+
+    Ok(())
+}
+
+/// Navigate the workspace's browser webview to a new URL.
+#[tauri::command]
+pub async fn browser_navigate(
+    app: AppHandle,
+    workspace_id: String,
+    url: String,
+) -> Result<(), String> {
+    let label = webview_label(&workspace_id);
+    let webview = app.get_webview(&label).ok_or("Browser webview not found")?;
+    let parsed: url::Url = url.parse().map_err(|e| format!("Invalid URL: {e}"))?;
+    webview.navigate(parsed).map_err(|e| format!("{e}"))
+}
+
+/// Go back in the browser history.
+#[tauri::command]
+pub async fn browser_go_back(app: AppHandle, workspace_id: String) -> Result<(), String> {
+    let label = webview_label(&workspace_id);
+    let webview = app.get_webview(&label).ok_or("Browser webview not found")?;
+    webview
+        .eval("history.back()")
+        .map_err(|e| format!("{e}"))
+}
+
+/// Go forward in the browser history.
+#[tauri::command]
+pub async fn browser_go_forward(app: AppHandle, workspace_id: String) -> Result<(), String> {
+    let label = webview_label(&workspace_id);
+    let webview = app.get_webview(&label).ok_or("Browser webview not found")?;
+    webview
+        .eval("history.forward()")
+        .map_err(|e| format!("{e}"))
+}
+
+/// Evaluate arbitrary JavaScript in the browser webview.
+#[tauri::command]
+pub async fn browser_eval(app: AppHandle, workspace_id: String, js: String) -> Result<(), String> {
+    let label = webview_label(&workspace_id);
+    let webview = app.get_webview(&label).ok_or("Browser webview not found")?;
+    webview.eval(&js).map_err(|e| format!("{e}"))
+}
+
+/// Reload the current page in the browser webview.
+#[tauri::command]
+pub async fn browser_reload(app: AppHandle, workspace_id: String) -> Result<(), String> {
+    let label = webview_label(&workspace_id);
+    let webview = app.get_webview(&label).ok_or("Browser webview not found")?;
+    webview
+        .eval("location.reload()")
+        .map_err(|e| format!("{e}"))
+}
+
+/// Update the position and size of the browser webview (called on panel resize).
+#[tauri::command]
+pub async fn browser_set_bounds(
+    app: AppHandle,
+    workspace_id: String,
+    x: f64,
+    y: f64,
+    width: f64,
+    height: f64,
+) -> Result<(), String> {
+    let label = webview_label(&workspace_id);
+    let webview = app.get_webview(&label).ok_or("Browser webview not found")?;
+    webview
+        .set_position(tauri::LogicalPosition::new(x, y))
+        .map_err(|e| format!("{e}"))?;
+    webview
+        .set_size(tauri::LogicalSize::new(width, height))
+        .map_err(|e| format!("{e}"))
+}
+
+/// Hide the browser webview (when the panel tab is not active or workspace switches away).
+#[tauri::command]
+pub async fn browser_hide(app: AppHandle, workspace_id: String) -> Result<(), String> {
+    let label = webview_label(&workspace_id);
+    if let Some(webview) = app.get_webview(&label) {
+        webview.hide().map_err(|e| format!("{e}"))?;
+    }
+    Ok(())
+}
+
+/// Show the browser webview (when the panel tab becomes active).
+#[tauri::command]
+pub async fn browser_show(app: AppHandle, workspace_id: String) -> Result<(), String> {
+    let label = webview_label(&workspace_id);
+    if let Some(webview) = app.get_webview(&label) {
+        webview.show().map_err(|e| format!("{e}"))?;
+    }
+    Ok(())
+}
+
+/// Destroy the browser webview for a workspace and remove it from LRU tracking.
+#[tauri::command]
+pub async fn browser_destroy(
+    app: AppHandle,
+    state: tauri::State<'_, BrowserState>,
+    workspace_id: String,
+) -> Result<(), String> {
+    let label = webview_label(&workspace_id);
+    if let Some(webview) = app.get_webview(&label) {
+        webview.close().map_err(|e| format!("{e}"))?;
+    }
+    let mut order = state.order.lock().unwrap();
+    order.retain(|id| id != &workspace_id);
+    Ok(())
+}

--- a/apps/dashboard/src-tauri/src/commands/mod.rs
+++ b/apps/dashboard/src-tauri/src/commands/mod.rs
@@ -10,5 +10,6 @@ pub mod ide_stub;
 pub mod window_manager;
 #[cfg(not(target_os = "macos"))]
 pub use ide_stub as ide;
+pub mod browser;
 pub mod webserver;
 pub mod window;

--- a/apps/dashboard/src-tauri/src/lib.rs
+++ b/apps/dashboard/src-tauri/src/lib.rs
@@ -9,6 +9,7 @@ use std::io::Write;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
+use commands::browser::BrowserState;
 use commands::webserver::{self as webserver, ManagedProcess, WebServerState};
 use state::{ActiveWorkspaceState, ProjectCache};
 use tauri::menu::{MenuBuilder, MenuItemBuilder, PredefinedMenuItem, SubmenuBuilder};
@@ -62,6 +63,7 @@ pub fn run() {
         .manage(WebServerState(ManagedProcess::new()))
         .manage(ActiveWorkspaceState::new())
         .manage(ProjectCache::new())
+        .manage(BrowserState::new())
         .invoke_handler(tauri::generate_handler![
             commands::ide::workspace_focus,
             commands::ide::workspace_close,
@@ -76,6 +78,16 @@ pub fn run() {
             commands::window::open_settings_window,
             commands::window::get_app_title,
             commands::window::set_app_mode,
+            commands::browser::browser_create,
+            commands::browser::browser_navigate,
+            commands::browser::browser_go_back,
+            commands::browser::browser_go_forward,
+            commands::browser::browser_eval,
+            commands::browser::browser_reload,
+            commands::browser::browser_set_bounds,
+            commands::browser::browser_hide,
+            commands::browser::browser_show,
+            commands::browser::browser_destroy,
         ])
         .setup(move |app| {
             let window = app.get_webview_window("main").unwrap();
@@ -217,6 +229,11 @@ pub fn run() {
                         return;
                     }
 
+                    for (label, wv) in app_handle_for_close.webviews() {
+                        if label.starts_with("browser-") {
+                            let _ = wv.close();
+                        }
+                    }
                     if let Some(tasks_win) = app_handle_for_close.get_webview_window("tasks") {
                         let _ = tasks_win.destroy();
                     }
@@ -272,6 +289,11 @@ pub fn run() {
             }
 
             let web_proc = &app_handle.state::<WebServerState>().0;
+            for (label, wv) in app_handle.webviews() {
+                if label.starts_with("browser-") {
+                    let _ = wv.close();
+                }
+            }
             if let Some(tasks_win) = app_handle.get_webview_window("tasks") {
                 let _ = tasks_win.destroy();
             }

--- a/apps/web/src/components/BrowserPanel.tsx
+++ b/apps/web/src/components/BrowserPanel.tsx
@@ -1,0 +1,426 @@
+import type { IDockviewPanelProps } from "dockview";
+import { ArrowLeft, ArrowRight, RotateCw, X } from "lucide-react";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { isTauri } from "../lib/is-tauri";
+
+const DEFAULT_URL = "";
+const BLANK_URL = "about:blank";
+const STORAGE_PREFIX = "band:browser-url:";
+
+// ---------------------------------------------------------------------------
+// Per-workspace URL persistence in localStorage
+// ---------------------------------------------------------------------------
+
+function saveUrl(workspaceId: string, url: string) {
+  try {
+    localStorage.setItem(`${STORAGE_PREFIX}${workspaceId}`, url);
+  } catch {}
+}
+
+function loadUrl(workspaceId: string): string | null {
+  try {
+    return localStorage.getItem(`${STORAGE_PREFIX}${workspaceId}`);
+  } catch {
+    return null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Browser panel component – renders an address bar and a placeholder div.
+// A native Tauri child webview is positioned over the placeholder area.
+// Each workspace gets its own persistent webview (hidden/shown on switch).
+// ---------------------------------------------------------------------------
+
+interface BrowserParams {
+  workspaceId: string;
+  wsActive?: boolean;
+}
+
+export function BrowserPanelComponent({ params, api }: IDockviewPanelProps<BrowserParams>) {
+  const workspaceId = params.workspaceId;
+
+  const [currentUrl, setCurrentUrl] = useState(() => loadUrl(workspaceId) ?? DEFAULT_URL);
+  const [inputUrl, setInputUrl] = useState(() => loadUrl(workspaceId) ?? DEFAULT_URL);
+  const [loading, setLoading] = useState(false);
+  const [created, setCreated] = useState(false);
+  const createdRef = useRef(false);
+  const placeholderRef = useRef<HTMLDivElement>(null);
+  const creatingRef = useRef(false);
+  const pendingNavRef = useRef<string | null>(null);
+  const workspaceIdRef = useRef(workspaceId);
+  workspaceIdRef.current = workspaceId;
+  const currentUrlRef = useRef(currentUrl);
+  currentUrlRef.current = currentUrl;
+
+  // ------- restore persisted URL when workspaceId becomes available -------
+  // useState initializers run on first mount when workspaceId may still be
+  // undefined (fromJSON restores panels with empty params). This effect
+  // syncs state from localStorage once the real workspaceId is injected.
+
+  useEffect(() => {
+    if (!workspaceId) return;
+    const saved = loadUrl(workspaceId);
+    if (saved) {
+      setCurrentUrl(saved);
+      setInputUrl(saved);
+    }
+  }, [workspaceId]);
+
+  // ------- helpers -------
+
+  const getBounds = useCallback(() => {
+    const el = placeholderRef.current;
+    if (!el) return null;
+    const rect = el.getBoundingClientRect();
+    return { x: rect.left, y: rect.top, width: rect.width, height: rect.height };
+  }, []);
+
+  const invoke = useCallback(async (cmd: string, args?: Record<string, unknown>) => {
+    if (!isTauri) return;
+    const { invoke: tauriInvoke } = await import("@tauri-apps/api/core");
+    return tauriInvoke(cmd, args);
+  }, []);
+
+  // ------- create or show webview once placeholder has real dimensions -------
+  //
+  // The panel may be mounted while its tab is inactive (dockview renders
+  // hidden tabs with display:none).  A simple setTimeout would see 0×0
+  // bounds and give up.  Instead we use a ResizeObserver that fires as
+  // soon as the placeholder gets a non-zero size (i.e. the tab is shown).
+
+  useEffect(() => {
+    if (!isTauri || created || creatingRef.current) return;
+    const el = placeholderRef.current;
+    if (!el) return;
+
+    let cancelled = false;
+
+    const tryCreate = async () => {
+      if (cancelled || createdRef.current || creatingRef.current) return;
+      const bounds = getBounds();
+      if (!bounds || bounds.width === 0 || bounds.height === 0) return;
+
+      observer.disconnect();
+      creatingRef.current = true;
+      try {
+        await invoke("browser_create", {
+          workspaceId,
+          ...bounds,
+          url: loadUrl(workspaceId) || currentUrlRef.current || BLANK_URL,
+        });
+        createdRef.current = true;
+        setCreated(true);
+        // If a navigation was requested while we were creating, flush it now
+        const pending = pendingNavRef.current;
+        if (pending) {
+          pendingNavRef.current = null;
+          await invoke("browser_navigate", {
+            workspaceId: workspaceIdRef.current,
+            url: pending,
+          });
+        }
+      } catch (e) {
+        console.error("Failed to create browser webview:", e);
+      } finally {
+        creatingRef.current = false;
+      }
+    };
+
+    // Watch for the placeholder gaining real dimensions
+    const observer = new ResizeObserver(() => {
+      tryCreate();
+    });
+    observer.observe(el);
+
+    // Also try after a short tick in case the tab is already visible
+    const timer = setTimeout(tryCreate, 50);
+
+    return () => {
+      cancelled = true;
+      clearTimeout(timer);
+      observer.disconnect();
+    };
+  }, [created, getBounds, invoke, workspaceId]);
+
+  // ------- listen for URL changes from the Rust side -------
+
+  useEffect(() => {
+    if (!isTauri) return;
+    let unlisten: (() => void) | undefined;
+
+    (async () => {
+      const { listen } = await import("@tauri-apps/api/event");
+      unlisten = await listen<{ url: string; workspace_id: string; loading: boolean }>(
+        "browser-url-changed",
+        (event) => {
+          // Only update if the event is for our workspace
+          if (event.payload.workspace_id !== workspaceIdRef.current) return;
+          const url = event.payload.url;
+          setLoading(event.payload.loading);
+          // Don't sync about:blank to the address bar or localStorage
+          if (url === BLANK_URL) return;
+          setCurrentUrl(url);
+          setInputUrl(url);
+          saveUrl(workspaceIdRef.current, url);
+        },
+      );
+    })();
+
+    return () => {
+      unlisten?.();
+    };
+  }, []);
+
+  // ------- visibility tracking (hide/show when tab switches) -------
+
+  useEffect(() => {
+    if (!isTauri || !created) return;
+
+    const handleVisibility = async (visible: boolean) => {
+      if (visible) {
+        await invoke("browser_show", { workspaceId });
+        const bounds = getBounds();
+        if (bounds && bounds.width > 0 && bounds.height > 0) {
+          await invoke("browser_set_bounds", { workspaceId, ...bounds });
+        }
+      } else {
+        await invoke("browser_hide", { workspaceId });
+      }
+    };
+
+    const d1 = api.onDidActiveChange((e) => {
+      handleVisibility(e.isActive);
+    });
+    const d2 = api.onDidVisibilityChange((e) => {
+      if (!e.isVisible) {
+        handleVisibility(false);
+      } else if (api.isActive) {
+        handleVisibility(true);
+      }
+    });
+
+    return () => {
+      d1.dispose();
+      d2.dispose();
+    };
+  }, [api, created, getBounds, invoke, workspaceId]);
+
+  // ------- workspace-level visibility -------
+  // The native webview is an OS-level layer that floats on top of the DOM.
+  // When the workspace is hidden (wsActive=false) we must explicitly hide
+  // the webview — CSS display:none on the React tree has no effect on it.
+
+  useEffect(() => {
+    if (!isTauri || !created) return;
+    const wsActive = params.wsActive !== false;
+
+    if (!wsActive) {
+      invoke("browser_hide", { workspaceId }).catch(() => {});
+    } else if (api.isActive) {
+      // Only re-show if the browser tab is the active tab in its group
+      invoke("browser_show", { workspaceId }).catch(() => {});
+      const bounds = getBounds();
+      if (bounds && bounds.width > 0 && bounds.height > 0) {
+        invoke("browser_set_bounds", { workspaceId, ...bounds }).catch(() => {});
+      }
+    }
+  }, [params.wsActive, api, created, getBounds, invoke, workspaceId]);
+
+  // ------- keep webview bounds in sync on resize -------
+
+  useEffect(() => {
+    if (!isTauri || !created) return;
+    const el = placeholderRef.current;
+    if (!el) return;
+
+    const observer = new ResizeObserver(() => {
+      const bounds = getBounds();
+      if (!bounds || bounds.width === 0 || bounds.height === 0) return;
+      invoke("browser_set_bounds", { workspaceId, ...bounds }).catch(() => {});
+    });
+    observer.observe(el);
+
+    return () => observer.disconnect();
+  }, [created, getBounds, invoke, workspaceId]);
+
+  // ------- destroy on unmount (workspace evicted from frontend cache) -------
+  // Workspace *switches* are handled by the wsActive effect (hide/show).
+  // Unmount only happens when the workspace view is fully evicted, so we
+  // destroy the native webview to free memory.
+
+  useEffect(() => {
+    return () => {
+      if (isTauri) {
+        const wsId = workspaceIdRef.current;
+        import("@tauri-apps/api/core").then(({ invoke: tauriInvoke }) => {
+          tauriInvoke("browser_destroy", { workspaceId: wsId }).catch(() => {});
+        });
+      }
+    };
+  }, []);
+
+  // ------- navigation handlers -------
+
+  const handleNavigate = useCallback(
+    async (rawUrl: string) => {
+      let normalized = rawUrl.trim();
+      if (!normalized) return;
+
+      if (!normalized.startsWith("http://") && !normalized.startsWith("https://")) {
+        if (normalized.includes(".") && !normalized.includes(" ")) {
+          normalized = `https://${normalized}`;
+        } else {
+          normalized = `https://www.google.com/search?q=${encodeURIComponent(normalized)}`;
+        }
+      }
+
+      setCurrentUrl(normalized);
+      setInputUrl(normalized);
+      setLoading(true);
+      saveUrl(workspaceId, normalized);
+
+      if (createdRef.current) {
+        try {
+          await invoke("browser_navigate", { workspaceId, url: normalized });
+        } catch (e) {
+          console.error("browser_navigate failed:", e);
+        }
+      } else {
+        // Webview still being created — queue the navigation
+        pendingNavRef.current = normalized;
+      }
+    },
+    [invoke, workspaceId],
+  );
+
+  const handleBack = useCallback(async () => {
+    try {
+      await invoke("browser_go_back", { workspaceId });
+    } catch (e) {
+      console.error("browser_go_back failed:", e);
+    }
+  }, [invoke, workspaceId]);
+
+  const handleForward = useCallback(async () => {
+    try {
+      await invoke("browser_go_forward", { workspaceId });
+    } catch (e) {
+      console.error("browser_go_forward failed:", e);
+    }
+  }, [invoke, workspaceId]);
+
+  const handleReload = useCallback(async () => {
+    try {
+      setLoading(true);
+      await invoke("browser_reload", { workspaceId });
+    } catch (e) {
+      console.error("browser_reload failed:", e);
+    }
+  }, [invoke, workspaceId]);
+
+  const handleStop = useCallback(async () => {
+    try {
+      // Stop loading by evaluating window.stop() in the webview
+      await invoke("browser_eval", { workspaceId, js: "window.stop()" });
+      setLoading(false);
+    } catch {
+      setLoading(false);
+    }
+  }, [invoke, workspaceId]);
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLInputElement>) => {
+      if (e.key === "Enter") {
+        e.preventDefault();
+        handleNavigate(inputUrl);
+      }
+    },
+    [inputUrl, handleNavigate],
+  );
+
+  // Don't render until workspaceId is injected — during layout sync fromJSON
+  // recreates panels with empty params before injectParams runs a tick later.
+  if (!workspaceId) return null;
+
+  // ------- non-Tauri fallback -------
+
+  if (!isTauri) {
+    return (
+      <div className="flex h-full items-center justify-center text-muted-foreground">
+        Browser panel is only available in the desktop app
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex h-full w-full flex-col">
+      {/* Keyframes for the loading bar (injected once, deduped by browser) */}
+      <style>{`@keyframes browser-bar-slide {
+  0% { transform: translateX(-100%); }
+  50% { transform: translateX(200%); }
+  100% { transform: translateX(-100%); }
+}`}</style>
+      {/* Address bar */}
+      <div className="relative flex h-10 shrink-0 items-center gap-1 border-b border-border bg-background px-2">
+        <button
+          type="button"
+          onClick={handleBack}
+          className="flex items-center justify-center rounded p-1.5 text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+          title="Back"
+        >
+          <ArrowLeft className="size-4" />
+        </button>
+        <button
+          type="button"
+          onClick={handleForward}
+          className="flex items-center justify-center rounded p-1.5 text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+          title="Forward"
+        >
+          <ArrowRight className="size-4" />
+        </button>
+        {loading ? (
+          <button
+            type="button"
+            onClick={handleStop}
+            className="flex items-center justify-center rounded p-1.5 text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+            title="Stop"
+          >
+            <X className="size-4" />
+          </button>
+        ) : (
+          <button
+            type="button"
+            onClick={handleReload}
+            className="flex items-center justify-center rounded p-1.5 text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+            title="Reload"
+          >
+            <RotateCw className="size-4" />
+          </button>
+        )}
+        <input
+          type="text"
+          value={inputUrl}
+          onChange={(e) => setInputUrl(e.target.value)}
+          onKeyDown={handleKeyDown}
+          onFocus={(e) => e.target.select()}
+          className="min-w-0 flex-1 rounded border border-transparent bg-muted/50 px-3 py-1.5 text-sm text-foreground outline-none transition-colors focus:border-border"
+          placeholder="Enter URL or search..."
+        />
+        {/* Loading progress bar — indeterminate sliding indicator */}
+        {loading && (
+          <div className="absolute inset-x-0 bottom-0 h-0.5 overflow-hidden bg-blue-500/10">
+            <div
+              className="h-full w-2/5 rounded-full bg-blue-500"
+              style={{
+                animation: "browser-bar-slide 1.4s ease-in-out infinite",
+              }}
+            />
+          </div>
+        )}
+      </div>
+
+      {/* Placeholder – the native webview is positioned over this area */}
+      <div ref={placeholderRef} className="min-h-0 flex-1" />
+    </div>
+  );
+}

--- a/apps/web/src/components/DockviewWorkspaceLayout.tsx
+++ b/apps/web/src/components/DockviewWorkspaceLayout.tsx
@@ -13,8 +13,15 @@ import {
   type IDockviewPanelHeaderProps,
   type IDockviewPanelProps,
 } from "dockview";
-import { FolderOpen, GitCompare, MessageSquare, Terminal as TerminalIcon } from "lucide-react";
+import {
+  FolderOpen,
+  GitCompare,
+  Globe,
+  MessageSquare,
+  Terminal as TerminalIcon,
+} from "lucide-react";
 import { lazy, Suspense, useCallback, useEffect, useRef, useState } from "react";
+import { isTauri } from "../lib/is-tauri";
 import { trpc } from "../lib/trpc-client";
 import { CodeBrowserView } from "./CodeBrowserView";
 import { WorkspaceChatPanel } from "./WorkspaceChatPanel";
@@ -37,12 +44,14 @@ const PANEL_ICONS: Record<string, React.FC<{ className?: string }>> = {
   changes: GitCompare,
   files: FolderOpen,
   terminal: TerminalIcon,
+  ...(isTauri ? { browser: Globe } : {}),
 };
 
 const PANEL_SHORTCUTS: Record<string, string> = {
   changes: "⌘E",
   files: "⌘G",
   terminal: "⌘J",
+  ...(isTauri ? { browser: "⌘B" } : {}),
 };
 
 // ---------------------------------------------------------------------------
@@ -52,6 +61,11 @@ const PANEL_SHORTCUTS: Record<string, string> = {
 const SplitTerminalContainer = lazy(() =>
   import("./SplitTerminalContainer").then((m) => ({ default: m.SplitTerminalContainer })),
 );
+
+// Lazy-load browser panel so the Tauri webview code is never bundled for web
+const LazyBrowserPanel = isTauri
+  ? lazy(() => import("./BrowserPanel").then((m) => ({ default: m.BrowserPanelComponent })))
+  : null;
 
 // ---------------------------------------------------------------------------
 // Panel params types
@@ -254,12 +268,25 @@ function BadgeTab(props: IDockviewPanelHeaderProps) {
 // Component and tab registries
 // ---------------------------------------------------------------------------
 
+// Wrap the lazy-loaded browser panel in Suspense so it can be registered
+// as a regular dockview component.
+// biome-ignore lint/suspicious/noExplicitAny: dockview requires generic panel props
+function BrowserPanelWrapper(props: IDockviewPanelProps<any>) {
+  if (!LazyBrowserPanel) return null;
+  return (
+    <Suspense fallback={null}>
+      <LazyBrowserPanel {...props} />
+    </Suspense>
+  );
+}
+
 // biome-ignore lint/suspicious/noExplicitAny: dockview requires generic panel props
 const components: Record<string, React.FunctionComponent<IDockviewPanelProps<any>>> = {
   chat: ChatPanelComponent,
   changes: ChangesPanelComponent,
   files: FilesPanelComponent,
   terminal: TerminalPanelComponent,
+  ...(isTauri ? { browser: BrowserPanelWrapper } : {}),
 };
 
 const tabComponents: Record<string, React.FunctionComponent<IDockviewPanelHeaderProps>> = {
@@ -297,8 +324,11 @@ function useDiffFileCount(workspaceId: string, isActive: boolean): number {
 // Required panel definitions & layout persistence
 // ---------------------------------------------------------------------------
 
-/** All panels that must always be present in the layout. */
-const REQUIRED_PANEL_IDS = ["chat", "changes", "files", "terminal"] as const;
+/** All panels that must always be present in the layout.
+ *  The browser panel is only available in the Tauri desktop app. */
+const REQUIRED_PANEL_IDS = isTauri
+  ? (["chat", "changes", "files", "terminal", "browser"] as const)
+  : (["chat", "changes", "files", "terminal"] as const);
 
 // ---------------------------------------------------------------------------
 // Layout persistence: shared structure + per-workspace active tabs
@@ -612,6 +642,9 @@ export function DockviewWorkspaceLayout({
       } else if (key === "g" && !e.shiftKey && api) {
         e.preventDefault();
         api.getPanel("files")?.api.setActive();
+      } else if (key === "b" && !e.shiftKey && api && isTauri) {
+        e.preventDefault();
+        api.getPanel("browser")?.api.setActive();
       }
     };
     window.addEventListener("keydown", handler, true);
@@ -644,6 +677,9 @@ export function DockviewWorkspaceLayout({
       api.getPanel("terminal")?.api.updateParameters({
         workspaceId,
       });
+      api.getPanel("browser")?.api.updateParameters({
+        workspaceId,
+      });
     },
     [
       workspaceId,
@@ -674,6 +710,7 @@ export function DockviewWorkspaceLayout({
         changes: "Changes",
         files: "Files",
         terminal: "Terminal",
+        browser: "Browser",
       };
 
       const opts: Record<string, unknown> = {
@@ -737,6 +774,17 @@ export function DockviewWorkspaceLayout({
         position: { referencePanel: "changes", direction: "within" },
         inactive: true,
       });
+
+      if (isTauri) {
+        api.addPanel({
+          id: "browser",
+          component: "browser",
+          title: "Browser",
+          params: { workspaceId },
+          position: { referencePanel: "changes", direction: "within" },
+          inactive: true,
+        });
+      }
 
       // Set chat panel to ~50% width
       try {
@@ -839,14 +887,15 @@ export function DockviewWorkspaceLayout({
   }, [injectParams]);
 
   // Propagate workspace active state only to panels that use it (chat,
-  // terminal).  Kept separate from injectParams so that a workspace switch
-  // doesn't trigger updateParameters on all 4 panels — changes and files
+  // terminal, browser).  Kept separate from injectParams so that a workspace
+  // switch doesn't trigger updateParameters on all panels — changes and files
   // don't care about wsActive and would re-render for nothing.
   useEffect(() => {
     const api = apiRef.current;
     if (!api) return;
     api.getPanel("chat")?.api.updateParameters({ wsActive: isActive });
     api.getPanel("terminal")?.api.updateParameters({ wsActive: isActive });
+    api.getPanel("browser")?.api.updateParameters({ wsActive: isActive });
   }, [isActive]);
 
   // Force dockview to recalculate layout after becoming visible.
@@ -865,6 +914,26 @@ export function DockviewWorkspaceLayout({
       });
     }
   }, [isActive]);
+
+  // Hide the browser webview when a dialog is open (z-ordering: native webview
+  // renders on top of the React DOM, so it would cover the dialog otherwise).
+  useEffect(() => {
+    if (!isTauri) return;
+    const isDialogOpen = quickOpenOpen || searchFilesOpen;
+
+    (async () => {
+      const { invoke } = await import("@tauri-apps/api/core");
+      if (isDialogOpen) {
+        invoke("browser_hide", { workspaceId }).catch(() => {});
+      } else {
+        // Only re-show if the browser panel is currently active
+        const browserPanel = apiRef.current?.getPanel("browser");
+        if (browserPanel?.api.isActive) {
+          invoke("browser_show", { workspaceId }).catch(() => {});
+        }
+      }
+    })();
+  }, [quickOpenOpen, searchFilesOpen, workspaceId]);
 
   return (
     <>


### PR DESCRIPTION
## Summary
- Adds a browser tab to the Tauri desktop app with a native child webview, address bar (back/forward/reload/stop), URL input with auto-navigation and Google search fallback
- Per-workspace webviews — each workspace gets its own persistent browser session that survives workspace switches (hidden/shown, not destroyed/recreated)
- LRU eviction cap of 5 webviews to bound memory, with URL persistence in localStorage for seamless restore after eviction
- Browser tab conditionally excluded from the web app bundle (lazy-loaded behind `isTauri` guard)

## Test plan
- [ ] Open workspace A → browser tab → navigate to a page, scroll down
- [ ] Switch to workspace B → browser shows fresh empty view
- [ ] Switch back to A → scroll position and URL preserved
- [ ] Open 6+ workspaces with browser → oldest webview gets evicted (LRU cap)
- [ ] After eviction, switching back restores the URL from localStorage
- [ ] Reload button works, loading indicator shows during navigation
- [ ] Enter key in address bar navigates correctly
- [ ] Web app (non-Tauri) does not show browser tab
- [ ] App exit cleans up all browser webviews

🤖 Generated with [Claude Code](https://claude.com/claude-code)