### PR TITLE
feat: change file browser to a collapsible tree view

### DIFF
--- a/apps/web/src/components/CodeBrowserView.tsx
+++ b/apps/web/src/components/CodeBrowserView.tsx
@@ -45,11 +45,6 @@ interface CodeBrowserViewProps {
   onFindInFile?: (fn: (() => void) | null) => void;
 }
 
-function directoryOf(filePath: string): string {
-  const idx = filePath.lastIndexOf("/");
-  return idx > 0 ? filePath.slice(0, idx) : "";
-}
-
 export function CodeBrowserView({
   workspaceId,
   file,
@@ -59,11 +54,6 @@ export function CodeBrowserView({
   onFindInFile,
 }: CodeBrowserViewProps) {
   const isDesktop = useIsDesktop();
-  const [currentPath, setCurrentPath] = useState(() => {
-    if (!file) return "";
-    const loc = parseFileLocation(file);
-    return directoryOf(loc.filePath);
-  });
   const [viewFilePath, setViewFilePath] = useState(() => {
     if (!file) return "";
     return parseFileLocation(file).filePath;
@@ -86,7 +76,6 @@ export function CodeBrowserView({
     if (file) {
       const loc = parseFileLocation(file);
       setViewFilePath(loc.filePath);
-      setCurrentPath(directoryOf(loc.filePath));
       setViewLine(loc.line);
       setViewLineEnd(loc.lineEnd);
       setViewColumn(loc.column);
@@ -101,9 +90,6 @@ export function CodeBrowserView({
       setViewLine(loc.line);
       setViewLineEnd(loc.lineEnd);
       setViewColumn(loc.column);
-      // Navigate the file browser to the file's parent directory
-      const lastSlash = loc.filePath.lastIndexOf("/");
-      setCurrentPath(lastSlash > 0 ? loc.filePath.slice(0, lastSlash) : "");
       onFileOpened?.();
     }
   }, [openFilePath, onFileOpened]);
@@ -172,9 +158,8 @@ export function CodeBrowserView({
     return (
       <FileBrowser
         workspaceId={workspaceId}
-        currentPath={currentPath}
-        onNavigate={setCurrentPath}
         onOpenFile={handleSelectFile}
+        selectedFile={viewFilePath}
       />
     );
   }
@@ -186,8 +171,6 @@ export function CodeBrowserView({
       <div className="w-60 shrink-0 overflow-hidden border-r border-border">
         <FileBrowser
           workspaceId={workspaceId}
-          currentPath={currentPath}
-          onNavigate={setCurrentPath}
           onOpenFile={handleSelectFile}
           compact
           selectedFile={viewFilePath}

--- a/packages/dashboard-core/src/components/FileBrowser.tsx
+++ b/packages/dashboard-core/src/components/FileBrowser.tsx
@@ -1,176 +1,354 @@
-import { ChevronRight, Folder } from "lucide-react";
-import { useEffect, useRef, useState } from "react";
+import { ChevronDown, ChevronRight, Folder, FolderOpen } from "lucide-react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useAdapter } from "../context";
 import { getFileIcon } from "../lib/file-icon";
 import type { FileEntry } from "../types";
 
 interface FileBrowserProps {
   workspaceId: string;
-  currentPath: string;
-  onNavigate: (path: string) => void;
   onOpenFile: (path: string) => void;
   /** Compact mode for sidebar use — smaller items */
   compact?: boolean;
-  /** Currently selected file path for highlighting */
+  /** Currently selected file path for highlighting and auto-expand */
   selectedFile?: string;
 }
 
-export function FileBrowser({
-  workspaceId,
-  currentPath,
-  onNavigate,
+// ---------------------------------------------------------------------------
+// Module-level caches — survive re-mounts so tree state is preserved when
+// the user switches between workspaces.
+// ---------------------------------------------------------------------------
+const expandedStateCache = new Map<string, Set<string>>();
+const dirContentsCache = new Map<string, Map<string, FileEntry[]>>();
+
+function getCachedExpanded(wsId: string): Set<string> {
+  let set = expandedStateCache.get(wsId);
+  if (!set) {
+    set = new Set([""]);
+    expandedStateCache.set(wsId, set);
+  }
+  return set;
+}
+
+function getCachedContents(wsId: string): Map<string, FileEntry[]> {
+  let map = dirContentsCache.get(wsId);
+  if (!map) {
+    map = new Map();
+    dirContentsCache.set(wsId, map);
+  }
+  return map;
+}
+
+// ---------------------------------------------------------------------------
+// TreeNode — renders a single file or directory row + children recursively
+// ---------------------------------------------------------------------------
+interface TreeNodeProps {
+  entry: FileEntry;
+  parentPath: string;
+  depth: number;
+  expandedPaths: Set<string>;
+  dirContents: Map<string, FileEntry[]>;
+  loadingPaths: Set<string>;
+  onToggle: (dirPath: string) => void;
+  onOpenFile: (filePath: string) => void;
+  compact?: boolean;
+  selectedFile?: string;
+  selectedRef?: React.RefObject<HTMLButtonElement | null>;
+}
+
+function TreeNode({
+  entry,
+  parentPath,
+  depth,
+  expandedPaths,
+  dirContents,
+  loadingPaths,
+  onToggle,
   onOpenFile,
   compact,
   selectedFile,
-}: FileBrowserProps) {
-  const adapter = useAdapter();
-  const breadcrumbsRef = useRef<HTMLDivElement>(null);
-  const [entries, setEntries] = useState<FileEntry[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
+  selectedRef,
+}: TreeNodeProps) {
+  const entryPath = parentPath ? `${parentPath}/${entry.name}` : entry.name;
+  const isDir = entry.type === "directory";
+  const isExpanded = isDir && expandedPaths.has(entryPath);
+  const isSelected = !isDir && selectedFile === entryPath;
+  const isLoading = isDir && loadingPaths.has(entryPath);
+  const children = isDir ? dirContents.get(entryPath) : undefined;
 
-  useEffect(() => {
-    if (!adapter.listWorkspaceFiles) {
-      setError("File browsing not supported");
-      setLoading(false);
-      return;
-    }
+  const indent = compact ? 12 : 16;
+  const basePad = compact ? 4 : 8;
 
-    let cancelled = false;
-    setLoading(true);
-    setError(null);
-
-    adapter
-      .listWorkspaceFiles(workspaceId, currentPath)
-      .then((result) => {
-        if (!cancelled) setEntries(result.entries);
-      })
-      .catch((err) => {
-        if (!cancelled) setError(err instanceof Error ? err.message : "Failed to list files");
-      })
-      .finally(() => {
-        if (!cancelled) setLoading(false);
-      });
-    return () => {
-      cancelled = true;
-    };
-  }, [adapter, workspaceId, currentPath]);
-
-  const breadcrumbs = currentPath ? currentPath.split("/") : [];
-
-  // Scroll breadcrumbs to the end so the current folder is visible
-  // biome-ignore lint/correctness/useExhaustiveDependencies: scroll when path changes
-  useEffect(() => {
-    const el = breadcrumbsRef.current;
-    if (el) {
-      el.scrollLeft = el.scrollWidth;
-    }
-  }, [currentPath]);
-
-  const handleBreadcrumb = (index: number) => {
-    if (index < 0) {
-      onNavigate("");
-    } else {
-      onNavigate(breadcrumbs.slice(0, index + 1).join("/"));
-    }
-  };
-
-  const handleClick = (entry: FileEntry) => {
-    const entryPath = currentPath ? `${currentPath}/${entry.name}` : entry.name;
-    if (entry.type === "directory") {
-      onNavigate(entryPath);
+  const handleClick = () => {
+    if (isDir) {
+      onToggle(entryPath);
     } else {
       onOpenFile(entryPath);
     }
   };
 
   return (
-    <div className="flex h-full flex-col overflow-hidden">
-      {/* Breadcrumbs */}
-      <div
-        ref={breadcrumbsRef}
-        className={`flex shrink-0 items-center gap-1 overflow-x-auto border-b border-border/50 text-xs [scrollbar-width:none] [&::-webkit-scrollbar]:hidden ${compact ? "h-9 px-2" : "px-4 py-2"}`}
+    <>
+      <button
+        ref={isSelected ? selectedRef : undefined}
+        type="button"
+        onClick={handleClick}
+        className={`flex w-full items-center text-left hover:bg-accent/50 ${
+          compact ? "h-[26px] gap-1 pr-3 text-xs" : "h-[30px] gap-1.5 pr-4 text-sm"
+        } ${isSelected ? "bg-accent text-accent-foreground" : ""}`}
+        style={{ paddingLeft: `${depth * indent + basePad}px` }}
       >
-        <button
-          type="button"
-          onClick={() => handleBreadcrumb(-1)}
-          className={`shrink-0 ${currentPath ? "text-muted-foreground hover:text-foreground" : "font-medium text-foreground"}`}
-        >
-          root
-        </button>
-        {breadcrumbs.map((segment, i) => (
-          <span
-            key={breadcrumbs.slice(0, i + 1).join("/")}
-            className="flex shrink-0 items-center gap-1"
-          >
-            <ChevronRight className="size-3 text-muted-foreground/50" />
-            <button
-              type="button"
-              onClick={() => handleBreadcrumb(i)}
-              className={`shrink-0 ${
-                i === breadcrumbs.length - 1
-                  ? "font-medium text-foreground"
-                  : "text-muted-foreground hover:text-foreground"
-              }`}
-            >
-              {segment}
-            </button>
-          </span>
-        ))}
-      </div>
+        {/* Chevron / spacer */}
+        {isDir ? (
+          isExpanded ? (
+            <ChevronDown className="size-3.5 shrink-0 text-muted-foreground/70" />
+          ) : (
+            <ChevronRight className="size-3.5 shrink-0 text-muted-foreground/70" />
+          )
+        ) : (
+          <span className="size-3.5 shrink-0" />
+        )}
 
-      {/* File list */}
-      <div className="min-h-0 flex-1 overflow-y-auto">
-        {loading && (
+        {/* Icon */}
+        {isDir ? (
+          isExpanded ? (
+            <FolderOpen className="size-4 shrink-0 text-blue-600 dark:text-blue-400" />
+          ) : (
+            <Folder className="size-4 shrink-0 text-blue-600 dark:text-blue-400" />
+          )
+        ) : (
+          (() => {
+            const FileIcon = getFileIcon(entry.name);
+            return <FileIcon className="size-4 shrink-0 text-muted-foreground" />;
+          })()
+        )}
+
+        {/* Name */}
+        <span className="min-w-0 flex-1 truncate">{entry.name}</span>
+      </button>
+
+      {/* Children — rendered when directory is expanded */}
+      {isExpanded && (
+        <>
+          {isLoading && !children?.length && (
+            <div
+              className="flex items-center text-xs text-muted-foreground/70"
+              style={{
+                paddingLeft: `${(depth + 1) * indent + basePad + 18}px`,
+                height: compact ? 26 : 30,
+              }}
+            >
+              Loading…
+            </div>
+          )}
+          {!isLoading && children && children.length === 0 && (
+            <div
+              className="flex items-center text-xs italic text-muted-foreground/50"
+              style={{
+                paddingLeft: `${(depth + 1) * indent + basePad + 18}px`,
+                height: compact ? 26 : 30,
+              }}
+            >
+              Empty
+            </div>
+          )}
+          {children?.map((child) => (
+            <TreeNode
+              key={child.name}
+              entry={child}
+              parentPath={entryPath}
+              depth={depth + 1}
+              expandedPaths={expandedPaths}
+              dirContents={dirContents}
+              loadingPaths={loadingPaths}
+              onToggle={onToggle}
+              onOpenFile={onOpenFile}
+              compact={compact}
+              selectedFile={selectedFile}
+              selectedRef={selectedRef}
+            />
+          ))}
+        </>
+      )}
+    </>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// FileBrowser — tree root, manages state & data fetching
+// ---------------------------------------------------------------------------
+export function FileBrowser({ workspaceId, onOpenFile, compact, selectedFile }: FileBrowserProps) {
+  const adapter = useAdapter();
+
+  // React state mirroring the module-level caches so changes trigger renders
+  const [expandedPaths, setExpandedPaths] = useState<Set<string>>(
+    () => new Set(getCachedExpanded(workspaceId)),
+  );
+  const [dirContents, setDirContents] = useState<Map<string, FileEntry[]>>(
+    () => new Map(getCachedContents(workspaceId)),
+  );
+  const [loadingPaths, setLoadingPaths] = useState<Set<string>>(new Set());
+
+  // Ref for scrolling the selected file into view
+  const selectedRef = useRef<HTMLButtonElement>(null);
+
+  // Track workspace switches — restore cached state
+  const prevWorkspaceRef = useRef(workspaceId);
+  useEffect(() => {
+    if (prevWorkspaceRef.current !== workspaceId) {
+      prevWorkspaceRef.current = workspaceId;
+      setExpandedPaths(new Set(getCachedExpanded(workspaceId)));
+      setDirContents(new Map(getCachedContents(workspaceId)));
+      setLoadingPaths(new Set());
+    }
+  }, [workspaceId]);
+
+  // ------- Fetch helpers -------
+  const fetchDir = useCallback(
+    async (dirPath: string): Promise<void> => {
+      if (!adapter.listWorkspaceFiles) return;
+
+      const cache = getCachedContents(workspaceId);
+      if (cache.has(dirPath)) {
+        // Already fetched — make sure React state includes it
+        setDirContents((prev) => (prev.has(dirPath) ? prev : new Map(cache)));
+        return;
+      }
+
+      setLoadingPaths((prev) => new Set(prev).add(dirPath));
+
+      try {
+        const result = await adapter.listWorkspaceFiles(workspaceId, dirPath);
+        cache.set(dirPath, result.entries);
+        setDirContents(new Map(cache));
+      } catch {
+        // Individual directory failures are silently ignored — the folder
+        // will simply show as empty or won't expand.
+      } finally {
+        setLoadingPaths((prev) => {
+          const next = new Set(prev);
+          next.delete(dirPath);
+          return next;
+        });
+      }
+    },
+    [adapter, workspaceId],
+  );
+
+  // Load root on mount / workspace change
+  useEffect(() => {
+    fetchDir("");
+  }, [fetchDir]);
+
+  // ------- Auto-expand to selected file -------
+  const prevSelectedRef = useRef<string | undefined>(undefined);
+
+  useEffect(() => {
+    if (!selectedFile || selectedFile === prevSelectedRef.current) {
+      prevSelectedRef.current = selectedFile;
+      return;
+    }
+    prevSelectedRef.current = selectedFile;
+
+    // Compute all parent directories that need to be expanded
+    const parts = selectedFile.split("/");
+    const dirsToExpand: string[] = [""];
+    for (let i = 0; i < parts.length - 1; i++) {
+      dirsToExpand.push(parts.slice(0, i + 1).join("/"));
+    }
+
+    const cached = getCachedExpanded(workspaceId);
+    let changed = false;
+    for (const dir of dirsToExpand) {
+      if (!cached.has(dir)) {
+        cached.add(dir);
+        changed = true;
+      }
+    }
+
+    if (changed) {
+      expandedStateCache.set(workspaceId, new Set(cached));
+      setExpandedPaths(new Set(cached));
+    }
+
+    // Fetch any directories whose contents haven't been loaded yet
+    for (const dir of dirsToExpand) {
+      fetchDir(dir);
+    }
+  }, [selectedFile, workspaceId, fetchDir]);
+
+  // Scroll to selected file after tree updates
+  // biome-ignore lint/correctness/useExhaustiveDependencies: scroll after tree settles for new selection
+  useEffect(() => {
+    if (selectedFile && selectedRef.current) {
+      // Small delay so the DOM has settled after lazy-loaded children render
+      const timer = setTimeout(() => {
+        selectedRef.current?.scrollIntoView({ block: "nearest" });
+      }, 50);
+      return () => clearTimeout(timer);
+    }
+  }, [selectedFile, dirContents]);
+
+  // ------- Toggle expand/collapse -------
+  const toggleExpand = useCallback(
+    (dirPath: string) => {
+      setExpandedPaths((prev) => {
+        const next = new Set(prev);
+        if (next.has(dirPath)) {
+          next.delete(dirPath);
+        } else {
+          next.add(dirPath);
+        }
+        expandedStateCache.set(workspaceId, new Set(next));
+        return next;
+      });
+
+      // Fetch if not yet loaded
+      fetchDir(dirPath);
+    },
+    [workspaceId, fetchDir],
+  );
+
+  // ------- Render -------
+  if (!adapter.listWorkspaceFiles) {
+    return (
+      <div className="flex h-32 items-center justify-center text-sm text-muted-foreground">
+        File browsing not supported
+      </div>
+    );
+  }
+
+  const rootEntries = dirContents.get("") ?? [];
+  const rootLoading = loadingPaths.has("");
+
+  return (
+    <div className="flex h-full flex-col overflow-hidden">
+      <div className="min-h-0 flex-1 overflow-y-auto py-1">
+        {rootLoading && rootEntries.length === 0 && (
           <div className="flex h-32 items-center justify-center text-sm text-muted-foreground">
-            Loading...
+            Loading…
           </div>
         )}
-        {error && (
-          <div className="flex h-32 items-center justify-center text-sm text-destructive">
-            {error}
-          </div>
-        )}
-        {!loading && !error && entries.length === 0 && (
+        {!rootLoading && rootEntries.length === 0 && (
           <div className="flex h-32 items-center justify-center text-sm text-muted-foreground">
             Empty directory
           </div>
         )}
-        {!loading &&
-          !error &&
-          entries.map((entry) => {
-            const entryPath = currentPath ? `${currentPath}/${entry.name}` : entry.name;
-            const isSelected = entry.type === "file" && selectedFile === entryPath;
-            return (
-              <button
-                key={entry.name}
-                type="button"
-                onClick={() => handleClick(entry)}
-                className={`flex w-full items-center text-left hover:bg-accent/50 ${
-                  compact ? "gap-2 px-3 py-2 text-sm" : "gap-3 px-4 py-2.5 text-sm"
-                } ${isSelected ? "bg-accent/50 text-foreground" : ""}`}
-              >
-                {entry.type === "directory" ? (
-                  <Folder
-                    className={`shrink-0 text-blue-600 dark:text-blue-400 ${compact ? "size-4" : "size-4"}`}
-                  />
-                ) : (
-                  (() => {
-                    const FileIcon = getFileIcon(entry.name);
-                    return (
-                      <FileIcon
-                        className={`shrink-0 text-muted-foreground ${compact ? "size-4" : "size-4"}`}
-                      />
-                    );
-                  })()
-                )}
-                <span className="min-w-0 flex-1 truncate">{entry.name}</span>
-                {!compact && entry.type === "directory" && (
-                  <ChevronRight className="size-3.5 shrink-0 text-muted-foreground/50" />
-                )}
-              </button>
-            );
-          })}
+        {rootEntries.map((entry) => (
+          <TreeNode
+            key={entry.name}
+            entry={entry}
+            parentPath=""
+            depth={0}
+            expandedPaths={expandedPaths}
+            dirContents={dirContents}
+            loadingPaths={loadingPaths}
+            onToggle={toggleExpand}
+            onOpenFile={onOpenFile}
+            compact={compact}
+            selectedFile={selectedFile}
+            selectedRef={selectedRef}
+          />
+        ))}
       </div>
     </div>
   );


### PR DESCRIPTION
Closes #242

## Summary

- Replace the flat file list + breadcrumb navigation with a proper **collapsible tree view** that reflects the directory hierarchy (like VS Code's explorer)
- Directories show expand/collapse chevrons and folder icons; files show type-specific icons
- Directory contents are **lazy-loaded** on first expand via the existing `listWorkspaceFiles` API
- **Tree state (expanded/collapsed folders) is preserved** when switching between workspaces using module-level caches keyed by workspace ID
- Selected files are **auto-expanded** and scrolled into view (e.g. from Quick Open or search)

## Test plan

- [ ] Open the code browser — root directory entries load as a tree
- [ ] Click a folder to expand it; click again to collapse
- [ ] Verify indentation increases with nesting depth
- [ ] Confirm folder icons change between closed/open states
- [ ] Select a file — verify it highlights in the tree
- [ ] Use Quick Open to jump to a deeply nested file — tree auto-expands
- [ ] Switch to a different workspace and back — expanded folders are preserved
- [ ] Test on mobile layout — tree works without sidebar mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)