### PR TITLE
fix: open external links from chat in system browser (#241)

### DIFF
--- a/apps/web/src/components/CodeBrowserView.tsx
+++ b/apps/web/src/components/CodeBrowserView.tsx
@@ -14,6 +14,7 @@ import { File } from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { Streamdown } from "streamdown";
 import { useIsDesktop } from "../hooks/useIsDesktop";
+import { streamdownComponents } from "./streamdown-components";
 
 const streamdownPlugins = { cjk, code, math, mermaid };
 
@@ -25,6 +26,7 @@ function renderMarkdown(content: string) {
         "[&>*:first-child]:mt-0 [&>*:last-child]:mb-0",
       )}
       plugins={streamdownPlugins}
+      components={streamdownComponents}
     >
       {content}
     </Streamdown>

--- a/apps/web/src/components/TerminalPanel.tsx
+++ b/apps/web/src/components/TerminalPanel.tsx
@@ -1,7 +1,7 @@
 import type { FitAddon } from "@xterm/addon-fit";
 import type { Terminal } from "@xterm/xterm";
 import { useEffect, useRef } from "react";
-import { isTauri } from "../lib/is-tauri";
+import { openExternalUrl } from "../lib/open-external-url";
 
 interface TerminalPanelProps {
   workspaceId: string;
@@ -49,17 +49,7 @@ export function TerminalPanel({ workspaceId, terminalId, visible }: TerminalPane
       const fitAddon = new XFitAddon();
       terminal.loadAddon(fitAddon);
       terminal.loadAddon(
-        new XWebLinksAddon((_event, uri) => {
-          // In Tauri, window.open() doesn't open the system browser.
-          // Use the shell plugin to open URLs externally.
-          if (isTauri) {
-            import("@tauri-apps/plugin-shell")
-              .then(({ open }) => open(uri))
-              .catch(() => window.open(uri));
-          } else {
-            window.open(uri, "_blank", "noopener");
-          }
-        }),
+        new XWebLinksAddon((_event, uri) => openExternalUrl(uri)),
       );
       terminal.open(containerRef.current!);
 

--- a/apps/web/src/components/TerminalPanel.tsx
+++ b/apps/web/src/components/TerminalPanel.tsx
@@ -48,9 +48,7 @@ export function TerminalPanel({ workspaceId, terminalId, visible }: TerminalPane
 
       const fitAddon = new XFitAddon();
       terminal.loadAddon(fitAddon);
-      terminal.loadAddon(
-        new XWebLinksAddon((_event, uri) => openExternalUrl(uri)),
-      );
+      terminal.loadAddon(new XWebLinksAddon((_event, uri) => openExternalUrl(uri)));
       terminal.open(containerRef.current!);
 
       // Alt+Arrow → word navigation (send ESC+b / ESC+f that shells understand)

--- a/apps/web/src/components/ai-elements/message.tsx
+++ b/apps/web/src/components/ai-elements/message.tsx
@@ -9,6 +9,7 @@ import type { ComponentProps, HTMLAttributes } from "react";
 import { memo, useCallback, useState } from "react";
 import { Streamdown } from "streamdown";
 
+import { streamdownComponents } from "../streamdown-components";
 import { FilePreviewOverlay } from "./file-preview-overlay";
 import { downloadFile, isTextMediaType } from "./file-preview-utils";
 
@@ -56,6 +57,7 @@ export const MessageResponse = memo(
         className,
       )}
       plugins={streamdownPlugins}
+      components={streamdownComponents}
       {...props}
     />
   ),

--- a/apps/web/src/components/streamdown-components.tsx
+++ b/apps/web/src/components/streamdown-components.tsx
@@ -1,0 +1,33 @@
+import type { AnchorHTMLAttributes } from "react";
+import { openExternalUrl } from "../lib/open-external-url";
+
+/**
+ * Custom `<a>` element for Streamdown that opens external links in the system
+ * browser rather than navigating the Tauri webview.
+ *
+ * Pass this via the Streamdown `components` prop:
+ *
+ *   <Streamdown components={streamdownComponents} ... />
+ */
+function ExternalLink({
+  href,
+  children,
+  node: _node,
+  ...props
+}: AnchorHTMLAttributes<HTMLAnchorElement> & { node?: unknown }) {
+  const handleClick = (e: React.MouseEvent<HTMLAnchorElement>) => {
+    if (href) {
+      e.preventDefault();
+      openExternalUrl(href);
+    }
+  };
+
+  return (
+    <a href={href} target="_blank" rel="noopener noreferrer" onClick={handleClick} {...props}>
+      {children}
+    </a>
+  );
+}
+
+/** Shared Streamdown component overrides. */
+export const streamdownComponents = { a: ExternalLink };

--- a/apps/web/src/lib/open-external-url.ts
+++ b/apps/web/src/lib/open-external-url.ts
@@ -11,9 +11,7 @@ import { isTauri } from "./is-tauri";
  */
 export function openExternalUrl(url: string): void {
   if (isTauri) {
-    import("@tauri-apps/plugin-shell")
-      .then(({ open }) => open(url))
-      .catch(() => window.open(url));
+    import("@tauri-apps/plugin-shell").then(({ open }) => open(url)).catch(() => window.open(url));
   } else {
     window.open(url, "_blank", "noopener");
   }

--- a/apps/web/src/lib/open-external-url.ts
+++ b/apps/web/src/lib/open-external-url.ts
@@ -1,0 +1,20 @@
+import { isTauri } from "./is-tauri";
+
+/**
+ * Opens a URL in the system browser.
+ *
+ * In Tauri, `window.open()` navigates the webview instead of opening the
+ * user's default browser.  We use the `@tauri-apps/plugin-shell` `open()`
+ * function for proper behaviour and fall back to `window.open()` on failure.
+ *
+ * In a regular web context, `window.open()` works as expected.
+ */
+export function openExternalUrl(url: string): void {
+  if (isTauri) {
+    import("@tauri-apps/plugin-shell")
+      .then(({ open }) => open(url))
+      .catch(() => window.open(url));
+  } else {
+    window.open(url, "_blank", "noopener");
+  }
+}


### PR DESCRIPTION
## Summary

Fixes #241 — external links in chat messages and the code browser did not open in the system browser when running in Tauri full editor mode.

- Extracted the Tauri `@tauri-apps/plugin-shell` open logic from `TerminalPanel` into a shared `openExternalUrl` utility
- Created a custom Streamdown `<a>` component that intercepts clicks and delegates to `openExternalUrl`
- Applied the custom component to both `MessageResponse` (chat) and `CodeBrowserView` (markdown preview)

## Test plan

- [ ] In Tauri full editor mode, have the agent return a message with an external link (e.g. GitHub URL)
- [ ] Click the link — it should open in the system browser
- [ ] Verify terminal links still work as before
- [ ] Verify links in the code browser markdown preview open externally
- [ ] In web browser mode, verify links still open in a new tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)