### PR TITLE
feat: add file browser tabs with navigation and markdown toggle

### DIFF
--- a/apps/web/src/components/CodeBrowserView.tsx
+++ b/apps/web/src/components/CodeBrowserView.tsx
@@ -1,10 +1,13 @@
 import {
   FileBrowser,
   FileViewer,
+  getFilePreviewType,
   parseFileLocation,
   SearchBar,
   scrollToLine,
+  toWorkspaceId,
   useEditorHistory,
+  useProjects,
   useSearch,
 } from "@band-app/dashboard-core";
 import { cn, Tooltip, TooltipContent, TooltipTrigger } from "@band-app/ui";
@@ -15,6 +18,8 @@ import { mermaid } from "@streamdown/mermaid";
 import {
   ChevronLeft,
   ChevronRight,
+  Code,
+  Eye,
   File,
   PanelLeftClose,
   PanelLeftOpen,
@@ -24,7 +29,9 @@ import {
 import { useCallback, useEffect, useRef, useState } from "react";
 import { Group, Panel, Separator, usePanelRef } from "react-resizable-panels";
 import { Streamdown } from "streamdown";
+import { useFileTabs } from "../hooks/useFileTabs";
 import { useIsDesktop } from "../hooks/useIsDesktop";
+import { FileTabBar } from "./FileTabBar";
 import { streamdownComponents } from "./streamdown-components";
 
 const streamdownPlugins = { cjk, code, math, mermaid };
@@ -210,6 +217,18 @@ export function CodeBrowserView({
   onSearchFiles,
 }: CodeBrowserViewProps) {
   const isDesktop = useIsDesktop();
+  const fileTabs = useFileTabs(workspaceId);
+  const { projects } = useProjects();
+  const workspacePath = (() => {
+    for (const proj of projects) {
+      for (const wt of proj.worktrees) {
+        if (toWorkspaceId(proj.name, wt.branch) === workspaceId) {
+          return wt.path;
+        }
+      }
+    }
+    return undefined;
+  })();
   const [viewFilePath, setViewFilePath] = useState(() => {
     if (!file) return "";
     return parseFileLocation(file).filePath;
@@ -226,6 +245,25 @@ export function CodeBrowserView({
     if (!file) return undefined;
     return parseFileLocation(file).column;
   });
+
+  // Markdown view mode (controlled from here, rendered in tab bar actions)
+  const [mdViewMode, setMdViewMode] = useState<"preview" | "source">("preview");
+  const isMarkdown = viewFilePath ? getFilePreviewType(viewFilePath) === "markdown" : false;
+
+  // Reset to preview when switching to a different file
+  // biome-ignore lint/correctness/useExhaustiveDependencies: reset on file change only
+  useEffect(() => {
+    setMdViewMode("preview");
+  }, [viewFilePath]);
+
+  // Open initial file as a tab (desktop only)
+  // biome-ignore lint/correctness/useExhaustiveDependencies: only on mount
+  useEffect(() => {
+    if (file) {
+      const loc = parseFileLocation(file);
+      fileTabs.openTab(loc.filePath);
+    }
+  }, []);
 
   // -------------------------------------------------------------------------
   // CodeMirror editor view ref (shared by find-in-file and navigation history)
@@ -284,6 +322,7 @@ export function CodeBrowserView({
         line: loc.line ?? 1,
         column: loc.column,
       });
+      fileTabs.openTab(loc.filePath);
       setViewFilePath(loc.filePath);
       setViewLine(loc.line);
       setViewLineEnd(loc.lineEnd);
@@ -301,6 +340,7 @@ export function CodeBrowserView({
         line: loc.line ?? 1,
         column: loc.column,
       });
+      fileTabs.openTab(loc.filePath);
       setViewFilePath(loc.filePath);
       setViewLine(loc.line);
       setViewLineEnd(loc.lineEnd);
@@ -356,13 +396,14 @@ export function CodeBrowserView({
   const handleSelectFile = useCallback(
     (filePath: string) => {
       pushDepartureAndArrival({ filePath });
+      fileTabs.openTab(filePath);
       setViewFilePath(filePath);
       setViewLine(undefined);
       setViewLineEnd(undefined);
       setViewColumn(undefined);
       onSelectFile?.(filePath);
     },
-    [onSelectFile, pushDepartureAndArrival],
+    [onSelectFile, pushDepartureAndArrival, fileTabs.openTab],
   );
 
   const handleBack = useCallback(() => {
@@ -373,12 +414,65 @@ export function CodeBrowserView({
     onSelectFile?.(null);
   }, [onSelectFile]);
 
+  // -------------------------------------------------------------------------
+  // Tab handlers
+  // -------------------------------------------------------------------------
+  const handleTabSelect = useCallback(
+    (filePath: string) => {
+      fileTabs.setActiveTab(filePath);
+      setViewFilePath(filePath);
+      setViewLine(undefined);
+      setViewLineEnd(undefined);
+      setViewColumn(undefined);
+      onSelectFile?.(filePath);
+    },
+    [fileTabs.setActiveTab, onSelectFile],
+  );
+
+  const handleTabClose = useCallback(
+    (filePath: string) => {
+      // Clear the unsaved edits cache so the file reloads fresh from
+      // the server when reopened (same key format as FileViewer).
+      try {
+        localStorage.removeItem(`band-edits:${workspaceId}\0${filePath}`);
+      } catch {
+        // storage unavailable
+      }
+      fileTabs.closeTab(filePath);
+    },
+    [fileTabs.closeTab, workspaceId],
+  );
+
+  // Sync viewFilePath when active tab changes due to a close.
+  // Only reacts to tab state changes — onSelectFile and viewFilePath are
+  // intentionally read as latest values to avoid re-triggering on every
+  // parent render or file navigation.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: onSelectFile and viewFilePath are intentionally excluded to prevent feedback loops
+  useEffect(() => {
+    if (fileTabs.activeTabPath === null && fileTabs.openTabs.length === 0) {
+      // All tabs closed — show empty state
+      setViewFilePath("");
+      setViewLine(undefined);
+      setViewLineEnd(undefined);
+      setViewColumn(undefined);
+      onSelectFile?.(null);
+    } else if (fileTabs.activeTabPath && fileTabs.activeTabPath !== viewFilePath) {
+      // Active tab changed (e.g. after closing) — sync to new active tab
+      setViewFilePath(fileTabs.activeTabPath);
+      setViewLine(undefined);
+      setViewLineEnd(undefined);
+      setViewColumn(undefined);
+      onSelectFile?.(fileTabs.activeTabPath);
+    }
+  }, [fileTabs.activeTabPath, fileTabs.openTabs.length]);
+
   const navigateToEntry = useCallback(
     (entry: { filePath: string; line?: number; column?: number }) => {
       const sameFile = entry.filePath === viewFilePath;
       // Prevent the file prop effect from overwriting the line we're about to set.
       // The route round-trip only carries the file path, not the line.
       if (!sameFile) skipFileEffectRef.current = true;
+      fileTabs.openTab(entry.filePath);
       setViewFilePath(entry.filePath);
       setViewLine(entry.line);
       setViewLineEnd(undefined);
@@ -397,7 +491,7 @@ export function CodeBrowserView({
         focusOnViewReadyRef.current = true;
       }
     },
-    [viewFilePath, onSelectFile],
+    [viewFilePath, onSelectFile, fileTabs.openTab],
   );
 
   const handleEditorGoBack = useCallback(() => {
@@ -422,6 +516,21 @@ export function CodeBrowserView({
       window.removeEventListener("band:editor-go-forward", handleGoForward);
     };
   }, [handleEditorGoBack, handleEditorGoForward]);
+
+  // Cmd+W / Ctrl+W to close active tab
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if ((e.metaKey || e.ctrlKey) && e.key === "w") {
+        if (fileTabs.activeTabPath) {
+          e.preventDefault();
+          e.stopPropagation();
+          handleTabClose(fileTabs.activeTabPath);
+        }
+      }
+    };
+    window.addEventListener("keydown", handler, { capture: true });
+    return () => window.removeEventListener("keydown", handler, { capture: true });
+  }, [fileTabs.activeTabPath, handleTabClose]);
 
   // -------------------------------------------------------------------------
   // Resizable file tree panel
@@ -548,9 +657,9 @@ export function CodeBrowserView({
         </button>
       </Separator>
 
-      {/* Right panel — file content */}
+      {/* Right panel — file tabs + content */}
       <Panel id="file-viewer" minSize="20%">
-        <div className="relative h-full overflow-hidden">
+        <div className="relative flex h-full flex-col overflow-hidden">
           {treeCollapsed && (
             <Tooltip>
               <TooltipTrigger asChild>
@@ -567,7 +676,67 @@ export function CodeBrowserView({
               </TooltipContent>
             </Tooltip>
           )}
-          <div className={treeCollapsed ? "h-full [&>div>div:first-child]:pl-8" : "h-full"}>
+
+          {/* Tab bar */}
+          <div className={treeCollapsed ? "[&>div]:pl-7" : ""}>
+            <FileTabBar
+              workspaceId={workspaceId}
+              workspacePath={workspacePath}
+              tabs={fileTabs.openTabs}
+              activeTabPath={fileTabs.activeTabPath}
+              onSelectTab={handleTabSelect}
+              onCloseTab={handleTabClose}
+              onGoBack={handleEditorGoBack}
+              onGoForward={handleEditorGoForward}
+              canGoBack={editorHistory.canGoBack}
+              canGoForward={editorHistory.canGoForward}
+              actions={
+                isMarkdown ? (
+                  <div className="flex items-center gap-0.5">
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <button
+                          type="button"
+                          onClick={() => setMdViewMode("preview")}
+                          className={`inline-flex size-6 items-center justify-center rounded-md transition-colors ${
+                            mdViewMode === "preview"
+                              ? "bg-accent text-accent-foreground"
+                              : "text-muted-foreground hover:bg-accent hover:text-foreground"
+                          }`}
+                        >
+                          <Eye className="size-3.5" />
+                        </button>
+                      </TooltipTrigger>
+                      <TooltipContent side="bottom" className="text-xs">
+                        Preview
+                      </TooltipContent>
+                    </Tooltip>
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <button
+                          type="button"
+                          onClick={() => setMdViewMode("source")}
+                          className={`inline-flex size-6 items-center justify-center rounded-md transition-colors ${
+                            mdViewMode === "source"
+                              ? "bg-accent text-accent-foreground"
+                              : "text-muted-foreground hover:bg-accent hover:text-foreground"
+                          }`}
+                        >
+                          <Code className="size-3.5" />
+                        </button>
+                      </TooltipTrigger>
+                      <TooltipContent side="bottom" className="text-xs">
+                        Source
+                      </TooltipContent>
+                    </Tooltip>
+                  </div>
+                ) : undefined
+              }
+            />
+          </div>
+
+          {/* File content */}
+          <div className="min-h-0 flex-1">
             {viewFilePath ? (
               <FileViewer
                 workspaceId={workspaceId}
@@ -576,13 +745,12 @@ export function CodeBrowserView({
                 lineEnd={viewLineEnd}
                 column={viewColumn}
                 onEditorView={handleEditorView}
-                onGoBack={handleEditorGoBack}
-                onGoForward={handleEditorGoForward}
-                canGoBack={editorHistory.canGoBack}
-                canGoForward={editorHistory.canGoForward}
                 onCursorLineChange={handleCursorLineChange}
                 renderMarkdown={renderMarkdown}
                 editable
+                hideTitleBar
+                viewMode={isMarkdown ? mdViewMode : undefined}
+                onViewModeChange={isMarkdown ? setMdViewMode : undefined}
                 toolbar={
                   search.searchOpen ? (
                     <SearchBar

--- a/apps/web/src/components/FileTabBar.tsx
+++ b/apps/web/src/components/FileTabBar.tsx
@@ -1,12 +1,12 @@
 import { getFileIcon } from "@band-app/dashboard-core";
 import {
   Button,
-  cn,
   ContextMenu,
   ContextMenuContent,
   ContextMenuItem,
   ContextMenuSeparator,
   ContextMenuTrigger,
+  cn,
   Dialog,
   DialogContent,
   DialogDescription,
@@ -85,6 +85,7 @@ export function FileTabBar({
   const [confirmClosePath, setConfirmClosePath] = useState<string | null>(null);
 
   // Auto-scroll active tab into view
+  // biome-ignore lint/correctness/useExhaustiveDependencies: activeTabPath triggers re-scroll when tab changes
   useEffect(() => {
     if (activeRef.current) {
       activeRef.current.scrollIntoView({ inline: "nearest", block: "nearest" });
@@ -232,19 +233,13 @@ export function FileTabBar({
                     <span className="min-w-0 flex-1 truncate">{basename}</span>
 
                     {/* Dirty indicator dot OR close button */}
-                    <span
-                      className="relative flex size-4 shrink-0 items-center justify-center"
+                    <button
+                      type="button"
+                      className="relative flex size-4 shrink-0 items-center justify-center bg-transparent border-none p-0"
                       onClick={(e) => {
                         e.stopPropagation();
                         handleClose(tab.filePath);
                       }}
-                      onKeyDown={(e) => {
-                        if (e.key === "Enter" || e.key === " ") {
-                          e.stopPropagation();
-                          handleClose(tab.filePath);
-                        }
-                      }}
-                      role="button"
                       tabIndex={-1}
                       aria-label={`Close ${basename}`}
                     >
@@ -259,7 +254,7 @@ export function FileTabBar({
                         /* Close icon — subtle, visible on tab hover */
                         <X className="size-3.5 rounded-sm opacity-0 hover:bg-accent group-hover:opacity-100 transition-opacity" />
                       )}
-                    </span>
+                    </button>
                   </button>
                 </ContextMenuTrigger>
 
@@ -288,7 +283,10 @@ export function FileTabBar({
       </div>
 
       {/* Unsaved changes confirmation dialog */}
-      <Dialog open={confirmClosePath !== null} onOpenChange={(open) => !open && setConfirmClosePath(null)}>
+      <Dialog
+        open={confirmClosePath !== null}
+        onOpenChange={(open) => !open && setConfirmClosePath(null)}
+      >
         <DialogContent showCloseButton={false}>
           <DialogHeader>
             <DialogTitle>Unsaved Changes</DialogTitle>

--- a/apps/web/src/components/FileTabBar.tsx
+++ b/apps/web/src/components/FileTabBar.tsx
@@ -1,0 +1,312 @@
+import { getFileIcon } from "@band-app/dashboard-core";
+import {
+  Button,
+  cn,
+  ContextMenu,
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuSeparator,
+  ContextMenuTrigger,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@band-app/ui";
+import { ChevronLeft, ChevronRight, Clipboard, Copy, X } from "lucide-react";
+import type React from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
+import type { FileTab } from "../hooks/useFileTabs";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function getBasename(filePath: string): string {
+  return filePath.split("/").pop() || filePath;
+}
+
+/** Check if a file has unsaved edits in the FileViewer localStorage cache */
+function hasDirtyEdits(workspaceId: string, filePath: string): boolean {
+  try {
+    return localStorage.getItem(`band-edits:${workspaceId}\0${filePath}`) != null;
+  } catch {
+    return false;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Props
+// ---------------------------------------------------------------------------
+
+interface FileTabBarProps {
+  workspaceId: string;
+  /** Absolute filesystem path of the workspace root (for "Copy Absolute Path") */
+  workspacePath?: string;
+  tabs: FileTab[];
+  activeTabPath: string | null;
+  onSelectTab: (filePath: string) => void;
+  onCloseTab: (filePath: string) => void;
+  /** Navigate back in editor history */
+  onGoBack?: () => void;
+  /** Navigate forward in editor history */
+  onGoForward?: () => void;
+  canGoBack?: boolean;
+  canGoForward?: boolean;
+  /** Action buttons rendered at the right end of the tab bar (e.g. markdown toggle) */
+  actions?: React.ReactNode;
+}
+
+// ---------------------------------------------------------------------------
+// FileTabBar
+// ---------------------------------------------------------------------------
+
+export function FileTabBar({
+  workspaceId,
+  workspacePath,
+  tabs,
+  activeTabPath,
+  onSelectTab,
+  onCloseTab,
+  onGoBack,
+  onGoForward,
+  canGoBack,
+  canGoForward,
+  actions,
+}: FileTabBarProps) {
+  const activeRef = useRef<HTMLButtonElement>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  // State for the unsaved-changes confirmation dialog
+  const [confirmClosePath, setConfirmClosePath] = useState<string | null>(null);
+
+  // Auto-scroll active tab into view
+  useEffect(() => {
+    if (activeRef.current) {
+      activeRef.current.scrollIntoView({ inline: "nearest", block: "nearest" });
+    }
+  }, [activeTabPath]);
+
+  // Horizontal wheel scrolling — scroll tabs left/right with the mouse wheel
+  useEffect(() => {
+    const el = containerRef.current;
+    if (!el) return;
+    const handler = (e: WheelEvent) => {
+      if (Math.abs(e.deltaY) > Math.abs(e.deltaX)) {
+        e.preventDefault();
+        el.scrollLeft += e.deltaY;
+      }
+    };
+    el.addEventListener("wheel", handler, { passive: false });
+    return () => el.removeEventListener("wheel", handler);
+  }, []);
+
+  const handleClose = useCallback(
+    (filePath: string) => {
+      if (hasDirtyEdits(workspaceId, filePath)) {
+        setConfirmClosePath(filePath);
+        return;
+      }
+      onCloseTab(filePath);
+    },
+    [onCloseTab, workspaceId],
+  );
+
+  const handleConfirmClose = useCallback(() => {
+    if (confirmClosePath) {
+      onCloseTab(confirmClosePath);
+      setConfirmClosePath(null);
+    }
+  }, [confirmClosePath, onCloseTab]);
+
+  const handleMouseDown = useCallback(
+    (e: React.MouseEvent, filePath: string) => {
+      // Middle-click to close
+      if (e.button === 1) {
+        e.preventDefault();
+        handleClose(filePath);
+      }
+    },
+    [handleClose],
+  );
+
+  const copyToClipboard = useCallback((text: string) => {
+    navigator.clipboard.writeText(text).catch(() => {
+      // clipboard unavailable
+    });
+  }, []);
+
+  if (tabs.length === 0) return null;
+
+  return (
+    <>
+      <div className="flex h-9 shrink-0 items-center border-b border-border/50 bg-background">
+        {/* Navigation arrows */}
+        {(onGoBack || onGoForward) && (
+          <div className="flex shrink-0 items-center gap-0.5 px-1">
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <button
+                  type="button"
+                  onClick={onGoBack}
+                  disabled={!canGoBack}
+                  className="inline-flex size-6 items-center justify-center rounded-md text-muted-foreground hover:bg-accent hover:text-foreground transition-colors disabled:opacity-30 disabled:pointer-events-none"
+                >
+                  <ChevronLeft className="size-3.5" />
+                </button>
+              </TooltipTrigger>
+              <TooltipContent side="bottom" className="text-xs">
+                Go Back{" "}
+                <kbd className="ml-1.5 rounded border border-popover-foreground/25 bg-popover-foreground/10 px-1 py-0.5 font-mono text-[14px]">
+                  ⌃-
+                </kbd>
+              </TooltipContent>
+            </Tooltip>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <button
+                  type="button"
+                  onClick={onGoForward}
+                  disabled={!canGoForward}
+                  className="inline-flex size-6 items-center justify-center rounded-md text-muted-foreground hover:bg-accent hover:text-foreground transition-colors disabled:opacity-30 disabled:pointer-events-none"
+                >
+                  <ChevronRight className="size-3.5" />
+                </button>
+              </TooltipTrigger>
+              <TooltipContent side="bottom" className="text-xs">
+                Go Forward{" "}
+                <kbd className="ml-1.5 rounded border border-popover-foreground/25 bg-popover-foreground/10 px-1 py-0.5 font-mono text-[14px]">
+                  ⌃⇧-
+                </kbd>
+              </TooltipContent>
+            </Tooltip>
+          </div>
+        )}
+
+        {/* Scrollable tabs area */}
+        <div
+          ref={containerRef}
+          className="flex min-w-0 flex-1 items-end self-stretch overflow-x-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+          role="tablist"
+        >
+          {tabs.map((tab) => {
+            const isActive = tab.filePath === activeTabPath;
+            const isDirty = hasDirtyEdits(workspaceId, tab.filePath);
+            const basename = getBasename(tab.filePath);
+            const Icon = getFileIcon(basename);
+            const absolutePath = workspacePath
+              ? `${workspacePath.replace(/\/$/, "")}/${tab.filePath}`
+              : tab.filePath;
+
+            return (
+              <ContextMenu key={tab.filePath}>
+                <ContextMenuTrigger asChild>
+                  <button
+                    ref={isActive ? activeRef : undefined}
+                    type="button"
+                    role="tab"
+                    aria-selected={isActive}
+                    title={tab.filePath}
+                    onClick={() => onSelectTab(tab.filePath)}
+                    onMouseDown={(e) => handleMouseDown(e, tab.filePath)}
+                    className={cn(
+                      "group relative flex h-full w-[160px] shrink-0 items-center gap-1.5 border-r border-border/30 px-3 text-xs transition-colors",
+                      isActive
+                        ? "bg-background text-foreground"
+                        : "bg-muted/30 text-muted-foreground hover:bg-muted/50 hover:text-foreground",
+                    )}
+                  >
+                    {/* Active tab indicator */}
+                    {isActive && (
+                      <div className="absolute bottom-0 left-0 right-0 h-[2px] bg-primary" />
+                    )}
+
+                    {/* File icon */}
+                    <Icon className="size-3.5 shrink-0" />
+
+                    {/* File name */}
+                    <span className="min-w-0 flex-1 truncate">{basename}</span>
+
+                    {/* Dirty indicator dot OR close button */}
+                    <span
+                      className="relative flex size-4 shrink-0 items-center justify-center"
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        handleClose(tab.filePath);
+                      }}
+                      onKeyDown={(e) => {
+                        if (e.key === "Enter" || e.key === " ") {
+                          e.stopPropagation();
+                          handleClose(tab.filePath);
+                        }
+                      }}
+                      role="button"
+                      tabIndex={-1}
+                      aria-label={`Close ${basename}`}
+                    >
+                      {isDirty ? (
+                        <>
+                          {/* Dirty dot — visible by default, hidden on hover (close shows instead) */}
+                          <span className="absolute size-2 rounded-full bg-yellow-400 group-hover:hidden" />
+                          {/* Close icon — hidden by default, visible on hover */}
+                          <X className="absolute hidden size-3.5 rounded-sm hover:bg-accent group-hover:block" />
+                        </>
+                      ) : (
+                        /* Close icon — subtle, visible on tab hover */
+                        <X className="size-3.5 rounded-sm opacity-0 hover:bg-accent group-hover:opacity-100 transition-opacity" />
+                      )}
+                    </span>
+                  </button>
+                </ContextMenuTrigger>
+
+                <ContextMenuContent>
+                  <ContextMenuItem onClick={() => copyToClipboard(tab.filePath)}>
+                    <Copy className="size-4" />
+                    Copy Relative Path
+                  </ContextMenuItem>
+                  <ContextMenuItem onClick={() => copyToClipboard(absolutePath)}>
+                    <Clipboard className="size-4" />
+                    Copy Absolute Path
+                  </ContextMenuItem>
+                  <ContextMenuSeparator />
+                  <ContextMenuItem onClick={() => handleClose(tab.filePath)}>
+                    <X className="size-4" />
+                    Close
+                  </ContextMenuItem>
+                </ContextMenuContent>
+              </ContextMenu>
+            );
+          })}
+        </div>
+
+        {/* Action buttons (e.g. markdown preview toggle) */}
+        {actions && <div className="flex shrink-0 items-center gap-0.5 px-1.5">{actions}</div>}
+      </div>
+
+      {/* Unsaved changes confirmation dialog */}
+      <Dialog open={confirmClosePath !== null} onOpenChange={(open) => !open && setConfirmClosePath(null)}>
+        <DialogContent showCloseButton={false}>
+          <DialogHeader>
+            <DialogTitle>Unsaved Changes</DialogTitle>
+            <DialogDescription>
+              &ldquo;{confirmClosePath ? getBasename(confirmClosePath) : ""}&rdquo; has unsaved
+              changes that will be lost if you close it.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setConfirmClosePath(null)}>
+              Cancel
+            </Button>
+            <Button variant="destructive" onClick={handleConfirmClose}>
+              Close Without Saving
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}

--- a/apps/web/src/hooks/useFileTabs.ts
+++ b/apps/web/src/hooks/useFileTabs.ts
@@ -1,0 +1,164 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface FileTab {
+  filePath: string;
+}
+
+export interface UseFileTabsReturn {
+  openTabs: FileTab[];
+  activeTabPath: string | null;
+  openTab: (filePath: string) => void;
+  closeTab: (filePath: string) => void;
+  setActiveTab: (filePath: string) => void;
+  closeOtherTabs: (filePath: string) => void;
+  closeAllTabs: () => void;
+}
+
+// ---------------------------------------------------------------------------
+// localStorage persistence
+// ---------------------------------------------------------------------------
+
+interface PersistedTabState {
+  tabs: string[];
+  active: string | null;
+}
+
+function storageKey(workspaceId: string): string {
+  return `band-open-tabs:${workspaceId}`;
+}
+
+function loadTabState(workspaceId: string): PersistedTabState | null {
+  try {
+    const raw = localStorage.getItem(storageKey(workspaceId));
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as PersistedTabState;
+    if (!Array.isArray(parsed.tabs)) return null;
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+function saveTabState(workspaceId: string, tabs: string[], active: string | null): void {
+  try {
+    const state: PersistedTabState = { tabs, active };
+    localStorage.setItem(storageKey(workspaceId), JSON.stringify(state));
+  } catch {
+    // storage unavailable
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Hook
+// ---------------------------------------------------------------------------
+
+export function useFileTabs(workspaceId: string): UseFileTabsReturn {
+  const [openTabs, setOpenTabs] = useState<FileTab[]>(() => {
+    const saved = loadTabState(workspaceId);
+    if (saved) return saved.tabs.map((filePath) => ({ filePath }));
+    return [];
+  });
+
+  const [activeTabPath, setActiveTabPathState] = useState<string | null>(() => {
+    const saved = loadTabState(workspaceId);
+    return saved?.active ?? null;
+  });
+
+  // Persist to localStorage whenever tabs or active tab changes.
+  // Skip the first mount to avoid redundant write of the just-loaded state.
+  const skipFirstPersist = useRef(true);
+  useEffect(() => {
+    if (skipFirstPersist.current) {
+      skipFirstPersist.current = false;
+      return;
+    }
+    saveTabState(
+      workspaceId,
+      openTabs.map((t) => t.filePath),
+      activeTabPath,
+    );
+  }, [workspaceId, openTabs, activeTabPath]);
+
+  // Reset state when workspace changes
+  const prevWorkspaceRef = useRef(workspaceId);
+  useEffect(() => {
+    if (prevWorkspaceRef.current !== workspaceId) {
+      prevWorkspaceRef.current = workspaceId;
+      skipFirstPersist.current = true;
+      const saved = loadTabState(workspaceId);
+      if (saved) {
+        setOpenTabs(saved.tabs.map((filePath) => ({ filePath })));
+        setActiveTabPathState(saved.active);
+      } else {
+        setOpenTabs([]);
+        setActiveTabPathState(null);
+      }
+    }
+  }, [workspaceId]);
+
+  const openTab = useCallback((filePath: string) => {
+    setOpenTabs((prev) => {
+      const exists = prev.some((t) => t.filePath === filePath);
+      if (exists) return prev;
+      return [...prev, { filePath }];
+    });
+    setActiveTabPathState(filePath);
+  }, []);
+
+  const closeTab = useCallback((filePath: string) => {
+    setOpenTabs((prev) => {
+      const idx = prev.findIndex((t) => t.filePath === filePath);
+      if (idx === -1) return prev;
+      const next = prev.filter((_, i) => i !== idx);
+
+      // Update active tab if the closed tab was active
+      setActiveTabPathState((currentActive) => {
+        if (currentActive !== filePath) return currentActive;
+        if (next.length === 0) return null;
+        // Prefer the tab at the same index (right neighbor), then fall back to left
+        const newIdx = Math.min(idx, next.length - 1);
+        return next[newIdx].filePath;
+      });
+
+      return next;
+    });
+  }, []);
+
+  const setActiveTab = useCallback(
+    (filePath: string) => {
+      // Only set active if the tab actually exists
+      const exists = openTabs.some((t) => t.filePath === filePath);
+      if (exists) {
+        setActiveTabPathState(filePath);
+      }
+    },
+    [openTabs],
+  );
+
+  const closeOtherTabs = useCallback((filePath: string) => {
+    setOpenTabs((prev) => {
+      const kept = prev.filter((t) => t.filePath === filePath);
+      return kept.length > 0 ? kept : [];
+    });
+    setActiveTabPathState(filePath);
+  }, []);
+
+  const closeAllTabs = useCallback(() => {
+    setOpenTabs([]);
+    setActiveTabPathState(null);
+  }, []);
+
+  return {
+    openTabs,
+    activeTabPath,
+    openTab,
+    closeTab,
+    setActiveTab,
+    closeOtherTabs,
+    closeAllTabs,
+  };
+}

--- a/packages/dashboard-core/src/components/FileViewer.tsx
+++ b/packages/dashboard-core/src/components/FileViewer.tsx
@@ -152,6 +152,7 @@ export function FileViewer({
 
   // Persist unsaved edits to cache when leaving a file (navigation or unmount),
   // and restore them when returning.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: controlledViewMode is intentionally excluded — we only reset internal view mode on file change, not when controlled prop changes
   useEffect(() => {
     const key = editsCacheKey(workspaceId, filePath);
     const cached = unsavedEditsCache.get(key);
@@ -370,7 +371,11 @@ export function FileViewer({
               title="Save (Cmd+S)"
               className="inline-flex size-6 items-center justify-center rounded-md hover:bg-accent disabled:opacity-50"
             >
-              {saving ? <Loader2 className="size-3.5 animate-spin" /> : <Save className="size-3.5" />}
+              {saving ? (
+                <Loader2 className="size-3.5 animate-spin" />
+              ) : (
+                <Save className="size-3.5" />
+              )}
             </button>
           )}
           {/* Markdown preview/source toggle icons */}

--- a/packages/dashboard-core/src/components/FileViewer.tsx
+++ b/packages/dashboard-core/src/components/FileViewer.tsx
@@ -49,6 +49,12 @@ interface FileViewerProps {
   canGoForward?: boolean;
   /** Called when the user jumps the cursor ≥10 lines (click, Page Up/Down, etc.) */
   onCursorLineChange?: (departureLine: number, arrivalLine: number) => void;
+  /** When true, hides the title bar (path, size, nav arrows). */
+  hideTitleBar?: boolean;
+  /** Controlled view mode for markdown files (preview vs source). When provided, FileViewer uses this instead of internal state. */
+  viewMode?: "preview" | "source";
+  /** Called when the user toggles between preview and source mode. */
+  onViewModeChange?: (mode: "preview" | "source") => void;
 }
 
 // localStorage-backed cache for unsaved edits — survives page reloads
@@ -117,12 +123,19 @@ export function FileViewer({
   canGoBack,
   canGoForward,
   onCursorLineChange,
+  hideTitleBar,
+  viewMode: controlledViewMode,
+  onViewModeChange,
 }: FileViewerProps) {
   const adapter = useAdapter();
   const [data, setData] = useState<FileContentResult | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  const [viewMode, setViewMode] = useState<"preview" | "source">("preview");
+  const [internalViewMode, setInternalViewMode] = useState<"preview" | "source">("preview");
+
+  // Support both controlled and uncontrolled view mode
+  const viewMode = controlledViewMode ?? internalViewMode;
+  const setViewMode = onViewModeChange ?? setInternalViewMode;
 
   // Editing state
   const [editedContent, setEditedContent] = useState<string | null>(null);
@@ -142,7 +155,8 @@ export function FileViewer({
   useEffect(() => {
     const key = editsCacheKey(workspaceId, filePath);
     const cached = unsavedEditsCache.get(key);
-    setViewMode("preview");
+    // Only reset internal view mode when uncontrolled
+    if (!controlledViewMode) setInternalViewMode("preview");
     setEditedContent(cached ?? null);
     setSaveError(null);
 
@@ -290,108 +304,109 @@ export function FileViewer({
 
   return (
     <div className="flex h-full flex-col overflow-hidden">
-      {/* Title bar */}
-      <div className="flex h-9 shrink-0 items-center gap-2 border-b border-border/50 px-3">
-        {onBack && (
-          <button
-            type="button"
-            onClick={handleBack}
-            className="inline-flex size-6 items-center justify-center rounded-md hover:bg-accent"
-          >
-            <ArrowLeft className="size-3.5" />
-          </button>
-        )}
-        {/* Editor navigation history buttons */}
-        {(onGoBack || onGoForward) && (
-          <div className="flex items-center gap-0.5">
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <button
-                  type="button"
-                  onClick={onGoBack}
-                  disabled={!canGoBack}
-                  className="inline-flex size-6 items-center justify-center rounded-md text-muted-foreground hover:bg-accent hover:text-foreground transition-colors disabled:opacity-30 disabled:pointer-events-none"
-                >
-                  <ChevronLeft className="size-3.5" />
-                </button>
-              </TooltipTrigger>
-              <TooltipContent side="bottom" className="text-xs">
-                Go Back{" "}
-                <kbd className="ml-1.5 rounded border border-popover-foreground/25 bg-popover-foreground/10 px-1 py-0.5 font-mono text-[14px]">
-                  ⌃-
-                </kbd>
-              </TooltipContent>
-            </Tooltip>
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <button
-                  type="button"
-                  onClick={onGoForward}
-                  disabled={!canGoForward}
-                  className="inline-flex size-6 items-center justify-center rounded-md text-muted-foreground hover:bg-accent hover:text-foreground transition-colors disabled:opacity-30 disabled:pointer-events-none"
-                >
-                  <ChevronRight className="size-3.5" />
-                </button>
-              </TooltipTrigger>
-              <TooltipContent side="bottom" className="text-xs">
-                Go Forward{" "}
-                <kbd className="ml-1.5 rounded border border-popover-foreground/25 bg-popover-foreground/10 px-1 py-0.5 font-mono text-[14px]">
-                  ⌃⇧-
-                </kbd>
-              </TooltipContent>
-            </Tooltip>
-          </div>
-        )}
-        <span className="min-w-0 flex-1 truncate font-mono text-xs">
-          {filePath}
-          {isDirty && <span className="ml-1 text-muted-foreground">(modified)</span>}
-        </span>
-        {saveError && <span className="shrink-0 text-xs text-destructive">{saveError}</span>}
-        {canEdit && isDirty && (
-          <button
-            type="button"
-            onClick={handleSave}
-            disabled={saving}
-            title="Save (Cmd+S)"
-            className="inline-flex size-6 items-center justify-center rounded-md hover:bg-accent disabled:opacity-50"
-          >
-            {saving ? <Loader2 className="size-3.5 animate-spin" /> : <Save className="size-3.5" />}
-          </button>
-        )}
-        {/* Markdown preview/source toggle icons */}
-        {showMarkdownToggle && (
-          <div className="flex shrink-0 items-center gap-0.5">
+      {/* Title bar — full version (mobile / non-tab views) */}
+      {!hideTitleBar && (
+        <div className="flex h-9 shrink-0 items-center gap-2 border-b border-border/50 px-3">
+          {onBack && (
             <button
               type="button"
-              onClick={() => setViewMode("preview")}
-              title="Preview"
-              className={`inline-flex size-6 items-center justify-center rounded-md transition-colors ${
-                viewMode === "preview"
-                  ? "bg-accent text-accent-foreground"
-                  : "text-muted-foreground hover:bg-accent hover:text-foreground"
-              }`}
+              onClick={handleBack}
+              className="inline-flex size-6 items-center justify-center rounded-md hover:bg-accent"
             >
-              <Eye className="size-3.5" />
+              <ArrowLeft className="size-3.5" />
             </button>
+          )}
+          {/* Editor navigation history buttons */}
+          {(onGoBack || onGoForward) && (
+            <div className="flex items-center gap-0.5">
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <button
+                    type="button"
+                    onClick={onGoBack}
+                    disabled={!canGoBack}
+                    className="inline-flex size-6 items-center justify-center rounded-md text-muted-foreground hover:bg-accent hover:text-foreground transition-colors disabled:opacity-30 disabled:pointer-events-none"
+                  >
+                    <ChevronLeft className="size-3.5" />
+                  </button>
+                </TooltipTrigger>
+                <TooltipContent side="bottom" className="text-xs">
+                  Go Back{" "}
+                  <kbd className="ml-1.5 rounded border border-popover-foreground/25 bg-popover-foreground/10 px-1 py-0.5 font-mono text-[14px]">
+                    ⌃-
+                  </kbd>
+                </TooltipContent>
+              </Tooltip>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <button
+                    type="button"
+                    onClick={onGoForward}
+                    disabled={!canGoForward}
+                    className="inline-flex size-6 items-center justify-center rounded-md text-muted-foreground hover:bg-accent hover:text-foreground transition-colors disabled:opacity-30 disabled:pointer-events-none"
+                  >
+                    <ChevronRight className="size-3.5" />
+                  </button>
+                </TooltipTrigger>
+                <TooltipContent side="bottom" className="text-xs">
+                  Go Forward{" "}
+                  <kbd className="ml-1.5 rounded border border-popover-foreground/25 bg-popover-foreground/10 px-1 py-0.5 font-mono text-[14px]">
+                    ⌃⇧-
+                  </kbd>
+                </TooltipContent>
+              </Tooltip>
+            </div>
+          )}
+          <span className="min-w-0 flex-1 truncate font-mono text-xs">
+            {filePath}
+            {isDirty && <span className="ml-1 text-muted-foreground">(modified)</span>}
+          </span>
+          {saveError && <span className="shrink-0 text-xs text-destructive">{saveError}</span>}
+          {canEdit && isDirty && (
             <button
               type="button"
-              onClick={() => setViewMode("source")}
-              title="Source"
-              className={`inline-flex size-6 items-center justify-center rounded-md transition-colors ${
-                viewMode === "source"
-                  ? "bg-accent text-accent-foreground"
-                  : "text-muted-foreground hover:bg-accent hover:text-foreground"
-              }`}
+              onClick={handleSave}
+              disabled={saving}
+              title="Save (Cmd+S)"
+              className="inline-flex size-6 items-center justify-center rounded-md hover:bg-accent disabled:opacity-50"
             >
-              <Code className="size-3.5" />
+              {saving ? <Loader2 className="size-3.5 animate-spin" /> : <Save className="size-3.5" />}
             </button>
-          </div>
-        )}
-        {data && (
-          <span className="shrink-0 text-xs text-muted-foreground">{formatSize(data.size)}</span>
-        )}
-      </div>
-
+          )}
+          {/* Markdown preview/source toggle icons */}
+          {showMarkdownToggle && (
+            <div className="flex shrink-0 items-center gap-0.5">
+              <button
+                type="button"
+                onClick={() => setViewMode("preview")}
+                title="Preview"
+                className={`inline-flex size-6 items-center justify-center rounded-md transition-colors ${
+                  viewMode === "preview"
+                    ? "bg-accent text-accent-foreground"
+                    : "text-muted-foreground hover:bg-accent hover:text-foreground"
+                }`}
+              >
+                <Eye className="size-3.5" />
+              </button>
+              <button
+                type="button"
+                onClick={() => setViewMode("source")}
+                title="Source"
+                className={`inline-flex size-6 items-center justify-center rounded-md transition-colors ${
+                  viewMode === "source"
+                    ? "bg-accent text-accent-foreground"
+                    : "text-muted-foreground hover:bg-accent hover:text-foreground"
+                }`}
+              >
+                <Code className="size-3.5" />
+              </button>
+            </div>
+          )}
+          {data && (
+            <span className="shrink-0 text-xs text-muted-foreground">{formatSize(data.size)}</span>
+          )}
+        </div>
+      )}
       {toolbar}
 
       {/* Content area */}


### PR DESCRIPTION
## Summary
- Add VS Code-style file tabs to the desktop code browser with fixed-width scrollable tabs, back/forward navigation arrows, middle-click and Cmd+W close, context menu (copy path, close), and unsaved changes confirmation dialog
- Move markdown preview/source toggle to the tab bar actions slot with controlled `viewMode` prop on FileViewer
- Hide FileViewer title bar in desktop mode (redundant with tabs); mobile view unchanged
- Persist open tabs to localStorage per workspace

## Test plan
- [ ] Open multiple files — tabs appear with correct file names and icons
- [ ] Click tabs to switch files; close with X button, middle-click, or Cmd+W
- [ ] Scroll tabs horizontally when many are open (mouse wheel or overflow)
- [ ] Back/forward arrows navigate editor history
- [ ] Open a `.md` file — preview/source toggle appears at right end of tab bar
- [ ] Edit a file, close tab — unsaved changes dialog appears
- [ ] Refresh page — tabs persist from localStorage
- [ ] Mobile view still shows full FileViewer title bar

🤖 Generated with [Claude Code](https://claude.com/claude-code)