### PR TITLE
UX polish: dockview flicker fixes, configurable workspace cache, chat lifecycle fixes

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -87,6 +87,7 @@
     "radix-ui": "^1.4.3",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
+    "remark-breaks": "^4.0.0",
     "sirv": "^3.0.0",
     "streamdown": "^2.3.0",
     "tailwind-merge": "^3.5.0",

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -9,6 +9,7 @@ import {
   DropdownMenuItem,
   DropdownMenuLabel,
   DropdownMenuSeparator,
+  DropdownMenuShortcut,
   DropdownMenuTrigger,
   Tooltip,
   TooltipContent,
@@ -860,6 +861,15 @@ export function ChatView({
     };
   }, [onNewSessionRef, handleNewSession]);
 
+  // Global keyboard shortcut: Cmd/Ctrl+Shift+N → start new session.
+  // Only the visible chat pane in the active workspace responds.
+  useEffect(() => {
+    if (!visible || !wsActive) return;
+    const onNewChat = () => handleNewSession();
+    window.addEventListener("band:new-chat-session", onNewChat);
+    return () => window.removeEventListener("band:new-chat-session", onNewChat);
+  }, [visible, wsActive, handleNewSession]);
+
   const queueMessage = useCallback(
     (text: string) => {
       setQueuedMessages((prev) => [...prev, text]);
@@ -1496,6 +1506,7 @@ function SessionHistoryMenu({
         <DropdownMenuItem onClick={() => onNewSession()}>
           <Plus className="size-3.5" />
           New session
+          <DropdownMenuShortcut>⌘⇧N</DropdownMenuShortcut>
         </DropdownMenuItem>
       </DropdownMenuContent>
     </DropdownMenu>

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -269,6 +269,17 @@ export function ChatView({
   // mount effect below — initialize loadingHistory to true so the skeleton
   // shows on the first render rather than briefly flashing the empty state.
   const [loadingHistory, setLoadingHistory] = useState(!!initialSessionId);
+  // True once the user explicitly clears the session via "New session". The
+  // `initialSessionId` prop reflects the parent's persisted activeSessionId
+  // and may stay stale for a tick (or longer) after handleNewSession fires,
+  // so we ignore it for skeleton/empty-state decisions once cleared.
+  const [initialSessionCleared, setInitialSessionCleared] = useState(false);
+  // The session this view is currently on, considering local navigation:
+  //   - activeSessionId once the mount effect / handleSelectSession sets it
+  //   - else the initialSessionId prop, unless the user explicitly cleared
+  // This is what render conditions should consult, not initialSessionId.
+  const currentSessionId =
+    activeSessionId ?? (initialSessionCleared ? undefined : initialSessionId);
   const [hasMore, setHasMore] = useState(false);
   const [loadingOlder, setLoadingOlder] = useState(false);
   const scrollHeightBeforePrependRef = useRef<number | null>(null);
@@ -789,6 +800,36 @@ export function ChatView({
     };
   }, [connectToRunningStream]);
 
+  // Release the SSE connection while the workspace is hidden so cached
+  // (but inactive) workspaces don't pin HTTP/1.1 connection slots —
+  // browsers cap at ~6 per origin and the dockview LRU keeps several
+  // workspaces alive at once. The server-side task keeps running
+  // independently; on reactivation we re-fetch the persisted session
+  // history (so messages that landed while we were hidden show up) and
+  // then resume any still-running stream via Last-Event-ID.
+  const prevWsActiveRef = useRef(wsActive);
+  useEffect(() => {
+    const prev = prevWsActiveRef.current;
+    prevWsActiveRef.current = wsActive;
+
+    if (prev && !wsActive) {
+      // Workspace just deactivated — abort any in-flight reconnect retry
+      // and close the active SSE fetch. transport.close() is a no-op when
+      // there's no open connection (idle chat).
+      cancelConnectAttempt();
+      transport.close();
+    } else if (!prev && wsActive && sessionIdRef.current) {
+      // Workspace just reactivated and we know about a session — refresh
+      // from the persisted JSONL state. loadMessages also calls
+      // connectToRunningStream at the end, so an in-flight task is
+      // resumed from Last-Event-ID. If the task completed while we were
+      // hidden, this is the only path that surfaces the final message
+      // (the resume endpoint returns 204 once the in-memory task is
+      // gone, so resumeStream alone wouldn't pick it up).
+      void loadMessages(sessionIdRef.current);
+    }
+  }, [wsActive, transport, cancelConnectAttempt, loadMessages]);
+
   // Cancel any in-flight reconnect on unmount or when the underlying
   // chat/key changes (transport gets recreated).
   // biome-ignore lint/correctness/useExhaustiveDependencies: chatKey/chatId trigger cleanup
@@ -835,6 +876,7 @@ export function ChatView({
     firstMessageIndexRef.current = undefined;
     setHasMore(false);
     setActiveSessionId(undefined);
+    setInitialSessionCleared(true);
     onActiveSessionChange?.(undefined);
     setMessages([]);
     setQueuedMessages([]);
@@ -989,7 +1031,7 @@ export function ChatView({
             the load is in flight. This prevents the empty state from
             flashing on first workspace load before chats.get resolves.
           */}
-          {isEmpty && sessionQueryDone && !initialSessionId && !loadingHistory && (
+          {isEmpty && sessionQueryDone && !currentSessionId && !loadingHistory && (
             <ConversationEmptyState
               icon={
                 agentType ? (
@@ -1003,7 +1045,7 @@ export function ChatView({
             />
           )}
 
-          {messages.length === 0 && (loadingHistory || !sessionQueryDone || !!initialSessionId) && (
+          {messages.length === 0 && (loadingHistory || !sessionQueryDone || !!currentSessionId) && (
             <ConversationSkeleton />
           )}
 

--- a/apps/web/src/components/DockviewChatContainer.tsx
+++ b/apps/web/src/components/DockviewChatContainer.tsx
@@ -177,13 +177,17 @@ function ChatTabContent({
 }) {
   const state = useChatPaneState(workspaceId, chatId);
 
-  // Update the dockview tab title based on session summary or agent label
+  // Update the dockview tab title based on session summary or agent label.
+  // Wait for sessionQueryDone before pushing a title so we don't flicker
+  // through agentLabel → sessionSummary on cold mount. Once the session
+  // query has resolved (with or without a summary), pick the best value.
   const setTitleRef = useRef(setTitle);
   setTitleRef.current = setTitle;
   useEffect(() => {
+    if (!state.sessionQueryDone) return;
     const title = state.activeSessionSummary || state.agentLabel || state.codingAgentId || "Chat";
     setTitleRef.current(title);
-  }, [state.activeSessionSummary, state.agentLabel, state.codingAgentId]);
+  }, [state.sessionQueryDone, state.activeSessionSummary, state.agentLabel, state.codingAgentId]);
 
   return (
     <div className="flex h-full w-full flex-col overflow-hidden">
@@ -202,15 +206,43 @@ function ChatTabContent({
 // Custom tab header: agent icon + name + close button
 // ---------------------------------------------------------------------------
 
+// Persist last-known tab title + agent type per chatId so a remount of the tab
+// header (workspace switch, dockview re-init) starts with the previous values
+// instead of the bare "Chat" placeholder + missing icon — eliminates the
+// fade-in flicker users saw when title/icon resolved asynchronously.
+function readCachedTabMeta(chatId: string): { title?: string; agentType?: string } {
+  if (!chatId) return {};
+  try {
+    const raw = sessionStorage.getItem(`band:chat-tab-meta:${chatId}`);
+    return raw ? JSON.parse(raw) : {};
+  } catch {
+    return {};
+  }
+}
+
+function writeCachedTabMeta(chatId: string, patch: { title?: string; agentType?: string }) {
+  if (!chatId) return;
+  try {
+    const prev = readCachedTabMeta(chatId);
+    sessionStorage.setItem(`band:chat-tab-meta:${chatId}`, JSON.stringify({ ...prev, ...patch }));
+  } catch {}
+}
+
 function ChatTab(props: IDockviewPanelHeaderProps<ChatTabParams>) {
-  const [title, setTitle] = useState(props.api.title ?? "Chat");
-  const [agentType, setAgentType] = useState<string | undefined>(undefined);
+  const initialChatId = props.params.chatId;
+  const initialCache = readCachedTabMeta(initialChatId);
+  const [title, setTitle] = useState(initialCache.title ?? props.api.title ?? "Chat");
+  const [agentType, setAgentType] = useState<string | undefined>(initialCache.agentType);
   const [panelCount, setPanelCount] = useState(props.containerApi.panels.length);
 
   useEffect(() => {
-    const d = props.api.onDidTitleChange(() => setTitle(props.api.title ?? "Chat"));
+    const d = props.api.onDidTitleChange(() => {
+      const next = props.api.title ?? "Chat";
+      setTitle(next);
+      writeCachedTabMeta(initialChatId, { title: next });
+    });
     return () => d.dispose();
-  }, [props.api]);
+  }, [props.api, initialChatId]);
 
   // Track panel count reactively for close button visibility
   useEffect(() => {
@@ -243,7 +275,10 @@ function ChatTab(props: IDockviewPanelHeaderProps<ChatTabParams>) {
         | undefined;
       const agentId = chatResult.chat?.agent ?? defaultAgentId ?? "";
       const found = codingAgents.find((a) => a.id === agentId);
-      if (found) setAgentType(found.type);
+      if (found) {
+        setAgentType(found.type);
+        writeCachedTabMeta(chatId, { agentType: found.type });
+      }
     });
     return () => {
       cancelled = true;
@@ -263,19 +298,34 @@ function ChatTab(props: IDockviewPanelHeaderProps<ChatTabParams>) {
   return (
     <div className="dv-default-tab">
       <div className="flex items-center gap-1.5 min-w-0">
-        {agentType && <AgentIcon type={agentType} className="size-3.5 shrink-0" />}
-        <span className="truncate">{title}</span>
-      </div>
-      {showClose && (
-        <button
-          type="button"
-          className="ml-1 inline-flex size-4 items-center justify-center rounded-sm opacity-60 hover:opacity-100 hover:bg-accent transition-colors"
-          onClick={handleClose}
-          title="Close tab"
+        {/* Reserve icon slot — opacity fades in once agentType resolves so
+            the icon does not pop in. Width is reserved either way. */}
+        <span
+          className="inline-flex size-3.5 shrink-0 items-center justify-center transition-opacity duration-150"
+          style={{ opacity: agentType ? 1 : 0 }}
         >
-          <X className="size-3" />
-        </button>
-      )}
+          {agentType && <AgentIcon type={agentType} className="size-3.5" />}
+        </span>
+        {/* Bounded width so chat tab does not reflow as title loads/changes. */}
+        <span className="truncate min-w-[6rem] max-w-[14rem]">{title}</span>
+      </div>
+      {/* Always render the close button slot — toggle visibility via opacity
+          instead of mounting/unmounting so panelCount swings (1 ↔ 2) do not
+          shift the tab width. */}
+      <button
+        type="button"
+        aria-hidden={!showClose}
+        tabIndex={showClose ? 0 : -1}
+        className="ml-1 inline-flex size-4 items-center justify-center rounded-sm opacity-60 hover:opacity-100 hover:bg-accent transition-opacity"
+        style={{
+          opacity: showClose ? undefined : 0,
+          pointerEvents: showClose ? undefined : "none",
+        }}
+        onClick={handleClose}
+        title="Close tab"
+      >
+        <X className="size-3" />
+      </button>
     </div>
   );
 }

--- a/apps/web/src/components/DockviewInstanceManager.tsx
+++ b/apps/web/src/components/DockviewInstanceManager.tsx
@@ -14,7 +14,10 @@ interface CachedWorkspace {
   lastAccessed: number;
 }
 
-const MAX_CACHED_WORKSPACES = 1;
+// Keep recently visited workspaces' dockview instances alive in memory so
+// switching between them is instantaneous (no init cost, no layout shift).
+// Bumped from 1 → 5 to eliminate flicker on the common A→B→A switch pattern.
+const MAX_CACHED_WORKSPACES = 5;
 
 /**
  * Manages multiple DockviewWorkspaceLayout instances with show/hide semantics.
@@ -125,17 +128,24 @@ export function DockviewInstanceManager() {
 
   return (
     <div className="absolute inset-0">
-      {Array.from(cache.values()).map(({ workspaceId }) => (
-        <div
-          key={workspaceId}
-          className="absolute inset-0"
-          style={
-            workspaceId === activeWorkspaceId ? undefined : { opacity: 0, pointerEvents: "none" }
-          }
-        >
-          <DockviewWorkspaceLayout workspaceId={workspaceId} onLayoutChange={handleLayoutChange} />
-        </div>
-      ))}
+      {Array.from(cache.values()).map(({ workspaceId }) => {
+        const isActive = workspaceId === activeWorkspaceId;
+        return (
+          <div
+            key={workspaceId}
+            className="absolute inset-0 transition-opacity duration-150 ease-out"
+            style={{
+              opacity: isActive ? 1 : 0,
+              pointerEvents: isActive ? undefined : "none",
+            }}
+          >
+            <DockviewWorkspaceLayout
+              workspaceId={workspaceId}
+              onLayoutChange={handleLayoutChange}
+            />
+          </div>
+        );
+      })}
     </div>
   );
 }

--- a/apps/web/src/components/DockviewInstanceManager.tsx
+++ b/apps/web/src/components/DockviewInstanceManager.tsx
@@ -1,4 +1,4 @@
-import { recordWorkspaceAccess } from "@band-app/dashboard-core";
+import { recordWorkspaceAccess, useSettingsQuery } from "@band-app/dashboard-core";
 import { useRouterState } from "@tanstack/react-router";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { parseWorkspaceFromPath } from "../lib/parse-workspace";
@@ -14,10 +14,12 @@ interface CachedWorkspace {
   lastAccessed: number;
 }
 
-// Keep recently visited workspaces' dockview instances alive in memory so
-// switching between them is instantaneous (no init cost, no layout shift).
-// Bumped from 1 → 5 to eliminate flicker on the common A→B→A switch pattern.
-const MAX_CACHED_WORKSPACES = 5;
+// Default cap on how many workspace dockview instances stay alive in memory
+// at once. Higher values eliminate skeleton flicker on common A↔B↔C cycles
+// at the cost of memory + background work for each cached instance.
+// Override per-user via `settings.maxCachedWorkspaces`.
+const DEFAULT_MAX_CACHED_WORKSPACES = 3;
+const MIN_MAX_CACHED_WORKSPACES = 1;
 
 /**
  * Manages multiple DockviewWorkspaceLayout instances with show/hide semantics.
@@ -25,7 +27,8 @@ const MAX_CACHED_WORKSPACES = 5;
  * Instead of destroying and recreating dockview on workspace switch, this
  * component keeps each visited workspace's dockview alive (hidden via CSS
  * `opacity: 0`) and shows the active one. An LRU strategy evicts the
- * oldest cached instance when the cache exceeds MAX_CACHED_WORKSPACES.
+ * oldest cached instance when the cache exceeds the configured
+ * `maxCachedWorkspaces` setting.
  *
  * IMPORTANT: `activeWorkspaceId` is derived synchronously from pathname (not
  * via useEffect) so the correct workspace is visible from the very first
@@ -38,6 +41,14 @@ export function DockviewInstanceManager() {
   const [cache, setCache] = useState<Map<string, CachedWorkspace>>(new Map());
 
   const pathname = useRouterState({ select: (s) => s.location.pathname });
+
+  // Max cached workspaces is user-configurable via settings. Clamp to a
+  // sensible floor so a misconfigured value can't break caching entirely.
+  const { settings } = useSettingsQuery();
+  const maxCachedWorkspaces = Math.max(
+    MIN_MAX_CACHED_WORKSPACES,
+    settings.maxCachedWorkspaces ?? DEFAULT_MAX_CACHED_WORKSPACES,
+  );
 
   // Derive active workspace synchronously from pathname — no useEffect delay.
   // This ensures the CSS display swap happens in the same render as the URL
@@ -60,7 +71,7 @@ export function DockviewInstanceManager() {
       });
 
       // LRU eviction: remove the oldest entry (excluding current)
-      if (next.size > MAX_CACHED_WORKSPACES) {
+      if (next.size > maxCachedWorkspaces) {
         let oldestKey: string | null = null;
         let oldestTime = Infinity;
         for (const [key, entry] of next) {

--- a/apps/web/src/components/DockviewWorkspaceLayout.tsx
+++ b/apps/web/src/components/DockviewWorkspaceLayout.tsx
@@ -9,7 +9,7 @@ import {
   useSettingsQuery,
   WorkspacePickerDialog,
 } from "@band-app/dashboard-core";
-import { Tooltip, TooltipContent, TooltipTrigger } from "@band-app/ui";
+import { cn, Tooltip, TooltipContent, TooltipTrigger } from "@band-app/ui";
 import {
   type DockviewApi,
   DockviewReact,
@@ -207,8 +207,12 @@ function DefaultTab(props: IDockviewPanelHeaderProps) {
         className="dv-default-tab-content"
         style={{ display: "flex", alignItems: "center", gap: 6 }}
       >
-        {Icon && <Icon className="size-4 shrink-0" />}
-        <span>{title}</span>
+        {Icon ? (
+          <Icon className="size-4 shrink-0" />
+        ) : (
+          <span className="inline-block size-4 shrink-0" aria-hidden />
+        )}
+        <span className="truncate">{title}</span>
       </div>
     </div>
   );
@@ -243,19 +247,31 @@ function BadgeTab(props: IDockviewPanelHeaderProps) {
     return () => d.dispose();
   }, [props.api]);
 
+  const hasBadge = badge != null && badge > 0;
+
   const tab = (
     <div className="dv-default-tab">
       <div
         className="dv-default-tab-content"
         style={{ display: "flex", alignItems: "center", gap: 6 }}
       >
-        {Icon && <Icon className="size-4 shrink-0" />}
-        <span>{title}</span>
-        {badge != null && badge > 0 && (
-          <span className="inline-flex h-5 min-w-5 items-center justify-center rounded-full bg-blue-500/20 px-1.5 text-xs font-medium text-blue-600 dark:text-blue-400">
-            {badge}
-          </span>
+        {Icon ? (
+          <Icon className="size-4 shrink-0" />
+        ) : (
+          <span className="inline-block size-4 shrink-0" aria-hidden />
         )}
+        <span className="truncate">{title}</span>
+        {/* Reserve badge slot — invisible when count is 0 so width stays
+            stable when diff stats load asynchronously after a workspace switch. */}
+        <span
+          aria-hidden={!hasBadge}
+          className={cn(
+            "inline-flex h-5 min-w-5 items-center justify-center rounded-full bg-blue-500/20 px-1.5 text-xs font-medium text-blue-600 dark:text-blue-400 transition-opacity",
+            hasBadge ? "opacity-100" : "opacity-0",
+          )}
+        >
+          {hasBadge ? badge : 0}
+        </span>
       </div>
     </div>
   );
@@ -733,7 +749,10 @@ export const DockviewWorkspaceLayout = memo(function DockviewWorkspaceLayout({
       const api = apiRef.current;
       const key = e.key.toLowerCase();
 
-      if (key === "p" && e.shiftKey) {
+      if (key === "n" && e.shiftKey) {
+        e.preventDefault();
+        window.dispatchEvent(new CustomEvent("band:new-chat-session"));
+      } else if (key === "p" && e.shiftKey) {
         e.preventDefault();
         setCommandPaletteOpen(true);
       } else if (key === "p" && !e.shiftKey) {

--- a/apps/web/src/components/ai-elements/message.tsx
+++ b/apps/web/src/components/ai-elements/message.tsx
@@ -7,6 +7,7 @@ import type { UIMessage } from "ai";
 import { Download, Expand, FileIcon } from "lucide-react";
 import type { ComponentProps, HTMLAttributes } from "react";
 import { memo, useCallback, useState } from "react";
+import remarkBreaks from "remark-breaks";
 import { defaultRehypePlugins, defaultRemarkPlugins, Streamdown } from "streamdown";
 
 import {
@@ -63,7 +64,11 @@ export const MessageResponse = memo(
       )}
       plugins={streamdownPlugins}
       components={fileLinkComponents}
-      remarkPlugins={[...Object.values(defaultRemarkPlugins), ...fileLinkRemarkPlugins]}
+      remarkPlugins={[
+        ...Object.values(defaultRemarkPlugins),
+        remarkBreaks,
+        ...fileLinkRemarkPlugins,
+      ]}
       rehypePlugins={[...Object.values(defaultRehypePlugins), ...fileLinkRehypePlugins]}
       urlTransform={fileLinkUrlTransform}
       {...props}

--- a/apps/web/src/lib/state.ts
+++ b/apps/web/src/lib/state.ts
@@ -74,6 +74,12 @@ export interface Settings {
   labels?: LabelDefinition[];
   tokenSecret?: string;
   autoStartTunnel?: boolean;
+  /**
+   * Maximum number of workspace dockview instances kept alive in memory at
+   * once. Higher values speed up switching back to recent workspaces at the
+   * cost of memory and background work. Defaults to 3 in the client.
+   */
+  maxCachedWorkspaces?: number;
   /** Extra fields not explicitly modeled. Preserved across read/write. */
   [key: string]: unknown;
 }

--- a/apps/web/src/routes/workspace.$workspaceId.tsx
+++ b/apps/web/src/routes/workspace.$workspaceId.tsx
@@ -133,12 +133,17 @@ function WorkspaceLayout() {
     setHydrated(true);
   }, []);
 
-  // Sync zustand active workspace from URL
+  // Sync zustand active workspace from URL.
+  // Two effects: one updates on param change, the other clears only on unmount.
+  // Combining them caused a brief null-then-set toggle on every workspace
+  // switch, which made sidebar cards flash inactive for one frame.
   const setActiveWorkspace = useDashboardStore((s) => s.setActiveWorkspace);
   useEffect(() => {
     setActiveWorkspace(decoded);
-    return () => setActiveWorkspace(null);
   }, [decoded, setActiveWorkspace]);
+  useEffect(() => {
+    return () => setActiveWorkspace(null);
+  }, [setActiveWorkspace]);
 
   // Clear needs_attention status when viewing this workspace
   const clearNeedsAttention = useDashboardStore((s) => s.clearNeedsAttention);

--- a/apps/web/src/styles/dockview-theme.css
+++ b/apps/web/src/styles/dockview-theme.css
@@ -52,8 +52,15 @@
   --dv-tab-margin: 0px;
 }
 
-/* No underline on selected tab — just brighter text + bold */
-.dockview-theme-band .dv-groupview.dv-active-group
+/* All tabs share the same font-weight so switching active tab does NOT
+   change glyph metrics → no reflow / layout shift in tab labels.
+   Active state is signaled via color (foreground vs muted-foreground)
+   set on the dockview CSS variables above, not via font-weight. */
+.dockview-theme-band .dv-tab {
+  font-weight: 600;
+}
+.dockview-theme-band
+  .dv-groupview.dv-active-group
   > .dv-tabs-and-actions-container
   .dv-tab.dv-active-tab,
 .dockview-theme-band
@@ -61,7 +68,6 @@
   > .dv-tabs-and-actions-container
   .dv-tab.dv-active-tab {
   box-shadow: none;
-  font-weight: 600;
 }
 
 /* Border below the tabs container */
@@ -116,8 +122,12 @@
   padding-right: 0.25rem;
 }
 
-/* No underline on selected chat tab — just brighter text + bold */
-.dockview-chat-tabs .dv-groupview.dv-active-group
+/* Uniform font-weight across all chat tabs → no reflow on active toggle. */
+.dockview-chat-tabs .dv-tab {
+  font-weight: 600;
+}
+.dockview-chat-tabs
+  .dv-groupview.dv-active-group
   > .dv-tabs-and-actions-container
   .dv-tab.dv-active-tab,
 .dockview-chat-tabs
@@ -125,7 +135,6 @@
   > .dv-tabs-and-actions-container
   .dv-tab.dv-active-tab {
   box-shadow: none;
-  font-weight: 600;
 }
 
 /* ---------------------------------------------------------------------------
@@ -169,8 +178,12 @@
   padding-right: 0.25rem;
 }
 
-/* No underline on selected browser tab — just brighter text + bold */
-.dockview-browser-tabs .dv-groupview.dv-active-group
+/* Uniform font-weight across all browser tabs → no reflow on active toggle. */
+.dockview-browser-tabs .dv-tab {
+  font-weight: 600;
+}
+.dockview-browser-tabs
+  .dv-groupview.dv-active-group
   > .dv-tabs-and-actions-container
   .dv-tab.dv-active-tab,
 .dockview-browser-tabs
@@ -178,7 +191,6 @@
   > .dv-tabs-and-actions-container
   .dv-tab.dv-active-tab {
   box-shadow: none;
-  font-weight: 600;
 }
 
 /* ---------------------------------------------------------------------------
@@ -222,8 +234,12 @@
   padding-right: 0.25rem;
 }
 
-/* No underline on selected terminal tab — just brighter text */
-.dockview-terminal-tabs .dv-groupview.dv-active-group
+/* Uniform font-weight across all terminal tabs → no reflow on active toggle. */
+.dockview-terminal-tabs .dv-tab {
+  font-weight: 600;
+}
+.dockview-terminal-tabs
+  .dv-groupview.dv-active-group
   > .dv-tabs-and-actions-container
   .dv-tab.dv-active-tab,
 .dockview-terminal-tabs
@@ -231,5 +247,4 @@
   > .dv-tabs-and-actions-container
   .dv-tab.dv-active-tab {
   box-shadow: none;
-  font-weight: 600;
 }

--- a/packages/dashboard-core/src/components/SettingsPage.tsx
+++ b/packages/dashboard-core/src/components/SettingsPage.tsx
@@ -72,6 +72,9 @@ export function SettingsPage({ open, onOpenChange }: Props) {
   const [labels, setLabels] = useState<LabelDefinition[]>(settings.labels ?? []);
   const [autoStartTunnel, setAutoStartTunnel] = useState(settings.autoStartTunnel ?? false);
   const [enableLSP, setEnableLSP] = useState(settings.enableLSP ?? false);
+  const [maxCachedWorkspaces, setMaxCachedWorkspaces] = useState(
+    settings.maxCachedWorkspaces?.toString() ?? "",
+  );
   const [selectedTheme, setSelectedTheme] = useState<Theme>(settings.theme ?? "system");
   const [agentModels, setAgentModels] = useState<
     Record<string, { id: string; name: string; description?: string }[]>
@@ -109,6 +112,7 @@ export function SettingsPage({ open, onOpenChange }: Props) {
     if (JSON.stringify(labels) !== JSON.stringify(settings.labels ?? [])) return true;
     if (autoStartTunnel !== (settings.autoStartTunnel ?? false)) return true;
     if (enableLSP !== (settings.enableLSP ?? false)) return true;
+    if (maxCachedWorkspaces !== (settings.maxCachedWorkspaces?.toString() ?? "")) return true;
     if (selectedTheme !== (settings.theme ?? "system")) return true;
     return false;
   }, [
@@ -121,6 +125,7 @@ export function SettingsPage({ open, onOpenChange }: Props) {
     labels,
     autoStartTunnel,
     enableLSP,
+    maxCachedWorkspaces,
     selectedTheme,
     settings,
   ]);
@@ -135,6 +140,7 @@ export function SettingsPage({ open, onOpenChange }: Props) {
     setLabels(settings.labels ?? []);
     setAutoStartTunnel(settings.autoStartTunnel ?? false);
     setEnableLSP(settings.enableLSP ?? false);
+    setMaxCachedWorkspaces(settings.maxCachedWorkspaces?.toString() ?? "");
     setSelectedTheme(settings.theme ?? "system");
   }, [
     settings.worktreesDir,
@@ -145,6 +151,7 @@ export function SettingsPage({ open, onOpenChange }: Props) {
     settings.labels,
     settings.autoStartTunnel,
     settings.enableLSP,
+    settings.maxCachedWorkspaces,
     settings.theme,
   ]);
 
@@ -165,6 +172,12 @@ export function SettingsPage({ open, onOpenChange }: Props) {
       if (Number.isNaN(n) || n <= 0 || n >= 65536) return;
       parsedPort = n;
     }
+    let parsedMaxCachedWorkspaces: number | undefined;
+    if (maxCachedWorkspaces.trim()) {
+      const n = parseInt(maxCachedWorkspaces.trim(), 10);
+      if (Number.isNaN(n) || n < 1 || n > 20) return;
+      parsedMaxCachedWorkspaces = n;
+    }
     await updateSettingsMutation.mutateAsync({
       worktreesDir: worktreesDir.trim() || null,
       codingAgents: codingAgents.length > 0 ? codingAgents : undefined,
@@ -175,6 +188,7 @@ export function SettingsPage({ open, onOpenChange }: Props) {
       tokenSecret: settings.tokenSecret,
       autoStartTunnel: autoStartTunnel || undefined,
       enableLSP: enableLSP || undefined,
+      maxCachedWorkspaces: parsedMaxCachedWorkspaces,
       theme: selectedTheme,
     });
   };
@@ -266,6 +280,25 @@ export function SettingsPage({ open, onOpenChange }: Props) {
                 description="Enable hover type info and go-to-definition in the code browser. Currently supports TypeScript and JavaScript. Uses additional memory per workspace."
               >
                 <Switch id="enable-lsp" checked={enableLSP} onCheckedChange={setEnableLSP} />
+              </SettingsRow>
+              <SettingsRow
+                variant="responsive"
+                htmlFor="max-cached-workspaces"
+                label="Cached workspaces"
+                description="How many recently visited workspaces to keep alive in memory for instant switching. Higher values use more memory. Leave empty for the default (3)."
+              >
+                <Input
+                  id="max-cached-workspaces"
+                  type="number"
+                  placeholder="3 (default)"
+                  value={maxCachedWorkspaces}
+                  onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                    setMaxCachedWorkspaces(e.target.value)
+                  }
+                  min={1}
+                  max={20}
+                  className="h-8 w-full text-sm sm:w-32"
+                />
               </SettingsRow>
             </SettingsSection>
 

--- a/packages/dashboard-core/src/types.ts
+++ b/packages/dashboard-core/src/types.ts
@@ -130,6 +130,13 @@ export interface Settings {
   autoStartTunnel?: boolean;
   enableLSP?: boolean;
   theme?: Theme;
+  /**
+   * Maximum number of workspace dockview instances kept alive in memory at
+   * once for instant switching. Higher values use more memory but make
+   * switching back to recent workspaces faster.
+   * @default 3
+   */
+  maxCachedWorkspaces?: number;
 }
 
 export interface HooksStatus {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -241,6 +241,9 @@ importers:
       react-dom:
         specifier: ^19.0.0
         version: 19.2.4(react@19.2.4)
+      remark-breaks:
+        specifier: ^4.0.0
+        version: 4.0.0
       sirv:
         specifier: ^3.0.0
         version: 3.0.2
@@ -4980,6 +4983,9 @@ packages:
   mdast-util-mdxjs-esm@2.0.1:
     resolution: {integrity: sha512-EcmOpxsZ96CvlP03NghtH1EsLtr0n9Tm4lPUJUBccV9RwUOneqSycg19n5HGzCf+10LozMRSObtVr3ee1WoHtg==}
 
+  mdast-util-newline-to-break@2.0.0:
+    resolution: {integrity: sha512-MbgeFca0hLYIEx/2zGsszCSEJJ1JSCdiY5xQxRcLDDGa8EPvlLPupJ4DSajbMPAnC0je8jfb9TiUATnxxrHUog==}
+
   mdast-util-phrasing@4.1.0:
     resolution: {integrity: sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==}
 
@@ -5598,6 +5604,9 @@ packages:
 
   rehype@13.0.2:
     resolution: {integrity: sha512-j31mdaRFrwFRUIlxGeuPXXKWQxet52RBQRvCmzl5eCefn/KGbomK5GMHNMsOJf55fgo3qw5tST5neDuarDYR2A==}
+
+  remark-breaks@4.0.0:
+    resolution: {integrity: sha512-IjEjJOkH4FuJvHZVIW0QCDWxcG96kCq7An/KVH2NfJe6rKZU2AsHeB3OEjPNRxi4QC34Xdx7I2KGYn6IpT7gxQ==}
 
   remark-cjk-friendly-gfm-strikethrough@1.2.3:
     resolution: {integrity: sha512-bXfMZtsaomK6ysNN/UGRIcasQAYkC10NtPmP0oOHOV8YOhA2TXmwRXCku4qOzjIFxAPfish5+XS0eIug2PzNZA==}
@@ -11381,6 +11390,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  mdast-util-newline-to-break@2.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-find-and-replace: 3.0.2
+
   mdast-util-phrasing@4.1.0:
     dependencies:
       '@types/mdast': 4.0.4
@@ -12294,6 +12308,12 @@ snapshots:
       '@types/hast': 3.0.4
       rehype-parse: 9.0.1
       rehype-stringify: 10.0.1
+      unified: 11.0.5
+
+  remark-breaks@4.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-newline-to-break: 2.0.0
       unified: 11.0.5
 
   remark-cjk-friendly-gfm-strikethrough@1.2.3(@types/mdast@4.0.4)(micromark-util-types@2.0.2)(micromark@4.0.2)(unified@11.0.5):


### PR DESCRIPTION
## Summary

Bundles two UX-polish cherry-picks from `develop` plus follow-on fixes for problems uncovered while testing them on top of main:

1. **`fix(chat): preserve newlines in agent markdown output`** — adds `remark-breaks` to the markdown pipeline so single newlines in agent responses render as `<br>` instead of being collapsed to spaces.
2. **`fix(ui): eliminate dockview tab/workspace switch flicker and add new-session shortcut`** — caches last-known tab title/agent type per chat in sessionStorage, reserves fixed-width slots for icon/badge/close button, splits the active-workspace effect to remove the null-then-set toggle, and adds **⌘⇧N** to start a new chat session. (These two are cherry-picks from `origin/develop`.)
3. **`feat(settings): configurable max cached workspaces`** — replaces the hardcoded `MAX_CACHED_WORKSPACES = 5` with a user setting (default `3`, range `1–20`). Wired through `Settings` types on both client (`dashboard-core`) and server (`apps/web`), exposed in `SettingsPage` as a numeric "Cached workspaces" row in General, read by `DockviewInstanceManager` via `useSettingsQuery` with a clamped floor of 1.
4. **`fix(chat): preserve chat state across workspace switches and new-session`** — two related lifecycle fixes:
   - **SSE refresh on workspace reactivation.** The cherry-picked LRU bump kept multiple workspaces' chats mounted; if a task was streaming when you switched away and *finished* while you were elsewhere, the resume endpoint returned 204 and the final assistant message stayed stranded in JSONL until reload. On `wsActive` flip false→true we now call `loadMessages(sessionId)` (which already does fetch-then-resume), instead of just `connectToRunningStream`.
   - **Skeleton stuck after "New session".** Both the skeleton and empty-state render conditions consulted `initialSessionId` (parent prop) directly. After `handleNewSession` cleared local state, the prop lagged the parent's `chats.get` refetch — skeleton rendered indefinitely, empty state never appeared. Tracks an `initialSessionCleared` flag and derives a `currentSessionId` for the render conditions.

## Test plan

- [ ] Switch between several workspaces (more than 3): older entries should LRU-evict, recent ones remain instant.
- [ ] Open Settings → General → "Cached workspaces". Empty input = default 3; 1–20 saves; out-of-range silently rejected (same as Web Server port).
- [ ] In a workspace, send a slow agent prompt. Switch to another workspace mid-stream. After the task completes server-side, return — the final assistant message should appear without a page reload.
- [ ] Click "New session" in the session-history dropdown. Empty state ("Send a message to start coding") should appear; skeleton should not stick.
- [ ] **⌘⇧N** in a focused chat starts a new session (same as the dropdown action).
- [ ] Agent markdown responses with single newlines render with line breaks preserved.
- [ ] No regressions on workspace switch flicker (icon/badge/close button slots stay stable).

🤖 Generated with [Claude Code](https://claude.com/claude-code)