### PR TITLE
feat: add auto-updates for Tauri desktop app

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -138,8 +138,11 @@ jobs:
           pnpm build:web
           pnpm --filter @band-app/dashboard build
 
-      - name: Build DMG
-        run: pnpm --filter @band-app/dashboard tauri build --ci --config '{"build":{"beforeBuildCommand":""}}'
+      - name: Build DMG and updater artifacts
+        run: pnpm --filter @band-app/dashboard tauri build --ci --config '{"build":{"beforeBuildCommand":""}}' --config apps/dashboard/src-tauri/tauri.prod.conf.json
+        env:
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
 
       - name: Commit and tag
         run: |
@@ -166,13 +169,63 @@ jobs:
             echo "EOF"
           } >> "$GITHUB_OUTPUT"
 
+      - name: Generate latest.json update manifest
+        id: manifest
+        run: |
+          VERSION="${{ steps.version.outputs.new_version }}"
+          TAG="v${VERSION}"
+          BUNDLE_DIR="apps/dashboard/src-tauri/target/release/bundle"
+
+          # Find the .app.tar.gz and its signature produced by the updater
+          APP_TAR=$(find "$BUNDLE_DIR/macos" -name '*.app.tar.gz' ! -name '*.sig' | head -1)
+          SIG_FILE="${APP_TAR}.sig"
+
+          if [ ! -f "$APP_TAR" ] || [ ! -f "$SIG_FILE" ]; then
+            echo "Error: updater artifacts not found"
+            echo "  APP_TAR=$APP_TAR"
+            echo "  SIG_FILE=$SIG_FILE"
+            ls -la "$BUNDLE_DIR/macos/" || true
+            exit 1
+          fi
+
+          SIGNATURE=$(cat "$SIG_FILE")
+          APP_TAR_NAME=$(basename "$APP_TAR")
+          PUB_DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+          DOWNLOAD_URL="https://github.com/${{ github.repository }}/releases/download/${TAG}/${APP_TAR_NAME}"
+
+          # Use jq to safely encode the multi-line signature into valid JSON
+          jq -n \
+            --arg version "$VERSION" \
+            --arg notes "See the release notes on GitHub for details." \
+            --arg pub_date "$PUB_DATE" \
+            --arg sig "$SIGNATURE" \
+            --arg url "$DOWNLOAD_URL" \
+            '{
+              version: $version,
+              notes: $notes,
+              pub_date: $pub_date,
+              platforms: {
+                "darwin-aarch64": { signature: $sig, url: $url },
+                "darwin-x86_64": { signature: $sig, url: $url }
+              }
+            }' > latest.json
+
+          echo "app_tar=$APP_TAR" >> "$GITHUB_OUTPUT"
+          echo "sig_file=$SIG_FILE" >> "$GITHUB_OUTPUT"
+          echo "Generated latest.json for $TAG"
+          cat latest.json
+
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
           tag_name: v${{ steps.version.outputs.new_version }}
           name: v${{ steps.version.outputs.new_version }}
           body: ${{ steps.changelog.outputs.changelog }}
