### PR TITLE
fix: let terminal handle Ctrl+key shortcuts when xterm is focused

### DIFF
--- a/apps/web/src/components/DockviewWorkspaceLayout.tsx
+++ b/apps/web/src/components/DockviewWorkspaceLayout.tsx
@@ -676,16 +676,26 @@ export const DockviewWorkspaceLayout = memo(function DockviewWorkspaceLayout({
     if (!isActive) return;
 
     const handler = (e: KeyboardEvent) => {
-      // Shift+Tab → toggle mode (Edit/Plan)
+      // When the terminal (xterm) is focused, let most keyboard shortcuts
+      // pass through so the shell receives them — e.g. Ctrl+R (reverse
+      // search), Ctrl+C (SIGINT), Ctrl+D (EOF), Ctrl+L (clear),
+      // Ctrl+A/E (line navigation), Ctrl+K (kill line), etc.
+      // Only Meta/Cmd-based shortcuts (Cmd+P, Cmd+Shift+P, …) are still
+      // handled at the app level when the terminal has focus.
+      const terminalFocused = document.activeElement?.closest(".xterm") != null;
+
+      // Shift+Tab → toggle mode (Edit/Plan) — skip when terminal focused
       if (e.key === "Tab" && e.shiftKey && !e.ctrlKey && !e.metaKey) {
+        if (terminalFocused) return;
         e.preventDefault();
         e.stopPropagation();
         window.dispatchEvent(new CustomEvent("band:toggle-mode"));
         return;
       }
 
-      // Ctrl+R (not Cmd+R) → workspace picker — on both macOS and Windows
+      // Ctrl+R (not Cmd+R) → workspace picker — skip when terminal focused
       if (e.ctrlKey && !e.metaKey && e.key.toLowerCase() === "r" && !e.shiftKey) {
+        if (terminalFocused) return;
         e.preventDefault();
         e.stopPropagation();
         setWorkspacePickerOpen(true);
@@ -708,8 +718,11 @@ export const DockviewWorkspaceLayout = memo(function DockviewWorkspaceLayout({
         return;
       }
 
+      // When terminal is focused, only handle Meta/Cmd-modified shortcuts.
+      // All plain Ctrl+key combos pass through to the terminal.
       const mod = e.metaKey || e.ctrlKey;
       if (!mod) return;
+      if (terminalFocused && !e.metaKey) return;
 
       const api = apiRef.current;
       const key = e.key.toLowerCase();


### PR DESCRIPTION
## Summary
- App-level keyboard shortcuts (Ctrl+R, Shift+Tab, Ctrl+letter combos) were intercepting keypresses before the terminal could handle them, making bash reverse search, SIGINT, EOF, line navigation etc. unusable
- Added terminal focus detection (`document.activeElement?.closest(".xterm")`) to the capture-phase keydown handler in `DockviewWorkspaceLayout.tsx`
- When xterm is focused: Ctrl-only shortcuts pass through to the terminal; Meta/Cmd shortcuts (Cmd+P, Cmd+Shift+P, etc.) still work at the app level

## Test plan
- [ ] Focus terminal, press Ctrl+R → bash reverse history search works (not workspace picker)
- [ ] Focus terminal, press Ctrl+C → sends SIGINT (not intercepted)
- [ ] Focus terminal, press Ctrl+D → sends EOF
- [ ] Focus terminal, press Ctrl+L → clears terminal
- [ ] Focus terminal, press Ctrl+A / Ctrl+E → cursor moves to beginning/end of line
- [ ] Focus terminal, press Cmd+P → quick open still works
- [ ] Focus terminal, press Cmd+Shift+P → command palette still works
- [ ] Focus terminal, press Cmd+J → terminal panel activation still works
- [ ] Focus non-terminal area, press Ctrl+R → workspace picker opens as before
- [ ] Focus non-terminal area, Shift+Tab → toggles mode as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)