### PR TITLE
feat: add Ctrl+Tab / Ctrl+Shift+Tab for file tab switching

### DIFF
--- a/apps/web/src/components/CodeBrowserView.tsx
+++ b/apps/web/src/components/CodeBrowserView.tsx
@@ -785,6 +785,31 @@ export function CodeBrowserView({
     return () => window.removeEventListener("band:lsp-navigate", handleLspNavigate);
   }, [pushDepartureAndArrival, fileTabs.openTab, onSelectFile]);
 
+  // Ctrl+Tab / Ctrl+Shift+Tab to switch between file tabs
+  useEffect(() => {
+    const handleNextTab = () => {
+      const tabs = fileTabs.openTabs;
+      if (tabs.length <= 1) return;
+      const currentIndex = tabs.findIndex((t) => t.filePath === fileTabs.activeTabPath);
+      const nextIndex = (currentIndex + 1) % tabs.length;
+      handleTabSelect(tabs[nextIndex].filePath);
+    };
+    const handlePrevTab = () => {
+      const tabs = fileTabs.openTabs;
+      if (tabs.length <= 1) return;
+      const currentIndex = tabs.findIndex((t) => t.filePath === fileTabs.activeTabPath);
+      const prevIndex = (currentIndex - 1 + tabs.length) % tabs.length;
+      handleTabSelect(tabs[prevIndex].filePath);
+    };
+
+    window.addEventListener("band:next-file-tab", handleNextTab);
+    window.addEventListener("band:prev-file-tab", handlePrevTab);
+    return () => {
+      window.removeEventListener("band:next-file-tab", handleNextTab);
+      window.removeEventListener("band:prev-file-tab", handlePrevTab);
+    };
+  }, [fileTabs.openTabs, fileTabs.activeTabPath, handleTabSelect]);
+
   // Cmd+W / Ctrl+W to close active tab
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {

--- a/apps/web/src/components/DockviewWorkspaceLayout.tsx
+++ b/apps/web/src/components/DockviewWorkspaceLayout.tsx
@@ -647,6 +647,22 @@ export const DockviewWorkspaceLayout = memo(function DockviewWorkspaceLayout({
         return;
       }
 
+      // Ctrl+Tab → next file tab
+      if (e.key === "Tab" && e.ctrlKey && !e.shiftKey) {
+        e.preventDefault();
+        e.stopPropagation();
+        window.dispatchEvent(new CustomEvent("band:next-file-tab"));
+        return;
+      }
+
+      // Ctrl+Shift+Tab → previous file tab
+      if (e.key === "Tab" && e.ctrlKey && e.shiftKey) {
+        e.preventDefault();
+        e.stopPropagation();
+        window.dispatchEvent(new CustomEvent("band:prev-file-tab"));
+        return;
+      }
+
       const mod = e.metaKey || e.ctrlKey;
       if (!mod) return;
 


### PR DESCRIPTION
## Summary
- Add `Ctrl+Tab` to switch to the next open file tab and `Ctrl+Shift+Tab` to switch to the previous tab
- Dispatches `band:next-file-tab` / `band:prev-file-tab` custom events from the global keyboard handler in `DockviewWorkspaceLayout`
- `CodeBrowserView` listens for these events and cycles through open tabs with wrap-around

## Changes
- `apps/web/src/components/DockviewWorkspaceLayout.tsx` — keyboard event dispatch for Ctrl+Tab / Ctrl+Shift+Tab
- `apps/web/src/components/CodeBrowserView.tsx` — event listeners that cycle through open file tabs

## Test plan
- [ ] Open multiple file tabs in the editor
- [ ] Press Ctrl+Tab — verify it switches to the next tab
- [ ] Press Ctrl+Shift+Tab — verify it switches to the previous tab
- [ ] On the last tab, press Ctrl+Tab — verify it wraps to the first tab
- [ ] On the first tab, press Ctrl+Shift+Tab — verify it wraps to the last tab
- [ ] With only one tab open, press Ctrl+Tab — verify nothing happens
- [ ] Verify Shift+Tab (toggle mode) still works independently

🤖 Generated with [Claude Code](https://claude.com/claude-code)