### PR TITLE
ci: stub bun sidecar for clippy and dashboard tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,7 +103,10 @@ jobs:
         run: |
           mkdir -p apps/web/dist apps/dashboard/src-tauri/binaries
           touch apps/web/dist/start-server.mjs
-          cp apps/cli/target/release/band "apps/dashboard/src-tauri/binaries/band-$(rustc -vV | sed -n 's/host: //p')"
+          TRIPLE="$(rustc -vV | sed -n 's/host: //p')"
+          cp apps/cli/target/release/band "apps/dashboard/src-tauri/binaries/band-$TRIPLE"
+          touch "apps/dashboard/src-tauri/binaries/bun-$TRIPLE"
+          chmod +x "apps/dashboard/src-tauri/binaries/bun-$TRIPLE"
           cargo clippy --manifest-path apps/dashboard/src-tauri/Cargo.toml -- -D warnings
 
       - name: Build web (needed by tests)


### PR DESCRIPTION
## PO Summary
Unblocks CI for the upcoming Bun sidecar work. No user-facing change — purely an internal CI plumbing fix so dashboard build checks succeed on Linux runners.

## Why
The Tauri dashboard build script validates every entry in `externalBin` exists at compile time. The `chore/build-stack` PR adds `binaries/bun` to `externalBin`, but `pull_request_target` runs the workflow from `main`, which currently only stubs `band` — not `bun`. Result: clippy step fails with `resource path 'binaries/bun-x86_64-unknown-linux-gnu' doesn't exist`.

Landing this on `main` first lets the `chore/build-stack` PR pass CI on rerun.

## Change
Adds `touch` + `chmod +x` for the bun stub alongside the existing band stub in the `Lint (cargo clippy — Dashboard)` step. Stub persists for the later `Test (Dashboard)` step in the same job.

## Test plan
- [ ] CI green on this PR (no `tauri.conf.json` change here, so it passes with the prior workflow)
- [ ] After merge, rerun CI on `chore/build-stack` PR and confirm clippy + dashboard tests pass