### PR TITLE
feat: make file browser editable with save support

### DIFF
--- a/apps/web/src/components/CodeBrowserView.tsx
+++ b/apps/web/src/components/CodeBrowserView.tsx
@@ -152,6 +152,7 @@ export function CodeBrowserView({
           column={viewColumn}
           onBack={handleBack}
           renderMarkdown={renderMarkdown}
+          editable
         />
       );
     }
@@ -188,6 +189,7 @@ export function CodeBrowserView({
             column={viewColumn}
             onEditorView={handleEditorView}
             renderMarkdown={renderMarkdown}
+            editable
             toolbar={
               search.searchOpen ? (
                 <SearchBar

--- a/apps/web/src/trpc/router.ts
+++ b/apps/web/src/trpc/router.ts
@@ -892,6 +892,37 @@ const workspaceRouter = t.router({
       };
     }),
 
+  saveFile: publicProcedure
+    .input(
+      z.object({
+        workspaceId: z.string(),
+        path: z.string().min(1),
+        content: z.string(),
+      }),
+    )
+    .mutation(async ({ input }) => {
+      const workspace = resolveWorkspace(input.workspaceId);
+      if (!workspace) {
+        throw new Error("Workspace not found");
+      }
+
+      const root = workspace.worktree.path;
+      const target = resolve(join(root, input.path));
+
+      if (!target.startsWith(root)) {
+        throw new Error("Invalid path");
+      }
+
+      const fileStat = await stat(target);
+      if (fileStat.isDirectory()) {
+        throw new Error("Cannot write to a directory");
+      }
+
+      await writeFile(target, input.content, "utf-8");
+
+      return { ok: true };
+    }),
+
   searchFiles: publicProcedure
     .input(
       z.object({

--- a/packages/dashboard-core/src/adapter.ts
+++ b/packages/dashboard-core/src/adapter.ts
@@ -85,6 +85,7 @@ export interface DashboardAdapter {
   ): Promise<FileDiffResult>;
   listWorkspaceFiles?(workspaceId: string, path: string): Promise<FileListResult>;
   getWorkspaceFile?(workspaceId: string, path: string): Promise<FileContentResult>;
+  saveWorkspaceFile?(workspaceId: string, path: string, content: string): Promise<void>;
 
   /** Get a URL for raw file content (images, PDFs, etc.) */
   getWorkspaceFileUrl?(workspaceId: string, path: string): string;

--- a/packages/dashboard-core/src/adapters/web.ts
+++ b/packages/dashboard-core/src/adapters/web.ts
@@ -266,6 +266,10 @@ export class WebDashboardAdapter implements DashboardAdapter {
     return (await this.trpc.workspace.getFile.query({ workspaceId, path })) as FileContentResult;
   }
 
+  async saveWorkspaceFile(workspaceId: string, path: string, content: string): Promise<void> {
+    await this.trpc.workspace.saveFile.mutate({ workspaceId, path, content });
+  }
+
   getWorkspaceFileUrl(workspaceId: string, path: string): string {
     return `/api/workspace-file/${encodeURIComponent(workspaceId)}/${path
       .split("/")

--- a/packages/dashboard-core/src/components/CodeMirrorEditor.tsx
+++ b/packages/dashboard-core/src/components/CodeMirrorEditor.tsx
@@ -1,0 +1,111 @@
+import { EditorState } from "@codemirror/state";
+import { EditorView } from "@codemirror/view";
+import { useEffect, useRef } from "react";
+import { useIsDark } from "../hooks/use-is-dark";
+import { baseEditorExtensions, loadLanguage, searchHighlightOnly } from "../lib/codemirror-setup";
+import { selectionToChatExtension } from "../lib/selection-to-chat";
+
+interface CodeMirrorEditorProps {
+  /** Initial content to populate the editor with */
+  content: string;
+  language: string;
+  className?: string;
+  /** Workspace-relative file path — enables "Add to Chat" on text selection */
+  filePath?: string;
+  /** Called when the EditorView is created or destroyed */
+  onEditorView?: (view: EditorView | null) => void;
+  /** Called whenever the document content changes */
+  onContentChange?: (content: string) => void;
+  /** Called when Cmd/Ctrl+S is pressed */
+  onSave?: () => void;
+}
+
+export function CodeMirrorEditor({
+  content,
+  language,
+  className,
+  filePath,
+  onEditorView,
+  onContentChange,
+  onSave,
+}: CodeMirrorEditorProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const viewRef = useRef<EditorView | null>(null);
+  const onEditorViewRef = useRef(onEditorView);
+  onEditorViewRef.current = onEditorView;
+  const onContentChangeRef = useRef(onContentChange);
+  onContentChangeRef.current = onContentChange;
+  const onSaveRef = useRef(onSave);
+  onSaveRef.current = onSave;
+  const isDark = useIsDark();
+
+  // Store content in a ref so the editor creation effect reads the latest
+  // value without re-running on every content prop change.
+  const initialContentRef = useRef(content);
+  initialContentRef.current = content;
+
+  // Create/recreate the editor when language or theme changes.
+  // We intentionally do NOT depend on `content` — the editor owns
+  // the document once created. Only language/theme/filePath changes
+  // warrant a full recreation.
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+
+    let cancelled = false;
+
+    const setup = async () => {
+      const langSupport = await loadLanguage(language);
+      if (cancelled) return;
+
+      // Destroy previous instance
+      if (viewRef.current) {
+        viewRef.current.destroy();
+        viewRef.current = null;
+        onEditorViewRef.current?.(null);
+      }
+
+      const extensions = [
+        ...baseEditorExtensions(isDark, () => onSaveRef.current?.()),
+        searchHighlightOnly(),
+        // Listener for content changes
+        EditorView.updateListener.of((update) => {
+          if (update.docChanged) {
+            onContentChangeRef.current?.(update.state.doc.toString());
+          }
+        }),
+      ];
+      if (filePath) {
+        extensions.push(selectionToChatExtension(filePath));
+      }
+      if (langSupport) {
+        extensions.push(langSupport);
+      }
+
+      const state = EditorState.create({
+        doc: initialContentRef.current,
+        extensions,
+      });
+
+      viewRef.current = new EditorView({
+        state,
+        parent: container,
+      });
+
+      onEditorViewRef.current?.(viewRef.current);
+    };
+
+    setup();
+
+    return () => {
+      cancelled = true;
+      if (viewRef.current) {
+        viewRef.current.destroy();
+        viewRef.current = null;
+        onEditorViewRef.current?.(null);
+      }
+    };
+  }, [language, isDark, filePath]);
+
+  return <div ref={containerRef} className={className} />;
+}

--- a/packages/dashboard-core/src/components/FileViewer.tsx
+++ b/packages/dashboard-core/src/components/FileViewer.tsx
@@ -1,11 +1,12 @@
 import type { EditorView } from "@codemirror/view";
-import { ArrowLeft, Code, Eye, FileWarning } from "lucide-react";
+import { ArrowLeft, Code, Eye, FileWarning, Loader2, Save } from "lucide-react";
 import type React from "react";
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useAdapter } from "../context";
 import { type FilePreviewType, getFilePreviewType } from "../lib/file-type";
 import { extensionToLanguage, filenameToLanguage } from "../lib/language-map";
 import type { FileContentResult } from "../types";
+import { CodeMirrorEditor } from "./CodeMirrorEditor";
 import { CodeMirrorViewer } from "./CodeMirrorViewer";
 import { ImagePreview } from "./ImagePreview";
 import { PdfPreview } from "./PdfPreview";
@@ -26,7 +27,40 @@ interface FileViewerProps {
   toolbar?: React.ReactNode;
   /** Optional markdown renderer — when provided, markdown files show a rendered preview with source toggle */
   renderMarkdown?: (content: string) => React.ReactNode;
+  /** When true, code files open in an editable editor instead of read-only viewer */
+  editable?: boolean;
 }
+
+// localStorage-backed cache for unsaved edits — survives page reloads
+const EDITS_PREFIX = "band-edits:";
+
+function editsCacheKey(workspaceId: string, filePath: string): string {
+  return `${EDITS_PREFIX}${workspaceId}\0${filePath}`;
+}
+
+const unsavedEditsCache = {
+  get(key: string): string | undefined {
+    try {
+      return localStorage.getItem(key) ?? undefined;
+    } catch {
+      return undefined;
+    }
+  },
+  set(key: string, value: string): void {
+    try {
+      localStorage.setItem(key, value);
+    } catch {
+      // quota exceeded or unavailable — silently ignore
+    }
+  },
+  delete(key: string): void {
+    try {
+      localStorage.removeItem(key);
+    } catch {
+      // unavailable — silently ignore
+    }
+  },
+};
 
 function getFilename(path: string): string {
   return path.split("/").pop() || path;
@@ -57,6 +91,7 @@ export function FileViewer({
   onEditorView,
   toolbar,
   renderMarkdown,
+  editable,
 }: FileViewerProps) {
   const adapter = useAdapter();
   const [data, setData] = useState<FileContentResult | null>(null);
@@ -64,13 +99,46 @@ export function FileViewer({
   const [error, setError] = useState<string | null>(null);
   const [viewMode, setViewMode] = useState<"preview" | "source">("preview");
 
+  // Editing state
+  const [editedContent, setEditedContent] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
+  const [saveError, setSaveError] = useState<string | null>(null);
+
+  const isDirty = editedContent !== null && editedContent !== data?.content;
+
+  const canEdit = editable && !!adapter.saveWorkspaceFile;
+
   const previewType: FilePreviewType = getFilePreviewType(filePath);
 
-  // Reset view mode when navigating to a different file
-  // biome-ignore lint/correctness/useExhaustiveDependencies: filePath intentionally triggers reset when user navigates to a different file
+  // Persist unsaved edits to cache when leaving a file (navigation or unmount),
+  // and restore them when returning.
   useEffect(() => {
+    const key = editsCacheKey(workspaceId, filePath);
+    const cached = unsavedEditsCache.get(key);
     setViewMode("preview");
-  }, [filePath]);
+    setEditedContent(cached ?? null);
+    setSaveError(null);
+
+    return () => {
+      // Save current edits to cache when leaving this file
+      const current = editedContentRef.current;
+      if (current !== null) {
+        unsavedEditsCache.set(key, current);
+      } else {
+        unsavedEditsCache.delete(key);
+      }
+    };
+  }, [workspaceId, filePath]);
+
+  // Warn before tab close when dirty
+  useEffect(() => {
+    if (!isDirty) return;
+    const handler = (e: BeforeUnloadEvent) => {
+      e.preventDefault();
+    };
+    window.addEventListener("beforeunload", handler);
+    return () => window.removeEventListener("beforeunload", handler);
+  }, [isDirty]);
 
   // Notify parent that editor view is unavailable in preview mode
   useEffect(() => {
@@ -123,6 +191,45 @@ export function FileViewer({
 
   const showMarkdownToggle = previewType === "markdown" && renderMarkdown;
 
+  // The content to display — use edited content when available, otherwise server content
+  const displayContent = editedContent ?? data?.content;
+
+  // Use a ref to avoid stale closure in the save handler
+  const editedContentRef = useRef(editedContent);
+  editedContentRef.current = editedContent;
+
+  const handleSave = useCallback(async () => {
+    if (!adapter.saveWorkspaceFile || editedContentRef.current === null) return;
+    setSaving(true);
+    setSaveError(null);
+    try {
+      await adapter.saveWorkspaceFile(workspaceId, filePath, editedContentRef.current);
+      // Update the data state so isDirty resets
+      const savedContent = editedContentRef.current;
+      setData((prev) => (prev ? { ...prev, content: savedContent } : prev));
+      // Clear cache — saved content is now on disk
+      unsavedEditsCache.delete(editsCacheKey(workspaceId, filePath));
+    } catch (err) {
+      setSaveError(err instanceof Error ? err.message : "Failed to save");
+    } finally {
+      setSaving(false);
+    }
+  }, [adapter, workspaceId, filePath]);
+
+  const handleContentChange = useCallback((newContent: string) => {
+    setEditedContent(newContent);
+  }, []);
+
+  const handleBack = useCallback(() => {
+    if (isDirty && !window.confirm("You have unsaved changes. Discard?")) {
+      return;
+    }
+    // Clear cache and ref so the cleanup effect doesn't re-save discarded edits
+    unsavedEditsCache.delete(editsCacheKey(workspaceId, filePath));
+    editedContentRef.current = null;
+    onBack?.();
+  }, [isDirty, onBack, workspaceId, filePath]);
+
   return (
     <div className="flex h-full flex-col overflow-hidden">
       {/* Title bar */}
@@ -130,15 +237,27 @@ export function FileViewer({
         {onBack && (
           <button
             type="button"
-            onClick={onBack}
+            onClick={handleBack}
             className="inline-flex size-6 items-center justify-center rounded-md hover:bg-accent"
           >
             <ArrowLeft className="size-3.5" />
           </button>
         )}
-        <span className="min-w-0 flex-1 truncate font-mono text-xs">{filePath}</span>
-        {data && (
-          <span className="shrink-0 text-xs text-muted-foreground">{formatSize(data.size)}</span>
+        <span className="min-w-0 flex-1 truncate font-mono text-xs">
+          {filePath}
+          {isDirty && <span className="ml-1 text-muted-foreground">(modified)</span>}
+        </span>
+        {saveError && <span className="shrink-0 text-xs text-destructive">{saveError}</span>}
+        {canEdit && isDirty && (
+          <button
+            type="button"
+            onClick={handleSave}
+            disabled={saving}
+            title="Save (Cmd+S)"
+            className="inline-flex size-6 items-center justify-center rounded-md hover:bg-accent disabled:opacity-50"
+          >
+            {saving ? <Loader2 className="size-3.5 animate-spin" /> : <Save className="size-3.5" />}
+          </button>
         )}
         {/* Markdown preview/source toggle icons */}
         {showMarkdownToggle && (
@@ -169,6 +288,9 @@ export function FileViewer({
             </button>
           </div>
         )}
+        {data && (
+          <span className="shrink-0 text-xs text-muted-foreground">{formatSize(data.size)}</span>
+        )}
       </div>
 
       {toolbar}
@@ -197,26 +319,37 @@ export function FileViewer({
           <PdfPreview src={fileUrl} filename={getFilename(filePath)} />
         )}
 
-        {/* Markdown preview (rendered) */}
+        {/* Markdown preview (rendered) — uses displayContent so edits show live */}
         {!loading &&
           !error &&
           previewType === "markdown" &&
           renderMarkdown &&
           viewMode === "preview" &&
-          data?.content && (
+          displayContent && (
             <div className="h-full overflow-auto">
               <div className="mx-auto max-w-3xl px-8 py-6 text-sm">
-                {renderMarkdown(data.content)}
+                {renderMarkdown(displayContent)}
               </div>
             </div>
           )}
 
-        {/* Source view: CodeMirror for markdown in source mode, or any code/text file */}
+        {/* Source view: editable editor or read-only viewer */}
         {!loading &&
           !error &&
           data?.content &&
           (previewType === "code" ||
-            (previewType === "markdown" && (!renderMarkdown || viewMode === "source"))) && (
+            (previewType === "markdown" && (!renderMarkdown || viewMode === "source"))) &&
+          (canEdit ? (
+            <CodeMirrorEditor
+              content={displayContent!}
+              language={lang}
+              className="h-full"
+              filePath={filePath}
+              onEditorView={onEditorView}
+              onContentChange={handleContentChange}
+              onSave={handleSave}
+            />
+          ) : (
             <CodeMirrorViewer
               content={data.content}
               language={lang}
@@ -227,7 +360,7 @@ export function FileViewer({
               column={column}
               onEditorView={onEditorView}
             />
-          )}
+          ))}
 
         {/* Binary file fallback (non-image, non-pdf) */}
         {!loading && !error && data?.binary && previewType === "code" && (

--- a/packages/dashboard-core/src/index.ts
+++ b/packages/dashboard-core/src/index.ts
@@ -7,6 +7,7 @@ export { AddProjectDialog } from "./components/AddProjectDialog";
 export { AgentStatusIndicator } from "./components/AgentStatusIndicator";
 export { AgentIcon, ClaudeIcon, CodexIcon } from "./components/agent-icons";
 export { CIStatusIndicator } from "./components/CIStatusIndicator";
+export { CodeMirrorEditor } from "./components/CodeMirrorEditor";
 export { CodeMirrorViewer } from "./components/CodeMirrorViewer";
 export { DashboardShell } from "./components/DashboardShell";
 export { type DiffStats, DiffView } from "./components/DiffView";

--- a/packages/dashboard-core/src/lib/codemirror-setup.ts
+++ b/packages/dashboard-core/src/lib/codemirror-setup.ts
@@ -1,7 +1,10 @@
-import { defaultKeymap } from "@codemirror/commands";
+import { defaultKeymap, history, historyKeymap } from "@codemirror/commands";
 import {
   bracketMatching,
   defaultHighlightStyle,
+  foldGutter,
+  foldKeymap,
+  indentOnInput,
   LanguageSupport,
   StreamLanguage,
   syntaxHighlighting,
@@ -15,7 +18,14 @@ import {
   StateEffect,
   StateField,
 } from "@codemirror/state";
-import { Decoration, type DecorationSet, EditorView, keymap, lineNumbers } from "@codemirror/view";
+import {
+  Decoration,
+  type DecorationSet,
+  EditorView,
+  type KeyBinding,
+  keymap,
+  lineNumbers,
+} from "@codemirror/view";
 import { vscodeDarkInit } from "@uiw/codemirror-theme-vscode";
 
 /**
@@ -180,6 +190,90 @@ export function baseViewerExtensions(isDark = true): Extension[] {
             },
             ".cm-activeLineGutter": { backgroundColor: "transparent" },
             ".cm-activeLine": { backgroundColor: "transparent" },
+            "&.cm-focused .cm-cursor": { borderLeftColor: "#24292f" },
+            "&.cm-focused .cm-selectionBackground, .cm-selectionBackground": {
+              backgroundColor: "rgba(0, 0, 0, 0.07)",
+            },
+            ".cm-line": { color: "#24292f" },
+            ".cm-searchMatch": {
+              backgroundColor: "rgba(255, 213, 0, 0.4)",
+              borderRadius: "2px",
+            },
+            ".cm-searchMatch-selected": {
+              backgroundColor: "rgba(255, 150, 50, 0.55)",
+            },
+          },
+      { dark: isDark },
+    ),
+  ];
+}
+
+/**
+ * Base extensions for an editable CodeMirror editor.
+ * Includes editing features: undo/redo, indent-on-input, fold gutter.
+ * Does NOT include readOnly or editable(false).
+ * @param isDark - Whether to use dark theme colours. Defaults to true for backwards compat.
+ * @param onSave - Optional callback invoked on Cmd/Ctrl+S.
+ */
+export function baseEditorExtensions(isDark = true, onSave?: () => void): Extension[] {
+  const saveKeyBinding: KeyBinding[] = onSave
+    ? [
+        {
+          key: "Mod-s",
+          run: () => {
+            onSave();
+            return true;
+          },
+        },
+      ]
+    : [];
+
+  return [
+    lineNumbers(),
+    history(),
+    foldGutter(),
+    bracketMatching(),
+    indentOnInput(),
+    highlightSelectionMatches(),
+    ...(isDark
+      ? [
+          vscodeDarkInit({
+            settings: {
+              background: "var(--background)",
+              gutterBackground: "var(--background)",
+            },
+          }),
+          syntaxHighlighting(defaultHighlightStyle, { fallback: true }),
+        ]
+      : [syntaxHighlighting(defaultHighlightStyle)]),
+    keymap.of([...saveKeyBinding, ...defaultKeymap, ...historyKeymap, ...foldKeymap]),
+    EditorView.theme(
+      isDark
+        ? {
+            "&": { height: "100%", fontSize: "13px" },
+            ".cm-scroller": { overflow: "auto" },
+            ".cm-lineNumbers": { paddingLeft: "12px", paddingRight: "12px" },
+            ".cm-activeLine": { backgroundColor: "rgba(255,255,255,0.03)" },
+            ".cm-activeLineGutter": { backgroundColor: "rgba(255,255,255,0.03)" },
+            ".cm-searchMatch": {
+              backgroundColor: "rgba(255, 213, 0, 0.35)",
+              borderRadius: "2px",
+            },
+            ".cm-searchMatch-selected": {
+              backgroundColor: "rgba(255, 150, 50, 0.5)",
+            },
+          }
+        : {
+            "&": { height: "100%", fontSize: "13px", backgroundColor: "var(--background)" },
+            ".cm-scroller": { overflow: "auto" },
+            ".cm-lineNumbers": { paddingLeft: "12px", paddingRight: "12px" },
+            ".cm-gutters": {
+              backgroundColor: "var(--background)",
+              border: "none",
+              color: "#6e7781",
+            },
+            ".cm-activeLine": { backgroundColor: "rgba(0,0,0,0.03)" },
+            ".cm-activeLineGutter": { backgroundColor: "rgba(0,0,0,0.03)" },
             "&.cm-focused .cm-cursor": { borderLeftColor: "#24292f" },
             "&.cm-focused .cm-selectionBackground, .cm-selectionBackground": {
               backgroundColor: "rgba(0, 0, 0, 0.07)",


### PR DESCRIPTION
## Summary

- Add inline file editing to the code browser — files open in an editable CodeMirror editor with syntax highlighting, undo/redo, code folding, and indent-on-input
- Save via Cmd/Ctrl+S shortcut or a save button in the title bar; dirty state shown with "(modified)" indicator
- Unsaved edits cached in localStorage so they survive navigation between files and page reloads
- New `saveFile` tRPC mutation writes content back to disk with path traversal protection
- Markdown preview reflects unsaved edits live when toggling between source and preview modes

## Changes

- **Backend**: `workspace.saveFile` mutation in `router.ts`
- **Adapter**: `saveWorkspaceFile` method on `DashboardAdapter` interface + `WebDashboardAdapter`
- **CodeMirror**: `baseEditorExtensions()` in `codemirror-setup.ts` (editable variant of `baseViewerExtensions`)
- **Components**: New `CodeMirrorEditor` component; `FileViewer` gains `editable` prop with dirty tracking, save, localStorage cache, and beforeunload guard
- **Wiring**: `CodeBrowserView` passes `editable` to `FileViewer`

## Test plan

- [ ] Open a text file in the code browser — editor should be editable (cursor visible, can type)
- [ ] Verify syntax highlighting for various file types (.ts, .py, .json, .md source mode)
- [ ] Make an edit → title bar shows "(modified)" and save icon appears
- [ ] Press Cmd+S → file saves, "(modified)" disappears
- [ ] Navigate to another file and back → unsaved edits are restored from cache
- [ ] Reload the page → unsaved edits are restored from localStorage
- [ ] Save clears the cache; editing after save creates a new dirty state
- [ ] Click back with unsaved changes → confirmation dialog appears
- [ ] Images, PDFs, and binary files still render as previews (not editable)
- [ ] Markdown preview mode shows live edits without saving

🤖 Generated with [Claude Code](https://claude.com/claude-code)