### PR TITLE
feat: add Ctrl+R workspace picker for quick switching

### DIFF
--- a/apps/web/src/components/DockviewInstanceManager.tsx
+++ b/apps/web/src/components/DockviewInstanceManager.tsx
@@ -1,3 +1,4 @@
+import { recordWorkspaceAccess } from "@band-app/dashboard-core";
 import { useRouterState } from "@tanstack/react-router";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { parseWorkspaceFromPath } from "../lib/parse-workspace";
@@ -74,8 +75,10 @@ export function DockviewInstanceManager() {
 
   // Update lastAccessed timestamp in a non-blocking effect (for LRU ordering).
   // This doesn't affect which workspace is visible — just eviction order.
+  // Also record the access in localStorage for the workspace picker.
   useEffect(() => {
     if (!activeWorkspaceId) return;
+    recordWorkspaceAccess(activeWorkspaceId);
     setCache((prev) => {
       const existing = prev.get(activeWorkspaceId);
       if (!existing) return prev;

--- a/apps/web/src/components/DockviewWorkspaceLayout.tsx
+++ b/apps/web/src/components/DockviewWorkspaceLayout.tsx
@@ -5,6 +5,7 @@ import {
   QuickOpenDialog,
   SearchFilesDialog,
   useSettingsQuery,
+  WorkspacePickerDialog,
 } from "@band-app/dashboard-core";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@band-app/ui";
 import {
@@ -601,6 +602,7 @@ export const DockviewWorkspaceLayout = memo(function DockviewWorkspaceLayout({
   const [quickOpenOpen, setQuickOpenOpen] = useState(false);
   const [quickOpenQuery, setQuickOpenQuery] = useState<string | undefined>(undefined);
   const [searchFilesOpen, setSearchFilesOpen] = useState(false);
+  const [workspacePickerOpen, setWorkspacePickerOpen] = useState(false);
 
   // Find-in-file: active panel registers its search callback here
   const findInFileRef = useRef<(() => void) | null>(null);
@@ -644,6 +646,14 @@ export const DockviewWorkspaceLayout = memo(function DockviewWorkspaceLayout({
         e.preventDefault();
         e.stopPropagation();
         window.dispatchEvent(new CustomEvent("band:toggle-mode"));
+        return;
+      }
+
+      // Ctrl+R (not Cmd+R) → workspace picker — on both macOS and Windows
+      if (e.ctrlKey && !e.metaKey && e.key.toLowerCase() === "r" && !e.shiftKey) {
+        e.preventDefault();
+        e.stopPropagation();
+        setWorkspacePickerOpen(true);
         return;
       }
 
@@ -1070,7 +1080,7 @@ export const DockviewWorkspaceLayout = memo(function DockviewWorkspaceLayout({
   // With multi-tab browsers, we hide/show ALL webviews for this workspace.
   useEffect(() => {
     if (!isTauri) return;
-    const isDialogOpen = quickOpenOpen || searchFilesOpen;
+    const isDialogOpen = quickOpenOpen || searchFilesOpen || workspacePickerOpen;
 
     (async () => {
       const { invoke } = await import("@tauri-apps/api/core");
@@ -1084,7 +1094,7 @@ export const DockviewWorkspaceLayout = memo(function DockviewWorkspaceLayout({
         }
       }
     })();
-  }, [quickOpenOpen, searchFilesOpen, workspaceId]);
+  }, [quickOpenOpen, searchFilesOpen, workspacePickerOpen, workspaceId]);
 
   return (
     <>
@@ -1117,6 +1127,7 @@ export const DockviewWorkspaceLayout = memo(function DockviewWorkspaceLayout({
         onOpenChange={setSearchFilesOpen}
         onOpenFile={handleOpenFile}
       />
+      <WorkspacePickerDialog open={workspacePickerOpen} onOpenChange={setWorkspacePickerOpen} />
     </>
   );
 });

--- a/packages/dashboard-core/src/components/WorkspacePickerDialog.tsx
+++ b/packages/dashboard-core/src/components/WorkspacePickerDialog.tsx
@@ -1,0 +1,127 @@
+import {
+  Command,
+  CommandEmpty,
+  CommandInput,
+  CommandItem,
+  CommandList,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@band-app/ui";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCapabilities } from "../context";
+import { useProjects } from "../hooks/use-projects";
+import { getRecentWorkspaceOrder, recordWorkspaceAccess } from "../lib/recent-workspaces";
+import { toWorkspaceId } from "../lib/workspace-id";
+import { useDashboardStore } from "../stores/index";
+import { AgentStatusIndicator } from "./AgentStatusIndicator";
+
+interface WorkspaceEntry {
+  workspaceId: string;
+  projectName: string;
+  branch: string;
+  agent?: { status: string } | null;
+}
+
+interface WorkspacePickerDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+export function WorkspacePickerDialog({ open, onOpenChange }: WorkspacePickerDialogProps) {
+  const { projects } = useProjects();
+  const capabilities = useCapabilities();
+  const activeWorkspaceId = useDashboardStore((s) => s.activeWorkspaceId);
+  const statuses = useDashboardStore((s) => s.statuses);
+  const openWorkspace = useDashboardStore((s) => s.openWorkspace);
+  const clearNeedsAttention = useDashboardStore((s) => s.clearNeedsAttention);
+
+  const [query, setQuery] = useState("");
+
+  // Read recent order once when the dialog opens
+  const [recentOrder, setRecentOrder] = useState<string[]>([]);
+  useEffect(() => {
+    if (open) {
+      setRecentOrder(getRecentWorkspaceOrder());
+    } else {
+      setQuery("");
+    }
+  }, [open]);
+
+  // Flatten all workspaces and sort by recency
+  const sortedWorkspaces = useMemo(() => {
+    const entries: WorkspaceEntry[] = [];
+    for (const project of projects) {
+      for (const worktree of project.worktrees) {
+        const workspaceId = toWorkspaceId(project.name, worktree.branch);
+        entries.push({
+          workspaceId,
+          projectName: project.name,
+          branch: worktree.branch,
+          agent: statuses[workspaceId]?.agent ?? worktree.agent,
+        });
+      }
+    }
+
+    const orderMap = new Map(recentOrder.map((id, i) => [id, i]));
+    entries.sort((a, b) => {
+      const ai = orderMap.get(a.workspaceId) ?? Number.MAX_SAFE_INTEGER;
+      const bi = orderMap.get(b.workspaceId) ?? Number.MAX_SAFE_INTEGER;
+      return ai - bi;
+    });
+
+    return entries;
+  }, [projects, statuses, recentOrder]);
+
+  const handleSelect = useCallback(
+    (workspaceId: string) => {
+      clearNeedsAttention(workspaceId);
+      recordWorkspaceAccess(workspaceId);
+      const href = capabilities.getWorkspaceHref?.(workspaceId);
+      if (href && capabilities.navigate) {
+        capabilities.navigate(href);
+      } else {
+        openWorkspace(workspaceId);
+      }
+      onOpenChange(false);
+    },
+    [capabilities, openWorkspace, clearNeedsAttention, onOpenChange],
+  );
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="overflow-hidden p-0 sm:max-w-[520px]" showCloseButton={false}>
+        <DialogHeader className="sr-only">
+          <DialogTitle>Switch Workspace</DialogTitle>
+          <DialogDescription>Search workspaces by name, project, or branch</DialogDescription>
+        </DialogHeader>
+        <Command shouldFilter={true}>
+          <CommandInput placeholder="Switch workspace..." value={query} onValueChange={setQuery} />
+          <CommandList className="max-h-[360px]">
+            <CommandEmpty>No workspaces found.</CommandEmpty>
+            {sortedWorkspaces.map((entry) => {
+              const isActive = activeWorkspaceId === entry.workspaceId;
+              return (
+                <CommandItem
+                  key={entry.workspaceId}
+                  value={`${entry.projectName} ${entry.branch}`}
+                  onSelect={() => handleSelect(entry.workspaceId)}
+                >
+                  <AgentStatusIndicator agent={entry.agent} />
+                  <span className="text-sm font-medium">
+                    {entry.projectName}/{entry.branch}
+                  </span>
+                  {isActive && (
+                    <span className="ml-auto shrink-0 text-xs text-muted-foreground">current</span>
+                  )}
+                </CommandItem>
+              );
+            })}
+          </CommandList>
+        </Command>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/packages/dashboard-core/src/index.ts
+++ b/packages/dashboard-core/src/index.ts
@@ -24,6 +24,7 @@ export { SearchFilesDialog } from "./components/SearchFilesDialog";
 export { SettingsPage } from "./components/SettingsPage";
 export { SetupStatusIndicator } from "./components/SetupStatusIndicator";
 export { WorkspaceCard } from "./components/WorkspaceCard";
+export { WorkspacePickerDialog } from "./components/WorkspacePickerDialog";
 export { type WorkspaceTab, WorkspaceTabNav } from "./components/WorkspaceTabNav";
 // Context
 export { DashboardProvider, useAdapter, useCapabilities } from "./context";
@@ -76,6 +77,7 @@ export { getFileIcon } from "./lib/file-icon";
 export { type FileLocation, formatFileLocation, parseFileLocation } from "./lib/file-location";
 export { type FilePreviewType, getFilePreviewType } from "./lib/file-type";
 export { extensionToLanguage, filenameToLanguage } from "./lib/language-map";
+export { getRecentWorkspaceOrder, recordWorkspaceAccess } from "./lib/recent-workspaces";
 export type { SelectionToChatDetail } from "./lib/selection-to-chat";
 export { isServiceHealthy, type ServiceHealth } from "./lib/service-health";
 // Lib

--- a/packages/dashboard-core/src/lib/recent-workspaces.ts
+++ b/packages/dashboard-core/src/lib/recent-workspaces.ts
@@ -1,0 +1,33 @@
+const STORAGE_KEY = "band-recent-workspaces";
+const MAX_ENTRIES = 50;
+
+/**
+ * Record a workspace as most-recently-accessed.
+ * Moves it to the front of the list (or inserts it if new).
+ */
+export function recordWorkspaceAccess(workspaceId: string): void {
+  const list = getRecentWorkspaceOrder();
+  const filtered = list.filter((id) => id !== workspaceId);
+  filtered.unshift(workspaceId);
+  if (filtered.length > MAX_ENTRIES) filtered.length = MAX_ENTRIES;
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(filtered));
+  } catch {
+    // localStorage full or unavailable — ignore
+  }
+}
+
+/**
+ * Returns workspace IDs ordered by most-recently-accessed first.
+ */
+export function getRecentWorkspaceOrder(): string[] {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    if (Array.isArray(parsed)) return parsed;
+  } catch {
+    // Corrupted data — ignore
+  }
+  return [];
+}


### PR DESCRIPTION
## Summary

- Adds a **Ctrl+R** keyboard shortcut that opens a quick workspace picker dialog for fast switching between workspaces
- Workspaces shown in a flat list sorted by **most recently accessed** (persisted in localStorage across sessions)
- Each entry displayed as `project/branch` with agent status indicator and "current" badge
- Fuzzy search filtering by project name or branch name using cmdk Command palette

## Changes

- **New:** `WorkspacePickerDialog` component (`packages/dashboard-core`)
- **New:** `recent-workspaces.ts` localStorage utility for tracking workspace access order
- **Modified:** `DockviewInstanceManager` — records workspace access on every switch
- **Modified:** `DockviewWorkspaceLayout` — Ctrl+R shortcut handler + dialog rendering

## Test plan

- [ ] Press Ctrl+R in a workspace — picker dialog opens, browser does NOT reload
- [ ] Cmd+R on macOS still triggers browser reload (only Ctrl+R opens picker)
- [ ] Search input is auto-focused, type to filter by project or branch name
- [ ] Arrow keys navigate, Enter selects, Escape closes
- [ ] Selecting a workspace navigates to it
- [ ] Workspaces are sorted by most recently accessed (switch between a few, reopen picker)
- [ ] Current workspace shows "current" label

🤖 Generated with [Claude Code](https://claude.com/claude-code)