### PR TITLE
feat: add keyboard shortcuts to all dockview containers

### DIFF
--- a/apps/web/src/components/DockviewBrowserContainer.tsx
+++ b/apps/web/src/components/DockviewBrowserContainer.tsx
@@ -9,7 +9,7 @@ import {
   type IDockviewPanelHeaderProps,
   type IDockviewPanelProps,
 } from "dockview";
-import { Globe, Plus, X } from "lucide-react";
+import { Columns2, Globe, Plus, Rows2, X } from "lucide-react";
 import React, {
   createContext,
   useCallback,
@@ -265,9 +265,12 @@ function BrowserTab(props: IDockviewPanelHeaderProps<BrowserTabParams>) {
 // ---------------------------------------------------------------------------
 
 const addTabRef: {
-  current: { onAdd: (groupId?: string) => void };
+  current: {
+    onAdd: (groupId?: string) => void;
+    onSplit: (groupId: string, direction: "right" | "below") => void;
+  };
 } = {
-  current: { onAdd: () => {} },
+  current: { onAdd: () => {}, onSplit: () => {} },
 };
 
 /** Shared ref for the close-tab action — used by BrowserTab's close button. */
@@ -286,6 +289,22 @@ const RightHeaderActions = React.memo(function RightHeaderActions(
   const groupId = props.group.id;
   return (
     <div className="flex items-center">
+      <button
+        type="button"
+        className="inline-flex size-8 items-center justify-center text-muted-foreground hover:text-foreground hover:bg-accent rounded transition-colors"
+        onClick={() => addTabRef.current.onSplit(groupId, "right")}
+        title="Split right"
+      >
+        <Columns2 className="size-3.5" />
+      </button>
+      <button
+        type="button"
+        className="inline-flex size-8 items-center justify-center text-muted-foreground hover:text-foreground hover:bg-accent rounded transition-colors"
+        onClick={() => addTabRef.current.onSplit(groupId, "below")}
+        title="Split down"
+      >
+        <Rows2 className="size-3.5" />
+      </button>
       <button
         type="button"
         className="inline-flex size-8 items-center justify-center text-muted-foreground hover:text-foreground hover:bg-accent rounded transition-colors"
@@ -335,6 +354,7 @@ export function DockviewBrowserContainer({
   const queryClient = useQueryClient();
   const apiRef = useRef<DockviewApi | null>(null);
   const isRestoringRef = useRef(false);
+  const containerRef = useRef<HTMLDivElement>(null);
 
   // Fetch layout AND browser records via React Query — cached across mounts
   // so re-visiting a workspace renders instantly from the cache.
@@ -404,6 +424,39 @@ export function DockviewBrowserContainer({
     [workspaceId],
   );
 
+  const handleSplit = useCallback(
+    async (groupId: string, direction: "right" | "below") => {
+      const api = apiRef.current;
+      if (!api) return;
+
+      const browserId = newBrowserId();
+      markBrowserFresh(browserId);
+
+      // Create the server-side browser record BEFORE adding the panel
+      try {
+        await trpc.browsers.create.mutate({ workspaceId, id: browserId });
+      } catch (err) {
+        console.error("[DockviewBrowserContainer] error creating split browser:", err);
+      }
+
+      api.addPanel({
+        id: browserId,
+        component: "browserTab",
+        tabComponent: "browserTab",
+        title: "New Tab",
+        params: {
+          workspaceId,
+          browserId,
+        },
+        position: {
+          referenceGroup: groupId,
+          direction,
+        },
+      } as Parameters<typeof api.addPanel>[0]);
+    },
+    [workspaceId],
+  );
+
   const closeTab = useCallback((browserId: string) => {
     const api = apiRef.current;
     if (!api || api.panels.length <= 1) return; // don't close last tab
@@ -420,12 +473,59 @@ export function DockviewBrowserContainer({
     // Layout change listeners will auto-persist
   }, []);
 
-  // Cmd/Ctrl+W → close the active browser tab
+  // Keyboard shortcuts:
+  // - Cmd/Ctrl+T → open a new browser tab
+  // - Cmd/Ctrl+W → close the active browser tab
+  // - Cmd/Ctrl+D → split right (vertical split)
+  // - Cmd/Ctrl+Shift+D → split down (horizontal split)
+  // - Cmd/Ctrl+R → reload the active browser tab (Tauri only)
+  // - Ctrl+(Shift)+Tab → cycle through tabs in the active group
   useEffect(() => {
     if (!visible) return;
     const handler = (e: KeyboardEvent) => {
+      // Only handle shortcut if this container (or a descendant) has focus
+      if (!containerRef.current?.contains(document.activeElement)) return;
+
+      const key = e.key.toLowerCase();
+
+      // Ctrl+(Shift)+Tab → cycle tabs within the active group
+      if (e.ctrlKey && !e.metaKey && key === "tab") {
+        e.preventDefault();
+        e.stopPropagation();
+        const api = apiRef.current;
+        const group = api?.activeGroup;
+        if (!group) return;
+        if (e.shiftKey) {
+          group.model.moveToPrevious();
+        } else {
+          group.model.moveToNext();
+        }
+        // Focus the address bar in the newly active panel.
+        requestAnimationFrame(() => {
+          const panel = api.activePanel;
+          if (!panel) return;
+          panel.view.content.element.querySelector<HTMLInputElement>("input[type='text']")?.focus();
+        });
+        return;
+      }
+
       const mod = e.metaKey || e.ctrlKey;
-      if (mod && e.key.toLowerCase() === "w" && !e.shiftKey) {
+      if (!mod) return;
+
+      if (key === "t" && !e.shiftKey) {
+        e.preventDefault();
+        e.stopPropagation();
+        handleAddTab().then(() => {
+          // Focus the address bar in the newly created panel.
+          requestAnimationFrame(() => {
+            const panel = apiRef.current?.activePanel;
+            if (!panel) return;
+            panel.view.content.element
+              .querySelector<HTMLInputElement>("input[type='text']")
+              ?.focus();
+          });
+        });
+      } else if (key === "w" && !e.shiftKey) {
         const api = apiRef.current;
         if (!api || api.panels.length <= 1) return;
         e.preventDefault();
@@ -434,18 +534,16 @@ export function DockviewBrowserContainer({
         if (active) {
           closeTab(active.id);
         }
-      }
-    };
-    window.addEventListener("keydown", handler, true);
-    return () => window.removeEventListener("keydown", handler, true);
-  }, [visible, closeTab]);
-
-  // Cmd/Ctrl+R → reload the active browser tab
-  useEffect(() => {
-    if (!visible || !isTauri) return;
-    const handler = async (e: KeyboardEvent) => {
-      const mod = e.metaKey || e.ctrlKey;
-      if (mod && e.key.toLowerCase() === "r" && !e.shiftKey) {
+      } else if (key === "d") {
+        e.preventDefault();
+        e.stopPropagation();
+        const api = apiRef.current;
+        if (!api) return;
+        const activeGroup = api.activeGroup;
+        if (!activeGroup) return;
+        const direction = e.shiftKey ? "below" : "right";
+        handleSplit(activeGroup.id, direction);
+      } else if (key === "r" && !e.shiftKey && isTauri) {
         const api = apiRef.current;
         if (!api) return;
         const active = api.activePanel;
@@ -453,17 +551,16 @@ export function DockviewBrowserContainer({
         if (!browserId) return;
         e.preventDefault();
         e.stopPropagation();
-        try {
-          const { invoke } = await import("@tauri-apps/api/core");
-          await invoke("browser_reload", { browserId });
-        } catch (err) {
-          console.error("[DockviewBrowserContainer] browser_reload failed:", err);
-        }
+        import("@tauri-apps/api/core")
+          .then(({ invoke }) => invoke("browser_reload", { browserId }))
+          .catch((err) => {
+            console.error("[DockviewBrowserContainer] browser_reload failed:", err);
+          });
       }
     };
     window.addEventListener("keydown", handler, true);
     return () => window.removeEventListener("keydown", handler, true);
-  }, [visible]);
+  }, [visible, closeTab, handleSplit, handleAddTab]);
 
   // Sync dockview panels when browsers are created/removed externally (e.g. CLI).
   useEffect(() => {
@@ -499,7 +596,7 @@ export function DockviewBrowserContainer({
   // instead of updateParameters — see the Provider wrapping DockviewReact.
 
   // Keep module-level refs in sync for stable Dockview components
-  addTabRef.current = { onAdd: handleAddTab };
+  addTabRef.current = { onAdd: handleAddTab, onSplit: handleSplit };
   closeTabRef.current = closeTab;
 
   // Use refs for the initial data so onReady's closure captures the latest
@@ -571,7 +668,7 @@ export function DockviewBrowserContainer({
   }
 
   return (
-    <div className="flex h-full w-full flex-col overflow-hidden">
+    <div ref={containerRef} className="flex h-full w-full flex-col overflow-hidden">
       <BrowserVisibilityContext.Provider value={visibilityValue}>
         <DockviewReact
           theme={browserTabTheme}

--- a/apps/web/src/components/DockviewChatContainer.tsx
+++ b/apps/web/src/components/DockviewChatContainer.tsx
@@ -15,7 +15,7 @@ import {
   type IDockviewPanelHeaderProps,
   type IDockviewPanelProps,
 } from "dockview";
-import { Clock, Plus, X } from "lucide-react";
+import { Clock, Columns2, Plus, Rows2, X } from "lucide-react";
 import React, {
   createContext,
   useCallback,
@@ -310,9 +310,13 @@ function ChatTab(props: IDockviewPanelHeaderProps<ChatTabParams>) {
 // ---------------------------------------------------------------------------
 
 const addTabRef: {
-  current: { agents: CodingAgentDef[]; onAdd: (agentId?: string, groupId?: string) => void };
+  current: {
+    agents: CodingAgentDef[];
+    onAdd: (agentId?: string, groupId?: string) => void;
+    onSplit: (groupId: string, direction: "right" | "below") => void;
+  };
 } = {
-  current: { agents: [], onAdd: () => {} },
+  current: { agents: [], onAdd: () => {}, onSplit: () => {} },
 };
 
 /** Shared ref for the close-tab action — used by ChatTab's close button. */
@@ -361,7 +365,7 @@ const RightHeaderActions = React.memo(function RightHeaderActions(
     return () => clearInterval(id);
   }, []);
 
-  const { agents, onAdd } = addTabRef.current;
+  const { agents, onAdd, onSplit } = addTabRef.current;
   const history = historyToggleRef.current;
   const groupId = props.group.id;
   return (
@@ -380,6 +384,22 @@ const RightHeaderActions = React.memo(function RightHeaderActions(
           <Clock className="size-3.5" />
         </button>
       )}
+      <button
+        type="button"
+        className="inline-flex size-8 items-center justify-center text-muted-foreground hover:text-foreground hover:bg-accent rounded transition-colors"
+        onClick={() => onSplit(groupId, "right")}
+        title="Split right"
+      >
+        <Columns2 className="size-3.5" />
+      </button>
+      <button
+        type="button"
+        className="inline-flex size-8 items-center justify-center text-muted-foreground hover:text-foreground hover:bg-accent rounded transition-colors"
+        onClick={() => onSplit(groupId, "below")}
+        title="Split down"
+      >
+        <Rows2 className="size-3.5" />
+      </button>
       <AddTabButton agents={agents} onAdd={(agentId) => onAdd(agentId, groupId)} />
     </div>
   );
@@ -421,6 +441,7 @@ export function DockviewChatContainer({
   const queryClient = useQueryClient();
   const apiRef = useRef<DockviewApi | null>(null);
   const isRestoringRef = useRef(false);
+  const containerRef = useRef<HTMLDivElement>(null);
 
   // Fetch layout via React Query — cached across mounts so re-visiting
   // a workspace renders instantly from the cache.
@@ -527,6 +548,32 @@ export function DockviewChatContainer({
     [workspaceId],
   );
 
+  const handleSplit = useCallback(
+    async (groupId: string, direction: "right" | "below") => {
+      const api = apiRef.current;
+      if (!api) return;
+
+      const chatId = newChatId();
+      markChatFresh(chatId);
+
+      api.addPanel({
+        id: chatId,
+        component: "chatTab",
+        tabComponent: "chatTab",
+        title: "Chat",
+        params: {
+          workspaceId,
+          chatId,
+        },
+        position: {
+          referenceGroup: groupId,
+          direction,
+        },
+      } as Parameters<typeof api.addPanel>[0]);
+    },
+    [workspaceId],
+  );
+
   const closeTab = useCallback((chatId: string) => {
     const api = apiRef.current;
     if (!api || api.panels.length <= 1) return; // don't close last tab
@@ -543,12 +590,45 @@ export function DockviewChatContainer({
     // Layout change listeners will auto-persist
   }, []);
 
-  // Cmd/Ctrl+W → close the active chat tab
+  // Keyboard shortcuts:
+  // - Cmd/Ctrl+T → open a new chat tab (default coding agent)
+  // - Cmd/Ctrl+W → close the active chat tab
+  // - Cmd/Ctrl+D → split right (vertical split)
+  // - Cmd/Ctrl+Shift+D → split down (horizontal split)
+  // - Ctrl+(Shift)+Tab → cycle through tabs in the active group
   useEffect(() => {
     if (!visible) return;
     const handler = (e: KeyboardEvent) => {
+      // Only handle shortcut if this container (or a descendant) has focus
+      if (!containerRef.current?.contains(document.activeElement)) return;
+
+      const key = e.key.toLowerCase();
+
+      // Ctrl+(Shift)+Tab → cycle tabs within the active group
+      if (e.ctrlKey && !e.metaKey && key === "tab") {
+        e.preventDefault();
+        e.stopPropagation();
+        const group = apiRef.current?.activeGroup;
+        if (!group) return;
+        if (e.shiftKey) {
+          group.model.moveToPrevious();
+        } else {
+          group.model.moveToNext();
+        }
+        // Re-focus the panel content so the container retains focus
+        // for subsequent keyboard shortcuts.
+        group.model.focusContent();
+        return;
+      }
+
       const mod = e.metaKey || e.ctrlKey;
-      if (mod && e.key.toLowerCase() === "w" && !e.shiftKey) {
+      if (!mod) return;
+
+      if (key === "t" && !e.shiftKey) {
+        e.preventDefault();
+        e.stopPropagation();
+        handleAddTab();
+      } else if (key === "w" && !e.shiftKey) {
         const api = apiRef.current;
         if (!api || api.panels.length <= 1) return;
         e.preventDefault();
@@ -557,17 +637,26 @@ export function DockviewChatContainer({
         if (active) {
           closeTab(active.id);
         }
+      } else if (key === "d") {
+        e.preventDefault();
+        e.stopPropagation();
+        const api = apiRef.current;
+        if (!api) return;
+        const activeGroup = api.activeGroup;
+        if (!activeGroup) return;
+        const direction = e.shiftKey ? "below" : "right";
+        handleSplit(activeGroup.id, direction);
       }
     };
     window.addEventListener("keydown", handler, true);
     return () => window.removeEventListener("keydown", handler, true);
-  }, [visible, closeTab]);
+  }, [visible, closeTab, handleSplit, handleAddTab]);
 
   // Visibility is now propagated via ChatVisibilityContext (React context)
   // instead of updateParameters — see the Provider wrapping DockviewReact.
 
   // Keep module-level refs in sync for stable Dockview components
-  addTabRef.current = { agents, onAdd: handleAddTab };
+  addTabRef.current = { agents, onAdd: handleAddTab, onSplit: handleSplit };
   closeTabRef.current = closeTab;
 
   // Use a ref for the initial layout so onReady's closure captures the latest
@@ -627,7 +716,7 @@ export function DockviewChatContainer({
   }
 
   return (
-    <div className="flex h-full w-full flex-col overflow-hidden">
+    <div ref={containerRef} className="flex h-full w-full flex-col overflow-hidden">
       <ChatVisibilityContext.Provider value={visibilityValue}>
         <DockviewReact
           theme={chatTabTheme}

--- a/apps/web/src/components/DockviewTerminalContainer.tsx
+++ b/apps/web/src/components/DockviewTerminalContainer.tsx
@@ -139,6 +139,7 @@ interface TerminalTabParams {
   command?: string;
   cwd?: string;
   env?: Record<string, string>;
+  autoFocus?: boolean;
 }
 
 function TerminalTabPanel({ params, api }: IDockviewPanelProps<TerminalTabParams>) {
@@ -172,6 +173,7 @@ function TerminalTabPanel({ params, api }: IDockviewPanelProps<TerminalTabParams
           terminalId={params.terminalId}
           visible={visible}
           paneMetadata={paneMetadata}
+          autoFocus={params.autoFocus}
           onTitleChange={onTitleChange}
         />
       </Suspense>
@@ -325,6 +327,7 @@ export function DockviewTerminalContainer({
   const queryClient = useQueryClient();
   const apiRef = useRef<DockviewApi | null>(null);
   const isRestoringRef = useRef(false);
+  const containerRef = useRef<HTMLDivElement>(null);
 
   // Fetch layout AND terminal records via React Query — cached across mounts
   const { data: initialData } = useQuery<TerminalLayoutData>({
@@ -371,6 +374,7 @@ export function DockviewTerminalContainer({
         params: {
           workspaceId,
           terminalId,
+          autoFocus: true,
         },
       };
 
@@ -408,6 +412,7 @@ export function DockviewTerminalContainer({
         params: {
           workspaceId,
           terminalId,
+          autoFocus: true,
         },
         position: {
           referenceGroup: groupId,
@@ -433,6 +438,16 @@ export function DockviewTerminalContainer({
       api.removePanel(panel);
     }
 
+    // After closing, focus the xterm textarea in the newly active panel
+    // so the terminal receives keyboard input immediately.
+    requestAnimationFrame(() => {
+      const activePanel = api.activePanel;
+      if (!activePanel) return;
+      activePanel.view.content.element
+        .querySelector<HTMLTextAreaElement>(".xterm-helper-textarea")
+        ?.focus();
+    });
+
     // Kill the terminal on the server (kills PTY + removes from layout + emits event)
     trpc.terminal.kill.mutate({ terminalId }).catch((err) => {
       console.error("[DockviewTerminalContainer] failed to kill terminal:", err);
@@ -440,18 +455,53 @@ export function DockviewTerminalContainer({
   }, []);
 
   // Keyboard shortcuts:
+  // - Cmd/Ctrl+T → open a new terminal tab
   // - Cmd/Ctrl+W → close the active terminal tab
   // - Cmd/Ctrl+D → split right (vertical split)
   // - Cmd/Ctrl+Shift+D → split down (horizontal split)
+  // - Ctrl+(Shift)+Tab → cycle through tabs in the active group
   useEffect(() => {
     if (!visible) return;
     const handler = (e: KeyboardEvent) => {
-      const mod = e.metaKey || e.ctrlKey;
-      if (!mod) return;
+      // Only handle shortcut if this container (or a descendant) has focus
+      if (!containerRef.current?.contains(document.activeElement)) return;
 
       const key = e.key.toLowerCase();
 
-      if (key === "w" && !e.shiftKey) {
+      // Ctrl+(Shift)+Tab → cycle tabs within the active group
+      if (e.ctrlKey && !e.metaKey && key === "tab") {
+        e.preventDefault();
+        e.stopPropagation();
+        const api = apiRef.current;
+        const group = api?.activeGroup;
+        if (!group) return;
+        if (e.shiftKey) {
+          group.model.moveToPrevious();
+        } else {
+          group.model.moveToNext();
+        }
+        // Focus the xterm helper textarea inside the newly active panel
+        // so the terminal actually receives keyboard input.
+        // focusContent() only focuses the dockview wrapper which makes the
+        // cursor blink but doesn't route keypresses to xterm.
+        requestAnimationFrame(() => {
+          const panel = api.activePanel;
+          if (!panel) return;
+          panel.view.content.element
+            .querySelector<HTMLTextAreaElement>(".xterm-helper-textarea")
+            ?.focus();
+        });
+        return;
+      }
+
+      const mod = e.metaKey || e.ctrlKey;
+      if (!mod) return;
+
+      if (key === "t" && !e.shiftKey) {
+        e.preventDefault();
+        e.stopPropagation();
+        handleAddTab();
+      } else if (key === "w" && !e.shiftKey) {
         const api = apiRef.current;
         if (!api || api.panels.length <= 1) return;
         e.preventDefault();
@@ -473,7 +523,7 @@ export function DockviewTerminalContainer({
     };
     window.addEventListener("keydown", handler, true);
     return () => window.removeEventListener("keydown", handler, true);
-  }, [visible, closeTab, handleSplit]);
+  }, [visible, closeTab, handleSplit, handleAddTab]);
 
   // Sync dockview panels when terminals are created/killed externally (e.g. CLI).
   useEffect(() => {
@@ -577,7 +627,7 @@ export function DockviewTerminalContainer({
   }
 
   return (
-    <div className="flex h-full w-full flex-col overflow-hidden">
+    <div ref={containerRef} className="flex h-full w-full flex-col overflow-hidden">
       <TerminalVisibilityContext.Provider value={visibilityValue}>
         <DockviewReact
           theme={terminalTabTheme}

--- a/apps/web/src/components/ai-elements/prompt-input.tsx
+++ b/apps/web/src/components/ai-elements/prompt-input.tsx
@@ -105,6 +105,18 @@ export const PromptInput = ({
     }
   }, [draftStorageKey]);
 
+  // Focus the textarea when the component first mounts and is visible.
+  // This ensures new chat tabs opened via keyboard shortcut (Cmd+T) get
+  // focus in the input field automatically.
+  const mountFocusedRef = useRef(false);
+  useEffect(() => {
+    if (mountFocusedRef.current || !visible) return;
+    mountFocusedRef.current = true;
+    requestAnimationFrame(() => {
+      textareaRef.current?.focus();
+    });
+  }, [visible]);
+
   // Ref for gating global event handlers — hidden workspaces must not
   // process events that would modify their textarea.
   const visibleRef = useRef(visible);


### PR DESCRIPTION
## Summary
- Add consistent keyboard shortcuts across terminal, chat, and browser containers: **Cmd+T** (new tab), **Cmd+D / Cmd+Shift+D** (split right/down), **Ctrl+Tab / Ctrl+Shift+Tab** (cycle tabs), **Cmd+W** (close tab)
- Each container uses a focus guard (`containerRef.contains(activeElement)`) so shortcuts only fire in the focused container — no cross-container interference
- Fix terminal focus after closing a tab (newly active terminal now receives keyboard input immediately)
- Auto-focus prompt input in new chat tabs opened via Cmd+T

## Test plan
- [ ] Focus terminal container → Cmd+T opens new terminal, Cmd+W closes it, Cmd+D splits right, Cmd+Shift+D splits down, Ctrl+Tab cycles tabs
- [ ] Focus chat container → same shortcuts work scoped to chat
- [ ] Focus browser container → same shortcuts work scoped to browser
- [ ] Verify shortcuts don't fire in unfocused containers
- [ ] Close a terminal tab → next terminal gets focus automatically
- [ ] Open new chat tab via Cmd+T → prompt input is auto-focused

🤖 Generated with [Claude Code](https://claude.com/claude-code)