### PR TITLE
fix: mobile back button in code browser

### DIFF
--- a/apps/web/src/components/CodeBrowserView.tsx
+++ b/apps/web/src/components/CodeBrowserView.tsx
@@ -417,6 +417,13 @@ export function CodeBrowserView({
       setViewLine(loc.line);
       setViewLineEnd(loc.lineEnd);
       setViewColumn(loc.column);
+    } else {
+      // File prop removed (e.g. route changed via back navigation) — clear
+      // view state so the mobile layout switches back to FileBrowser.
+      setViewFilePath("");
+      setViewLine(undefined);
+      setViewLineEnd(undefined);
+      setViewColumn(undefined);
     }
   }, [file]);
 


### PR DESCRIPTION
## Summary

Fix the back button not working on mobile when viewing a file in the code browser.

**Root cause:** The `useEffect` in `CodeBrowserView` that syncs `viewFilePath` with the `file` prop only handled the truthy case (navigating to a file) but had no `else` branch to clear state when `file` became falsy. This caused the mobile view to stay stuck on `FileViewer` when:
- Using the browser back gesture (swipe/hardware back)
- During the race window between a local state update and a deferred route transition

**Fix:** Added an `else` branch to clear `viewFilePath` and related state when the `file` prop becomes falsy, so the mobile layout correctly switches back to `FileBrowser`.

Safe for desktop — on desktop, `viewFilePath` is always cleared locally before the `file` prop changes, so the `else` branch is a no-op.

## Test plan

- [ ] Open a file on mobile → tap back arrow → returns to file browser
- [ ] Open a file on mobile → use browser back gesture → returns to file browser
- [ ] Desktop file navigation, tab close, editor history → unchanged behavior