### PR TITLE
fix: remove PORT env var leak into child processes

### DIFF
--- a/apps/web/src/trpc/router.ts
+++ b/apps/web/src/trpc/router.ts
@@ -1088,7 +1088,7 @@ const tunnelRouter = t.router({
 
   start: publicProcedure.input(z.object({}).optional()).mutation(async () => {
     log.debug("tunnel.start called");
-    const port = parseInt(process.env.PORT || "3456", 10);
+    const port = parseInt(process.env.BAND_PORT || "3456", 10);
     log.debug("tunnel.start: port=%d", port);
     try {
       await startTunnel({ port });

--- a/apps/web/start-server.ts
+++ b/apps/web/start-server.ts
@@ -62,6 +62,10 @@ process.on("uncaughtException", (error: Error) => {
 // so paths are relative to dist/.
 const clientDir = join(import.meta.dirname, "client");
 const port = parseInt(process.env.PORT || "3456", 10);
+// Remove PORT so child processes don't inherit it (issue #269).
+// Store as BAND_PORT for internal re-reads (e.g. tunnel start).
+delete process.env.PORT;
+process.env.BAND_PORT = String(port);
 
 const { handleAuth, expectedToken } = createAuthMiddleware(getOrCreateToken());
 

--- a/apps/web/test-server.ts
+++ b/apps/web/test-server.ts
@@ -13,6 +13,7 @@ import { createContext } from "./src/trpc/context.ts";
 import { appRouter } from "./src/trpc/router.ts";
 
 const port = parseInt(process.env.PORT || "0", 10);
+delete process.env.PORT;
 
 const server = createServer(async (req: IncomingMessage, res: ServerResponse) => {
   const url = new URL(req.url!, `http://${req.headers.host}`);


### PR DESCRIPTION
Closes #269

## Summary

Band sets `PORT` when starting the web server, but this env var leaks into every child process (git, cloudflared, brew, user scripts), causing conflicts with tools that auto-detect port from `PORT`.

**Fix:** Delete `PORT` from `process.env` immediately after reading it at server startup. Store the value as `BAND_PORT` for the one internal re-read (tunnel start handler).

## Changes

- **`start-server.ts`** — After parsing PORT, delete it from process.env and set BAND_PORT
- **`router.ts`** — Tunnel start handler reads BAND_PORT instead of PORT
- **`test-server.ts`** — Same delete pattern for consistency

This single fix automatically plugs 8+ leak sites (git, gh, cloudflared, brew, user scripts, etc.) without touching any of those call sites. Existing defensive patterns in `setup-runner.ts` and `terminal-manager.ts` become harmless defense-in-depth.

## Test plan

- [x] Build succeeds
- [x] 356/357 tests pass (1 pre-existing flaky test unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)