### PR TITLE
Optimize workspace switching with visibility store, React Query caching, and server-persisted browser URLs

### DIFF
--- a/apps/cli/src/main.rs
+++ b/apps/cli/src/main.rs
@@ -42,6 +42,11 @@ enum Commands {
         #[command(subcommand)]
         cmd: ChatsCmd,
     },
+    /// Manage browser tabs
+    Browser {
+        #[command(subcommand)]
+        cmd: BrowserCmd,
+    },
     /// Manage scheduled cronjobs
     Cronjobs {
         #[command(subcommand)]
@@ -230,6 +235,43 @@ enum ChatsCmd {
     Remove {
         /// Chat pane ID
         chat_id: String,
+    },
+}
+
+#[derive(Subcommand)]
+enum BrowserCmd {
+    /// List browser tabs for a workspace
+    List {
+        /// Workspace ID
+        workspace_id: String,
+    },
+    /// Create a new browser tab
+    Create {
+        /// Workspace ID
+        workspace_id: String,
+        /// Initial URL to navigate to
+        #[arg(long)]
+        url: Option<String>,
+        /// Display name for the browser tab
+        #[arg(long)]
+        name: Option<String>,
+    },
+    /// Navigate a browser tab to a URL
+    Navigate {
+        /// Browser tab ID
+        browser_id: String,
+        /// URL to navigate to
+        url: String,
+    },
+    /// Get a browser tab's current state
+    Get {
+        /// Browser tab ID
+        browser_id: String,
+    },
+    /// Remove a browser tab
+    Remove {
+        /// Browser tab ID
+        browser_id: String,
     },
 }
 
@@ -424,6 +466,19 @@ fn main() {
             ChatsCmd::Send { chat_id, message } => cmd_chats_send(&chat_id, &message),
             ChatsCmd::Stop { chat_id } => cmd_chats_stop(&chat_id),
             ChatsCmd::Remove { chat_id } => cmd_chats_remove(&chat_id),
+        },
+        Commands::Browser { cmd } => match cmd {
+            BrowserCmd::List { workspace_id } => cmd_browser_list(&workspace_id),
+            BrowserCmd::Create {
+                workspace_id,
+                url,
+                name,
+            } => cmd_browser_create(&workspace_id, url.as_deref(), name.as_deref()),
+            BrowserCmd::Navigate { browser_id, url } => {
+                cmd_browser_navigate(&browser_id, &url)
+            }
+            BrowserCmd::Get { browser_id } => cmd_browser_get(&browser_id),
+            BrowserCmd::Remove { browser_id } => cmd_browser_remove(&browser_id),
         },
         Commands::Cronjobs { cmd } => match cmd {
             CronjobsCmd::List { project, workspace } => {
@@ -935,6 +990,127 @@ fn cmd_chats_remove(chat_id: &str) -> Result<CommandResult, String> {
     Ok(CommandResult {
         text: format!("Chat {chat_id} removed\n"),
         json: serde_json::json!({"ok": true, "chatId": chat_id}),
+    })
+}
+
+// --- Browser commands ---
+
+fn cmd_browser_list(workspace_id: &str) -> Result<CommandResult, String> {
+    let client = api::ApiClient::from_settings()?;
+    let data = client.trpc_query(
+        "browsers.list",
+        &serde_json::json!({"workspaceId": workspace_id}),
+    )?;
+
+    let browsers = data
+        .get("browsers")
+        .and_then(|b| b.as_array())
+        .cloned()
+        .unwrap_or_default();
+
+    let mut rows: Vec<[String; 4]> = Vec::new();
+    let mut json_browsers = Vec::new();
+    for browser in &browsers {
+        let id = browser.get("id").and_then(|v| v.as_str()).unwrap_or("");
+        let name = browser.get("name").and_then(|v| v.as_str()).unwrap_or("");
+        let url = browser.get("url").and_then(|v| v.as_str()).unwrap_or("");
+        let status = browser
+            .get("status")
+            .and_then(|v| v.as_str())
+            .unwrap_or("");
+        rows.push([
+            id.to_string(),
+            name.to_string(),
+            url.to_string(),
+            status.to_string(),
+        ]);
+        json_browsers.push(browser.clone());
+    }
+
+    let text = format_table(&["ID", "NAME", "URL", "STATUS"], &rows);
+
+    Ok(CommandResult {
+        text,
+        json: serde_json::json!({"browsers": json_browsers}),
+    })
+}
+
+fn cmd_browser_create(
+    workspace_id: &str,
+    url: Option<&str>,
+    name: Option<&str>,
+) -> Result<CommandResult, String> {
+    let client = api::ApiClient::from_settings()?;
+    let mut input = serde_json::json!({"workspaceId": workspace_id});
+    if let Some(u) = url {
+        input["url"] = serde_json::json!(u);
+    }
+    if let Some(n) = name {
+        input["name"] = serde_json::json!(n);
+    }
+    let data = client.trpc_mutate("browsers.create", &input)?;
+    let browser = data
+        .get("browser")
+        .cloned()
+        .unwrap_or(serde_json::Value::Null);
+    let id = browser.get("id").and_then(|v| v.as_str()).unwrap_or("");
+
+    Ok(CommandResult {
+        text: format!("{id}\n"),
+        json: serde_json::json!({"browser": browser}),
+    })
+}
+
+fn cmd_browser_navigate(browser_id: &str, url: &str) -> Result<CommandResult, String> {
+    let client = api::ApiClient::from_settings()?;
+    client.trpc_mutate(
+        "browsers.navigate",
+        &serde_json::json!({"browserId": browser_id, "url": url}),
+    )?;
+
+    Ok(CommandResult {
+        text: format!("Navigated {browser_id} to {url}\n"),
+        json: serde_json::json!({"ok": true, "browserId": browser_id, "url": url}),
+    })
+}
+
+fn cmd_browser_get(browser_id: &str) -> Result<CommandResult, String> {
+    let client = api::ApiClient::from_settings()?;
+    let data = client.trpc_query(
+        "browsers.get",
+        &serde_json::json!({"browserId": browser_id}),
+    )?;
+
+    let browser = data
+        .get("browser")
+        .cloned()
+        .unwrap_or(serde_json::Value::Null);
+    let id = browser.get("id").and_then(|v| v.as_str()).unwrap_or("");
+    let name = browser.get("name").and_then(|v| v.as_str()).unwrap_or("");
+    let url = browser.get("url").and_then(|v| v.as_str()).unwrap_or("");
+    let status = browser
+        .get("status")
+        .and_then(|v| v.as_str())
+        .unwrap_or("");
+
+    let text = format!("ID:     {id}\nName:   {name}\nURL:    {url}\nStatus: {status}\n");
+
+    Ok(CommandResult {
+        text,
+        json: serde_json::json!({"browser": browser}),
+    })
+}
+
+fn cmd_browser_remove(browser_id: &str) -> Result<CommandResult, String> {
+    let client = api::ApiClient::from_settings()?;
+    client.trpc_mutate(
+        "browsers.remove",
+        &serde_json::json!({"browserId": browser_id}),
+    )?;
+
+    Ok(CommandResult {
+        text: format!("Browser {browser_id} removed\n"),
+        json: serde_json::json!({"ok": true, "browserId": browser_id}),
     })
 }
 
@@ -1947,6 +2123,49 @@ pub(crate) fn build_schema(command: Option<&str>) -> Result<serde_json::Value, S
                 {"name": "chat_id", "type": "string", "required": true, "positional": true, "description": "Chat pane ID"},
             ],
             "notes": "Removes the chat pane, kills the associated agent process, and cleans up state."
+        }),
+        serde_json::json!({
+            "name": "browser list",
+            "description": "List browser tabs for a workspace",
+            "parameters": [
+                {"name": "workspace_id", "type": "string", "required": true, "positional": true, "description": "Workspace ID"},
+            ],
+            "notes": "Text output: `ID\\tNAME\\tURL\\tSTATUS` (tab-separated table).\nJSON output: `{\"browsers\": [{\"id\": \"...\", \"name\": \"...\", \"url\": \"...\", \"status\": \"...\"}]}`"
+        }),
+        serde_json::json!({
+            "name": "browser create",
+            "description": "Create a new browser tab in a workspace",
+            "parameters": [
+                {"name": "workspace_id", "type": "string", "required": true, "positional": true, "description": "Workspace ID"},
+                {"name": "--url", "type": "string", "required": false, "description": "Initial URL to navigate to"},
+                {"name": "--name", "type": "string", "required": false, "description": "Display name for the browser tab"},
+            ],
+            "notes": "Text output: the new browser tab ID.\nJSON output: `{\"browser\": {\"id\": \"...\", ...}}`"
+        }),
+        serde_json::json!({
+            "name": "browser navigate",
+            "description": "Navigate a browser tab to a URL",
+            "parameters": [
+                {"name": "browser_id", "type": "string", "required": true, "positional": true, "description": "Browser tab ID"},
+                {"name": "url", "type": "string", "required": true, "positional": true, "description": "URL to navigate to"},
+            ],
+            "notes": "Updates the browser tab's URL in the server state."
+        }),
+        serde_json::json!({
+            "name": "browser get",
+            "description": "Get a browser tab's current state",
+            "parameters": [
+                {"name": "browser_id", "type": "string", "required": true, "positional": true, "description": "Browser tab ID"},
+            ],
+            "notes": "Text output: formatted key-value pairs.\nJSON output: `{\"browser\": {\"id\": \"...\", \"name\": \"...\", \"url\": \"...\", \"status\": \"...\"}}`"
+        }),
+        serde_json::json!({
+            "name": "browser remove",
+            "description": "Remove a browser tab",
+            "parameters": [
+                {"name": "browser_id", "type": "string", "required": true, "positional": true, "description": "Browser tab ID"},
+            ],
+            "notes": "Removes the browser tab and cleans up state."
         }),
         serde_json::json!({
             "name": "notify",

--- a/apps/dashboard/src-tauri/src/commands/browser.rs
+++ b/apps/dashboard/src-tauri/src/commands/browser.rs
@@ -6,11 +6,11 @@ use tauri::{AppHandle, Emitter, Manager, WebviewUrl};
 
 /// Maximum number of browser webviews kept alive simultaneously.
 /// When exceeded the least-recently-used webview is closed.
-const MAX_BROWSER_WEBVIEWS: usize = 5;
+const MAX_BROWSER_WEBVIEWS: usize = 10;
 
 /// Managed state that tracks browser webview creation order for LRU eviction.
 pub struct BrowserState {
-    /// Workspace IDs whose browser webviews are currently alive, ordered from
+    /// Browser IDs whose webviews are currently alive, ordered from
     /// oldest (front) to newest (back).
     pub order: Mutex<Vec<String>>,
 }
@@ -27,22 +27,29 @@ impl BrowserState {
 #[derive(Clone, Serialize)]
 struct BrowserUrlChanged {
     url: String,
-    workspace_id: String,
+    browser_id: String,
     /// `true` while the page is still loading, `false` when finished.
     loading: bool,
 }
 
-/// Build the webview label for a given workspace.
-fn webview_label(workspace_id: &str) -> String {
-    format!("browser-{workspace_id}")
+/// Payload emitted to the frontend with the page's `<title>` after load.
+#[derive(Clone, Serialize)]
+struct BrowserTitleChanged {
+    browser_id: String,
+    title: String,
+}
+
+/// Build the webview label for a given browser tab.
+fn webview_label(browser_id: &str) -> String {
+    format!("browser-{browser_id}")
 }
 
 /// Enforce the LRU cap by closing the oldest browser webview(s).
-fn enforce_lru(app: &AppHandle, state: &BrowserState, new_workspace_id: &str) {
+fn enforce_lru(app: &AppHandle, state: &BrowserState, new_browser_id: &str) {
     let mut order = state.order.lock().unwrap();
 
-    // If this workspace already has a webview, bump it to the end (most recent).
-    if let Some(pos) = order.iter().position(|id| id == new_workspace_id) {
+    // If this browser tab already has a webview, bump it to the end (most recent).
+    if let Some(pos) = order.iter().position(|id| id == new_browser_id) {
         order.remove(pos);
     }
 
@@ -57,30 +64,30 @@ fn enforce_lru(app: &AppHandle, state: &BrowserState, new_workspace_id: &str) {
         }
     }
 
-    order.push(new_workspace_id.to_string());
+    order.push(new_browser_id.to_string());
 }
 
 // ---------------------------------------------------------------------------
 // Commands
 // ---------------------------------------------------------------------------
 
-/// Create (or show) a child webview for the given workspace's browser panel.
+/// Create (or show) a child webview for the given browser tab.
 ///
-/// If a webview for this workspace already exists it is shown and repositioned.
+/// If a webview for this browser tab already exists it is shown and repositioned.
 /// Otherwise a new child webview is created inside the main window.
 #[tauri::command]
 #[allow(clippy::too_many_arguments)]
 pub async fn browser_create(
     app: AppHandle,
     state: tauri::State<'_, BrowserState>,
-    workspace_id: String,
+    browser_id: String,
     x: f64,
     y: f64,
     width: f64,
     height: f64,
     url: String,
 ) -> Result<(), String> {
-    let label = webview_label(&workspace_id);
+    let label = webview_label(&browser_id);
 
     // If the webview already exists, just show + reposition it.
     if let Some(existing) = app.get_webview(&label) {
@@ -90,22 +97,22 @@ pub async fn browser_create(
         // Bump to most-recent in LRU order.
         {
             let mut order = state.order.lock().unwrap();
-            if let Some(pos) = order.iter().position(|id| id == &workspace_id) {
+            if let Some(pos) = order.iter().position(|id| id == &browser_id) {
                 order.remove(pos);
-                order.push(workspace_id);
+                order.push(browser_id);
             }
         }
         return Ok(());
     }
 
     // Enforce LRU cap before creating a new webview.
-    enforce_lru(&app, &state, &workspace_id);
+    enforce_lru(&app, &state, &browser_id);
 
     let window = app.get_window("main").ok_or("Main window not found")?;
     let parsed_url: url::Url = url.parse().map_err(|e| format!("Invalid URL: {e}"))?;
 
     let app_handle = app.clone();
-    let ws_id = workspace_id.clone();
+    let b_id = browser_id.clone();
     let builder = tauri::webview::WebviewBuilder::new(&label, WebviewUrl::External(parsed_url))
         .on_page_load(move |webview, payload| {
             let loading = matches!(payload.event(), PageLoadEvent::Started);
@@ -114,10 +121,52 @@ pub async fn browser_create(
                     "browser-url-changed",
                     BrowserUrlChanged {
                         url: current_url.to_string(),
-                        workspace_id: ws_id.clone(),
+                        browser_id: b_id.clone(),
                         loading,
                     },
                 );
+            }
+
+            // After the page finishes loading, read the WKWebView's `title`
+            // property (macOS) and emit it to the frontend so the tab label
+            // reflects the page's <title>.
+            if matches!(payload.event(), PageLoadEvent::Finished) {
+                #[cfg(target_os = "macos")]
+                {
+                    let app_for_title = app_handle.clone();
+                    let bid_for_title = b_id.clone();
+                    let _ = webview.with_webview(move |wv| {
+                        #[allow(clippy::let_unit_value)]
+                        use cocoa::base::{id, nil};
+                        use objc::{msg_send, sel, sel_impl};
+                        unsafe {
+                            let wk: id = wv.inner() as id;
+                            let title_ns: id = msg_send![wk, title];
+                            let title = if title_ns.is_null() || title_ns == nil {
+                                String::new()
+                            } else {
+                                let bytes: *const std::os::raw::c_char =
+                                    msg_send![title_ns, UTF8String];
+                                if bytes.is_null() {
+                                    String::new()
+                                } else {
+                                    std::ffi::CStr::from_ptr(bytes)
+                                        .to_string_lossy()
+                                        .into_owned()
+                                }
+                            };
+                            if !title.is_empty() {
+                                let _ = app_for_title.emit(
+                                    "browser-title-changed",
+                                    BrowserTitleChanged {
+                                        browser_id: bid_for_title,
+                                        title,
+                                    },
+                                );
+                            }
+                        }
+                    });
+                }
             }
         });
 
@@ -132,14 +181,14 @@ pub async fn browser_create(
     Ok(())
 }
 
-/// Navigate the workspace's browser webview to a new URL.
+/// Navigate the browser tab's webview to a new URL.
 #[tauri::command]
 pub async fn browser_navigate(
     app: AppHandle,
-    workspace_id: String,
+    browser_id: String,
     url: String,
 ) -> Result<(), String> {
-    let label = webview_label(&workspace_id);
+    let label = webview_label(&browser_id);
     let webview = app.get_webview(&label).ok_or("Browser webview not found")?;
     let parsed: url::Url = url.parse().map_err(|e| format!("Invalid URL: {e}"))?;
     webview.navigate(parsed).map_err(|e| format!("{e}"))
@@ -147,16 +196,16 @@ pub async fn browser_navigate(
 
 /// Go back in the browser history.
 #[tauri::command]
-pub async fn browser_go_back(app: AppHandle, workspace_id: String) -> Result<(), String> {
-    let label = webview_label(&workspace_id);
+pub async fn browser_go_back(app: AppHandle, browser_id: String) -> Result<(), String> {
+    let label = webview_label(&browser_id);
     let webview = app.get_webview(&label).ok_or("Browser webview not found")?;
     webview.eval("history.back()").map_err(|e| format!("{e}"))
 }
 
 /// Go forward in the browser history.
 #[tauri::command]
-pub async fn browser_go_forward(app: AppHandle, workspace_id: String) -> Result<(), String> {
-    let label = webview_label(&workspace_id);
+pub async fn browser_go_forward(app: AppHandle, browser_id: String) -> Result<(), String> {
+    let label = webview_label(&browser_id);
     let webview = app.get_webview(&label).ok_or("Browser webview not found")?;
     webview
         .eval("history.forward()")
@@ -165,16 +214,16 @@ pub async fn browser_go_forward(app: AppHandle, workspace_id: String) -> Result<
 
 /// Evaluate arbitrary JavaScript in the browser webview.
 #[tauri::command]
-pub async fn browser_eval(app: AppHandle, workspace_id: String, js: String) -> Result<(), String> {
-    let label = webview_label(&workspace_id);
+pub async fn browser_eval(app: AppHandle, browser_id: String, js: String) -> Result<(), String> {
+    let label = webview_label(&browser_id);
     let webview = app.get_webview(&label).ok_or("Browser webview not found")?;
     webview.eval(&js).map_err(|e| format!("{e}"))
 }
 
 /// Reload the current page in the browser webview.
 #[tauri::command]
-pub async fn browser_reload(app: AppHandle, workspace_id: String) -> Result<(), String> {
-    let label = webview_label(&workspace_id);
+pub async fn browser_reload(app: AppHandle, browser_id: String) -> Result<(), String> {
+    let label = webview_label(&browser_id);
     let webview = app.get_webview(&label).ok_or("Browser webview not found")?;
     webview
         .eval("location.reload()")
@@ -185,13 +234,13 @@ pub async fn browser_reload(app: AppHandle, workspace_id: String) -> Result<(), 
 #[tauri::command]
 pub async fn browser_set_bounds(
     app: AppHandle,
-    workspace_id: String,
+    browser_id: String,
     x: f64,
     y: f64,
     width: f64,
     height: f64,
 ) -> Result<(), String> {
-    let label = webview_label(&workspace_id);
+    let label = webview_label(&browser_id);
     let webview = app.get_webview(&label).ok_or("Browser webview not found")?;
     webview
         .set_position(tauri::LogicalPosition::new(x, y))
@@ -203,8 +252,8 @@ pub async fn browser_set_bounds(
 
 /// Hide the browser webview (when the panel tab is not active or workspace switches away).
 #[tauri::command]
-pub async fn browser_hide(app: AppHandle, workspace_id: String) -> Result<(), String> {
-    let label = webview_label(&workspace_id);
+pub async fn browser_hide(app: AppHandle, browser_id: String) -> Result<(), String> {
+    let label = webview_label(&browser_id);
     if let Some(webview) = app.get_webview(&label) {
         webview.hide().map_err(|e| format!("{e}"))?;
     }
@@ -213,26 +262,71 @@ pub async fn browser_hide(app: AppHandle, workspace_id: String) -> Result<(), St
 
 /// Show the browser webview (when the panel tab becomes active).
 #[tauri::command]
-pub async fn browser_show(app: AppHandle, workspace_id: String) -> Result<(), String> {
-    let label = webview_label(&workspace_id);
+pub async fn browser_show(app: AppHandle, browser_id: String) -> Result<(), String> {
+    let label = webview_label(&browser_id);
     if let Some(webview) = app.get_webview(&label) {
         webview.show().map_err(|e| format!("{e}"))?;
     }
     Ok(())
 }
 
-/// Destroy the browser webview for a workspace and remove it from LRU tracking.
+/// Destroy the browser webview for a browser tab and remove it from LRU tracking.
 #[tauri::command]
 pub async fn browser_destroy(
     app: AppHandle,
     state: tauri::State<'_, BrowserState>,
-    workspace_id: String,
+    browser_id: String,
 ) -> Result<(), String> {
-    let label = webview_label(&workspace_id);
+    let label = webview_label(&browser_id);
     if let Some(webview) = app.get_webview(&label) {
         webview.close().map_err(|e| format!("{e}"))?;
     }
     let mut order = state.order.lock().unwrap();
-    order.retain(|id| id != &workspace_id);
+    order.retain(|id| id != &browser_id);
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Workspace-level bulk commands (for dialog hiding etc.)
+// ---------------------------------------------------------------------------
+
+/// Hide ALL browser webviews whose IDs are tracked in the LRU.
+/// Used when a dialog opens over the workspace — native webviews float above
+/// the DOM and would otherwise cover the dialog.
+///
+/// Since browser IDs contain the workspace ID as context (stored server-side),
+/// we simply hide every tracked webview. The caller should only invoke this
+/// when the workspace is the active one.
+#[tauri::command]
+pub async fn browser_hide_all_for_workspace(
+    app: AppHandle,
+    state: tauri::State<'_, BrowserState>,
+    #[allow(unused_variables)] workspace_id: String,
+) -> Result<(), String> {
+    let order = state.order.lock().unwrap();
+    for browser_id in order.iter() {
+        let label = webview_label(browser_id);
+        if let Some(webview) = app.get_webview(&label) {
+            let _ = webview.hide();
+        }
+    }
+    Ok(())
+}
+
+/// Show ALL browser webviews whose IDs are tracked in the LRU.
+/// Counterpart to `browser_hide_all_for_workspace`.
+#[tauri::command]
+pub async fn browser_show_all_for_workspace(
+    app: AppHandle,
+    state: tauri::State<'_, BrowserState>,
+    #[allow(unused_variables)] workspace_id: String,
+) -> Result<(), String> {
+    let order = state.order.lock().unwrap();
+    for browser_id in order.iter() {
+        let label = webview_label(browser_id);
+        if let Some(webview) = app.get_webview(&label) {
+            let _ = webview.show();
+        }
+    }
     Ok(())
 }

--- a/apps/dashboard/src-tauri/src/lib.rs
+++ b/apps/dashboard/src-tauri/src/lib.rs
@@ -100,6 +100,8 @@ pub fn run() {
             commands::browser::browser_hide,
             commands::browser::browser_show,
             commands::browser::browser_destroy,
+            commands::browser::browser_hide_all_for_workspace,
+            commands::browser::browser_show_all_for_workspace,
         ])
         .setup(move |app| {
             let window = app.get_webview_window("main").unwrap();

--- a/apps/web/src/components/BrowserPanel.tsx
+++ b/apps/web/src/components/BrowserPanel.tsx
@@ -2,6 +2,7 @@ import type { IDockviewPanelProps } from "dockview";
 import { ArrowLeft, ArrowRight, RotateCw, X } from "lucide-react";
 import { useCallback, useEffect, useRef, useState, useSyncExternalStore } from "react";
 import { isTauri } from "../lib/is-tauri";
+import { trpc } from "../lib/trpc-client";
 
 const DEFAULT_URL = "";
 const BLANK_URL = "about:blank";
@@ -41,15 +42,14 @@ function setFaviconUrl(browserId: string, url: string) {
 
 function subscribeFavicons(cb: () => void) {
   faviconListeners.add(cb);
-  return () => { faviconListeners.delete(cb); };
+  return () => {
+    faviconListeners.delete(cb);
+  };
 }
 
 /** Reactive hook that returns the current favicon URL for a browser tab. */
 export function useFavicon(browserId: string): string | undefined {
-  return useSyncExternalStore(
-    subscribeFavicons,
-    () => faviconMap.get(browserId),
-  );
+  return useSyncExternalStore(subscribeFavicons, () => faviconMap.get(browserId));
 }
 
 // ---------------------------------------------------------------------------
@@ -471,11 +471,14 @@ export function BrowserPanelComponent({ params, api }: IDockviewPanelProps<Brows
 export function BrowserPaneComponent({
   params,
   api,
-}: { params: BrowserPaneParams; api: IDockviewPanelProps<BrowserPaneParams>["api"] }) {
-  const { workspaceId, browserId, initialUrl } = params;
+}: {
+  params: BrowserPaneParams;
+  api: IDockviewPanelProps<BrowserPaneParams>["api"];
+}) {
+  const { browserId, initialUrl } = params;
 
-  const [currentUrl, setCurrentUrl] = useState(() => loadUrl(browserId) ?? initialUrl ?? DEFAULT_URL);
-  const [inputUrl, setInputUrl] = useState(() => loadUrl(browserId) ?? initialUrl ?? DEFAULT_URL);
+  const [currentUrl, setCurrentUrl] = useState(() => initialUrl ?? DEFAULT_URL);
+  const [inputUrl, setInputUrl] = useState(() => initialUrl ?? DEFAULT_URL);
   const [loading, setLoading] = useState(false);
   const [created, setCreated] = useState(false);
   const createdRef = useRef(false);
@@ -486,16 +489,6 @@ export function BrowserPaneComponent({
   browserIdRef.current = browserId;
   const currentUrlRef = useRef(currentUrl);
   currentUrlRef.current = currentUrl;
-
-  // ------- restore persisted URL when browserId becomes available -------
-  useEffect(() => {
-    if (!browserId) return;
-    const saved = loadUrl(browserId);
-    if (saved) {
-      setCurrentUrl(saved);
-      setInputUrl(saved);
-    }
-  }, [browserId]);
 
   // ------- helpers -------
 
@@ -511,6 +504,39 @@ export function BrowserPaneComponent({
     const { invoke: tauriInvoke } = await import("@tauri-apps/api/core");
     return tauriInvoke(cmd, args);
   }, []);
+
+  // ------- fetch URL from server when no initialUrl param -------
+  // The server browser record is the source of truth for the URL.
+  // When a browser is created via CLI with --url, or on workspace revisit,
+  // the panel is added without an initialUrl param — fetch it from the server.
+  useEffect(() => {
+    if (!browserId || initialUrl) return;
+
+    let cancelled = false;
+    trpc.browsers.get
+      .query({ browserId })
+      .then((result) => {
+        if (cancelled) return;
+        const url = result.browser?.url;
+        if (!url || url === "" || url === BLANK_URL) return;
+        setCurrentUrl(url);
+        setInputUrl(url);
+        if (createdRef.current) {
+          // Webview exists — navigate it directly.
+          invoke("browser_navigate", { browserId, url }).catch(() => {});
+        } else {
+          // Webview not yet created — queue it so tryCreate flushes after
+          // browser_create completes (same mechanism as handleNavigate).
+          pendingNavRef.current = url;
+        }
+      })
+      .catch(() => {
+        // Server fetch failed — the user can still type a URL manually
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [browserId, initialUrl, invoke]);
 
   // ------- create or show webview once placeholder has real dimensions -------
   useEffect(() => {
@@ -531,7 +557,7 @@ export function BrowserPaneComponent({
         await invoke("browser_create", {
           browserId,
           ...bounds,
-          url: loadUrl(browserId) || currentUrlRef.current || BLANK_URL,
+          url: currentUrlRef.current || BLANK_URL,
         });
         createdRef.current = true;
         setCreated(true);
@@ -563,14 +589,18 @@ export function BrowserPaneComponent({
     };
   }, [created, getBounds, invoke, browserId]);
 
-  // ------- listen for URL changes from the Rust side -------
+  // ------- listen for URL / title changes from the Rust side -------
+  // Persist URL to server (debounced) so it survives workspace switches.
+  const urlPersistTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
   useEffect(() => {
     if (!isTauri) return;
-    let unlisten: (() => void) | undefined;
+    let unlistenUrl: (() => void) | undefined;
+    let unlistenTitle: (() => void) | undefined;
 
     (async () => {
       const { listen } = await import("@tauri-apps/api/event");
-      unlisten = await listen<{ url: string; browser_id: string; loading: boolean }>(
+      unlistenUrl = await listen<{ url: string; browser_id: string; loading: boolean }>(
         "browser-url-changed",
         (event) => {
           if (event.payload.browser_id !== browserIdRef.current) return;
@@ -579,7 +609,12 @@ export function BrowserPaneComponent({
           if (url === BLANK_URL) return;
           setCurrentUrl(url);
           setInputUrl(url);
-          saveUrl(browserIdRef.current, url);
+
+          // Persist to server (debounced to avoid hammering on redirect chains)
+          if (urlPersistTimer.current) clearTimeout(urlPersistTimer.current);
+          urlPersistTimer.current = setTimeout(() => {
+            trpc.browsers.navigate.mutate({ browserId: browserIdRef.current, url }).catch(() => {});
+          }, 500);
 
           // Try to extract favicon from the URL's origin
           try {
@@ -590,12 +625,23 @@ export function BrowserPaneComponent({
           }
         },
       );
+      unlistenTitle = await listen<{ browser_id: string; title: string }>(
+        "browser-title-changed",
+        (event) => {
+          if (event.payload.browser_id !== browserIdRef.current) return;
+          if (event.payload.title) {
+            api.setTitle(event.payload.title);
+          }
+        },
+      );
     })();
 
     return () => {
-      unlisten?.();
+      unlistenUrl?.();
+      unlistenTitle?.();
+      if (urlPersistTimer.current) clearTimeout(urlPersistTimer.current);
     };
-  }, []);
+  }, [api]);
 
   // ------- visibility tracking (hide/show when tab switches) -------
   // In dockview, `isActive` = globally focused (only one panel at a time),
@@ -691,7 +737,6 @@ export function BrowserPaneComponent({
       setCurrentUrl(normalized);
       setInputUrl(normalized);
       setLoading(true);
-      saveUrl(browserId, normalized);
 
       if (createdRef.current) {
         try {

--- a/apps/web/src/components/BrowserPanel.tsx
+++ b/apps/web/src/components/BrowserPanel.tsx
@@ -1,6 +1,6 @@
 import type { IDockviewPanelProps } from "dockview";
 import { ArrowLeft, ArrowRight, RotateCw, X } from "lucide-react";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState, useSyncExternalStore } from "react";
 import { isTauri } from "../lib/is-tauri";
 
 const DEFAULT_URL = "";
@@ -23,6 +23,44 @@ function loadUrl(workspaceId: string): string | null {
   } catch {
     return null;
   }
+}
+
+// ---------------------------------------------------------------------------
+// Favicon store — tracks per-browser favicon URLs emitted by Tauri.
+// ---------------------------------------------------------------------------
+
+const faviconMap = new Map<string, string>();
+const faviconListeners = new Set<() => void>();
+
+function setFaviconUrl(browserId: string, url: string) {
+  if (faviconMap.get(browserId) !== url) {
+    faviconMap.set(browserId, url);
+    for (const listener of faviconListeners) listener();
+  }
+}
+
+function subscribeFavicons(cb: () => void) {
+  faviconListeners.add(cb);
+  return () => { faviconListeners.delete(cb); };
+}
+
+/** Reactive hook that returns the current favicon URL for a browser tab. */
+export function useFavicon(browserId: string): string | undefined {
+  return useSyncExternalStore(
+    subscribeFavicons,
+    () => faviconMap.get(browserId),
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Browser pane params — used by DockviewBrowserContainer for multi-tab support.
+// ---------------------------------------------------------------------------
+
+export interface BrowserPaneParams {
+  workspaceId: string;
+  browserId: string;
+  wsActive?: boolean;
+  initialUrl?: string;
 }
 
 // ---------------------------------------------------------------------------
@@ -420,6 +458,371 @@ export function BrowserPanelComponent({ params, api }: IDockviewPanelProps<Brows
       </div>
 
       {/* Placeholder – the native webview is positioned over this area */}
+      <div ref={placeholderRef} className="min-h-0 flex-1" />
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// BrowserPaneComponent — multi-tab variant keyed by browserId.
+// Used by DockviewBrowserContainer to render individual browser tabs.
+// ---------------------------------------------------------------------------
+
+export function BrowserPaneComponent({
+  params,
+  api,
+}: { params: BrowserPaneParams; api: IDockviewPanelProps<BrowserPaneParams>["api"] }) {
+  const { workspaceId, browserId, initialUrl } = params;
+
+  const [currentUrl, setCurrentUrl] = useState(() => loadUrl(browserId) ?? initialUrl ?? DEFAULT_URL);
+  const [inputUrl, setInputUrl] = useState(() => loadUrl(browserId) ?? initialUrl ?? DEFAULT_URL);
+  const [loading, setLoading] = useState(false);
+  const [created, setCreated] = useState(false);
+  const createdRef = useRef(false);
+  const placeholderRef = useRef<HTMLDivElement>(null);
+  const creatingRef = useRef(false);
+  const pendingNavRef = useRef<string | null>(null);
+  const browserIdRef = useRef(browserId);
+  browserIdRef.current = browserId;
+  const currentUrlRef = useRef(currentUrl);
+  currentUrlRef.current = currentUrl;
+
+  // ------- restore persisted URL when browserId becomes available -------
+  useEffect(() => {
+    if (!browserId) return;
+    const saved = loadUrl(browserId);
+    if (saved) {
+      setCurrentUrl(saved);
+      setInputUrl(saved);
+    }
+  }, [browserId]);
+
+  // ------- helpers -------
+
+  const getBounds = useCallback(() => {
+    const el = placeholderRef.current;
+    if (!el) return null;
+    const rect = el.getBoundingClientRect();
+    return { x: rect.left, y: rect.top, width: rect.width, height: rect.height };
+  }, []);
+
+  const invoke = useCallback(async (cmd: string, args?: Record<string, unknown>) => {
+    if (!isTauri) return;
+    const { invoke: tauriInvoke } = await import("@tauri-apps/api/core");
+    return tauriInvoke(cmd, args);
+  }, []);
+
+  // ------- create or show webview once placeholder has real dimensions -------
+  useEffect(() => {
+    if (!isTauri || created || creatingRef.current) return;
+    const el = placeholderRef.current;
+    if (!el) return;
+
+    let cancelled = false;
+
+    const tryCreate = async () => {
+      if (cancelled || createdRef.current || creatingRef.current) return;
+      const bounds = getBounds();
+      if (!bounds || bounds.width === 0 || bounds.height === 0) return;
+
+      observer.disconnect();
+      creatingRef.current = true;
+      try {
+        await invoke("browser_create", {
+          browserId,
+          ...bounds,
+          url: loadUrl(browserId) || currentUrlRef.current || BLANK_URL,
+        });
+        createdRef.current = true;
+        setCreated(true);
+        const pending = pendingNavRef.current;
+        if (pending) {
+          pendingNavRef.current = null;
+          await invoke("browser_navigate", {
+            browserId: browserIdRef.current,
+            url: pending,
+          });
+        }
+      } catch (e) {
+        console.error("Failed to create browser webview:", e);
+      } finally {
+        creatingRef.current = false;
+      }
+    };
+
+    const observer = new ResizeObserver(() => {
+      tryCreate();
+    });
+    observer.observe(el);
+    const timer = setTimeout(tryCreate, 50);
+
+    return () => {
+      cancelled = true;
+      clearTimeout(timer);
+      observer.disconnect();
+    };
+  }, [created, getBounds, invoke, browserId]);
+
+  // ------- listen for URL changes from the Rust side -------
+  useEffect(() => {
+    if (!isTauri) return;
+    let unlisten: (() => void) | undefined;
+
+    (async () => {
+      const { listen } = await import("@tauri-apps/api/event");
+      unlisten = await listen<{ url: string; browser_id: string; loading: boolean }>(
+        "browser-url-changed",
+        (event) => {
+          if (event.payload.browser_id !== browserIdRef.current) return;
+          const url = event.payload.url;
+          setLoading(event.payload.loading);
+          if (url === BLANK_URL) return;
+          setCurrentUrl(url);
+          setInputUrl(url);
+          saveUrl(browserIdRef.current, url);
+
+          // Try to extract favicon from the URL's origin
+          try {
+            const origin = new URL(url).origin;
+            setFaviconUrl(browserIdRef.current, `${origin}/favicon.ico`);
+          } catch {
+            // ignore invalid URLs
+          }
+        },
+      );
+    })();
+
+    return () => {
+      unlisten?.();
+    };
+  }, []);
+
+  // ------- visibility tracking (hide/show when tab switches) -------
+  // In dockview, `isActive` = globally focused (only one panel at a time),
+  // while `isVisible` = content area is on screen (multiple in a split).
+  // We show/hide based on *visibility*, not active focus, so split views
+  // keep both native webviews rendered simultaneously.
+  useEffect(() => {
+    if (!isTauri || !created) return;
+
+    const showWebview = async () => {
+      await invoke("browser_show", { browserId });
+      const bounds = getBounds();
+      if (bounds && bounds.width > 0 && bounds.height > 0) {
+        await invoke("browser_set_bounds", { browserId, ...bounds });
+      }
+    };
+
+    const hideWebview = async () => {
+      await invoke("browser_hide", { browserId });
+    };
+
+    const d = api.onDidVisibilityChange((e) => {
+      if (e.isVisible) {
+        showWebview();
+      } else {
+        hideWebview();
+      }
+    });
+
+    return () => {
+      d.dispose();
+    };
+  }, [api, created, getBounds, invoke, browserId]);
+
+  // ------- workspace-level visibility -------
+  useEffect(() => {
+    if (!isTauri || !created) return;
+    const wsActive = params.wsActive !== false;
+
+    if (!wsActive) {
+      invoke("browser_hide", { browserId }).catch(() => {});
+    } else if (api.isVisible) {
+      invoke("browser_show", { browserId }).catch(() => {});
+      const bounds = getBounds();
+      if (bounds && bounds.width > 0 && bounds.height > 0) {
+        invoke("browser_set_bounds", { browserId, ...bounds }).catch(() => {});
+      }
+    }
+  }, [params.wsActive, api, created, getBounds, invoke, browserId]);
+
+  // ------- keep webview bounds in sync on resize -------
+  useEffect(() => {
+    if (!isTauri || !created) return;
+    const el = placeholderRef.current;
+    if (!el) return;
+
+    const observer = new ResizeObserver(() => {
+      const bounds = getBounds();
+      if (!bounds || bounds.width === 0 || bounds.height === 0) return;
+      invoke("browser_set_bounds", { browserId, ...bounds }).catch(() => {});
+    });
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [created, getBounds, invoke, browserId]);
+
+  // ------- destroy on unmount -------
+  useEffect(() => {
+    return () => {
+      if (isTauri) {
+        const bId = browserIdRef.current;
+        import("@tauri-apps/api/core").then(({ invoke: tauriInvoke }) => {
+          tauriInvoke("browser_destroy", { browserId: bId }).catch(() => {});
+        });
+      }
+    };
+  }, []);
+
+  // ------- navigation handlers -------
+
+  const handleNavigate = useCallback(
+    async (rawUrl: string) => {
+      let normalized = rawUrl.trim();
+      if (!normalized) return;
+
+      if (!normalized.startsWith("http://") && !normalized.startsWith("https://")) {
+        if (normalized.includes(".") && !normalized.includes(" ")) {
+          normalized = `https://${normalized}`;
+        } else {
+          normalized = `https://www.google.com/search?q=${encodeURIComponent(normalized)}`;
+        }
+      }
+
+      setCurrentUrl(normalized);
+      setInputUrl(normalized);
+      setLoading(true);
+      saveUrl(browserId, normalized);
+
+      if (createdRef.current) {
+        try {
+          await invoke("browser_navigate", { browserId, url: normalized });
+        } catch (e) {
+          console.error("browser_navigate failed:", e);
+        }
+      } else {
+        pendingNavRef.current = normalized;
+      }
+    },
+    [invoke, browserId],
+  );
+
+  const handleBack = useCallback(async () => {
+    try {
+      await invoke("browser_go_back", { browserId });
+    } catch (e) {
+      console.error("browser_go_back failed:", e);
+    }
+  }, [invoke, browserId]);
+
+  const handleForward = useCallback(async () => {
+    try {
+      await invoke("browser_go_forward", { browserId });
+    } catch (e) {
+      console.error("browser_go_forward failed:", e);
+    }
+  }, [invoke, browserId]);
+
+  const handleReload = useCallback(async () => {
+    try {
+      setLoading(true);
+      await invoke("browser_reload", { browserId });
+    } catch (e) {
+      console.error("browser_reload failed:", e);
+    }
+  }, [invoke, browserId]);
+
+  const handleStop = useCallback(async () => {
+    try {
+      await invoke("browser_eval", { browserId, js: "window.stop()" });
+      setLoading(false);
+    } catch {
+      setLoading(false);
+    }
+  }, [invoke, browserId]);
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLInputElement>) => {
+      if (e.key === "Enter") {
+        e.preventDefault();
+        handleNavigate(inputUrl);
+      }
+    },
+    [inputUrl, handleNavigate],
+  );
+
+  if (!browserId) return null;
+
+  if (!isTauri) {
+    return (
+      <div className="flex h-full items-center justify-center text-muted-foreground">
+        Browser panel is only available in the desktop app
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex h-full w-full flex-col">
+      <style>{`@keyframes browser-bar-slide {
+  0% { transform: translateX(-100%); }
+  50% { transform: translateX(200%); }
+  100% { transform: translateX(-100%); }
+}`}</style>
+      <div className="relative flex h-10 shrink-0 items-center gap-1 border-b border-border bg-background px-2">
+        <button
+          type="button"
+          onClick={handleBack}
+          className="flex items-center justify-center rounded p-1.5 text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+          title="Back"
+        >
+          <ArrowLeft className="size-4" />
+        </button>
+        <button
+          type="button"
+          onClick={handleForward}
+          className="flex items-center justify-center rounded p-1.5 text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+          title="Forward"
+        >
+          <ArrowRight className="size-4" />
+        </button>
+        {loading ? (
+          <button
+            type="button"
+            onClick={handleStop}
+            className="flex items-center justify-center rounded p-1.5 text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+            title="Stop"
+          >
+            <X className="size-4" />
+          </button>
+        ) : (
+          <button
+            type="button"
+            onClick={handleReload}
+            className="flex items-center justify-center rounded p-1.5 text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+            title="Reload"
+          >
+            <RotateCw className="size-4" />
+          </button>
+        )}
+        <input
+          type="text"
+          value={inputUrl}
+          onChange={(e) => setInputUrl(e.target.value)}
+          onKeyDown={handleKeyDown}
+          onFocus={(e) => e.target.select()}
+          className="min-w-0 flex-1 rounded border border-transparent bg-muted/50 px-3 py-1.5 text-sm text-foreground outline-none transition-colors focus:border-border"
+          placeholder="Enter URL or search..."
+        />
+        {loading && (
+          <div className="absolute inset-x-0 bottom-0 h-0.5 overflow-hidden bg-blue-500/10">
+            <div
+              className="h-full w-2/5 rounded-full bg-blue-500"
+              style={{
+                animation: "browser-bar-slide 1.4s ease-in-out infinite",
+              }}
+            />
+          </div>
+        )}
+      </div>
       <div ref={placeholderRef} className="min-h-0 flex-1" />
     </div>
   );

--- a/apps/web/src/components/DockviewBrowserContainer.tsx
+++ b/apps/web/src/components/DockviewBrowserContainer.tsx
@@ -1,3 +1,5 @@
+import { useAdapter } from "@band-app/dashboard-core";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import {
   type DockviewApi,
   DockviewReact,
@@ -17,7 +19,6 @@ import React, {
   useRef,
   useState,
 } from "react";
-import { useAdapter } from "@band-app/dashboard-core";
 import { isTauri } from "../lib/is-tauri";
 import { trpc } from "../lib/trpc-client";
 import { BrowserPaneComponent, type BrowserPaneParams, useFavicon } from "./BrowserPanel";
@@ -60,12 +61,45 @@ export function newBrowserId(): string {
 }
 
 // ---------------------------------------------------------------------------
-// Debounced server persistence (500ms)
+// React Query cache key
+// ---------------------------------------------------------------------------
+
+function browserLayoutKey(workspaceId: string) {
+  return ["browserLayout", workspaceId] as const;
+}
+
+// ---------------------------------------------------------------------------
+// Debounced server persistence (500ms) — also updates React Query cache
+// so the next mount renders instantly from cached data.
 // ---------------------------------------------------------------------------
 
 const saveTimers = new Map<string, ReturnType<typeof setTimeout>>();
 
-function persistToServer(workspaceId: string, layout: unknown): void {
+interface PersistOptions {
+  queryClient?: ReturnType<typeof useQueryClient>;
+}
+
+function panelIdsFromLayout(layout: unknown): Set<string> {
+  if (typeof layout === "object" && layout !== null) {
+    const panels = (layout as Record<string, unknown>).panels;
+    if (typeof panels === "object" && panels !== null) {
+      return new Set(Object.keys(panels as Record<string, unknown>));
+    }
+  }
+  return new Set();
+}
+
+function persistToServer(workspaceId: string, layout: unknown, opts?: PersistOptions): void {
+  // Update React Query cache immediately so next mount is instant.
+  // Derive browserIds from the layout's panels map so the cache stays
+  // in sync — prevents orphan-pruning on remount after CLI additions.
+  if (opts?.queryClient) {
+    opts.queryClient.setQueryData(browserLayoutKey(workspaceId), {
+      layout,
+      browserIds: panelIdsFromLayout(layout),
+    });
+  }
+
   const existing = saveTimers.get(workspaceId);
   if (existing) clearTimeout(existing);
   saveTimers.set(
@@ -77,6 +111,15 @@ function persistToServer(workspaceId: string, layout: unknown): void {
       });
     }, 500),
   );
+}
+
+// ---------------------------------------------------------------------------
+// Cached data shape
+// ---------------------------------------------------------------------------
+
+interface BrowserLayoutData {
+  layout: unknown | null;
+  browserIds: Set<string>;
 }
 
 // ---------------------------------------------------------------------------
@@ -289,36 +332,37 @@ export function DockviewBrowserContainer({
   wsActive,
 }: DockviewBrowserContainerProps) {
   const adapter = useAdapter();
+  const queryClient = useQueryClient();
   const apiRef = useRef<DockviewApi | null>(null);
   const isRestoringRef = useRef(false);
 
-  // Pre-fetch layout AND browser records from server before mounting dockview.
-  // We need both so we can prune layout panels whose browser records were deleted.
-  const [initialData, setInitialData] = useState<{
-    loaded: boolean;
-    layout: unknown | null;
-    browserIds: Set<string> | null;
-  }>({ loaded: false, layout: null, browserIds: null });
-
-  useEffect(() => {
-    Promise.all([
-      trpc.browserLayout.get.query({ workspaceId }).catch(() => ({ tree: null })),
-      trpc.browsers.list.query({ workspaceId }).catch(() => ({ browsers: [] })),
-    ]).then(([{ tree }, { browsers }]) => {
-      setInitialData({
-        loaded: true,
+  // Fetch layout AND browser records via React Query — cached across mounts
+  // so re-visiting a workspace renders instantly from the cache.
+  const { data: initialData } = useQuery<BrowserLayoutData>({
+    queryKey: browserLayoutKey(workspaceId),
+    queryFn: async () => {
+      const [{ tree }, { browsers }] = await Promise.all([
+        trpc.browserLayout.get.query({ workspaceId }).catch(() => ({ tree: null })),
+        trpc.browsers.list
+          .query({ workspaceId })
+          .catch(() => ({ browsers: [] as { id: string }[] })),
+      ]);
+      return {
         layout: tree,
         browserIds: new Set(browsers.map((b: { id: string }) => b.id)),
-      });
-    });
-  }, [workspaceId]);
+      };
+    },
+    staleTime: Number.POSITIVE_INFINITY, // never auto-refetch — we manage persistence ourselves
+  });
 
-  // Debounced persist: serialize the full dockview layout
+  // Debounced persist: serialize the full dockview layout + update cache
+  const queryClientRef = useRef(queryClient);
+  queryClientRef.current = queryClient;
   const schedulePersist = useCallback(() => {
     if (isRestoringRef.current) return;
     const api = apiRef.current;
     if (!api) return;
-    persistToServer(workspaceId, api.toJSON());
+    persistToServer(workspaceId, api.toJSON(), { queryClient: queryClientRef.current });
   }, [workspaceId]);
 
   const handleAddTab = useCallback(
@@ -460,9 +504,9 @@ export function DockviewBrowserContainer({
 
   // Use refs for the initial data so onReady's closure captures the latest
   const initialLayoutRef = useRef<unknown | null>(null);
-  initialLayoutRef.current = initialData.layout;
+  initialLayoutRef.current = initialData?.layout ?? null;
   const initialBrowserIdsRef = useRef<Set<string> | null>(null);
-  initialBrowserIdsRef.current = initialData.browserIds;
+  initialBrowserIdsRef.current = initialData?.browserIds ?? null;
 
   const onReady = useCallback(
     (event: DockviewReadyEvent) => {
@@ -483,9 +527,7 @@ export function DockviewBrowserContainer({
 
         // Prune panels whose browser records no longer exist on the server.
         if (knownBrowserIds) {
-          const orphans = event.api.panels.filter(
-            (p) => !knownBrowserIds.has(p.id),
-          );
+          const orphans = event.api.panels.filter((p) => !knownBrowserIds.has(p.id));
           for (const orphan of orphans) {
             event.api.removePanel(orphan);
           }
@@ -502,7 +544,7 @@ export function DockviewBrowserContainer({
       } else {
         // No saved layout — create a default tab
         createDefaultPanel(event.api, workspaceId);
-        persistToServer(workspaceId, event.api.toJSON());
+        persistToServer(workspaceId, event.api.toJSON(), { queryClient: queryClientRef.current });
       }
 
       // Listen for any layout changes and auto-persist
@@ -522,8 +564,9 @@ export function DockviewBrowserContainer({
     [visible, wsActive],
   );
 
-  // Don't render dockview until the initial layout is fetched from the server
-  if (!initialData.loaded) {
+  // Don't render dockview until the initial layout is fetched from the server.
+  // On subsequent visits, React Query returns cached data instantly — no loading.
+  if (!initialData) {
     return <div className="flex h-full w-full items-center justify-center" />;
   }
 

--- a/apps/web/src/components/DockviewBrowserContainer.tsx
+++ b/apps/web/src/components/DockviewBrowserContainer.tsx
@@ -1,0 +1,563 @@
+import {
+  type DockviewApi,
+  DockviewReact,
+  type DockviewReadyEvent,
+  type DockviewTheme,
+  type IDockviewHeaderActionsProps,
+  type IDockviewPanelHeaderProps,
+  type IDockviewPanelProps,
+} from "dockview";
+import { Globe, Plus, X } from "lucide-react";
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import { useAdapter } from "@band-app/dashboard-core";
+import { isTauri } from "../lib/is-tauri";
+import { trpc } from "../lib/trpc-client";
+import { BrowserPaneComponent, type BrowserPaneParams, useFavicon } from "./BrowserPanel";
+
+// ---------------------------------------------------------------------------
+// Track browser IDs that were just created by an "add tab" action.
+// BrowserPane checks this to skip server fetch and start fresh.
+// ---------------------------------------------------------------------------
+
+const freshBrowserIds = new Set<string>();
+
+/** Mark a browserId as freshly created (by add-tab). */
+export function markBrowserFresh(browserId: string): void {
+  freshBrowserIds.add(browserId);
+}
+
+/** Check (and consume) whether a browserId is fresh. */
+export function consumeBrowserFresh(browserId: string): boolean {
+  return freshBrowserIds.delete(browserId);
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** crypto.randomUUID() fallback for insecure contexts. */
+function uuid(): string {
+  if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
+    return crypto.randomUUID();
+  }
+  const bytes = crypto.getRandomValues(new Uint8Array(16));
+  bytes[6] = (bytes[6] & 0x0f) | 0x40;
+  bytes[8] = (bytes[8] & 0x3f) | 0x80;
+  const hex = Array.from(bytes, (b) => b.toString(16).padStart(2, "0")).join("");
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
+}
+
+export function newBrowserId(): string {
+  return `browser_${uuid()}`;
+}
+
+// ---------------------------------------------------------------------------
+// Debounced server persistence (500ms)
+// ---------------------------------------------------------------------------
+
+const saveTimers = new Map<string, ReturnType<typeof setTimeout>>();
+
+function persistToServer(workspaceId: string, layout: unknown): void {
+  const existing = saveTimers.get(workspaceId);
+  if (existing) clearTimeout(existing);
+  saveTimers.set(
+    workspaceId,
+    setTimeout(() => {
+      saveTimers.delete(workspaceId);
+      trpc.browserLayout.save.mutate({ workspaceId, tree: layout }).catch((err) => {
+        console.error("[DockviewBrowserContainer] failed to persist layout:", err);
+      });
+    }, 500),
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Legacy layout detection
+// ---------------------------------------------------------------------------
+
+function isDockviewLayout(obj: unknown): boolean {
+  if (typeof obj !== "object" || obj === null) return false;
+  const o = obj as Record<string, unknown>;
+  return typeof o.grid === "object" && typeof o.panels === "object";
+}
+
+// ---------------------------------------------------------------------------
+// Dockview theme (reuse the band theme from the outer instance)
+// ---------------------------------------------------------------------------
+
+const browserTabTheme: DockviewTheme = {
+  name: "band",
+  className: "dockview-theme-band dockview-browser-tabs",
+};
+
+// ---------------------------------------------------------------------------
+// Browser tab panel component (renders inside each dockview tab)
+// ---------------------------------------------------------------------------
+
+// Visibility context — propagated from DockviewBrowserContainer via React
+// context instead of dockview's updateParameters (which clobbers params).
+const BrowserVisibilityContext = createContext({ visible: true, wsActive: true });
+
+interface BrowserTabParams {
+  workspaceId: string;
+  browserId: string;
+  initialUrl?: string;
+}
+
+function BrowserTabPanel({ params, api }: IDockviewPanelProps<BrowserTabParams>) {
+  const { visible } = useContext(BrowserVisibilityContext);
+
+  if (!params.workspaceId || !params.browserId) return null;
+
+  // Build params for BrowserPaneComponent (it uses IDockviewPanelProps shape)
+  // Pass `visible` (which combines outer panel visibility AND workspace activity)
+  // as `wsActive` — BrowserPaneComponent uses this to hide/show the native webview
+  // for reasons external to the inner browser dockview (e.g. switching to Changes tab).
+  const paneParams: BrowserPaneParams = {
+    workspaceId: params.workspaceId,
+    browserId: params.browserId,
+    wsActive: visible,
+    initialUrl: params.initialUrl,
+  };
+
+  return (
+    <div className="flex h-full w-full flex-col overflow-hidden">
+      <BrowserPaneComponent
+        params={paneParams}
+        api={api}
+        // biome-ignore lint/suspicious/noExplicitAny: dockview panel props require matching shape
+        {...({} as any)}
+      />
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Custom tab header: globe icon + title + close button
+// ---------------------------------------------------------------------------
+
+function BrowserTab(props: IDockviewPanelHeaderProps<BrowserTabParams>) {
+  const [title, setTitle] = useState(props.api.title ?? "New Tab");
+  const [panelCount, setPanelCount] = useState(props.containerApi.panels.length);
+  const [faviconError, setFaviconError] = useState(false);
+
+  const browserId = props.params.browserId;
+  const faviconUrl = useFavicon(browserId);
+  const prevFaviconRef = useRef(faviconUrl);
+
+  // Reset error state when the favicon URL changes
+  if (faviconUrl !== prevFaviconRef.current) {
+    prevFaviconRef.current = faviconUrl;
+    if (faviconError) setFaviconError(false);
+  }
+
+  useEffect(() => {
+    const d = props.api.onDidTitleChange(() => setTitle(props.api.title ?? "New Tab"));
+    return () => d.dispose();
+  }, [props.api]);
+
+  // Track panel count reactively for close button visibility
+  useEffect(() => {
+    const cApi = props.containerApi;
+    const update = () => setPanelCount(cApi.panels.length);
+    const d1 = cApi.onDidAddPanel(update);
+    const d2 = cApi.onDidRemovePanel(update);
+    return () => {
+      d1.dispose();
+      d2.dispose();
+    };
+  }, [props.containerApi]);
+
+  const handleClose = useCallback(
+    (e: React.MouseEvent) => {
+      e.stopPropagation();
+      closeTabRef.current?.(browserId);
+    },
+    [browserId],
+  );
+
+  const showClose = panelCount > 1;
+
+  const showFavicon = faviconUrl && !faviconError;
+
+  return (
+    <div className="dv-default-tab">
+      <div className="flex items-center gap-1.5 min-w-0">
+        {showFavicon ? (
+          <img
+            src={faviconUrl}
+            alt=""
+            className="size-3.5 shrink-0"
+            onError={() => setFaviconError(true)}
+          />
+        ) : (
+          <Globe className="size-3.5 shrink-0 text-muted-foreground" />
+        )}
+        <span className="truncate">{title}</span>
+      </div>
+      {showClose && (
+        <button
+          type="button"
+          className="ml-1 inline-flex size-4 items-center justify-center rounded-sm opacity-60 hover:opacity-100 hover:bg-accent transition-colors"
+          onClick={handleClose}
+          title="Close tab"
+        >
+          <X className="size-3" />
+        </button>
+      )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Shared refs for stable Dockview components
+// ---------------------------------------------------------------------------
+
+const addTabRef: {
+  current: { onAdd: (groupId?: string) => void };
+} = {
+  current: { onAdd: () => {} },
+};
+
+/** Shared ref for the close-tab action — used by BrowserTab's close button. */
+const closeTabRef: { current: ((browserId: string) => void) | null } = {
+  current: null,
+};
+
+/**
+ * Stable component for DockviewReact's rightHeaderActionsComponent.
+ * Reads callback from the module-level ref to avoid the
+ * "only React.memo/forwardRef/function components accepted" error.
+ */
+const RightHeaderActions = React.memo(function RightHeaderActions(
+  props: IDockviewHeaderActionsProps,
+) {
+  const groupId = props.group.id;
+  return (
+    <div className="flex items-center">
+      <button
+        type="button"
+        className="inline-flex size-8 items-center justify-center text-muted-foreground hover:text-foreground hover:bg-accent rounded transition-colors"
+        onClick={() => addTabRef.current.onAdd(groupId)}
+        title="New browser tab"
+      >
+        <Plus className="size-4" />
+      </button>
+    </div>
+  );
+});
+
+// ---------------------------------------------------------------------------
+// Dockview panel/tab component registries
+// ---------------------------------------------------------------------------
+
+const browserPanelComponents: Record<
+  string,
+  React.FunctionComponent<IDockviewPanelProps<BrowserTabParams>>
+> = {
+  browserTab: BrowserTabPanel,
+};
+
+const browserTabComponents: Record<
+  string,
+  React.FunctionComponent<IDockviewPanelHeaderProps<BrowserTabParams>>
+> = {
+  browserTab: BrowserTab,
+};
+
+// ---------------------------------------------------------------------------
+// Main container
+// ---------------------------------------------------------------------------
+
+interface DockviewBrowserContainerProps {
+  workspaceId: string;
+  visible: boolean;
+  wsActive?: boolean;
+}
+
+export function DockviewBrowserContainer({
+  workspaceId,
+  visible,
+  wsActive,
+}: DockviewBrowserContainerProps) {
+  const adapter = useAdapter();
+  const apiRef = useRef<DockviewApi | null>(null);
+  const isRestoringRef = useRef(false);
+
+  // Pre-fetch layout AND browser records from server before mounting dockview.
+  // We need both so we can prune layout panels whose browser records were deleted.
+  const [initialData, setInitialData] = useState<{
+    loaded: boolean;
+    layout: unknown | null;
+    browserIds: Set<string> | null;
+  }>({ loaded: false, layout: null, browserIds: null });
+
+  useEffect(() => {
+    Promise.all([
+      trpc.browserLayout.get.query({ workspaceId }).catch(() => ({ tree: null })),
+      trpc.browsers.list.query({ workspaceId }).catch(() => ({ browsers: [] })),
+    ]).then(([{ tree }, { browsers }]) => {
+      setInitialData({
+        loaded: true,
+        layout: tree,
+        browserIds: new Set(browsers.map((b: { id: string }) => b.id)),
+      });
+    });
+  }, [workspaceId]);
+
+  // Debounced persist: serialize the full dockview layout
+  const schedulePersist = useCallback(() => {
+    if (isRestoringRef.current) return;
+    const api = apiRef.current;
+    if (!api) return;
+    persistToServer(workspaceId, api.toJSON());
+  }, [workspaceId]);
+
+  const handleAddTab = useCallback(
+    async (groupId?: string) => {
+      const api = apiRef.current;
+      if (!api) return;
+
+      const browserId = newBrowserId();
+      markBrowserFresh(browserId);
+
+      // Create the server-side browser record BEFORE adding the panel
+      try {
+        await trpc.browsers.create.mutate({ workspaceId, id: browserId });
+      } catch (err) {
+        console.error("[DockviewBrowserContainer] error pre-creating browser:", err);
+      }
+
+      // Build panel options, targeting the specific group if provided
+      const options: Parameters<typeof api.addPanel>[0] = {
+        id: browserId,
+        component: "browserTab",
+        tabComponent: "browserTab",
+        title: "New Tab",
+        params: {
+          workspaceId,
+          browserId,
+        },
+      };
+
+      if (groupId) {
+        (options as Record<string, unknown>).position = {
+          referenceGroup: groupId,
+        };
+      }
+
+      api.addPanel(options);
+      // Layout change listeners will auto-persist
+    },
+    [workspaceId],
+  );
+
+  const closeTab = useCallback((browserId: string) => {
+    const api = apiRef.current;
+    if (!api || api.panels.length <= 1) return; // don't close last tab
+
+    const panel = api.getPanel(browserId);
+    if (panel) {
+      api.removePanel(panel);
+    }
+
+    // Delete the server-side browser record so closed tabs don't linger.
+    trpc.browsers.remove.mutate({ browserId }).catch((err) => {
+      console.error("[DockviewBrowserContainer] failed to remove browser:", err);
+    });
+    // Layout change listeners will auto-persist
+  }, []);
+
+  // Cmd/Ctrl+W → close the active browser tab
+  useEffect(() => {
+    if (!visible) return;
+    const handler = (e: KeyboardEvent) => {
+      const mod = e.metaKey || e.ctrlKey;
+      if (mod && e.key.toLowerCase() === "w" && !e.shiftKey) {
+        const api = apiRef.current;
+        if (!api || api.panels.length <= 1) return;
+        e.preventDefault();
+        e.stopPropagation();
+        const active = api.activePanel;
+        if (active) {
+          closeTab(active.id);
+        }
+      }
+    };
+    window.addEventListener("keydown", handler, true);
+    return () => window.removeEventListener("keydown", handler, true);
+  }, [visible, closeTab]);
+
+  // Cmd/Ctrl+R → reload the active browser tab
+  useEffect(() => {
+    if (!visible || !isTauri) return;
+    const handler = async (e: KeyboardEvent) => {
+      const mod = e.metaKey || e.ctrlKey;
+      if (mod && e.key.toLowerCase() === "r" && !e.shiftKey) {
+        const api = apiRef.current;
+        if (!api) return;
+        const active = api.activePanel;
+        const browserId = (active?.params as BrowserTabParams | undefined)?.browserId;
+        if (!browserId) return;
+        e.preventDefault();
+        e.stopPropagation();
+        try {
+          const { invoke } = await import("@tauri-apps/api/core");
+          await invoke("browser_reload", { browserId });
+        } catch (err) {
+          console.error("[DockviewBrowserContainer] browser_reload failed:", err);
+        }
+      }
+    };
+    window.addEventListener("keydown", handler, true);
+    return () => window.removeEventListener("keydown", handler, true);
+  }, [visible]);
+
+  // Sync dockview panels when browsers are created/removed externally (e.g. CLI).
+  useEffect(() => {
+    return adapter.subscribeStatusEvents((event) => {
+      if (event.workspaceId !== workspaceId) return;
+      const api = apiRef.current;
+      if (!api) return;
+
+      if (event.kind === "browser-created" && typeof event.browserId === "string") {
+        // Skip if this panel already exists (we created it ourselves)
+        if (api.getPanel(event.browserId)) return;
+        api.addPanel({
+          id: event.browserId,
+          component: "browserTab",
+          tabComponent: "browserTab",
+          title: "New Tab",
+          params: { workspaceId, browserId: event.browserId },
+        });
+      } else if (event.kind === "browser-removed" && typeof event.browserId === "string") {
+        const panel = api.getPanel(event.browserId);
+        if (panel) {
+          api.removePanel(panel);
+          // If that was the last panel, create a fresh default tab
+          if (api.panels.length === 0) {
+            createDefaultPanel(api, workspaceId);
+          }
+        }
+      }
+    });
+  }, [adapter, workspaceId]);
+
+  // Visibility is now propagated via BrowserVisibilityContext (React context)
+  // instead of updateParameters — see the Provider wrapping DockviewReact.
+
+  // Keep module-level refs in sync for stable Dockview components
+  addTabRef.current = { onAdd: handleAddTab };
+  closeTabRef.current = closeTab;
+
+  // Use refs for the initial data so onReady's closure captures the latest
+  const initialLayoutRef = useRef<unknown | null>(null);
+  initialLayoutRef.current = initialData.layout;
+  const initialBrowserIdsRef = useRef<Set<string> | null>(null);
+  initialBrowserIdsRef.current = initialData.browserIds;
+
+  const onReady = useCallback(
+    (event: DockviewReadyEvent) => {
+      apiRef.current = event.api;
+      const savedLayout = initialLayoutRef.current;
+      const knownBrowserIds = initialBrowserIdsRef.current;
+
+      if (savedLayout && isDockviewLayout(savedLayout)) {
+        // Restore full dockview layout (preserves groups, splits, sizes)
+        isRestoringRef.current = true;
+        try {
+          // biome-ignore lint/suspicious/noExplicitAny: dockview fromJSON API requires any
+          event.api.fromJSON(savedLayout as any);
+        } catch (err) {
+          console.error("[DockviewBrowserContainer] fromJSON failed, creating default:", err);
+          createDefaultPanel(event.api, workspaceId);
+        }
+
+        // Prune panels whose browser records no longer exist on the server.
+        if (knownBrowserIds) {
+          const orphans = event.api.panels.filter(
+            (p) => !knownBrowserIds.has(p.id),
+          );
+          for (const orphan of orphans) {
+            event.api.removePanel(orphan);
+          }
+          // If all panels were orphaned, create a fresh default tab.
+          if (event.api.panels.length === 0) {
+            createDefaultPanel(event.api, workspaceId);
+          }
+        }
+
+        // Allow persistence after restoration settles
+        setTimeout(() => {
+          isRestoringRef.current = false;
+        }, 0);
+      } else {
+        // No saved layout — create a default tab
+        createDefaultPanel(event.api, workspaceId);
+        persistToServer(workspaceId, event.api.toJSON());
+      }
+
+      // Listen for any layout changes and auto-persist
+      const persist = () => schedulePersist();
+      event.api.onDidLayoutChange(persist);
+      event.api.onDidAddPanel(persist);
+      event.api.onDidRemovePanel(persist);
+      event.api.onDidActivePanelChange(persist);
+      event.api.onDidAddGroup(persist);
+      event.api.onDidRemoveGroup(persist);
+    },
+    [workspaceId, schedulePersist],
+  );
+
+  const visibilityValue = useMemo(
+    () => ({ visible: visible && wsActive !== false, wsActive: wsActive !== false }),
+    [visible, wsActive],
+  );
+
+  // Don't render dockview until the initial layout is fetched from the server
+  if (!initialData.loaded) {
+    return <div className="flex h-full w-full items-center justify-center" />;
+  }
+
+  return (
+    <div className="flex h-full w-full flex-col overflow-hidden">
+      <BrowserVisibilityContext.Provider value={visibilityValue}>
+        <DockviewReact
+          theme={browserTabTheme}
+          className="h-full"
+          components={browserPanelComponents}
+          tabComponents={browserTabComponents}
+          defaultTabComponent={BrowserTab}
+          onReady={onReady}
+          rightHeaderActionsComponent={RightHeaderActions}
+        />
+      </BrowserVisibilityContext.Provider>
+    </div>
+  );
+}
+
+function createDefaultPanel(api: DockviewApi, workspaceId: string): void {
+  const browserId = newBrowserId();
+  // Create server-side record for the default tab
+  trpc.browsers.create.mutate({ workspaceId, id: browserId }).catch((err) => {
+    console.error("[DockviewBrowserContainer] error creating default browser:", err);
+  });
+  api.addPanel({
+    id: browserId,
+    component: "browserTab",
+    tabComponent: "browserTab",
+    title: "Browser",
+    params: {
+      workspaceId,
+      browserId,
+    },
+  });
+}

--- a/apps/web/src/components/DockviewChatContainer.tsx
+++ b/apps/web/src/components/DockviewChatContainer.tsx
@@ -15,7 +15,15 @@ import {
   type IDockviewPanelProps,
 } from "dockview";
 import { Clock, Plus, X } from "lucide-react";
-import React, { useCallback, useEffect, useRef, useState } from "react";
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import { trpc } from "../lib/trpc-client";
 import { ChatPane, type CodingAgentDef, useChatPaneState } from "./ChatPane";
 
@@ -100,30 +108,30 @@ const chatTabTheme: DockviewTheme = {
 // Chat tab panel component (renders inside each dockview tab)
 // ---------------------------------------------------------------------------
 
+// Visibility context — propagated from DockviewChatContainer via React
+// context instead of dockview's updateParameters (which clobbers params).
+const ChatVisibilityContext = createContext({ visible: true, wsActive: true });
+
 interface ChatTabParams {
   workspaceId: string;
   chatId: string;
-  visible: boolean;
-  wsActive: boolean;
 }
 
 function ChatTabPanel({ params, api }: IDockviewPanelProps<ChatTabParams>) {
-  // Track visibility: combine parent visibility param with dockview's own active state.
-  // Read params directly from props — dockview-react's bridge re-renders with merged
-  // params on every updateParameters call. Calling api.getParameters() returns only
-  // the last update payload (not merged), which would drop workspaceId/chatId after
-  // a partial { visible, wsActive } update and blank the panel.
+  // Track visibility: combine parent visibility context with dockview's own active state
   const [tabActive, setTabActive] = useState(api.isActive);
+  const { visible: parentVisible, wsActive } = useContext(ChatVisibilityContext);
 
   useEffect(() => {
     const d = api.onDidActiveChange((e) => setTabActive(e.isActive));
-    return () => d.dispose();
+    return () => {
+      d.dispose();
+    };
   }, [api]);
 
   if (!params.workspaceId || !params.chatId) return null;
 
-  const visible = params.visible && tabActive;
-  const wsActive = params.wsActive;
+  const visible = parentVisible && tabActive;
 
   return (
     <ChatTabContent
@@ -137,7 +145,7 @@ function ChatTabPanel({ params, api }: IDockviewPanelProps<ChatTabParams>) {
   );
 }
 
-/** Separate component so hooks work properly (params change via updateParameters). */
+/** Separate component so hooks work properly. */
 function ChatTabContent({
   workspaceId,
   chatId,
@@ -389,10 +397,6 @@ export function DockviewChatContainer({
 }: DockviewChatContainerProps) {
   const apiRef = useRef<DockviewApi | null>(null);
   const isRestoringRef = useRef(false);
-  const visibleRef = useRef(visible);
-  const wsActiveRef = useRef(wsActive);
-  visibleRef.current = visible;
-  wsActiveRef.current = wsActive;
 
   // Pre-fetch layout from server before mounting dockview
   const [initialData, setInitialData] = useState<{
@@ -486,8 +490,6 @@ export function DockviewChatContainer({
         params: {
           workspaceId,
           chatId,
-          visible: visibleRef.current && wsActiveRef.current !== false,
-          wsActive: wsActiveRef.current !== false,
         },
       };
 
@@ -539,17 +541,8 @@ export function DockviewChatContainer({
     return () => window.removeEventListener("keydown", handler, true);
   }, [visible, closeTab]);
 
-  // Update visibility params when parent visibility changes
-  useEffect(() => {
-    const api = apiRef.current;
-    if (!api) return;
-    for (const panel of api.panels) {
-      panel.api.updateParameters({
-        visible: visible && wsActive !== false,
-        wsActive: wsActive !== false,
-      });
-    }
-  }, [visible, wsActive]);
+  // Visibility is now propagated via ChatVisibilityContext (React context)
+  // instead of updateParameters — see the Provider wrapping DockviewReact.
 
   // Keep module-level refs in sync for stable Dockview components
   addTabRef.current = { agents, onAdd: handleAddTab };
@@ -575,13 +568,7 @@ export function DockviewChatContainer({
           createDefaultPanel(event.api, workspaceId);
         }
 
-        // Update visibility params to current values (may be stale in saved data)
-        for (const panel of event.api.panels) {
-          panel.api.updateParameters({
-            visible: visibleRef.current && wsActiveRef.current !== false,
-            wsActive: wsActiveRef.current !== false,
-          });
-        }
+        // Visibility is propagated via ChatVisibilityContext — no param update needed.
 
         // Allow persistence after restoration settles
         setTimeout(() => {
@@ -589,19 +576,7 @@ export function DockviewChatContainer({
         }, 0);
       } else {
         // No saved layout — create a default tab
-        const chatId = newChatId();
-        event.api.addPanel({
-          id: chatId,
-          component: "chatTab",
-          tabComponent: "chatTab",
-          title: "Chat",
-          params: {
-            workspaceId,
-            chatId,
-            visible: visibleRef.current && wsActiveRef.current !== false,
-            wsActive: wsActiveRef.current !== false,
-          },
-        });
+        createDefaultPanel(event.api, workspaceId);
 
         persistToServer(workspaceId, event.api.toJSON());
       }
@@ -618,6 +593,11 @@ export function DockviewChatContainer({
     [workspaceId, schedulePersist],
   );
 
+  const visibilityValue = useMemo(
+    () => ({ visible: visible && wsActive !== false, wsActive: wsActive !== false }),
+    [visible, wsActive],
+  );
+
   // Don't render dockview until the initial layout is fetched from the server
   if (!initialData.loaded) {
     return <div className="flex h-full w-full items-center justify-center" />;
@@ -625,15 +605,17 @@ export function DockviewChatContainer({
 
   return (
     <div className="flex h-full w-full flex-col overflow-hidden">
-      <DockviewReact
-        theme={chatTabTheme}
-        className="h-full"
-        components={chatPanelComponents}
-        tabComponents={chatTabComponents}
-        defaultTabComponent={ChatTab}
-        onReady={onReady}
-        rightHeaderActionsComponent={RightHeaderActions}
-      />
+      <ChatVisibilityContext.Provider value={visibilityValue}>
+        <DockviewReact
+          theme={chatTabTheme}
+          className="h-full"
+          components={chatPanelComponents}
+          tabComponents={chatTabComponents}
+          defaultTabComponent={ChatTab}
+          onReady={onReady}
+          rightHeaderActionsComponent={RightHeaderActions}
+        />
+      </ChatVisibilityContext.Provider>
     </div>
   );
 }
@@ -648,8 +630,6 @@ function createDefaultPanel(api: DockviewApi, workspaceId: string): void {
     params: {
       workspaceId,
       chatId,
-      visible: true,
-      wsActive: true,
     },
   });
 }

--- a/apps/web/src/components/DockviewChatContainer.tsx
+++ b/apps/web/src/components/DockviewChatContainer.tsx
@@ -5,6 +5,7 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@band-app/ui";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import {
   type DockviewApi,
   DockviewReact,
@@ -65,12 +66,34 @@ export function newChatId(): string {
 }
 
 // ---------------------------------------------------------------------------
-// Debounced server persistence (500ms)
+// React Query cache key
+// ---------------------------------------------------------------------------
+
+function chatLayoutKey(workspaceId: string) {
+  return ["chatLayout", workspaceId] as const;
+}
+
+// ---------------------------------------------------------------------------
+// Debounced server persistence (500ms) — also updates React Query cache
+// so the next mount renders instantly from cached data.
 // ---------------------------------------------------------------------------
 
 const saveTimers = new Map<string, ReturnType<typeof setTimeout>>();
 
-function persistToServer(workspaceId: string, layout: unknown): void {
+interface ChatPersistOptions {
+  queryClient?: ReturnType<typeof useQueryClient>;
+}
+
+interface ChatLayoutData {
+  layout: unknown | null;
+}
+
+function persistToServer(workspaceId: string, layout: unknown, opts?: ChatPersistOptions): void {
+  // Update React Query cache immediately so next mount is instant
+  if (opts?.queryClient) {
+    opts.queryClient.setQueryData(chatLayoutKey(workspaceId), { layout });
+  }
+
   const existing = saveTimers.get(workspaceId);
   if (existing) clearTimeout(existing);
   saveTimers.set(
@@ -395,25 +418,22 @@ export function DockviewChatContainer({
   visible,
   wsActive,
 }: DockviewChatContainerProps) {
+  const queryClient = useQueryClient();
   const apiRef = useRef<DockviewApi | null>(null);
   const isRestoringRef = useRef(false);
 
-  // Pre-fetch layout from server before mounting dockview
-  const [initialData, setInitialData] = useState<{
-    loaded: boolean;
-    layout: unknown | null;
-  }>({ loaded: false, layout: null });
-
-  useEffect(() => {
-    trpc.chatLayout.get
-      .query({ workspaceId })
-      .then(({ tree }) => {
-        setInitialData({ loaded: true, layout: tree });
-      })
-      .catch(() => {
-        setInitialData({ loaded: true, layout: null });
-      });
-  }, [workspaceId]);
+  // Fetch layout via React Query — cached across mounts so re-visiting
+  // a workspace renders instantly from the cache.
+  const { data: initialData } = useQuery<ChatLayoutData>({
+    queryKey: chatLayoutKey(workspaceId),
+    queryFn: async () => {
+      const { tree } = await trpc.chatLayout.get
+        .query({ workspaceId })
+        .catch(() => ({ tree: null }));
+      return { layout: tree };
+    },
+    staleTime: Number.POSITIVE_INFINITY, // never auto-refetch — we manage persistence ourselves
+  });
 
   // Load agents for the "add tab" dropdown
   const [agents, setAgents] = useState<CodingAgentDef[]>([]);
@@ -429,12 +449,14 @@ export function DockviewChatContainer({
       .catch(() => {});
   }, []);
 
-  // Debounced persist: serialize the full dockview layout
+  // Debounced persist: serialize the full dockview layout + update cache
+  const queryClientRef = useRef(queryClient);
+  queryClientRef.current = queryClient;
   const schedulePersist = useCallback(() => {
     if (isRestoringRef.current) return;
     const api = apiRef.current;
     if (!api) return;
-    persistToServer(workspaceId, api.toJSON());
+    persistToServer(workspaceId, api.toJSON(), { queryClient: queryClientRef.current });
   }, [workspaceId]);
 
   const handleAddTab = useCallback(
@@ -550,7 +572,7 @@ export function DockviewChatContainer({
 
   // Use a ref for the initial layout so onReady's closure captures the latest
   const initialLayoutRef = useRef<unknown | null>(null);
-  initialLayoutRef.current = initialData.layout;
+  initialLayoutRef.current = initialData?.layout ?? null;
 
   const onReady = useCallback(
     (event: DockviewReadyEvent) => {
@@ -578,7 +600,7 @@ export function DockviewChatContainer({
         // No saved layout — create a default tab
         createDefaultPanel(event.api, workspaceId);
 
-        persistToServer(workspaceId, event.api.toJSON());
+        persistToServer(workspaceId, event.api.toJSON(), { queryClient: queryClientRef.current });
       }
 
       // Listen for any layout changes and auto-persist
@@ -598,8 +620,9 @@ export function DockviewChatContainer({
     [visible, wsActive],
   );
 
-  // Don't render dockview until the initial layout is fetched from the server
-  if (!initialData.loaded) {
+  // Don't render dockview until the initial layout is fetched from the server.
+  // On subsequent visits, React Query returns cached data instantly — no loading.
+  if (!initialData) {
     return <div className="flex h-full w-full items-center justify-center" />;
   }
 

--- a/apps/web/src/components/DockviewInstanceManager.tsx
+++ b/apps/web/src/components/DockviewInstanceManager.tsx
@@ -1,6 +1,7 @@
 import { useRouterState } from "@tanstack/react-router";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { parseWorkspaceFromPath } from "../lib/parse-workspace";
+import { setWsActive } from "../lib/workspace-visibility-store";
 import { DockviewWorkspaceLayout } from "./DockviewWorkspaceLayout";
 
 // ---------------------------------------------------------------------------
@@ -12,7 +13,7 @@ interface CachedWorkspace {
   lastAccessed: number;
 }
 
-const MAX_CACHED_WORKSPACES = 5;
+const MAX_CACHED_WORKSPACES = 1;
 
 /**
  * Manages multiple DockviewWorkspaceLayout instances with show/hide semantics.
@@ -112,6 +113,13 @@ export function DockviewInstanceManager() {
 
   if (cache.size === 0 || activeWorkspaceId === null) return null;
 
+  // Sync workspace visibility to the external store so leaf components
+  // can subscribe via useWsActive() without Context cascade re-renders.
+  // setWsActive is idempotent — safe to call during render.
+  for (const { workspaceId } of cache.values()) {
+    setWsActive(workspaceId, workspaceId === activeWorkspaceId);
+  }
+
   return (
     <div className="absolute inset-0">
       {Array.from(cache.values()).map(({ workspaceId }) => (
@@ -122,11 +130,7 @@ export function DockviewInstanceManager() {
             workspaceId === activeWorkspaceId ? undefined : { opacity: 0, pointerEvents: "none" }
           }
         >
-          <DockviewWorkspaceLayout
-            workspaceId={workspaceId}
-            isActive={workspaceId === activeWorkspaceId}
-            onLayoutChange={handleLayoutChange}
-          />
+          <DockviewWorkspaceLayout workspaceId={workspaceId} onLayoutChange={handleLayoutChange} />
         </div>
       ))}
     </div>

--- a/apps/web/src/components/DockviewWorkspaceLayout.tsx
+++ b/apps/web/src/components/DockviewWorkspaceLayout.tsx
@@ -22,10 +22,11 @@ import {
   MessageSquare,
   Terminal as TerminalIcon,
 } from "lucide-react";
-import { lazy, memo, Suspense, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { createContext, lazy, memo, Suspense, useCallback, useContext, useEffect, useMemo, useRef, useState } from "react";
 import { isTauri } from "../lib/is-tauri";
 import { trpc } from "../lib/trpc-client";
 import { CodeBrowserView } from "./CodeBrowserView";
+import { DockviewBrowserContainer } from "./DockviewBrowserContainer";
 import { DockviewChatContainer } from "./DockviewChatContainer";
 
 // ---------------------------------------------------------------------------
@@ -46,14 +47,14 @@ const PANEL_ICONS: Record<string, React.FC<{ className?: string }>> = {
   changes: GitCompare,
   files: FolderOpen,
   terminal: TerminalIcon,
-  ...(isTauri ? { browser: Globe } : {}),
+  browser: Globe,
 };
 
 const PANEL_SHORTCUTS: Record<string, string> = {
   changes: "⌘E",
   files: "⌘G",
   terminal: "⌘J",
-  ...(isTauri ? { browser: "⌘B" } : {}),
+  browser: "⌘B",
 };
 
 // ---------------------------------------------------------------------------
@@ -64,10 +65,15 @@ const SplitTerminalContainer = lazy(() =>
   import("./SplitTerminalContainer").then((m) => ({ default: m.SplitTerminalContainer })),
 );
 
-// Lazy-load browser panel so the Tauri webview code is never bundled for web
-const LazyBrowserPanel = isTauri
-  ? lazy(() => import("./BrowserPanel").then((m) => ({ default: m.BrowserPanelComponent })))
-  : null;
+// Browser panel params (browser container handles its own lazy loading internally)
+
+
+// ---------------------------------------------------------------------------
+// Workspace-active context — propagated via React context instead of
+// dockview's updateParameters (which clobbers the full param object).
+// ---------------------------------------------------------------------------
+
+const WsActiveContext = createContext(true);
 
 // ---------------------------------------------------------------------------
 // Panel params types
@@ -75,7 +81,6 @@ const LazyBrowserPanel = isTauri
 
 interface ChatParams {
   workspaceId: string;
-  wsActive?: boolean;
 }
 
 interface ChangesParams {
@@ -98,7 +103,6 @@ interface FilesParams {
 
 interface TerminalParams {
   workspaceId: string;
-  wsActive?: boolean;
 }
 
 // ---------------------------------------------------------------------------
@@ -111,17 +115,14 @@ function ChatPanelComponent({ params, api }: IDockviewPanelProps<ChatParams>) {
   // (Changes, Files, Terminal) is focused.  `isVisible` is only false when
   // the panel is behind another tab in a tabbed group.
   const [isVisible, setIsVisible] = useState(api.isVisible);
+  const wsActive = useContext(WsActiveContext);
 
   useEffect(() => {
     const d = api.onDidVisibilityChange((e) => setIsVisible(e.isVisible));
     return () => d.dispose();
   }, [api]);
 
-  const visible = params.wsActive !== false && isVisible;
-  // Workspace is active (but the chat tab may not be the focused tab).
-  // Used by PromptInput to accept "Add to Chat" events from sibling panels
-  // (e.g. Changes, Files) even when the Chat tab isn't in front.
-  const wsActive = params.wsActive !== false;
+  const visible = wsActive && isVisible;
 
   // Don't render until workspaceId is injected — during layout sync fromJSON
   // recreates panels with empty params before injectParams runs a tick later.
@@ -165,13 +166,14 @@ function FilesPanelComponent({ params }: IDockviewPanelProps<FilesParams>) {
 function TerminalPanelComponent({ params, api }: IDockviewPanelProps<TerminalParams>) {
   // Track physical visibility — same approach as ChatPanelComponent.
   const [isVisible, setIsVisible] = useState(api.isVisible);
+  const wsActive = useContext(WsActiveContext);
 
   useEffect(() => {
     const d = api.onDidVisibilityChange((e) => setIsVisible(e.isVisible));
     return () => d.dispose();
   }, [api]);
 
-  const visible = params.wsActive !== false && isVisible;
+  const visible = wsActive && isVisible;
 
   if (!params.workspaceId) return null;
 
@@ -268,20 +270,40 @@ function BadgeTab(props: IDockviewPanelHeaderProps) {
 }
 
 // ---------------------------------------------------------------------------
-// Component and tab registries
+// Browser panel wrapper — renders DockviewBrowserContainer (multi-tab)
+// Same pattern as ChatPanelComponent → DockviewChatContainer.
 // ---------------------------------------------------------------------------
 
-// Wrap the lazy-loaded browser panel in Suspense so it can be registered
-// as a regular dockview component.
-// biome-ignore lint/suspicious/noExplicitAny: dockview requires generic panel props
-function BrowserPanelWrapper(props: IDockviewPanelProps<any>) {
-  if (!LazyBrowserPanel) return null;
+interface BrowserParams {
+  workspaceId: string;
+}
+
+function BrowserPanelComponent({ params, api }: IDockviewPanelProps<BrowserParams>) {
+  // Track physical visibility — same approach as ChatPanelComponent.
+  const [isVisible, setIsVisible] = useState(api.isVisible);
+  const wsActive = useContext(WsActiveContext);
+
+  useEffect(() => {
+    const d = api.onDidVisibilityChange((e) => setIsVisible(e.isVisible));
+    return () => d.dispose();
+  }, [api]);
+
+  const visible = wsActive && isVisible;
+
+  if (!params.workspaceId) return null;
+
   return (
-    <Suspense fallback={null}>
-      <LazyBrowserPanel {...props} />
-    </Suspense>
+    <DockviewBrowserContainer
+      workspaceId={params.workspaceId}
+      visible={visible}
+      wsActive={wsActive}
+    />
   );
 }
+
+// ---------------------------------------------------------------------------
+// Component and tab registries
+// ---------------------------------------------------------------------------
 
 // biome-ignore lint/suspicious/noExplicitAny: dockview requires generic panel props
 const components: Record<string, React.FunctionComponent<IDockviewPanelProps<any>>> = {
@@ -289,7 +311,7 @@ const components: Record<string, React.FunctionComponent<IDockviewPanelProps<any
   changes: ChangesPanelComponent,
   files: FilesPanelComponent,
   terminal: TerminalPanelComponent,
-  ...(isTauri ? { browser: BrowserPanelWrapper } : {}),
+  browser: BrowserPanelComponent,
 };
 
 const tabComponents: Record<string, React.FunctionComponent<IDockviewPanelHeaderProps>> = {
@@ -327,11 +349,14 @@ function useDiffFileCount(workspaceId: string, isActive: boolean): number {
 // Required panel definitions & layout persistence
 // ---------------------------------------------------------------------------
 
-/** All panels that must always be present in the layout.
- *  The browser panel is only available in the Tauri desktop app. */
-const REQUIRED_PANEL_IDS = isTauri
-  ? (["chat", "changes", "files", "terminal", "browser"] as const)
-  : (["chat", "changes", "files", "terminal"] as const);
+/** All panels that must always be present in the layout. */
+const REQUIRED_PANEL_IDS = [
+  "chat",
+  "changes",
+  "files",
+  "terminal",
+  "browser",
+] as const;
 
 // ---------------------------------------------------------------------------
 // Layout persistence: shared structure + per-workspace active tabs
@@ -661,7 +686,7 @@ export const DockviewWorkspaceLayout = memo(function DockviewWorkspaceLayout({
       } else if (key === "g" && !e.shiftKey && api) {
         e.preventDefault();
         if (!hiddenPanelsRef.current.includes("files")) api.getPanel("files")?.api.setActive();
-      } else if (key === "b" && !e.shiftKey && api && isTauri) {
+      } else if (key === "b" && !e.shiftKey && api) {
         e.preventDefault();
         if (!hiddenPanelsRef.current.includes("browser")) api.getPanel("browser")?.api.setActive();
       } else if (key === "-") {
@@ -870,7 +895,7 @@ export const DockviewWorkspaceLayout = memo(function DockviewWorkspaceLayout({
         }
       }
 
-      if (isTauri && !hidden.includes("browser")) {
+      if (!hidden.includes("browser")) {
         if (rightGroupRef) {
           api.addPanel({
             id: "browser",
@@ -1003,17 +1028,8 @@ export const DockviewWorkspaceLayout = memo(function DockviewWorkspaceLayout({
     if (api) injectParams(api);
   }, [injectParams]);
 
-  // Propagate workspace active state only to panels that use it (chat,
-  // terminal, browser).  Kept separate from injectParams so that a workspace
-  // switch doesn't trigger updateParameters on all panels — changes and files
-  // don't care about wsActive and would re-render for nothing.
-  useEffect(() => {
-    const api = apiRef.current;
-    if (!api) return;
-    api.getPanel("chat")?.api.updateParameters({ wsActive: isActive });
-    api.getPanel("terminal")?.api.updateParameters({ wsActive: isActive });
-    api.getPanel("browser")?.api.updateParameters({ wsActive: isActive });
-  }, [isActive]);
+  // wsActive is now propagated via WsActiveContext (React context) instead of
+  // updateParameters — see the WsActiveContext.Provider wrapping DockviewReact.
 
   // React to hiddenPanels changes: remove newly-hidden panels, add newly-shown ones
   const prevHiddenRef = useRef<string[]>(hiddenPanels);
@@ -1059,8 +1075,9 @@ export const DockviewWorkspaceLayout = memo(function DockviewWorkspaceLayout({
     });
   }, [isActive]);
 
-  // Hide the browser webview when a dialog is open (z-ordering: native webview
-  // renders on top of the React DOM, so it would cover the dialog otherwise).
+  // Hide all browser webviews when a dialog is open (z-ordering: native
+  // webviews render on top of the React DOM, so they would cover dialogs).
+  // With multi-tab browsers, we hide/show ALL webviews for this workspace.
   useEffect(() => {
     if (!isTauri) return;
     const isDialogOpen = quickOpenOpen || searchFilesOpen;
@@ -1068,12 +1085,12 @@ export const DockviewWorkspaceLayout = memo(function DockviewWorkspaceLayout({
     (async () => {
       const { invoke } = await import("@tauri-apps/api/core");
       if (isDialogOpen) {
-        invoke("browser_hide", { workspaceId }).catch(() => {});
+        invoke("browser_hide_all_for_workspace", { workspaceId }).catch(() => {});
       } else {
         // Only re-show if the browser panel is currently active
         const browserPanel = apiRef.current?.getPanel("browser");
         if (browserPanel?.api.isActive) {
-          invoke("browser_show", { workspaceId }).catch(() => {});
+          invoke("browser_show_all_for_workspace", { workspaceId }).catch(() => {});
         }
       }
     })();
@@ -1082,14 +1099,16 @@ export const DockviewWorkspaceLayout = memo(function DockviewWorkspaceLayout({
   return (
     <>
       <div ref={containerRef} className="h-full">
-        <DockviewReact
-          theme={bandTheme}
-          className="h-full"
-          components={components}
-          tabComponents={tabComponents}
-          defaultTabComponent={DefaultTab}
-          onReady={onReady}
-        />
+        <WsActiveContext.Provider value={isActive}>
+          <DockviewReact
+            theme={bandTheme}
+            className="h-full"
+            components={components}
+            tabComponents={tabComponents}
+            defaultTabComponent={DefaultTab}
+            onReady={onReady}
+          />
+        </WsActiveContext.Provider>
       </div>
 
       <QuickOpenDialog

--- a/apps/web/src/components/DockviewWorkspaceLayout.tsx
+++ b/apps/web/src/components/DockviewWorkspaceLayout.tsx
@@ -22,9 +22,10 @@ import {
   MessageSquare,
   Terminal as TerminalIcon,
 } from "lucide-react";
-import { createContext, lazy, memo, Suspense, useCallback, useContext, useEffect, useMemo, useRef, useState } from "react";
+import { lazy, memo, Suspense, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { isTauri } from "../lib/is-tauri";
 import { trpc } from "../lib/trpc-client";
+import { useWsActive } from "../lib/workspace-visibility-store";
 import { CodeBrowserView } from "./CodeBrowserView";
 import { DockviewBrowserContainer } from "./DockviewBrowserContainer";
 import { DockviewChatContainer } from "./DockviewChatContainer";
@@ -67,14 +68,6 @@ const SplitTerminalContainer = lazy(() =>
 
 // Browser panel params (browser container handles its own lazy loading internally)
 
-
-// ---------------------------------------------------------------------------
-// Workspace-active context — propagated via React context instead of
-// dockview's updateParameters (which clobbers the full param object).
-// ---------------------------------------------------------------------------
-
-const WsActiveContext = createContext(true);
-
 // ---------------------------------------------------------------------------
 // Panel params types
 // ---------------------------------------------------------------------------
@@ -115,7 +108,7 @@ function ChatPanelComponent({ params, api }: IDockviewPanelProps<ChatParams>) {
   // (Changes, Files, Terminal) is focused.  `isVisible` is only false when
   // the panel is behind another tab in a tabbed group.
   const [isVisible, setIsVisible] = useState(api.isVisible);
-  const wsActive = useContext(WsActiveContext);
+  const wsActive = useWsActive(params.workspaceId ?? "");
 
   useEffect(() => {
     const d = api.onDidVisibilityChange((e) => setIsVisible(e.isVisible));
@@ -166,7 +159,7 @@ function FilesPanelComponent({ params }: IDockviewPanelProps<FilesParams>) {
 function TerminalPanelComponent({ params, api }: IDockviewPanelProps<TerminalParams>) {
   // Track physical visibility — same approach as ChatPanelComponent.
   const [isVisible, setIsVisible] = useState(api.isVisible);
-  const wsActive = useContext(WsActiveContext);
+  const wsActive = useWsActive(params.workspaceId ?? "");
 
   useEffect(() => {
     const d = api.onDidVisibilityChange((e) => setIsVisible(e.isVisible));
@@ -281,7 +274,7 @@ interface BrowserParams {
 function BrowserPanelComponent({ params, api }: IDockviewPanelProps<BrowserParams>) {
   // Track physical visibility — same approach as ChatPanelComponent.
   const [isVisible, setIsVisible] = useState(api.isVisible);
-  const wsActive = useContext(WsActiveContext);
+  const wsActive = useWsActive(params.workspaceId ?? "");
 
   useEffect(() => {
     const d = api.onDidVisibilityChange((e) => setIsVisible(e.isVisible));
@@ -350,13 +343,7 @@ function useDiffFileCount(workspaceId: string, isActive: boolean): number {
 // ---------------------------------------------------------------------------
 
 /** All panels that must always be present in the layout. */
-const REQUIRED_PANEL_IDS = [
-  "chat",
-  "changes",
-  "files",
-  "terminal",
-  "browser",
-] as const;
+const REQUIRED_PANEL_IDS = ["chat", "changes", "files", "terminal", "browser"] as const;
 
 // ---------------------------------------------------------------------------
 // Layout persistence: shared structure + per-workspace active tabs
@@ -550,7 +537,6 @@ function loadLayout(workspaceId: string): unknown | null {
 
 interface DockviewWorkspaceLayoutProps {
   workspaceId: string;
-  isActive: boolean;
   /** Called when the user makes a STRUCTURAL layout change (panel move,
    *  resize, tab reorder — NOT simple tab activation).  The instance
    *  manager uses this to evict hidden workspaces so they pick up the
@@ -560,9 +546,13 @@ interface DockviewWorkspaceLayoutProps {
 
 export const DockviewWorkspaceLayout = memo(function DockviewWorkspaceLayout({
   workspaceId,
-  isActive,
   onLayoutChange,
 }: DockviewWorkspaceLayoutProps) {
+  // Subscribe to workspace visibility from the external store.
+  // Only re-renders when this workspace's visibility actually changes —
+  // no Context cascade to panel components.
+  const isActive = useWsActive(workspaceId);
+
   const apiRef = useRef<DockviewApi | null>(null);
   const containerRef = useRef<HTMLDivElement>(null);
 
@@ -1028,8 +1018,8 @@ export const DockviewWorkspaceLayout = memo(function DockviewWorkspaceLayout({
     if (api) injectParams(api);
   }, [injectParams]);
 
-  // wsActive is now propagated via WsActiveContext (React context) instead of
-  // updateParameters — see the WsActiveContext.Provider wrapping DockviewReact.
+  // wsActive is propagated via an external store (useWsActive) — panel
+  // components subscribe directly, avoiding React Context cascade re-renders.
 
   // React to hiddenPanels changes: remove newly-hidden panels, add newly-shown ones
   const prevHiddenRef = useRef<string[]>(hiddenPanels);
@@ -1099,16 +1089,14 @@ export const DockviewWorkspaceLayout = memo(function DockviewWorkspaceLayout({
   return (
     <>
       <div ref={containerRef} className="h-full">
-        <WsActiveContext.Provider value={isActive}>
-          <DockviewReact
-            theme={bandTheme}
-            className="h-full"
-            components={components}
-            tabComponents={tabComponents}
-            defaultTabComponent={DefaultTab}
-            onReady={onReady}
-          />
-        </WsActiveContext.Provider>
+        <DockviewReact
+          theme={bandTheme}
+          className="h-full"
+          components={components}
+          tabComponents={tabComponents}
+          defaultTabComponent={DefaultTab}
+          onReady={onReady}
+        />
       </div>
 
       <QuickOpenDialog

--- a/apps/web/src/lib/browser-layout-manager.ts
+++ b/apps/web/src/lib/browser-layout-manager.ts
@@ -1,0 +1,65 @@
+/**
+ * Browser layout persistence.
+ *
+ * Stores the dockview layout tree that describes how browser tabs are
+ * arranged within a workspace. One row per workspace in the `panel_states`
+ * table with `panelType = "browser_layout"`.
+ */
+
+import {
+  deletePanelStatesForWorkspace,
+  insertPanelState,
+  listPanelStatesForWorkspace,
+  updatePanelState,
+} from "./panel-state-store";
+
+const PANEL_TYPE = "browser_layout";
+
+function layoutId(workspaceId: string): string {
+  return `browser_layout_${workspaceId}`;
+}
+
+/**
+ * Get the browser layout tree for a workspace.
+ * Returns the parsed JSON tree or null if no layout is stored.
+ */
+export function getBrowserLayout(workspaceId: string): unknown | null {
+  const rows = listPanelStatesForWorkspace(workspaceId, PANEL_TYPE);
+  if (rows.length === 0) return null;
+  try {
+    return JSON.parse(rows[0].state);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Save (upsert) the browser layout tree for a workspace.
+ */
+export function saveBrowserLayout(workspaceId: string, tree: unknown): void {
+  const id = layoutId(workspaceId);
+  const state = JSON.stringify(tree);
+  const now = Date.now();
+
+  const rows = listPanelStatesForWorkspace(workspaceId, PANEL_TYPE);
+  if (rows.length > 0) {
+    updatePanelState(id, { state, updatedAt: now });
+  } else {
+    insertPanelState({
+      id,
+      workspaceId,
+      panelType: PANEL_TYPE,
+      state,
+      createdAt: now,
+      updatedAt: now,
+    });
+  }
+}
+
+/**
+ * Delete the browser layout for a workspace.
+ * Called when a workspace is removed.
+ */
+export function deleteBrowserLayout(workspaceId: string): void {
+  deletePanelStatesForWorkspace(workspaceId, PANEL_TYPE);
+}

--- a/apps/web/src/lib/browser-layout-manager.ts
+++ b/apps/web/src/lib/browser-layout-manager.ts
@@ -1,65 +1,44 @@
 /**
  * Browser layout persistence.
  *
- * Stores the dockview layout tree that describes how browser tabs are
- * arranged within a workspace. One row per workspace in the `panel_states`
- * table with `panelType = "browser_layout"`.
+ * Thin wrapper around DockviewLayoutManager for browser tab layouts.
+ * Each workspace gets one row in the `panel_states` table with
+ * `panelType = "browser_layout"`.
  */
 
-import {
-  deletePanelStatesForWorkspace,
-  insertPanelState,
-  listPanelStatesForWorkspace,
-  updatePanelState,
-} from "./panel-state-store";
+import { DockviewLayoutManager } from "./dockview-layout-manager";
 
-const PANEL_TYPE = "browser_layout";
+const manager = new DockviewLayoutManager("browser_layout");
 
-function layoutId(workspaceId: string): string {
-  return `browser_layout_${workspaceId}`;
-}
+export const getBrowserLayout = (workspaceId: string) => manager.get(workspaceId);
+export const saveBrowserLayout = (workspaceId: string, tree: unknown) =>
+  manager.save(workspaceId, tree);
+export const deleteBrowserLayout = (workspaceId: string) => manager.delete(workspaceId);
 
 /**
- * Get the browser layout tree for a workspace.
- * Returns the parsed JSON tree or null if no layout is stored.
+ * Add a browser panel to the saved dockview layout.
  */
-export function getBrowserLayout(workspaceId: string): unknown | null {
-  const rows = listPanelStatesForWorkspace(workspaceId, PANEL_TYPE);
-  if (rows.length === 0) return null;
-  try {
-    return JSON.parse(rows[0].state);
-  } catch {
-    return null;
-  }
-}
-
-/**
- * Save (upsert) the browser layout tree for a workspace.
- */
-export function saveBrowserLayout(workspaceId: string, tree: unknown): void {
-  const id = layoutId(workspaceId);
-  const state = JSON.stringify(tree);
-  const now = Date.now();
-
-  const rows = listPanelStatesForWorkspace(workspaceId, PANEL_TYPE);
-  if (rows.length > 0) {
-    updatePanelState(id, { state, updatedAt: now });
-  } else {
-    insertPanelState({
-      id,
+export function addBrowserToLayout(
+  workspaceId: string,
+  browserId: string,
+  opts?: { title?: string; initialUrl?: string },
+): void {
+  manager.addPanel(workspaceId, {
+    id: browserId,
+    contentComponent: "browserTab",
+    tabComponent: "browserTab",
+    title: opts?.title ?? "New Tab",
+    params: {
       workspaceId,
-      panelType: PANEL_TYPE,
-      state,
-      createdAt: now,
-      updatedAt: now,
-    });
-  }
+      browserId,
+      ...(opts?.initialUrl ? { initialUrl: opts.initialUrl } : {}),
+    },
+  });
 }
 
 /**
- * Delete the browser layout for a workspace.
- * Called when a workspace is removed.
+ * Remove a browser panel from the saved dockview layout.
  */
-export function deleteBrowserLayout(workspaceId: string): void {
-  deletePanelStatesForWorkspace(workspaceId, PANEL_TYPE);
+export function removeBrowserFromLayout(workspaceId: string, browserId: string): void {
+  manager.removePanel(workspaceId, browserId);
 }

--- a/apps/web/src/lib/browser-manager.ts
+++ b/apps/web/src/lib/browser-manager.ts
@@ -1,0 +1,283 @@
+/**
+ * Browser tab lifecycle management.
+ *
+ * Each browser tab maps to a webview instance (native on desktop, iframe on web).
+ * Modeled on chat-manager.ts — in-memory registry backed by the
+ * generic `panel_states` table for persistence across server restarts.
+ */
+
+import { createLogger } from "@band-app/logger";
+import {
+  deletePanelState,
+  deletePanelStatesForWorkspace,
+  insertPanelState,
+  listPanelStates,
+  updatePanelState,
+} from "./panel-state-store";
+
+const log = createLogger("browser-manager");
+
+const PANEL_TYPE = "browser";
+
+export type BrowserStatus = "idle" | "loading" | "error";
+
+export interface BrowserTab {
+  id: string;
+  workspaceId: string;
+  name: string;
+  url: string;
+  status: BrowserStatus;
+}
+
+/** Shape of the JSON blob stored in `panel_states.state` for browser panels. */
+interface BrowserPanelState {
+  name: string;
+  url: string;
+  status: BrowserStatus;
+}
+
+// ---------------------------------------------------------------------------
+// In-memory indices
+// ---------------------------------------------------------------------------
+
+/** Primary index: browserId -> BrowserTab */
+const browserTabs = new Map<string, BrowserTab>();
+
+/** Reverse index: workspaceId -> Set<browserId> */
+const workspaceBrowsers = new Map<string, Set<string>>();
+
+/**
+ * Lazy initialization flag.  In dev mode (vite dev) the module may be loaded
+ * without an explicit `loadBrowsersFromDb()` call from start-server.ts.  The
+ * first public read ensures the DB is hydrated so callers always see
+ * persisted browser records.
+ */
+let _initialized = false;
+
+function ensureInitialized(): void {
+  if (_initialized) return;
+  _initialized = true;
+  loadBrowsersFromDb();
+}
+
+function addToIndex(tab: BrowserTab): void {
+  browserTabs.set(tab.id, tab);
+  let ids = workspaceBrowsers.get(tab.workspaceId);
+  if (!ids) {
+    ids = new Set();
+    workspaceBrowsers.set(tab.workspaceId, ids);
+  }
+  ids.add(tab.id);
+}
+
+function removeFromIndex(browserId: string): void {
+  const tab = browserTabs.get(browserId);
+  if (!tab) return;
+  browserTabs.delete(browserId);
+  const ids = workspaceBrowsers.get(tab.workspaceId);
+  if (ids) {
+    ids.delete(browserId);
+    if (ids.size === 0) {
+      workspaceBrowsers.delete(tab.workspaceId);
+    }
+  }
+}
+
+function serializeState(tab: BrowserTab): string {
+  const blob: BrowserPanelState = {
+    name: tab.name,
+    url: tab.url,
+    status: tab.status,
+  };
+  return JSON.stringify(blob);
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+export interface CreateBrowserOptions {
+  /** Explicit ID — use when the client already generated one. */
+  id?: string;
+  name?: string;
+  url?: string;
+}
+
+/**
+ * Create a new browser tab for a workspace.
+ * Persists to panel_states table and adds to in-memory registry.
+ */
+export function createBrowser(workspaceId: string, options?: CreateBrowserOptions): BrowserTab {
+  const now = Date.now();
+
+  const tab: BrowserTab = {
+    id: options?.id ?? `browser_${crypto.randomUUID()}`,
+    workspaceId,
+    name: options?.name ?? "Browser",
+    url: options?.url ?? "",
+    status: "idle",
+  };
+
+  insertPanelState({
+    id: tab.id,
+    workspaceId: tab.workspaceId,
+    panelType: PANEL_TYPE,
+    state: serializeState(tab),
+    createdAt: now,
+    updatedAt: now,
+  });
+
+  addToIndex(tab);
+  log.info({ browserId: tab.id, workspaceId, url: tab.url }, "browser tab created");
+  return tab;
+}
+
+/**
+ * Get a browser tab by ID.
+ */
+export function getBrowser(browserId: string): BrowserTab | undefined {
+  ensureInitialized();
+  return browserTabs.get(browserId);
+}
+
+/**
+ * List all browser tabs for a workspace.
+ */
+export function listBrowsers(workspaceId: string): BrowserTab[] {
+  ensureInitialized();
+  const ids = workspaceBrowsers.get(workspaceId);
+  if (!ids) return [];
+  const tabs: BrowserTab[] = [];
+  for (const id of ids) {
+    const tab = browserTabs.get(id);
+    if (tab) tabs.push(tab);
+  }
+  return tabs;
+}
+
+export interface UpdateBrowserOptions {
+  name?: string;
+  url?: string;
+}
+
+/**
+ * Update a browser tab's configuration.
+ */
+export function updateBrowser(
+  browserId: string,
+  updates: UpdateBrowserOptions,
+): BrowserTab | undefined {
+  const tab = browserTabs.get(browserId);
+  if (!tab) return undefined;
+
+  if (updates.name !== undefined) tab.name = updates.name;
+  if (updates.url !== undefined) tab.url = updates.url;
+
+  updatePanelState(browserId, {
+    state: serializeState(tab),
+    updatedAt: Date.now(),
+  });
+
+  log.info({ browserId, updates }, "browser tab updated");
+  return tab;
+}
+
+/**
+ * Update a browser tab's current URL.
+ * Called when the browser navigates (from frontend or CLI).
+ */
+export function updateBrowserUrl(browserId: string, url: string): void {
+  const tab = browserTabs.get(browserId);
+  if (!tab) return;
+  tab.url = url;
+
+  updatePanelState(browserId, {
+    state: serializeState(tab),
+    updatedAt: Date.now(),
+  });
+}
+
+/**
+ * Update a browser tab's status.
+ */
+export function updateBrowserStatus(browserId: string, status: BrowserStatus): void {
+  const tab = browserTabs.get(browserId);
+  if (!tab) return;
+  tab.status = status;
+
+  updatePanelState(browserId, {
+    state: serializeState(tab),
+    updatedAt: Date.now(),
+  });
+}
+
+/**
+ * Remove a browser tab. Removes from DB and in-memory maps.
+ */
+export function removeBrowser(browserId: string): boolean {
+  const tab = browserTabs.get(browserId);
+  if (!tab) return false;
+
+  // Remove from DB
+  deletePanelState(browserId);
+
+  // Remove from in-memory maps
+  removeFromIndex(browserId);
+
+  log.info({ browserId, workspaceId: tab.workspaceId }, "browser tab removed");
+  return true;
+}
+
+/**
+ * Remove all browser tabs for a workspace.
+ * Called when a workspace is deleted.
+ */
+export function removeWorkspaceBrowsers(workspaceId: string): void {
+  const ids = workspaceBrowsers.get(workspaceId);
+  if (!ids) return;
+
+  for (const browserId of [...ids]) {
+    browserTabs.delete(browserId);
+  }
+
+  // Bulk delete browser panel states from DB
+  deletePanelStatesForWorkspace(workspaceId, PANEL_TYPE);
+
+  workspaceBrowsers.delete(workspaceId);
+  log.info({ workspaceId }, "all browser tabs removed for workspace");
+}
+
+/**
+ * Load all browser tabs from the database into the in-memory registry.
+ * Called on server startup. Resets all statuses to "idle".
+ */
+export function loadBrowsersFromDb(): number {
+  _initialized = true;
+  const rows = listPanelStates(PANEL_TYPE);
+  const now = Date.now();
+
+  for (const row of rows) {
+    const parsed = JSON.parse(row.state) as BrowserPanelState;
+
+    // Reset status to idle on startup
+    parsed.status = "idle";
+    updatePanelState(row.id, {
+      state: JSON.stringify(parsed),
+      updatedAt: now,
+    });
+
+    const tab: BrowserTab = {
+      id: row.id,
+      workspaceId: row.workspaceId,
+      name: parsed.name,
+      url: parsed.url,
+      status: "idle",
+    };
+    addToIndex(tab);
+  }
+
+  if (rows.length > 0) {
+    log.info({ count: rows.length }, "loaded browser tabs from database");
+  }
+  return rows.length;
+}

--- a/apps/web/src/lib/chat-layout-manager.ts
+++ b/apps/web/src/lib/chat-layout-manager.ts
@@ -1,65 +1,43 @@
 /**
  * Chat layout persistence.
  *
- * Stores the binary split tree that describes how chat panes are arranged
- * within a workspace. One row per workspace in the `panel_states` table
- * with `panelType = "chat_layout"`.
+ * Thin wrapper around DockviewLayoutManager for chat pane layouts.
+ * Each workspace gets one row in the `panel_states` table with
+ * `panelType = "chat_layout"`.
  */
 
-import {
-  deletePanelStatesForWorkspace,
-  insertPanelState,
-  listPanelStatesForWorkspace,
-  updatePanelState,
-} from "./panel-state-store";
+import { DockviewLayoutManager } from "./dockview-layout-manager";
 
-const PANEL_TYPE = "chat_layout";
+const manager = new DockviewLayoutManager("chat_layout");
 
-function layoutId(workspaceId: string): string {
-  return `layout_${workspaceId}`;
-}
+export const getChatLayout = (workspaceId: string) => manager.get(workspaceId);
+export const saveChatLayout = (workspaceId: string, tree: unknown) =>
+  manager.save(workspaceId, tree);
+export const deleteChatLayout = (workspaceId: string) => manager.delete(workspaceId);
 
 /**
- * Get the chat layout tree for a workspace.
- * Returns the parsed JSON tree or null if no layout is stored.
+ * Add a chat panel to the saved dockview layout.
  */
-export function getChatLayout(workspaceId: string): unknown | null {
-  const rows = listPanelStatesForWorkspace(workspaceId, PANEL_TYPE);
-  if (rows.length === 0) return null;
-  try {
-    return JSON.parse(rows[0].state);
-  } catch {
-    return null;
-  }
-}
-
-/**
- * Save (upsert) the chat layout tree for a workspace.
- */
-export function saveChatLayout(workspaceId: string, tree: unknown): void {
-  const id = layoutId(workspaceId);
-  const state = JSON.stringify(tree);
-  const now = Date.now();
-
-  const rows = listPanelStatesForWorkspace(workspaceId, PANEL_TYPE);
-  if (rows.length > 0) {
-    updatePanelState(id, { state, updatedAt: now });
-  } else {
-    insertPanelState({
-      id,
+export function addChatToLayout(
+  workspaceId: string,
+  chatId: string,
+  opts?: { title?: string },
+): void {
+  manager.addPanel(workspaceId, {
+    id: chatId,
+    contentComponent: "chatTab",
+    tabComponent: "chatTab",
+    title: opts?.title ?? "Chat",
+    params: {
       workspaceId,
-      panelType: PANEL_TYPE,
-      state,
-      createdAt: now,
-      updatedAt: now,
-    });
-  }
+      chatId,
+    },
+  });
 }
 
 /**
- * Delete the chat layout for a workspace.
- * Called when a workspace is removed.
+ * Remove a chat panel from the saved dockview layout.
  */
-export function deleteChatLayout(workspaceId: string): void {
-  deletePanelStatesForWorkspace(workspaceId, PANEL_TYPE);
+export function removeChatFromLayout(workspaceId: string, chatId: string): void {
+  manager.removePanel(workspaceId, chatId);
 }

--- a/apps/web/src/lib/dockview-layout-manager.ts
+++ b/apps/web/src/lib/dockview-layout-manager.ts
@@ -1,0 +1,238 @@
+/**
+ * Generic dockview layout persistence and mutation.
+ *
+ * Provides get/save/delete for dockview layout trees stored in the
+ * `panel_states` table, plus server-side helpers to add/remove panels
+ * without needing a live dockview instance.
+ *
+ * Usage:
+ *   const browserLayouts = new DockviewLayoutManager("browser_layout");
+ *   browserLayouts.get(workspaceId);
+ *   browserLayouts.addPanel(workspaceId, panelId, { ... });
+ */
+
+import {
+  deletePanelStatesForWorkspace,
+  insertPanelState,
+  listPanelStatesForWorkspace,
+  updatePanelState,
+} from "./panel-state-store";
+
+// ---------------------------------------------------------------------------
+// Dockview layout types
+//
+// The dockview `toJSON()` output has this shape:
+//   {
+//     grid: {
+//       root: GridNode (tree of branch/leaf nodes),
+//       height, width, orientation
+//     },
+//     panels: Record<panelId, PanelState>,
+//     activeGroup?: string
+//   }
+//
+// grid.root is a recursive tree:
+//   leaf:   { type: "leaf",   data: { id, views: [panelId, ...], activeView? }, size }
+//   branch: { type: "branch", data: [child, ...], size }
+//
+// `views` references panel IDs in the `panels` map.
+// ---------------------------------------------------------------------------
+
+export interface DockviewLayout {
+  grid: {
+    root: GridNode;
+    height: number;
+    width: number;
+    orientation: string;
+  };
+  panels: Record<string, PanelState>;
+  activeGroup?: string;
+}
+
+export interface GridNode {
+  type: "leaf" | "branch";
+  data: LeafData | GridNode[];
+  size?: number;
+  visible?: boolean;
+}
+
+export interface LeafData {
+  id: string;
+  views: string[];
+  activeView?: string;
+  [key: string]: unknown;
+}
+
+export interface PanelState {
+  id: string;
+  contentComponent?: string;
+  tabComponent?: string;
+  title?: string;
+  params?: Record<string, unknown>;
+  [key: string]: unknown;
+}
+
+// ---------------------------------------------------------------------------
+// Grid tree utilities
+// ---------------------------------------------------------------------------
+
+function isLeaf(node: GridNode): node is GridNode & { data: LeafData } {
+  return node.type === "leaf" && typeof node.data === "object" && !Array.isArray(node.data);
+}
+
+function isBranch(node: GridNode): node is GridNode & { data: GridNode[] } {
+  return node.type === "branch" && Array.isArray(node.data);
+}
+
+function findFirstLeaf(node: GridNode): LeafData | null {
+  if (isLeaf(node)) return node.data;
+  if (isBranch(node)) {
+    for (const child of node.data) {
+      const found = findFirstLeaf(child);
+      if (found) return found;
+    }
+  }
+  return null;
+}
+
+function removeFromGrid(node: GridNode, panelId: string): void {
+  if (isLeaf(node)) {
+    const idx = node.data.views.indexOf(panelId);
+    if (idx !== -1) {
+      node.data.views.splice(idx, 1);
+      if (node.data.activeView === panelId) {
+        node.data.activeView = node.data.views[0];
+      }
+    }
+  } else if (isBranch(node)) {
+    for (const child of node.data) {
+      removeFromGrid(child, panelId);
+    }
+  }
+}
+
+export function isDockviewLayout(obj: unknown): obj is DockviewLayout {
+  if (typeof obj !== "object" || obj === null) return false;
+  const o = obj as Record<string, unknown>;
+  return typeof o.grid === "object" && typeof o.panels === "object";
+}
+
+// ---------------------------------------------------------------------------
+// DockviewLayoutManager
+// ---------------------------------------------------------------------------
+
+export class DockviewLayoutManager {
+  constructor(private readonly panelType: string) {}
+
+  private layoutId(workspaceId: string): string {
+    return `${this.panelType}_${workspaceId}`;
+  }
+
+  /**
+   * Get the layout tree for a workspace.
+   * Returns the parsed JSON tree or null if no layout is stored.
+   */
+  get(workspaceId: string): unknown | null {
+    const rows = listPanelStatesForWorkspace(workspaceId, this.panelType);
+    if (rows.length === 0) return null;
+    try {
+      return JSON.parse(rows[0].state);
+    } catch {
+      return null;
+    }
+  }
+
+  /**
+   * Save (upsert) the layout tree for a workspace.
+   */
+  save(workspaceId: string, tree: unknown): void {
+    const id = this.layoutId(workspaceId);
+    const state = JSON.stringify(tree);
+    const now = Date.now();
+
+    const rows = listPanelStatesForWorkspace(workspaceId, this.panelType);
+    if (rows.length > 0) {
+      updatePanelState(id, { state, updatedAt: now });
+    } else {
+      insertPanelState({
+        id,
+        workspaceId,
+        panelType: this.panelType,
+        state,
+        createdAt: now,
+        updatedAt: now,
+      });
+    }
+  }
+
+  /**
+   * Delete the layout for a workspace.
+   */
+  delete(workspaceId: string): void {
+    deletePanelStatesForWorkspace(workspaceId, this.panelType);
+  }
+
+  /**
+   * Add a panel to the saved dockview layout.
+   *
+   * Appends the panel to the first group's `views` array and adds the panel
+   * entry to the `panels` map. If no layout exists, creates a fresh one-tab layout.
+   */
+  addPanel(workspaceId: string, panel: PanelState): void {
+    const raw = this.get(workspaceId);
+
+    if (raw && isDockviewLayout(raw)) {
+      raw.panels[panel.id] = panel;
+
+      const leaf = findFirstLeaf(raw.grid.root);
+      if (leaf) {
+        leaf.views.push(panel.id);
+        leaf.activeView = panel.id;
+      }
+
+      this.save(workspaceId, raw);
+    } else {
+      const groupId = `group_${panel.id}`;
+      const layout: DockviewLayout = {
+        grid: {
+          root: {
+            type: "leaf",
+            data: { id: groupId, views: [panel.id], activeView: panel.id },
+            size: 1,
+          },
+          height: 500,
+          width: 500,
+          orientation: "HORIZONTAL",
+        },
+        panels: { [panel.id]: panel },
+        activeGroup: groupId,
+      };
+      this.save(workspaceId, layout);
+    }
+  }
+
+  /**
+   * Remove a panel from the saved dockview layout.
+   *
+   * Removes the panel from the `panels` map and from any group's `views` array.
+   */
+  removePanel(workspaceId: string, panelId: string): void {
+    const raw = this.get(workspaceId);
+    if (!raw || !isDockviewLayout(raw)) return;
+
+    delete raw.panels[panelId];
+    removeFromGrid(raw.grid.root, panelId);
+
+    this.save(workspaceId, raw);
+  }
+
+  /**
+   * List all panel IDs in the saved layout.
+   * Useful for reconciling layout with live records.
+   */
+  listPanelIds(workspaceId: string): string[] {
+    const raw = this.get(workspaceId);
+    if (!raw || !isDockviewLayout(raw)) return [];
+    return Object.keys(raw.panels);
+  }
+}

--- a/apps/web/src/lib/watcher.ts
+++ b/apps/web/src/lib/watcher.ts
@@ -25,7 +25,9 @@ export interface StatusEvent {
     | "branch-status"
     | "tunnel-url"
     | "tunnel-error"
-    | "setup-status";
+    | "setup-status"
+    | "browser-created"
+    | "browser-removed";
   status?: WorkspaceStatus;
   statuses?: WorkspaceStatus[];
   workspaceId?: string;
@@ -36,6 +38,7 @@ export interface StatusEvent {
   setupState?: "running" | "completed" | "failed";
   setupError?: string;
   runningSetups?: string[];
+  browserId?: string;
 }
 
 type StatusListener = (event: StatusEvent) => void;

--- a/apps/web/src/lib/workspace-visibility-store.ts
+++ b/apps/web/src/lib/workspace-visibility-store.ts
@@ -1,0 +1,78 @@
+/**
+ * Workspace visibility store.
+ *
+ * Tracks whether each workspace is active (visible to the user) without
+ * using React Context, so changing visibility doesn't cascade re-renders
+ * through the entire component tree. Only components that subscribe via
+ * `useSyncExternalStore` re-render — typically just the leaf components
+ * with Tauri side effects (browser_hide/show, terminal attach/detach).
+ */
+
+import { useCallback, useSyncExternalStore } from "react";
+
+// ---------------------------------------------------------------------------
+// Store
+// ---------------------------------------------------------------------------
+
+interface VisibilityState {
+  wsActive: boolean;
+}
+
+type Listener = () => void;
+
+const state = new Map<string, VisibilityState>();
+const listeners = new Map<string, Set<Listener>>();
+
+const DEFAULT: VisibilityState = { wsActive: true };
+
+function notify(workspaceId: string): void {
+  const set = listeners.get(workspaceId);
+  if (set) {
+    for (const cb of set) cb();
+  }
+}
+
+/**
+ * Set the workspace visibility. Call from DockviewInstanceManager when
+ * the active workspace changes.
+ */
+export function setWsActive(workspaceId: string, wsActive: boolean): void {
+  const prev = state.get(workspaceId);
+  if (prev?.wsActive === wsActive) return; // no-op
+  state.set(workspaceId, { wsActive });
+  notify(workspaceId);
+}
+
+/**
+ * Read the current visibility for a workspace (non-reactive).
+ */
+export function getWsActive(workspaceId: string): boolean {
+  return state.get(workspaceId)?.wsActive ?? DEFAULT.wsActive;
+}
+
+function subscribe(workspaceId: string, cb: Listener): () => void {
+  let set = listeners.get(workspaceId);
+  if (!set) {
+    set = new Set();
+    listeners.set(workspaceId, set);
+  }
+  set.add(cb);
+  return () => {
+    set.delete(cb);
+    if (set.size === 0) listeners.delete(workspaceId);
+  };
+}
+
+// ---------------------------------------------------------------------------
+// React hook
+// ---------------------------------------------------------------------------
+
+/**
+ * Subscribe to workspace visibility changes. Only re-renders when the
+ * wsActive value for this workspace actually changes.
+ */
+export function useWsActive(workspaceId: string): boolean {
+  const sub = useCallback((cb: Listener) => subscribe(workspaceId, cb), [workspaceId]);
+  const snap = useCallback(() => getWsActive(workspaceId), [workspaceId]);
+  return useSyncExternalStore(sub, snap);
+}

--- a/apps/web/src/styles/dockview-theme.css
+++ b/apps/web/src/styles/dockview-theme.css
@@ -117,3 +117,44 @@
   align-items: center;
   padding-right: 0.25rem;
 }
+
+/* ---------------------------------------------------------------------------
+ * Nested browser tabs — same compact styling as chat tabs for the inner
+ * dockview instance used for multi-browser tabs within the browser panel.
+ * --------------------------------------------------------------------------- */
+
+.dockview-browser-tabs {
+  --dv-tabs-and-actions-container-height: 32px;
+  --dv-tabs-and-actions-container-font-size: 12px;
+}
+
+.dockview-browser-tabs .dv-tab {
+  padding-left: 0.5rem;
+  padding-right: 0.5rem;
+  max-width: 200px;
+}
+
+/* Hide the sash/resize handle — tabs, not split panes */
+.dockview-browser-tabs .dv-resize-container > .dv-resize-handle-horizontal,
+.dockview-browser-tabs .dv-resize-container > .dv-resize-handle-vertical {
+  display: none;
+}
+
+/* Disable drag-and-drop reordering in nested browser tabs */
+.dockview-browser-tabs .dv-tab {
+  cursor: default;
+}
+
+/* Hide the built-in tab overflow dropdown — its popup gets clipped by
+   ancestor overflow:hidden in the nested dockview. Tabs are already
+   horizontally scrollable so users can still reach all tabs. */
+.dockview-browser-tabs .dv-tabs-overflow-dropdown-root {
+  display: none;
+}
+
+/* Right-side actions area (the + button) */
+.dockview-browser-tabs .dv-right-actions-container {
+  display: flex;
+  align-items: center;
+  padding-right: 0.25rem;
+}

--- a/apps/web/src/trpc/router.ts
+++ b/apps/web/src/trpc/router.ts
@@ -10,8 +10,10 @@ import { Cron } from "croner";
 import { z } from "zod";
 import { createMetadataAgent, getOrCreateAgent, replaceAgent } from "../lib/agent-pool";
 import {
+  addBrowserToLayout,
   deleteBrowserLayout,
   getBrowserLayout,
+  removeBrowserFromLayout,
   saveBrowserLayout,
 } from "../lib/browser-layout-manager";
 import {
@@ -2327,6 +2329,10 @@ const browsersRouter = t.router({
         name: input.name,
         url: input.url,
       });
+      addBrowserToLayout(input.workspaceId, browser.id, {
+        title: input.name,
+        initialUrl: input.url,
+      });
       emit({ kind: "browser-created", workspaceId: input.workspaceId, browserId: browser.id });
       return { browser };
     }),
@@ -2360,7 +2366,14 @@ const browsersRouter = t.router({
   remove: publicProcedure.input(z.object({ browserId: z.string() })).mutation(({ input }) => {
     const browser = getBrowser(input.browserId);
     removeBrowser(input.browserId);
-    emit({ kind: "browser-removed", workspaceId: browser?.workspaceId, browserId: input.browserId });
+    if (browser?.workspaceId) {
+      removeBrowserFromLayout(browser.workspaceId, input.browserId);
+    }
+    emit({
+      kind: "browser-removed",
+      workspaceId: browser?.workspaceId,
+      browserId: input.browserId,
+    });
     return { ok: true };
   }),
 });

--- a/apps/web/src/trpc/router.ts
+++ b/apps/web/src/trpc/router.ts
@@ -9,6 +9,20 @@ import { initTRPC, TRPCError } from "@trpc/server";
 import { Cron } from "croner";
 import { z } from "zod";
 import { createMetadataAgent, getOrCreateAgent, replaceAgent } from "../lib/agent-pool";
+import {
+  deleteBrowserLayout,
+  getBrowserLayout,
+  saveBrowserLayout,
+} from "../lib/browser-layout-manager";
+import {
+  createBrowser,
+  getBrowser,
+  listBrowsers,
+  removeBrowser,
+  removeWorkspaceBrowsers,
+  updateBrowser,
+  updateBrowserUrl,
+} from "../lib/browser-manager";
 import { deleteChatLayout, getChatLayout, saveChatLayout } from "../lib/chat-layout-manager";
 import {
   createChat,
@@ -394,6 +408,12 @@ const workspacesRouter = t.router({
 
             // Clean up chat layout tree
             deleteChatLayout(workspaceId);
+
+            // Clean up all browser tabs
+            removeWorkspaceBrowsers(workspaceId);
+
+            // Clean up browser layout tree
+            deleteBrowserLayout(workspaceId);
 
             // Kill any running terminal PTY sessions
             killWorkspaceTerminals(workspaceId);
@@ -2267,6 +2287,85 @@ const chatsRouter = t.router({
 });
 
 // ---------------------------------------------------------------------------
+// Browser Layout (split pane tree persistence)
+// ---------------------------------------------------------------------------
+
+const browserLayoutRouter = t.router({
+  get: publicProcedure.input(z.object({ workspaceId: z.string() })).query(({ input }) => {
+    return { tree: getBrowserLayout(input.workspaceId) };
+  }),
+
+  save: publicProcedure
+    .input(z.object({ workspaceId: z.string(), tree: z.unknown() }))
+    .mutation(({ input }) => {
+      saveBrowserLayout(input.workspaceId, input.tree);
+      return { ok: true };
+    }),
+});
+
+// ---------------------------------------------------------------------------
+// Browsers (multi-tab browser management)
+// ---------------------------------------------------------------------------
+
+const browsersRouter = t.router({
+  list: publicProcedure.input(z.object({ workspaceId: z.string() })).query(({ input }) => {
+    return { browsers: listBrowsers(input.workspaceId) };
+  }),
+
+  create: publicProcedure
+    .input(
+      z.object({
+        workspaceId: z.string(),
+        id: z.string().optional(),
+        name: z.string().optional(),
+        url: z.string().optional(),
+      }),
+    )
+    .mutation(({ input }) => {
+      const browser = createBrowser(input.workspaceId, {
+        id: input.id,
+        name: input.name,
+        url: input.url,
+      });
+      emit({ kind: "browser-created", workspaceId: input.workspaceId, browserId: browser.id });
+      return { browser };
+    }),
+
+  get: publicProcedure.input(z.object({ browserId: z.string() })).query(({ input }) => {
+    const browser = getBrowser(input.browserId);
+    return { browser: browser ?? null };
+  }),
+
+  update: publicProcedure
+    .input(
+      z.object({
+        browserId: z.string(),
+        name: z.string().optional(),
+        url: z.string().optional(),
+      }),
+    )
+    .mutation(({ input }) => {
+      const { browserId, ...updates } = input;
+      const browser = updateBrowser(browserId, updates);
+      return { browser };
+    }),
+
+  navigate: publicProcedure
+    .input(z.object({ browserId: z.string(), url: z.string() }))
+    .mutation(({ input }) => {
+      updateBrowserUrl(input.browserId, input.url);
+      return { ok: true };
+    }),
+
+  remove: publicProcedure.input(z.object({ browserId: z.string() })).mutation(({ input }) => {
+    const browser = getBrowser(input.browserId);
+    removeBrowser(input.browserId);
+    emit({ kind: "browser-removed", workspaceId: browser?.workspaceId, browserId: input.browserId });
+    return { ok: true };
+  }),
+});
+
+// ---------------------------------------------------------------------------
 // Queue (persisted queued messages)
 // ---------------------------------------------------------------------------
 
@@ -2387,6 +2486,8 @@ export const appRouter = t.router({
   chat: chatRouter,
   chatLayout: chatLayoutRouter,
   chats: chatsRouter,
+  browserLayout: browserLayoutRouter,
+  browsers: browsersRouter,
   statuses: statusesRouter,
   status: statusRouter,
   cronjobs: cronjobsRouter,


### PR DESCRIPTION
## Summary
- Replace React Context with `useSyncExternalStore` for workspace visibility to eliminate cascade re-renders on workspace switch
- Add React Query caching (`staleTime: Infinity`) to browser and chat dockview containers so inner layouts render instantly on workspace revisit without server fetch delay
- Remove localStorage URL persistence from `BrowserPaneComponent` in favor of server as single source of truth — browser URL changes are debounce-persisted via tRPC `browsers.navigate`, and fetched on mount when no `initialUrl` param is provided (fixes CLI `--url` not loading)
- Add `browser-title-changed` Tauri event listener to update dockview tab titles from page `<title>`
- Reduce `MAX_CACHED_WORKSPACES` from 5 to 1

## Test plan
- [ ] Switch between two workspaces rapidly — no flash of previous workspace content
- [ ] Navigate to a URL in a browser tab, switch workspace and back — URL persists and loads
- [ ] Create browser via CLI with `--url` flag — URL loads automatically in the panel
- [ ] Open multiple browser tabs — page titles update in tab headers
- [ ] Chat container restores instantly on workspace revisit (no loading spinner)

🤖 Generated with [Claude Code](https://claude.com/claude-code)