### PR TITLE
fix: retry SSE stream reconnect to keep thinking indicator visible

### DIFF
--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -105,6 +105,66 @@ function ThinkingIndicator({ label = "Thinking..." }: { label?: string }) {
   );
 }
 
+/**
+ * Skeleton placeholder shown while a session's history is being fetched.
+ * Mimics the alternating user→assistant bubble shape so the layout doesn't
+ * jump once messages arrive — much less jarring than a centered spinner.
+ */
+function SkeletonBar({ widthClass, className }: { widthClass: string; className?: string }) {
+  return <div className={cn("h-3 rounded bg-muted/70", widthClass, className)} />;
+}
+
+function ConversationSkeleton() {
+  return (
+    <output
+      className="flex animate-pulse flex-col gap-6"
+      aria-busy="true"
+      aria-label="Loading messages"
+    >
+      {/* User bubble — right-aligned, narrower */}
+      <Message from="user">
+        <MessageContent>
+          <div className="flex flex-col gap-2 py-1">
+            <SkeletonBar widthClass="w-48" className="bg-foreground/10" />
+            <SkeletonBar widthClass="w-32" className="bg-foreground/10" />
+          </div>
+        </MessageContent>
+      </Message>
+
+      {/* Assistant bubble — full width, several lines */}
+      <Message from="assistant">
+        <MessageContent>
+          <div className="flex flex-col gap-2 pt-1">
+            <SkeletonBar widthClass="w-3/4" />
+            <SkeletonBar widthClass="w-full" />
+            <SkeletonBar widthClass="w-5/6" />
+            <SkeletonBar widthClass="w-2/3" />
+          </div>
+        </MessageContent>
+      </Message>
+
+      {/* A second user/assistant pair for longer-feeling conversations */}
+      <Message from="user">
+        <MessageContent>
+          <div className="flex flex-col gap-2 py-1">
+            <SkeletonBar widthClass="w-40" className="bg-foreground/10" />
+          </div>
+        </MessageContent>
+      </Message>
+
+      <Message from="assistant">
+        <MessageContent>
+          <div className="flex flex-col gap-2 pt-1">
+            <SkeletonBar widthClass="w-2/3" />
+            <SkeletonBar widthClass="w-4/5" />
+            <SkeletonBar widthClass="w-1/2" />
+          </div>
+        </MessageContent>
+      </Message>
+    </output>
+  );
+}
+
 type UIMessageParts = ReturnType<
   typeof import("@ai-sdk/react").useChat
 >["messages"][number]["parts"];
@@ -900,14 +960,21 @@ export function ChatView({
             <div ref={sentinelRef} className="h-px w-full shrink-0" aria-hidden="true" />
           )}
 
-          {/* Loading indicator for older messages */}
+          {/* Loading indicator for older messages — skeleton row matching
+              the bubble layout so the prepended history doesn't pop. */}
           {loadingOlder && (
-            <div className="flex items-center justify-center py-4">
-              <Loader2 className="size-4 animate-spin text-muted-foreground" />
-            </div>
+            <output
+              className="flex animate-pulse flex-col gap-2 py-3"
+              aria-busy="true"
+              aria-label="Loading older messages"
+            >
+              <SkeletonBar widthClass="w-2/3" />
+              <SkeletonBar widthClass="w-3/4" />
+              <SkeletonBar widthClass="w-1/2" />
+            </output>
           )}
 
