### PR TITLE
feat: add revert file button to changes view

### DIFF
--- a/apps/web/src/lib/terminal-split-tree.ts
+++ b/apps/web/src/lib/terminal-split-tree.ts
@@ -1,5 +1,18 @@
 // Pure functions + types for the binary split tree used by terminal splits.
 
+/** crypto.randomUUID() is unavailable in insecure contexts (plain HTTP on non-localhost). */
+function uuid(): string {
+  if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
+    return crypto.randomUUID();
+  }
+  // Fallback: build a v4 UUID from crypto.getRandomValues (available in all browsers)
+  const bytes = crypto.getRandomValues(new Uint8Array(16));
+  bytes[6] = (bytes[6] & 0x0f) | 0x40; // version 4
+  bytes[8] = (bytes[8] & 0x3f) | 0x80; // variant 1
+  const hex = Array.from(bytes, (b) => b.toString(16).padStart(2, "0")).join("");
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
+}
+
 export type SplitDirection = "horizontal" | "vertical";
 
 export interface SplitNode {
@@ -21,7 +34,7 @@ export type TreeNode = SplitNode | LeafNode;
  * Create a new leaf node with a random terminalId.
  */
 export function createLeaf(): LeafNode {
-  return { type: "leaf", terminalId: crypto.randomUUID() };
+  return { type: "leaf", terminalId: uuid() };
 }
 
 /**
@@ -34,7 +47,7 @@ export function splitLeaf(tree: TreeNode, targetId: string, direction: SplitDire
     if (tree.terminalId === targetId) {
       return {
         type: "split",
-        nodeId: crypto.randomUUID(),
+        nodeId: uuid(),
         direction,
         children: [tree, createLeaf()],
         sizes: [50, 50],

--- a/apps/web/src/trpc/router.ts
+++ b/apps/web/src/trpc/router.ts
@@ -865,6 +865,66 @@ const workspaceRouter = t.router({
       return { diff };
     }),
 
+  revertFile: publicProcedure
+    .input(
+      z.object({
+        workspaceId: z.string(),
+        filePath: z.string(),
+        diffMode: z.enum(["uncommitted", "branch"]),
+      }),
+    )
+    .mutation(async ({ input }) => {
+      const workspace = resolveWorkspace(input.workspaceId);
+      if (!workspace) {
+        throw new Error("Workspace not found");
+      }
+
+      const cwd = workspace.worktree.path;
+      const { filePath, diffMode } = input;
+
+      // Determine the file status server-side
+      const untrackedOutput = await execGit(["ls-files", "--others", "--exclude-standard"], cwd);
+      const untrackedFiles = untrackedOutput.trim().split("\n").filter(Boolean);
+
+      if (untrackedFiles.includes(filePath)) {
+        // Untracked file — just delete it
+        await rm(join(cwd, filePath), { force: true });
+        return { ok: true };
+      }
+
+      // Resolve the reference commit for the diff mode
+      let ref: string;
+      if (diffMode === "uncommitted") {
+        try {
+          ref = (await execGit(["rev-parse", "HEAD"], cwd)).trim();
+        } catch {
+          ref = (await execGit(["hash-object", "-t", "tree", "/dev/null"], cwd)).trim();
+        }
+      } else {
+        const defaultBranch = workspace.project.defaultBranch;
+        try {
+          ref = (await execGit(["merge-base", defaultBranch, "HEAD"], cwd)).trim();
+        } catch {
+          ref = (await execGit(["hash-object", "-t", "tree", "/dev/null"], cwd)).trim();
+        }
+      }
+
+      // Determine the tracked file status from the diff
+      const nameStatusOutput = await execGit(["diff", "--name-status", ref, "--", filePath], cwd);
+      const statusLine = nameStatusOutput.trim().split("\n").filter(Boolean)[0];
+      const fileStatus = statusLine ? statusLine[0] : null;
+
+      if (fileStatus === "A") {
+        // Added (staged) file — remove from index and delete from working tree
+        await execGit(["rm", "-f", "--", filePath], cwd);
+      } else {
+        // Modified, Deleted, or Renamed — restore to the reference commit
+        await execGit(["checkout", ref, "--", filePath], cwd);
+      }
+
+      return { ok: true };
+    }),
+
   listFiles: publicProcedure
     .input(z.object({ workspaceId: z.string(), path: z.string().default("") }))
     .query(async ({ input }) => {

--- a/packages/dashboard-core/src/adapter.ts
+++ b/packages/dashboard-core/src/adapter.ts
@@ -87,6 +87,9 @@ export interface DashboardAdapter {
   getWorkspaceFile?(workspaceId: string, path: string): Promise<FileContentResult>;
   saveWorkspaceFile?(workspaceId: string, path: string, content: string): Promise<void>;
 
+  /** Revert a single file to its original state, discarding all changes. */
+  revertFile?(workspaceId: string, filePath: string, diffMode: string): Promise<void>;
+
   /** Get a URL for raw file content (images, PDFs, etc.) */
   getWorkspaceFileUrl?(workspaceId: string, path: string): string;
 

--- a/packages/dashboard-core/src/adapters/web.ts
+++ b/packages/dashboard-core/src/adapters/web.ts
@@ -270,6 +270,10 @@ export class WebDashboardAdapter implements DashboardAdapter {
     await this.trpc.workspace.saveFile.mutate({ workspaceId, path, content });
   }
 
+  async revertFile(workspaceId: string, filePath: string, diffMode: string): Promise<void> {
+    await this.trpc.workspace.revertFile.mutate({ workspaceId, filePath, diffMode });
+  }
+
   getWorkspaceFileUrl(workspaceId: string, path: string): string {
     return `/api/workspace-file/${encodeURIComponent(workspaceId)}/${path
       .split("/")

--- a/packages/dashboard-core/src/components/DiffView.tsx
+++ b/packages/dashboard-core/src/components/DiffView.tsx
@@ -1,4 +1,13 @@
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@band-app/ui";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@band-app/ui";
 import { MergeView, unifiedMergeView } from "@codemirror/merge";
 import { SearchQuery } from "@codemirror/search";
 import { EditorState, RangeSetBuilder, Text } from "@codemirror/state";
@@ -15,6 +24,7 @@ import {
   Rows2,
   Search,
   SquareArrowOutUpRight,
+  Undo2,
 } from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useAdapter } from "../context";
@@ -29,6 +39,7 @@ import type { SSEEvent } from "../lib/sse";
 import type { DiffMode, FileStatus, WorkspaceDiffSummary } from "../types";
 import { ChangesFileTree } from "./ChangesFileTree";
 import { FileStatusBadge } from "./FileStatusBadge";
+import { RevertFileDialog } from "./RevertFileDialog";
 import { SearchBar, type SearchOptions } from "./SearchBar";
 
 export interface DiffStats {
@@ -524,6 +535,7 @@ interface LazyFileRowProps {
   onLoadMoreContext: (filename: string) => void;
   onShowFullFile: (filename: string) => void;
   onOpenFile?: (filename: string) => void;
+  onRevertFile?: (filename: string) => void;
   onEditorViews?: (filename: string, views: EditorView[]) => void;
 }
 
@@ -538,10 +550,12 @@ function LazyFileRow({
   onLoadMoreContext,
   onShowFullFile,
   onOpenFile,
+  onRevertFile,
   onEditorViews,
 }: LazyFileRowProps) {
   const [isOpen, setIsOpen] = useState(expandAll);
   const [copied, setCopied] = useState(false);
+  const [revertDialogOpen, setRevertDialogOpen] = useState(false);
 
   const handleEditorViews = useCallback(
     (views: EditorView[]) => {
@@ -611,53 +625,96 @@ function LazyFileRow({
         <span className="min-w-0 flex-1 overflow-x-auto whitespace-nowrap font-mono [scrollbar-width:none]">
           {filename} <FileStatusBadge status={status} />
         </span>
-        <span
-          title="Copy file path"
-          onClick={(e) => {
-            e.preventDefault();
-            e.stopPropagation();
-            navigator.clipboard.writeText(filename).catch(() => {});
-            setCopied(true);
-            setTimeout(() => setCopied(false), 1500);
-          }}
-          onKeyDown={(e) => {
-            if (e.key === "Enter") {
-              e.stopPropagation();
-              navigator.clipboard.writeText(filename).catch(() => {});
-              setCopied(true);
-              setTimeout(() => setCopied(false), 1500);
-            }
-          }}
-          className="shrink-0 rounded p-1 text-muted-foreground hover:bg-accent hover:text-foreground"
-        >
-          {copied ? (
-            <Check className="size-3.5 text-green-600 dark:text-green-400" />
-          ) : (
-            <Copy className="size-3.5" />
-          )}
-        </span>
-        {onOpenFile && (
-          <span
-            title="Open in code browser"
-            onClick={(e) => {
-              e.preventDefault();
-              e.stopPropagation();
-              const line = diff ? firstChangeLine(diff) : undefined;
-              onOpenFile(formatFileLocation(filename, line));
-            }}
-            onKeyDown={(e) => {
-              if (e.key === "Enter") {
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <span
+              onClick={(e) => {
+                e.preventDefault();
                 e.stopPropagation();
-                const line = diff ? firstChangeLine(diff) : undefined;
-                onOpenFile(formatFileLocation(filename, line));
-              }
-            }}
-            className="shrink-0 rounded p-1 text-muted-foreground hover:bg-accent hover:text-foreground"
-          >
-            <SquareArrowOutUpRight className="size-3.5" />
-          </span>
+                navigator.clipboard.writeText(filename).catch(() => {});
+                setCopied(true);
+                setTimeout(() => setCopied(false), 1500);
+              }}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") {
+                  e.stopPropagation();
+                  navigator.clipboard.writeText(filename).catch(() => {});
+                  setCopied(true);
+                  setTimeout(() => setCopied(false), 1500);
+                }
+              }}
+              className="shrink-0 rounded p-1 text-muted-foreground hover:bg-accent hover:text-foreground"
+            >
+              {copied ? (
+                <Check className="size-3.5 text-green-600 dark:text-green-400" />
+              ) : (
+                <Copy className="size-3.5" />
+              )}
+            </span>
+          </TooltipTrigger>
+          <TooltipContent side="bottom">Copy file path</TooltipContent>
+        </Tooltip>
+        {onRevertFile && (
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <span
+                onClick={(e) => {
+                  e.preventDefault();
+                  e.stopPropagation();
+                  setRevertDialogOpen(true);
+                }}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter") {
+                    e.stopPropagation();
+                    setRevertDialogOpen(true);
+                  }
+                }}
+                className="shrink-0 rounded p-1 text-muted-foreground hover:bg-accent hover:text-foreground"
+              >
+                <Undo2 className="size-3.5" />
+              </span>
+            </TooltipTrigger>
+            <TooltipContent side="bottom">Revert file</TooltipContent>
+          </Tooltip>
+        )}
+        {onOpenFile && (
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <span
+                onClick={(e) => {
+                  e.preventDefault();
+                  e.stopPropagation();
+                  const line = diff ? firstChangeLine(diff) : undefined;
+                  onOpenFile(formatFileLocation(filename, line));
+                }}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter") {
+                    e.stopPropagation();
+                    const line = diff ? firstChangeLine(diff) : undefined;
+                    onOpenFile(formatFileLocation(filename, line));
+                  }
+                }}
+                className="shrink-0 rounded p-1 text-muted-foreground hover:bg-accent hover:text-foreground"
+              >
+                <SquareArrowOutUpRight className="size-3.5" />
+              </span>
+            </TooltipTrigger>
+            <TooltipContent side="bottom">Open in code browser</TooltipContent>
+          </Tooltip>
         )}
       </button>
+      {onRevertFile && (
+        <RevertFileDialog
+          open={revertDialogOpen}
+          onOpenChange={setRevertDialogOpen}
+          onConfirm={() => {
+            setRevertDialogOpen(false);
+            onRevertFile(filename);
+          }}
+          filename={filename}
+          fileStatus={status}
+        />
+      )}
       {isOpen && (
         <div className="border-t border-border/20 bg-muted/30">
           {diffError && <div className="px-4 py-4 text-sm text-destructive">{diffError}</div>}
@@ -947,6 +1004,31 @@ export function DiffView({
       fetchFileDiff(filename, undefined, 99999);
     },
     [fetchFileDiff],
+  );
+
+  const handleRevertFile = useCallback(
+    (filename: string) => {
+      const revertFile = adapter.revertFile;
+      if (!revertFile) return;
+
+      revertFile
+        .call(adapter, workspaceId, filename, diffMode)
+        .then(() => {
+          // Remove from diff cache
+          setDiffCache((prev) => {
+            const next = new Map(prev);
+            next.delete(filename);
+            return next;
+          });
+          expandedFilesRef.current.delete(filename);
+          // Force refresh to update the file list
+          fetchSummaryRef.current?.(true);
+        })
+        .catch((err) => {
+          console.error("Failed to revert file:", err);
+        });
+    },
+    [adapter, workspaceId, diffMode],
   );
 
   // -------------------------------------------------------------------------
@@ -1261,6 +1343,7 @@ export function DiffView({
                 onLoadMoreContext={handleLoadMoreContext}
                 onShowFullFile={handleShowFullFile}
                 onOpenFile={onOpenFile}
+                onRevertFile={adapter.revertFile ? handleRevertFile : undefined}
                 onEditorViews={handleEditorViews}
               />
             ))}

--- a/packages/dashboard-core/src/components/RevertFileDialog.tsx
+++ b/packages/dashboard-core/src/components/RevertFileDialog.tsx
@@ -1,0 +1,65 @@
+import {
+  Button,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@band-app/ui";
+import { AlertTriangle } from "lucide-react";
+import type { FileStatus } from "../types";
+
+interface Props {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onConfirm: () => void;
+  filename: string;
+  fileStatus: FileStatus | undefined;
+}
+
+function statusDescription(status: FileStatus | undefined): string {
+  switch (status) {
+    case "A":
+      return "This file was added and will be deleted.";
+    case "U":
+      return "This file is untracked and will be deleted.";
+    case "D":
+      return "This file was deleted and will be restored.";
+    case "M":
+      return "All changes to this file will be discarded.";
+    case "R":
+      return "This file was renamed and will be restored to its original path.";
+    default:
+      return "All changes to this file will be discarded.";
+  }
+}
+
+export function RevertFileDialog({ open, onOpenChange, onConfirm, filename, fileStatus }: Props) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-[425px]" onClick={(e) => e.stopPropagation()}>
+        <DialogHeader>
+          <DialogTitle>Revert file</DialogTitle>
+          <DialogDescription>
+            Are you sure you want to revert <strong className="break-all">{filename}</strong>?
+          </DialogDescription>
+        </DialogHeader>
+        <div className="flex flex-col gap-2 text-sm">
+          <div className="flex items-start gap-2 rounded-md border border-yellow-500/30 bg-yellow-500/10 p-3">
+            <AlertTriangle className="mt-0.5 size-4 shrink-0 text-yellow-500" />
+            <span>{statusDescription(fileStatus)} This action cannot be undone.</span>
+          </div>
+        </div>
+        <DialogFooter>
+          <Button variant="ghost" onClick={() => onOpenChange(false)}>
+            Cancel
+          </Button>
+          <Button variant="destructive" onClick={onConfirm}>
+            Revert
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}


### PR DESCRIPTION
## Summary

- Add a **Revert file** button to each file entry in the changes view, placed between the copy-path and open-in-browser buttons
- Clicking the button opens a confirmation dialog with a context-aware warning (e.g. "This file was added and will be deleted" vs "All changes to this file will be discarded")
- The server-side `revertFile` tRPC mutation determines the file status and applies the appropriate git operation (checkout, rm, or delete) — no status is forwarded from the client
- Replace `title` attributes on all file action buttons with proper Radix UI tooltips
- Fix `crypto.randomUUID` crash when accessing the app over plain HTTP on a non-localhost address

## Files changed

- `apps/web/src/trpc/router.ts` — new `revertFile` mutation
- `packages/dashboard-core/src/adapter.ts` — add `revertFile` to adapter interface
- `packages/dashboard-core/src/adapters/web.ts` — implement `revertFile` in web adapter
- `packages/dashboard-core/src/components/RevertFileDialog.tsx` — new confirmation dialog
- `packages/dashboard-core/src/components/DiffView.tsx` — add button, tooltips, wire up handler
- `apps/web/src/lib/terminal-split-tree.ts` — `crypto.randomUUID` fallback for insecure contexts