### PR TITLE
Add workspace terminal configuration support

### DIFF
--- a/apps/web/src/components/SplitTerminalContainer.tsx
+++ b/apps/web/src/components/SplitTerminalContainer.tsx
@@ -1,18 +1,22 @@
 import { Columns2, Rows2, X } from "lucide-react";
 import { lazy, Suspense, useCallback, useEffect, useRef, useState } from "react";
 import { Group, Panel, Separator } from "react-resizable-panels";
+import { buildTreeFromConfig, type PaneMetadata } from "../lib/terminal-config-utils";
 import {
   countLeaves,
   createLeaf,
   type LeafNode,
+  loadPaneMeta,
   loadTree,
   removeLeaf,
   type SplitNode,
+  savePaneMeta,
   saveTree,
   splitLeaf,
   type TreeNode,
   updateNodeSizes,
 } from "../lib/terminal-split-tree";
+import { trpc } from "../lib/trpc-client";
 
 // Lazy-load TerminalPanel to avoid importing @xterm CJS during SSR
 const TerminalPanel = lazy(() =>
@@ -28,21 +32,71 @@ export function SplitTerminalContainer({ workspaceId, visible }: SplitTerminalCo
   const [tree, setTree] = useState<TreeNode>(() => {
     const stored = loadTree(workspaceId);
     if (stored) return stored;
-    const fresh = createLeaf();
-    saveTree(workspaceId, fresh);
-    return fresh;
+    // Temporary leaf — don't save to localStorage yet so the useEffect
+    // can detect "no stored tree" and attempt to fetch server config first.
+    return createLeaf();
   });
 
-  // Reload tree when workspace changes
+  const [paneMetadata, setPaneMetadata] = useState<Record<string, PaneMetadata>>(() => {
+    const stored = loadPaneMeta(workspaceId);
+    return (stored as Record<string, PaneMetadata>) ?? {};
+  });
+
+  const [focusTerminalId, setFocusTerminalId] = useState<string | null>(null);
+
+  // Track whether we've already applied config for this workspace
+  // so we don't re-apply on every re-mount
+  const configAppliedRef = useRef<string | null>(null);
+
+  // On mount or workspace change: check for config-driven layout
   useEffect(() => {
-    const stored = loadTree(workspaceId);
-    if (stored) {
-      setTree(stored);
-    } else {
-      const fresh = createLeaf();
-      saveTree(workspaceId, fresh);
-      setTree(fresh);
+    const storedTree = loadTree(workspaceId);
+    if (storedTree) {
+      // If a tree already exists in localStorage, use it as-is
+      setTree(storedTree);
+      const storedMeta = loadPaneMeta(workspaceId);
+      setPaneMetadata((storedMeta as Record<string, PaneMetadata>) ?? {});
+      setFocusTerminalId(null);
+      return;
     }
+
+    // No stored tree — try to build from server config
+    if (configAppliedRef.current === workspaceId) return;
+
+    let cancelled = false;
+
+    trpc.workspace.getTerminalConfig
+      .query({ workspaceId })
+      .then(({ config }) => {
+        if (cancelled) return;
+        configAppliedRef.current = workspaceId;
+
+        if (config) {
+          const result = buildTreeFromConfig(config);
+          saveTree(workspaceId, result.tree);
+          savePaneMeta(workspaceId, result.paneMetadata);
+          setTree(result.tree);
+          setPaneMetadata(result.paneMetadata);
+          setFocusTerminalId(result.focusTerminalId);
+        } else {
+          // No config — keep the default single leaf
+          const fresh = createLeaf();
+          saveTree(workspaceId, fresh);
+          setTree(fresh);
+          setPaneMetadata({});
+          setFocusTerminalId(null);
+        }
+      })
+      .catch(() => {
+        // Failed to fetch config — keep the default leaf
+        if (!cancelled) {
+          configAppliedRef.current = workspaceId;
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
   }, [workspaceId]);
 
   const handleSplit = useCallback(
@@ -83,6 +137,8 @@ export function SplitTerminalContainer({ workspaceId, visible }: SplitTerminalCo
         onSplit={handleSplit}
         onClose={handleClose}
         totalLeaves={totalLeaves}
+        paneMetadata={paneMetadata}
+        focusTerminalId={focusTerminalId}
       />
     </div>
   );
@@ -99,6 +155,8 @@ interface RenderNodeProps {
   onSplit: (terminalId: string, direction: "horizontal" | "vertical") => void;
   onClose: (terminalId: string) => void;
   totalLeaves: number;
+  paneMetadata: Record<string, PaneMetadata>;
+  focusTerminalId: string | null;
 }
 
 function RenderNode({
@@ -108,6 +166,8 @@ function RenderNode({
   onSplit,
   onClose,
   totalLeaves,
+  paneMetadata,
+  focusTerminalId,
 }: RenderNodeProps) {
   if (node.type === "leaf") {
     return (
@@ -118,6 +178,8 @@ function RenderNode({
         onSplit={onSplit}
         onClose={onClose}
         showClose={totalLeaves > 1}
+        metadata={paneMetadata[node.terminalId]}
+        autoFocus={focusTerminalId === node.terminalId}
       />
     );
   }
@@ -131,6 +193,8 @@ function RenderNode({
       onSplit={onSplit}
       onClose={onClose}
       totalLeaves={totalLeaves}
+      paneMetadata={paneMetadata}
+      focusTerminalId={focusTerminalId}
     />
   );
 }
@@ -146,9 +210,20 @@ interface SplitPaneProps {
   onSplit: (terminalId: string, direction: "horizontal" | "vertical") => void;
   onClose: (terminalId: string) => void;
   totalLeaves: number;
+  paneMetadata: Record<string, PaneMetadata>;
+  focusTerminalId: string | null;
 }
 
-function SplitPane({ node, workspaceId, visible, onSplit, onClose, totalLeaves }: SplitPaneProps) {
+function SplitPane({
+  node,
+  workspaceId,
+  visible,
+  onSplit,
+  onClose,
+  totalLeaves,
+  paneMetadata,
+  focusTerminalId,
+}: SplitPaneProps) {
   const orientation = node.direction === "horizontal" ? "horizontal" : "vertical";
 
   const defaultLayout = node.sizes
@@ -195,6 +270,8 @@ function SplitPane({ node, workspaceId, visible, onSplit, onClose, totalLeaves }
           onSplit={onSplit}
           onClose={onClose}
           totalLeaves={totalLeaves}
+          paneMetadata={paneMetadata}
+          focusTerminalId={focusTerminalId}
         />
       </Panel>
       <Separator
@@ -212,6 +289,8 @@ function SplitPane({ node, workspaceId, visible, onSplit, onClose, totalLeaves }
           onSplit={onSplit}
           onClose={onClose}
           totalLeaves={totalLeaves}
+          paneMetadata={paneMetadata}
+          focusTerminalId={focusTerminalId}
         />
       </Panel>
     </Group>
@@ -229,32 +308,57 @@ interface LeafPaneProps {
   onSplit: (terminalId: string, direction: "horizontal" | "vertical") => void;
   onClose: (terminalId: string) => void;
   showClose: boolean;
+  metadata?: PaneMetadata;
+  autoFocus?: boolean;
 }
 
-function LeafPane({ node, workspaceId, visible, onSplit, onClose, showClose }: LeafPaneProps) {
+function LeafPane({
+  node,
+  workspaceId,
+  visible,
+  onSplit,
+  onClose,
+  showClose,
+  metadata,
+  autoFocus,
+}: LeafPaneProps) {
   return (
     <div className="flex h-full w-full flex-col">
       {/* Compact toolbar */}
-      <div className="flex h-7 shrink-0 items-center justify-end gap-0.5 border-b border-neutral-700/50 px-1">
-        <ToolbarButton
-          title="Split Horizontal"
-          onClick={() => onSplit(node.terminalId, "horizontal")}
-        >
-          <Columns2 className="size-3.5" />
-        </ToolbarButton>
-        <ToolbarButton title="Split Vertical" onClick={() => onSplit(node.terminalId, "vertical")}>
-          <Rows2 className="size-3.5" />
-        </ToolbarButton>
-        {showClose && (
-          <ToolbarButton title="Close Terminal" onClick={() => onClose(node.terminalId)}>
-            <X className="size-3.5" />
-          </ToolbarButton>
+      <div className="flex h-7 shrink-0 items-center border-b border-neutral-700/50 px-1">
+        {metadata?.name && (
+          <span className="mr-auto truncate pl-1 text-xs text-neutral-400">{metadata.name}</span>
         )}
+        <div className="ml-auto flex items-center gap-0.5">
+          <ToolbarButton
+            title="Split Horizontal"
+            onClick={() => onSplit(node.terminalId, "horizontal")}
+          >
+            <Columns2 className="size-3.5" />
+          </ToolbarButton>
+          <ToolbarButton
+            title="Split Vertical"
+            onClick={() => onSplit(node.terminalId, "vertical")}
+          >
+            <Rows2 className="size-3.5" />
+          </ToolbarButton>
+          {showClose && (
+            <ToolbarButton title="Close Terminal" onClick={() => onClose(node.terminalId)}>
+              <X className="size-3.5" />
+            </ToolbarButton>
+          )}
+        </div>
       </div>
       {/* Terminal */}
       <div className="min-h-0 flex-1">
         <Suspense fallback={null}>
-          <TerminalPanel workspaceId={workspaceId} terminalId={node.terminalId} visible={visible} />
+          <TerminalPanel
+            workspaceId={workspaceId}
+            terminalId={node.terminalId}
+            visible={visible}
+            paneMetadata={metadata}
+            autoFocus={autoFocus}
+          />
         </Suspense>
       </div>
     </div>

--- a/apps/web/src/components/TerminalPanel.tsx
+++ b/apps/web/src/components/TerminalPanel.tsx
@@ -2,14 +2,25 @@ import type { FitAddon } from "@xterm/addon-fit";
 import type { Terminal } from "@xterm/xterm";
 import { useEffect, useRef } from "react";
 import { openExternalUrl } from "../lib/open-external-url";
+import type { PaneMetadata } from "../lib/terminal-config-utils";
 
 interface TerminalPanelProps {
   workspaceId: string;
   terminalId: string;
   visible: boolean;
+  /** Optional metadata from workspace terminal config (command, cwd, env). */
+  paneMetadata?: PaneMetadata;
+  /** When true, auto-focus this terminal after it opens. */
+  autoFocus?: boolean;
 }
 
-export function TerminalPanel({ workspaceId, terminalId, visible }: TerminalPanelProps) {
+export function TerminalPanel({
+  workspaceId,
+  terminalId,
+  visible,
+  paneMetadata,
+  autoFocus,
+}: TerminalPanelProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const terminalRef = useRef<Terminal | null>(null);
   const fitAddonRef = useRef<FitAddon | null>(null);
@@ -86,6 +97,16 @@ export function TerminalPanel({ workspaceId, terminalId, visible }: TerminalPane
       wsRef.current = ws;
 
       ws.onopen = () => {
+        // Send init message with pane metadata (command, cwd, env) if available.
+        // The server uses this to configure the PTY on first spawn.
+        if (paneMetadata && (paneMetadata.command || paneMetadata.cwd || paneMetadata.env)) {
+          const initMsg: Record<string, unknown> = { type: "init" };
+          if (paneMetadata.command) initMsg.command = paneMetadata.command;
+          if (paneMetadata.cwd) initMsg.cwd = paneMetadata.cwd;
+          if (paneMetadata.env) initMsg.env = paneMetadata.env;
+          ws.send(JSON.stringify(initMsg));
+        }
+
         fitAddon.fit();
         ws.send(
           JSON.stringify({
@@ -94,6 +115,11 @@ export function TerminalPanel({ workspaceId, terminalId, visible }: TerminalPane
             rows: terminal.rows,
           }),
         );
+
+        // Auto-focus this terminal if requested
+        if (autoFocus) {
+          terminal.focus();
+        }
       };
 
       ws.onmessage = (event) => {
@@ -141,7 +167,7 @@ export function TerminalPanel({ workspaceId, terminalId, visible }: TerminalPane
       cancelled = true;
       cleanup?.();
     };
-  }, [terminalId, workspaceId]);
+  }, [terminalId, workspaceId, paneMetadata, autoFocus]);
 
   // Refit when visibility changes and notify server of new size
   useEffect(() => {

--- a/apps/web/src/lib/terminal-config-utils.ts
+++ b/apps/web/src/lib/terminal-config-utils.ts
@@ -1,0 +1,90 @@
+/**
+ * Pure functions to convert a WorkspaceTerminalConfig layout tree
+ * into the runtime TreeNode + PaneMetadata used by SplitTerminalContainer.
+ *
+ * This module runs on the client only (uses crypto.randomUUID).
+ */
+
+import type { TerminalLayoutNode, WorkspaceTerminalConfig } from "@band-app/dashboard-core";
+import { createLeaf, type SplitDirection, type TreeNode } from "./terminal-split-tree";
+
+// ---------------------------------------------------------------------------
+// Pane metadata — persisted alongside the tree in localStorage
+// ---------------------------------------------------------------------------
+
+export interface PaneMetadata {
+  name?: string;
+  command?: string;
+  cwd?: string;
+  env?: Record<string, string>;
+  focus?: boolean;
+}
+
+export interface BuildResult {
+  tree: TreeNode;
+  paneMetadata: Record<string, PaneMetadata>; // terminalId -> metadata
+  focusTerminalId: string | null;
+}
+
+// ---------------------------------------------------------------------------
+// Max nesting depth to prevent pathological configs
+// ---------------------------------------------------------------------------
+
+const MAX_DEPTH = 10;
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Convert a validated WorkspaceTerminalConfig into the runtime split tree
+ * and a map of per-pane metadata.
+ */
+export function buildTreeFromConfig(config: WorkspaceTerminalConfig): BuildResult {
+  const paneMetadata: Record<string, PaneMetadata> = {};
+  let focusTerminalId: string | null = null;
+
+  function walk(node: TerminalLayoutNode, depth: number): TreeNode {
+    if (depth > MAX_DEPTH) {
+      // Too deep — collapse to a plain leaf
+      return createLeaf();
+    }
+
+    if ("pane" in node) {
+      const leaf = createLeaf();
+      const meta: PaneMetadata = {};
+      if (node.pane.name) meta.name = node.pane.name;
+      if (node.pane.command) meta.command = node.pane.command;
+      if (node.pane.cwd) meta.cwd = node.pane.cwd;
+      if (node.pane.env) meta.env = node.pane.env;
+      if (node.pane.focus) {
+        meta.focus = true;
+        focusTerminalId = leaf.terminalId;
+      }
+      if (Object.keys(meta).length > 0) {
+        paneMetadata[leaf.terminalId] = meta;
+      }
+      return leaf;
+    }
+
+    // Split node
+    const direction: SplitDirection = node.direction;
+    const splitRatio = node.split ?? 0.5;
+    const leftSize = Math.round(splitRatio * 100);
+    const rightSize = 100 - leftSize;
+
+    const leftChild = walk(node.children[0], depth + 1);
+    const rightChild = walk(node.children[1], depth + 1);
+
+    return {
+      type: "split",
+      nodeId: crypto.randomUUID(),
+      direction,
+      children: [leftChild, rightChild],
+      sizes: [leftSize, rightSize],
+    };
+  }
+
+  const tree = walk(config.layout, 0);
+  return { tree, paneMetadata, focusTerminalId };
+}

--- a/apps/web/src/lib/terminal-config.ts
+++ b/apps/web/src/lib/terminal-config.ts
@@ -1,0 +1,80 @@
+import type { WorkspaceTerminalConfig } from "@band-app/dashboard-core";
+import { createLogger } from "@band-app/logger";
+import { z } from "zod";
+import { loadProjectConfig } from "./project-config";
+
+const log = createLogger("terminal-config");
+
+// ---------------------------------------------------------------------------
+// Zod schemas for workspace.terminal configuration
+// ---------------------------------------------------------------------------
+
+const TerminalPaneConfigSchema = z.object({
+  name: z.string().optional(),
+  command: z.string().optional(),
+  cwd: z.string().optional(),
+  env: z.record(z.string()).optional(),
+  focus: z.boolean().optional(),
+});
+
+const PaneNodeSchema = z.object({
+  pane: TerminalPaneConfigSchema,
+});
+
+type TerminalLayoutNodeInput =
+  | { pane: z.infer<typeof TerminalPaneConfigSchema> }
+  | {
+      direction: "horizontal" | "vertical";
+      split?: number;
+      children: [TerminalLayoutNodeInput, TerminalLayoutNodeInput];
+    };
+
+const TerminalLayoutNodeSchema: z.ZodType<TerminalLayoutNodeInput> = z.lazy(() =>
+  z.union([
+    PaneNodeSchema,
+    z.object({
+      direction: z.enum(["horizontal", "vertical"]),
+      split: z.number().min(0.1).max(0.9).optional().default(0.5),
+      children: z.tuple([TerminalLayoutNodeSchema, TerminalLayoutNodeSchema]),
+    }),
+  ]),
+);
+
+const WorkspaceTerminalConfigSchema = z.object({
+  layout: TerminalLayoutNodeSchema,
+});
+
+// ---------------------------------------------------------------------------
+// Config loader
+// ---------------------------------------------------------------------------
+
+/**
+ * Load and validate the workspace terminal configuration from
+ * `.band/config.json`. Returns `null` when the config file doesn't exist,
+ * doesn't contain a `workspace.terminal` block, or fails validation.
+ */
+export function loadWorkspaceTerminalConfig(
+  worktreePath: string,
+  projectPath: string,
+): WorkspaceTerminalConfig | null {
+  const raw = loadProjectConfig(worktreePath, projectPath);
+  if (!raw) return null;
+
+  const terminalBlock =
+    raw.workspace && typeof raw.workspace === "object"
+      ? (raw.workspace as Record<string, unknown>).terminal
+      : undefined;
+
+  if (!terminalBlock) return null;
+
+  const result = WorkspaceTerminalConfigSchema.safeParse(terminalBlock);
+  if (!result.success) {
+    log.warn(
+      "Invalid workspace.terminal config: %s",
+      result.error.issues.map((i) => `${i.path.join(".")}: ${i.message}`).join("; "),
+    );
+    return null;
+  }
+
+  return result.data;
+}

--- a/apps/web/src/lib/terminal-manager.ts
+++ b/apps/web/src/lib/terminal-manager.ts
@@ -8,6 +8,15 @@ const log = createLogger("terminal");
 
 const MAX_SCROLLBACK_SIZE = 100_000;
 
+export interface SpawnOptions {
+  /** Shell command to auto-run after the PTY spawns. */
+  command?: string;
+  /** Working directory, resolved relative to the workspace root. */
+  cwd?: string;
+  /** Extra environment variables merged into the base env. */
+  env?: Record<string, string>;
+}
+
 interface TerminalSession {
   pty: IPty;
   scrollback: string;
@@ -23,10 +32,14 @@ const workspaceTerminals = new Map<string, Set<string>>();
 /**
  * Spawns a new terminal session for the given workspace and terminalId.
  * Always creates a new PTY (each split pane gets its own shell).
+ *
+ * When `options` is provided, the PTY can use a custom working directory,
+ * extra environment variables, and an initial command written to stdin.
  */
 export async function spawnTerminal(
   workspaceId: string,
   terminalId: string,
+  options?: SpawnOptions,
 ): Promise<TerminalSession> {
   const workspace = resolveWorkspace(workspaceId);
   if (!workspace) {
@@ -48,7 +61,26 @@ export async function spawnTerminal(
   // Remove PORT so workspace dev servers don't inherit the Band server's port
   delete env.PORT;
 
-  const cwd = workspace.worktree.path;
+  // Merge extra env from spawn options
+  if (options?.env) {
+    Object.assign(env, options.env);
+  }
+
+  // Resolve cwd: options.cwd is relative to workspace root
+  const workspaceRoot = workspace.worktree.path;
+  let cwd = workspaceRoot;
+  if (options?.cwd) {
+    const resolved = join(workspaceRoot, options.cwd);
+    // Security: ensure the resolved path stays within the workspace
+    if (!resolved.startsWith(workspaceRoot)) {
+      log.warn("Ignoring cwd %s — resolves outside workspace root %s", options.cwd, workspaceRoot);
+    } else if (existsSync(resolved)) {
+      cwd = resolved;
+    } else {
+      log.warn("Ignoring cwd %s — directory does not exist", options.cwd);
+    }
+  }
+
   if (!existsSync(cwd)) {
     throw new Error(`Workspace directory does not exist: ${cwd}`);
   }
@@ -82,6 +114,11 @@ export async function spawnTerminal(
 
   const session: TerminalSession = { pty: ptyProcess, scrollback: "", workspaceId };
   terminals.set(terminalId, session);
+
+  // Auto-run initial command if provided
+  if (options?.command) {
+    ptyProcess.write(`${options.command}\n`);
+  }
 
   // Register in reverse index
   let ids = workspaceTerminals.get(workspaceId);

--- a/apps/web/src/lib/terminal-split-tree.ts
+++ b/apps/web/src/lib/terminal-split-tree.ts
@@ -143,6 +143,7 @@ export function updateNodeSizes(tree: TreeNode, nodeId: string, sizes: [number, 
 }
 
 const STORAGE_PREFIX = "band:terminal-splits:";
+const PANE_META_PREFIX = "band:terminal-pane-meta:";
 
 /**
  * Persist the split tree for a workspace to localStorage.
@@ -165,5 +166,44 @@ export function loadTree(workspaceId: string): TreeNode | null {
     return raw ? (JSON.parse(raw) as TreeNode) : null;
   } catch {
     return null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Pane metadata persistence (command, cwd, env, name, focus per terminal)
+// ---------------------------------------------------------------------------
+
+/**
+ * Persist pane metadata for a workspace to localStorage.
+ */
+export function savePaneMeta(workspaceId: string, meta: Record<string, unknown>): void {
+  try {
+    localStorage.setItem(`${PANE_META_PREFIX}${workspaceId}`, JSON.stringify(meta));
+  } catch {
+    // localStorage may be full or unavailable
+  }
+}
+
+/**
+ * Load persisted pane metadata for a workspace from localStorage.
+ * Returns `null` if nothing is stored or the data is corrupt.
+ */
+export function loadPaneMeta(workspaceId: string): Record<string, unknown> | null {
+  try {
+    const raw = localStorage.getItem(`${PANE_META_PREFIX}${workspaceId}`);
+    return raw ? (JSON.parse(raw) as Record<string, unknown>) : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Remove persisted pane metadata for a workspace.
+ */
+export function clearPaneMeta(workspaceId: string): void {
+  try {
+    localStorage.removeItem(`${PANE_META_PREFIX}${workspaceId}`);
+  } catch {
+    // ignore
   }
 }

--- a/apps/web/src/lib/terminal-ws.ts
+++ b/apps/web/src/lib/terminal-ws.ts
@@ -5,6 +5,7 @@ import {
   getTerminalSession,
   killTerminal,
   resizeTerminal,
+  type SpawnOptions,
   spawnTerminal,
 } from "./terminal-manager";
 
@@ -20,29 +21,99 @@ export async function handleTerminalConnection(ws: WebSocket, req: IncomingMessa
     return;
   }
 
-  // Try reconnection first, otherwise spawn a new terminal
-  let session = getTerminalSession(terminalId);
-  if (!session) {
-    try {
-      session = await spawnTerminal(workspaceId, terminalId);
-    } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
-      log.error(
-        "Failed to spawn terminal %s for workspace %s: %s",
-        terminalId,
-        workspaceId,
-        message,
-      );
-      ws.close(4001, message);
-      return;
-    }
+  // Reconnection: reuse existing PTY session
+  const existing = getTerminalSession(terminalId);
+  if (existing) {
+    attachSession(ws, terminalId, workspaceId, existing, false);
+    return;
   }
 
-  log.debug("Terminal connected: %s (workspace %s)", terminalId, workspaceId);
+  // New terminal: wait for the first message which may be an `init` with
+  // spawn options (command, cwd, env). If the first message is NOT an init,
+  // spawn with defaults and process the message normally.
+  ws.once("message", async (data: Buffer | string) => {
+    const message = data.toString();
+
+    let spawnOpts: SpawnOptions | undefined;
+    let pendingMessage: string | undefined;
+
+    if (message.startsWith("{")) {
+      try {
+        const parsed = JSON.parse(message);
+        if (parsed.type === "init") {
+          spawnOpts = {
+            command: typeof parsed.command === "string" ? parsed.command : undefined,
+            cwd: typeof parsed.cwd === "string" ? parsed.cwd : undefined,
+            env:
+              parsed.env && typeof parsed.env === "object" && !Array.isArray(parsed.env)
+                ? (parsed.env as Record<string, string>)
+                : undefined,
+          };
+        } else {
+          // Not an init message — spawn with defaults and queue for processing
+          pendingMessage = message;
+        }
+      } catch {
+        // Not valid JSON — treat as raw terminal input
+        pendingMessage = message;
+      }
+    } else {
+      pendingMessage = message;
+    }
+
+    let session: Awaited<ReturnType<typeof spawnTerminal>>;
+    try {
+      session = await spawnTerminal(workspaceId, terminalId, spawnOpts);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      log.error("Failed to spawn terminal %s for workspace %s: %s", terminalId, workspaceId, msg);
+      ws.close(4001, msg);
+      return;
+    }
+
+    attachSession(ws, terminalId, workspaceId, session, true);
+
+    // Process the queued message (resize, close, or raw input)
+    if (pendingMessage) {
+      handleMessage(ws, terminalId, session, pendingMessage);
+    }
+  });
+
+  // If the WebSocket closes before any message arrives, do nothing
+  ws.once("close", () => {
+    ws.removeAllListeners("message");
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Attach a PTY session to a WebSocket
+// ---------------------------------------------------------------------------
+
+interface TerminalSession {
+  pty: {
+    onData: (cb: (data: string) => void) => { dispose: () => void };
+    onExit: (cb: (e: { exitCode: number }) => void) => { dispose: () => void };
+    write: (data: string) => void;
+  };
+  scrollback: string;
+  workspaceId: string;
+}
+
+function attachSession(
+  ws: WebSocket,
+  terminalId: string,
+  workspaceId: string,
+  session: TerminalSession,
+  isNew: boolean,
+): void {
+  log.debug(
+    "Terminal %s: %s (workspace %s)",
+    isNew ? "connected" : "reconnected",
+    terminalId,
+    workspaceId,
+  );
 
   // Replay buffered scrollback so the client sees previous output.
-  // Strip terminal query sequences (e.g. cursor position request \x1b[6n)
-  // that would cause xterm.js to send spurious responses back to the PTY.
   if (session.scrollback.length > 0) {
     ws.send(stripTerminalQueries(session.scrollback));
   }
@@ -64,25 +135,7 @@ export async function handleTerminalConnection(ws: WebSocket, req: IncomingMessa
 
   // WebSocket input -> PTY
   ws.on("message", (data: Buffer | string) => {
-    const message = data.toString();
-    // Check for JSON commands
-    if (message.startsWith("{")) {
-      try {
-        const parsed = JSON.parse(message);
-        if (parsed.type === "resize" && parsed.cols && parsed.rows) {
-          resizeTerminal(terminalId, parsed.cols, parsed.rows);
-          return;
-        }
-        if (parsed.type === "close") {
-          killTerminal(terminalId);
-          ws.close(1000, "Terminal closed by client");
-          return;
-        }
-      } catch {
-        // Not valid JSON, treat as regular input
-      }
-    }
-    session.pty.write(message);
+    handleMessage(ws, terminalId, session, data.toString());
   });
 
   // WebSocket close -> detach listeners but keep PTY alive
@@ -92,6 +145,43 @@ export async function handleTerminalConnection(ws: WebSocket, req: IncomingMessa
     log.debug("Terminal disconnected: %s (PTY kept alive)", terminalId);
   });
 }
+
+// ---------------------------------------------------------------------------
+// Handle a single WebSocket message
+// ---------------------------------------------------------------------------
+
+function handleMessage(
+  ws: WebSocket,
+  terminalId: string,
+  session: TerminalSession,
+  message: string,
+): void {
+  if (message.startsWith("{")) {
+    try {
+      const parsed = JSON.parse(message);
+      if (parsed.type === "resize" && parsed.cols && parsed.rows) {
+        resizeTerminal(terminalId, parsed.cols, parsed.rows);
+        return;
+      }
+      if (parsed.type === "close") {
+        killTerminal(terminalId);
+        ws.close(1000, "Terminal closed by client");
+        return;
+      }
+      if (parsed.type === "init") {
+        // Init after session is already established — ignore
+        return;
+      }
+    } catch {
+      // Not valid JSON, treat as regular input
+    }
+  }
+  session.pty.write(message);
+}
+
+// ---------------------------------------------------------------------------
+// Strip terminal query escape sequences from scrollback
+// ---------------------------------------------------------------------------
 
 /**
  * Strip terminal query/request escape sequences from scrollback so

--- a/apps/web/src/trpc/router.ts
+++ b/apps/web/src/trpc/router.ts
@@ -70,6 +70,7 @@ import {
   TaskConflictError,
 } from "../lib/task-runner";
 import { listTasks, loadTask } from "../lib/task-store";
+import { loadWorkspaceTerminalConfig } from "../lib/terminal-config";
 import { killWorkspaceTerminals } from "../lib/terminal-manager";
 import { getTunnelStatus, startTunnel, stopTunnel } from "../lib/tunnel";
 import { emit, subscribe as subscribeStatus } from "../lib/watcher";
@@ -620,6 +621,15 @@ const LANG_MAP: Record<string, string> = {
 };
 
 const workspaceRouter = t.router({
+  getTerminalConfig: publicProcedure
+    .input(z.object({ workspaceId: z.string() }))
+    .query(({ input }) => {
+      const workspace = resolveWorkspace(input.workspaceId);
+      if (!workspace) return { config: null };
+      const config = loadWorkspaceTerminalConfig(workspace.worktree.path, workspace.project.path);
+      return { config };
+    }),
+
   getDiff: publicProcedure
     .input(
       z.object({

--- a/apps/web/tests/terminal-config.test.ts
+++ b/apps/web/tests/terminal-config.test.ts
@@ -1,0 +1,425 @@
+import { execFileSync, spawn } from "node:child_process";
+import { mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from "node:fs";
+import { createServer } from "node:net";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { seedSettings, seedState } from "./helpers/seed-state";
+
+const PROJECT_ROOT = join(import.meta.dirname, "..");
+const DEFAULT_TOKEN = "terminal-config-test-token";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+interface ServerHandle {
+  url: string;
+  home: string;
+  close: () => Promise<void>;
+}
+
+function createTmpHome(): string {
+  const tmp = realpathSync(mkdtempSync(join(tmpdir(), "band-terminal-config-test-")));
+  mkdirSync(join(tmp, ".band"), { recursive: true });
+  return tmp;
+}
+
+function getRandomPort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const srv = createServer();
+    srv.listen(0, "127.0.0.1", () => {
+      const { port } = srv.address() as { port: number };
+      srv.close(() => resolve(port));
+    });
+    srv.on("error", reject);
+  });
+}
+
+async function startServer(
+  opts: { tmpHome?: string; env?: Record<string, string> } = {},
+): Promise<ServerHandle> {
+  const home = opts.tmpHome || createTmpHome();
+  const port = await getRandomPort();
+
+  return new Promise((resolve, reject) => {
+    const child = spawn("node", ["dist/start-server.mjs"], {
+      cwd: PROJECT_ROOT,
+      env: {
+        ...process.env,
+        HOME: home,
+        PORT: String(port),
+        NODE_ENV: "production",
+        ...opts.env,
+      },
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+
+    let stderr = "";
+    let settled = false;
+
+    child.stderr!.on("data", (chunk: Buffer) => {
+      stderr += chunk.toString();
+    });
+
+    child.stdout!.on("data", (chunk: Buffer) => {
+      const text = chunk.toString();
+      if (text.includes("listening") && !settled) {
+        settled = true;
+        resolve({
+          url: `http://127.0.0.1:${port}`,
+          home,
+          close: () =>
+            new Promise<void>((r) => {
+              child.on("exit", () => r());
+              child.kill("SIGTERM");
+            }),
+        });
+      }
+    });
+
+    child.on("error", (err) => {
+      if (!settled) {
+        settled = true;
+        reject(err);
+      }
+    });
+
+    child.on("exit", (code) => {
+      if (!settled) {
+        settled = true;
+        reject(new Error(`Server exited with code ${code} before listening.\nstderr: ${stderr}`));
+      }
+    });
+
+    setTimeout(() => {
+      if (!settled) {
+        settled = true;
+        child.kill("SIGTERM");
+        reject(new Error(`Server did not start within 15 s.\nstderr: ${stderr}`));
+      }
+    }, 15_000);
+  });
+}
+
+// ---------------------------------------------------------------------------
+// tRPC HTTP helpers
+// ---------------------------------------------------------------------------
+
+const defaultHeaders = { Cookie: `band_token=${DEFAULT_TOKEN}` };
+
+async function trpcQuery(serverUrl: string, procedure: string, input?: unknown) {
+  const url =
+    input !== undefined
+      ? `${serverUrl}/trpc/${procedure}?input=${encodeURIComponent(JSON.stringify(input))}`
+      : `${serverUrl}/trpc/${procedure}`;
+  return fetch(url, { headers: defaultHeaders });
+}
+
+async function trpcData<T>(res: Response): Promise<T> {
+  const body = (await res.json()) as { result: { data: T } };
+  return body.result.data;
+}
+
+// ---------------------------------------------------------------------------
+// Git helpers
+// ---------------------------------------------------------------------------
+
+const gitEnv = {
+  ...process.env,
+  GIT_AUTHOR_NAME: "Test",
+  GIT_AUTHOR_EMAIL: "test@test.com",
+  GIT_COMMITTER_NAME: "Test",
+  GIT_COMMITTER_EMAIL: "test@test.com",
+};
+
+function git(cwd: string, args: string[]): string {
+  return execFileSync("git", args, { cwd, env: gitEnv, encoding: "utf-8" });
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("workspace.getTerminalConfig", () => {
+  let server: ServerHandle;
+  let tmpHome: string;
+  let repoPath: string;
+
+  beforeAll(async () => {
+    tmpHome = createTmpHome();
+
+    // Create a git repo
+    repoPath = join(tmpHome, "repo");
+    mkdirSync(repoPath, { recursive: true });
+    git(repoPath, ["init", "-b", "main"]);
+    writeFileSync(join(repoPath, "README.md"), "# Test\n");
+    git(repoPath, ["add", "."]);
+    git(repoPath, ["commit", "-m", "initial commit"]);
+
+    seedState(tmpHome, {
+      projects: [
+        {
+          name: "repo",
+          path: repoPath,
+          defaultBranch: "main",
+          worktrees: [{ branch: "main", path: repoPath }],
+        },
+      ],
+    });
+    seedSettings(tmpHome, {
+      tokenSecret: DEFAULT_TOKEN,
+      worktreesDir: join(tmpHome, ".band", "worktrees"),
+    });
+    server = await startServer({ tmpHome });
+  });
+
+  afterAll(async () => {
+    await server.close();
+    rmSync(tmpHome, { recursive: true, force: true });
+  });
+
+  it("returns null when no config exists", async () => {
+    const res = await trpcQuery(server.url, "workspace.getTerminalConfig", {
+      workspaceId: "repo-main",
+    });
+    expect(res.status).toBe(200);
+    const data = await trpcData<{ config: null }>(res);
+    expect(data.config).toBeNull();
+  });
+
+  it("returns null when config has no workspace.terminal block", async () => {
+    // Write a config without workspace.terminal
+    const configDir = join(repoPath, ".band");
+    mkdirSync(configDir, { recursive: true });
+    writeFileSync(join(configDir, "config.json"), JSON.stringify({ setup: "npm install" }));
+
+    const res = await trpcQuery(server.url, "workspace.getTerminalConfig", {
+      workspaceId: "repo-main",
+    });
+    expect(res.status).toBe(200);
+    const data = await trpcData<{ config: null }>(res);
+    expect(data.config).toBeNull();
+  });
+
+  it("returns parsed config with a single pane layout", async () => {
+    const terminalConfig = {
+      workspace: {
+        terminal: {
+          layout: {
+            pane: {
+              name: "shell",
+              command: "echo hello",
+            },
+          },
+        },
+      },
+    };
+
+    const configDir = join(repoPath, ".band");
+    mkdirSync(configDir, { recursive: true });
+    writeFileSync(join(configDir, "config.json"), JSON.stringify(terminalConfig));
+
+    const res = await trpcQuery(server.url, "workspace.getTerminalConfig", {
+      workspaceId: "repo-main",
+    });
+    expect(res.status).toBe(200);
+    const data = await trpcData<{
+      config: {
+        layout: { pane: { name: string; command: string } };
+      };
+    }>(res);
+    expect(data.config).not.toBeNull();
+    expect(data.config.layout).toHaveProperty("pane");
+    expect((data.config.layout as { pane: { name: string } }).pane.name).toBe("shell");
+    expect((data.config.layout as { pane: { command: string } }).pane.command).toBe("echo hello");
+  });
+
+  it("returns parsed config with nested splits", async () => {
+    const terminalConfig = {
+      workspace: {
+        terminal: {
+          layout: {
+            direction: "horizontal",
+            split: 0.5,
+            children: [
+              {
+                pane: {
+                  name: "dev server",
+                  command: "npm run dev",
+                  cwd: ".",
+                },
+              },
+              {
+                direction: "vertical",
+                split: 0.5,
+                children: [
+                  {
+                    pane: {
+                      name: "tests",
+                      command: "npm run test:watch",
+                    },
+                  },
+                  {
+                    pane: {
+                      name: "shell",
+                      focus: true,
+                    },
+                  },
+                ],
+              },
+            ],
+          },
+        },
+      },
+    };
+
+    const configDir = join(repoPath, ".band");
+    mkdirSync(configDir, { recursive: true });
+    writeFileSync(join(configDir, "config.json"), JSON.stringify(terminalConfig));
+
+    const res = await trpcQuery(server.url, "workspace.getTerminalConfig", {
+      workspaceId: "repo-main",
+    });
+    expect(res.status).toBe(200);
+    const data = await trpcData<{
+      config: {
+        layout: {
+          direction: string;
+          split: number;
+          children: unknown[];
+        };
+      };
+    }>(res);
+    expect(data.config).not.toBeNull();
+    expect(data.config.layout.direction).toBe("horizontal");
+    expect(data.config.layout.split).toBe(0.5);
+    expect(data.config.layout.children).toHaveLength(2);
+  });
+
+  it("returns config with pane env and cwd", async () => {
+    const terminalConfig = {
+      workspace: {
+        terminal: {
+          layout: {
+            pane: {
+              name: "dev",
+              command: "npm start",
+              cwd: "./packages/api",
+              env: { PORT: "4000", NODE_ENV: "development" },
+            },
+          },
+        },
+      },
+    };
+
+    const configDir = join(repoPath, ".band");
+    mkdirSync(configDir, { recursive: true });
+    writeFileSync(join(configDir, "config.json"), JSON.stringify(terminalConfig));
+
+    const res = await trpcQuery(server.url, "workspace.getTerminalConfig", {
+      workspaceId: "repo-main",
+    });
+    expect(res.status).toBe(200);
+    const data = await trpcData<{
+      config: {
+        layout: {
+          pane: {
+            name: string;
+            cwd: string;
+            env: Record<string, string>;
+          };
+        };
+      };
+    }>(res);
+    expect(data.config.layout.pane.cwd).toBe("./packages/api");
+    expect(data.config.layout.pane.env).toEqual({ PORT: "4000", NODE_ENV: "development" });
+  });
+
+  it("returns null for invalid config (malformed layout)", async () => {
+    const invalidConfig = {
+      workspace: {
+        terminal: {
+          layout: {
+            direction: "horizontal",
+            // Missing children
+          },
+        },
+      },
+    };
+
+    const configDir = join(repoPath, ".band");
+    mkdirSync(configDir, { recursive: true });
+    writeFileSync(join(configDir, "config.json"), JSON.stringify(invalidConfig));
+
+    const res = await trpcQuery(server.url, "workspace.getTerminalConfig", {
+      workspaceId: "repo-main",
+    });
+    expect(res.status).toBe(200);
+    const data = await trpcData<{ config: null }>(res);
+    expect(data.config).toBeNull();
+  });
+
+  it("returns null for invalid split value", async () => {
+    const invalidConfig = {
+      workspace: {
+        terminal: {
+          layout: {
+            direction: "horizontal",
+            split: 1.5, // Out of range (should be 0.1–0.9)
+            children: [{ pane: { name: "a" } }, { pane: { name: "b" } }],
+          },
+        },
+      },
+    };
+
+    const configDir = join(repoPath, ".band");
+    mkdirSync(configDir, { recursive: true });
+    writeFileSync(join(configDir, "config.json"), JSON.stringify(invalidConfig));
+
+    const res = await trpcQuery(server.url, "workspace.getTerminalConfig", {
+      workspaceId: "repo-main",
+    });
+    expect(res.status).toBe(200);
+    const data = await trpcData<{ config: null }>(res);
+    expect(data.config).toBeNull();
+  });
+
+  it("returns null for unknown workspace", async () => {
+    const res = await trpcQuery(server.url, "workspace.getTerminalConfig", {
+      workspaceId: "nonexistent-branch",
+    });
+    expect(res.status).toBe(200);
+    const data = await trpcData<{ config: null }>(res);
+    expect(data.config).toBeNull();
+  });
+
+  it("applies default split value of 0.5 when split is omitted", async () => {
+    const terminalConfig = {
+      workspace: {
+        terminal: {
+          layout: {
+            direction: "vertical",
+            // split omitted — should default to 0.5
+            children: [{ pane: { name: "left" } }, { pane: { name: "right" } }],
+          },
+        },
+      },
+    };
+
+    const configDir = join(repoPath, ".band");
+    mkdirSync(configDir, { recursive: true });
+    writeFileSync(join(configDir, "config.json"), JSON.stringify(terminalConfig));
+
+    const res = await trpcQuery(server.url, "workspace.getTerminalConfig", {
+      workspaceId: "repo-main",
+    });
+    expect(res.status).toBe(200);
+    const data = await trpcData<{
+      config: {
+        layout: { direction: string; split: number; children: unknown[] };
+      };
+    }>(res);
+    expect(data.config.layout.split).toBe(0.5);
+  });
+});

--- a/packages/dashboard-core/src/index.ts
+++ b/packages/dashboard-core/src/index.ts
@@ -117,9 +117,12 @@ export type {
   Settings,
   SetupState,
   SetupStatus,
+  TerminalLayoutNode,
+  TerminalPaneConfig,
   WorkspaceBranchStatus,
   WorkspaceDiff,
   WorkspaceDiffSummary,
   WorkspaceStatus,
+  WorkspaceTerminalConfig,
   WorktreeInfo,
 } from "./types";

--- a/packages/dashboard-core/src/types.ts
+++ b/packages/dashboard-core/src/types.ts
@@ -89,6 +89,30 @@ export interface BandConfig {
   apps?: AppConfig[];
 }
 
+// ---------------------------------------------------------------------------
+// Workspace terminal configuration (recursive split-tree layout)
+// ---------------------------------------------------------------------------
+
+export interface TerminalPaneConfig {
+  name?: string;
+  command?: string;
+  cwd?: string;
+  env?: Record<string, string>;
+  focus?: boolean;
+}
+
+export type TerminalLayoutNode =
+  | { pane: TerminalPaneConfig }
+  | {
+      direction: "horizontal" | "vertical";
+      split?: number;
+      children: [TerminalLayoutNode, TerminalLayoutNode];
+    };
+
+export interface WorkspaceTerminalConfig {
+  layout: TerminalLayoutNode;
+}
+
 export type CodingAgentType = "claude-code" | "codex" | "gemini-cli" | "cursor-cli" | "opencode";
 
 export interface CodingAgentConfig {


### PR DESCRIPTION
## Summary

Adds support for defining terminal layouts in `.band/config.json` under `workspace.terminal`. When a workspace opens for the first time, the client fetches the validated config from the server, builds the split-tree layout, and spawns PTYs with custom commands, working directories, and environment variables.

### Changes

- **Types**: `TerminalPaneConfig`, `TerminalLayoutNode`, `WorkspaceTerminalConfig` in dashboard-core
- **Server**: Zod schema with recursive validation, `workspace.getTerminalConfig` tRPC endpoint, `SpawnOptions` for terminal-manager, WebSocket `init` message handling
- **Client**: Config-to-tree converter, pane metadata persistence in localStorage, config-driven `SplitTerminalContainer` initialization, pane names in toolbar, auto-focus support

### Example config

```json
{
  "workspace": {
    "terminal": {
      "layout": {
        "direction": "horizontal",
        "split": 0.6,
        "children": [
          { "pane": { "name": "dev", "command": "pnpm dev:web" } },
          { "pane": { "name": "shell", "focus": true } }
        ]
      }
    }
  }
}
```

## Test plan

- [x] 9 integration tests covering: no config, missing terminal block, single pane, nested splits, env/cwd, invalid configs, unknown workspace, default split value
- [x] All 374 existing tests still pass (1 pre-existing failure unrelated)
- [x] Build passes clean

Closes #287

🤖 Generated with [Claude Code](https://claude.com/claude-code)