### PR TITLE
Add per-agent model setting to coding agent config

### DIFF
--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -218,29 +218,10 @@ export function ChatView({
   }, [workspaceId]);
 
   const [modes, setModes] = useState<{ id: string; name: string; description?: string }[]>([]);
-  const modeStorageKey = `band-mode:${workspaceId}`;
-  const [selectedMode, setSelectedMode] = useState<string | undefined>(() => {
-    try {
-      return sessionStorage.getItem(modeStorageKey) ?? undefined;
-    } catch {
-      return undefined;
-    }
-  });
-  const handleModeSelect = useCallback(
-    (mode: string | undefined) => {
-      setSelectedMode(mode);
-      try {
-        if (mode) {
-          sessionStorage.setItem(modeStorageKey, mode);
-        } else {
-          sessionStorage.removeItem(modeStorageKey);
-        }
-      } catch {
-        // ignore storage errors
-      }
-    },
-    [modeStorageKey],
-  );
+  const [selectedMode, setSelectedMode] = useState<string | undefined>();
+  const handleModeSelect = useCallback((mode: string | undefined) => {
+    setSelectedMode(mode);
+  }, []);
   useEffect(() => {
     trpc.modes.list
       .query({ agentId: codingAgentId || undefined })
@@ -270,32 +251,22 @@ export function ChatView({
   }, [modes, selectedMode, handleModeSelect]);
 
   const [models, setModels] = useState<{ id: string; name: string; description?: string }[]>([]);
-  const [selectedModel, setSelectedModel] = useState<string | undefined>(() => {
-    try {
-      return sessionStorage.getItem(`band-model:${workspaceId}`) ?? undefined;
-    } catch {
-      return undefined;
-    }
-  });
+  // Default model from agent settings (per agent type)
+  const [agentDefaultModel, setAgentDefaultModel] = useState<string | undefined>();
+  // Explicit user override from the model dropdown
+  const [userModelOverride, setUserModelOverride] = useState<string | undefined>();
+  // Effective model: user override takes precedence, then agent default
+  const selectedModel = userModelOverride ?? agentDefaultModel;
+
   useEffect(() => {
     trpc.models.list
       .query({ agentId: codingAgentId || undefined })
-      .then((data) =>
-        setModels(data.models as { id: string; name: string; description?: string }[]),
-      )
+      .then((data) => {
+        setModels(data.models as { id: string; name: string; description?: string }[]);
+        setAgentDefaultModel((data.defaultModel as string) || undefined);
+      })
       .catch(() => setModels([]));
   }, [codingAgentId]);
-  useEffect(() => {
-    try {
-      if (selectedModel) {
-        sessionStorage.setItem(`band-model:${workspaceId}`, selectedModel);
-      } else {
-        sessionStorage.removeItem(`band-model:${workspaceId}`);
-      }
-    } catch {
-      // sessionStorage may not be available
-    }
-  }, [selectedModel, workspaceId]);
 
   const [queuedMessages, setQueuedMessages] = useState<string[]>([]);
 
@@ -330,8 +301,8 @@ export function ChatView({
   }, [transport, selectedMode]);
 
   useEffect(() => {
-    transport.model = selectedModel;
-  }, [transport, selectedModel]);
+    transport.model = userModelOverride ?? agentDefaultModel;
+  }, [transport, userModelOverride, agentDefaultModel]);
 
   useEffect(() => {
     transport.codingAgentId = codingAgentId;
@@ -930,7 +901,7 @@ export function ChatView({
                 <ModelMenu
                   models={models}
                   selected={selectedModel}
-                  onSelect={setSelectedModel}
+                  onSelect={setUserModelOverride}
                   agentType={agentType}
                 />
               )}
@@ -1023,6 +994,7 @@ function ModelMenu({
   agentType?: string;
 }) {
   const current = models.find((m) => m.id === selected) ?? models[0];
+  const displayName = current?.name ?? "Model";
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
@@ -1035,7 +1007,7 @@ function ModelMenu({
           ) : (
             <ChevronDown className="size-3" />
           )}
-          {current?.name ?? "Model"}
+          {displayName}
         </button>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="start" className="min-w-[140px]">
@@ -1045,7 +1017,7 @@ function ModelMenu({
             onClick={() => onSelect(model.id)}
             className={cn(
               "flex flex-col items-start gap-0.5",
-              model.id === (selected ?? models[0]?.id) ? "bg-accent" : "",
+              model.id === selected ? "bg-accent" : "",
             )}
           >
             <span className="text-sm font-medium">{model.name}</span>

--- a/apps/web/src/components/TasksPageContent.tsx
+++ b/apps/web/src/components/TasksPageContent.tsx
@@ -433,6 +433,7 @@ interface CodingAgentDef {
   id: string;
   type: string;
   label: string;
+  model?: string;
 }
 
 function NewTaskDialog({
@@ -509,7 +510,11 @@ function NewTaskDialog({
       .then((data) => {
         const newModels = data.models as ModelInfo[];
         setModels(newModels);
-        setSelectedModel((prev) => (newModels.some((m) => m.id === prev) ? prev : ""));
+        // Pre-select the agent's configured default model from settings
+        const defaultModel = (data.defaultModel as string) ?? "";
+        setSelectedModel((prev) =>
+          prev && newModels.some((m) => m.id === prev) ? prev : defaultModel,
+        );
       })
       .catch(() => setModels([]));
   }, [open, selectedAgent]);

--- a/apps/web/src/lib/agent-pool.ts
+++ b/apps/web/src/lib/agent-pool.ts
@@ -1,3 +1,5 @@
+import { readFileSync } from "node:fs";
+import { homedir } from "node:os";
 import { join } from "node:path";
 import {
   type CodingAgent,
@@ -15,9 +17,29 @@ const g = globalThis as unknown as Record<symbol, unknown>;
 if (!g[POOL_KEY]) g[POOL_KEY] = new Map<string, CodingAgent>();
 const pool = g[POOL_KEY] as Map<string, CodingAgent>;
 
+/**
+ * Read the 'model' field from ~/.claude/settings.json as a fallback
+ * for claude-code agents that don't have a model set in Band settings.
+ */
+function loadClaudeSettingsModel(): string | undefined {
+  try {
+    const data = readFileSync(join(homedir(), ".claude", "settings.json"), "utf-8");
+    const parsed = JSON.parse(data) as Record<string, unknown>;
+    return typeof parsed.model === "string" ? parsed.model : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
 function getAgentConfig(worktreePath: string, agentId?: string): CodingAgentConfig {
   const settings = loadSettings();
   const agentDef = getAgentDefinition(settings, agentId);
+
+  // Resolve model: prefer Band agent definition, fall back to ~/.claude/settings.json for claude-code
+  let model = agentDef.model;
+  if (!model && agentDef.type === "claude-code") {
+    model = loadClaudeSettingsModel();
+  }
 
   return {
     type: agentDef.type,
@@ -26,6 +48,7 @@ function getAgentConfig(worktreePath: string, agentId?: string): CodingAgentConf
     additionalDirectories: [join(bandHome(), "uploads"), join(bandHome(), "shared")],
     options: {
       executablePath: agentDef.command,
+      model,
     },
   } as CodingAgentConfig;
 }

--- a/apps/web/src/lib/state.ts
+++ b/apps/web/src/lib/state.ts
@@ -63,6 +63,7 @@ export interface CodingAgentDefinition {
   type: string;
   label: string;
   command?: string;
+  model?: string;
 }
 
 export interface Settings {

--- a/apps/web/src/trpc/router.ts
+++ b/apps/web/src/trpc/router.ts
@@ -51,6 +51,7 @@ import {
   bandHome,
   deleteBranchStatus,
   deleteWorkspaceStatus,
+  getAgentDefinition,
   getWorkspaceStatus,
   loadCurrentStatuses,
   loadSettings,
@@ -1980,10 +1981,11 @@ const modelsRouter = t.router({
     .input(z.object({ agentId: z.string().optional() }))
     .query(async ({ input }) => {
       const agent = await createMetadataAgent(input.agentId);
-      if (agent.listModels) {
-        return { models: await agent.listModels() };
-      }
-      return { models: [] };
+      const models = agent.listModels ? await agent.listModels() : [];
+      // Include the agent's configured default model from Band settings
+      const settings = loadSettings();
+      const agentDef = getAgentDefinition(settings, input.agentId);
+      return { models, defaultModel: agentDef.model };
     }),
 });
 

--- a/packages/dashboard-core/src/adapter.ts
+++ b/packages/dashboard-core/src/adapter.ts
@@ -39,6 +39,9 @@ export interface DashboardAdapter {
   getSettings(): Promise<Settings>;
   updateSettings(settings: Settings): Promise<void>;
 
+  // Models (for agent configuration)
+  listModels?(agentId?: string): Promise<{ id: string; name: string; description?: string }[]>;
+
   // Event subscriptions (return unsubscribe fn)
   subscribeAgentStatus(
     onSnapshot: (statuses: WorkspaceStatus[]) => void,

--- a/packages/dashboard-core/src/adapters/web.ts
+++ b/packages/dashboard-core/src/adapters/web.ts
@@ -113,6 +113,13 @@ export class WebDashboardAdapter implements DashboardAdapter {
     await this.trpc.settings.update.mutate(settings as unknown as Record<string, unknown>);
   }
 
+  async listModels(
+    agentId?: string,
+  ): Promise<{ id: string; name: string; description?: string }[]> {
+    const data = await this.trpc.models.list.query({ agentId });
+    return data.models as { id: string; name: string; description?: string }[];
+  }
+
   private statusHandlers = new Set<(data: SSEEvent) => void>();
   private statusSubscription: { unsubscribe: () => void } | null = null;
   private reconnectTimer: ReturnType<typeof setTimeout> | null = null;

--- a/packages/dashboard-core/src/components/SettingsPage.tsx
+++ b/packages/dashboard-core/src/components/SettingsPage.tsx
@@ -24,7 +24,7 @@ import {
   Trash2,
 } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
-import { useCapabilities } from "../context";
+import { useAdapter, useCapabilities } from "../context";
 import { useUpdateSettings } from "../hooks/use-settings-mutations";
 import { useSettingsQuery } from "../hooks/use-settings-query";
 import { playSound, SOUNDS, type SoundId } from "../lib/sounds";
@@ -138,6 +138,26 @@ export function SettingsPage({ onClose, hideTitle }: Props) {
   const [enableLSP, setEnableLSP] = useState(settings.enableLSP ?? false);
   const [selectedTheme, setSelectedTheme] = useState<Theme>(settings.theme ?? "system");
   const [appMode, setAppMode] = useState<AppMode>(settings.appMode ?? "side-panel");
+  const [agentModels, setAgentModels] = useState<
+    Record<string, { id: string; name: string; description?: string }[]>
+  >({});
+
+  const adapter = useAdapter();
+
+  // Fetch available models for each enabled agent type
+  useEffect(() => {
+    if (!adapter.listModels) return;
+    for (const agent of codingAgents) {
+      adapter
+        .listModels(agent.id)
+        .then((models) => {
+          setAgentModels((prev) => ({ ...prev, [agent.type]: models }));
+        })
+        .catch(() => {
+          // Models unavailable for this agent type
+        });
+    }
+  }, [codingAgents, adapter]);
 
   const isTauriApp = typeof window !== "undefined" && "__TAURI_INTERNALS__" in window;
 
@@ -549,6 +569,46 @@ export function SettingsPage({ onClose, hideTitle }: Props) {
                         className="h-7 text-xs"
                       />
                     </div>
+                    {(agentModels[known.type]?.length ?? 0) > 0 && (
+                      <div className="space-y-1">
+                        <Label className="text-xs text-muted-foreground">Default model</Label>
+                        <DropdownMenu>
+                          <DropdownMenuTrigger asChild>
+                            <Button
+                              variant="outline"
+                              size="sm"
+                              className="w-full justify-between font-normal h-7 text-xs px-2"
+                            >
+                              {agentModels[known.type]?.find((m) => m.id === agent?.model)?.name ??
+                                "Default"}
+                              <ChevronDown className="size-3 opacity-50" />
+                            </Button>
+                          </DropdownMenuTrigger>
+                          <DropdownMenuContent
+                            align="start"
+                            className="w-[--radix-dropdown-menu-trigger-width]"
+                          >
+                            <DropdownMenuRadioGroup
+                              value={agent?.model ?? ""}
+                              onValueChange={(v: string) =>
+                                setCodingAgents((prev) =>
+                                  prev.map((a) =>
+                                    a.type === known.type ? { ...a, model: v || undefined } : a,
+                                  ),
+                                )
+                              }
+                            >
+                              <DropdownMenuRadioItem value="">Default</DropdownMenuRadioItem>
+                              {agentModels[known.type]?.map((m) => (
+                                <DropdownMenuRadioItem key={m.id} value={m.id}>
+                                  {m.name}
+                                </DropdownMenuRadioItem>
+                              ))}
+                            </DropdownMenuRadioGroup>
+                          </DropdownMenuContent>
+                        </DropdownMenu>
+                      </div>
+                    )}
                   </div>
                 )}
               </div>

--- a/packages/dashboard-core/src/types.ts
+++ b/packages/dashboard-core/src/types.ts
@@ -101,6 +101,7 @@ export interface CodingAgentDefinition {
   type: CodingAgentType;
   label: string;
   command?: string;
+  model?: string;
 }
 
 export interface NotificationSettings {


### PR DESCRIPTION
## Summary
- Added `model` field to `CodingAgentDefinition` so users can configure which model each coding agent (Claude Code, Codex, OpenCode) uses
- Added model dropdown per agent in Settings UI, populated by querying available models from each agent's SDK
- Wired model through `agent-pool.ts` → `CodingAgentConfig.options.model` → SDK `query()` call
- For claude-code agents, falls back to `~/.claude/settings.json` model when no Band setting exists
- Chat UI reflects configured default model; removed all sessionStorage persistence for model/mode selections
- `models.list` tRPC endpoint now returns `defaultModel` alongside available models

## Test plan
- [ ] Open Settings, verify model dropdown appears for each enabled coding agent
- [ ] Select a model in Settings, save, verify it persists across page reloads
- [ ] Open a chat with each agent type, verify the configured default model is pre-selected
- [ ] Override model in chat, verify override works for current session without persisting
- [ ] Verify claude-code agent falls back to `~/.claude/settings.json` model when no Band setting exists

🤖 Generated with [Claude Code](https://claude.com/claude-code)