### PR TITLE
Fix diff view line numbers and Add to Chat from non-chat tabs

### DIFF
--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -147,6 +147,8 @@ interface ChatViewProps {
   agentType?: string;
   codingAgentId?: string;
   visible?: boolean;
+  /** Workspace is active (even if the chat tab isn't the focused tab). */
+  wsActive?: boolean;
 }
 
 export function ChatView({
@@ -163,6 +165,7 @@ export function ChatView({
   agentType,
   codingAgentId,
   visible,
+  wsActive,
 }: ChatViewProps) {
   const sessionIdRef = useRef<string | undefined>(undefined);
   const lastEventIdRef = useRef<number | undefined>(undefined);
@@ -907,7 +910,12 @@ export function ChatView({
 
       <div className="mx-auto w-full max-w-3xl shrink-0 px-3 lg:px-4 pt-2 pb-4 standalone:pb-[env(safe-area-inset-bottom)]">
         <TaskListWidget tasks={taskMap} workspaceId={workspaceId} />
-        <PromptInput onSubmit={handleSubmit} draftKey={workspaceId} visible={visible}>
+        <PromptInput
+          onSubmit={handleSubmit}
+          draftKey={workspaceId}
+          visible={visible}
+          wsActive={wsActive}
+        >
           <SlashCommandSuggestions skills={skills} />
           <FileMentionSuggestions workspaceId={workspaceId} />
           <PromptInputTextarea

--- a/apps/web/src/components/DockviewWorkspaceLayout.tsx
+++ b/apps/web/src/components/DockviewWorkspaceLayout.tsx
@@ -118,13 +118,19 @@ function ChatPanelComponent({ params, api }: IDockviewPanelProps<ChatParams>) {
 
   // Chat is visible only when both the workspace is active AND the tab is active
   const visible = params.wsActive !== false && tabActive;
+  // Workspace is active (but the chat tab may not be the focused tab).
+  // Used by PromptInput to accept "Add to Chat" events from sibling panels
+  // (e.g. Changes, Files) even when the Chat tab isn't in front.
+  const wsActive = params.wsActive !== false;
 
   // Don't render until workspaceId is injected — during layout sync fromJSON
   // recreates panels with empty params before injectParams runs a tick later.
   // Rendering with undefined workspaceId would cause draft/session state issues.
   if (!params.workspaceId) return null;
 
-  return <WorkspaceChatPanel workspaceId={params.workspaceId} visible={visible} />;
+  return (
+    <WorkspaceChatPanel workspaceId={params.workspaceId} visible={visible} wsActive={wsActive} />
+  );
 }
 
 function ChangesPanelComponent({ params }: IDockviewPanelProps<ChangesParams>) {

--- a/apps/web/src/components/WorkspaceChatPanel.tsx
+++ b/apps/web/src/components/WorkspaceChatPanel.tsx
@@ -13,9 +13,11 @@ interface CodingAgentDef {
 interface WorkspaceChatPanelProps {
   workspaceId: string;
   visible?: boolean;
+  /** Workspace is active (even if the chat tab isn't the focused tab). */
+  wsActive?: boolean;
 }
 
-export function WorkspaceChatPanel({ workspaceId, visible }: WorkspaceChatPanelProps) {
+export function WorkspaceChatPanel({ workspaceId, visible, wsActive }: WorkspaceChatPanelProps) {
   const [supportsSessionListing, setSupportsSessionListing] = useState(false);
   const [initialSessionId, setInitialSessionId] = useState<string | undefined>(undefined);
   const [sessionQueryDone, setSessionQueryDone] = useState(false);
@@ -226,6 +228,7 @@ export function WorkspaceChatPanel({ workspaceId, visible }: WorkspaceChatPanelP
           agentType={currentAgent?.type}
           codingAgentId={currentAgentId}
           visible={visible}
+          wsActive={wsActive}
         />
       </div>
     </div>

--- a/apps/web/src/components/ai-elements/prompt-input.tsx
+++ b/apps/web/src/components/ai-elements/prompt-input.tsx
@@ -50,6 +50,10 @@ export type PromptInputProps = Omit<HTMLAttributes<HTMLFormElement>, "onSubmit">
   /** Whether the prompt input is currently visible/active. Used to gate global
    *  event handlers so hidden workspaces' textareas aren't modified. */
   visible?: boolean;
+  /** Whether the workspace is active (even if the chat tab isn't focused).
+   *  Used to accept "Add to Chat" events from sibling panels (Changes, Files)
+   *  when the Chat tab isn't in front. Falls back to `visible` if not set. */
+  wsActive?: boolean;
 };
 
 function readDraft(key: string | null): string {
@@ -66,6 +70,7 @@ export const PromptInput = ({
   onSubmit,
   draftKey,
   visible,
+  wsActive,
   children,
   ...props
 }: PromptInputProps) => {
@@ -104,6 +109,11 @@ export const PromptInput = ({
   // process events that would modify their textarea.
   const visibleRef = useRef(visible);
   visibleRef.current = visible;
+  // wsActive gates the "Add to Chat" handler: true when the workspace is active
+  // even if the chat tab isn't the focused tab, so events from sibling panels
+  // (Changes, Files) are still processed.
+  const wsActiveRef = useRef(wsActive ?? visible);
+  wsActiveRef.current = wsActive ?? visible;
 
   const addFiles = useCallback((newFiles: FileList | File[]) => {
     const valid = Array.from(newFiles).filter((f) => f.size <= MAX_FILE_SIZE);
@@ -198,12 +208,14 @@ export const PromptInput = ({
   }, []);
 
   // Listen for "Add to Chat" events from CodeMirror editors.
-  // Only process the event when this prompt is visible — with workspace
+  // Only process the event when this workspace is active — with workspace
   // show/hide, multiple PromptInput instances are mounted simultaneously
-  // and we must not modify hidden workspaces' textareas.
+  // and we must not modify hidden workspaces' textareas.  We gate on
+  // wsActive (not visible) so that events from sibling panels like
+  // Changes or Files are still processed even when the Chat tab isn't focused.
   useEffect(() => {
     const handler = (e: Event) => {
-      if (visibleRef.current === false) return;
+      if (wsActiveRef.current === false) return;
       const { filePath, startLine, endLine } = (e as CustomEvent<SelectionToChatDetail>).detail;
 
       const lineRef =

--- a/packages/dashboard-core/src/components/DiffView.tsx
+++ b/packages/dashboard-core/src/components/DiffView.tsx
@@ -2,7 +2,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@
 import { MergeView, unifiedMergeView } from "@codemirror/merge";
 import { SearchQuery } from "@codemirror/search";
 import { EditorState, Text } from "@codemirror/state";
-import { EditorView } from "@codemirror/view";
+import { EditorView, lineNumbers } from "@codemirror/view";
 import {
   ChevronsDownUp,
   ChevronsUpDown,
@@ -113,48 +113,66 @@ function detectLanguage(filePath: string): string {
   return extensionToLanguage(ext) || filenameToLanguage(name) || "plaintext";
 }
 
-interface DiffLine {
-  type: "add" | "del" | "context";
-  text: string;
+interface ParsedDiff {
+  oldText: string;
+  newText: string;
+  /** Actual file line number for each line in oldText (0-indexed array, values are 1-based line numbers). */
+  oldLineNumbers: number[];
+  /** Actual file line number for each line in newText (0-indexed array, values are 1-based line numbers). */
+  newLineNumbers: number[];
 }
 
-function parseDiffLines(hunks: string): DiffLine[] {
+/**
+ * Parses a unified diff string into old/new text with their actual file line numbers.
+ * Hunk headers (@@ -oldStart,count +newStart,count @@) are used to track the real
+ * line offsets so that trimmed/collapsed diffs display correct line numbers.
+ */
+function parseDiff(hunks: string): ParsedDiff {
   const lines = hunks.split("\n");
-  const result: DiffLine[] = [];
+  const oldLines: string[] = [];
+  const newLines: string[] = [];
+  const oldLineNumbers: number[] = [];
+  const newLineNumbers: number[] = [];
+
   let inHunk = false;
+  let oldLineNum = 1;
+  let newLineNum = 1;
+
   for (const line of lines) {
     if (line.startsWith("@@")) {
       inHunk = true;
-      // Skip hunk headers — the merge view shows its own markers
+      const match = line.match(/@@ -(\d+)(?:,\d+)? \+(\d+)(?:,\d+)? @@/);
+      if (match) {
+        oldLineNum = parseInt(match[1], 10);
+        newLineNum = parseInt(match[2], 10);
+      }
     } else if (inHunk) {
       if (line.startsWith("+")) {
-        result.push({ type: "add", text: line.slice(1) });
+        newLines.push(line.slice(1));
+        newLineNumbers.push(newLineNum);
+        newLineNum++;
       } else if (line.startsWith("-")) {
-        result.push({ type: "del", text: line.slice(1) });
+        oldLines.push(line.slice(1));
+        oldLineNumbers.push(oldLineNum);
+        oldLineNum++;
       } else if (line.startsWith(" ") || line === "") {
-        result.push({ type: "context", text: line.slice(1) || "" });
+        const text = line.slice(1) || "";
+        oldLines.push(text);
+        newLines.push(text);
+        oldLineNumbers.push(oldLineNum);
+        newLineNumbers.push(newLineNum);
+        oldLineNum++;
+        newLineNum++;
       }
     }
   }
-  return result;
-}
 
-function buildOldNew(diffLines: DiffLine[]): { oldText: string; newText: string } {
-  const oldLines: string[] = [];
-  const newLines: string[] = [];
-
-  for (const line of diffLines) {
-    if (line.type === "context") {
-      oldLines.push(line.text);
-      newLines.push(line.text);
-    } else if (line.type === "add") {
-      newLines.push(line.text);
-    } else if (line.type === "del") {
-      oldLines.push(line.text);
-    }
-  }
-
-  return { oldText: oldLines.join("\n"), newText: newLines.join("\n") };
+  return {
+    oldText: oldLines.join("\n"),
+    newText: newLines.join("\n"),
+    oldLineNumbers,
+    newLineNumbers,
+  };
 }
 
 const diffTheme = EditorView.theme({
@@ -198,16 +216,21 @@ function DiffFileContent({
         viewRef.current = null;
       }
 
-      const diffLines = parseDiffLines(hunks);
-      const { oldText, newText } = buildOldNew(diffLines);
+      const { oldText, newText, oldLineNumbers, newLineNumbers } = parseDiff(hunks);
+
+      /** Creates a lineNumbers extension that maps document lines to actual file line numbers. */
+      const makeLineNumbers = (lineMap: number[]) =>
+        lineNumbers({
+          formatNumber: (n) => {
+            if (n >= 1 && n <= lineMap.length) {
+              return String(lineMap[n - 1]);
+            }
+            return String(n);
+          },
+        });
 
       if (viewMode === "split") {
-        const sharedExtensions = [
-          ...baseViewerExtensions(isDark),
-          searchHighlightOnly(),
-          selectionToChatExtension(filename),
-          diffTheme,
-        ];
+        const sharedExtensions = [searchHighlightOnly(), diffTheme];
         if (langSupport) {
           sharedExtensions.push(langSupport);
         }
@@ -215,11 +238,21 @@ function DiffFileContent({
         viewRef.current = new MergeView({
           a: {
             doc: oldText,
-            extensions: sharedExtensions,
+            extensions: [
+              ...baseViewerExtensions(isDark, { skipLineNumbers: true }),
+              makeLineNumbers(oldLineNumbers),
+              selectionToChatExtension(filename, oldLineNumbers),
+              ...sharedExtensions,
+            ],
           },
           b: {
             doc: newText,
-            extensions: sharedExtensions,
+            extensions: [
+              ...baseViewerExtensions(isDark, { skipLineNumbers: true }),
+              makeLineNumbers(newLineNumbers),
+              selectionToChatExtension(filename, newLineNumbers),
+              ...sharedExtensions,
+            ],
           },
           parent: container,
           highlightChanges: false,
@@ -229,9 +262,10 @@ function DiffFileContent({
         onEditorViewsRef.current?.([viewRef.current.a, viewRef.current.b]);
       } else {
         const extensions = [
-          ...baseViewerExtensions(isDark),
+          ...baseViewerExtensions(isDark, { skipLineNumbers: true }),
+          makeLineNumbers(newLineNumbers),
           searchHighlightOnly(),
-          selectionToChatExtension(filename),
+          selectionToChatExtension(filename, newLineNumbers),
           unifiedMergeView({
             original: Text.of(oldText.split("\n")),
             mergeControls: false,

--- a/packages/dashboard-core/src/lib/codemirror-setup.ts
+++ b/packages/dashboard-core/src/lib/codemirror-setup.ts
@@ -142,12 +142,17 @@ export async function loadLanguage(lang: string): Promise<LanguageSupport | null
 /**
  * Base extensions for a read-only CodeMirror viewer.
  * @param isDark - Whether to use dark theme colours. Defaults to true for backwards compat.
+ * @param opts.skipLineNumbers - When true, omit the default lineNumbers() extension
+ *   so callers can supply a custom one (e.g. with remapped line numbers for diffs).
  */
-export function baseViewerExtensions(isDark = true): Extension[] {
+export function baseViewerExtensions(
+  isDark = true,
+  opts?: { skipLineNumbers?: boolean },
+): Extension[] {
   return [
     EditorState.readOnly.of(true),
     EditorView.editable.of(false),
-    lineNumbers(),
+    ...(opts?.skipLineNumbers ? [] : [lineNumbers()]),
     bracketMatching(),
     highlightSelectionMatches(),
     ...(isDark

--- a/packages/dashboard-core/src/lib/selection-to-chat.ts
+++ b/packages/dashboard-core/src/lib/selection-to-chat.ts
@@ -31,8 +31,12 @@ const setSelectionTooltip = StateEffect.define<Tooltip | null>();
  * {@link SelectionToChatDetail} payload.
  *
  * @param filePath - The workspace-relative file path shown in the reference.
+ * @param lineNumberMap - Optional 0-indexed array mapping document line numbers
+ *   to actual file line numbers. When provided, the dispatched event will use
+ *   the mapped line numbers instead of the raw document line numbers. This is
+ *   used by the diff view where trimmed content starts at a line offset.
  */
-export function selectionToChatExtension(filePath: string): Extension {
+export function selectionToChatExtension(filePath: string, lineNumberMap?: number[]): Extension {
   // --- StateField: holds the current tooltip (set via effect) ----------------
 
   const tooltipField = StateField.define<Tooltip | null>({
@@ -107,8 +111,18 @@ export function selectionToChatExtension(filePath: string): Extension {
             if (from === to) return;
 
             const selectedText = view.state.sliceDoc(from, to);
-            const startLine = view.state.doc.lineAt(from).number;
-            const endLine = view.state.doc.lineAt(to).number;
+            const docStartLine = view.state.doc.lineAt(from).number;
+            const docEndLine = view.state.doc.lineAt(to).number;
+            // When a line number map is provided (e.g. diff view with trimmed
+            // content), translate document line numbers to actual file lines.
+            const startLine =
+              lineNumberMap && docStartLine >= 1 && docStartLine <= lineNumberMap.length
+                ? lineNumberMap[docStartLine - 1]
+                : docStartLine;
+            const endLine =
+              lineNumberMap && docEndLine >= 1 && docEndLine <= lineNumberMap.length
+                ? lineNumberMap[docEndLine - 1]
+                : docEndLine;
 
             const detail: SelectionToChatDetail = {
               filePath,


### PR DESCRIPTION
## Summary

- Parse hunk headers to display actual file line numbers in diff view instead of starting from 1
- Pass line number map to `selectionToChatExtension` so Add to Chat dispatches correct file line numbers from diff view
- Separate `wsActive` (workspace-level) from `visible` (tab-level) in PromptInput so Add to Chat events from sibling tabs like Changes are not silently dropped

Closes #239

## Test plan

- [ ] Open a workspace with changes, verify diff view shows correct file line numbers (not starting from 1)
- [ ] Select text in the diff view, click "Add to Chat" — verify the correct line range appears in chat
- [ ] Verify Add to Chat works from both split and unified diff modes
- [ ] Verify Add to Chat still works from the file editor view

🤖 Generated with [Claude Code](https://claude.com/claude-code)