### PR TITLE
fix: bundle typescript-language-server and typescript in DMG build

### DIFF
--- a/apps/web/scripts/build-server.sh
+++ b/apps/web/scripts/build-server.sh
@@ -74,6 +74,49 @@ if [ "${NPM_PUBLISH:-}" != "1" ]; then
   mkdir -p dist/node_modules/file-uri-to-path
   cp -RL "$BINDINGS_PEERS/file-uri-to-path"/* dist/node_modules/file-uri-to-path/
 
+  # -----------------------------------------------------------------------
+  # Bundle typescript-language-server + typescript for LSP support.
+  # typescript-language-server's cli.mjs is a self-contained bundle — it
+  # only imports Node built-ins at the top level.  It locates tsserver via
+  # createRequire(import.meta.url).resolve('typescript'), so typescript
+  # must be resolvable from within the package directory.
+  # -----------------------------------------------------------------------
+
+  # typescript-language-server package
+  TS_LSP_REAL="$(cd node_modules/typescript-language-server && pwd -P)"
+  mkdir -p dist/node_modules/typescript-language-server/lib
+  cp "$TS_LSP_REAL/package.json" dist/node_modules/typescript-language-server/
+  cp "$TS_LSP_REAL/lib/cli.mjs" dist/node_modules/typescript-language-server/lib/
+  cp "$TS_LSP_REAL/lib/cli.mjs.map" dist/node_modules/typescript-language-server/lib/ 2>/dev/null || true
+
+  # typescript package — needed by the language server for tsserver
+  TS_REAL="$(cd node_modules/typescript && pwd -P)"
+  mkdir -p dist/node_modules/typescript/lib
+  mkdir -p dist/node_modules/typescript/bin
+  cp "$TS_REAL/package.json" dist/node_modules/typescript/
+  cp "$TS_REAL/bin/tsserver" dist/node_modules/typescript/bin/
+  cp "$TS_REAL/lib/tsserver.js" dist/node_modules/typescript/lib/
+  cp "$TS_REAL/lib/_tsserver.js" dist/node_modules/typescript/lib/
+  cp "$TS_REAL/lib/typescript.js" dist/node_modules/typescript/lib/
+
+  # .bin shims — simple wrappers that work with any basedir (no hardcoded
+  # pnpm-store paths).  The LSP manager adds this directory to PATH.
+  mkdir -p dist/node_modules/.bin
+
+  cat > dist/node_modules/.bin/typescript-language-server <<'SHIM'
+#!/bin/sh
+basedir=$(dirname "$(echo "$0" | sed -e 's,\\,/,g')")
+exec node "$basedir/../typescript-language-server/lib/cli.mjs" "$@"
+SHIM
+  chmod +x dist/node_modules/.bin/typescript-language-server
+
+  cat > dist/node_modules/.bin/tsserver <<'SHIM'
+#!/bin/sh
+basedir=$(dirname "$(echo "$0" | sed -e 's,\\,/,g')")
+exec node "$basedir/../typescript/bin/tsserver" "$@"
+SHIM
+  chmod +x dist/node_modules/.bin/tsserver
+
   # Resolve the monorepo root (where the pnpm store lives).
   # The SDK packages below are deps of packages/coding-agent, not apps/web,
   # so they only exist in the root node_modules/.pnpm store.


### PR DESCRIPTION
## Summary

- Fixes LSP failing when running from the packaged DMG — `typescript-language-server` and `typescript` were not included in the app bundle
- Updates `build-server.sh` to copy the typescript-language-server package (self-contained bundled `cli.mjs`) and the minimal set of typescript files needed for tsserver
- Creates portable `.bin` shims that use relative paths instead of pnpm's hardcoded absolute store paths

## Test plan

- [x] Build script runs successfully (`pnpm run build`)
- [x] Bundled `dist/node_modules/.bin/typescript-language-server --version` returns `5.1.3`
- [x] Bundled `dist/node_modules/.bin/tsserver` starts without error
- [ ] Install DMG on macOS → open a workspace → verify LSP completions work

🤖 Generated with [Claude Code](https://claude.com/claude-code)