### PR TITLE
build: stop bundling claude-agent-sdk platform binary

### DIFF
--- a/apps/web/scripts/build-server.sh
+++ b/apps/web/scripts/build-server.sh
@@ -122,39 +122,11 @@ SHIM
   # so they only exist in the root node_modules/.pnpm store.
   MONO_ROOT="$(cd ../.. && pwd)"
 
-  # Copy claude-agent-sdk platform-specific native binary.
-  # SDK 0.2.x ships a native `claude` binary per platform via optional
-  # dependency packages named @anthropic-ai/claude-agent-sdk-<platform>-<arch>
-  # (and -musl on Linux). At runtime the SDK resolves
-  #   require.resolve("@anthropic-ai/claude-agent-sdk-<platform>-<arch>/claude")
-  # so the platform package directory needs to be present under
-  # dist/node_modules/. Copy whichever variants exist for the current
-  # platform.
-  CLAUDE_SDK_PLATFORM_PKGS=""
-  case "$(uname -s)" in
-    Darwin)
-      case "$(uname -m)" in
-        arm64) CLAUDE_SDK_PLATFORM_PKGS="@anthropic-ai/claude-agent-sdk-darwin-arm64" ;;
-        x86_64) CLAUDE_SDK_PLATFORM_PKGS="@anthropic-ai/claude-agent-sdk-darwin-x64" ;;
-      esac
-      ;;
-    Linux)
-      case "$(uname -m)" in
-        aarch64|arm64) CLAUDE_SDK_PLATFORM_PKGS="@anthropic-ai/claude-agent-sdk-linux-arm64 @anthropic-ai/claude-agent-sdk-linux-arm64-musl" ;;
-        x86_64) CLAUDE_SDK_PLATFORM_PKGS="@anthropic-ai/claude-agent-sdk-linux-x64 @anthropic-ai/claude-agent-sdk-linux-x64-musl" ;;
-      esac
-      ;;
-  esac
-
-  for PKG in $CLAUDE_SDK_PLATFORM_PKGS; do
-    PKG_SRC="$(find "$MONO_ROOT/node_modules/.pnpm" -maxdepth 4 -path "*/$PKG" -type d 2>/dev/null | head -1)"
-    if [ -n "$PKG_SRC" ] && [ -f "$PKG_SRC/claude" ]; then
-      mkdir -p "dist/node_modules/$PKG"
-      cp "$PKG_SRC/package.json" "dist/node_modules/$PKG/"
-      cp "$PKG_SRC/claude" "dist/node_modules/$PKG/"
-      chmod +x "dist/node_modules/$PKG/claude"
-    fi
-  done
+  # NOTE: We deliberately do NOT bundle the @anthropic-ai/claude-agent-sdk
+  # platform-specific native binary (~206MB on macOS arm64). Bundling it
+  # makes the Tauri app balloon to ~300MB. Band users are developers using
+  # AI coding agents, so they already have `claude` installed on PATH —
+  # the SDK resolves it from there at runtime.
 
   # Copy Codex SDK package.json so createRequire(import.meta.url).resolve("@openai/codex/package.json")
   # works from dist/. The actual codex CLI binary is expected to be installed on the user's system.

--- a/apps/web/tests/build-output.test.ts
+++ b/apps/web/tests/build-output.test.ts
@@ -43,11 +43,11 @@ describe("build output", () => {
     ).toBe(true);
   });
 
-  it.skipIf(skipSdkChecks)("contains Claude Code SDK native binary", () => {
-    // SDK 0.2.x ships a native `claude` binary per platform under
-    // @anthropic-ai/claude-agent-sdk-<platform>-<arch>. Build copies the
-    // matching package into dist/node_modules. Linux has both glibc and
-    // musl variants — accept either.
+  it.skipIf(skipSdkChecks)("does NOT bundle Claude Code SDK native binary", () => {
+    // We deliberately do NOT bundle the ~206MB platform binary shipped by
+    // @anthropic-ai/claude-agent-sdk-<platform>-<arch>. Band users have
+    // `claude` installed already, and the SDK resolves it from PATH at
+    // runtime. Keeping it out shrinks the Tauri DMG by ~200MB.
     const platform = process.platform;
     const arch = process.arch;
     const candidates =
@@ -58,7 +58,7 @@ describe("build output", () => {
           ]
         : [`@anthropic-ai/claude-agent-sdk-${platform}-${arch}`];
     const found = candidates.some((pkg) => existsSync(join(dist, "node_modules", pkg, "claude")));
-    expect(found).toBe(true);
+    expect(found).toBe(false);
   });
 
   it.skipIf(skipSdkChecks)("contains Codex SDK package", () => {


### PR DESCRIPTION
## Summary

- Drops the 206MB Bun-compiled `claude` binary from `apps/web/dist/node_modules/`. Tauri DMG was bloating from ~80MB to ~300MB.
- Band users already have `claude` installed on PATH — let the SDK resolve it from there at runtime instead of shipping our own copy.
- Flips the corresponding `build-output.test.ts` assertion so it now guards against accidentally re-introducing the bundle.

## Test plan

- [ ] `pnpm --filter @band-app/server build` succeeds and `apps/web/dist/` drops from ~219MB to ~57MB
- [ ] `apps/web/dist/node_modules/@anthropic-ai/claude-agent-sdk-darwin-arm64/` is NOT present
- [ ] `pnpm --filter @band-app/server test` passes (build-output assertions all green)
- [ ] Tauri build produces a smaller DMG and starting a Claude Code task still works end-to-end against the system `claude` binary

🤖 Generated with [Claude Code](https://claude.com/claude-code)