### PR TITLE
Improve Quick Open with recent files and last query persistence

### DIFF
--- a/apps/web/src/components/DockviewWorkspaceLayout.tsx
+++ b/apps/web/src/components/DockviewWorkspaceLayout.tsx
@@ -25,6 +25,7 @@ import {
   Terminal as TerminalIcon,
 } from "lucide-react";
 import { lazy, memo, Suspense, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useRecentFiles } from "../hooks/useRecentFiles";
 import { isTauri } from "../lib/is-tauri";
 import { trpc } from "../lib/trpc-client";
 import { useWsActive } from "../lib/workspace-visibility-store";
@@ -604,6 +605,10 @@ export const DockviewWorkspaceLayout = memo(function DockviewWorkspaceLayout({
   const [quickOpenQuery, setQuickOpenQuery] = useState<string | undefined>(undefined);
   const [searchFilesOpen, setSearchFilesOpen] = useState(false);
   const [commandPaletteOpen, setCommandPaletteOpen] = useState(false);
+  const [lastQuickOpenQuery, setLastQuickOpenQuery] = useState("");
+
+  // Recent files tracking
+  const { recentFiles, trackFile } = useRecentFiles(workspaceId);
 
   // Find-in-file: active panel registers its search callback here
   const findInFileRef = useRef<(() => void) | null>(null);
@@ -617,25 +622,33 @@ export const DockviewWorkspaceLayout = memo(function DockviewWorkspaceLayout({
   }, []);
 
   // Open file from Changes panel or dialogs → activate Files panel
-  const handleOpenFile = useCallback((filename: string) => {
-    // Store clean path (without line refs) as currentFile so that
-    // go-to-line (:N) in quick open works correctly.
-    const cleanPath = parseFileLocation(filename).filePath;
-    setCurrentFile(cleanPath);
-    setOpenFilePath(filename);
-    const api = apiRef.current;
-    if (api) {
-      api.getPanel("files")?.api.setActive();
-    }
-  }, []);
+  const handleOpenFile = useCallback(
+    (filename: string) => {
+      // Store clean path (without line refs) as currentFile so that
+      // go-to-line (:N) in quick open works correctly.
+      const cleanPath = parseFileLocation(filename).filePath;
+      setCurrentFile(cleanPath);
+      setOpenFilePath(filename);
+      trackFile(cleanPath);
+      const api = apiRef.current;
+      if (api) {
+        api.getPanel("files")?.api.setActive();
+      }
+    },
+    [trackFile],
+  );
 
   const handleFileOpened = useCallback(() => {
     setOpenFilePath(null);
   }, []);
 
-  const handleSelectFile = useCallback((filePath: string | null) => {
-    setCurrentFile(filePath ?? undefined);
-  }, []);
+  const handleSelectFile = useCallback(
+    (filePath: string | null) => {
+      setCurrentFile(filePath ?? undefined);
+      if (filePath) trackFile(filePath);
+    },
+    [trackFile],
+  );
 
   // Command palette: central command registry for Cmd+Shift+P
   const paletteCommands = useMemo(
@@ -1151,6 +1164,9 @@ export const DockviewWorkspaceLayout = memo(function DockviewWorkspaceLayout({
         currentFile={currentFile}
         initialQuery={quickOpenQuery}
         autoOpen={quickOpenQuery != null}
+        recentFiles={recentFiles}
+        lastQuery={lastQuickOpenQuery}
+        onQueryChange={setLastQuickOpenQuery}
       />
       <SearchFilesDialog
         workspaceId={workspaceId}

--- a/apps/web/src/hooks/useRecentFiles.ts
+++ b/apps/web/src/hooks/useRecentFiles.ts
@@ -1,0 +1,51 @@
+import { useCallback, useEffect, useState } from "react";
+
+// ---------------------------------------------------------------------------
+// Module-level store — survives React remounts, cleared on page reload.
+// ---------------------------------------------------------------------------
+
+const MAX_RECENT = 50;
+
+/** workspaceId → ordered list of file paths (most-recent-first) */
+const recentFilesMap = new Map<string, string[]>();
+
+function getRecent(workspaceId: string): string[] {
+  return recentFilesMap.get(workspaceId) ?? [];
+}
+
+function addRecent(workspaceId: string, filePath: string): string[] {
+  const list = getRecent(workspaceId).filter((f) => f !== filePath);
+  list.unshift(filePath);
+  if (list.length > MAX_RECENT) list.length = MAX_RECENT;
+  recentFilesMap.set(workspaceId, list);
+  return list;
+}
+
+// ---------------------------------------------------------------------------
+// Hook
+// ---------------------------------------------------------------------------
+
+export interface UseRecentFilesReturn {
+  recentFiles: string[];
+  trackFile: (filePath: string) => void;
+}
+
+export function useRecentFiles(workspaceId: string): UseRecentFilesReturn {
+  const [recentFiles, setRecentFiles] = useState<string[]>(() => getRecent(workspaceId));
+
+  // Re-sync when workspace changes
+  useEffect(() => {
+    setRecentFiles(getRecent(workspaceId));
+  }, [workspaceId]);
+
+  const trackFile = useCallback(
+    (filePath: string) => {
+      if (!filePath) return;
+      const updated = addRecent(workspaceId, filePath);
+      setRecentFiles(updated);
+    },
+    [workspaceId],
+  );
+
+  return { recentFiles, trackFile };
+}

--- a/packages/dashboard-core/src/components/QuickOpenDialog.tsx
+++ b/packages/dashboard-core/src/components/QuickOpenDialog.tsx
@@ -28,6 +28,12 @@ interface QuickOpenDialogProps {
   /** When true and only one result is found, auto-open it without showing
    *  the dialog. The dialog is still shown if there are 0 or 2+ results. */
   autoOpen?: boolean;
+  /** Recently accessed files, shown when the search query is empty. */
+  recentFiles?: string[];
+  /** The last search query, restored when the dialog opens (lower priority than initialQuery). */
+  lastQuery?: string;
+  /** Called on close with the current query so the parent can persist it. */
+  onQueryChange?: (query: string) => void;
 }
 
 export function QuickOpenDialog({
@@ -38,6 +44,9 @@ export function QuickOpenDialog({
   currentFile,
   initialQuery,
   autoOpen,
+  recentFiles,
+  lastQuery,
+  onQueryChange,
 }: QuickOpenDialogProps) {
   const adapter = useAdapter();
   const [query, setQuery] = useState("");
@@ -50,22 +59,44 @@ export function QuickOpenDialog({
   // (when `loading` is still its initial `false` value).
   const searchResolved = useRef(false);
 
-  // Seed query from initialQuery when the dialog opens
+  // Seed query from initialQuery (chat links) or lastQuery when the dialog opens
   useEffect(() => {
-    if (open && initialQuery) {
-      setQuery(initialQuery);
+    if (open) {
+      if (initialQuery) {
+        setQuery(initialQuery);
+      } else if (lastQuery) {
+        setQuery(lastQuery);
+        // Select all text so typing immediately replaces it.
+        // Use requestAnimationFrame to ensure the input is rendered and focused.
+        requestAnimationFrame(() => {
+          const input = document.querySelector<HTMLInputElement>('[data-slot="command-input"]');
+          input?.select();
+        });
+      }
     }
-  }, [open, initialQuery]);
+  }, [open, initialQuery, lastQuery]);
 
   // Parse line/column reference from the query (e.g. "src/main.rs:42" -> line 42)
   const parsedQuery = useMemo(() => parseFileLocation(query), [query]);
   const searchQuery = parsedQuery.filePath;
+
+  // Whether to show recent files instead of searching
+  const showRecent =
+    searchQuery === "" && parsedQuery.line == null && recentFiles && recentFiles.length > 0;
 
   useEffect(() => {
     if (!open || !adapter.searchWorkspaceFiles) return;
 
     // Skip file search when the query is a pure go-to-line (":42")
     if (searchQuery === "" && parsedQuery.line != null) {
+      setFiles([]);
+      setLoading(false);
+      searchResolved.current = true;
+      return;
+    }
+
+    // When query is empty and we have recent files, skip the server search
+    if (showRecent) {
       setFiles([]);
       setLoading(false);
       searchResolved.current = true;
@@ -96,7 +127,7 @@ export function QuickOpenDialog({
       cancelled = true;
       if (debounceRef.current) clearTimeout(debounceRef.current);
     };
-  }, [adapter, workspaceId, searchQuery, parsedQuery.line, open]);
+  }, [adapter, workspaceId, searchQuery, parsedQuery.line, open, showRecent]);
 
   // Auto-open: wait for the initial search to resolve, then either open the
   // single result directly or reveal the dialog for the user to pick.
@@ -133,15 +164,23 @@ export function QuickOpenDialog({
     }
   }, [autoOpen, files, open, parsedQuery, onOpenFile, onOpenChange]);
 
-  // Reset on close
+  // Keep a ref to the current query so the close effect can read it without depending on it
+  const queryRef = useRef(query);
+  queryRef.current = query;
+
+  // Reset on close — persist the last query first
   useEffect(() => {
     if (!open) {
+      // Save the current query before clearing so the parent can restore it
+      // on next open. We read from a ref to avoid adding `query` to deps
+      // (which would fire this effect on every keystroke).
+      onQueryChange?.(queryRef.current);
       setQuery("");
       setFiles([]);
       autoOpened.current = false;
       searchResolved.current = false;
     }
-  }, [open]);
+  }, [open, onQueryChange]);
 
   // "Go to line in current file" — when query is just ":N" with no filename
   const isGoToLine = parsedQuery.filePath === "" && parsedQuery.line != null;
@@ -167,6 +206,10 @@ export function QuickOpenDialog({
     },
     [onOpenFile, onOpenChange, parsedQuery],
   );
+
+  // The list of files to render: recent files when query is empty, search results otherwise
+  const displayFiles = showRecent ? recentFiles : files;
+  const groupHeading = showRecent ? "Recent files" : undefined;
 
   return (
     <Dialog open={open && dialogVisible} onOpenChange={onOpenChange}>
@@ -204,8 +247,8 @@ export function QuickOpenDialog({
             ) : (
               <>
                 <CommandEmpty>{loading ? "Searching..." : "No files found."}</CommandEmpty>
-                <CommandGroup>
-                  {files.map((file) => {
+                <CommandGroup heading={groupHeading}>
+                  {displayFiles.map((file) => {
                     const fileName = file.split("/").pop() || file;
                     const Icon = getFileIcon(fileName);
                     return (


### PR DESCRIPTION
## Summary

- Show recently accessed files (sorted by recency) when the Quick Open dialog search input is empty
- Remember the last search query across dialog opens, pre-filled and selected so typing replaces it
- Track file access across all entry points: Quick Open, Search in Files, chat links, file tree, and tab switches

## Changes

- **New `useRecentFiles` hook** (`apps/web/src/hooks/useRecentFiles.ts`): Module-level Map stores up to 50 recently accessed files per workspace (in-memory, survives React remounts)
- **`QuickOpenDialog`**: Three new optional props (`recentFiles`, `lastQuery`, `onQueryChange`). Displays recent files when query is empty, restores last query on open with select-all
- **`DockviewWorkspaceLayout`**: Wires recent file tracking into `handleOpenFile` and `handleSelectFile` callbacks, passes state to QuickOpenDialog

## Test plan

- [ ] Open several files via file tree, Quick Open, and Search in Files
- [ ] Press Cmd+P with empty input — verify recent files appear sorted by recency
- [ ] Type a query, select a file, reopen Cmd+P — verify last query is pre-filled and selected
- [ ] Type over the selected text — verify it replaces immediately
- [ ] Test chat file links still auto-open correctly
- [ ] Verify go-to-line (`:42`) still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)