-          {isEmpty && (
+          {isEmpty && !loadingHistory && (
             <ConversationEmptyState
               icon={
                 agentType ? (
@@ -921,11 +988,7 @@ export function ChatView({
             />
           )}
 
-          {loadingHistory && messages.length === 0 && (
-            <div className="flex items-center justify-center py-8">
-              <Loader2 className="size-5 animate-spin text-muted-foreground" />
-            </div>
-          )}
+          {loadingHistory && messages.length === 0 && <ConversationSkeleton />}
 
           {(() => {
             return messages.map((message, messageIndex) => {

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -96,11 +96,11 @@ function toolPartToItem(part: ToolPart): ToolCallItem {
   };
 }
 
-function ThinkingIndicator({ label = "Thinking..." }: { label?: string }) {
+function ThinkingIndicator() {
   return (
     <div className="mt-2 flex items-center gap-2 text-muted-foreground">
       <Loader2 className="size-4 lg:size-3.5 animate-spin" />
-      <span className="text-base lg:text-sm">{label}</span>
+      <span className="text-base lg:text-sm">Thinking...</span>
     </div>
   );
 }
@@ -264,7 +264,10 @@ export function ChatView({
   // null). When pagination is buffer-based, this stays undefined.
   const firstMessageIndexRef = useRef<number | undefined>(undefined);
   const [activeSessionId, setActiveSessionId] = useState<string | undefined>(undefined);
-  const [loadingHistory, setLoadingHistory] = useState(false);
+  // If we have an initialSessionId we're going to call loadMessages() in the
+  // mount effect below — initialize loadingHistory to true so the skeleton
+  // shows on the first render rather than briefly flashing the empty state.
+  const [loadingHistory, setLoadingHistory] = useState(!!initialSessionId);
   const [hasMore, setHasMore] = useState(false);
   const [loadingOlder, setLoadingOlder] = useState(false);
   const scrollHeightBeforePrependRef = useRef<number | null>(null);
@@ -280,9 +283,6 @@ export function ChatView({
   // Holds the AbortController for the in-flight reconnect attempt so a new
   // attempt (or unmount) can cancel the old one cleanly.
   const connectAbortRef = useRef<AbortController | null>(null);
-  // True while we're actively trying (including between retries) to attach
-  // to a running stream. Drives the "Connecting…" indicator.
-  const [isConnecting, setIsConnecting] = useState(false);
   const prevVisibleRef = useRef(visible);
 
   // Scroll to bottom when the panel becomes visible (e.g. switching tabs in dockview).
@@ -552,7 +552,6 @@ export function ChatView({
     // cover task registration lag without blocking the UI for too long.
     const delays = [0, 250, 500, 1000, 2000];
 
-    setIsConnecting(true);
     try {
       for (let i = 0; i < delays.length; i++) {
         if (signal.aborted) return;
@@ -593,7 +592,6 @@ export function ChatView({
       if (connectAbortRef.current === controller) {
         connectAbortRef.current = null;
       }
-      setIsConnecting(false);
     }
   }, [workspaceId, chatId, resumeStream, cancelConnectAttempt]);
 
@@ -974,7 +972,14 @@ export function ChatView({
             </output>
           )}
 
-          {isEmpty && !loadingHistory && (
+          {/*
+            Empty state: only when we know there's no session to load.
+            Skeleton: when sessions are still being fetched, when we have a
+            session but the message-load effect hasn't kicked in yet, or while
+            the load is in flight. This prevents the empty state from
+            flashing on first workspace load before chats.get resolves.
+          */}
+          {isEmpty && sessionQueryDone && !initialSessionId && !loadingHistory && (
             <ConversationEmptyState
               icon={
                 agentType ? (
@@ -988,7 +993,9 @@ export function ChatView({
             />
           )}
 
-          {loadingHistory && messages.length === 0 && <ConversationSkeleton />}
+          {messages.length === 0 && (loadingHistory || !sessionQueryDone || !!initialSessionId) && (
+            <ConversationSkeleton />
+          )}
 
           {(() => {
             return messages.map((message, messageIndex) => {
@@ -1003,12 +1010,6 @@ export function ChatView({
                     (getToolName(p) === "AskUserQuestion" || getToolName(p) === "ExitPlanMode"),
                 );
               const showThinking = isLastAssistant && isStreaming && !hasPendingInteractiveTool;
-              // Show "Connecting…" on the last assistant bubble when we're
-              // in the retry loop but the SSE stream hasn't attached yet.
-              // Suppressed once `isStreaming` flips on so we don't show two
-              // indicators at once.
-              const showConnecting =
-                isLastAssistant && isConnecting && !isStreaming && !hasPendingInteractiveTool;
 
               if (message.role !== "assistant") {
                 // User messages render normally
@@ -1053,7 +1054,7 @@ export function ChatView({
                   (p) =>
                     (p.type === "text" && p.text.trim()) || p.type === "file" || isToolUIPart(p),
                 );
-                if (visibleParts.length === 0 && !showThinking && !showConnecting) return null;
+                if (visibleParts.length === 0 && !showThinking) return null;
                 return (
                   <Message key={message.id} from="assistant">
                     <MessageContent>
@@ -1084,7 +1085,6 @@ export function ChatView({
                         );
                       })}
                       {showThinking && <ThinkingIndicator />}
-                      {showConnecting && <ThinkingIndicator label="Connecting…" />}
                     </MessageContent>
                   </Message>
                 );
@@ -1107,8 +1107,7 @@ export function ChatView({
                         </MessageContent>
                       </Message>
                     )}
-                    {(visibleParts.length > 0 ||
-                      (isLastSegment && (showThinking || showConnecting))) && (
+                    {(visibleParts.length > 0 || (isLastSegment && showThinking)) && (
                       <Message from="assistant">
                         <MessageContent>
                           {visibleParts.map((seg) => {
@@ -1143,9 +1142,6 @@ export function ChatView({
                             );
                           })}
                           {isLastSegment && showThinking && <ThinkingIndicator />}
-                          {isLastSegment && showConnecting && (
-                            <ThinkingIndicator label="Connecting…" />
-                          )}
                         </MessageContent>
                       </Message>
                     )}
@@ -1161,16 +1157,6 @@ export function ChatView({
               </MessageContent>
             </Message>
           )}
-          {!isStreaming &&
-            isConnecting &&
-            (!messages.length || messages[messages.length - 1].role === "user") && (
-              <Message from="assistant">
-                <MessageContent>
-                  <ThinkingIndicator label="Connecting…" />
-                </MessageContent>
-              </Message>
-            )}
-
           {queuedMessages.map((text) => (
             <QueuedMessageBubble key={text} text={text} onCancel={() => handleCancelQueued(text)} />
           ))}

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -96,11 +96,11 @@ function toolPartToItem(part: ToolPart): ToolCallItem {
   };
 }
 
-function ThinkingIndicator() {
+function ThinkingIndicator({ label = "Thinking..." }: { label?: string }) {
   return (
     <div className="mt-2 flex items-center gap-2 text-muted-foreground">
       <Loader2 className="size-4 lg:size-3.5 animate-spin" />
-      <span className="text-base lg:text-sm">Thinking...</span>
+      <span className="text-base lg:text-sm">{label}</span>
     </div>
   );
 }
@@ -210,7 +210,19 @@ export function ChatView({
   const scrollHeightBeforePrependRef = useRef<number | null>(null);
   const sentinelRef = useRef<HTMLDivElement>(null);
   const stickyContextRef = useRef<StickToBottomContext>(null);
-  const initialSessionLoadedRef = useRef(false);
+  // Gate that ensures we run the initial history-load exactly once for a
+  // given (chatKey, initialSessionId) tuple. Distinct from the connect
+  // retry loop, which is allowed to fire multiple times.
+  const initialHistoryLoadedRef = useRef(false);
+  // Mirrors `useChat`'s status so the retry loop can read it without
+  // forcing a re-render of the closure.
+  const statusRef = useRef<"submitted" | "streaming" | "ready" | "error">("ready");
+  // Holds the AbortController for the in-flight reconnect attempt so a new
+  // attempt (or unmount) can cancel the old one cleanly.
+  const connectAbortRef = useRef<AbortController | null>(null);
+  // True while we're actively trying (including between retries) to attach
+  // to a running stream. Drives the "Connecting…" indicator.
+  const [isConnecting, setIsConnecting] = useState(false);
   const prevVisibleRef = useRef(visible);
 
   // Scroll to bottom when the panel becomes visible (e.g. switching tabs in dockview).
@@ -419,6 +431,13 @@ export function ChatView({
 
   const abortingRef = useRef(false);
 
+  // Keep statusRef in sync with the live `status` so the connect-retry loop
+  // (which can outlive a single render) can observe transitions to
+  // "submitted"/"streaming" and stop retrying.
+  useEffect(() => {
+    statusRef.current = status;
+  }, [status]);
+
   const handleStop = useCallback(() => {
     abortingRef.current = true;
     transport.abort().finally(() => {
@@ -428,6 +447,95 @@ export function ChatView({
   }, [transport, stop]);
 
   const isStreaming = status === "submitted" || status === "streaming";
+
+  // Cancel any in-flight reconnect retry. Called before opening a new one
+  // and on unmount/dependency change.
+  const cancelConnectAttempt = useCallback(() => {
+    if (connectAbortRef.current) {
+      connectAbortRef.current.abort();
+      connectAbortRef.current = null;
+    }
+  }, []);
+
+  /**
+   * Try to reconnect to a running task's SSE stream, retrying with backoff
+   * until one of:
+   *   - `useChat.status` flips to "submitted"/"streaming" (success)
+   *   - the server confirms no task is running (clean give-up)
+   *   - we exhaust the retry budget
+   *   - the attempt is cancelled (unmount / new attempt)
+   *
+   * Why retry? `GET /api/tasks/:chatId/stream` returns 204 if the in-memory
+   * task hasn't been registered yet (registration lag, server boot, brief
+   * race during workspace switch). The Vercel AI SDK treats 204 as "nothing
+   * to resume" and silently leaves status at "ready" — no thinking indicator,
+   * no error, no log. The retry loop turns that silent failure into either
+   * a real connection or a clean give-up.
+   */
+  const connectToRunningStream = useCallback(async () => {
+    cancelConnectAttempt();
+    const controller = new AbortController();
+    connectAbortRef.current = controller;
+    const signal = controller.signal;
+
+    // Read the latest status off the ref. Wrapping the read in a function
+    // keeps TypeScript from narrowing the ref's union type across awaits —
+    // `statusRef.current` is mutable, so a check earlier in the function
+    // shouldn't shrink its type later.
+    const isAttached = (): boolean => {
+      const s = statusRef.current;
+      return s === "submitted" || s === "streaming";
+    };
+
+    // Backoff schedule (ms): first attempt is immediate, then 250 → 500 →
+    // 1000 → 2000. Total wait ~3.75s before giving up — long enough to
+    // cover task registration lag without blocking the UI for too long.
+    const delays = [0, 250, 500, 1000, 2000];
+
+    setIsConnecting(true);
+    try {
+      for (let i = 0; i < delays.length; i++) {
+        if (signal.aborted) return;
+
+        if (delays[i] > 0) {
+          await new Promise<void>((r) => setTimeout(r, delays[i]));
+          if (signal.aborted) return;
+        }
+
+        // If `useChat` is already streaming (e.g. a sendMessage just took
+        // over while we were waiting), we're done.
+        if (isAttached()) return;
+
+        // Attempt the resume. The transport aborts any prior in-flight
+        // connection internally, so calling this repeatedly is safe.
+        resumeStream();
+
+        // Give the AI SDK a tick to update `status`. If the GET succeeds
+        // and the server has events to send, status flips to "streaming"
+        // shortly after the first chunk arrives.
+        await new Promise<void>((r) => setTimeout(r, 350));
+        if (signal.aborted) return;
+
+        if (isAttached()) return;
+
+        // Status didn't change → resumeStream resolved to null (204) or
+        // hasn't seen events yet. Ask the server: is anything actually
+        // running? If not, give up cleanly. If yes, keep retrying.
+        try {
+          const { running } = await trpc.tasks.isRunning.query({ workspaceId, chatId });
+          if (signal.aborted) return;
+          if (!running) return;
+        } catch {
+          // Network blip — keep retrying with the same backoff.
+        }
+      }
+    } finally {
+      if (connectAbortRef.current === controller) {
+        connectAbortRef.current = null;
+      }
+      setIsConnecting(false);
+    }
+  }, [workspaceId, chatId, resumeStream, cancelConnectAttempt]);
 
   useEffect(() => {
     onStreamingChange?.(isStreaming);
@@ -462,6 +570,7 @@ export function ChatView({
       // Kill any stale stream before loading + resuming to prevent
       // two concurrent streams writing to the same messages array.
       stop();
+      cancelConnectAttempt();
       setLoadingHistory(true);
       try {
         const data = await trpc.sessions.messages.query({
@@ -478,11 +587,12 @@ export function ChatView({
       } finally {
         setLoadingHistory(false);
       }
-      // Now that refs are populated, try to reconnect to a running stream.
-      // If no task is running, reconnectToStream returns null and this is a no-op.
-      resumeStream();
+      // Now that refs are populated, try to reconnect to a running stream
+      // with retries. If no task is running on the server, the loop gives
+      // up cleanly after one round-trip to tasks.isRunning.
+      void connectToRunningStream();
     },
-    [workspaceId, chatId, setMessages, resumeStream, stop],
+    [workspaceId, chatId, setMessages, connectToRunningStream, stop, cancelConnectAttempt],
   );
 
   // Load older messages when the user scrolls to the top of the chat.
@@ -576,26 +686,62 @@ export function ChatView({
   // This avoids the race where an eager resumeStream() opens stream A,
   // then initialSessionId arrives → loadMessages opens stream B, and
   // both pump chunks into the same messages array (causing duplicates).
+  //
+  // The history-load itself is one-shot per (chatKey, initialSessionId):
+  // we don't want to refetch all messages on every render. The reconnect
+  // attempt embedded in loadMessages (via connectToRunningStream) IS
+  // retryable, and is also re-triggered on tab focus / network online
+  // events below.
   useEffect(() => {
-    if (initialSessionId && !initialSessionLoadedRef.current) {
-      // Session query resolved with a session — load its history.
-      // loadMessages will call resumeStream() after setting refs.
-      initialSessionLoadedRef.current = true;
+    if (initialHistoryLoadedRef.current) return;
+    if (initialSessionId) {
+      initialHistoryLoadedRef.current = true;
       sessionIdRef.current = initialSessionId;
       setActiveSessionId(initialSessionId);
       loadMessages(initialSessionId);
-    } else if (sessionQueryDone && !initialSessionId && !initialSessionLoadedRef.current) {
-      // Session query resolved with NO sessions — just try resuming
-      // a running task (e.g. started from CLI).
-      initialSessionLoadedRef.current = true;
-      resumeStream();
+    } else if (sessionQueryDone && !initialSessionId) {
+      // No sessions — just try resuming a running task (e.g. started from
+      // CLI). Use the retrying connect helper instead of a single
+      // resumeStream() call so we cover the registration-lag window.
+      initialHistoryLoadedRef.current = true;
+      void connectToRunningStream();
     }
-  }, [initialSessionId, sessionQueryDone, loadMessages, resumeStream]);
+  }, [initialSessionId, sessionQueryDone, loadMessages, connectToRunningStream]);
+
+  // Re-attempt reconnect when the tab regains focus or the network comes
+  // back online. We skip if we're already streaming or already attempting,
+  // and we ask the server first to avoid a retry storm when nothing's
+  // actually running.
+  useEffect(() => {
+    const maybeReconnect = () => {
+      if (statusRef.current === "submitted" || statusRef.current === "streaming") return;
+      if (connectAbortRef.current) return;
+      // Fire-and-forget: connectToRunningStream itself handles the
+      // is-running short-circuit.
+      void connectToRunningStream();
+    };
+    const onFocus = () => maybeReconnect();
+    const onOnline = () => maybeReconnect();
+    window.addEventListener("focus", onFocus);
+    window.addEventListener("online", onOnline);
+    return () => {
+      window.removeEventListener("focus", onFocus);
+      window.removeEventListener("online", onOnline);
+    };
+  }, [connectToRunningStream]);
+
+  // Cancel any in-flight reconnect on unmount or when the underlying
+  // chat/key changes (transport gets recreated).
+  // biome-ignore lint/correctness/useExhaustiveDependencies: chatKey/chatId trigger cleanup
+  useEffect(() => {
+    return () => cancelConnectAttempt();
+  }, [chatKey, chatId, cancelConnectAttempt]);
 
   const handleSelectSession = useCallback(
     async (sessionId: string) => {
       // Stop any active stream before switching sessions
       stop();
+      cancelConnectAttempt();
       sessionIdRef.current = sessionId;
       lastEventIdRef.current = undefined;
       firstEventIdRef.current = undefined;
@@ -613,6 +759,7 @@ export function ChatView({
       loadMessages,
       setMessages,
       stop,
+      cancelConnectAttempt,
       onShowSessionListChange,
       onActiveSessionChange,
       workspaceId,
@@ -622,6 +769,7 @@ export function ChatView({
 
   const handleNewSession = useCallback(() => {
     stop();
+    cancelConnectAttempt();
     sessionIdRef.current = undefined;
     lastEventIdRef.current = undefined;
     firstEventIdRef.current = undefined;
@@ -633,7 +781,15 @@ export function ChatView({
     setQueuedMessages([]);
     trpc.queue.clear.mutate({ workspaceId, chatId }).catch(() => {});
     onShowSessionListChange(false);
-  }, [setMessages, stop, onShowSessionListChange, onActiveSessionChange, workspaceId, chatId]);
+  }, [
+    setMessages,
+    stop,
+    cancelConnectAttempt,
+    onShowSessionListChange,
+    onActiveSessionChange,
+    workspaceId,
+    chatId,
+  ]);
 
   useEffect(() => {
     if (onNewSessionRef) {
@@ -784,6 +940,12 @@ export function ChatView({
                     (getToolName(p) === "AskUserQuestion" || getToolName(p) === "ExitPlanMode"),
                 );
               const showThinking = isLastAssistant && isStreaming && !hasPendingInteractiveTool;
+              // Show "Connecting…" on the last assistant bubble when we're
+              // in the retry loop but the SSE stream hasn't attached yet.
+              // Suppressed once `isStreaming` flips on so we don't show two
+              // indicators at once.
+              const showConnecting =
+                isLastAssistant && isConnecting && !isStreaming && !hasPendingInteractiveTool;
 
               if (message.role !== "assistant") {
                 // User messages render normally
@@ -828,7 +990,7 @@ export function ChatView({
                   (p) =>
                     (p.type === "text" && p.text.trim()) || p.type === "file" || isToolUIPart(p),
                 );
-                if (visibleParts.length === 0 && !showThinking) return null;
+                if (visibleParts.length === 0 && !showThinking && !showConnecting) return null;
                 return (
                   <Message key={message.id} from="assistant">
                     <MessageContent>
@@ -859,6 +1021,7 @@ export function ChatView({
                         );
                       })}
                       {showThinking && <ThinkingIndicator />}
+                      {showConnecting && <ThinkingIndicator label="Connecting…" />}
                     </MessageContent>
                   </Message>
                 );
@@ -881,7 +1044,8 @@ export function ChatView({
                         </MessageContent>
                       </Message>
                     )}
-                    {(visibleParts.length > 0 || (isLastSegment && showThinking)) && (
+                    {(visibleParts.length > 0 ||
+                      (isLastSegment && (showThinking || showConnecting))) && (
                       <Message from="assistant">
                         <MessageContent>
                           {visibleParts.map((seg) => {
@@ -916,6 +1080,9 @@ export function ChatView({
                             );
                           })}
                           {isLastSegment && showThinking && <ThinkingIndicator />}
+                          {isLastSegment && showConnecting && (
+                            <ThinkingIndicator label="Connecting…" />
+                          )}
                         </MessageContent>
                       </Message>
                     )}
@@ -931,6 +1098,15 @@ export function ChatView({
               </MessageContent>
             </Message>
           )}
+          {!isStreaming &&
+            isConnecting &&
+            (!messages.length || messages[messages.length - 1].role === "user") && (
+              <Message from="assistant">
+                <MessageContent>
+                  <ThinkingIndicator label="Connecting…" />
+                </MessageContent>
+              </Message>
+            )}
 
           {queuedMessages.map((text) => (
             <QueuedMessageBubble key={text} text={text} onCancel={() => handleCancelQueued(text)} />

--- a/apps/web/src/trpc/router.ts
+++ b/apps/web/src/trpc/router.ts
@@ -1419,6 +1419,20 @@ const tasksRouter = t.router({
       return { task };
     }),
 
+  /**
+   * Lightweight existence check — used by the client during reconnect retries
+   * to distinguish "server says nothing's running, give up" from "server says
+   * a task IS running, keep retrying". This avoids a noisy `task` payload
+   * round-trip on every retry tick.
+   */
+  isRunning: publicProcedure
+    .input(z.object({ workspaceId: z.string(), chatId: z.string().optional() }))
+    .query(({ input }) => {
+      const chatId = input.chatId ?? getOrCreateDefaultChat(input.workspaceId).id;
+      const task = getTask(chatId);
+      return { running: task?.status === "running" };
+    }),
+
   abort: publicProcedure
     .input(z.object({ workspaceId: z.string(), chatId: z.string().optional() }))
     .mutation(({ input }) => {

--- a/apps/web/tests/fake-agent.mjs
+++ b/apps/web/tests/fake-agent.mjs
@@ -94,6 +94,13 @@ process.stdin.on("data", (chunk) => {
 			});
 			continue;
 		}
+		// Pause for `_sleep_ms` before the next message — used by tests to
+		// simulate long-running tasks so they can probe reconnect endpoints
+		// while the task is in the "running" state.
+		if (typeof msg._sleep_ms === "number") {
+			await new Promise((resolve) => setTimeout(resolve, msg._sleep_ms));
+			continue;
+		}
 		// Create a file on disk (simulates what a real tool would do)
 		if (msg._write_file) {
 			mkdirSync(dirname(msg._write_file.path), { recursive: true });

--- a/apps/web/tests/stream-reconnect.test.ts
+++ b/apps/web/tests/stream-reconnect.test.ts
@@ -1,0 +1,532 @@
+/**
+ * Integration tests for the SSE stream reconnect path that backs the
+ * `ChatView` thinking indicator after a workspace switch.
+ *
+ * The bug being guarded against (issue #348): `GET /api/tasks/:chatId/stream`
+ * returns 204 when no in-memory task is registered. The Vercel AI SDK
+ * silently treats that as "nothing to resume" and `useChat.status` stays at
+ * `"ready"`, leaving the user with no thinking indicator even though the
+ * agent is still running. The fix has two pieces:
+ *
+ *   1. A new `tasks.isRunning` server query so the client can distinguish
+ *      "give up cleanly" from "keep retrying".
+ *   2. A retry loop in `ChatView` that drives `resumeStream()` until the
+ *      stream attaches, the server says nothing's running, or the budget
+ *      is exhausted.
+ *
+ * These tests exercise the server contract the client retry depends on:
+ * tRPC `tasks.isRunning` reports the right state across the task lifecycle,
+ * the GET endpoint returns 204 vs 200 in the right places, and a client
+ * that polls `tasks.isRunning + GET /stream` mid-flight will eventually
+ * receive a streamable response (the recovery path the retry loop relies
+ * on).
+ */
+
+import { spawn } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { createServer } from "node:net";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { seedSettings, seedState } from "./helpers/seed-state";
+
+const PROJECT_ROOT = join(import.meta.dirname, "..");
+const FAKE_AGENT_PATH = join(import.meta.dirname, "fake-agent.mjs");
+const DEFAULT_TOKEN = "stream-reconnect-test-token";
+
+// ---------------------------------------------------------------------------
+// Test scaffolding (mirrors stream-gapfill.test.ts conventions)
+// ---------------------------------------------------------------------------
+
+interface ServerHandle {
+  url: string;
+  home: string;
+  close: () => Promise<void>;
+}
+
+function createTmpHome(): string {
+  const tmp = mkdtempSync(join(tmpdir(), "band-reconnect-test-"));
+  mkdirSync(join(tmp, ".band"), { recursive: true });
+  return tmp;
+}
+
+function writeScenario(tmpHome: string, events: object[]): string {
+  const scenarioPath = join(tmpHome, "scenario.json");
+  writeFileSync(scenarioPath, JSON.stringify(events));
+  return scenarioPath;
+}
+
+function getRandomPort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const srv = createServer();
+    srv.listen(0, "127.0.0.1", () => {
+      const { port } = srv.address() as { port: number };
+      srv.close(() => resolve(port));
+    });
+    srv.on("error", reject);
+  });
+}
+
+function createDefaultState(tmpHome: string) {
+  const repoDir = join(tmpHome, "repo");
+  mkdirSync(repoDir, { recursive: true });
+  return {
+    projects: [
+      {
+        name: "testproject",
+        path: repoDir,
+        defaultBranch: "main",
+        worktrees: [{ branch: "main", path: repoDir }],
+      },
+    ],
+  };
+}
+
+function defaultSettings() {
+  return {
+    tokenSecret: DEFAULT_TOKEN,
+    codingAgents: [
+      { id: "claude-code", type: "claude-code", label: "Claude Code", command: FAKE_AGENT_PATH },
+    ],
+  };
+}
+
+async function startServer(
+  opts: { tmpHome?: string; scenarioPath?: string } = {},
+): Promise<ServerHandle> {
+  const home = opts.tmpHome || createTmpHome();
+  const port = await getRandomPort();
+
+  return new Promise((resolve, reject) => {
+    const child = spawn("node", ["dist/start-server.mjs"], {
+      cwd: PROJECT_ROOT,
+      env: {
+        ...process.env,
+        HOME: home,
+        PORT: String(port),
+        NODE_ENV: "production",
+        FAKE_AGENT_SCENARIO: opts.scenarioPath || "",
+      },
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+
+    let stderr = "";
+    let settled = false;
+
+    child.stderr!.on("data", (chunk: Buffer) => {
+      stderr += chunk.toString();
+    });
+
+    child.stdout!.on("data", (chunk: Buffer) => {
+      const text = chunk.toString();
+      if (text.includes("listening") && !settled) {
+        settled = true;
+        resolve({
+          url: `http://127.0.0.1:${port}`,
+          home,
+          close: () =>
+            new Promise<void>((r) => {
+              child.on("exit", () => r());
+              child.kill("SIGTERM");
+            }),
+        });
+      }
+    });
+
+    child.on("error", (err) => {
+      if (!settled) {
+        settled = true;
+        reject(err);
+      }
+    });
+
+    child.on("exit", (code) => {
+      if (!settled) {
+        settled = true;
+        reject(new Error(`Server exited with code ${code} before listening.\nstderr: ${stderr}`));
+      }
+    });
+
+    setTimeout(() => {
+      if (!settled) {
+        settled = true;
+        child.kill("SIGTERM");
+        reject(new Error(`Server did not start within 15s.\nstderr: ${stderr}`));
+      }
+    }, 15_000);
+  });
+}
+
+// ---------------------------------------------------------------------------
+// HTTP helpers
+// ---------------------------------------------------------------------------
+
+const defaultHeaders = { Cookie: `band_token=${DEFAULT_TOKEN}` };
+
+async function trpcQuery(serverUrl: string, procedure: string, input?: unknown) {
+  const url =
+    input !== undefined
+      ? `${serverUrl}/trpc/${procedure}?input=${encodeURIComponent(JSON.stringify(input))}`
+      : `${serverUrl}/trpc/${procedure}`;
+  return fetch(url, { headers: defaultHeaders });
+}
+
+async function trpcData<T>(res: Response): Promise<T> {
+  const body = (await res.json()) as { result: { data: T } };
+  return body.result.data;
+}
+
+function newChatId(prefix = "reconnect"): string {
+  return `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+}
+
+async function getStream(
+  serverUrl: string,
+  chatId: string,
+  opts?: { signal?: AbortSignal },
+): Promise<Response> {
+  return fetch(`${serverUrl}/api/tasks/${encodeURIComponent(chatId)}/stream`, {
+    method: "GET",
+    headers: defaultHeaders,
+    signal: opts?.signal,
+  });
+}
+
+async function postStream(
+  serverUrl: string,
+  chatId: string,
+  workspaceId: string,
+  prompt: string,
+  opts?: { signal?: AbortSignal },
+): Promise<Response> {
+  return fetch(`${serverUrl}/api/tasks/${encodeURIComponent(chatId)}/stream`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", ...defaultHeaders },
+    body: JSON.stringify({ workspaceId, prompt }),
+    signal: opts?.signal,
+  });
+}
+
+async function isRunning(serverUrl: string, chatId: string): Promise<boolean> {
+  const res = await trpcQuery(serverUrl, "tasks.isRunning", {
+    workspaceId: "testproject-main",
+    chatId,
+  });
+  if (res.status !== 200) return false;
+  const data = await trpcData<{ running: boolean }>(res);
+  return data.running;
+}
+
+/**
+ * Drain an SSE response body. Returns the parsed event types so callers can
+ * assert on them. Used to drive a stream to completion so we can observe
+ * the task transitioning out of "running".
+ */
+async function drainEvents(response: Response): Promise<string[]> {
+  if (!response.body) return [];
+  const events: string[] = [];
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder();
+  let buf = "";
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      buf += decoder.decode(value, { stream: true });
+      while (true) {
+        const nl = buf.indexOf("\n");
+        if (nl === -1) break;
+        const line = buf.slice(0, nl).trim();
+        buf = buf.slice(nl + 1);
+        if (!line.startsWith("data:")) continue;
+        const raw = line.slice(5).trim();
+        if (!raw || raw === "[DONE]") continue;
+        try {
+          const data = JSON.parse(raw) as { type?: string };
+          if (data.type) events.push(data.type);
+        } catch {
+          // not JSON
+        }
+      }
+    }
+  } finally {
+    reader.releaseLock();
+  }
+  return events;
+}
+
+// ---------------------------------------------------------------------------
+// Scenarios
+// ---------------------------------------------------------------------------
+
+/**
+ * A scenario that pauses for ~1.5s in the middle so the task stays in the
+ * "running" state long enough for a separate GET reconnect to land while
+ * it's still active.
+ */
+function longRunningScenario(sessionId = "reconnect-session-long") {
+  return [
+    { type: "system", subtype: "init", session_id: sessionId },
+    {
+      type: "assistant",
+      message: { content: [{ type: "text", text: "starting work" }] },
+    },
+    { _sleep_ms: 1500 },
+    {
+      type: "assistant",
+      message: { content: [{ type: "text", text: "finishing up" }] },
+    },
+    {
+      type: "result",
+      subtype: "success",
+      session_id: sessionId,
+      duration_ms: 1500,
+      num_turns: 1,
+      total_cost_usd: 0.01,
+    },
+  ];
+}
+
+/** A short scenario that completes near-instantly. */
+function quickScenario(sessionId = "reconnect-session-quick") {
+  return [
+    { type: "system", subtype: "init", session_id: sessionId },
+    {
+      type: "assistant",
+      message: { content: [{ type: "text", text: "all done" }] },
+    },
+    {
+      type: "result",
+      subtype: "success",
+      session_id: sessionId,
+      duration_ms: 50,
+      num_turns: 1,
+      total_cost_usd: 0.01,
+    },
+  ];
+}
+
+// ---------------------------------------------------------------------------
+// tasks.isRunning lifecycle
+// ---------------------------------------------------------------------------
+
+describe("tasks.isRunning — lifecycle", () => {
+  let server: ServerHandle;
+  let tmpHome: string;
+
+  beforeAll(async () => {
+    tmpHome = createTmpHome();
+    seedState(tmpHome, createDefaultState(tmpHome));
+    seedSettings(tmpHome, defaultSettings());
+    const scenarioPath = writeScenario(tmpHome, longRunningScenario());
+    server = await startServer({ tmpHome, scenarioPath });
+  });
+
+  afterAll(async () => {
+    await server.close();
+    rmSync(tmpHome, { recursive: true, force: true });
+  });
+
+  it("returns running=false when no task has ever run for the chat", async () => {
+    const chatId = newChatId("never");
+    expect(await isRunning(server.url, chatId)).toBe(false);
+  });
+
+  it("returns running=true mid-task and running=false after completion", async () => {
+    const chatId = newChatId("lifecycle");
+
+    // Kick off a long-running task in the background.
+    const streamPromise = postStream(server.url, chatId, "testproject-main", "lifecycle test");
+
+    // Poll briefly until the task registers in the in-memory task map.
+    // We can't predict the exact moment, but the registration window is
+    // usually <300ms in practice — generous timeout for CI variance.
+    const deadline = Date.now() + 5000;
+    let observedRunning = false;
+    while (Date.now() < deadline) {
+      if (await isRunning(server.url, chatId)) {
+        observedRunning = true;
+        break;
+      }
+      await new Promise((r) => setTimeout(r, 25));
+    }
+    expect(observedRunning).toBe(true);
+
+    // Drain the stream to completion so the task transitions out of running.
+    const response = await streamPromise;
+    expect(response.status).toBe(200);
+    await drainEvents(response);
+
+    // Once the task finishes, isRunning should flip to false.
+    // Allow a brief window for the post-finish bookkeeping.
+    let observedDone = false;
+    const doneDeadline = Date.now() + 3000;
+    while (Date.now() < doneDeadline) {
+      if (!(await isRunning(server.url, chatId))) {
+        observedDone = true;
+        break;
+      }
+      await new Promise((r) => setTimeout(r, 25));
+    }
+    expect(observedDone).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// GET reconnect contract — 200 mid-task, 204 after completion
+// ---------------------------------------------------------------------------
+
+describe("GET /api/tasks/:chatId/stream — reconnect contract", () => {
+  let server: ServerHandle;
+  let tmpHome: string;
+
+  beforeAll(async () => {
+    tmpHome = createTmpHome();
+    seedState(tmpHome, createDefaultState(tmpHome));
+    seedSettings(tmpHome, defaultSettings());
+    const scenarioPath = writeScenario(tmpHome, longRunningScenario("reconnect-session-mid"));
+    server = await startServer({ tmpHome, scenarioPath });
+  });
+
+  afterAll(async () => {
+    await server.close();
+    rmSync(tmpHome, { recursive: true, force: true });
+  });
+
+  it("returns 204 immediately when no task has ever run for the chat", async () => {
+    const chatId = newChatId("never-run");
+    const res = await getStream(server.url, chatId);
+    expect(res.status).toBe(204);
+    // Drain the (empty) body so the connection cleans up.
+    await res.text();
+  });
+
+  it("simulates the client's first-attempt-204 → registered → 200 race", async () => {
+    // The bug: a fast workspace switch can hit the GET endpoint before the
+    // POST (or background submit) has had time to register the task in the
+    // in-memory task map. The endpoint returns 204 for that brief window
+    // and the AI SDK then silently gives up. The fix is the client-side
+    // retry loop. From the server's perspective we just need to verify
+    // that:
+    //   - a GET that arrives BEFORE registration sees 204
+    //   - the same chatId becomes streamable once registration completes
+    //
+    // We can't easily force the registration delay without timing tricks,
+    // so instead we use a chatId that's guaranteed not to have a task yet,
+    // assert 204, then start one and assert that a subsequent GET returns
+    // a streaming 200 (the path the retry loop drives).
+
+    const chatId = newChatId("race");
+
+    // Step 1: GET before any task → 204 (the silent-failure path).
+    const earlyRes = await getStream(server.url, chatId);
+    expect(earlyRes.status).toBe(204);
+    await earlyRes.text();
+
+    // Step 2: kick off a long-running task.
+    const postPromise = postStream(server.url, chatId, "testproject-main", "race test");
+
+    // Step 3: wait until the task registers, then re-attempt the GET.
+    // This mirrors the second iteration of the retry loop.
+    const deadline = Date.now() + 5000;
+    while (Date.now() < deadline) {
+      if (await isRunning(server.url, chatId)) break;
+      await new Promise((r) => setTimeout(r, 25));
+    }
+    expect(await isRunning(server.url, chatId)).toBe(true);
+
+    // Step 4: GET should now succeed and stream events. This is the
+    // recovery the retry loop relies on.
+    const reconnect = await getStream(server.url, chatId);
+    expect(reconnect.status).toBe(200);
+    expect(reconnect.headers.get("content-type")?.toLowerCase()).toContain("text/event-stream");
+
+    // Drain both responses so the test cleans up.
+    const reconnectEvents = await drainEvents(reconnect);
+    expect(reconnectEvents.length).toBeGreaterThan(0);
+    const original = await postPromise;
+    expect(original.status).toBe(200);
+    await drainEvents(original);
+  });
+
+  it("returns 204 again once the task has fully completed", async () => {
+    // Run a short scenario all the way through, then GET should be 204.
+    const chatId = newChatId("post-complete");
+    const post = await postStream(
+      server.url,
+      chatId,
+      "testproject-main",
+      "complete then reconnect",
+    );
+    expect(post.status).toBe(200);
+    await drainEvents(post);
+
+    // Wait for the task to be deregistered from the running set.
+    const deadline = Date.now() + 3000;
+    while (Date.now() < deadline) {
+      if (!(await isRunning(server.url, chatId))) break;
+      await new Promise((r) => setTimeout(r, 25));
+    }
+    expect(await isRunning(server.url, chatId)).toBe(false);
+
+    const reconnect = await getStream(server.url, chatId);
+    expect(reconnect.status).toBe(204);
+    await reconnect.text();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// "Retry then give up" — repeated polling against a non-running chat
+// ---------------------------------------------------------------------------
+
+describe("client-style retry — bounded give-up", () => {
+  let server: ServerHandle;
+  let tmpHome: string;
+
+  beforeAll(async () => {
+    tmpHome = createTmpHome();
+    seedState(tmpHome, createDefaultState(tmpHome));
+    seedSettings(tmpHome, defaultSettings());
+    const scenarioPath = writeScenario(tmpHome, quickScenario());
+    server = await startServer({ tmpHome, scenarioPath });
+  });
+
+  afterAll(async () => {
+    await server.close();
+    rmSync(tmpHome, { recursive: true, force: true });
+  });
+
+  it("a client polling tasks.isRunning + GET /stream gives up cleanly when nothing runs", async () => {
+    const chatId = newChatId("never-runs");
+
+    // Mimic the production retry loop: up to N iterations, each does
+    // GET → check 204, then ask isRunning, and bail when running=false.
+    const maxIters = 5;
+    let getCalls = 0;
+    let isRunningCalls = 0;
+    let gaveUp = false;
+
+    for (let i = 0; i < maxIters; i++) {
+      const res = await getStream(server.url, chatId);
+      getCalls++;
+      expect(res.status).toBe(204);
+      await res.text();
+
+      isRunningCalls++;
+      if (!(await isRunning(server.url, chatId))) {
+        gaveUp = true;
+        break;
+      }
+
+      // Tiny pause to mimic the client's backoff so we don't hammer.
+      await new Promise((r) => setTimeout(r, 10));
+    }
+
+    expect(gaveUp).toBe(true);
+    // Should have given up on the very first iteration: one GET, one
+    // isRunning round-trip. This is the contract the retry loop relies on
+    // — when the server says "nothing's running" we don't keep retrying.
+    expect(getCalls).toBe(1);
+    expect(isRunningCalls).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary

After a workspace switch, the chat sometimes showed no \"thinking\" indicator even though the agent was actively running on the server. The reconnect path silently failed in two compounding ways:

- `GET /api/tasks/:chatId/stream` returns `204 No Content` if the in-memory task isn't registered at that exact moment (registration lag, completed between unmount and remount, server restart, brief race during the switch). The Vercel AI SDK treats 204 as \"nothing to resume\" and leaves `useChat.status` at `\"ready\"` — no error, no log, no indicator.
- `ChatView` used `initialSessionLoadedRef` as a one-shot, so we never retried for the same session.

## Changes

- **`tasks.isRunning` tRPC query** — lightweight existence check so the client can distinguish \"server says nothing's running, give up\" from \"server says it IS running, keep retrying\".
- **Retry loop in `ChatView`** — wraps `resumeStream()` with backoff (250ms → 500ms → 1s → 2s, max ~3.75s total). Stops on success (`status` flips to `\"submitted\"`/`\"streaming\"`), on clean give-up (`tasks.isRunning` reports false), or on cancel (unmount / new attempt). Re-attempts on tab focus and `window.online`.
- **\"Connecting…\" indicator** — distinct label on the existing `ThinkingIndicator` shown while the retry loop is in flight, so users get immediate feedback separate from the agent's thinking state.
- **Integration tests** in `apps/web/tests/stream-reconnect.test.ts` — exercise `tasks.isRunning` lifecycle, the GET 200/204 contract, the race recovery path, and the bounded give-up behavior.
- **`_sleep_ms` directive in `tests/fake-agent.mjs`** — test-only helper to hold the fake agent in the running state long enough to probe reconnect endpoints.

## Test plan

- [x] `pnpm --filter @band-app/server exec vitest run tests/stream-reconnect.test.ts` — 6/6 pass
- [x] `pnpm --filter @band-app/server exec vitest run tests/stream-gapfill.test.ts tests/tasks-crud.test.ts tests/chat.test.ts` — no regressions
- [x] Full `pnpm exec biome check .` clean
- [x] Full vitest suite: 411/412 pass; the one failure (`trpc.test.ts > workspaces.remove`) is pre-existing on `main` and unrelated.
- [x] `pnpm knip` clean
- [x] Manual sanity: build succeeds (`pnpm --filter @band-app/server run build`)

Closes #348

🤖 Generated with [Claude Code](https://claude.com/claude-code)