### PR TITLE
fix: persist Chat tab selection on mobile when switching workspaces

### DIFF
--- a/apps/web/src/routes/workspace.$workspaceId.tsx
+++ b/apps/web/src/routes/workspace.$workspaceId.tsx
@@ -152,11 +152,12 @@ function WorkspaceLayout() {
 
   // Persist the full sub-path (e.g. "/code/src/index.ts") so it can be
   // restored when navigating back — this remembers both the active tab
-  // and the specific file the user was viewing.
+  // and the specific file the user was viewing.  An empty string means
+  // the Chat tab (the workspace index route).
   useEffect(() => {
     const prefix = `/workspace/${workspaceId}`;
-    if (pathname.length > prefix.length && pathname.startsWith(prefix)) {
-      const subPath = pathname.slice(prefix.length); // e.g. "/code/src/index.ts"
+    if (pathname.startsWith(prefix)) {
+      const subPath = pathname.slice(prefix.length); // e.g. "/code/src/index.ts", "" for chat
       try {
         sessionStorage.setItem(`band-tab:${decoded}`, subPath);
       } catch {}

--- a/packages/dashboard-core/src/adapters/web.ts
+++ b/packages/dashboard-core/src/adapters/web.ts
@@ -319,10 +319,7 @@ export class WebCapabilities implements PlatformCapabilities {
       if (stored !== null) {
         // Empty string means the Chat tab (workspace index route);
         // non-empty values must match a known sub-path prefix.
-        if (
-          stored === "" ||
-          VALID_TAB_PREFIXES.some((p) => stored.startsWith(p))
-        ) {
+        if (stored === "" || VALID_TAB_PREFIXES.some((p) => stored.startsWith(p))) {
           return `${base}${stored}`;
         }
       }

--- a/packages/dashboard-core/src/adapters/web.ts
+++ b/packages/dashboard-core/src/adapters/web.ts
@@ -316,8 +316,15 @@ export class WebCapabilities implements PlatformCapabilities {
     const base = `/workspace/${encodeURIComponent(workspaceId)}`;
     try {
       const stored = sessionStorage.getItem(`band-tab:${workspaceId}`);
-      if (stored && VALID_TAB_PREFIXES.some((p) => stored.startsWith(p))) {
-        return `${base}${stored}`;
+      if (stored !== null) {
+        // Empty string means the Chat tab (workspace index route);
+        // non-empty values must match a known sub-path prefix.
+        if (
+          stored === "" ||
+          VALID_TAB_PREFIXES.some((p) => stored.startsWith(p))
+        ) {
+          return `${base}${stored}`;
+        }
       }
     } catch {}
     return base;


### PR DESCRIPTION
## Summary

On mobile, switching between workspaces remembered the Changes and Files tabs but not the Chat tab. Two issues caused this:

1. **Save side** — The tab persistence effect only wrote to `sessionStorage` when a sub-path existed (`pathname.length > prefix.length`), but Chat lives at the bare workspace URL with no sub-path, so it was never saved. Stale values from other tabs persisted instead.
2. **Restore side** — `VALID_TAB_PREFIXES` only included `/changes`, `/code`, `/terminal`, so even if Chat state were saved, it would be filtered out.

### Fix
- Removed the `pathname.length > prefix.length` guard so the Chat tab now saves an empty string `""` to sessionStorage
- Changed the restore logic to accept `stored === ""` as a valid value (meaning the Chat tab / workspace index route)

## Test plan
- [ ] On mobile, navigate to a workspace's Chat tab, switch to another workspace, then switch back — should restore to Chat
- [ ] On mobile, navigate to Changes tab, switch away and back — should still restore to Changes
- [ ] On mobile, navigate to Files tab, switch away and back — should still restore to Files
- [ ] On mobile, go to Chat → Code → Chat → navigate away → come back — should restore to Chat (not Code)