### PR TITLE
fix: remove auto-approve for plan mode and AskUserQuestion (#299)

### DIFF
--- a/apps/web/src/lib/pending-inputs.ts
+++ b/apps/web/src/lib/pending-inputs.ts
@@ -30,3 +30,10 @@ export function rejectPendingInput(approvalId: string, error: Error): boolean {
   pending.reject(error);
   return true;
 }
+
+export function rejectAllPendingInputs(error: Error): void {
+  for (const [approvalId, pending] of pendingInputs) {
+    pendingInputs.delete(approvalId);
+    pending.reject(error);
+  }
+}

--- a/apps/web/src/lib/task-runner.ts
+++ b/apps/web/src/lib/task-runner.ts
@@ -5,7 +5,7 @@ import type { UIMessageChunk } from "ai";
 import { getAgent, getOrCreateAgent, replaceAgent } from "./agent-pool";
 import { getChat, updateChatStatus } from "./chat-manager";
 import { mimeTypeFromFilename } from "./mime-types";
-import { createPendingInput } from "./pending-inputs";
+import { createPendingInput, rejectAllPendingInputs } from "./pending-inputs";
 import { shiftQueuedMessage } from "./queued-message-store";
 import { bandHome, upsertWorkspaceStatus } from "./state";
 import { generateTaskId, markTaskFailed, saveTask } from "./task-store";
@@ -233,6 +233,9 @@ export function abortTask(chatId: string): boolean {
     return false;
   }
 
+  // Reject any pending user-input promises so the agent adapter doesn't hang.
+  rejectAllPendingInputs(new Error("Task aborted by user"));
+
   const agent = getAgent(chatId);
   if (agent?.abort) {
     agent.abort();
@@ -258,6 +261,8 @@ export function cancelTask(taskId: string): { cancelled: boolean; workspaceId?: 
   // Search in-memory tasks for a running task with this record ID
   for (const [chatId, task] of tasks) {
     if (task.taskRecordId === taskId && task.status === "running") {
+      rejectAllPendingInputs(new Error("Task cancelled"));
+
       const agent = getAgent(chatId);
       if (agent?.abort) {
         agent.abort();
@@ -328,23 +333,13 @@ async function runTask(chatId: string, task: InternalTask) {
   const working = upsertWorkspaceStatus(task.workspaceId, { status: "working" });
   emitStatusEvent({ kind: "update", status: working });
 
-  agent.onUserInputNeeded = async (request) => {
-    // Set status to needs_attention while waiting for user input
-    const needsAttention = upsertWorkspaceStatus(task.workspaceId, { status: "needs_attention" });
-    emitStatusEvent({ kind: "update", status: needsAttention });
-
-    const answers = await createPendingInput(request.approvalId);
-
-    // Restore working status after user responds
-    const restored = upsertWorkspaceStatus(task.workspaceId, { status: "working" });
-    emitStatusEvent({ kind: "update", status: restored });
-
-    return answers;
-  };
-
   // Per-workspace shared directory so concurrent tasks don't collide.
   const sharedDir = join(bandHome(), "shared", task.workspaceId);
   mkdirSync(sharedDir, { recursive: true });
+
+  /** Tools that require user interaction — their tool-input-available broadcast
+   * is handled exclusively by onUserInputNeeded (which enriches the input). */
+  const INTERACTIVE_TOOLS = new Set(["AskUserQuestion", "ExitPlanMode"]);
 
   let textPartId = "";
   let textStarted = false;
@@ -359,6 +354,38 @@ async function runTask(chatId: string, task: InternalTask) {
       textStarted = false;
     }
   }
+
+  agent.onUserInputNeeded = async (request) => {
+    // End any in-progress text block so the approval card renders below it.
+    endText();
+
+    // Always broadcast the interactive tool call with the enriched input so
+    // the UI can render the approval component immediately. This is the
+    // authoritative broadcast for interactive tools — the tool-use event
+    // handler deliberately skips broadcasting for these tools to avoid a
+    // race where the tool-use handler broadcasts first with empty input
+    // ({}) and then this callback's enriched input (with plan content etc.)
+    // is skipped because announcedToolCalls already has the ID.
+    announcedToolCalls.add(request.toolCallId);
+    broadcast(chatId, {
+      type: "tool-input-available",
+      toolCallId: request.toolCallId,
+      toolName: request.toolName,
+      input: request.input,
+    });
+
+    // Set status to needs_attention while waiting for user input
+    const needsAttention = upsertWorkspaceStatus(task.workspaceId, { status: "needs_attention" });
+    emitStatusEvent({ kind: "update", status: needsAttention });
+
+    const answers = await createPendingInput(request.approvalId);
+
+    // Restore working status after user responds
+    const restored = upsertWorkspaceStatus(task.workspaceId, { status: "working" });
+    emitStatusEvent({ kind: "update", status: restored });
+
+    return answers;
+  };
 
   try {
     const sessionOptions =
@@ -412,13 +439,19 @@ async function runTask(chatId: string, task: InternalTask) {
         case "tool-use": {
           endText();
           announcedToolCalls.add(event.toolCallId);
-          broadcast(chatId, {
-            type: "tool-input-available",
-            toolCallId: event.toolCallId,
-            toolName: event.toolName,
-            input: event.input,
-            ...(event.displayTitle ? { title: event.displayTitle } : {}),
-          });
+          // Interactive tools (ExitPlanMode, AskUserQuestion) are broadcast
+          // from onUserInputNeeded which has the enriched input. Skip here
+          // to avoid broadcasting with raw/empty input that would either
+          // race with or overwrite the enriched broadcast.
+          if (!INTERACTIVE_TOOLS.has(event.toolName)) {
+            broadcast(chatId, {
+              type: "tool-input-available",
+              toolCallId: event.toolCallId,
+              toolName: event.toolName,
+              input: event.input,
+              ...(event.displayTitle ? { title: event.displayTitle } : {}),
+            });
+          }
           break;
         }
 

--- a/packages/coding-agent/src/adapters/claude-code.ts
+++ b/packages/coding-agent/src/adapters/claude-code.ts
@@ -25,8 +25,6 @@ import type {
 
 const log = createLogger("coding-agent:claude-code");
 
-const ASK_USER_QUESTION_TIMEOUT_MS = 5 * 60 * 1000; // 5 minutes
-
 /**
  * Read the most recently modified plan file.
  *
@@ -230,31 +228,14 @@ export class ClaudeCodeAdapter implements CodingAgent {
         }
       }
 
-      try {
-        const answers = await Promise.race([
-          this.onUserInputNeeded({
-            approvalId,
-            toolCallId: options.toolUseID,
-            toolName,
-            input: enrichedInput,
-          }),
-          new Promise<never>((_, reject) =>
-            setTimeout(() => reject(new Error("User input timeout")), ASK_USER_QUESTION_TIMEOUT_MS),
-          ),
-        ]);
+      const answers = await this.onUserInputNeeded({
+        approvalId,
+        toolCallId: options.toolUseID,
+        toolName,
+        input: enrichedInput,
+      });
 
-        return { behavior: "deny", message: formatUserAnswer(answers) };
-      } catch (err) {
-        log.warn({ err, approvalId }, `${toolName} timed out or errored, auto-allowing`);
-        // If the conversation has already been closed (process exited while
-        // waiting for user input), throw instead of returning a response that
-        // the SDK would try to write to the dead transport — which causes an
-        // unhandled "ProcessTransport is not ready for writing" rejection.
-        if (!this.activeConversation) {
-          throw new Error("Conversation closed while waiting for user input");
-        }
-        return { behavior: "allow", updatedInput: input };
-      }
+      return { behavior: "deny", message: formatUserAnswer(answers) };
     };
 
     const permissionMode = options?.mode === "plan" ? ("plan" as const) : undefined;


### PR DESCRIPTION
## Summary

- Remove auto-approve timeout for interactive tools (`ExitPlanMode`, `AskUserQuestion`) — agent now waits indefinitely for user input via the Band dashboard
- Fix race condition where interactive tools broadcast with empty input before enriched input (plan content) was available, causing "Thinking..." to be stuck during live streaming
- Add `rejectAllPendingInputs()` cleanup on task abort/cancel to prevent leaked promises
- Set workspace status to `needs_attention` while awaiting user input

Closes #299

## Test plan

- [ ] Submit a task that triggers plan mode — verify the plan approval card appears in the dashboard during live streaming (not just after refresh)
- [ ] Submit a task that triggers `AskUserQuestion` — verify the question UI surfaces in the dashboard
- [ ] Approve/reject a plan — verify the agent continues/stops appropriately
- [ ] Abort a task while an interactive tool is pending — verify clean cleanup without leaked promises
- [ ] Refresh the page while an interactive tool is pending — verify the approval card still renders

🤖 Generated with [Claude Code](https://claude.com/claude-code)