### PR TITLE
feat: make project list sidebar resizable (#244)

### DIFF
--- a/apps/web/src/components/DesktopLayout.tsx
+++ b/apps/web/src/components/DesktopLayout.tsx
@@ -4,9 +4,9 @@ import { type ReactNode, useCallback, useRef } from "react";
 import { Group, Panel, Separator } from "react-resizable-panels";
 import {
   loadSidebarWidth,
-  saveSidebarWidth,
   SIDEBAR_MAX_SIZE,
   SIDEBAR_MIN_SIZE,
+  saveSidebarWidth,
 } from "../lib/sidebar-width";
 
 interface DesktopLayoutProps {
@@ -34,7 +34,14 @@ export function DesktopLayout({ toolbarExtra }: DesktopLayoutProps) {
         defaultLayout={defaultLayout}
         onLayoutChanged={handleSidebarResize}
       >
-        <Panel id="sidebar" defaultSize={SIDEBAR_MIN_SIZE} minSize={SIDEBAR_MIN_SIZE} maxSize={SIDEBAR_MAX_SIZE} collapsible collapsedSize="0%">
+        <Panel
+          id="sidebar"
+          defaultSize={SIDEBAR_MIN_SIZE}
+          minSize={SIDEBAR_MIN_SIZE}
+          maxSize={SIDEBAR_MAX_SIZE}
+          collapsible
+          collapsedSize="0%"
+        >
           <div className="h-full border-r border-border overflow-hidden">
             <DashboardShell toolbarExtra={toolbarExtra} />
           </div>

--- a/apps/web/src/components/DesktopLayout.tsx
+++ b/apps/web/src/components/DesktopLayout.tsx
@@ -1,28 +1,57 @@
 import { DashboardShell } from "@band-app/dashboard-core";
 import { MessageSquare } from "lucide-react";
-import type { ReactNode } from "react";
+import { type ReactNode, useCallback, useRef } from "react";
+import { Group, Panel, Separator } from "react-resizable-panels";
+import {
+  loadSidebarWidth,
+  saveSidebarWidth,
+  SIDEBAR_MAX_SIZE,
+  SIDEBAR_MIN_SIZE,
+} from "../lib/sidebar-width";
 
 interface DesktopLayoutProps {
   toolbarExtra?: ReactNode;
 }
 
 export function DesktopLayout({ toolbarExtra }: DesktopLayoutProps) {
+  const savedWidth = loadSidebarWidth();
+  const defaultLayout = savedWidth ? { sidebar: savedWidth, main: 100 - savedWidth } : undefined;
+  const skipFirstLayoutCallback = useRef(true);
+  const handleSidebarResize = useCallback((layout: Record<string, number>) => {
+    if (skipFirstLayoutCallback.current) {
+      skipFirstLayoutCallback.current = false;
+      return;
+    }
+    if (layout.sidebar != null) {
+      saveSidebarWidth(layout.sidebar);
+    }
+  }, []);
+
   return (
     <div className="flex h-dvh w-full overflow-hidden bg-background text-foreground">
-      {/* Left Panel — Project List */}
-      <div className="w-80 shrink-0 border-r border-border overflow-hidden">
-        <DashboardShell toolbarExtra={toolbarExtra} />
-      </div>
-
-      {/* Empty state — no workspace selected */}
-      <div className="flex-1 min-w-0 overflow-hidden">
-        <div className="flex h-full items-center justify-center">
-          <div className="flex flex-col items-center gap-3 text-center px-8">
-            <MessageSquare className="size-8 text-muted-foreground/30" />
-            <p className="text-sm text-muted-foreground">Select a workspace to get started</p>
+      <Group
+        orientation="horizontal"
+        defaultLayout={defaultLayout}
+        onLayoutChanged={handleSidebarResize}
+      >
+        <Panel id="sidebar" defaultSize={SIDEBAR_MIN_SIZE} minSize={SIDEBAR_MIN_SIZE} maxSize={SIDEBAR_MAX_SIZE} collapsible collapsedSize="0%">
+          <div className="h-full border-r border-border overflow-hidden">
+            <DashboardShell toolbarExtra={toolbarExtra} />
           </div>
-        </div>
-      </div>
+        </Panel>
+        <Separator className="w-[3px] bg-transparent hover:bg-accent-foreground/20 active:bg-accent-foreground/30 transition-colors cursor-col-resize" />
+        <Panel id="main" minSize="20%">
+          {/* Empty state — no workspace selected */}
+          <div className="flex-1 min-w-0 overflow-hidden">
+            <div className="flex h-full items-center justify-center">
+              <div className="flex flex-col items-center gap-3 text-center px-8">
+                <MessageSquare className="size-8 text-muted-foreground/30" />
+                <p className="text-sm text-muted-foreground">Select a workspace to get started</p>
+              </div>
+            </div>
+          </div>
+        </Panel>
+      </Group>
     </div>
   );
 }

--- a/apps/web/src/components/TauriTitleBar.tsx
+++ b/apps/web/src/components/TauriTitleBar.tsx
@@ -1,3 +1,4 @@
+import { PanelLeftClose, PanelLeftOpen } from "lucide-react";
 import { type RefObject, useEffect, useRef, useState } from "react";
 
 /** Attaches a native mousedown → startDragging listener to a ref. */
@@ -24,10 +25,14 @@ function useTauriDrag(ref: RefObject<HTMLElement | null>) {
 interface TauriTitleBarProps {
   /** Static title. If omitted, fetches the app title from Tauri. */
   title?: string;
+  /** Callback to toggle the sidebar. When provided, a toggle button is shown. */
+  onToggleSidebar?: () => void;
+  /** Whether the sidebar is currently collapsed. */
+  sidebarCollapsed?: boolean;
 }
 
 /** Draggable Tauri title bar that works with external-URL webviews. */
-export function TauriTitleBar({ title }: TauriTitleBarProps) {
+export function TauriTitleBar({ title, onToggleSidebar, sidebarCollapsed }: TauriTitleBarProps) {
   const [appTitle, setAppTitle] = useState(title ?? "Band");
   const ref = useRef<HTMLDivElement>(null);
 
@@ -44,8 +49,22 @@ export function TauriTitleBar({ title }: TauriTitleBarProps) {
     <div
       ref={ref}
       data-tauri-drag-region
-      className="h-[28px] shrink-0 flex items-center justify-center"
+      className="h-[28px] shrink-0 flex items-center justify-center relative"
     >
+      {onToggleSidebar && (
+        <button
+          type="button"
+          onClick={onToggleSidebar}
+          className="absolute left-[70px] top-1/2 -translate-y-1/2 flex items-center justify-center rounded p-0.5 text-muted-foreground hover:text-foreground hover:bg-accent/50 transition-colors"
+          title={sidebarCollapsed ? "Show sidebar" : "Hide sidebar"}
+        >
+          {sidebarCollapsed ? (
+            <PanelLeftOpen className="size-3.5" />
+          ) : (
+            <PanelLeftClose className="size-3.5" />
+          )}
+        </button>
+      )}
       <span className="text-xs font-medium text-muted-foreground select-none pointer-events-none">
         {appTitle}
       </span>

--- a/apps/web/src/lib/sidebar-width.ts
+++ b/apps/web/src/lib/sidebar-width.ts
@@ -1,0 +1,30 @@
+const SIDEBAR_WIDTH_KEY = "band:sidebar-width";
+
+/**
+ * Load the persisted sidebar width as a percentage (0–100).
+ * Falls back to null if nothing is stored yet.
+ */
+export function loadSidebarWidth(): number | null {
+  try {
+    const stored = localStorage.getItem(SIDEBAR_WIDTH_KEY);
+    if (stored) {
+      const parsed = Number.parseFloat(stored);
+      if (!Number.isNaN(parsed) && parsed > 0 && parsed < 100) {
+        return parsed;
+      }
+    }
+  } catch {}
+  return null;
+}
+
+export function saveSidebarWidth(width: number): void {
+  try {
+    localStorage.setItem(SIDEBAR_WIDTH_KEY, String(width));
+  } catch {}
+}
+
+/** Minimum sidebar size — matches the original fixed w-80 (320px / 20rem) width */
+export const SIDEBAR_MIN_SIZE = "20rem";
+
+/** Maximum sidebar size as a percentage string (numbers are treated as px by react-resizable-panels) */
+export const SIDEBAR_MAX_SIZE = "60%";

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -14,13 +14,20 @@ import {
   useRouter,
   useRouterState,
 } from "@tanstack/react-router";
-import { useCallback, useEffect } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { Group, Panel, Separator, usePanelRef } from "react-resizable-panels";
 import { DockviewInstanceManager } from "../components/DockviewInstanceManager";
 import { TauriTitleBar } from "../components/TauriTitleBar";
 import { ToolbarButtons } from "../components/ToolbarButtons";
 import { useIsDesktop } from "../hooks/useIsDesktop";
 import { useNavigationHistory } from "../hooks/useNavigationHistory";
 import { isTauri } from "../lib/is-tauri";
+import {
+  loadSidebarWidth,
+  saveSidebarWidth,
+  SIDEBAR_MAX_SIZE,
+  SIDEBAR_MIN_SIZE,
+} from "../lib/sidebar-width";
 import "../styles/globals.css";
 
 const adapter = isTauri ? new HybridDashboardAdapter() : new WebDashboardAdapter();
@@ -163,6 +170,37 @@ function AppShell() {
   const routerNavigate = useCallback((href: string) => router.navigate({ to: href }), [router]);
   useNavigationHistory(routerNavigate, capabilities);
 
+  // Resizable sidebar: load persisted width and skip the first layout callback
+  // (react-resizable-panels fires it on mount with a computed layout that may
+  // differ from the default before the container has its final CSS dimensions).
+  const savedWidth = loadSidebarWidth();
+  const defaultLayout = savedWidth ? { sidebar: savedWidth, main: 100 - savedWidth } : undefined;
+  const skipFirstLayoutCallback = useRef(true);
+  const handleSidebarResize = useCallback((layout: Record<string, number>) => {
+    if (skipFirstLayoutCallback.current) {
+      skipFirstLayoutCallback.current = false;
+      return;
+    }
+    if (layout.sidebar != null) {
+      saveSidebarWidth(layout.sidebar);
+    }
+  }, []);
+
+  // Collapsible sidebar (Tauri title bar toggle)
+  const sidebarPanelRef = usePanelRef();
+  const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
+  const toggleSidebar = useCallback(() => {
+    const panel = sidebarPanelRef.current;
+    if (!panel) return;
+    if (panel.isCollapsed()) {
+      panel.expand();
+    } else {
+      panel.collapse();
+    }
+  }, [sidebarPanelRef]);
+  const handleSidebarCollapse = useCallback(() => setSidebarCollapsed(true), []);
+  const handleSidebarExpand = useCallback(() => setSidebarCollapsed(false), []);
+
   if (!isDesktop || isStandalone) {
     return <Outlet />;
   }
@@ -171,15 +209,43 @@ function AppShell() {
 
   return (
     <div className="flex flex-col h-dvh w-full overflow-hidden bg-background text-foreground">
-      {isTauriFullEditor && <TauriTitleBar />}
-      <div className="flex flex-1 min-h-0 overflow-hidden">
-        <div className="w-80 shrink-0 border-r border-border overflow-hidden">
-          <DashboardShell toolbarExtra={<ToolbarButtons />} hideTitleBar={isTauriFullEditor} />
-        </div>
-        <div className="flex-1 min-w-0 overflow-hidden relative">
-          <Outlet />
-          <DockviewInstanceManager />
-        </div>
+      {isTauriFullEditor && (
+        <TauriTitleBar
+          onToggleSidebar={toggleSidebar}
+          sidebarCollapsed={sidebarCollapsed}
+        />
+      )}
+      <div className="flex-1 min-h-0 overflow-hidden">
+        <Group
+          orientation="horizontal"
+          defaultLayout={defaultLayout}
+          onLayoutChanged={handleSidebarResize}
+        >
+          <Panel
+            id="sidebar"
+            defaultSize={SIDEBAR_MIN_SIZE}
+            minSize={SIDEBAR_MIN_SIZE}
+            maxSize={SIDEBAR_MAX_SIZE}
+            collapsible
+            collapsedSize="0%"
+            panelRef={sidebarPanelRef}
+            onResize={(size) => {
+              if (size.asPercentage === 0) handleSidebarCollapse();
+              else handleSidebarExpand();
+            }}
+          >
+            <div className="h-full border-r border-border overflow-hidden">
+              <DashboardShell toolbarExtra={<ToolbarButtons />} hideTitleBar={isTauriFullEditor} />
+            </div>
+          </Panel>
+          <Separator className="w-[3px] bg-transparent hover:bg-accent-foreground/20 active:bg-accent-foreground/30 transition-colors cursor-col-resize" />
+          <Panel id="main" minSize="20%">
+            <div className="h-full min-w-0 overflow-hidden relative">
+              <Outlet />
+              <DockviewInstanceManager />
+            </div>
+          </Panel>
+        </Group>
       </div>
     </div>
   );

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -24,9 +24,9 @@ import { useNavigationHistory } from "../hooks/useNavigationHistory";
 import { isTauri } from "../lib/is-tauri";
 import {
   loadSidebarWidth,
-  saveSidebarWidth,
   SIDEBAR_MAX_SIZE,
   SIDEBAR_MIN_SIZE,
+  saveSidebarWidth,
 } from "../lib/sidebar-width";
 import "../styles/globals.css";
 
@@ -210,10 +210,7 @@ function AppShell() {
   return (
     <div className="flex flex-col h-dvh w-full overflow-hidden bg-background text-foreground">
       {isTauriFullEditor && (
-        <TauriTitleBar
-          onToggleSidebar={toggleSidebar}
-          sidebarCollapsed={sidebarCollapsed}
-        />
+        <TauriTitleBar onToggleSidebar={toggleSidebar} sidebarCollapsed={sidebarCollapsed} />
       )}
       <div className="flex-1 min-h-0 overflow-hidden">
         <Group


### PR DESCRIPTION
## Summary
- Replace fixed `w-80` sidebar with `react-resizable-panels` for drag-to-resize
- Default/min width: 320px (20rem), matching the original; max width: 60%
- Sidebar collapses fully when dragged below minimum
- Tauri full-editor mode: toggle button in the title bar to collapse/expand
- Width persisted to localStorage across sessions

Closes #244

## Test plan
- [ ] Resize sidebar by dragging the right edge in both browser and Tauri
- [ ] Verify sidebar starts at 320px (original width)
- [ ] Drag below minimum to verify it collapses
- [ ] Refresh page and verify persisted width is restored
- [ ] In Tauri full-editor mode, verify toggle button in title bar collapses/expands sidebar
- [ ] Verify toggle button is positioned to the right of macOS traffic lights

🤖 Generated with [Claude Code](https://claude.com/claude-code)