### PR TITLE
feat: add file tree sidebar to changes panel

### DIFF
--- a/packages/dashboard-core/src/components/ChangesFileTree.tsx
+++ b/packages/dashboard-core/src/components/ChangesFileTree.tsx
@@ -1,0 +1,158 @@
+import { ChevronDown, ChevronRight, Folder, FolderOpen } from "lucide-react";
+import { useEffect, useMemo, useState } from "react";
+import { buildFileTree, type FileTreeNode } from "../lib/build-file-tree";
+import { getFileIcon } from "../lib/file-icon";
+import type { FileStatus } from "../types";
+import { FileStatusBadge } from "./FileStatusBadge";
+
+interface ChangesFileTreeProps {
+  fileStatuses: Record<string, FileStatus>;
+  onSelectFile: (filePath: string) => void;
+}
+
+interface ChangesTreeNodeProps {
+  node: FileTreeNode;
+  depth: number;
+  expandedPaths: Set<string>;
+  onToggle: (path: string) => void;
+  onSelectFile: (filePath: string) => void;
+}
+
+function ChangesTreeNode({
+  node,
+  depth,
+  expandedPaths,
+  onToggle,
+  onSelectFile,
+}: ChangesTreeNodeProps) {
+  const isDir = node.children !== undefined;
+  const isExpanded = isDir && expandedPaths.has(node.path);
+
+  const handleClick = () => {
+    if (isDir) {
+      onToggle(node.path);
+    } else {
+      onSelectFile(node.path);
+    }
+  };
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={handleClick}
+        className="flex h-[26px] w-full items-center gap-1 pr-3 text-left text-xs hover:bg-accent/50"
+        style={{ paddingLeft: `${depth * 12 + 4}px` }}
+      >
+        {/* Chevron / spacer */}
+        {isDir ? (
+          isExpanded ? (
+            <ChevronDown className="size-3.5 shrink-0 text-muted-foreground/70" />
+          ) : (
+            <ChevronRight className="size-3.5 shrink-0 text-muted-foreground/70" />
+          )
+        ) : (
+          <span className="size-3.5 shrink-0" />
+        )}
+
+        {/* Icon */}
+        {isDir ? (
+          isExpanded ? (
+            <FolderOpen className="size-4 shrink-0 text-blue-600 dark:text-blue-400" />
+          ) : (
+            <Folder className="size-4 shrink-0 text-blue-600 dark:text-blue-400" />
+          )
+        ) : (
+          (() => {
+            // Use the last segment of the node name for icon detection
+            const fileName = node.name.includes("/") ? node.name.split("/").pop()! : node.name;
+            const FileIcon = getFileIcon(fileName);
+            return <FileIcon className="size-4 shrink-0 text-muted-foreground" />;
+          })()
+        )}
+
+        {/* Name */}
+        <span className="min-w-0 flex-1 truncate">{node.name}</span>
+
+        {/* Status badge for files */}
+        {!isDir && node.status && <FileStatusBadge status={node.status} />}
+      </button>
+
+      {/* Children — rendered when directory is expanded */}
+      {isExpanded &&
+        node.children?.map((child) => (
+          <ChangesTreeNode
+            key={child.path}
+            node={child}
+            depth={depth + 1}
+            expandedPaths={expandedPaths}
+            onToggle={onToggle}
+            onSelectFile={onSelectFile}
+          />
+        ))}
+    </>
+  );
+}
+
+/**
+ * Collects all directory paths from a file tree (for initial expanded state).
+ */
+function collectDirPaths(nodes: FileTreeNode[]): string[] {
+  const paths: string[] = [];
+  for (const node of nodes) {
+    if (node.children) {
+      paths.push(node.path);
+      paths.push(...collectDirPaths(node.children));
+    }
+  }
+  return paths;
+}
+
+export function ChangesFileTree({ fileStatuses, onSelectFile }: ChangesFileTreeProps) {
+  const tree = useMemo(() => buildFileTree(fileStatuses), [fileStatuses]);
+
+  // All directories expanded by default (changed-file sets are typically small)
+  const [expandedPaths, setExpandedPaths] = useState<Set<string>>(() => {
+    return new Set(collectDirPaths(tree));
+  });
+
+  // Re-expand all when tree changes (new diff summary)
+  useEffect(() => {
+    setExpandedPaths(new Set(collectDirPaths(tree)));
+  }, [tree]);
+
+  const handleToggle = (path: string) => {
+    setExpandedPaths((prev) => {
+      const next = new Set(prev);
+      if (next.has(path)) {
+        next.delete(path);
+      } else {
+        next.add(path);
+      }
+      return next;
+    });
+  };
+
+  if (tree.length === 0) {
+    return (
+      <div className="flex h-16 items-center justify-center text-xs text-muted-foreground">
+        No files
+      </div>
+    );
+  }
+
+  return (
+    <>
+      {tree.map((node) => (
+        <ChangesTreeNode
+          key={node.path}
+          node={node}
+          depth={0}
+          expandedPaths={expandedPaths}
+          onToggle={handleToggle}
+          onSelectFile={onSelectFile}
+        />
+      ))}
+    </>
+  );
+}

