### PR TITLE
fix(ci): stop committing version bumps back to main in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.RELEASE_PAT }}
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
@@ -151,30 +150,25 @@ jobs:
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
 
-      - name: Commit and tag
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add -A
-          git commit -m "chore: release v${{ steps.version.outputs.new_version }}"
-          git tag "v${{ steps.version.outputs.new_version }}"
-          git push origin main --follow-tags
-
       - name: Generate changelog
         id: changelog
         run: |
-          LAST_TAG=$(git describe --tags --abbrev=0 HEAD^ 2>/dev/null || echo "")
+          LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
           if [ -n "$LAST_TAG" ]; then
-            RANGE="${LAST_TAG}..v${{ steps.version.outputs.new_version }}"
+            CHANGELOG=$(git log "${LAST_TAG}..HEAD" --pretty=format:"- %s" --no-merges | grep -v "^- chore: release" || true)
           else
-            RANGE="v${{ steps.version.outputs.new_version }}"
+            CHANGELOG=$(git log --pretty=format:"- %s" --no-merges | grep -v "^- chore: release" || true)
           fi
-          CHANGELOG=$(git log $RANGE --pretty=format:"- %s" --no-merges | grep -v "^- chore: release" || true)
           {
             echo "changelog<<EOF"
             echo "$CHANGELOG"
             echo "EOF"
           } >> "$GITHUB_OUTPUT"
+
+      - name: Create and push tag
+        run: |
+          git tag "v${{ steps.version.outputs.new_version }}"
+          git push origin "v${{ steps.version.outputs.new_version }}"
 
       - name: Generate latest.json update manifest
         id: manifest


### PR DESCRIPTION
## Summary
- Removed the "Commit and tag" step that pushed a release commit directly to main (which failed branch protection requiring the 'Lint, Test & Build' status check)
- Version bumps now happen in-place during the build for artifact stamping but are never committed back to main
- A lightweight tag is created and pushed separately (tags aren't protected by the ruleset)
- Removed `RELEASE_PAT` from checkout since the default `GITHUB_TOKEN` with `contents: write` is sufficient for tag operations

## Test plan
- [ ] Trigger the release workflow via `workflow_dispatch` and verify:
  - The version is correctly stamped into build artifacts
  - A tag is created and pushed without any commit to main
  - The GitHub Release is created with the correct tag and artifacts
  - npm publish succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)