-          files: apps/dashboard/src-tauri/target/release/bundle/dmg/*.dmg
+          files: |
+            apps/dashboard/src-tauri/target/release/bundle/dmg/*.dmg
+            ${{ steps.manifest.outputs.app_tar }}
+            ${{ steps.manifest.outputs.sig_file }}
+            latest.json
 
       - name: Publish to npm
         working-directory: apps/web

--- a/apps/dashboard/src-tauri/Cargo.lock
+++ b/apps/dashboard/src-tauri/Cargo.lock
@@ -48,6 +48,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+dependencies = [
+ "derive_arbitrary",
+]
+
+[[package]]
 name = "atk"
 version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -97,7 +106,9 @@ dependencies = [
  "tauri-build",
  "tauri-plugin-dialog",
  "tauri-plugin-fs",
+ "tauri-plugin-process",
  "tauri-plugin-shell",
+ "tauri-plugin-updater",
  "tokio",
  "ureq",
  "url",
@@ -595,6 +606,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "derive_more"
 version = "0.99.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -850,6 +872,17 @@ checksum = "38e2275cc4e4fc009b0669731a1e5ab7ebf11f469eaede2bab9309a5b4d6057f"
 dependencies = [
  "memoffset",
  "rustc_version",
+]
+
+[[package]]
+name = "filetime"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "libredox",
 ]
 
 [[package]]
@@ -1438,6 +1471,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-rustls"
+version = "0.27.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+]
+
+[[package]]
 name = "hyper-util"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1839,8 +1887,17 @@ version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1744e39d1d6a9948f4f388969627434e31128196de472883b39f148769bfe30a"
 dependencies = [
+ "bitflags 2.11.0",
  "libc",
+ "plain",
+ "redox_syscall 0.7.4",
 ]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
@@ -1946,6 +2003,12 @@ name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "minisign-verify"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22f9645cb765ea72b8111f36c522475d2daa0d22c957a9826437e97534bc4e9e"
 
 [[package]]
 name = "miniz_oxide"
@@ -2239,6 +2302,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-osa-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f112d1746737b0da274ef79a23aac283376f335f4095a083a267a082f21db0c0"
+dependencies = [
+ "bitflags 2.11.0",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-foundation",
+]
+
+[[package]]
 name = "objc2-quartz-core"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2308,6 +2383,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2321,6 +2402,20 @@ checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "osakit"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "732c71caeaa72c065bb69d7ea08717bd3f4863a4f451402fc9513e29dbd5261b"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+ "objc2-osa-kit",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -2366,7 +2461,7 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.5.18",
  "smallvec",
  "windows-link 0.2.1",
 ]
@@ -2587,6 +2682,12 @@ name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
+name = "plain"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "plist"
@@ -2849,6 +2950,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f450ad9c3b1da563fb6948a8e0fb0fb9269711c9c73d9ea1de5058c79c8d643a"
+dependencies = [
+ "bitflags 2.11.0",
+]
+
+[[package]]
 name = "redox_users"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2922,15 +3032,20 @@ dependencies = [
  "http-body",
  "http-body-util",
  "hyper",
+ "hyper-rustls",
  "hyper-util",
  "js-sys",
  "log",
  "percent-encoding",
  "pin-project-lite",
+ "rustls",
+ "rustls-pki-types",
+ "rustls-platform-verifier",
  "serde",
  "serde_json",
  "sync_wrapper",
  "tokio",
+ "tokio-rustls",
  "tokio-util",
  "tower",
  "tower-http",
@@ -2996,6 +3111,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags 2.11.0",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "rustls"
 version = "0.23.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3011,6 +3139,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-native-certs"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
 name = "rustls-pki-types"
 version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3018,6 +3158,33 @@ checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
 dependencies = [
  "zeroize",
 ]
+
+[[package]]
+name = "rustls-platform-verifier"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
+dependencies = [
+ "core-foundation",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
@@ -3043,6 +3210,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3101,6 +3277,29 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags 2.11.0",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "selectors"
@@ -3430,7 +3629,7 @@ dependencies = [
  "objc2-foundation",
  "objc2-quartz-core",
  "raw-window-handle",
- "redox_syscall",
+ "redox_syscall 0.5.18",
  "tracing",
  "wasm-bindgen",
  "web-sys",
@@ -3648,6 +3847,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tar"
+version = "0.4.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22692a6476a21fa75fdfc11d452fda482af402c008cdbaf3476414e122040973"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
+]
+
+[[package]]
 name = "target-lexicon"
 version = "0.12.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3825,6 +4035,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-process"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d55511a7bf6cd70c8767b02c97bf8134fa434daf3926cfc1be0a0f94132d165a"
+dependencies = [
+ "tauri",
+ "tauri-plugin",
+]
+
+[[package]]
 name = "tauri-plugin-shell"
 version = "2.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3843,6 +4063,39 @@ dependencies = [
  "tauri-plugin",
  "thiserror 2.0.18",
  "tokio",
+]
+
+[[package]]
+name = "tauri-plugin-updater"
+version = "2.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "806d9dac662c2e4594ff03c647a552f2c9bd544e7d0f683ec58f872f952ce4af"
+dependencies = [
+ "base64 0.22.1",
+ "dirs",
+ "flate2",
+ "futures-util",
+ "http",
+ "infer",
+ "log",
+ "minisign-verify",
+ "osakit",
+ "percent-encoding",
+ "reqwest",
+ "rustls",
+ "semver",
+ "serde",
+ "serde_json",
+ "tar",
+ "tauri",
+ "tauri-plugin",
+ "tempfile",
+ "thiserror 2.0.18",
+ "time",
+ "tokio",
+ "url",
+ "windows-sys 0.60.2",
+ "zip",
 ]
 
 [[package]]
@@ -3944,6 +4197,19 @@ dependencies = [
  "dunce",
  "embed-resource",
  "toml 0.9.12+spec-1.1.0",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.4.2",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4051,6 +4317,16 @@ dependencies = [
  "signal-hook-registry",
  "socket2",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
 ]
 
 [[package]]
@@ -4663,6 +4939,15 @@ dependencies = [
  "pkg-config",
  "soup3-sys",
  "system-deps",
+]
+
+[[package]]
+name = "webpki-root-certs"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -5332,6 +5617,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "xattr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+dependencies = [
+ "libc",
+ "rustix",
+]
+
+[[package]]
 name = "yoke"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5432,6 +5727,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "zip"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa8cd6af31c3b31c6631b8f483848b91589021b28fffe50adada48d4f4d2ed1"
+dependencies = [
+ "arbitrary",
+ "crc32fast",
+ "indexmap 2.13.0",
+ "memchr",
 ]
 
 [[package]]

--- a/apps/dashboard/src-tauri/Cargo.toml
+++ b/apps/dashboard/src-tauri/Cargo.toml
@@ -28,6 +28,8 @@ tokio = { version = "1", features = ["process", "time", "net"] }
 url = "2"
 wry = "0.54.3"
 ureq = { version = "3", features = ["json"] }
+tauri-plugin-updater = "2"
+tauri-plugin-process = "2"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 cocoa = "0.26"

--- a/apps/dashboard/src-tauri/capabilities/default.json
+++ b/apps/dashboard/src-tauri/capabilities/default.json
@@ -19,6 +19,8 @@
     "shell:allow-open",
     "dialog:default",
     "dialog:allow-open",
-    "core:window:allow-start-dragging"
+    "core:window:allow-start-dragging",
+    "updater:default",
+    "process:default"
   ]
 }

--- a/apps/dashboard/src-tauri/src/commands/mod.rs
+++ b/apps/dashboard/src-tauri/src/commands/mod.rs
@@ -11,5 +11,6 @@ pub mod window_manager;
 #[cfg(not(target_os = "macos"))]
 pub use ide_stub as ide;
 pub mod browser;
+pub mod updater;
 pub mod webserver;
 pub mod window;

--- a/apps/dashboard/src-tauri/src/commands/updater.rs
+++ b/apps/dashboard/src-tauri/src/commands/updater.rs
@@ -1,0 +1,115 @@
+use crate::dash_log;
+use tauri_plugin_dialog::{DialogExt, MessageDialogButtons, MessageDialogKind};
+use tauri_plugin_updater::UpdaterExt;
+
+/// Whether the updater is enabled (true only when `TAURI_SIGNING_PRIVATE_KEY`
+/// was present at compile time, i.e. in CI release builds).
+pub const UPDATER_ENABLED: bool = option_env!("TAURI_SIGNING_PRIVATE_KEY").is_some();
+
+/// Check for updates and prompt the user to install if one is available.
+///
+/// When `interactive` is true, a dialog is shown even when no update is found
+/// (useful for the "Check for Updates…" menu item). When false, the check is
+/// silent unless an update exists (used for the automatic startup check).
+pub async fn check_for_update(app: tauri::AppHandle, interactive: bool) {
+    let updater = match app.updater() {
+        Ok(updater) => updater,
+        Err(e) => {
+            dash_log!("updater: failed to create updater: {e}");
+            if interactive {
+                show_info(
+                    &app,
+                    "Update Error",
+                    &format!("Failed to check for updates: {e}"),
+                );
+            }
+            return;
+        }
+    };
+
+    let update = match updater.check().await {
+        Ok(update) => update,
+        Err(e) => {
+            dash_log!("updater: check failed: {e}");
+            if interactive {
+                show_info(
+                    &app,
+                    "Update Error",
+                    "Failed to check for updates. Please try again later.",
+                );
+            }
+            return;
+        }
+    };
+
+    let Some(update) = update else {
+        dash_log!("updater: no update available");
+        if interactive {
+            show_info(
+                &app,
+                "No Updates Available",
+                "You're running the latest version of Band.",
+            );
+        }
+        return;
+    };
+
+    let version = update.version.clone();
+    dash_log!("updater: update available — v{version}");
+
+    // Ask the user whether they want to install the update.
+    let (tx, rx) = tokio::sync::oneshot::channel::<bool>();
+    app.dialog()
+        .message(format!(
+            "Band v{version} is available. Would you like to download and install it now?"
+        ))
+        .title("Update Available")
+        .buttons(MessageDialogButtons::OkCancelCustom(
+            "Update".into(),
+            "Later".into(),
+        ))
+        .show(move |accepted| {
+            let _ = tx.send(accepted);
+        });
+
+    if !rx.await.unwrap_or(false) {
+        return;
+    }
+
+    dash_log!("updater: downloading v{version}…");
+
+    if let Err(e) = update
+        .download_and_install(
+            |chunk_length, content_length| {
+                dash_log!(
+                    "updater: progress — {chunk_length} bytes (total: {})",
+                    content_length.unwrap_or(0)
+                );
+            },
+            || {
+                dash_log!("updater: download finished, installing…");
+            },
+        )
+        .await
+    {
+        dash_log!("updater: install failed: {e}");
+        show_info(
+            &app,
+            "Update Failed",
+            &format!("Failed to install the update: {e}"),
+        );
+        return;
+    }
+
+    dash_log!("updater: installed v{version}, restarting…");
+    app.restart();
+}
+
+/// Show an informational message dialog (non-blocking, fire-and-forget).
+fn show_info(app: &tauri::AppHandle, title: &str, message: &str) {
+    app.dialog()
+        .message(message)
+        .title(title)
+        .kind(MessageDialogKind::Info)
+        .show(|_| {});
+}

--- a/apps/dashboard/src-tauri/src/lib.rs
+++ b/apps/dashboard/src-tauri/src/lib.rs
@@ -140,8 +140,8 @@ pub fn run() {
                 .build()?;
 
             // Build the Band application menu with About and Check for Updates.
-            let mut band_menu = SubmenuBuilder::new(app, "Band")
-                .item(&PredefinedMenuItem::about(app, None, None)?);
+            let mut band_menu =
+                SubmenuBuilder::new(app, "Band").item(&PredefinedMenuItem::about(app, None, None)?);
 
             if UPDATER_ENABLED {
                 let check_updates_item =

--- a/apps/dashboard/src-tauri/src/lib.rs
+++ b/apps/dashboard/src-tauri/src/lib.rs
@@ -10,6 +10,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
 use commands::browser::BrowserState;
+use commands::updater::UPDATER_ENABLED;
 use commands::webserver::{self as webserver, ManagedProcess, WebServerState};
 use state::{ActiveWorkspaceState, FocusManagementState, ProjectCache};
 use tauri::menu::{MenuBuilder, MenuItemBuilder, PredefinedMenuItem, SubmenuBuilder};
@@ -17,7 +18,7 @@ use tauri::Manager;
 
 const MAX_LOG_SIZE: u64 = 5 * 1024 * 1024; // 5 MB
 
-fn log_to_file(msg: &str) {
+pub(crate) fn log_to_file(msg: &str) {
     let Some(home) = dirs::home_dir() else {
         return;
     };
@@ -33,11 +34,12 @@ fn log_to_file(msg: &str) {
     }
 }
 
+#[macro_export]
 macro_rules! dash_log {
     ($($arg:tt)*) => {{
         let msg = format!($($arg)*);
         eprintln!("{}", msg);
-        crate::log_to_file(&msg);
+        $crate::log_to_file(&msg);
     }};
 }
 
@@ -56,10 +58,17 @@ pub fn run() {
     let cleaned_up = Arc::new(AtomicBool::new(false));
     let cleaned_up_setup = cleaned_up.clone();
 
-    let app = tauri::Builder::default()
+    let mut builder = tauri::Builder::default()
         .plugin(tauri_plugin_fs::init())
         .plugin(tauri_plugin_shell::init())
         .plugin(tauri_plugin_dialog::init())
+        .plugin(tauri_plugin_process::init());
+
+    if UPDATER_ENABLED {
+        builder = builder.plugin(tauri_plugin_updater::Builder::new().build());
+    }
+
+    let app = builder
         .manage(WebServerState(ManagedProcess::new()))
         .manage(ActiveWorkspaceState::new())
         .manage(ProjectCache::new())
@@ -130,7 +139,28 @@ pub fn run() {
                 .item(&settings_item)
                 .build()?;
 
+            // Build the Band application menu with About and Check for Updates.
+            let mut band_menu = SubmenuBuilder::new(app, "Band")
+                .item(&PredefinedMenuItem::about(app, None, None)?);
+
+            if UPDATER_ENABLED {
+                let check_updates_item =
+                    MenuItemBuilder::with_id("check_for_updates", "Check for Updates…")
+                        .build(app)?;
+                band_menu = band_menu.separator().item(&check_updates_item);
+            }
+
+            let band_menu = band_menu
+                .separator()
+                .item(&PredefinedMenuItem::hide(app, None)?)
+                .item(&PredefinedMenuItem::hide_others(app, None)?)
+                .item(&PredefinedMenuItem::show_all(app, None)?)
+                .separator()
+                .item(&PredefinedMenuItem::quit(app, None)?)
+                .build()?;
+
             let menu = MenuBuilder::new(app)
+                .item(&band_menu)
                 .item(&edit_menu)
                 .item(&view_menu)
                 .build()?;
@@ -179,6 +209,11 @@ pub fn run() {
                     let handle = app_handle.clone();
                     tauri::async_runtime::spawn(async move {
                         let _ = commands::window::open_settings_window(handle).await;
+                    });
+                } else if event.id() == "check_for_updates" {
+                    let handle = app_handle.clone();
+                    tauri::async_runtime::spawn(async move {
+                        commands::updater::check_for_update(handle, true).await;
                     });
                 }
             });
@@ -261,6 +296,16 @@ pub fn run() {
                 focus_state
                     .0
                     .store(false, std::sync::atomic::Ordering::SeqCst);
+            }
+
+            // Check for updates silently after a short delay so the app
+            // is fully loaded before we hit the network.
+            if UPDATER_ENABLED {
+                let update_handle = app.handle().clone();
+                tauri::async_runtime::spawn(async move {
+                    tokio::time::sleep(std::time::Duration::from_secs(10)).await;
+                    commands::updater::check_for_update(update_handle, false).await;
+                });
             }
 
             // Poll the frontmost VS Code window to track active workspace.

--- a/apps/dashboard/src-tauri/tauri.prod.conf.json
+++ b/apps/dashboard/src-tauri/tauri.prod.conf.json
@@ -6,9 +6,7 @@
   "plugins": {
     "updater": {
       "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IEYyRTAzMDhCMjYyMTM4RjIKUldUeU9DRW1pekRnOHI3S2pvWHZIQjNkK0RUTG8vZzNhNG9aUUIzNTNCT2ZnQ0dlRkFsYmZjalMK",
-      "endpoints": [
-        "https://github.com/band-app/band/releases/latest/download/latest.json"
-      ]
+      "endpoints": ["https://github.com/band-app/band/releases/latest/download/latest.json"]
     }
   }
 }

--- a/apps/dashboard/src-tauri/tauri.prod.conf.json
+++ b/apps/dashboard/src-tauri/tauri.prod.conf.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://schema.tauri.app/config/2",
+  "bundle": {
+    "createUpdaterArtifacts": true
+  },
+  "plugins": {
+    "updater": {
+      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IEYyRTAzMDhCMjYyMTM4RjIKUldUeU9DRW1pekRnOHI3S2pvWHZIQjNkK0RUTG8vZzNhNG9aUUIzNTNCT2ZnQ0dlRkFsYmZjalMK",
+      "endpoints": [
+        "https://github.com/band-app/band/releases/latest/download/latest.json"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Add auto-update support to the Band desktop app using Tauri's updater plugin, modeled after [opencode's implementation](https://github.com/sst/opencode).

- **Updater plugin**: `tauri-plugin-updater` checks GitHub releases for new versions
- **Conditional enablement**: updater only active when `TAURI_SIGNING_PRIVATE_KEY` is set at build time (CI releases only, dev builds skip it)
- **Menu item**: "Check for Updates…" in the Band application menu
- **Auto-check**: silent update check 10 seconds after app launch
- **Native dialogs**: confirmation prompt to download and install, then automatic restart
- **Signed artifacts**: release workflow generates `.app.tar.gz` + `.sig` + `latest.json` manifest
- **GitHub Releases as CDN**: updater fetches `latest.json` from the latest release

## Changes

- `apps/dashboard/src-tauri/Cargo.toml` — add `tauri-plugin-updater` and `tauri-plugin-process`
- `apps/dashboard/src-tauri/src/commands/updater.rs` — new module with update check logic and native dialogs
- `apps/dashboard/src-tauri/src/lib.rs` — register plugins, add Band app menu with "Check for Updates…", auto-check on startup
- `apps/dashboard/src-tauri/capabilities/default.json` — add `updater:default` and `process:default` permissions
- `apps/dashboard/src-tauri/tauri.prod.conf.json` — production config with updater endpoint and signing public key
- `.github/workflows/release.yml` — build signed updater artifacts and generate `latest.json` manifest

## Setup (already done)

- [x] Generated signing keys (`~/.tauri/band.key`)
- [x] Added `TAURI_SIGNING_PRIVATE_KEY` GitHub secret
- [x] Added `TAURI_SIGNING_PRIVATE_KEY_PASSWORD` GitHub secret
- [x] Set public key in `tauri.prod.conf.json`