### PR TITLE
feat(cli): replace `tasks create` with top-level `chat` command

### DIFF
--- a/.claude/skills/backlog-burner/SKILL.md
+++ b/.claude/skills/backlog-burner/SKILL.md
@@ -5,7 +5,7 @@ description: Master orchestrator that burns through a project backlog. Runs as a
 
 # Backlog Burner — Master Orchestrator
 
-Supervises all workspaces in a project. On every run: checks what's idle, what's approved, what needs attention, and what's next in the backlog. Dispatches work via `band tasks create` and cleans up finished workspaces.
+Supervises all workspaces in a project. On every run: checks what's idle, what's approved, what needs attention, and what's next in the backlog. Dispatches work via `band chat` and cleans up finished workspaces.
 
 This skill is designed to run as a **project-scoped cronjob on the main branch**. Set it up with:
 
@@ -60,7 +60,7 @@ For each open PR where `reviewDecision == "APPROVED"` or has an `approved` label
 3. Submit a merge task:
 
 ```sh
-band tasks create <workspace_id> --prompt "The PR #<number> has been approved. Merge it and clean up:
+band chat <workspace_id> --message "The PR #<number> has been approved. Merge it and clean up:
 
 1. Wait for CI: gh pr checks <number> --watch --fail-fast
 2. If CI passes, squash merge: gh pr merge <number> --squash --delete-branch
@@ -97,7 +97,7 @@ git -C <worktree_path> rev-list --count main..HEAD
 Submit task to continue work:
 
 ```sh
-band tasks create <workspace_id> --prompt "Continue implementing issue #<number>. Read the progress comment on the GitHub issue for context on what has been done. Pick up where the last agent left off. When implementation is complete, create a PR."
+band chat <workspace_id> --message "Continue implementing issue #<number>. Read the progress comment on the GitHub issue for context on what has been done. Pick up where the last agent left off. When implementation is complete, create a PR."
 ```
 
 **If workspace is fresh (no commits ahead, no PR):**
@@ -106,7 +106,7 @@ Fetch the issue and submit the full implementation prompt:
 
 ```sh
 ISSUE_BODY=$(gh issue view <number> --repo $REPO --json title,body -q '.title + "\n\n" + .body')
-band tasks create <workspace_id> --prompt "Implement GitHub issue #<number>:\n\n$ISSUE_BODY\n\nTrack progress by maintaining a comment on the issue with a checklist. Create a PR when done."
+band chat <workspace_id> --message "Implement GitHub issue #<number>:\n\n$ISSUE_BODY\n\nTrack progress by maintaining a comment on the issue with a checklist. Create a PR when done."
 ```
 
 ### 4. Pick Up New Issues from the Backlog

--- a/apps/cli/skills/band-cli.md
+++ b/apps/cli/skills/band-cli.md
@@ -1,7 +1,7 @@
 ---
 name: band-cli
 version: 0.1.0
-description: Programmatic workspace management for Band. Use when the user wants to create, list, or remove Band workspaces or projects, manage tasks, manage tunnels, manage terminal sessions, or check settings via the Band CLI.
+description: Programmatic workspace management for Band. Use when the user wants to create, list, or remove Band workspaces or projects, send chat messages to coding agents, manage tasks, manage tunnels, manage terminal sessions, or check settings via the Band CLI.
 allowed-tools: Bash
 argument-hint: [command] [args...]
 ---
@@ -60,14 +60,21 @@ band workspaces create my-app feat/auth --prompt "Add JWT authentication to the 
 band workspaces list --output json | jq '.workspaces[] | select(.project == "my-app") | .branch'
 ```
 
