### PR TITLE
feat: clickable file path links in chat messages

### DIFF
--- a/apps/web/src/components/DockviewWorkspaceLayout.tsx
+++ b/apps/web/src/components/DockviewWorkspaceLayout.tsx
@@ -570,6 +570,7 @@ export function DockviewWorkspaceLayout({
 
   // Dialog state
   const [quickOpenOpen, setQuickOpenOpen] = useState(false);
+  const [quickOpenQuery, setQuickOpenQuery] = useState<string | undefined>(undefined);
   const [searchFilesOpen, setSearchFilesOpen] = useState(false);
 
   // Find-in-file: active panel registers its search callback here
@@ -649,6 +650,20 @@ export function DockviewWorkspaceLayout({
     };
     window.addEventListener("keydown", handler, true);
     return () => window.removeEventListener("keydown", handler, true);
+  }, [isActive]);
+
+  // Listen for file link clicks from chat messages → open Quick Open with query
+  useEffect(() => {
+    if (!isActive) return;
+    const handler = (e: Event) => {
+      const detail = (e as CustomEvent<{ filename: string }>).detail;
+      if (detail?.filename) {
+        setQuickOpenQuery(detail.filename);
+        setQuickOpenOpen(true);
+      }
+    };
+    window.addEventListener("band:open-file", handler);
+    return () => window.removeEventListener("band:open-file", handler);
   }, [isActive]);
 
   // Wire callbacks into panels after layout restore (functions cannot be serialized).
@@ -949,8 +964,13 @@ export function DockviewWorkspaceLayout({
       <QuickOpenDialog
         workspaceId={workspaceId}
         open={quickOpenOpen}
-        onOpenChange={setQuickOpenOpen}
+        onOpenChange={(open) => {
+          setQuickOpenOpen(open);
+          if (!open) setQuickOpenQuery(undefined);
+        }}
         onOpenFile={handleOpenFile}
+        initialQuery={quickOpenQuery}
+        autoOpen={quickOpenQuery != null}
       />
       <SearchFilesDialog
         workspaceId={workspaceId}

--- a/apps/web/src/components/ai-elements/file-link-components.tsx
+++ b/apps/web/src/components/ai-elements/file-link-components.tsx
@@ -2,7 +2,12 @@ import { parseFileLocation } from "@band-app/dashboard-core";
 import { cn } from "@band-app/ui";
 import type { ComponentProps } from "react";
 import { useCallback } from "react";
-import { type Components, defaultUrlTransform, type ExtraProps, type UrlTransform } from "streamdown";
+import {
+  type Components,
+  defaultUrlTransform,
+  type ExtraProps,
+  type UrlTransform,
+} from "streamdown";
 
 // ---------------------------------------------------------------------------
 // Known file extensions (derived from dashboard-core file-icon.ts)
@@ -10,37 +15,127 @@ import { type Components, defaultUrlTransform, type ExtraProps, type UrlTransfor
 
 const KNOWN_EXTENSIONS = new Set([
   // Code
-  "ts", "tsx", "js", "jsx", "mjs", "cjs", "py", "rb", "go", "rs",
-  "java", "kt", "swift", "c", "cpp", "h", "hpp", "cs", "php", "r",
-  "lua", "zig", "mts", "cts", "ex", "exs", "erl", "hs", "scala",
-  "clj", "dart", "vue", "svelte",
+  "ts",
+  "tsx",
+  "js",
+  "jsx",
+  "mjs",
+  "cjs",
+  "py",
+  "rb",
+  "go",
+  "rs",
+  "java",
+  "kt",
+  "swift",
+  "c",
+  "cpp",
+  "h",
+  "hpp",
+  "cs",
+  "php",
+  "r",
+  "lua",
+  "zig",
+  "mts",
+  "cts",
+  "ex",
+  "exs",
+  "erl",
+  "hs",
+  "scala",
+  "clj",
+  "dart",
+  "vue",
+  "svelte",
   // Web / markup
-  "html", "htm", "css", "scss", "less", "sass",
+  "html",
+  "htm",
+  "css",
+  "scss",
+  "less",
+  "sass",
   // Data / config
-  "json", "jsonc", "json5", "yaml", "yml", "toml", "ini", "xml", "csv",
-  "graphql", "gql", "tf", "hcl", "env", "proto",
+  "json",
+  "jsonc",
+  "json5",
+  "yaml",
+  "yml",
+  "toml",
+  "ini",
+  "xml",
+  "csv",
+  "graphql",
+  "gql",
+  "tf",
+  "hcl",
+  "env",
+  "proto",
   // Text / docs
-  "md", "mdx", "txt", "rst", "tex", "log",
+  "md",
+  "mdx",
+  "txt",
+  "rst",
+  "tex",
+  "log",
   // Shell
-  "sh", "bash", "zsh", "fish", "ps1", "bat", "cmd",
+  "sh",
+  "bash",
+  "zsh",
+  "fish",
+  "ps1",
+  "bat",
+  "cmd",
   // Images
-  "png", "jpg", "jpeg", "gif", "svg", "webp", "ico", "bmp", "avif",
+  "png",
+  "jpg",
+  "jpeg",
+  "gif",
+  "svg",
+  "webp",
+  "ico",
+  "bmp",
+  "avif",
   // Database
-  "sql", "sqlite", "db",
+  "sql",
+  "sqlite",
+  "db",
   // Config
-  "editorconfig", "prettierrc", "eslintrc", "lock",
+  "editorconfig",
+  "prettierrc",
+  "eslintrc",
+  "lock",
   // Package / archive
-  "zip", "tar", "gz", "tgz", "wasm",
+  "zip",
+  "tar",
+  "gz",
+  "tgz",
+  "wasm",
   // Misc
-  "diff", "patch",
+  "diff",
+  "patch",
 ]);
 
 const KNOWN_FILENAMES = new Set([
-  "dockerfile", "docker-compose.yml", "docker-compose.yaml",
-  "makefile", "rakefile", "procfile", "gemfile", "vagrantfile",
-  ".gitignore", ".gitattributes", ".npmrc", ".nvmrc",
-  ".prettierrc", ".eslintrc", ".editorconfig",
-  ".env", ".env.local", ".env.development", ".env.production",
+  "dockerfile",
+  "docker-compose.yml",
+  "docker-compose.yaml",
+  "makefile",
+  "rakefile",
+  "procfile",
+  "gemfile",
+  "vagrantfile",
+  ".gitignore",
+  ".gitattributes",
+  ".npmrc",
+  ".nvmrc",
+  ".prettierrc",
+  ".eslintrc",
+  ".editorconfig",
+  ".env",
+  ".env.local",
+  ".env.development",
+  ".env.production",
 ]);
 
 // ---------------------------------------------------------------------------
@@ -100,9 +195,7 @@ export function isFilePath(text: string): boolean {
 // ---------------------------------------------------------------------------
 
 function dispatchOpenFile(filename: string) {
-  window.dispatchEvent(
-    new CustomEvent("band:open-file", { detail: { filename } }),
-  );
+  window.dispatchEvent(new CustomEvent("band:open-file", { detail: { filename } }));
 }
 
 // ---------------------------------------------------------------------------
@@ -302,9 +395,9 @@ function remarkFileLinks() {
       FILE_PATH_WITH_LINE_RE.lastIndex = 0;
       const parts: MdastNode[] = [];
       let lastIndex = 0;
-      let match: RegExpExecArray | null;
+      let match: RegExpExecArray | null = FILE_PATH_WITH_LINE_RE.exec(value);
 
-      while ((match = FILE_PATH_WITH_LINE_RE.exec(value)) !== null) {
+      while (match !== null) {
         const matchText = match[0];
 
         // Quick sanity check — must parse as a valid file path
@@ -323,6 +416,7 @@ function remarkFileLinks() {
         });
 
         lastIndex = match.index + matchText.length;
+        match = FILE_PATH_WITH_LINE_RE.exec(value);
       }
 
       // No matches — leave the text node unchanged

--- a/apps/web/src/components/ai-elements/file-link-components.tsx
+++ b/apps/web/src/components/ai-elements/file-link-components.tsx
@@ -1,0 +1,362 @@
+import { parseFileLocation } from "@band-app/dashboard-core";
+import { cn } from "@band-app/ui";
+import type { ComponentProps } from "react";
+import { useCallback } from "react";
+import { type Components, defaultUrlTransform, type ExtraProps, type UrlTransform } from "streamdown";
+
+// ---------------------------------------------------------------------------
+// Known file extensions (derived from dashboard-core file-icon.ts)
+// ---------------------------------------------------------------------------
+
+const KNOWN_EXTENSIONS = new Set([
+  // Code
+  "ts", "tsx", "js", "jsx", "mjs", "cjs", "py", "rb", "go", "rs",
+  "java", "kt", "swift", "c", "cpp", "h", "hpp", "cs", "php", "r",
+  "lua", "zig", "mts", "cts", "ex", "exs", "erl", "hs", "scala",
+  "clj", "dart", "vue", "svelte",
+  // Web / markup
+  "html", "htm", "css", "scss", "less", "sass",
+  // Data / config
+  "json", "jsonc", "json5", "yaml", "yml", "toml", "ini", "xml", "csv",
+  "graphql", "gql", "tf", "hcl", "env", "proto",
+  // Text / docs
+  "md", "mdx", "txt", "rst", "tex", "log",
+  // Shell
+  "sh", "bash", "zsh", "fish", "ps1", "bat", "cmd",
+  // Images
+  "png", "jpg", "jpeg", "gif", "svg", "webp", "ico", "bmp", "avif",
+  // Database
+  "sql", "sqlite", "db",
+  // Config
+  "editorconfig", "prettierrc", "eslintrc", "lock",
+  // Package / archive
+  "zip", "tar", "gz", "tgz", "wasm",
+  // Misc
+  "diff", "patch",
+]);
+
+const KNOWN_FILENAMES = new Set([
+  "dockerfile", "docker-compose.yml", "docker-compose.yaml",
+  "makefile", "rakefile", "procfile", "gemfile", "vagrantfile",
+  ".gitignore", ".gitattributes", ".npmrc", ".nvmrc",
+  ".prettierrc", ".eslintrc", ".editorconfig",
+  ".env", ".env.local", ".env.development", ".env.production",
+]);
+
+// ---------------------------------------------------------------------------
+// File path detection
+// ---------------------------------------------------------------------------
+
+function getExtension(filePath: string): string {
+  const name = filePath.split("/").pop() ?? filePath;
+  const dot = name.lastIndexOf(".");
+  return dot >= 0 ? name.slice(dot + 1).toLowerCase() : "";
+}
+
+function getBasename(filePath: string): string {
+  return (filePath.split("/").pop() ?? filePath).toLowerCase();
+}
+
+/**
+ * Checks if a string looks like a file path that should be linked.
+ *
+ * For inline code (backtick-wrapped), matches file paths with or without
+ * line indicators. For plain text (remark plugin), callers should only
+ * pass strings that already have a line indicator.
+ */
+export function isFilePath(text: string): boolean {
+  const trimmed = text.trim();
+  if (!trimmed) return false;
+
+  // Reject URLs
+  if (/^[a-z][a-z0-9+.-]*:\/\//i.test(trimmed)) return false;
+
+  const loc = parseFileLocation(trimmed);
+  const filePath = loc.filePath;
+
+  // Must not be empty after parsing
+  if (!filePath) return false;
+
+  const ext = getExtension(filePath);
+  const basename = getBasename(filePath);
+  const hasKnownExtension = KNOWN_EXTENSIONS.has(ext);
+  const isKnownFilename = KNOWN_FILENAMES.has(basename);
+
+  if (!hasKnownExtension && !isKnownFilename) return false;
+
+  // For bare filenames without a path separator, require a line indicator
+  // to avoid false positives (e.g. "utils.ts" alone is ambiguous, but
+  // "utils.ts:42" is clearly a file reference)
+  const hasSlash = filePath.includes("/");
+  const hasLineIndicator = loc.line != null;
+
+  if (!hasSlash && !hasLineIndicator && !isKnownFilename) return false;
+
+  return true;
+}
+
+// ---------------------------------------------------------------------------
+// Custom event dispatcher
+// ---------------------------------------------------------------------------
+
+function dispatchOpenFile(filename: string) {
+  window.dispatchEvent(
+    new CustomEvent("band:open-file", { detail: { filename } }),
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Rehype plugin — wrap inline code file paths in <a> links
+// ---------------------------------------------------------------------------
+
+// biome-ignore lint/suspicious/noExplicitAny: unified/hast plugin operates on untyped AST nodes
+type HastNode = any;
+
+/**
+ * Recursively extract plain text content from a hast node's children.
+ * Handles both simple text children and nested elements (e.g. Shiki
+ * spans from syntax-highlighted inline code).
+ */
+function extractHastText(node: HastNode): string | null {
+  if (!Array.isArray(node.children)) return null;
+  let text = "";
+  for (const child of node.children) {
+    if (child.type === "text") {
+      text += child.value;
+    } else if (child.type === "element" && Array.isArray(child.children)) {
+      const childText = extractHastText(child);
+      if (childText === null) return null;
+      text += childText;
+    } else {
+      return null;
+    }
+  }
+  return text;
+}
+
+/**
+ * Rehype plugin that finds inline `<code>` elements (not inside `<pre>`)
+ * whose text matches a file path pattern, and wraps them in an `<a>` tag
+ * with `href="band-file:..."`.
+ *
+ * This avoids overriding the `code` component, so the @streamdown/code
+ * Shiki plugin continues to render fenced code blocks normally.
+ */
+function rehypeFileLinkedCode() {
+  return (tree: HastNode) => {
+    walkHast(tree);
+  };
+
+  function walkHast(node: HastNode) {
+    // Process both root and element nodes
+    if ((node.type !== "element" && node.type !== "root") || !Array.isArray(node.children)) {
+      return;
+    }
+
+    // Process children (iterate over a copy since we may mutate)
+    const children = [...node.children];
+    for (let i = 0; i < children.length; i++) {
+      const child = children[i];
+      if (child.type !== "element") continue;
+
+      // Skip <pre> children entirely (fenced code blocks)
+      if (child.tagName === "pre") continue;
+
+      if (child.tagName === "code" && node.tagName !== "pre") {
+        // This is an inline <code> element
+        const text = extractHastText(child);
+        if (text && isFilePath(text)) {
+          // Wrap the <code> in an <a href="band-file:..."> element
+          const link: HastNode = {
+            type: "element",
+            tagName: "a",
+            properties: { href: `band-file:${text.trim()}` },
+            children: [child],
+          };
+          // Replace the child in the parent's children array
+          node.children[i] = link;
+        }
+      } else {
+        // Recurse into other elements
+        walkHast(child);
+      }
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Streamdown component overrides
+// ---------------------------------------------------------------------------
+
+/**
+ * Streamdown `a` component override.
+ *
+ * Intercepts links with the `band-file:` protocol (generated by the
+ * remarkFileLinks and rehypeFileLinkedCode plugins) and dispatches an
+ * open-file event instead of navigating. All other links render normally.
+ */
+function FileLinkedAnchor(props: ComponentProps<"a"> & ExtraProps) {
+  const { node: _node, href, children, ...rest } = props;
+
+  const isBandFile = typeof href === "string" && href.startsWith("band-file:");
+
+  const handleClick = useCallback(
+    (e: React.MouseEvent) => {
+      if (isBandFile && href) {
+        e.preventDefault();
+        e.stopPropagation();
+        const filename = href.slice("band-file:".length);
+        dispatchOpenFile(filename);
+      }
+    },
+    [isBandFile, href],
+  );
+
+  if (isBandFile) {
+    return (
+      <a
+        {...rest}
+        href={href}
+        onClick={handleClick}
+        className={cn(
+          rest.className,
+          "cursor-pointer no-underline hover:underline hover:decoration-blue-500/50 dark:hover:decoration-blue-400/50",
+        )}
+        title={`Open ${href?.slice("band-file:".length)}`}
+      >
+        {children}
+      </a>
+    );
+  }
+
+  // Default link rendering — open external links in new tab
+  return (
+    <a href={href} target="_blank" rel="noopener noreferrer" {...rest}>
+      {children}
+    </a>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Remark plugin — detect file paths with line indicators in plain text
+// ---------------------------------------------------------------------------
+
+/**
+ * Regex to match file paths with line indicators in plain text.
+ *
+ * Matches patterns like:
+ *   src/main.rs:42
+ *   app.tsx:10-20
+ *   components/Button.tsx:15:8
+ *   ./src/utils.ts:5
+ *   ../lib/index.js:100
+ *
+ * Requires a line indicator (`:number`) to avoid false positives in
+ * plain text. The path must contain a file extension.
+ */
+const FILE_PATH_WITH_LINE_RE =
+  /(?:^|(?<=[\s(,[\]]))(?:\.{0,2}\/)?(?:[a-zA-Z0-9_@./-]*\/)?[a-zA-Z0-9_.-]+\.[a-zA-Z0-9]+:\d+(?:[-:]\d+)?(?=$|[\s),.\]!?;])/g;
+
+/** Node types whose children should not be processed */
+const SKIP_PARENTS = new Set(["code", "inlineCode", "link", "linkReference"]);
+
+// biome-ignore lint/suspicious/noExplicitAny: unified plugin operates on untyped AST nodes
+type MdastNode = any;
+
+/**
+ * Walk the mdast tree and call `visitor` on each text node, providing
+ * the parent so the visitor can splice replacements into the parent's
+ * children array.
+ */
+function walkText(
+  node: MdastNode,
+  visitor: (text: MdastNode, parent: MdastNode, index: number) => void,
+  parent?: MdastNode,
+  index?: number,
+) {
+  if (SKIP_PARENTS.has(node.type)) return;
+
+  if (node.type === "text" && parent) {
+    visitor(node, parent, index!);
+    return;
+  }
+
+  if (Array.isArray(node.children)) {
+    // Walk in reverse so splicing doesn't shift indices
+    for (let i = node.children.length - 1; i >= 0; i--) {
+      walkText(node.children[i], visitor, node, i);
+    }
+  }
+}
+
+/**
+ * Remark plugin that detects file paths with line indicators in plain
+ * text and wraps them in link nodes with `band-file:` protocol.
+ */
+function remarkFileLinks() {
+  return (tree: MdastNode) => {
+    walkText(tree, (textNode, parent, index) => {
+      const value: string = textNode.value;
+      if (!value) return;
+
+      FILE_PATH_WITH_LINE_RE.lastIndex = 0;
+      const parts: MdastNode[] = [];
+      let lastIndex = 0;
+      let match: RegExpExecArray | null;
+
+      while ((match = FILE_PATH_WITH_LINE_RE.exec(value)) !== null) {
+        const matchText = match[0];
+
+        // Quick sanity check — must parse as a valid file path
+        if (!isFilePath(matchText)) continue;
+
+        // Add preceding text
+        if (match.index > lastIndex) {
+          parts.push({ type: "text", value: value.slice(lastIndex, match.index) });
+        }
+
+        // Add link node wrapping the matched file path
+        parts.push({
+          type: "link",
+          url: `band-file:${matchText}`,
+          children: [{ type: "text", value: matchText }],
+        });
+
+        lastIndex = match.index + matchText.length;
+      }
+
+      // No matches — leave the text node unchanged
+      if (parts.length === 0) return;
+
+      // Add trailing text
+      if (lastIndex < value.length) {
+        parts.push({ type: "text", value: value.slice(lastIndex) });
+      }
+
+      // Replace the original text node with the new parts
+      parent.children.splice(index, 1, ...parts);
+    });
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Exports
+// ---------------------------------------------------------------------------
+
+/** Component overrides for Streamdown — only `a` (no `code` override to
+ *  avoid conflicting with the @streamdown/code Shiki plugin). */
+export const fileLinkComponents: Components = {
+  a: FileLinkedAnchor,
+};
+
+/** Remark plugins: detect file paths in plain text. */
+export const fileLinkRemarkPlugins = [remarkFileLinks];
+
+/** Rehype plugins: wrap inline `<code>` file paths in `<a>` links. */
+export const fileLinkRehypePlugins = [rehypeFileLinkedCode];
+
+/** URL transform that allows `band-file:` protocol through the sanitizer. */
+export const fileLinkUrlTransform: UrlTransform = (url, key, node) => {
+  if (url.startsWith("band-file:")) return url;
+  return defaultUrlTransform(url, key, node);
+};

--- a/apps/web/src/components/ai-elements/message.tsx
+++ b/apps/web/src/components/ai-elements/message.tsx
@@ -9,6 +9,12 @@ import type { ComponentProps, HTMLAttributes } from "react";
 import { memo, useCallback, useState } from "react";
 import { Streamdown } from "streamdown";
 
+import {
+  fileLinkComponents,
+  fileLinkRehypePlugins,
+  fileLinkRemarkPlugins,
+  fileLinkUrlTransform,
+} from "./file-link-components";
 import { FilePreviewOverlay } from "./file-preview-overlay";
 import { downloadFile, isTextMediaType } from "./file-preview-utils";
 
@@ -56,6 +62,10 @@ export const MessageResponse = memo(
         className,
       )}
       plugins={streamdownPlugins}
+      components={fileLinkComponents}
+      remarkPlugins={fileLinkRemarkPlugins}
+      rehypePlugins={fileLinkRehypePlugins}
+      urlTransform={fileLinkUrlTransform}
       {...props}
     />
   ),

--- a/apps/web/src/routes/workspace.$workspaceId.tsx
+++ b/apps/web/src/routes/workspace.$workspaceId.tsx
@@ -1,6 +1,7 @@
 import {
   AgentIcon,
   type DiffStats,
+  QuickOpenDialog,
   useDashboardStore,
   useSettingsQuery,
   type WorkspaceTab,
@@ -292,6 +293,33 @@ function MobileWorkspaceLayout({
     };
   }, [workspaceId, chatKey]); // eslint-disable-line react-hooks/exhaustive-deps
 
+  // Quick Open state for file link clicks from chat
+  const [quickOpenOpen, setQuickOpenOpen] = useState(false);
+  const [quickOpenQuery, setQuickOpenQuery] = useState<string | undefined>(undefined);
+
+  const handleOpenFile = useCallback(
+    (filename: string) => {
+      navigate({
+        to: "/workspace/$workspaceId/code/$",
+        params: { workspaceId: encodedId, _splat: filename },
+      });
+    },
+    [navigate, encodedId],
+  );
+
+  // Listen for file link clicks from chat messages → open Quick Open with query
+  useEffect(() => {
+    const handler = (e: Event) => {
+      const detail = (e as CustomEvent<{ filename: string }>).detail;
+      if (detail?.filename) {
+        setQuickOpenQuery(detail.filename);
+        setQuickOpenOpen(true);
+      }
+    };
+    window.addEventListener("band:open-file", handler);
+    return () => window.removeEventListener("band:open-file", handler);
+  }, []);
+
   const handleSwitchAgent = useCallback(
     async (agentId: string) => {
       setShowAgentMenu(false);
@@ -429,6 +457,17 @@ function MobileWorkspaceLayout({
           <main className="flex min-h-0 flex-1 flex-col">
             <Outlet />
           </main>
+          <QuickOpenDialog
+            workspaceId={workspaceId}
+            open={quickOpenOpen}
+            onOpenChange={(open) => {
+              setQuickOpenOpen(open);
+              if (!open) setQuickOpenQuery(undefined);
+            }}
+            onOpenFile={handleOpenFile}
+            initialQuery={quickOpenQuery}
+            autoOpen={quickOpenQuery != null}
+          />
         </div>
       </AgentSwitcherContext.Provider>
     </SessionListContext.Provider>

--- a/packages/dashboard-core/src/components/QuickOpenDialog.tsx
+++ b/packages/dashboard-core/src/components/QuickOpenDialog.tsx
@@ -21,6 +21,11 @@ interface QuickOpenDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   onOpenFile: (path: string) => void;
+  /** When set, the dialog opens with this query pre-filled. Cleared on close. */
+  initialQuery?: string;
+  /** When true and only one result is found, auto-open it without showing
+   *  the dialog. The dialog is still shown if there are 0 or 2+ results. */
+  autoOpen?: boolean;
 }
 
 export function QuickOpenDialog({
@@ -28,12 +33,26 @@ export function QuickOpenDialog({
   open,
   onOpenChange,
   onOpenFile,
+  initialQuery,
+  autoOpen,
 }: QuickOpenDialogProps) {
   const adapter = useAdapter();
   const [query, setQuery] = useState("");
   const [files, setFiles] = useState<string[]>([]);
   const [loading, setLoading] = useState(false);
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Track whether a search has resolved at least once since the dialog opened.
+  // This prevents the auto-open effect from firing before the search starts
+  // (when `loading` is still its initial `false` value).
+  const searchResolved = useRef(false);
+
+  // Seed query from initialQuery when the dialog opens
+  useEffect(() => {
+    if (open && initialQuery) {
+      setQuery(initialQuery);
+    }
+  }, [open, initialQuery]);
 
   // Parse line/column reference from the query (e.g. "src/main.rs:42" -> line 42)
   const parsedQuery = useMemo(() => parseFileLocation(query), [query]);
@@ -55,7 +74,10 @@ export function QuickOpenDialog({
         })
         .catch(() => {})
         .finally(() => {
-          if (!cancelled) setLoading(false);
+          if (!cancelled) {
+            setLoading(false);
+            searchResolved.current = true;
+          }
         });
     }, delay);
 
@@ -65,11 +87,48 @@ export function QuickOpenDialog({
     };
   }, [adapter, workspaceId, searchQuery, open]);
 
+  // Auto-open: wait for the initial search to resolve, then either open the
+  // single result directly or reveal the dialog for the user to pick.
+  // While waiting, `dialogVisible` stays false so no UI flash occurs.
+  const autoOpened = useRef(false);
+  const [dialogVisible, setDialogVisible] = useState(!autoOpen);
+
+  // When the dialog opens with autoOpen, hide it until search resolves.
+  // When opened normally (no autoOpen), show it immediately.
+  // This is needed because useState(!autoOpen) only evaluates on mount —
+  // if autoOpen changes later, dialogVisible won't update automatically.
+  useEffect(() => {
+    if (open) {
+      setDialogVisible(!autoOpen);
+    }
+  }, [open, autoOpen]);
+
+  useEffect(() => {
+    if (!open || !autoOpen || autoOpened.current) return;
+    if (!searchResolved.current) return; // search hasn't completed yet
+
+    autoOpened.current = true;
+    if (files.length === 1) {
+      // Single result — open it directly, never show the dialog
+      const location = formatFileLocation(files[0], parsedQuery.line, {
+        lineEnd: parsedQuery.lineEnd,
+        column: parsedQuery.column,
+      });
+      onOpenFile(location);
+      onOpenChange(false);
+    } else {
+      // 0 or 2+ results — reveal the dialog so the user can pick
+      setDialogVisible(true);
+    }
+  }, [autoOpen, loading, files, open, parsedQuery, onOpenFile, onOpenChange]);
+
   // Reset on close
   useEffect(() => {
     if (!open) {
       setQuery("");
       setFiles([]);
+      autoOpened.current = false;
+      searchResolved.current = false;
     }
   }, [open]);
 
@@ -86,7 +145,7 @@ export function QuickOpenDialog({
   );
 
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
+    <Dialog open={open && dialogVisible} onOpenChange={onOpenChange}>
       <DialogContent className="overflow-hidden p-0 sm:max-w-[520px]" showCloseButton={false}>
         <DialogHeader className="sr-only">
           <DialogTitle>Quick Open</DialogTitle>

--- a/packages/dashboard-core/src/components/QuickOpenDialog.tsx
+++ b/packages/dashboard-core/src/components/QuickOpenDialog.tsx
@@ -120,7 +120,7 @@ export function QuickOpenDialog({
       // 0 or 2+ results — reveal the dialog so the user can pick
       setDialogVisible(true);
     }
-  }, [autoOpen, loading, files, open, parsedQuery, onOpenFile, onOpenChange]);
+  }, [autoOpen, files, open, parsedQuery, onOpenFile, onOpenChange]);
 
   // Reset on close
   useEffect(() => {


### PR DESCRIPTION
## Summary
- Add remark/rehype plugins and Streamdown component overrides to detect file paths in chat messages (both backtick-wrapped and plain text with line indicators like `src/main.rs:42`) and render them as clickable links
- Clicking a file link opens Quick Open with the path pre-filled; single results auto-open directly without showing the dialog, multiple results show the picker
- Add `initialQuery` and `autoOpen` props to `QuickOpenDialog` for programmatic use from file links
- Works in both desktop (dockview) and mobile (router) layouts

## Test plan
- [ ] In a workspace chat, verify backtick-wrapped file paths (e.g. `src/components/Button.tsx`) appear as clickable links
- [ ] Verify plain text file paths with line indicators (e.g. `src/main.rs:42`) are linked
- [ ] Click a file link with a unique filename — should auto-open the file without showing the dialog
- [ ] Click a file link matching multiple files — should show Quick Open dialog with results
- [ ] Verify fenced code blocks still render correctly with syntax highlighting
- [ ] Verify regular Quick Open (Cmd+P) still works normally without auto-open behavior
- [ ] Test in mobile layout — file links should work via Quick Open there too

🤖 Generated with [Claude Code](https://claude.com/claude-code)