### PR TITLE
feat: add Cmd+Shift+P command palette

### DIFF
--- a/apps/web/src/components/DockviewWorkspaceLayout.tsx
+++ b/apps/web/src/components/DockviewWorkspaceLayout.tsx
@@ -1,4 +1,6 @@
 import {
+  buildCommands,
+  CommandPaletteDialog,
   type DiffStats,
   DiffView,
   parseFileLocation,
@@ -601,6 +603,7 @@ export const DockviewWorkspaceLayout = memo(function DockviewWorkspaceLayout({
   const [quickOpenOpen, setQuickOpenOpen] = useState(false);
   const [quickOpenQuery, setQuickOpenQuery] = useState<string | undefined>(undefined);
   const [searchFilesOpen, setSearchFilesOpen] = useState(false);
+  const [commandPaletteOpen, setCommandPaletteOpen] = useState(false);
 
   // Find-in-file: active panel registers its search callback here
   const findInFileRef = useRef<(() => void) | null>(null);
@@ -634,6 +637,25 @@ export const DockviewWorkspaceLayout = memo(function DockviewWorkspaceLayout({
     setCurrentFile(filePath ?? undefined);
   }, []);
 
+  // Command palette: central command registry for Cmd+Shift+P
+  const paletteCommands = useMemo(
+    () =>
+      buildCommands({
+        getApi: () => apiRef.current,
+        getHiddenPanels: () => hiddenPanelsRef.current,
+        openQuickOpen: () => setQuickOpenOpen(true),
+        openSearchFiles: () => setSearchFilesOpen(true),
+        findInFile: () => {
+          if (findInFileRef.current) {
+            findInFileRef.current();
+          } else {
+            window.dispatchEvent(new CustomEvent("band:find-in-file"));
+          }
+        },
+      }),
+    [],
+  );
+
   // Global keyboard shortcuts (capture phase) — only active for the visible workspace
   useEffect(() => {
     if (!isActive) return;
@@ -653,7 +675,10 @@ export const DockviewWorkspaceLayout = memo(function DockviewWorkspaceLayout({
       const api = apiRef.current;
       const key = e.key.toLowerCase();
 
-      if (key === "p" && !e.shiftKey) {
+      if (key === "p" && e.shiftKey) {
+        e.preventDefault();
+        setCommandPaletteOpen(true);
+      } else if (key === "p" && !e.shiftKey) {
         e.preventDefault();
         setQuickOpenOpen(true);
       } else if (key === "f" && e.shiftKey) {
@@ -1070,7 +1095,7 @@ export const DockviewWorkspaceLayout = memo(function DockviewWorkspaceLayout({
   // With multi-tab browsers, we hide/show ALL webviews for this workspace.
   useEffect(() => {
     if (!isTauri) return;
-    const isDialogOpen = quickOpenOpen || searchFilesOpen;
+    const isDialogOpen = quickOpenOpen || searchFilesOpen || commandPaletteOpen;
 
     (async () => {
       const { invoke } = await import("@tauri-apps/api/core");
@@ -1084,7 +1109,7 @@ export const DockviewWorkspaceLayout = memo(function DockviewWorkspaceLayout({
         }
       }
     })();
-  }, [quickOpenOpen, searchFilesOpen, workspaceId]);
+  }, [quickOpenOpen, searchFilesOpen, commandPaletteOpen, workspaceId]);
 
   return (
     <>
@@ -1116,6 +1141,11 @@ export const DockviewWorkspaceLayout = memo(function DockviewWorkspaceLayout({
         open={searchFilesOpen}
         onOpenChange={setSearchFilesOpen}
         onOpenFile={handleOpenFile}
+      />
+      <CommandPaletteDialog
+        open={commandPaletteOpen}
+        onOpenChange={setCommandPaletteOpen}
+        commands={paletteCommands}
       />
     </>
   );

--- a/packages/dashboard-core/src/components/CommandPaletteDialog.tsx
+++ b/packages/dashboard-core/src/components/CommandPaletteDialog.tsx
@@ -1,0 +1,58 @@
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+  CommandShortcut,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@band-app/ui";
+import { useCallback } from "react";
+import { formatShortcut, type PaletteCommand } from "../lib/command-registry";
+
+interface CommandPaletteDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  commands: PaletteCommand[];
+}
+
+export function CommandPaletteDialog({ open, onOpenChange, commands }: CommandPaletteDialogProps) {
+  const handleSelect = useCallback(
+    (cmd: PaletteCommand) => {
+      onOpenChange(false);
+      // Run the action after the dialog closes to avoid focus conflicts
+      requestAnimationFrame(() => cmd.action());
+    },
+    [onOpenChange],
+  );
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="overflow-hidden p-0 sm:max-w-[520px]" showCloseButton={false}>
+        <DialogHeader className="sr-only">
+          <DialogTitle>Command Palette</DialogTitle>
+          <DialogDescription>Search for a command to run</DialogDescription>
+        </DialogHeader>
+        <Command>
+          <CommandInput placeholder="Search commands..." />
+          <CommandList className="max-h-[360px]">
+            <CommandEmpty>No commands found.</CommandEmpty>
+            <CommandGroup>
+              {commands.map((cmd) => (
+                <CommandItem key={cmd.id} value={cmd.label} onSelect={() => handleSelect(cmd)}>
+                  <span className="text-sm">{cmd.label}</span>
+                  <CommandShortcut>{formatShortcut(cmd.shortcut)}</CommandShortcut>
+                </CommandItem>
+              ))}
+            </CommandGroup>
+          </CommandList>
+        </Command>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/packages/dashboard-core/src/index.ts
+++ b/packages/dashboard-core/src/index.ts
@@ -9,6 +9,7 @@ export { AgentIcon, ClaudeIcon, CodexIcon } from "./components/agent-icons";
 export { CIStatusIndicator } from "./components/CIStatusIndicator";
 export { CodeMirrorEditor } from "./components/CodeMirrorEditor";
 export { CodeMirrorViewer } from "./components/CodeMirrorViewer";
+export { CommandPaletteDialog } from "./components/CommandPaletteDialog";
 export { DashboardShell } from "./components/DashboardShell";
 export { type DiffStats, DiffView } from "./components/DiffView";
 export { FileBrowser } from "./components/FileBrowser";
@@ -75,6 +76,8 @@ export {
   scrollToSearchMatch,
   serializeEditorState,
 } from "./lib/codemirror-setup";
+export type { CommandRegistryDeps, PaletteCommand } from "./lib/command-registry";
+export { buildCommands, formatShortcut, isMacPlatform } from "./lib/command-registry";
 export { getFileIcon } from "./lib/file-icon";
 export { type FileLocation, formatFileLocation, parseFileLocation } from "./lib/file-location";
 export { type FilePreviewType, getFilePreviewType } from "./lib/file-type";

--- a/packages/dashboard-core/src/lib/command-registry.ts
+++ b/packages/dashboard-core/src/lib/command-registry.ts
@@ -1,0 +1,149 @@
+/**
+ * Central command registry for the command palette (Cmd+Shift+P).
+ *
+ * All palette-visible commands are defined here so they can be referenced by
+ * both the CommandPaletteDialog component and the keyboard shortcut handler.
+ */
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface PaletteCommand {
+  /** Unique identifier for the command. */
+  id: string;
+  /** Human-readable label shown in the palette. */
+  label: string;
+  /**
+   * Canonical keyboard shortcut string.
+   * Use `Cmd+` for the platform modifier (⌘ on Mac, Ctrl elsewhere).
+   * Examples: `"Cmd+P"`, `"Cmd+Shift+F"`, `"Shift+Tab"`.
+   */
+  shortcut: string;
+  /** Callback executed when the command is selected. */
+  action: () => void;
+}
+
+export interface CommandRegistryDeps {
+  /** Returns the current DockviewApi (reads from a ref at call time). */
+  getApi: () => { getPanel(id: string): { api: { setActive(): void } } | undefined } | null;
+  /** Returns the current list of hidden panel ids (reads from a ref). */
+  getHiddenPanels: () => string[];
+  /** Open the Quick Open dialog. */
+  openQuickOpen: () => void;
+  /** Open the Search Files dialog. */
+  openSearchFiles: () => void;
+  /** Trigger find-in-file for the active editor. */
+  findInFile: () => void;
+}
+
+// ---------------------------------------------------------------------------
+// Platform detection
+// ---------------------------------------------------------------------------
+
+export function isMacPlatform(): boolean {
+  if (typeof navigator === "undefined") return false;
+  // Prefer the modern User-Agent Client Hints API when available
+  const ua = navigator as Navigator & {
+    userAgentData?: { platform?: string };
+  };
+  if (ua.userAgentData?.platform) {
+    return ua.userAgentData.platform === "macOS";
+  }
+  return /Mac|iPhone|iPad|iPod/.test(navigator.platform ?? "");
+}
+
+// ---------------------------------------------------------------------------
+// Shortcut formatting
+// ---------------------------------------------------------------------------
+
+/**
+ * Convert a canonical shortcut string to a platform-appropriate display string.
+ *
+ * On macOS: `Cmd+` → `⌘`, `Shift+` → `⇧`, `Alt+` → `⌥`
+ * On others: `Cmd+` → `Ctrl+`
+ */
+export function formatShortcut(shortcut: string): string {
+  const mac = isMacPlatform();
+  if (mac) {
+    return shortcut
+      .replace(/Cmd\+/g, "⌘")
+      .replace(/Shift\+/g, "⇧")
+      .replace(/Alt\+/g, "⌥");
+  }
+  return shortcut.replace(/Cmd\+/g, "Ctrl+");
+}
+
+// ---------------------------------------------------------------------------
+// Command builder
+// ---------------------------------------------------------------------------
+
+function activatePanel(deps: CommandRegistryDeps, panelId: string): void {
+  if (deps.getHiddenPanels().includes(panelId)) return;
+  deps.getApi()?.getPanel(panelId)?.api.setActive();
+}
+
+export function buildCommands(deps: CommandRegistryDeps): PaletteCommand[] {
+  return [
+    {
+      id: "quick-open",
+      label: "Quick Open",
+      shortcut: "Cmd+P",
+      action: () => deps.openQuickOpen(),
+    },
+    {
+      id: "search-files",
+      label: "Search in Files",
+      shortcut: "Cmd+Shift+F",
+      action: () => deps.openSearchFiles(),
+    },
+    {
+      id: "find-in-file",
+      label: "Find in File",
+      shortcut: "Cmd+F",
+      action: () => deps.findInFile(),
+    },
+    {
+      id: "show-changes",
+      label: "Show Changes",
+      shortcut: "Cmd+E",
+      action: () => activatePanel(deps, "changes"),
+    },
+    {
+      id: "show-terminal",
+      label: "Show Terminal",
+      shortcut: "Cmd+J",
+      action: () => activatePanel(deps, "terminal"),
+    },
+    {
+      id: "show-files",
+      label: "Show Files",
+      shortcut: "Cmd+G",
+      action: () => activatePanel(deps, "files"),
+    },
+    {
+      id: "show-browser",
+      label: "Show Browser",
+      shortcut: "Cmd+B",
+      action: () => activatePanel(deps, "browser"),
+    },
+    {
+      id: "editor-go-back",
+      label: "Go Back",
+      shortcut: "Cmd+-",
+      action: () => window.dispatchEvent(new CustomEvent("band:editor-go-back")),
+    },
+    {
+      id: "editor-go-forward",
+      label: "Go Forward",
+      shortcut: "Cmd+Shift+-",
+      action: () => window.dispatchEvent(new CustomEvent("band:editor-go-forward")),
+    },
+    {
+      id: "toggle-mode",
+      label: "Toggle Edit/Plan Mode",
+      shortcut: "Shift+Tab",
+      action: () => window.dispatchEvent(new CustomEvent("band:toggle-mode")),
+    },
+  ];
+}


### PR DESCRIPTION
## Summary

- Adds a **command palette** dialog triggered by `Cmd+Shift+P` (or `Ctrl+Shift+P` on non-Mac) that lists all available keyboard shortcuts and actions
- Introduces a **central command registry** (`command-registry.ts`) defining all 10 palette commands with their shortcuts and actions, making it easy to add new commands later
- Uses cmdk's built-in fuzzy search for filtering and the existing `CommandShortcut` UI component for displaying platform-appropriate shortcut labels (⌘⇧F on Mac, Ctrl+Shift+F elsewhere)

## Test plan

- [ ] Press `Cmd+Shift+P` — command palette dialog opens
- [ ] Type to filter commands (fuzzy matching works)
- [ ] Select a command with Enter or mouse click — command executes, palette closes
- [ ] Press Escape — palette closes
- [ ] Verify `Cmd+P` still opens Quick Open (not intercepted)
- [ ] Verify all listed shortcuts still work independently
- [ ] On non-Mac, shortcuts display as `Ctrl+` instead of `⌘`

🤖 Generated with [Claude Code](https://claude.com/claude-code)