### PR TITLE
fix: move CLI install admin elevation from web server to Tauri app

### DIFF
--- a/apps/dashboard/src-tauri/src/commands/ide.rs
+++ b/apps/dashboard/src-tauri/src/commands/ide.rs
@@ -735,6 +735,38 @@ pub fn check_app_exists(app_name: String) -> bool {
         .is_ok_and(|output| output.status.success())
 }
 
+/// Install the CLI by creating a symlink with administrator privileges.
+/// Runs `osascript` to show a macOS admin password dialog — this works
+/// because the Tauri app is the foreground GUI process (unlike the web
+/// server, which can't reliably show GUI dialogs).
+#[tauri::command]
+pub fn install_cli(binary_path: String, symlink_path: String) -> Result<(), String> {
+    let cmd = format!(
+        "ln -sf '{}' '{}'",
+        binary_path.replace('\'', "'\\''"),
+        symlink_path.replace('\'', "'\\''")
+    );
+    let script = format!(
+        "do shell script \"{}\" with administrator privileges",
+        cmd.replace('\\', "\\\\").replace('"', "\\\"")
+    );
+    let output = std::process::Command::new("osascript")
+        .args(["-e", &script])
+        .output()
+        .map_err(|e| format!("Failed to run osascript: {e}"))?;
+
+    if output.status.success() {
+        Ok(())
+    } else {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        if stderr.contains("User canceled") || stderr.contains("-128") {
+            Err("Admin password prompt cancelled".to_string())
+        } else {
+            Err(format!("Failed to install CLI: {stderr}"))
+        }
+    }
+}
+
 /// Opens a path with a specific macOS application.
 #[tauri::command]
 pub fn open_with_app(path: String, app_name: String) -> Result<(), String> {

--- a/apps/dashboard/src-tauri/src/commands/ide_stub.rs
+++ b/apps/dashboard/src-tauri/src/commands/ide_stub.rs
@@ -61,3 +61,8 @@ pub fn check_app_exists(_app_name: String) -> bool {
 pub fn open_with_app(_path: String, _app_name: String) -> Result<(), String> {
     Err("Not supported on this platform".to_string())
 }
+
+#[tauri::command]
+pub fn install_cli(_binary_path: String, _symlink_path: String) -> Result<(), String> {
+    Err("Not supported on this platform".to_string())
+}

--- a/apps/dashboard/src-tauri/src/lib.rs
+++ b/apps/dashboard/src-tauri/src/lib.rs
@@ -83,6 +83,7 @@ pub fn run() {
             commands::ide::reveal_in_finder,
             commands::ide::check_app_exists,
             commands::ide::open_with_app,
+            commands::ide::install_cli,
             commands::webserver::webserver_start,
             commands::webserver::webserver_stop,
             commands::window::open_tasks_window,

--- a/apps/web/src/lib/cli.ts
+++ b/apps/web/src/lib/cli.ts
@@ -1,10 +1,6 @@
-import { execFile } from "node:child_process";
 import { accessSync, constants, lstatSync, realpathSync, symlinkSync, unlinkSync } from "node:fs";
 import { platform } from "node:os";
 import { dirname, join, resolve } from "node:path";
-import { promisify } from "node:util";
-
-const execFileP = promisify(execFile);
 
 export type CliStatus =
   | "Installed"
@@ -13,10 +9,10 @@ export type CliStatus =
   | "DirNotFound"
   | "NotWritable";
 
-const SYMLINK_PATH = "/usr/local/bin/band";
+export const SYMLINK_PATH = "/usr/local/bin/band";
 
 /** Find the CLI binary by trying multiple resolution strategies. */
-function findCliBinary(): string | null {
+export function findCliBinary(): string | null {
   const strategies = [
     // cwd = apps/web/ (Vite dev and production server)
     resolve(process.cwd(), ".."),
@@ -91,7 +87,7 @@ export interface InstallCliOptions {
   allowPrompt?: boolean;
 }
 
-export async function installCli(opts: InstallCliOptions = {}): Promise<void> {
+export async function installCli(_opts: InstallCliOptions = {}): Promise<void> {
   const binaryPath = findCliBinary();
   if (!binaryPath) {
     throw new Error(
@@ -114,43 +110,18 @@ export async function installCli(opts: InstallCliOptions = {}): Promise<void> {
   }
 
   if (platform() === "darwin") {
-    if (opts.allowPrompt) {
-      await installViaOsascript(binaryPath, SYMLINK_PATH);
-      return;
-    }
-    // On macOS the user can elevate by clicking the Install button —
-    // surface a friendly message rather than telling them to run sudo.
-    throw new Error("admin password required");
+    // Elevation must happen in the Tauri desktop app (foreground GUI process).
+    // Throw a recognizable error so the hybrid adapter can catch it and
+    // delegate to the Tauri `install_cli` command.
+    throw new Error("elevation-required");
   }
 
   throw new Error(`Run: sudo ln -sf "${binaryPath}" "${SYMLINK_PATH}"`);
 }
 
-/** Quote a string for use as a single shell argument inside single quotes. */
-function shellQuote(s: string): string {
-  return `'${s.replace(/'/g, "'\\''")}'`;
-}
-
-/** Quote a string as an AppleScript string literal. */
-function appleScriptString(s: string): string {
-  return `"${s.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`;
-}
-
-/**
- * On macOS, run `ln -sf` with admin privileges via osascript so the OS
- * displays a single password prompt instead of asking the user to run sudo
- * in a terminal.
- */
-async function installViaOsascript(binaryPath: string, symlinkPath: string): Promise<void> {
-  const cmd = `ln -sf ${shellQuote(binaryPath)} ${shellQuote(symlinkPath)}`;
-  const script = `do shell script ${appleScriptString(cmd)} with administrator privileges`;
-  try {
-    await execFileP("osascript", ["-e", script]);
-  } catch (err) {
-    const message = err instanceof Error ? err.message : String(err);
-    if (message.includes("User canceled") || message.includes("-128")) {
-      throw new Error("Admin password prompt cancelled");
-    }
-    throw new Error(`Failed to install band CLI: ${message}`);
-  }
+/** Resolve the CLI binary path and symlink path for the frontend. */
+export function resolveCliPaths(): { binaryPath: string; symlinkPath: string } | null {
+  const binaryPath = findCliBinary();
+  if (!binaryPath) return null;
+  return { binaryPath, symlinkPath: SYMLINK_PATH };
 }

--- a/apps/web/src/trpc/router.ts
+++ b/apps/web/src/trpc/router.ts
@@ -38,7 +38,7 @@ import {
   updateChatActiveSession,
   updateChatStatus,
 } from "../lib/chat-manager";
-import { checkCli, installCli } from "../lib/cli";
+import { checkCli, installCli, resolveCliPaths } from "../lib/cli";
 import { convertEventsToUIMessages, convertHistoryToUIMessages } from "../lib/convert-events";
 import { reloadSchedules, stopJobsForKey } from "../lib/cronjob-scheduler";
 import {
@@ -608,6 +608,10 @@ const cliRouter = t.router({
   check: publicProcedure.query(async () => {
     const status = await checkCli();
     return { status };
+  }),
+
+  resolve: publicProcedure.query(() => {
+    return resolveCliPaths();
   }),
 
   install: publicProcedure

--- a/packages/dashboard-core/src/adapters/hybrid.ts
+++ b/packages/dashboard-core/src/adapters/hybrid.ts
@@ -58,6 +58,33 @@ export class HybridDashboardAdapter extends WebDashboardAdapter {
     return super.openWorkspace(workspaceId);
   }
 
+  async installCli(opts?: { allowPrompt?: boolean }): Promise<void> {
+    try {
+      // Try the web server path first (works when /usr/local/bin is writable)
+      await super.installCli();
+      return;
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      // If elevation is needed, the user explicitly clicked Install, and we're
+      // in Tauri, delegate to the desktop app which can show the macOS admin
+      // password dialog (it's the foreground GUI process).
+      if (opts?.allowPrompt && isTauri() && message.includes("elevation-required")) {
+        const paths = await this.trpc.cli.resolve.query();
+        if (!paths) {
+          throw new Error(
+            "Could not find band CLI binary. Build it first with: cargo build --release -p band-cli",
+          );
+        }
+        await tauriInvoke("install_cli", {
+          binaryPath: paths.binaryPath,
+          symlinkPath: paths.symlinkPath,
+        });
+        return;
+      }
+      throw err;
+    }
+  }
+
   subscribeActiveWorkspace(onChange: (workspaceId: string | null) => void): Unsubscribe {
     if (!isTauri() || this._appMode === "full-editor") {
       return super.subscribeActiveWorkspace(onChange);

--- a/packages/dashboard-core/src/adapters/web.ts
+++ b/packages/dashboard-core/src/adapters/web.ts
@@ -29,7 +29,7 @@ export class WebDashboardAdapter implements DashboardAdapter {
   // The AppRouter type lives in apps/web which cannot be imported here
   // (circular dep). Type safety comes from the DashboardAdapter interface.
   // biome-ignore lint/suspicious/noExplicitAny: tRPC client without router type
-  private trpc: any = createTRPCClient({
+  protected trpc: any = createTRPCClient({
     links: [
       splitLink({
         condition: (op) => op.type === "subscription",

--- a/packages/dashboard-core/src/components/DashboardShell.tsx
+++ b/packages/dashboard-core/src/components/DashboardShell.tsx
@@ -241,7 +241,7 @@ export function DashboardShell({ toolbarExtra, hideTitleBar }: DashboardShellPro
           <span className="text-blue-700 dark:text-blue-200">
             {cliState.status === "conflict"
               ? "A different `band` binary exists — replace it to use the bundled CLI"
-              : "Install band CLI"}
+              : `Install band CLI${cliState.status === "manual" && cliState.reason ? ` — ${cliState.reason}` : ""}`}
           </span>
           <Button variant="outline" size="sm" className="shrink-0 text-xs" onClick={installCli}>
             Install


### PR DESCRIPTION
## Summary

- Move the osascript admin-elevation path from the web server to the Tauri desktop app, fixing the "Install band CLI" button that did nothing when `/usr/local/bin` is not writable
- The web server (background Node.js process) can't reliably show macOS GUI dialogs — the Tauri app IS the foreground process and can show them correctly
- Add `cli.resolve` tRPC query so the frontend can get binary/symlink paths to pass to Tauri
- Only prompt for admin password on explicit user click (not auto-install on startup)

## Changes

- **`apps/dashboard/src-tauri/src/commands/ide.rs`** — Add `install_cli` Tauri command (follows `pick_folder` pattern)
- **`apps/dashboard/src-tauri/src/lib.rs`** — Register command in `generate_handler!`
- **`apps/web/src/lib/cli.ts`** — Remove `installViaOsascript`, throw `"elevation-required"` instead
- **`apps/web/src/trpc/router.ts`** — Add `cli.resolve` query returning `{ binaryPath, symlinkPath }`
- **`packages/dashboard-core/src/adapters/hybrid.ts`** — Override `installCli` to delegate to Tauri on elevation
- **`packages/dashboard-core/src/adapters/web.ts`** — Change `trpc` from `private` to `protected`
- **`packages/dashboard-core/src/components/DashboardShell.tsx`** — Show install reason in CLI banner

## Test plan

- [ ] On a Mac where `/usr/local/bin` is writable: CLI auto-installs without prompting
- [ ] On a Mac where `/usr/local/bin` is NOT writable: banner shows "Install band CLI", clicking Install shows macOS admin password dialog via Tauri
- [ ] Cancelling the admin dialog shows appropriate error message
- [ ] Web-only mode (no Tauri) still shows manual instructions

🤖 Generated with [Claude Code](https://claude.com/claude-code)