### PR TITLE
fix: dirty indicator persists after closing tab without saving

### DIFF
--- a/apps/web/src/components/CodeBrowserView.tsx
+++ b/apps/web/src/components/CodeBrowserView.tsx
@@ -565,6 +565,11 @@ export function CodeBrowserView({
 
   const handleTabClose = useCallback(
     (filePath: string) => {
+      // Tell FileViewer to discard its in-memory edited content ref BEFORE
+      // the tab switch triggers a re-render.  This prevents the cleanup
+      // effect from re-saving the dirty content back to localStorage.
+      window.dispatchEvent(new CustomEvent("band:discard-edits", { detail: { filePath } }));
+
       // Clear the unsaved edits cache so the file reloads fresh from
       // the server when reopened (same key format as FileViewer).
       try {
@@ -572,6 +577,8 @@ export function CodeBrowserView({
       } catch {
         // storage unavailable
       }
+      // Notify listeners (FileTabBar) that dirty state changed
+      window.dispatchEvent(new CustomEvent("band:dirty-change"));
       fileTabs.closeTab(filePath);
     },
     [fileTabs.closeTab, workspaceId],

--- a/packages/dashboard-core/src/components/FileViewer.tsx
+++ b/packages/dashboard-core/src/components/FileViewer.tsx
@@ -178,6 +178,22 @@ export function FileViewer({
     };
   }, [workspaceId, filePath]);
 
+  // Listen for discard-edits events from handleTabClose.  When the parent
+  // closes a tab with "Close Without Saving", it dispatches this event
+  // BEFORE the tab switch so we can null out the ref synchronously.
+  // The cleanup effect (above) then sees null and skips re-saving.
+  useEffect(() => {
+    const handler = (e: Event) => {
+      const detail = (e as CustomEvent).detail;
+      if (detail?.filePath === filePath) {
+        editedContentRef.current = null;
+        setEditedContent(null);
+      }
+    };
+    window.addEventListener("band:discard-edits", handler);
+    return () => window.removeEventListener("band:discard-edits", handler);
+  }, [filePath]);
+
   // Warn before tab close when dirty
   useEffect(() => {
     if (!isDirty) return;


### PR DESCRIPTION
## Summary

- Fix race condition where FileViewer's cleanup effect re-saved dirty content to localStorage after `handleTabClose` had already cleared it
- Add `band:discard-edits` custom event so `handleTabClose` can signal FileViewer to null out its `editedContentRef` before the tab switch triggers cleanup
- Dispatch `band:dirty-change` event on tab close so the yellow dot disappears immediately

## Root Cause

When closing a tab with "Close Without Saving":
1. `handleTabClose` cleared the localStorage cache
2. `fileTabs.closeTab()` triggered a re-render
3. FileViewer's cleanup effect ran and **re-saved** the dirty content from `editedContentRef.current`

The new `band:discard-edits` event runs synchronously before the tab close, nulling the ref so the cleanup skips the re-save.

## Test plan

- [ ] Open a file, make edits, see the yellow dirty indicator
- [ ] Close the tab, click "Close Without Saving"
- [ ] Reopen the same file — should load fresh from disk with no dirty indicator
- [ ] Open a file, make edits, switch to another tab, switch back — edits are still preserved (normal tab switching unaffected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)