--- a/packages/dashboard-core/src/components/DiffView.tsx
+++ b/packages/dashboard-core/src/components/DiffView.tsx
@@ -8,6 +8,8 @@ import {
   ChevronsUpDown,
   Columns2,
   Loader2,
+  PanelLeftClose,
+  PanelLeftOpen,
   Rows2,
   Search,
   SquareArrowOutUpRight,
@@ -22,6 +24,8 @@ import { extensionToLanguage, filenameToLanguage } from "../lib/language-map";
 import { selectionToChatExtension } from "../lib/selection-to-chat";
 import type { SSEEvent } from "../lib/sse";
 import type { DiffMode, FileStatus, WorkspaceDiffSummary } from "../types";
+import { ChangesFileTree } from "./ChangesFileTree";
+import { FileStatusBadge } from "./FileStatusBadge";
 import { SearchBar, type SearchOptions } from "./SearchBar";
 
 export interface DiffStats {
@@ -79,6 +83,44 @@ function storeExpandAll(v: boolean) {
   } catch {}
 }
 
+const SIDEBAR_OPEN_KEY = "band:diff-sidebar-open";
+
+function getStoredSidebarOpen(): boolean {
+  try {
+    const v = localStorage.getItem(SIDEBAR_OPEN_KEY);
+    if (v === "false") return false;
+  } catch {}
+  return true;
+}
+
+function storeSidebarOpen(v: boolean) {
+  try {
+    localStorage.setItem(SIDEBAR_OPEN_KEY, v ? "true" : "false");
+  } catch {}
+}
+
+const SIDEBAR_WIDTH_KEY = "band:diff-sidebar-width";
+const SIDEBAR_DEFAULT_WIDTH = 220;
+const SIDEBAR_MIN_WIDTH = 120;
+const SIDEBAR_MAX_WIDTH = 500;
+
+function getStoredSidebarWidth(): number {
+  try {
+    const v = localStorage.getItem(SIDEBAR_WIDTH_KEY);
+    if (v) {
+      const n = parseInt(v, 10);
+      if (n >= SIDEBAR_MIN_WIDTH && n <= SIDEBAR_MAX_WIDTH) return n;
+    }
+  } catch {}
+  return SIDEBAR_DEFAULT_WIDTH;
+}
+
+function storeSidebarWidth(v: number) {
+  try {
+    localStorage.setItem(SIDEBAR_WIDTH_KEY, String(v));
+  } catch {}
+}
+
 interface DiffViewProps {
   workspaceId: string;
   active?: boolean;
@@ -91,19 +133,6 @@ interface DiffViewProps {
 function firstChangeLine(hunks: string): number | undefined {
   const match = hunks.match(/@@ [^ ]+ \+(\d+)/);
   return match ? parseInt(match[1], 10) : undefined;
-}
-
-const statusColors: Record<FileStatus, string> = {
-  A: "text-green-600 dark:text-green-400",
-  M: "text-blue-600 dark:text-blue-400",
-  D: "text-red-600 dark:text-red-400",
-  R: "text-purple-600 dark:text-purple-400",
-  U: "text-yellow-600 dark:text-yellow-400",
-};
-
-function FileStatusBadge({ status }: { status: FileStatus | undefined }) {
-  if (!status) return null;
-  return <span className={`shrink-0 text-xs font-bold ${statusColors[status]}`}>{status}</span>;
 }
 
 function detectLanguage(filePath: string): string {
@@ -378,6 +407,7 @@ interface LazyFileRowProps {
   mergeBase: string;
   viewMode: ViewMode;
   expandAll: boolean;
+  focusedFile: { path: string; seq: number } | null;
   onOpenFile?: (filename: string) => void;
   onEditorViews?: (filename: string, views: EditorView[]) => void;
 }
@@ -389,6 +419,7 @@ function LazyFileRow({
   mergeBase,
   viewMode,
   expandAll,
+  focusedFile,
   onOpenFile,
   onEditorViews,
 }: LazyFileRowProps) {
@@ -424,6 +455,21 @@ function LazyFileRow({
   useEffect(() => {
     setIsOpen(expandAll);
   }, [expandAll]);
+
+  // Open and scroll into view when focused from the file tree sidebar
+  useEffect(() => {
+    if (focusedFile && focusedFile.path === filename) {
+      setIsOpen(true);
+      // Defer scroll to allow the DOM to update after opening
+      requestAnimationFrame(() => {
+        const elementId = `diff-file-${encodeURIComponent(filename)}`;
+        const element = document.getElementById(elementId);
+        if (element) {
+          element.scrollIntoView({ behavior: "smooth", block: "start" });
+        }
+      });
+    }
+  }, [focusedFile, filename]);
 
   // Fetch diff when expanded and not cached (or mergeBase/contextLines changed)
   useEffect(() => {
@@ -624,6 +670,41 @@ export function DiffView({
     setExpandAllState(v);
     storeExpandAll(v);
   }, []);
+  const [sidebarOpen, setSidebarOpenState] = useState(getStoredSidebarOpen);
+  const setSidebarOpen = useCallback((v: boolean) => {
+    setSidebarOpenState(v);
+    storeSidebarOpen(v);
+  }, []);
+  const [sidebarWidth, setSidebarWidth] = useState(getStoredSidebarWidth);
+
+  const handleResizeStart = useCallback(
+    (e: React.MouseEvent) => {
+      e.preventDefault();
+      const startX = e.clientX;
+      const startWidth = sidebarWidth;
+      let lastWidth = startWidth;
+
+      const handleMouseMove = (ev: MouseEvent) => {
+        const delta = ev.clientX - startX;
+        lastWidth = Math.min(SIDEBAR_MAX_WIDTH, Math.max(SIDEBAR_MIN_WIDTH, startWidth + delta));
+        setSidebarWidth(lastWidth);
+      };
+
+      const handleMouseUp = () => {
+        document.removeEventListener("mousemove", handleMouseMove);
+        document.removeEventListener("mouseup", handleMouseUp);
+        document.body.style.cursor = "";
+        document.body.style.userSelect = "";
+        storeSidebarWidth(lastWidth);
+      };
+
+      document.addEventListener("mousemove", handleMouseMove);
+      document.addEventListener("mouseup", handleMouseUp);
+      document.body.style.cursor = "col-resize";
+      document.body.style.userSelect = "none";
+    },
+    [sidebarWidth],
+  );
 
   // -------------------------------------------------------------------------
   // Find-in-diff state
@@ -641,6 +722,16 @@ export function DiffView({
   );
 
   const search = useSearch({ getViews, collectMatches, onFindInFile });
+
+  // Track which file was clicked in the file tree sidebar so LazyFileRow can
+  // expand and scroll to it. We use a counter to allow re-clicking the same file.
+  const [focusedFile, setFocusedFile] = useState<{ path: string; seq: number } | null>(null);
+  const focusSeqRef = useRef(0);
+
+  const handleScrollToFile = useCallback((filePath: string) => {
+    focusSeqRef.current += 1;
+    setFocusedFile({ path: filePath, seq: focusSeqRef.current });
+  }, []);
 
   // Editor views registry — also dispatches active search to newly registered views
   const handleEditorViews = useCallback(
@@ -750,119 +841,166 @@ export function DiffView({
   filenamesRef.current = filenames;
 
   return (
-    <div className="flex h-full flex-col overflow-hidden">
-      <div className="flex shrink-0 items-center justify-between border-b border-border px-4 py-2">
-        <div className="flex items-center gap-3">
-          <div>
-            <div className="text-sm text-muted-foreground">
-              <span className="font-medium text-foreground">{summary.stats.filesChanged}</span>{" "}
-              {summary.stats.filesChanged === 1 ? "file" : "files"} changed
-              {summary.stats.insertions > 0 && (
-                <span className="ml-2 text-green-600 dark:text-green-400">
-                  +{summary.stats.insertions}
-                </span>
-              )}
-              {summary.stats.deletions > 0 && (
-                <span className="ml-1 text-red-600 dark:text-red-400">
-                  -{summary.stats.deletions}
-                </span>
-              )}
-            </div>
-            <div className="mt-0.5 text-xs text-muted-foreground">
-              {summary.baseBranch} &larr; {summary.headBranch}
-            </div>
-          </div>
-        </div>
-        <div className="flex items-center gap-2">
-          <button
-            type="button"
-            onClick={search.handleOpenSearch}
-            className="inline-flex items-center rounded-md border border-border/50 bg-muted/50 px-2 py-1 text-xs text-muted-foreground transition-colors hover:text-foreground"
-            title="Find in changes (⌘F)"
-          >
-            <Search className="size-3.5" />
-          </button>
-          <button
-            type="button"
-            onClick={() => setExpandAll(!expandAll)}
-            className={`inline-flex items-center rounded-md border border-border/50 px-2 py-1 text-xs transition-colors ${
-              expandAll
-                ? "bg-accent text-foreground"
-                : "bg-muted/50 text-muted-foreground hover:text-foreground"
-            }`}
-            title={expandAll ? "Collapse all files" : "Expand all files"}
-          >
-            {expandAll ? (
-              <ChevronsDownUp className="size-3.5" />
-            ) : (
-              <ChevronsUpDown className="size-3.5" />
-            )}
-          </button>
-          <Select value={diffMode} onValueChange={(v) => setDiffMode(v as DiffMode)}>
-            <SelectTrigger className="h-7 w-auto gap-1 rounded-md border-border/50 bg-muted/50 px-2.5 text-xs">
-              <SelectValue />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value="uncommitted">Uncommitted</SelectItem>
-              <SelectItem value="branch">{baseBranch ?? "base"}</SelectItem>
-            </SelectContent>
-          </Select>
-          <div className="hidden items-center rounded-md border border-border/50 bg-muted/50 md:flex">
+    <div className="flex h-full overflow-hidden">
+      {/* LEFT: File tree sidebar — desktop only */}
+      {sidebarOpen && (
+        <div
+          data-diff-sidebar
+          className="hidden shrink-0 flex-col md:flex"
+          style={{ width: sidebarWidth }}
+        >
+          <div className="flex shrink-0 items-center justify-between border-b border-border px-3 py-2">
+            <span className="text-xs font-medium text-muted-foreground">Files</span>
             <button
               type="button"
-              onClick={() => setViewMode("unified")}
-              className={`inline-flex items-center gap-1 rounded-l-md px-2 py-1 text-xs transition-colors ${
-                viewMode === "unified"
-                  ? "bg-accent text-foreground"
-                  : "text-muted-foreground hover:text-foreground"
-              }`}
-              title="Unified view"
+              onClick={() => setSidebarOpen(false)}
+              className="rounded p-0.5 text-muted-foreground hover:bg-accent/50 hover:text-foreground"
+              title="Hide file tree"
             >
-              <Rows2 className="size-3.5" />
-            </button>
-            <button
-              type="button"
-              onClick={() => setViewMode("split")}
-              className={`inline-flex items-center gap-1 rounded-r-md px-2 py-1 text-xs transition-colors ${
-                viewMode === "split"
-                  ? "bg-accent text-foreground"
-                  : "text-muted-foreground hover:text-foreground"
-              }`}
-              title="Split view"
-            >
-              <Columns2 className="size-3.5" />
+              <PanelLeftClose className="size-3.5" />
             </button>
           </div>
+          <div className="min-h-0 flex-1 overflow-y-auto py-1">
+            <ChangesFileTree fileStatuses={fileStatuses} onSelectFile={handleScrollToFile} />
+          </div>
         </div>
-      </div>
-      {search.searchOpen && (
-        <SearchBar
-          ref={search.searchBarRef}
-          query={search.searchQuery}
-          onQueryChange={search.setSearchQuery}
-          options={search.searchOptions}
-          onOptionsChange={search.setSearchOptions}
-          placeholder="Find in changes..."
-          matchInfo={search.matchInfo}
-          onNext={search.handleNext}
-          onPrevious={search.handlePrevious}
-          onClose={search.handleCloseSearch}
+      )}
+
+      {/* Resize handle between sidebar and main content */}
+      {sidebarOpen && (
+        <div
+          onMouseDown={handleResizeStart}
+          className="hidden w-[3px] shrink-0 cursor-col-resize bg-border/50 transition-colors hover:bg-accent-foreground/20 active:bg-accent-foreground/30 md:block"
         />
       )}
-      <div className="min-h-0 flex-1 overflow-y-auto">
-        {filenames.map((filename) => (
-          <LazyFileRow
-            key={filename}
-            filename={filename}
-            status={fileStatuses[filename]}
-            workspaceId={workspaceId}
-            mergeBase={summary.mergeBase}
-            viewMode={viewMode}
-            expandAll={expandAll}
-            onOpenFile={onOpenFile}
-            onEditorViews={handleEditorViews}
+
+      {/* RIGHT: Main content (toolbar + file list) */}
+      <div className="flex min-w-0 flex-1 flex-col overflow-hidden">
+        <div className="flex shrink-0 items-center justify-between border-b border-border px-4 py-2">
+          <div className="flex items-center gap-3">
+            {/* Sidebar toggle — only visible on desktop when sidebar is closed */}
+            {!sidebarOpen && (
+              <button
+                type="button"
+                onClick={() => setSidebarOpen(true)}
+                className="hidden items-center rounded-md border border-border/50 bg-muted/50 px-2 py-1 text-xs text-muted-foreground transition-colors hover:text-foreground md:inline-flex"
+                title="Show file tree"
+              >
+                <PanelLeftOpen className="size-3.5" />
+              </button>
+            )}
+            <div>
+              <div className="text-sm text-muted-foreground">
+                <span className="font-medium text-foreground">{summary.stats.filesChanged}</span>{" "}
+                {summary.stats.filesChanged === 1 ? "file" : "files"} changed
+                {summary.stats.insertions > 0 && (
+                  <span className="ml-2 text-green-600 dark:text-green-400">
+                    +{summary.stats.insertions}
+                  </span>
+                )}
+                {summary.stats.deletions > 0 && (
+                  <span className="ml-1 text-red-600 dark:text-red-400">
+                    -{summary.stats.deletions}
+                  </span>
+                )}
+              </div>
+              <div className="mt-0.5 text-xs text-muted-foreground">
+                {summary.baseBranch} &larr; {summary.headBranch}
+              </div>
+            </div>
+          </div>
+          <div className="flex items-center gap-2">
+            <button
+              type="button"
+              onClick={search.handleOpenSearch}
+              className="inline-flex items-center rounded-md border border-border/50 bg-muted/50 px-2 py-1 text-xs text-muted-foreground transition-colors hover:text-foreground"
+              title="Find in changes (⌘F)"
+            >
+              <Search className="size-3.5" />
+            </button>
+            <button
+              type="button"
+              onClick={() => setExpandAll(!expandAll)}
+              className={`inline-flex items-center rounded-md border border-border/50 px-2 py-1 text-xs transition-colors ${
+                expandAll
+                  ? "bg-accent text-foreground"
+                  : "bg-muted/50 text-muted-foreground hover:text-foreground"
+              }`}
+              title={expandAll ? "Collapse all files" : "Expand all files"}
+            >
+              {expandAll ? (
+                <ChevronsDownUp className="size-3.5" />
+              ) : (
+                <ChevronsUpDown className="size-3.5" />
+              )}
+            </button>
+            <Select value={diffMode} onValueChange={(v) => setDiffMode(v as DiffMode)}>
+              <SelectTrigger className="h-7 w-auto gap-1 rounded-md border-border/50 bg-muted/50 px-2.5 text-xs">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="uncommitted">Uncommitted</SelectItem>
+                <SelectItem value="branch">{baseBranch ?? "base"}</SelectItem>
+              </SelectContent>
+            </Select>
+            <div className="hidden items-center rounded-md border border-border/50 bg-muted/50 md:flex">
+              <button
+                type="button"
+                onClick={() => setViewMode("unified")}
+                className={`inline-flex items-center gap-1 rounded-l-md px-2 py-1 text-xs transition-colors ${
+                  viewMode === "unified"
+                    ? "bg-accent text-foreground"
+                    : "text-muted-foreground hover:text-foreground"
+                }`}
+                title="Unified view"
+              >
+                <Rows2 className="size-3.5" />
+              </button>
+              <button
+                type="button"
+                onClick={() => setViewMode("split")}
+                className={`inline-flex items-center gap-1 rounded-r-md px-2 py-1 text-xs transition-colors ${
+                  viewMode === "split"
+                    ? "bg-accent text-foreground"
+                    : "text-muted-foreground hover:text-foreground"
+                }`}
+                title="Split view"
+              >
+                <Columns2 className="size-3.5" />
+              </button>
+            </div>
+          </div>
+        </div>
+        {search.searchOpen && (
+          <SearchBar
+            ref={search.searchBarRef}
+            query={search.searchQuery}
+            onQueryChange={search.setSearchQuery}
+            options={search.searchOptions}
+            onOptionsChange={search.setSearchOptions}
+            placeholder="Find in changes..."
+            matchInfo={search.matchInfo}
+            onNext={search.handleNext}
+            onPrevious={search.handlePrevious}
+            onClose={search.handleCloseSearch}
           />
-        ))}
+        )}
+        <div className="min-h-0 flex-1 overflow-y-auto">
+          {filenames.map((filename) => (
+            <LazyFileRow
+              key={filename}
+              filename={filename}
+              status={fileStatuses[filename]}
+              workspaceId={workspaceId}
+              mergeBase={summary.mergeBase}
+              viewMode={viewMode}
+              expandAll={expandAll}
+              focusedFile={focusedFile}
+              onOpenFile={onOpenFile}
+              onEditorViews={handleEditorViews}
+            />
+          ))}
+        </div>
       </div>
     </div>
   );

--- a/packages/dashboard-core/src/components/FileStatusBadge.tsx
+++ b/packages/dashboard-core/src/components/FileStatusBadge.tsx
@@ -1,0 +1,14 @@
+import type { FileStatus } from "../types";
+
+const statusColors: Record<FileStatus, string> = {
+  A: "text-green-600 dark:text-green-400",
+  M: "text-blue-600 dark:text-blue-400",
+  D: "text-red-600 dark:text-red-400",
+  R: "text-purple-600 dark:text-purple-400",
+  U: "text-yellow-600 dark:text-yellow-400",
+};
+
+export function FileStatusBadge({ status }: { status: FileStatus | undefined }) {
+  if (!status) return null;
+  return <span className={`shrink-0 text-xs font-bold ${statusColors[status]}`}>{status}</span>;
+}

--- a/packages/dashboard-core/src/lib/build-file-tree.ts
+++ b/packages/dashboard-core/src/lib/build-file-tree.ts
@@ -1,0 +1,95 @@
+import type { FileStatus } from "../types";
+
+export interface FileTreeNode {
+  /** Display name — for compressed dirs this could be "src/components" */
+  name: string;
+  /** Full path from root (the key into fileStatuses for leaf files) */
+  path: string;
+  /** File status badge — only set on leaf file nodes */
+  status?: FileStatus;
+  /** Children nodes — only set on directory nodes, sorted: dirs first, then files, alphabetically */
+  children?: FileTreeNode[];
+}
+
+interface TrieNode {
+  children: Map<string, TrieNode>;
+  status?: FileStatus;
+}
+
+/**
+ * Builds a hierarchical file tree from a flat map of file paths to statuses.
+ *
+ * Features:
+ * - Path compression: single-child directory chains merge into one node
+ *   (e.g., "src/lib" instead of nested src → lib)
+ * - Sorting: directories first (alphabetical), then files (alphabetical)
+ */
+export function buildFileTree(fileStatuses: Record<string, FileStatus>): FileTreeNode[] {
+  // 1. Build trie from flat paths
+  const root: TrieNode = { children: new Map() };
+
+  for (const [filePath, status] of Object.entries(fileStatuses)) {
+    const parts = filePath.split("/");
+    let current = root;
+
+    for (let i = 0; i < parts.length; i++) {
+      const part = parts[i];
+      if (!current.children.has(part)) {
+        current.children.set(part, { children: new Map() });
+      }
+      current = current.children.get(part)!;
+
+      // Mark leaf node with status
+      if (i === parts.length - 1) {
+        current.status = status;
+      }
+    }
+  }
+
+  // 2. Convert trie to FileTreeNode[] with path compression
+  return trieToNodes(root, "");
+}
+
+function trieToNodes(trie: TrieNode, parentPath: string): FileTreeNode[] {
+  const nodes: FileTreeNode[] = [];
+
+  for (const [name, child] of trie.children) {
+    const fullPath = parentPath ? `${parentPath}/${name}` : name;
+    const isFile = child.status !== undefined && child.children.size === 0;
+
+    if (isFile) {
+      nodes.push({ name, path: fullPath, status: child.status });
+    } else {
+      // Directory node — apply path compression
+      let compressedName = name;
+      let compressedPath = fullPath;
+      let current = child;
+
+      // Compress single-child directory chains (only when child is also a directory)
+      while (current.children.size === 1 && current.status === undefined) {
+        const [childName, grandchild] = current.children.entries().next().value as [
+          string,
+          TrieNode,
+        ];
+        const isChildFile = grandchild.status !== undefined && grandchild.children.size === 0;
+        if (isChildFile) break; // Don't compress a dir with a single file child
+        compressedName = `${compressedName}/${childName}`;
+        compressedPath = `${compressedPath}/${childName}`;
+        current = grandchild;
+      }
+
+      const children = trieToNodes(current, compressedPath);
+      nodes.push({ name: compressedName, path: compressedPath, children });
+    }
+  }
+
+  // Sort: directories first (alphabetical), then files (alphabetical)
+  nodes.sort((a, b) => {
+    const aIsDir = a.children !== undefined;
+    const bIsDir = b.children !== undefined;
+    if (aIsDir !== bIsDir) return aIsDir ? -1 : 1;
+    return a.name.localeCompare(b.name);
+  });
+
+  return nodes;
+}


### PR DESCRIPTION
## Summary

- Add a collapsible file tree sidebar to the diff/changes view that organizes changed files by directory with path compression
- Clicking a file in the tree expands its diff row and scrolls to it
- Sidebar is resizable via drag handle (width persisted to localStorage) and desktop-only (hidden on mobile)

### New files
- `build-file-tree.ts` — pure utility: builds hierarchical tree from flat file paths with path compression and sorting
- `ChangesFileTree.tsx` — tree sidebar component with expand/collapse, file icons, and status badges
- `FileStatusBadge.tsx` — extracted shared component (A/M/D/R/U badges)

### Modified
- `DiffView.tsx` — sidebar state, horizontal layout, resize handle, focus-and-scroll on tree click

## Test plan
- [ ] Open a workspace with changes, verify file tree sidebar appears on desktop
- [ ] Click files in the tree — diff row should expand and scroll into view
- [ ] Drag the resize handle between sidebar and diff content
- [ ] Collapse sidebar with close button, reopen with toolbar button
- [ ] Resize the browser to mobile width — sidebar should be hidden
- [ ] Switch diff modes (uncommitted/branch) — tree should update
- [ ] Refresh page — sidebar open/closed state and width should persist

🤖 Generated with [Claude Code](https://claude.com/claude-code)