### PR TITLE
fix: CodeMirror auto-indentation, Tab handling, and dirty state tracking

### DIFF
--- a/apps/web/src/components/FileTabBar.tsx
+++ b/apps/web/src/components/FileTabBar.tsx
@@ -19,7 +19,7 @@ import {
 } from "@band-app/ui";
 import { ChevronLeft, ChevronRight, Clipboard, Copy, X } from "lucide-react";
 import type React from "react";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useReducer, useRef, useState } from "react";
 import type { FileTab } from "../hooks/useFileTabs";
 
 // ---------------------------------------------------------------------------
@@ -83,6 +83,13 @@ export function FileTabBar({
 
   // State for the unsaved-changes confirmation dialog
   const [confirmClosePath, setConfirmClosePath] = useState<string | null>(null);
+
+  // Re-render when dirty state changes (FileViewer dispatches "band:dirty-change")
+  const [, forceUpdate] = useReducer((x: number) => x + 1, 0);
+  useEffect(() => {
+    window.addEventListener("band:dirty-change", forceUpdate);
+    return () => window.removeEventListener("band:dirty-change", forceUpdate);
+  }, []);
 
   // Auto-scroll active tab into view
   // biome-ignore lint/correctness/useExhaustiveDependencies: activeTabPath triggers re-scroll when tab changes

--- a/packages/dashboard-core/package.json
+++ b/packages/dashboard-core/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "@babel/runtime": "^7.29.2",
     "@band-app/ui": "workspace:^",
+    "@codemirror/autocomplete": "^6.18.4",
     "@codemirror/commands": "^6.8.1",
     "@codemirror/lang-cpp": "^6.0.2",
     "@codemirror/lang-css": "^6.3.1",

--- a/packages/dashboard-core/src/components/CodeMirrorEditor.tsx
+++ b/packages/dashboard-core/src/components/CodeMirrorEditor.tsx
@@ -16,6 +16,13 @@ import { selectionToChatExtension } from "../lib/selection-to-chat";
 interface CodeMirrorEditorProps {
   /** Initial content to populate the editor with */
   content: string;
+  /**
+   * Original on-disk content. When provided and differs from `content`,
+   * the editor initializes with this first, then applies `content` as an
+   * undoable transaction so Cmd+Z can revert to the original.
+   * This is used when restoring cached edits after page reload.
+   */
+  originalContent?: string;
   language: string;
   className?: string;
   /** Workspace-relative file path — enables "Add to Chat" on text selection */
@@ -34,12 +41,11 @@ interface CodeMirrorEditorProps {
   onSave?: () => void;
   /** Called when the user jumps the cursor ≥10 lines (click, Page Up/Down, etc.) */
   onCursorLineChange?: (departureLine: number, arrivalLine: number) => void;
-  /** Called when Cmd/Ctrl+Z is pressed but undo history is empty (revert to disk) */
-  onRevert?: () => void;
 }
 
 export function CodeMirrorEditor({
   content,
+  originalContent,
   language,
   className,
   filePath,
@@ -50,7 +56,6 @@ export function CodeMirrorEditor({
   onContentChange,
   onSave,
   onCursorLineChange,
-  onRevert,
 }: CodeMirrorEditorProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const viewRef = useRef<EditorView | null>(null);
@@ -62,8 +67,6 @@ export function CodeMirrorEditor({
   onSaveRef.current = onSave;
   const onCursorLineChangeRef = useRef(onCursorLineChange);
   onCursorLineChangeRef.current = onCursorLineChange;
-  const onRevertRef = useRef(onRevert);
-  onRevertRef.current = onRevert;
   const isDark = useIsDark();
 
   // Store line props in refs so the creation effect can read them without re-running
@@ -79,6 +82,14 @@ export function CodeMirrorEditor({
   const initialContentRef = useRef(content);
   initialContentRef.current = content;
 
+  const originalContentRef = useRef(originalContent);
+  originalContentRef.current = originalContent;
+
+  // On recreation (theme/language change), we save the editor's current
+  // document here so the new instance preserves the user's edits.
+  // null = first creation (use props instead).
+  const recreationDocRef = useRef<string | null>(null);
+
   // Create/recreate the editor when language or theme changes.
   // We intentionally do NOT depend on `content` — the editor owns
   // the document once created. Only language/theme/filePath changes
@@ -93,7 +104,7 @@ export function CodeMirrorEditor({
       const langSupport = await loadLanguage(language);
       if (cancelled) return;
 
-      // Destroy previous instance
+      // Destroy previous instance — current doc was already saved in cleanup
       if (viewRef.current) {
         viewRef.current.destroy();
         viewRef.current = null;
@@ -104,7 +115,6 @@ export function CodeMirrorEditor({
         ...baseEditorExtensions(
           isDark,
           () => onSaveRef.current?.(),
-          () => onRevertRef.current?.(),
         ),
         searchHighlightOnly(),
         ...lineHighlightExtension(isDark),
@@ -125,8 +135,35 @@ export function CodeMirrorEditor({
         extensions.push(langSupport);
       }
 
+      // Determine the initial document:
+      // 1. Recreation (theme/language change) → use the saved document
+      // 2. First creation with cached edits → start with original so cached
+      //    edits become an undoable transaction (Cmd+Z reverts to original)
+      // 3. Normal first creation → use content prop directly
+      const savedDoc = recreationDocRef.current;
+      recreationDocRef.current = null;
+
+      let initDoc: string;
+      let pendingReplace: string | null = null;
+
+      if (savedDoc !== null) {
+        // Recreation — preserve the user's current document
+        initDoc = savedDoc;
+      } else if (
+        originalContentRef.current != null &&
+        originalContentRef.current !== initialContentRef.current
+      ) {
+        // First creation with cached edits — start with original content
+        // and queue the cached edits as an undoable transaction
+        initDoc = originalContentRef.current;
+        pendingReplace = initialContentRef.current;
+      } else {
+        // Normal creation — no cached edits
+        initDoc = initialContentRef.current;
+      }
+
       const state = EditorState.create({
-        doc: initialContentRef.current,
+        doc: initDoc,
         extensions,
       });
 
@@ -134,6 +171,14 @@ export function CodeMirrorEditor({
         state,
         parent: container,
       });
+
+      // Apply cached edits as a transaction so they appear in undo history.
+      // After this, Cmd+Z will revert back to the original disk content.
+      if (pendingReplace !== null) {
+        viewRef.current.dispatch({
+          changes: { from: 0, to: initDoc.length, insert: pendingReplace },
+        });
+      }
 
       // Scroll to line after creation
       if (lineRef.current) {
@@ -148,6 +193,8 @@ export function CodeMirrorEditor({
     return () => {
       cancelled = true;
       if (viewRef.current) {
+        // Save current document so recreation preserves user edits
+        recreationDocRef.current = viewRef.current.state.doc.toString();
         viewRef.current.destroy();
         viewRef.current = null;
         onEditorViewRef.current?.(null);

--- a/packages/dashboard-core/src/components/CodeMirrorEditor.tsx
+++ b/packages/dashboard-core/src/components/CodeMirrorEditor.tsx
@@ -112,10 +112,7 @@ export function CodeMirrorEditor({
       }
 
       const extensions = [
-        ...baseEditorExtensions(
-          isDark,
-          () => onSaveRef.current?.(),
-        ),
+        ...baseEditorExtensions(isDark, () => onSaveRef.current?.()),
         searchHighlightOnly(),
         ...lineHighlightExtension(isDark),
         cursorLineTracker((departureLine, arrivalLine) =>

--- a/packages/dashboard-core/src/components/FileViewer.tsx
+++ b/packages/dashboard-core/src/components/FileViewer.tsx
@@ -143,6 +143,8 @@ export function FileViewer({
   const [saveError, setSaveError] = useState<string | null>(null);
 
   const editorViewRef = useRef<EditorView | null>(null);
+  const dataRef = useRef(data);
+  dataRef.current = data;
 
   const isDirty = editedContent !== null && editedContent !== data?.content;
 
@@ -251,6 +253,7 @@ export function FileViewer({
       setData((prev) => (prev ? { ...prev, content: savedContent } : prev));
       // Clear cache — saved content is now on disk
       unsavedEditsCache.delete(editsCacheKey(workspaceId, filePath));
+      window.dispatchEvent(new CustomEvent("band:dirty-change"));
     } catch (err) {
       setSaveError(err instanceof Error ? err.message : "Failed to save");
     } finally {
@@ -258,9 +261,26 @@ export function FileViewer({
     }
   }, [adapter, workspaceId, filePath]);
 
-  const handleContentChange = useCallback((newContent: string) => {
-    setEditedContent(newContent);
-  }, []);
+  const handleContentChange = useCallback(
+    (newContent: string) => {
+      const key = editsCacheKey(workspaceId, filePath);
+      // When undo brings the content back to the on-disk version, clear
+      // the edited state entirely so the dirty indicators (title bar +
+      // tab dot) disappear and the localStorage cache is cleaned up.
+      if (newContent === dataRef.current?.content) {
+        setEditedContent(null);
+        unsavedEditsCache.delete(key);
+      } else {
+        setEditedContent(newContent);
+        // Write to localStorage immediately so FileTabBar's hasDirtyEdits()
+        // returns the correct value when it re-renders.
+        unsavedEditsCache.set(key, newContent);
+      }
+      // Notify FileTabBar (and any other listener) that dirty state changed
+      window.dispatchEvent(new CustomEvent("band:dirty-change"));
+    },
+    [workspaceId, filePath],
+  );
 
   // Capture the EditorView locally (for revert) while forwarding to the parent
   const handleEditorView = useCallback(
@@ -270,28 +290,6 @@ export function FileViewer({
     },
     [onEditorView],
   );
-
-  // Revert to on-disk version: refetch, replace editor content, clear draft cache.
-  // Called by Cmd/Ctrl+Z when the CodeMirror undo history is empty.
-  const handleRevert = useCallback(async () => {
-    if (!adapter.getWorkspaceFile) return;
-    try {
-      const result = await adapter.getWorkspaceFile(workspaceId, filePath);
-      setData(result);
-      setEditedContent(null);
-      editedContentRef.current = null;
-      unsavedEditsCache.delete(editsCacheKey(workspaceId, filePath));
-      // Replace the editor document in-place
-      const view = editorViewRef.current;
-      if (view && result.content != null) {
-        view.dispatch({
-          changes: { from: 0, to: view.state.doc.length, insert: result.content },
-        });
-      }
-    } catch {
-      // Fetch error — leave current content as-is
-    }
-  }, [adapter, workspaceId, filePath]);
 
   const handleBack = useCallback(() => {
     if (isDirty && !window.confirm("You have unsaved changes. Discard?")) {
@@ -461,6 +459,7 @@ export function FileViewer({
           (canEdit ? (
             <CodeMirrorEditor
               content={displayContent!}
+              originalContent={data?.content}
               language={lang}
               className="h-full"
               filePath={filePath}
@@ -471,7 +470,6 @@ export function FileViewer({
               onContentChange={handleContentChange}
               onSave={handleSave}
               onCursorLineChange={onCursorLineChange}
-              onRevert={handleRevert}
             />
           ) : (
             <CodeMirrorViewer

--- a/packages/dashboard-core/src/lib/codemirror-setup.ts
+++ b/packages/dashboard-core/src/lib/codemirror-setup.ts
@@ -1,16 +1,25 @@
-import { defaultKeymap, history, historyKeymap, undo, undoDepth } from "@codemirror/commands";
+import { closeBrackets, closeBracketsKeymap } from "@codemirror/autocomplete";
+import {
+  defaultKeymap,
+  history,
+  historyKeymap,
+  indentLess,
+  indentMore,
+} from "@codemirror/commands";
 import {
   bracketMatching,
   defaultHighlightStyle,
   foldGutter,
   foldKeymap,
   indentOnInput,
+  indentUnit,
   LanguageSupport,
   StreamLanguage,
   syntaxHighlighting,
 } from "@codemirror/language";
 import { highlightSelectionMatches, SearchQuery } from "@codemirror/search";
 import {
+  EditorSelection,
   EditorState,
   type Extension,
   type Range,
@@ -214,19 +223,87 @@ export function baseViewerExtensions(
 }
 
 /**
+ * Custom Enter handler that provides reliable continuation indentation.
+ *
+ * Several CodeMirror language packages have incomplete or misleading
+ * `indentNodeProp` rules.  For example `@codemirror/lang-rust` defines
+ * `continuedIndent()` on `Statement` but has no `delimitedIndent` for
+ * brace-delimited blocks.  This causes two failure modes:
+ *
+ *  • `getIndentation` returns **0** inside a block → cursor jumps to col 1.
+ *  • `getIndentation` returns a **false-positive continuation indent**
+ *    (e.g. +1 level after a completed `let … ;`) → cursor over-indents.
+ *
+ * Rather than trying to distinguish correct vs. incorrect language values,
+ * this handler uses simple heuristics that are reliable across every
+ * language:
+ *
+ *  1. Copy the current line's leading whitespace.
+ *  2. Add one indent level when the line ends with `{`, `(`, or `[`.
+ *  3. Handle the "between brackets" case (`{|}` → `{\n  |\n}`).
+ *
+ * Language-specific re-indentation (e.g. auto-dedent when typing `}`) is
+ * still handled by `indentOnInput()` which runs independently.
+ */
+function smartNewlineAndIndent(view: EditorView): boolean {
+  const { state } = view;
+
+  // For multiple cursors, defer to the default handler.
+  if (state.selection.ranges.length > 1) return false;
+
+  const { from, to } = state.selection.main;
+  const line = state.doc.lineAt(from);
+  const leadingWS = /^\s*/.exec(line.text)![0];
+  const textBeforeCursor = line.text.slice(0, from - line.from).trimEnd();
+  const opensBlock = /[{(\[]$/.test(textBeforeCursor);
+
+  const afterLine = state.doc.lineAt(to);
+  const textAfterCursor = afterLine.text.slice(to - afterLine.from).trimStart();
+  const closesBlock = /^[})\]]/.test(textAfterCursor);
+  const unit = state.facet(indentUnit);
+
+  if (opensBlock && closesBlock) {
+    // Between brackets:  {|}  →  {\n  |\n}
+    const inner = "\n" + leadingWS + unit;
+    const outer = "\n" + leadingWS;
+    view.dispatch(
+      state.update({
+        changes: { from, to, insert: inner + outer },
+        selection: EditorSelection.cursor(from + inner.length),
+        userEvent: "input",
+      }),
+    );
+    return true;
+  }
+
+  const extra = opensBlock ? unit : "";
+  const insert = "\n" + leadingWS + extra;
+  view.dispatch(
+    state.update({
+      changes: { from, to, insert },
+      selection: EditorSelection.cursor(from + insert.length),
+      userEvent: "input",
+    }),
+  );
+  return true;
+}
+
+/**
  * Base extensions for an editable CodeMirror editor.
  * Includes editing features: undo/redo, indent-on-input, fold gutter.
  * Does NOT include readOnly or editable(false).
  * @param isDark - Whether to use dark theme colours. Defaults to true for backwards compat.
  * @param onSave - Optional callback invoked on Cmd/Ctrl+S.
- * @param onRevert - Optional callback invoked on Cmd/Ctrl+Z when the undo history is empty.
- *                   Typically used to reload the file from disk when no more undos are available.
+ * @param opts.indent - Indentation string: `"  "` (2 spaces), `"    "` (4 spaces), or `"\t"`. Defaults to `"  "`.
+ * @param opts.tabSize - Display width of a tab character. Defaults to the indent string length, or 4 for tabs.
  */
 export function baseEditorExtensions(
   isDark = true,
   onSave?: () => void,
-  onRevert?: () => void,
+  opts?: { indent?: string; tabSize?: number },
 ): Extension[] {
+  const indent = opts?.indent ?? "  ";
+  const tabSize = opts?.tabSize ?? (indent === "\t" ? 4 : indent.length);
   const customKeyBindings: KeyBinding[] = [
     ...(onSave
       ? [
@@ -239,22 +316,6 @@ export function baseEditorExtensions(
           } satisfies KeyBinding,
         ]
       : []),
-    ...(onRevert
-      ? [
-          {
-            key: "Mod-z",
-            run: (view: EditorView) => {
-              // If there are undoable changes, do a normal undo
-              if (undoDepth(view.state) > 0) {
-                return undo(view);
-              }
-              // Otherwise revert to the on-disk version
-              onRevert();
-              return true;
-            },
-          } satisfies KeyBinding,
-        ]
-      : []),
   ];
 
   return [
@@ -262,7 +323,10 @@ export function baseEditorExtensions(
     history(),
     foldGutter(),
     bracketMatching(),
+    closeBrackets(),
     indentOnInput(),
+    indentUnit.of(indent),
+    EditorState.tabSize.of(tabSize),
     highlightSelectionMatches(),
     ...(isDark
       ? [
@@ -275,7 +339,39 @@ export function baseEditorExtensions(
           syntaxHighlighting(defaultHighlightStyle, { fallback: true }),
         ]
       : [syntaxHighlighting(defaultHighlightStyle)]),
-    keymap.of([...customKeyBindings, ...defaultKeymap, ...historyKeymap, ...foldKeymap]),
+    keymap.of([
+      ...customKeyBindings,
+      { key: "Enter", run: smartNewlineAndIndent },
+      { key: "Tab", run: indentMore },
+      { key: "Shift-Tab", run: indentLess },
+      ...closeBracketsKeymap,
+      ...defaultKeymap,
+      ...historyKeymap,
+      ...foldKeymap,
+      // Catch-all: absorb undo/redo when the history is empty so the
+      // event is preventDefault-ed and doesn't trigger parent handlers.
+      { key: "Mod-z", run: () => true },
+      { key: "Mod-Shift-z", run: () => true },
+      { key: "Mod-y", run: () => true },
+    ]),
+    // CodeMirror calls preventDefault() on handled keys but never
+    // stopPropagation(), so keyboard events always bubble to parent
+    // DOM elements (React components, global listeners, etc.).
+    // Explicitly stop propagation for keys the editor owns.
+    EditorView.domEventHandlers({
+      keydown(event) {
+        const mod = event.metaKey || event.ctrlKey;
+        if (
+          event.key === "Tab" ||
+          (mod && event.key.toLowerCase() === "z") ||
+          (mod && event.key.toLowerCase() === "y")
+        ) {
+          event.stopPropagation();
+        }
+        // Return false so CM's own keymap processing still runs.
+        return false;
+      },
+    }),
     EditorView.theme(
       isDark
         ? {

--- a/packages/dashboard-core/src/lib/codemirror-setup.ts
+++ b/packages/dashboard-core/src/lib/codemirror-setup.ts
@@ -255,7 +255,7 @@ function smartNewlineAndIndent(view: EditorView): boolean {
   const line = state.doc.lineAt(from);
   const leadingWS = /^\s*/.exec(line.text)![0];
   const textBeforeCursor = line.text.slice(0, from - line.from).trimEnd();
-  const opensBlock = /[{(\[]$/.test(textBeforeCursor);
+  const opensBlock = /[{([]$/.test(textBeforeCursor);
 
   const afterLine = state.doc.lineAt(to);
   const textAfterCursor = afterLine.text.slice(to - afterLine.from).trimStart();
@@ -264,8 +264,8 @@ function smartNewlineAndIndent(view: EditorView): boolean {
 
   if (opensBlock && closesBlock) {
     // Between brackets:  {|}  →  {\n  |\n}
-    const inner = "\n" + leadingWS + unit;
-    const outer = "\n" + leadingWS;
+    const inner = `\n${leadingWS}${unit}`;
+    const outer = `\n${leadingWS}`;
     view.dispatch(
       state.update({
         changes: { from, to, insert: inner + outer },
@@ -277,7 +277,7 @@ function smartNewlineAndIndent(view: EditorView): boolean {
   }
 
   const extra = opensBlock ? unit : "";
-  const insert = "\n" + leadingWS + extra;
+  const insert = `\n${leadingWS}${extra}`;
   view.dispatch(
     state.update({
       changes: { from, to, insert },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -322,6 +322,9 @@ importers:
       '@band-app/ui':
         specifier: workspace:^
         version: link:../ui
+      '@codemirror/autocomplete':
+        specifier: ^6.18.4
+        version: 6.20.1
       '@codemirror/commands':
         specifier: ^6.8.1
         version: 6.10.3


### PR DESCRIPTION
## Summary
- Fix auto-indentation on Enter for all languages (Rust, TypeScript, etc.) — cursor no longer jumps to column 1 inside code blocks
- Add Tab/Shift-Tab indent/dedent with proper keyboard event isolation (stopPropagation)
- Add closeBrackets() for auto-pairing brackets and quotes
- Remove the "revert to disk on empty undo" behavior (onRevert)
- Make indent unit configurable (2-space, 4-space, tabs) via opts parameter
- Fix dirty state tracking: yellow dot indicator on file tabs now updates reactively during editing, disappears when undoing to original, and survives page reload with working undo history

## Test plan
- [ ] Open a Rust or TypeScript file, press Enter inside a function body — cursor should auto-indent
- [ ] Press Enter between `{}` — should create inner indented line with closing brace on next line
- [ ] Tab indents selected lines, Shift-Tab dedents
- [ ] Edit a file — yellow dot appears on the tab immediately
- [ ] Undo all changes — yellow dot disappears
- [ ] Edit a file, reload the page — edits are restored and Cmd+Z reverts to original clean state
- [ ] Cmd+S saves the file and clears the dirty indicator

🤖 Generated with [Claude Code](https://claude.com/claude-code)