### PR TITLE
Add browser-like zoom support (Cmd+=/Cmd+-/Cmd+0)

### DIFF
--- a/apps/dashboard/src-tauri/src/lib.rs
+++ b/apps/dashboard/src-tauri/src/lib.rs
@@ -170,7 +170,7 @@ pub fn run() {
                         .cloned()
                         .or_else(|| app_handle.get_webview_window("main"));
                     if let Some(win) = target {
-                        let _ = win.eval(&format!(
+                        let _ = win.eval(format!(
                             "if(window.__bandZoom)window.__bandZoom('{action}')"
                         ));
                     }

--- a/apps/dashboard/src-tauri/src/lib.rs
+++ b/apps/dashboard/src-tauri/src/lib.rs
@@ -107,11 +107,24 @@ pub fn run() {
             let reload_item = MenuItemBuilder::with_id("reload", "Reload")
                 .accelerator("CmdOrCtrl+R")
                 .build(app)?;
+            let zoom_in_item = MenuItemBuilder::with_id("zoom_in", "Zoom In")
+                .accelerator("CmdOrCtrl+=")
+                .build(app)?;
+            let zoom_out_item = MenuItemBuilder::with_id("zoom_out", "Zoom Out")
+                .accelerator("CmdOrCtrl+-")
+                .build(app)?;
+            let zoom_reset_item = MenuItemBuilder::with_id("zoom_reset", "Actual Size")
+                .accelerator("CmdOrCtrl+0")
+                .build(app)?;
             let settings_item = MenuItemBuilder::with_id("settings", "Settings...")
                 .accelerator("CmdOrCtrl+Comma")
                 .build(app)?;
             let view_menu = SubmenuBuilder::new(app, "View")
                 .item(&reload_item)
+                .separator()
+                .item(&zoom_in_item)
+                .item(&zoom_out_item)
+                .item(&zoom_reset_item)
                 .separator()
                 .item(&settings_item)
                 .build()?;
@@ -138,6 +151,28 @@ pub fn run() {
                         if let Ok(url) = win.url() {
                             let _ = win.navigate(url);
                         }
+                    }
+                } else if event.id() == "zoom_in"
+                    || event.id() == "zoom_out"
+                    || event.id() == "zoom_reset"
+                {
+                    let action = match event.id().0.as_str() {
+                        "zoom_in" => "in",
+                        "zoom_out" => "out",
+                        _ => "reset",
+                    };
+                    // Apply zoom to the focused window (or main as fallback).
+                    // The JS function is registered by ZoomSync in __root.tsx.
+                    let target = app_handle
+                        .webview_windows()
+                        .values()
+                        .find(|w| w.is_focused().unwrap_or(false))
+                        .cloned()
+                        .or_else(|| app_handle.get_webview_window("main"));
+                    if let Some(win) = target {
+                        let _ = win.eval(&format!(
+                            "if(window.__bandZoom)window.__bandZoom('{action}')"
+                        ));
                     }
                 } else if event.id() == "settings" {
                     let handle = app_handle.clone();

--- a/apps/web/src/hooks/useZoom.ts
+++ b/apps/web/src/hooks/useZoom.ts
@@ -1,0 +1,49 @@
+import { useEffect } from "react";
+import { isTauri } from "../lib/is-tauri";
+import { zoomIn, zoomOut, zoomReset } from "../lib/zoom";
+
+/**
+ * Browser-mode keyboard shortcut handler for zoom.
+ *
+ * Registers Cmd+= (zoom in), Cmd+- (zoom out), and Cmd+0 (reset).
+ * Only active outside Tauri — in Tauri mode the native View menu
+ * accelerators intercept these keys before they reach the webview.
+ */
+export function useZoom(): void {
+  useEffect(() => {
+    // In Tauri, the View menu accelerators handle Cmd+=/Cmd+-/Cmd+0
+    // before they reach the webview, so skip the JS listener.
+    if (isTauri) return;
+
+    const handler = (e: KeyboardEvent) => {
+      if (!(e.metaKey || e.ctrlKey)) return;
+
+      // Cmd+= or Cmd++ → zoom in
+      // On US keyboards, Shift is needed for +, but = and + share a key.
+      if (e.key === "=" || e.key === "+") {
+        e.preventDefault();
+        e.stopPropagation();
+        zoomIn();
+        return;
+      }
+
+      // Cmd+- → zoom out
+      if (e.key === "-") {
+        e.preventDefault();
+        e.stopPropagation();
+        zoomOut();
+        return;
+      }
+
+      // Cmd+0 → reset zoom
+      if (e.key === "0") {
+        e.preventDefault();
+        e.stopPropagation();
+        zoomReset();
+      }
+    };
+
+    window.addEventListener("keydown", handler, true);
+    return () => window.removeEventListener("keydown", handler, true);
+  }, []);
+}

--- a/apps/web/src/lib/zoom.ts
+++ b/apps/web/src/lib/zoom.ts
@@ -1,0 +1,52 @@
+const ZOOM_LEVEL_KEY = "band:zoom-level";
+
+export const DEFAULT_ZOOM = 1.0;
+export const MIN_ZOOM = 0.5;
+export const MAX_ZOOM = 2.0;
+export const ZOOM_STEP = 0.1;
+
+/**
+ * Load the persisted zoom level (0.5–2.0).
+ * Falls back to DEFAULT_ZOOM if nothing is stored or the value is invalid.
+ */
+export function loadZoomLevel(): number {
+  try {
+    const stored = localStorage.getItem(ZOOM_LEVEL_KEY);
+    if (stored) {
+      const parsed = Number.parseFloat(stored);
+      if (!Number.isNaN(parsed) && parsed >= MIN_ZOOM && parsed <= MAX_ZOOM) {
+        return parsed;
+      }
+    }
+  } catch {}
+  return DEFAULT_ZOOM;
+}
+
+/** Persist a zoom level to localStorage, clamped and rounded. */
+export function saveZoomLevel(level: number): void {
+  const clamped = Math.min(MAX_ZOOM, Math.max(MIN_ZOOM, level));
+  const rounded = Math.round(clamped * 100) / 100;
+  try {
+    localStorage.setItem(ZOOM_LEVEL_KEY, String(rounded));
+  } catch {}
+}
+
+/** Apply a zoom level to the document root and persist it. */
+export function applyZoomLevel(level: number): void {
+  const clamped = Math.min(MAX_ZOOM, Math.max(MIN_ZOOM, level));
+  const rounded = Math.round(clamped * 100) / 100;
+  document.documentElement.style.zoom = String(rounded);
+  saveZoomLevel(rounded);
+}
+
+export function zoomIn(): void {
+  applyZoomLevel(loadZoomLevel() + ZOOM_STEP);
+}
+
+export function zoomOut(): void {
+  applyZoomLevel(loadZoomLevel() - ZOOM_STEP);
+}
+
+export function zoomReset(): void {
+  applyZoomLevel(DEFAULT_ZOOM);
+}

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -21,6 +21,7 @@ import { TauriTitleBar } from "../components/TauriTitleBar";
 import { ToolbarButtons } from "../components/ToolbarButtons";
 import { useIsDesktop } from "../hooks/useIsDesktop";
 import { useNavigationHistory } from "../hooks/useNavigationHistory";
+import { useZoom } from "../hooks/useZoom";
 import { isTauri } from "../lib/is-tauri";
 import {
   loadSidebarWidth,
@@ -28,6 +29,7 @@ import {
   SIDEBAR_MIN_SIZE,
   saveSidebarWidth,
 } from "../lib/sidebar-width";
+import { applyZoomLevel, loadZoomLevel, zoomIn, zoomOut, zoomReset } from "../lib/zoom";
 import "../styles/globals.css";
 
 const adapter = isTauri ? new HybridDashboardAdapter() : new WebDashboardAdapter();
@@ -69,6 +71,10 @@ function NotFound() {
 /** Blocking script injected into <head> to apply the theme before first paint.
  *  Reads a cached theme value from localStorage (written by ThemeSync). */
 const THEME_INIT_SCRIPT = `(function(){try{var t=localStorage.getItem("band-theme")||"dark";var d=document.documentElement;if(t==="system"){if(window.matchMedia("(prefers-color-scheme:dark)").matches)d.classList.add("dark");else d.classList.remove("dark")}else if(t==="dark"){d.classList.add("dark")}else{d.classList.remove("dark")}}catch(e){document.documentElement.classList.add("dark")}})()`;
+
+/** Blocking script injected into <head> to apply the zoom level before first paint.
+ *  Reads a cached zoom value from localStorage (written by ZoomSync / zoom.ts). */
+const ZOOM_INIT_SCRIPT = `(function(){try{var z=localStorage.getItem("band:zoom-level");if(z){var n=parseFloat(z);if(!isNaN(n)&&n>=0.5&&n<=2)document.documentElement.style.zoom=String(n)}}catch(e){}})()`;
 
 /** Applies a theme value ("dark", "light", or "system") to the document root. */
 function applyTheme(theme: string) {
@@ -124,6 +130,47 @@ function ThemeSync() {
   return null;
 }
 
+/** Syncs the zoom level across windows and exposes a global function
+ *  for the Tauri menu handler to call via window.eval(). */
+function ZoomSync() {
+  useEffect(() => {
+    // Safety net: apply the persisted zoom level on mount.
+    // The blocking script should have already set it, but this
+    // handles edge cases (e.g., new secondary window created later).
+    applyZoomLevel(loadZoomLevel());
+
+    // Expose a global function that the Rust menu event handler can call
+    // via webview.eval("if(window.__bandZoom)window.__bandZoom('in')").
+    (window as unknown as Record<string, unknown>).__bandZoom = (action: string) => {
+      if (action === "in") zoomIn();
+      else if (action === "out") zoomOut();
+      else zoomReset();
+    };
+
+    return () => {
+      delete (window as unknown as Record<string, unknown>).__bandZoom;
+    };
+  }, []);
+
+  // Cross-window zoom sync via the storage event.
+  // When another window updates "band:zoom-level" in localStorage,
+  // apply the change immediately to this window's DOM.
+  useEffect(() => {
+    const handleStorage = (e: StorageEvent) => {
+      if (e.key !== "band:zoom-level" || !e.newValue) return;
+      const level = Number.parseFloat(e.newValue);
+      if (!Number.isNaN(level) && level >= 0.5 && level <= 2) {
+        document.documentElement.style.zoom = String(level);
+      }
+    };
+
+    window.addEventListener("storage", handleStorage);
+    return () => window.removeEventListener("storage", handleStorage);
+  }, []);
+
+  return null;
+}
+
 const STANDALONE_ROUTES = ["/tasks", "/cronjobs", "/settings"];
 
 /**
@@ -169,6 +216,10 @@ function AppShell() {
   // Cmd+[ / Cmd+] — back/forward through workspace history
   const routerNavigate = useCallback((href: string) => router.navigate({ to: href }), [router]);
   useNavigationHistory(routerNavigate, capabilities);
+
+  // Cmd+= / Cmd+- / Cmd+0 — zoom in/out/reset (browser mode only;
+  // in Tauri the View menu accelerators handle these keys)
+  useZoom();
 
   // Resizable sidebar: load persisted width and skip the first layout callback
   // (react-resizable-panels fires it on mount with a computed layout that may
@@ -255,10 +306,13 @@ function RootLayout() {
         <HeadContent />
         {/* biome-ignore lint/security/noDangerouslySetInnerHtml: static inline script to prevent theme flash */}
         <script dangerouslySetInnerHTML={{ __html: THEME_INIT_SCRIPT }} />
+        {/* biome-ignore lint/security/noDangerouslySetInnerHtml: static inline script to prevent zoom layout flash */}
+        <script dangerouslySetInnerHTML={{ __html: ZOOM_INIT_SCRIPT }} />
       </head>
       <body>
         <DashboardProvider adapter={adapter} capabilities={capabilities}>
           <ThemeSync />
+          <ZoomSync />
           <ModeSync />
           <TooltipProvider>
             <AppShell />


### PR DESCRIPTION
## Summary

- Add Cmd+= (zoom in), Cmd+- (zoom out), Cmd+0 (reset) keyboard shortcuts that scale the entire webview content
- Add Zoom In, Zoom Out, and Actual Size items to the Tauri View menu with native accelerators
- Persist zoom level in localStorage across app restarts with a blocking init script to prevent layout flash
- Cross-window sync so all open windows (main, tasks, cronjobs, settings) stay at the same zoom level

## Changes

- **`apps/web/src/lib/zoom.ts`** — New zoom persistence module (load/save/apply with 0.5×–2.0× range, 0.1 step)
- **`apps/web/src/hooks/useZoom.ts`** — Keyboard shortcut hook for browser mode (Tauri uses native menu accelerators)
- **`apps/web/src/routes/__root.tsx`** — ZOOM_INIT_SCRIPT in `<head>`, ZoomSync component, useZoom hook integration
- **`apps/dashboard/src-tauri/src/lib.rs`** — View menu items + event handlers that call `window.__bandZoom()` via eval

## Test plan

- [ ] In Tauri app: Cmd+= zooms in, Cmd+- zooms out, Cmd+0 resets to 100%
- [ ] View menu shows Zoom In / Zoom Out / Actual Size with correct accelerators
- [ ] Zoom level persists after restarting the app
- [ ] Secondary windows (tasks, cronjobs, settings) sync zoom level
- [ ] In regular browser: Cmd+=/Cmd+-/Cmd+0 work via JS fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)