### PR TITLE
feat: improve Search Files dialog UX

### DIFF
--- a/packages/dashboard-core/src/components/SearchBar.tsx
+++ b/packages/dashboard-core/src/components/SearchBar.tsx
@@ -106,7 +106,7 @@ export const SearchBar = forwardRef<SearchBarHandle, SearchBarProps>(function Se
         value={query}
         onChange={(e) => onQueryChange(e.target.value)}
         onKeyDown={(e) => {
-          if (e.key === "Enter") {
+          if (e.key === "Enter" && (onNext || onPrevious)) {
             e.preventDefault();
             if (e.shiftKey) onPrevious?.();
             else onNext?.();

--- a/packages/dashboard-core/src/components/SearchFilesDialog.tsx
+++ b/packages/dashboard-core/src/components/SearchFilesDialog.tsx
@@ -38,6 +38,7 @@ export function SearchFilesDialog({
     regex: false,
   });
   const [results, setResults] = useState<ContentSearchMatch[]>([]);
+  const [selectedValue, setSelectedValue] = useState("");
   const [loading, setLoading] = useState(false);
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const searchBarRef = useRef<SearchBarHandle>(null);
@@ -77,13 +78,13 @@ export function SearchFilesDialog({
     };
   }, [adapter, workspaceId, query, searchOptions, open]);
 
-  // Reset on close, auto-focus on open
+  // Auto-focus and select text on open so typing replaces previous query
   useEffect(() => {
-    if (!open) {
-      setQuery("");
-      setResults([]);
-    } else {
-      requestAnimationFrame(() => searchBarRef.current?.focus());
+    if (open) {
+      requestAnimationFrame(() => {
+        searchBarRef.current?.focus();
+        searchBarRef.current?.select();
+      });
     }
   }, [open]);
 
@@ -97,6 +98,28 @@ export function SearchFilesDialog({
     }
     return Array.from(map.entries());
   }, [results]);
+
+  // Auto-select the first result only when the current selection is no longer valid
+  const selectedValueRef = useRef(selectedValue);
+  selectedValueRef.current = selectedValue;
+
+  useEffect(() => {
+    if (grouped.length > 0) {
+      const current = selectedValueRef.current;
+      const stillValid =
+        current &&
+        grouped.some(([file, matches]) =>
+          matches.some((m) => `${file}:${m.line}:${m.content}` === current),
+        );
+      if (!stillValid) {
+        const [file, matches] = grouped[0];
+        const first = matches[0];
+        setSelectedValue(`${file}:${first.line}:${first.content}`);
+      }
+    } else {
+      setSelectedValue("");
+    }
+  }, [grouped]);
 
   const handleSelect = useCallback(
     (filePath: string, line: number) => {
@@ -115,7 +138,7 @@ export function SearchFilesDialog({
           <DialogTitle>Search in Files</DialogTitle>
           <DialogDescription>Text search across workspace files</DialogDescription>
         </DialogHeader>
-        <Command shouldFilter={false}>
+        <Command shouldFilter={false} value={selectedValue} onValueChange={setSelectedValue}>
           <SearchBar
             ref={searchBarRef}
             query={query}


### PR DESCRIPTION
## Summary
- **Remember last search query:** When the Search Files dialog (Cmd+Shift+F) is reopened, the previous query and results are preserved. Text is pre-selected so typing immediately replaces it.
- **Auto-select first result:** When search results appear, the first result is always highlighted so Enter immediately navigates to that file and line. Selection is preserved across dialog reopens.
- **Fix Enter key navigation:** SearchBar no longer swallows Enter when no navigation callbacks are provided, allowing cmdk to handle item selection.

## Test plan
- [ ] Open Search Files (Cmd+Shift+F), type a query, see results, close the dialog
- [ ] Reopen — query should be pre-filled and selected; results should reappear
- [ ] Type a new query — should replace the pre-selected text
- [ ] When results appear, first result should be highlighted
- [ ] Press Enter — should navigate to the highlighted file and line
- [ ] Navigate with arrow keys, close dialog, reopen — selection should be preserved
- [ ] Verify in-file search bar (Cmd+F) still works correctly with Enter for next match

🤖 Generated with [Claude Code](https://claude.com/claude-code)