### PR TITLE
fix(dashboard): render top-toolbar tooltips below the trigger

### DIFF
--- a/packages/dashboard-core/src/components/DashboardShell.tsx
+++ b/packages/dashboard-core/src/components/DashboardShell.tsx
@@ -172,7 +172,7 @@ export function DashboardShell({ toolbarMenuItems, hideTitleBar }: DashboardShel
                   </Button>
                 </DropdownMenuTrigger>
               </TooltipTrigger>
-              <TooltipContent>More</TooltipContent>
+              <TooltipContent side="bottom">More</TooltipContent>
             </Tooltip>
             <DropdownMenuContent align="start">
               <DropdownMenuItem onClick={() => setEditMode((v) => !v)}>
@@ -250,7 +250,7 @@ export function DashboardShell({ toolbarMenuItems, hideTitleBar }: DashboardShel
                 <Plus className="size-5" />
               </Button>
             </TooltipTrigger>
-            <TooltipContent>Add project</TooltipContent>
+            <TooltipContent side="bottom">Add project</TooltipContent>
           </Tooltip>
         </div>
       </div>


### PR DESCRIPTION
Closes #245.

## Summary

The hamburger (`More`) and `Add project` tooltips in the project-list toolbar use the default Radix `side="top"`, which on macOS Tauri places the popup directly into the strip reserved for the traffic-light cluster — the tooltip ends up half-behind the close/minimize/maximize buttons. The toolbar layout itself was already fine; only the tooltip side was wrong.

Both buttons sit in the topmost toolbar row of the dashboard sidebar, so flip them to `side="bottom"`. The popups now drop down into the project-list area and stay clear of the macOS title-bar overlay.

## Test plan

- [ ] macOS Tauri dashboard mode: hover the hamburger menu → "More" tooltip appears *below* the button, fully visible, no overlap with traffic lights.
- [ ] macOS Tauri dashboard mode: hover the `+` button → "Add project" tooltip appears below the button.
- [ ] Web (`localhost:3456`): same — tooltips render below the buttons (no regression).
- [ ] No layout / spacing change to the toolbar itself.

## Before / After

Before: tooltip from the hamburger button rendered upward into the traffic-light strip on macOS Tauri (see screenshot in #245).
After: tooltip renders below the button.

🤖 Generated with [Claude Code](https://claude.com/claude-code)