-### Task management
+### Chat / task management
 
 ```sh
+# Send a message to the workspace's default chat panel (auto-detects
+# the workspace from the current directory, picks the active chat tab)
+band chat --message "Fix the failing tests"
+
+# Same, but with an explicit workspace
+band chat ws_abc123 --message "Fix the failing tests"
+
+# Target a specific chat pane instead of the default one
+band chat ws_abc123 --chat-id chat_abc --message "Investigate the perf regression"
+
 # List running tasks
 band tasks list --status running
-
-# Submit a task to a workspace
-band tasks create ws_abc123 --prompt "Fix the failing tests"
 
 # Watch task output
 band tasks watch --workspace ws_abc123

--- a/apps/cli/src/main.rs
+++ b/apps/cli/src/main.rs
@@ -39,6 +39,29 @@ enum Commands {
         #[command(subcommand)]
         cmd: TasksCmd,
     },
+    /// Send a message to a workspace chat (defaults to the workspace's active chat panel)
+    Chat {
+        /// Workspace ID (auto-detected from cwd if omitted)
+        workspace_id: Option<String>,
+        /// Message text to send
+        #[arg(long)]
+        message: String,
+        /// Target a specific chat pane instead of the workspace default
+        #[arg(long)]
+        chat_id: Option<String>,
+        /// Maximum number of agentic turns
+        #[arg(long)]
+        max_turns: Option<u32>,
+        /// Agent mode (e.g. 'plan', 'edit')
+        #[arg(long)]
+        mode: Option<String>,
+        /// Model to use for the coding agent (e.g. 'claude-opus-4-20250514')
+        #[arg(long)]
+        model: Option<String>,
+        /// Coding agent ID (e.g. 'claude-code')
+        #[arg(long)]
+        agent: Option<String>,
+    },
     /// Manage chat panes (multi-agent)
     Chats {
         #[command(subcommand)]
@@ -154,26 +177,6 @@ enum TasksCmd {
         /// Filter by status (running, completed, failed)
         #[arg(long)]
         status: Option<String>,
-    },
-    /// Submit a new task to the coding agent
-    Create {
-        /// Workspace ID
-        workspace_id: String,
-        /// Prompt text to send to the agent
-        #[arg(long)]
-        prompt: String,
-        /// Maximum number of agentic turns
-        #[arg(long)]
-        max_turns: Option<u32>,
-        /// Agent mode (e.g. 'plan', 'edit')
-        #[arg(long)]
-        mode: Option<String>,
-        /// Model to use for the coding agent (e.g. 'claude-opus-4-20250514')
-        #[arg(long)]
-        model: Option<String>,
-        /// Coding agent ID to use (e.g. 'claude-code')
-        #[arg(long)]
-        agent: Option<String>,
     },
     /// Cancel a running task
     Cancel {
@@ -508,25 +511,27 @@ fn main() {
             TasksCmd::List { project, status } => {
                 cmd_tasks_list(project.as_deref(), status.as_deref())
             }
-            TasksCmd::Create {
-                workspace_id,
-                prompt,
-                max_turns,
-                mode,
-                model,
-                agent,
-            } => cmd_tasks_create(
-                &workspace_id,
-                &prompt,
-                max_turns,
-                mode.as_deref(),
-                model.as_deref(),
-                agent.as_deref(),
-            ),
             TasksCmd::Cancel { task_id } => cmd_tasks_cancel(&task_id),
             TasksCmd::Rerun { task_id } => cmd_tasks_rerun(&task_id),
             TasksCmd::Watch { .. } => unreachable!(),
         },
+        Commands::Chat {
+            workspace_id,
+            message,
+            chat_id,
+            max_turns,
+            mode,
+            model,
+            agent,
+        } => cmd_chat(
+            workspace_id.as_deref(),
+            &message,
+            chat_id.as_deref(),
+            max_turns,
+            mode.as_deref(),
+            model.as_deref(),
+            agent.as_deref(),
+        ),
         Commands::Chats { cmd } => match cmd {
             ChatsCmd::List { workspace_id } => cmd_chats_list(&workspace_id),
             ChatsCmd::Create {
@@ -917,45 +922,6 @@ fn cmd_tasks_list(project: Option<&str>, status: Option<&str>) -> Result<Command
     })
 }
 
-fn cmd_tasks_create(
-    workspace_id: &str,
-    prompt: &str,
-    max_turns: Option<u32>,
-    mode: Option<&str>,
-    model: Option<&str>,
-    agent: Option<&str>,
-) -> Result<CommandResult, String> {
-    let client = api::ApiClient::from_settings()?;
-    let mut input = serde_json::json!({
-        "workspaceId": workspace_id,
-        "prompt": prompt,
-    });
-    if let Some(max_turns) = max_turns {
-        input["maxTurns"] = serde_json::json!(max_turns);
-    }
-    if let Some(mode) = mode {
-        input["mode"] = serde_json::json!(mode);
-    }
-    if let Some(model) = model {
-        input["model"] = serde_json::json!(model);
-    }
-    if let Some(agent) = agent {
-        input["codingAgentId"] = serde_json::json!(agent);
-    }
-    let data = client.trpc_mutate("tasks.submit", &input)?;
-
-    let id = data.get("id").and_then(|i| i.as_str()).unwrap_or("");
-    let ws = data
-        .get("workspaceId")
-        .and_then(|w| w.as_str())
-        .unwrap_or("");
-
-    Ok(CommandResult {
-        text: format!("{id}\n"),
-        json: serde_json::json!({"id": id, "workspaceId": ws}),
-    })
-}
-
 fn cmd_tasks_cancel(task_id: &str) -> Result<CommandResult, String> {
     let client = api::ApiClient::from_settings()?;
     client.trpc_mutate("tasks.cancel", &serde_json::json!({"taskId": task_id}))?;
@@ -1083,6 +1049,64 @@ fn cmd_chats_remove(chat_id: &str) -> Result<CommandResult, String> {
     Ok(CommandResult {
         text: format!("Chat {chat_id} removed\n"),
         json: serde_json::json!({"ok": true, "chatId": chat_id}),
+    })
+}
+
+/// Send a message to a workspace chat, defaulting to the workspace's active
+/// chat panel when no `--chat-id` is provided. Returns the task id.
+///
+/// Server-side, `tasks.submit` resolves the default chat via
+/// `getOrCreateDefaultChat`, which honors the saved chat layout's active
+/// panel. So passing no `chatId` here matches the chat the user is looking
+/// at in the dashboard.
+fn cmd_chat(
+    workspace_id: Option<&str>,
+    message: &str,
+    chat_id: Option<&str>,
+    max_turns: Option<u32>,
+    mode: Option<&str>,
+    model: Option<&str>,
+    agent: Option<&str>,
+) -> Result<CommandResult, String> {
+    let client = api::ApiClient::from_settings()?;
+    let workspace_id = resolve_workspace_id(&client, None, workspace_id)?;
+
+    let mut input = serde_json::json!({
+        "workspaceId": workspace_id,
+        "prompt": message,
+    });
+    if let Some(chat_id) = chat_id {
+        input["chatId"] = serde_json::json!(chat_id);
+    }
+    if let Some(max_turns) = max_turns {
+        input["maxTurns"] = serde_json::json!(max_turns);
+    }
+    if let Some(mode) = mode {
+        input["mode"] = serde_json::json!(mode);
+    }
+    if let Some(model) = model {
+        input["model"] = serde_json::json!(model);
+    }
+    if let Some(agent) = agent {
+        input["codingAgentId"] = serde_json::json!(agent);
+    }
+
+    let data = client.trpc_mutate("tasks.submit", &input)?;
+
+    let id = data.get("id").and_then(|i| i.as_str()).unwrap_or("");
+    let ws = data
+        .get("workspaceId")
+        .and_then(|w| w.as_str())
+        .unwrap_or("");
+    let resolved_chat_id = data.get("chatId").and_then(|c| c.as_str()).unwrap_or("");
+
+    Ok(CommandResult {
+        text: format!("{id}\n"),
+        json: serde_json::json!({
+            "id": id,
+            "workspaceId": ws,
+            "chatId": resolved_chat_id,
+        }),
     })
 }
 
@@ -2400,7 +2424,7 @@ pub(crate) fn build_schema(command: Option<&str>) -> Result<serde_json::Value, S
                 {"name": "--model", "type": "string", "required": false, "description": "Model to use for the coding agent (e.g. 'claude-opus-4-20250514')"},
                 {"name": "--agent", "type": "string", "required": false, "description": "Coding agent ID to use (overrides workspace default)"},
             ],
-            "notes": "Returns the worktree path. Idempotent — creating an existing workspace returns its path. Runs `.band/config.json` `setup` script if present (non-fatal).\n\n**Always use `--prompt` when the user wants work to begin immediately.** This submits a task to the coding agent right after workspace creation, so the agent starts working without a separate step. Only omit `--prompt` when the user explicitly wants to create the workspace for manual/later use.\n\nWhen to use `--prompt` (most cases):\n```sh\n# User says \"create a workspace and implement X\" or \"start working on X\"\nband workspaces create my-app feat/auth --prompt \"Implement GitHub issue #42: Add JWT authentication\"\n\n# User says \"create a workspace for issue #99 and start implementing\"\nband workspaces create my-app fix/bug-99 --prompt \"Fix issue #99: login redirect loop. See https://github.com/org/repo/issues/99\"\n```\n\nWhen to omit `--prompt` (rare — user explicitly wants no task):\n```sh\n# User says \"just create a workspace, I'll work on it myself\"\nband workspaces create my-app feat/experiment\n```\n\n**Do NOT create a workspace without `--prompt` and then separately run `band tasks create`.** That is two steps for what `--prompt` does in one."
+            "notes": "Returns the worktree path. Idempotent — creating an existing workspace returns its path. Runs `.band/config.json` `setup` script if present (non-fatal).\n\n**Always use `--prompt` when the user wants work to begin immediately.** This submits a task to the coding agent right after workspace creation, so the agent starts working without a separate step. Only omit `--prompt` when the user explicitly wants to create the workspace for manual/later use.\n\nWhen to use `--prompt` (most cases):\n```sh\n# User says \"create a workspace and implement X\" or \"start working on X\"\nband workspaces create my-app feat/auth --prompt \"Implement GitHub issue #42: Add JWT authentication\"\n\n# User says \"create a workspace for issue #99 and start implementing\"\nband workspaces create my-app fix/bug-99 --prompt \"Fix issue #99: login redirect loop. See https://github.com/org/repo/issues/99\"\n```\n\nWhen to omit `--prompt` (rare — user explicitly wants no task):\n```sh\n# User says \"just create a workspace, I'll work on it myself\"\nband workspaces create my-app feat/experiment\n```\n\n**Do NOT create a workspace without `--prompt` and then separately run `band chat`.** That is two steps for what `--prompt` does in one."
         }),
         serde_json::json!({
             "name": "workspaces remove",
@@ -2443,19 +2467,6 @@ pub(crate) fn build_schema(command: Option<&str>) -> Result<serde_json::Value, S
                 {"name": "--status", "type": "string", "required": false, "description": "Filter by status (running, completed, failed)"},
             ],
             "notes": "Text output: `ID\\tSTATUS\\tWORKSPACE\\tPROMPT` (tab-separated table).\nJSON output: `{\"tasks\": [{\"id\": \"...\", \"status\": \"...\", \"project\": \"...\", \"branch\": \"...\", \"prompt\": \"...\"}]}`"
-        }),
-        serde_json::json!({
-            "name": "tasks create",
-            "description": "Submit a new task to the coding agent",
-            "parameters": [
-                {"name": "workspace_id", "type": "string", "required": true, "positional": true, "description": "Workspace ID"},
-                {"name": "--prompt", "type": "string", "required": true, "description": "Prompt text to send to the agent"},
-                {"name": "--max-turns", "type": "integer", "required": false, "description": "Maximum number of agentic turns"},
-                {"name": "--mode", "type": "string", "required": false, "description": "Agent mode (e.g. 'plan', 'edit')"},
-                {"name": "--model", "type": "string", "required": false, "description": "Model to use for the coding agent (e.g. 'claude-opus-4-20250514')"},
-                {"name": "--agent", "type": "string", "required": false, "description": "Coding agent ID to use (overrides workspace default)"},
-            ],
-            "notes": "Submits a new task to the coding agent. Returns the task ID.\nJSON output: `{\"id\": \"...\", \"workspaceId\": \"...\"}`"
         }),
         serde_json::json!({
             "name": "tasks cancel",
@@ -2531,6 +2542,20 @@ pub(crate) fn build_schema(command: Option<&str>) -> Result<serde_json::Value, S
                 {"name": "key", "type": "string", "required": true, "positional": true, "description": "Storage key (project name or workspace ID)"},
                 {"name": "id", "type": "string", "required": true, "positional": true, "description": "Cronjob ID (e.g. cj_1234567890)"},
             ]
+        }),
+        serde_json::json!({
+            "name": "chat",
+            "description": "Send a message to a workspace chat (defaults to the workspace's active chat panel)",
+            "parameters": [
+                {"name": "workspace_id", "type": "string", "required": false, "positional": true, "description": "Workspace ID (auto-detected from cwd if omitted)"},
+                {"name": "--message", "type": "string", "required": true, "description": "Message text to send"},
+                {"name": "--chat-id", "type": "string", "required": false, "description": "Target a specific chat pane instead of the workspace default"},
+                {"name": "--max-turns", "type": "integer", "required": false, "description": "Maximum number of agentic turns"},
+                {"name": "--mode", "type": "string", "required": false, "description": "Agent mode (e.g. 'plan', 'edit')"},
+                {"name": "--model", "type": "string", "required": false, "description": "Model to use for the coding agent (e.g. 'claude-opus-4-20250514')"},
+                {"name": "--agent", "type": "string", "required": false, "description": "Coding agent ID to use (overrides workspace default)"},
+            ],
+            "notes": "Sends a message to the workspace's chat. When `--chat-id` is omitted, the server resolves the workspace's *active* chat panel (the tab the user last focused in the dashboard), falling back to the first panel in the saved layout, then to the first chat in the registry, and finally creating a new \"Chat\" panel if the workspace has none. This means CLI prompts land in the same conversation the user is looking at.\n\nReturns the task ID.\nJSON output: `{\"id\": \"tsk_...\", \"workspaceId\": \"...\", \"chatId\": \"chat_...\"}`\n\nReplaces the removed `tasks create` command. Use `--chat-id` to target a specific chat pane (look it up with `band chats list <workspace_id>`)."
         }),
         serde_json::json!({
             "name": "chats list",

--- a/apps/cli/tests/integration.rs
+++ b/apps/cli/tests/integration.rs
@@ -72,19 +72,27 @@ impl TestEnv {
 
         // Wait for "listening" on stdout with a timeout.
         // Spawn a reader thread so we can enforce a deadline without blocking
-        // the test forever if the server fails to start.
+        // the test forever if the server fails to start. The thread keeps
+        // draining stdout for the full lifetime of the server — otherwise
+        // the OS pipe buffer fills up under chatty pino logging and the
+        // server blocks on its next write, causing later requests to hang
+        // or get reset.
         let stdout = child.stdout.take().unwrap();
         let (tx, rx) = std::sync::mpsc::channel();
         std::thread::spawn(move || {
             let reader = BufReader::new(stdout);
+            let mut signaled = false;
             for line in reader.lines() {
                 let line = line.unwrap_or_default();
-                if line.contains("listening") {
+                if !signaled && line.contains("listening") {
                     let _ = tx.send(true);
-                    return;
+                    signaled = true;
                 }
+                // Continue reading to keep the pipe drained.
             }
-            let _ = tx.send(false);
+            if !signaled {
+                let _ = tx.send(false);
+            }
         });
         let found = rx.recv_timeout(Duration::from_secs(30)).unwrap_or(false);
         if !found {
@@ -165,6 +173,26 @@ fn seed_db(band_dir: &Path, repo_path: &Path, settings: &serde_json::Value) {
     assert!(
         output.status.success(),
         "seed-db.mjs failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+/// Seed a chat layout (dockview tree) directly into the `panel_states`
+/// table. Used by tests that exercise default-chat-panel resolution
+/// without going through the dashboard UI to drive the layout.
+fn seed_chat_layout(band_dir: &Path, workspace_id: &str, layout: &serde_json::Value) {
+    let seed_script = Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/seed-chat-layout.mjs");
+    let output = Command::new("node")
+        .arg(&seed_script)
+        .arg(band_dir)
+        .arg(workspace_id)
+        .arg(layout.to_string())
+        .output()
+        .expect("seed-chat-layout.mjs failed to execute");
+
+    assert!(
+        output.status.success(),
+        "seed-chat-layout.mjs failed: {}",
         String::from_utf8_lossy(&output.stderr)
     );
 }
@@ -1025,7 +1053,7 @@ fn tasks_list_json_empty() {
 }
 
 #[test]
-fn tasks_create_returns_task_id() {
+fn chat_returns_task_id() {
     let env = TestEnv::new();
 
     // Create a workspace first
@@ -1037,13 +1065,7 @@ fn tasks_create_returns_task_id() {
     );
 
     let workspace_id = "my-project-feat-task-test";
-    let output = env.band(&[
-        "tasks",
-        "create",
-        workspace_id,
-        "--prompt",
-        "write hello world",
-    ]);
+    let output = env.band(&["chat", workspace_id, "--message", "write hello world"]);
     assert!(output.status.success(), "stderr: {}", stderr(&output));
 
     let out = stdout(&output);
@@ -1054,16 +1076,15 @@ fn tasks_create_returns_task_id() {
 }
 
 #[test]
-fn tasks_create_json_output() {
+fn chat_json_output_includes_chat_id() {
     let env = TestEnv::new();
 
     env.band(&["workspaces", "create", "my-project", "feat/task-json"]);
 
     let output = env.band(&[
-        "tasks",
-        "create",
+        "chat",
         "my-project-feat-task-json",
-        "--prompt",
+        "--message",
         "hello",
         "--output",
         "json",
@@ -1081,6 +1102,13 @@ fn tasks_create_json_output() {
         "my-project-feat-task-json",
         "json: {json}"
     );
+    // No --chat-id was passed, so the server resolved the default panel.
+    // The chatId should be populated and look like a chat id.
+    let resolved = json["chatId"].as_str().unwrap_or("");
+    assert!(
+        resolved.starts_with("chat_"),
+        "expected resolved chatId to start with chat_: {json}"
+    );
 }
 
 #[test]
@@ -1090,10 +1118,9 @@ fn tasks_list_shows_submitted_task() {
     env.band(&["workspaces", "create", "my-project", "feat/task-list"]);
 
     let create_out = env.band(&[
-        "tasks",
-        "create",
+        "chat",
         "my-project-feat-task-list",
-        "--prompt",
+        "--message",
         "do something",
         "--output",
         "json",
@@ -1120,13 +1147,7 @@ fn tasks_list_filter_by_project() {
 
     env.band(&["workspaces", "create", "my-project", "feat/filter-proj"]);
 
-    env.band(&[
-        "tasks",
-        "create",
-        "my-project-feat-filter-proj",
-        "--prompt",
-        "hello",
-    ]);
+    env.band(&["chat", "my-project-feat-filter-proj", "--message", "hello"]);
 
     let output = env.band(&[
         "tasks",
@@ -1160,27 +1181,25 @@ fn tasks_cancel_nonexistent_fails() {
 }
 
 #[test]
-fn tasks_create_conflict_returns_error() {
+fn chat_conflict_returns_error() {
     let env = TestEnv::new();
 
     env.band(&["workspaces", "create", "my-project", "feat/conflict"]);
 
     // Submit first task — will start running
     let out1 = env.band(&[
-        "tasks",
-        "create",
+        "chat",
         "my-project-feat-conflict",
-        "--prompt",
+        "--message",
         "first task",
     ]);
     assert!(out1.status.success(), "stderr: {}", stderr(&out1));
 
     // Immediately submit a second task — should fail with conflict
     let out2 = env.band(&[
-        "tasks",
-        "create",
+        "chat",
         "my-project-feat-conflict",
-        "--prompt",
+        "--message",
         "second task",
     ]);
     // Might succeed (if first finished fast) or fail with conflict
@@ -1196,10 +1215,9 @@ fn tasks_watch_json_streams_events() {
 
     // Submit a task (it will likely fail since no agent is configured)
     env.band(&[
-        "tasks",
-        "create",
+        "chat",
         "my-project-feat-watch-test",
-        "--prompt",
+        "--message",
         "hello world",
     ]);
 
@@ -1234,10 +1252,9 @@ fn tasks_watch_text_no_ansi_when_piped() {
 
     env.band(&["workspaces", "create", "my-project", "feat/watch-ansi"]);
     env.band(&[
-        "tasks",
-        "create",
+        "chat",
         "my-project-feat-watch-ansi",
-        "--prompt",
+        "--message",
         "hello world",
     ]);
 
@@ -1270,10 +1287,9 @@ fn tasks_watch_verbose_flag_accepted() {
 
     env.band(&["workspaces", "create", "my-project", "feat/watch-verbose"]);
     env.band(&[
-        "tasks",
-        "create",
+        "chat",
         "my-project-feat-watch-verbose",
-        "--prompt",
+        "--message",
         "hello",
     ]);
 
@@ -1298,10 +1314,9 @@ fn tasks_watch_tools_off_hides_tools() {
 
     env.band(&["workspaces", "create", "my-project", "feat/watch-tools-off"]);
     env.band(&[
-        "tasks",
-        "create",
+        "chat",
         "my-project-feat-watch-tools-off",
-        "--prompt",
+        "--message",
         "hello",
     ]);
 
@@ -1336,13 +1351,7 @@ fn tasks_watch_auto_detect_workspace_from_cwd() {
     );
     let worktree_path = stdout(&create_out);
 
-    env.band(&[
-        "tasks",
-        "create",
-        "my-project-feat-watch-cwd",
-        "--prompt",
-        "hello",
-    ]);
+    env.band(&["chat", "my-project-feat-watch-cwd", "--message", "hello"]);
 
     std::thread::sleep(std::time::Duration::from_millis(2000));
 
@@ -1390,10 +1399,9 @@ fn tasks_list_text_output() {
 
     env.band(&["workspaces", "create", "my-project", "feat/task-text"]);
     env.band(&[
-        "tasks",
-        "create",
+        "chat",
         "my-project-feat-task-text",
-        "--prompt",
+        "--message",
         "test task",
     ]);
 
@@ -1701,6 +1709,272 @@ fn cronjobs_list_text_output_shows_table() {
     assert!(out.contains("0 9 * * 1"), "expected cron expr: {out}");
 }
 
+// --- Chat command / default-panel resolution tests ---
+
+#[test]
+fn chat_creates_default_panel_when_workspace_has_no_chats() {
+    let env = TestEnv::new();
+    let create = env.band(&["workspaces", "create", "my-project", "feat/chat-empty"]);
+    assert!(create.status.success(), "stderr: {}", stderr(&create));
+
+    // No chats yet — `band chat` should lazily create one and target it.
+    let output = env.band(&[
+        "chat",
+        "my-project-feat-chat-empty",
+        "--message",
+        "first message",
+        "--output",
+        "json",
+    ]);
+    assert!(output.status.success(), "stderr: {}", stderr(&output));
+
+    let json: serde_json::Value = serde_json::from_str(&stdout(&output))
+        .unwrap_or_else(|e| panic!("invalid JSON: {e}\nstdout: {}", stdout(&output)));
+    let resolved_chat = json["chatId"].as_str().unwrap_or("");
+    assert!(
+        resolved_chat.starts_with("chat_"),
+        "expected a chat id to be resolved: {json}"
+    );
+
+    // The chat now exists in the workspace's chat list.
+    let list = env.band(&[
+        "chats",
+        "list",
+        "my-project-feat-chat-empty",
+        "--output",
+        "json",
+    ]);
+    assert!(list.status.success(), "stderr: {}", stderr(&list));
+    let list_json: serde_json::Value = serde_json::from_str(&stdout(&list)).unwrap();
+    let chats = list_json["chats"].as_array().expect("chats array");
+    assert!(
+        chats.iter().any(|c| c["id"] == resolved_chat),
+        "expected resolved chat in workspace list: {list_json}"
+    );
+}
+
+#[test]
+fn chat_targets_first_chat_when_no_layout() {
+    let env = TestEnv::new();
+    env.band(&["workspaces", "create", "my-project", "feat/chat-no-layout"]);
+    let workspace_id = "my-project-feat-chat-no-layout";
+
+    // `workspaces create` lazily creates a default chat panel for the
+    // workspace, so `chats list` already returns one entry. Add a second
+    // pane to exercise the "more than one chat, no layout" path.
+    env.band(&[
+        "chats",
+        "create",
+        workspace_id,
+        "--name",
+        "Second",
+        "--output",
+        "json",
+    ]);
+
+    // Snapshot the workspace's chats in registry order so we can assert
+    // that `chat` (no --chat-id) resolves to the first one.
+    let list = env.band(&["chats", "list", workspace_id, "--output", "json"]);
+    assert!(list.status.success(), "stderr: {}", stderr(&list));
+    let list_json: serde_json::Value = serde_json::from_str(&stdout(&list)).unwrap();
+    let chats = list_json["chats"].as_array().expect("chats array");
+    assert!(chats.len() >= 2, "expected at least 2 chats: {list_json}");
+    let first_id = chats[0]["id"].as_str().unwrap().to_string();
+
+    // Without a saved chat layout, `chat` should fall back to the first
+    // chat in the registry (insertion order).
+    let output = env.band(&[
+        "chat",
+        workspace_id,
+        "--message",
+        "hello",
+        "--output",
+        "json",
+    ]);
+    assert!(output.status.success(), "stderr: {}", stderr(&output));
+    let json: serde_json::Value = serde_json::from_str(&stdout(&output)).unwrap();
+    assert_eq!(
+        json["chatId"].as_str().unwrap(),
+        first_id,
+        "expected first chat in the registry to be the default: {json}"
+    );
+}
+
+#[test]
+fn chat_targets_active_panel_from_layout() {
+    let env = TestEnv::new();
+    env.band(&["workspaces", "create", "my-project", "feat/chat-layout"]);
+    let workspace_id = "my-project-feat-chat-layout";
+
+    // Add a second pane on top of the auto-created default. We'll mark
+    // this one as active in the layout below.
+    let second = env.band(&[
+        "chats",
+        "create",
+        workspace_id,
+        "--name",
+        "Active",
+        "--output",
+        "json",
+    ]);
+    assert!(second.status.success(), "stderr: {}", stderr(&second));
+    let second_json: serde_json::Value = serde_json::from_str(&stdout(&second)).unwrap();
+    let second_id = second_json["chat"]["id"].as_str().unwrap().to_string();
+
+    // Snapshot the registry-order first chat so the assertion below is
+    // sharp: we want to verify the resolution differs from "first chat".
+    let list = env.band(&["chats", "list", workspace_id, "--output", "json"]);
+    let list_json: serde_json::Value = serde_json::from_str(&stdout(&list)).unwrap();
+    let first_id = list_json["chats"][0]["id"].as_str().unwrap().to_string();
+    assert_ne!(first_id, second_id, "list should have at least 2 chats");
+
+    // Persist a chat layout that marks `second_id` as the active view of
+    // the active group — mimicking the user clicking that tab in the
+    // dashboard. The layout shape mirrors what
+    // DockviewLayoutManager.addPanel writes.
+    let group_id = format!("group_{second_id}");
+    let layout = serde_json::json!({
+        "grid": {
+            "root": {
+                "type": "leaf",
+                "data": {
+                    "id": group_id,
+                    "views": [first_id.clone(), second_id.clone()],
+                    "activeView": second_id.clone(),
+                },
+                "size": 1,
+            },
+            "height": 500,
+            "width": 500,
+            "orientation": "HORIZONTAL",
+        },
+        "panels": {
+            first_id.clone(): {
+                "id": first_id,
+                "contentComponent": "chatTab",
+                "tabComponent": "chatTab",
+                "title": "First",
+                "params": {"workspaceId": workspace_id, "chatId": first_id.clone()},
+            },
+            second_id.clone(): {
+                "id": second_id,
+                "contentComponent": "chatTab",
+                "tabComponent": "chatTab",
+                "title": "Active",
+                "params": {"workspaceId": workspace_id, "chatId": second_id.clone()},
+            },
+        },
+        "activeGroup": group_id,
+    });
+    seed_chat_layout(&env.band_dir, workspace_id, &layout);
+
+    // `band chat` without --chat-id should target the active panel from
+    // the saved layout — not the first chat in insertion order.
+    let output = env.band(&[
+        "chat",
+        workspace_id,
+        "--message",
+        "to active panel",
+        "--output",
+        "json",
+    ]);
+    assert!(output.status.success(), "stderr: {}", stderr(&output));
+    let json: serde_json::Value = serde_json::from_str(&stdout(&output)).unwrap();
+    assert_eq!(
+        json["chatId"].as_str().unwrap(),
+        second_id,
+        "expected layout's active panel to be the default: {json}"
+    );
+}
+
+#[test]
+fn chat_explicit_chat_id_overrides_default() {
+    let env = TestEnv::new();
+    env.band(&["workspaces", "create", "my-project", "feat/chat-explicit"]);
+    let workspace_id = "my-project-feat-chat-explicit";
+
+    env.band(&["chats", "create", workspace_id, "--name", "First"]);
+    let second = env.band(&[
+        "chats",
+        "create",
+        workspace_id,
+        "--name",
+        "Second",
+        "--output",
+        "json",
+    ]);
+    let second_json: serde_json::Value = serde_json::from_str(&stdout(&second)).unwrap();
+    let second_id = second_json["chat"]["id"].as_str().unwrap().to_string();
+
+    let output = env.band(&[
+        "chat",
+        workspace_id,
+        "--chat-id",
+        &second_id,
+        "--message",
+        "directly",
+        "--output",
+        "json",
+    ]);
+    assert!(output.status.success(), "stderr: {}", stderr(&output));
+    let json: serde_json::Value = serde_json::from_str(&stdout(&output)).unwrap();
+    assert_eq!(
+        json["chatId"].as_str().unwrap(),
+        second_id,
+        "expected --chat-id to win over default resolution: {json}"
+    );
+}
+
+#[test]
+fn chat_auto_detects_workspace_from_cwd() {
+    let env = TestEnv::new();
+
+    let create_out = env.band(&["workspaces", "create", "my-project", "feat/chat-cwd"]);
+    assert!(
+        create_out.status.success(),
+        "stderr: {}",
+        stderr(&create_out)
+    );
+    let worktree_path = stdout(&create_out);
+
+    // Run `band chat` with NO workspace_id from inside the worktree.
+    let output = env.band_in(
+        Path::new(&worktree_path),
+        &["chat", "--message", "auto-detect", "--output", "json"],
+    );
+    assert!(output.status.success(), "stderr: {}", stderr(&output));
+
+    let json: serde_json::Value = serde_json::from_str(&stdout(&output)).unwrap();
+    assert_eq!(
+        json["workspaceId"].as_str().unwrap(),
+        "my-project-feat-chat-cwd",
+        "expected workspace to be auto-detected from cwd: {json}"
+    );
+}
+
+#[test]
+fn chat_outside_workspace_fails_with_helpful_error() {
+    let env = TestEnv::new();
+
+    // A git repo that is NOT a registered workspace.
+    let unrelated = env.tmp.path().join("chat-unrelated");
+    fs::create_dir_all(&unrelated).unwrap();
+    git(&unrelated, &["init", "-b", "main"]);
+    git(&unrelated, &["commit", "--allow-empty", "-m", "init"]);
+
+    let output = env.band_in(&unrelated, &["chat", "--message", "hello"]);
+
+    assert!(
+        !output.status.success(),
+        "expected failure when not in a registered workspace"
+    );
+    let err = stderr(&output);
+    assert!(
+        err.contains("No workspace found"),
+        "expected helpful error: {err}"
+    );
+}
+
 // --- Schema tests ---
 
 #[test]
@@ -1724,10 +1998,14 @@ fn schema_lists_all_commands() {
     assert!(names.contains(&"workspaces remove"), "missing: {names:?}");
     assert!(names.contains(&"settings"), "missing: {names:?}");
     assert!(names.contains(&"tasks list"), "missing: {names:?}");
-    assert!(names.contains(&"tasks create"), "missing: {names:?}");
+    assert!(
+        !names.contains(&"tasks create"),
+        "expected `tasks create` to be removed (replaced by `chat`): {names:?}"
+    );
     assert!(names.contains(&"tasks cancel"), "missing: {names:?}");
     assert!(names.contains(&"tasks rerun"), "missing: {names:?}");
     assert!(names.contains(&"tasks watch"), "missing: {names:?}");
+    assert!(names.contains(&"chat"), "missing: {names:?}");
     assert!(names.contains(&"tunnel status"), "missing: {names:?}");
     assert!(names.contains(&"tunnel start"), "missing: {names:?}");
     assert!(names.contains(&"tunnel stop"), "missing: {names:?}");

--- a/apps/cli/tests/seed-chat-layout.mjs
+++ b/apps/cli/tests/seed-chat-layout.mjs
@@ -1,0 +1,30 @@
+#!/usr/bin/env node
+// Seed a chat layout (dockview tree) directly into the panel_states table.
+// Used by integration tests that exercise the default-chat-panel resolution.
+//
+// Usage: node seed-chat-layout.mjs <band_dir> <workspace_id> <layout_json>
+//
+// Mirrors the schema used by `chatLayout.save` so the running server picks
+// up the layout the next time `getChatLayout(workspaceId)` is called (every
+// call reads from DB).
+
+import { join } from "node:path";
+import { DatabaseSync } from "node:sqlite";
+
+const [bandDir, workspaceId, layoutJson] = process.argv.slice(2);
+if (!bandDir || !workspaceId || !layoutJson) {
+  console.error(
+    "Usage: node seed-chat-layout.mjs <band_dir> <workspace_id> <layout_json>",
+  );
+  process.exit(1);
+}
+
+const db = new DatabaseSync(join(bandDir, "band.db"));
+const id = `chat_layout_${workspaceId}`;
+const now = Date.now();
+db.prepare(
+  `INSERT OR REPLACE INTO panel_states
+     (id, workspace_id, panel_type, state, created_at, updated_at)
+   VALUES (?, ?, 'chat_layout', ?, ?, ?)`,
+).run(id, workspaceId, layoutJson, now, now);
+db.close();

--- a/apps/web/src/lib/chat-manager.ts
+++ b/apps/web/src/lib/chat-manager.ts
@@ -8,6 +8,8 @@
 
 import { createLogger } from "@band-app/logger";
 import { removeAgent } from "./agent-pool";
+import { getChatLayout } from "./chat-layout-manager";
+import { defaultPanelIdFromLayout } from "./dockview-layout-manager";
 import {
   deletePanelState,
   deletePanelStatesForWorkspace,
@@ -397,11 +399,31 @@ export function loadChatsFromDb(): number {
 
 /**
  * Get or create a default chat pane for a workspace.
- * Used for backward compatibility when the client hasn't been updated to
- * pass chatId yet — ensures every workspace has at least one chat pane.
+ *
+ * Resolution order:
+ *   1. The active panel from the saved chat layout (e.g. the tab the user
+ *      last focused in the dashboard). This makes CLI commands like
+ *      `band chat ...` target the same chat the user is looking at.
+ *   2. The first chat panel in the saved layout, even if not active.
+ *   3. The first chat in the in-memory registry (insertion order).
+ *   4. A freshly-created "Chat" panel if the workspace has none yet.
+ *
+ * Used by the CLI (`band chat`), cronjobs, and tRPC routes that accept an
+ * optional chatId — all of them want a single deterministic answer to
+ * "which chat does this workspace mean by default".
  */
 export function getOrCreateDefaultChat(workspaceId: string): ChatSession {
   const chats = listChats(workspaceId);
-  if (chats.length > 0) return chats[0];
+
+  if (chats.length > 0) {
+    const layout = getChatLayout(workspaceId);
+    const layoutDefault = defaultPanelIdFromLayout(layout);
+    if (layoutDefault) {
+      const match = chats.find((c) => c.id === layoutDefault);
+      if (match) return match;
+    }
+    return chats[0];
+  }
+
   return createChat(workspaceId, { name: "Chat" });
 }

--- a/apps/web/src/lib/dockview-layout-manager.ts
+++ b/apps/web/src/lib/dockview-layout-manager.ts
@@ -95,6 +95,49 @@ function findFirstLeaf(node: GridNode): LeafData | null {
   return null;
 }
 
+function findLeafById(node: GridNode, groupId: string): LeafData | null {
+  if (isLeaf(node)) return node.data.id === groupId ? node.data : null;
+  if (isBranch(node)) {
+    for (const child of node.data) {
+      const found = findLeafById(child, groupId);
+      if (found) return found;
+    }
+  }
+  return null;
+}
+
+/**
+ * Pick the panel a deterministic "default" lookup should target.
+ *
+ * Preference order:
+ *   1. The `activeView` of the layout's `activeGroup` (the panel the user
+ *      last had focus on).
+ *   2. The `activeView` of the first leaf (first group in the tree).
+ *   3. The first entry of `views` in the first leaf.
+ *
+ * Returns null if no panel can be resolved (empty/invalid layout).
+ */
+export function defaultPanelIdFromLayout(layout: unknown): string | null {
+  if (!layout || !isDockviewLayout(layout)) return null;
+
+  if (layout.activeGroup) {
+    const leaf = findLeafById(layout.grid.root, layout.activeGroup);
+    if (leaf) {
+      if (leaf.activeView && leaf.views.includes(leaf.activeView)) {
+        return leaf.activeView;
+      }
+      if (leaf.views.length > 0) return leaf.views[0];
+    }
+  }
+
+  const firstLeaf = findFirstLeaf(layout.grid.root);
+  if (!firstLeaf) return null;
+  if (firstLeaf.activeView && firstLeaf.views.includes(firstLeaf.activeView)) {
+    return firstLeaf.activeView;
+  }
+  return firstLeaf.views[0] ?? null;
+}
+
 function removeFromGrid(node: GridNode, panelId: string): void {
   if (isLeaf(node)) {
     const idx = node.data.views.indexOf(panelId);


### PR DESCRIPTION
## Summary

- Removes `band tasks create` (which duplicated `band chat` functionality) and adds a top-level `band chat` command that defaults to the workspace's *active* chat panel.
- `getOrCreateDefaultChat` now consults the saved chat layout (`activeGroup` → `activeView` → first leaf → registry order) so CLI prompts and cronjobs land in the chat tab the user is looking at in the dashboard.
- Auto-detects workspace from cwd; supports explicit `--chat-id` to target a specific pane.
- Updates `apps/cli/skills/band-cli.md` and the project-tracked `backlog-burner` skill to use `band chat`.

## Note on issue tracking

The linked branch name references **#349**, but issue #349 is actually about a *different* bug (chat showing no history when a workspace is opened during agent setup). I searched open and closed issues for one matching this scope ("remove task command", "default chat panel") and didn't find one. Rather than open a fresh issue, I'm flagging this discrepancy here — happy to:

- (a) keep the PR untracked from #349, or
- (b) open a fresh issue and link it,
- (c) split #349 into two issues (the original session-history bug + this CLI cleanup).

Whatever the maintainer prefers.

## What's coupled to this

`getOrCreateDefaultChat` is shared by:

- `tasks.submit` (used by `band chat`, `chats.send`, and `workspaces create --prompt`)
- `cronjobs trigger` (manual)
- `cronjob-scheduler.executeCronjob` (scheduled fires)
- 20+ tRPC routes that accept an optional `chatId`

So the layout-aware default applies everywhere — including cronjobs, which now run in the active chat panel rather than `chats[0]`.

## Test plan

- [x] All 88 CLI integration tests pass (9 new + ported existing ones)
- [x] `cargo fmt --check` clean
- [x] `cargo clippy -- -D warnings` clean for CLI and dashboard
- [x] `pnpm exec biome check .` clean
- [x] `pnpm knip` clean
- [x] `pnpm jscpd` no new clones
- [x] `band schema` shows `chat`, hides `tasks create`, retains `tasks list/cancel/rerun/watch`
- [x] Generated SKILL.md (`band generate-skills`) reflects the new command surface

🤖 Generated with [Claude Code](https://claude.com/claude-code)