### PR TITLE
fix: handle repos with no commits in changes view

### DIFF
--- a/apps/web/src/trpc/router.ts
+++ b/apps/web/src/trpc/router.ts
@@ -637,7 +637,12 @@ const workspaceRouter = t.router({
 
       let mergeBase: string;
       if (input.diffMode === "uncommitted") {
-        mergeBase = (await execGit(["rev-parse", "HEAD"], cwd)).trim();
+        try {
+          mergeBase = (await execGit(["rev-parse", "HEAD"], cwd)).trim();
+        } catch {
+          // No commits yet — diff against the empty tree so all staged files appear as new
+          mergeBase = (await execGit(["hash-object", "-t", "tree", "/dev/null"], cwd)).trim();
+        }
       } else {
         try {
           mergeBase = (await execGit(["merge-base", defaultBranch, "HEAD"], cwd)).trim();
@@ -735,7 +740,12 @@ const workspaceRouter = t.router({
 
       let mergeBase: string;
       if (input.diffMode === "uncommitted") {
-        mergeBase = (await execGit(["rev-parse", "HEAD"], cwd)).trim();
+        try {
+          mergeBase = (await execGit(["rev-parse", "HEAD"], cwd)).trim();
+        } catch {
+          // No commits yet — diff against the empty tree so all staged files appear as new
+          mergeBase = (await execGit(["hash-object", "-t", "tree", "/dev/null"], cwd)).trim();
+        }
       } else {
         try {
           mergeBase = (await execGit(["merge-base", defaultBranch, "HEAD"], cwd)).trim();


### PR DESCRIPTION
## Summary

- Wraps `git rev-parse HEAD` calls in `getDiff` and `getDiffSummary` with try/catch, falling back to the empty tree hash when HEAD doesn't exist
- Prevents the fatal `ambiguous argument 'HEAD'` error when opening the changes view in a repository with no commits

## Test plan

- [ ] Open changes view in a repo with no commits — should show untracked files instead of crashing
- [ ] Open changes view in a repo with commits — should work as before (no regression)
- [ ] Existing `git.test.ts` tests pass

Closes #267

🤖 Generated with [Claude Code](https://claude.com/claude-code)