### PR TITLE
fix: disable focus/window management in full-editor mode at runtime

### DIFF
--- a/apps/dashboard/src-tauri/src/commands/ide.rs
+++ b/apps/dashboard/src-tauri/src/commands/ide.rs
@@ -1,9 +1,11 @@
 use crate::api::ApiClient;
 use crate::state;
-use crate::state::{ActiveWorkspaceState, ProjectCache};
+use crate::state::{ActiveWorkspaceState, FocusManagementState, ProjectCache};
 use std::collections::{HashMap, VecDeque};
 use std::ffi::c_void;
 use std::path::{Path, PathBuf};
+use std::sync::atomic::AtomicBool;
+use std::sync::Arc;
 use std::time::Duration;
 use tauri::{Emitter, Manager};
 
@@ -403,7 +405,9 @@ pub fn raise_workspace_windows(workspace_id: &str, cache: &ProjectCache) {
 
 /// Start a background thread that polls the frontmost window
 /// and updates active workspace state when the focused workspace changes.
-pub fn start_focus_polling(app_handle: tauri::AppHandle) {
+/// The thread exits when `enabled` is set to `false` (e.g. when the app
+/// switches to full-editor mode).
+pub fn start_focus_polling(app_handle: tauri::AppHandle, enabled: Arc<AtomicBool>) {
     let active_state = {
         let s = app_handle.state::<ActiveWorkspaceState>();
         s.inner().0.clone()
@@ -430,6 +434,12 @@ pub fn start_focus_polling(app_handle: tauri::AppHandle) {
 
         loop {
             std::thread::sleep(Duration::from_millis(500));
+
+            // Exit the polling thread when focus management is disabled
+            // (e.g. user switched to full-editor mode at runtime).
+            if !enabled.load(std::sync::atomic::Ordering::SeqCst) {
+                break;
+            }
 
             // Refresh project cache from web server every 5 seconds
             if last_cache_refresh.elapsed() >= Duration::from_secs(5) {
@@ -503,7 +513,18 @@ pub fn workspace_focus(
     app_handle: tauri::AppHandle,
     active_state: tauri::State<'_, ActiveWorkspaceState>,
     project_cache: tauri::State<'_, ProjectCache>,
+    focus_state: tauri::State<'_, FocusManagementState>,
 ) -> Result<(), String> {
+    // In full-editor mode, external window management is disabled.
+    // The frontend adapter already guards this, but we check here as
+    // defense in depth.
+    if !focus_state
+        .0
+        .load(std::sync::atomic::Ordering::SeqCst)
+    {
+        return Ok(());
+    }
+
     use std::sync::Mutex;
     use std::time::Instant;
 

--- a/apps/dashboard/src-tauri/src/commands/ide.rs
+++ b/apps/dashboard/src-tauri/src/commands/ide.rs
@@ -518,10 +518,7 @@ pub fn workspace_focus(
     // In full-editor mode, external window management is disabled.
     // The frontend adapter already guards this, but we check here as
     // defense in depth.
-    if !focus_state
-        .0
-        .load(std::sync::atomic::Ordering::SeqCst)
-    {
+    if !focus_state.0.load(std::sync::atomic::Ordering::SeqCst) {
         return Ok(());
     }
 

--- a/apps/dashboard/src-tauri/src/commands/ide_stub.rs
+++ b/apps/dashboard/src-tauri/src/commands/ide_stub.rs
@@ -1,9 +1,11 @@
 //! Stub implementations of the IDE commands for non-macOS platforms.
 //! The real implementation lives in `ide.rs` and uses macOS-specific APIs.
 
-use crate::state::{ActiveWorkspaceState, ProjectCache};
+use crate::state::{ActiveWorkspaceState, FocusManagementState, ProjectCache};
+use std::sync::atomic::AtomicBool;
+use std::sync::Arc;
 
-pub fn start_focus_polling(_app_handle: tauri::AppHandle) {}
+pub fn start_focus_polling(_app_handle: tauri::AppHandle, _enabled: Arc<AtomicBool>) {}
 
 pub fn raise_workspace_windows(_workspace_id: &str, _cache: &ProjectCache) {}
 
@@ -12,6 +14,7 @@ pub fn workspace_focus(
     _workspace_id: String,
     _active_state: tauri::State<'_, ActiveWorkspaceState>,
     _project_cache: tauri::State<'_, ProjectCache>,
+    _focus_state: tauri::State<'_, FocusManagementState>,
 ) -> Result<(), String> {
     Err("Not supported on this platform".to_string())
 }

--- a/apps/dashboard/src-tauri/src/commands/window.rs
+++ b/apps/dashboard/src-tauri/src/commands/window.rs
@@ -1,3 +1,5 @@
+use crate::state::FocusManagementState;
+use std::sync::atomic::Ordering;
 use tauri::{AppHandle, Manager, WebviewUrl, WebviewWindowBuilder};
 
 /// Derives a URL for a secondary window by taking the main window's origin
@@ -94,6 +96,14 @@ pub async fn set_app_mode(app: AppHandle, mode: String) -> Result<(), String> {
         .get_webview_window("main")
         .ok_or("Main window not found")?;
 
+    // Toggle focus management based on the new mode.
+    // In full-editor mode, the Tauri app IS the editor, so focus polling
+    // and automatic window raising must be disabled.
+    let focus_state = app.state::<FocusManagementState>();
+    let was_enabled = focus_state.0.load(Ordering::SeqCst);
+    let should_enable = mode != "full-editor";
+    focus_state.0.store(should_enable, Ordering::SeqCst);
+
     let monitor = window
         .current_monitor()
         .map_err(|e| format!("Failed to get monitor: {e}"))?
@@ -120,6 +130,14 @@ pub async fn set_app_mode(app: AppHandle, mode: String) -> Result<(), String> {
         let _ = window.set_position(tauri::Position::Logical(tauri::LogicalPosition::new(
             0.0, 0.0,
         )));
+    }
+
+    // Start focus polling if switching from full-editor to side-panel.
+    // The old polling thread (if any) already exited when the flag was
+    // set to false.
+    if should_enable && !was_enabled {
+        let flag = focus_state.inner().0.clone();
+        crate::commands::ide::start_focus_polling(app.clone(), flag);
     }
 
     // Reload the main webview so it picks up the new app mode from settings

--- a/apps/dashboard/src-tauri/src/lib.rs
+++ b/apps/dashboard/src-tauri/src/lib.rs
@@ -11,7 +11,7 @@ use std::sync::Arc;
 
 use commands::browser::BrowserState;
 use commands::webserver::{self as webserver, ManagedProcess, WebServerState};
-use state::{ActiveWorkspaceState, ProjectCache};
+use state::{ActiveWorkspaceState, FocusManagementState, ProjectCache};
 use tauri::menu::{MenuBuilder, MenuItemBuilder, PredefinedMenuItem, SubmenuBuilder};
 use tauri::Manager;
 
@@ -64,6 +64,7 @@ pub fn run() {
         .manage(ActiveWorkspaceState::new())
         .manage(ProjectCache::new())
         .manage(BrowserState::new())
+        .manage(FocusManagementState::new(true))
         .invoke_handler(tauri::generate_handler![
             commands::ide::workspace_focus,
             commands::ide::workspace_close,
@@ -218,10 +219,20 @@ pub fn run() {
                 }
             }
 
+            // Update the focus-management flag based on the persisted app mode.
+            // Default is `true` (enabled); disable it in full-editor mode.
+            let focus_state = app.state::<FocusManagementState>();
+            if app_mode == "full-editor" {
+                focus_state
+                    .0
+                    .store(false, std::sync::atomic::Ordering::SeqCst);
+            }
+
             // Poll the frontmost VS Code window to track active workspace.
             // Only needed in side-panel mode where we manage external IDE windows.
             if app_mode != "full-editor" {
-                commands::ide::start_focus_polling(app.handle().clone());
+                let focus_flag = focus_state.inner().0.clone();
+                commands::ide::start_focus_polling(app.handle().clone(), focus_flag);
             }
 
             // Kill web server and close secondary windows on app exit.
@@ -265,15 +276,24 @@ pub fn run() {
                 }
             });
 
-            // Raise the active workspace's app windows when dashboard gains focus.
-            // Only in side-panel mode where external IDE windows are managed.
-            if app_mode != "full-editor" {
+            // Raise the active workspace's app windows when the dashboard gains focus.
+            // The handler is always registered but checks the focus-management flag
+            // at runtime so it becomes a no-op in full-editor mode (and respects
+            // runtime mode switches via `set_app_mode`).
+            {
+                let focus_flag = app.state::<FocusManagementState>().inner().0.clone();
                 let active_ws_state: std::sync::Arc<std::sync::Mutex<Option<String>>> =
                     app.state::<ActiveWorkspaceState>().inner().0.clone();
                 let raise_cache = app.state::<ProjectCache>().inner().clone();
                 let window_ref = app.get_webview_window("main").unwrap();
                 window_ref.on_window_event(move |event| {
                     if let tauri::WindowEvent::Focused(true) = event {
+                        // Skip window raising when focus management is disabled
+                        // (full-editor mode).
+                        if !focus_flag.load(std::sync::atomic::Ordering::SeqCst) {
+                            return;
+                        }
+
                         let workspace_id: Option<String> =
                             active_ws_state.lock().ok().and_then(|guard| guard.clone());
 

--- a/apps/dashboard/src-tauri/src/state.rs
+++ b/apps/dashboard/src-tauri/src/state.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Serialize};
 use std::fs;
 use std::path::PathBuf;
+use std::sync::atomic::AtomicBool;
 use std::sync::{Arc, Mutex};
 
 // --- Data types for API responses ---
@@ -91,6 +92,19 @@ pub fn load_settings() -> Result<Settings, String> {
     }
     let data = fs::read_to_string(&path).map_err(|e| format!("Failed to read settings: {e}"))?;
     serde_json::from_str(&data).map_err(|e| format!("Failed to parse settings: {e}"))
+}
+
+// --- Focus management state (shared flag for runtime mode toggling) ---
+
+/// Tracks whether focus management (polling, window raising) is enabled.
+/// Set to `false` in full-editor mode so the Tauri app does not interfere
+/// with the user's window arrangement.
+pub struct FocusManagementState(pub Arc<AtomicBool>);
+
+impl FocusManagementState {
+    pub fn new(enabled: bool) -> Self {
+        Self(Arc::new(AtomicBool::new(enabled)))
+    }
 }
 
 // --- In-memory active workspace state ---


### PR DESCRIPTION
## Summary

When the Tauri app switches between "side-panel" and "full-editor" mode at runtime via Settings, focus polling and window-raise-on-focus logic kept running because the guards only applied at startup. This caused unexpected window behavior in full-editor mode (auto-focusing, repositioning, bringing windows to front).

**Root cause:** `start_focus_polling()` had no stop mechanism, `on_window_event` closures can't be unregistered, and `set_app_mode` only resized the window without updating any Rust-side state.

**Fix:** Introduced a shared `FocusManagementState` (`Arc<AtomicBool>`) checked dynamically by all focus/window management code:

- Focus polling thread exits when the flag is set to `false`
- Window-raise event handler becomes a no-op when disabled
- `workspace_focus` command early-returns when disabled (defense in depth)
- `set_app_mode` toggles the flag and starts/stops polling as needed

### Files changed

- `state.rs` — New `FocusManagementState` type
- `lib.rs` — Wire up shared state, always register event handler with runtime check
- `ide.rs` — Stop flag in polling loop, guard on `workspace_focus`
- `window.rs` — Runtime toggle in `set_app_mode`
- `ide_stub.rs` — Signature parity for non-macOS builds

Closes #240

🤖 Generated with [Claude Code](https://claude.com/claude-code)