### PR TITLE
fix: read plan files from workspace .claude/plans instead of home directory

### DIFF
--- a/packages/coding-agent/src/adapters/claude-code.ts
+++ b/packages/coding-agent/src/adapters/claude-code.ts
@@ -26,18 +26,12 @@ import type {
 const log = createLogger("coding-agent:claude-code");
 
 /**
- * Read the most recently modified plan file.
+ * Read the most recently modified plan file from the workspace.
  *
- * Claude Code stores plans under `<CLAUDE_CONFIG_DIR>/plans/` which
- * defaults to `~/.claude/plans/` but can be overridden via the
- * `CLAUDE_CONFIG_DIR` env var. We check both the configured/default
- * location and `~/.band/plans/` (legacy) and return whichever has
- * the newest file.
+ * Claude Code writes plans into `<workspaceDir>/.claude/plans/`.
  */
-function readLatestPlanFile(): string | undefined {
-  const home = homedir();
-  const configDir = process.env.CLAUDE_CONFIG_DIR || join(home, ".claude");
-  const plansDirs = [join(configDir, "plans"), join(home, ".band", "plans")];
+function readLatestPlanFile(workspaceDir: string): string | undefined {
+  const plansDirs = [join(workspaceDir, ".claude", "plans")];
 
   let newest: { path: string; mtime: number } | undefined;
   for (const dir of plansDirs) {
@@ -222,7 +216,7 @@ export class ClaudeCodeAdapter implements CodingAgent {
       // the UI can render a plan preview.
       let enrichedInput = input as Record<string, unknown>;
       if (toolName === "ExitPlanMode") {
-        const planContent = readLatestPlanFile();
+        const planContent = readLatestPlanFile(this.workspaceDir);
         if (planContent) {
           enrichedInput = { ...enrichedInput, plan: planContent };
         }


### PR DESCRIPTION
## Summary
- Fixed `readLatestPlanFile` to read plan files from the workspace's `.claude/plans/` directory instead of the global `~/.claude/plans/`
- Removed the legacy `~/.band/plans/` fallback path that is no longer needed
- The function now accepts a `workspaceDir` parameter and is called with `this.workspaceDir`

## Test plan
- [ ] Open a workspace and enter plan mode
- [ ] Verify the agent writes a plan to `<workspace>/.claude/plans/`
- [ ] Approve the plan via ExitPlanMode and confirm the plan content is displayed correctly in the UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)