### PR TITLE
feat(chat): context meter — token usage donut in chat input

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,6 +20,10 @@ Unit tests with heavy mocking verify that your mocks work, not that your system 
 
 See `.claude/skills/integration-tests.md` for the full set of rules and examples.
 
+### Exceptions
+
+- `packages/coding-agent/tests/codex-adapter.test.ts` is an event-mapping unit test that mocks `@openai/codex-sdk` via a custom Node loader (`tests/register-mock-loader.mjs` + `tests/mocks/codex-sdk.mjs`). The Codex SDK communicates with a subprocess over stdin/stdout, so MSW does not apply, and exercising the real `codex` binary is impractical in CI. The test is allowed to remain as-is until the SDK exposes a network seam or a stub binary; do not extend this pattern to other adapters.
+
 ## Git Hooks & CI
 
 This repo has a pre-push hook (`.husky/pre-push`) that runs linting, formatting, and clippy checks. **Never bypass git hooks** — do not use `--no-verify` on `git push` or `git commit`. If a hook fails, fix the underlying issue instead of skipping the check.

--- a/apps/web/src/api/task-stream.ts
+++ b/apps/web/src/api/task-stream.ts
@@ -220,7 +220,7 @@ async function handlePost(
 
   const { workspaceId, prompt, sessionId, maxTurns, mode, model, codingAgentId, files } = body;
 
-  if (!workspaceId || !prompt) {
+  if (!workspaceId || !prompt?.trim()) {
     res.writeHead(400, { "Content-Type": "application/json" });
     res.end(JSON.stringify({ error: "workspaceId and prompt are required" }));
     return;

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -204,11 +204,19 @@ function splitMessageAtQueueBoundaries(parts: UIMessageParts): QueueSegment[] {
   return segments;
 }
 
+interface ModelInfo {
+  id: string;
+  name: string;
+  description?: string;
+  /** Approximate max input context window in tokens, when known. */
+  contextWindow?: number;
+}
+
 interface AgentGroup {
   agentId: string;
   agentType: string;
   agentLabel: string;
-  models: { id: string; name: string; description?: string }[];
+  models: ModelInfo[];
   defaultModel?: string;
 }
 
@@ -388,7 +396,7 @@ export function ChatView({
     return () => window.removeEventListener("band:toggle-mode", handler);
   }, [modes, selectedMode, handleModeSelect]);
 
-  const [models, setModels] = useState<{ id: string; name: string; description?: string }[]>([]);
+  const [models, setModels] = useState<ModelInfo[]>([]);
   const [agentGroups, setAgentGroups] = useState<AgentGroup[]>([]);
   // Default model from agent settings (per agent type)
   const [agentDefaultModel, setAgentDefaultModel] = useState<string | undefined>();
@@ -396,6 +404,12 @@ export function ChatView({
   const [userModelOverride, setUserModelOverride] = useState<string | undefined>();
   // Effective model: user override takes precedence, then agent default
   const selectedModel = userModelOverride ?? agentDefaultModel;
+  // Resolved ModelInfo for the active selection — flows the SDK-reported
+  // contextWindow into the meter so it doesn't have to guess from the id.
+  const selectedModelInfo = useMemo(
+    () => models.find((m) => m.id === selectedModel),
+    [models, selectedModel],
+  );
 
   // Drop the SDK-reported `maxContextTokens` when the model changes — that
   // value was for the prior model and would otherwise stick until the next
@@ -1245,7 +1259,9 @@ export function ChatView({
 
       <div className="mx-auto w-full max-w-3xl shrink-0 px-3 lg:px-4 pt-2 pb-4 standalone:pb-[env(safe-area-inset-bottom)]">
         <TaskListWidget tasks={taskMap} workspaceId={workspaceId} />
-        {contextMeterEnabled && <ContextMeter usage={usage} model={selectedModel} />}
+        {contextMeterEnabled && (
+          <ContextMeter usage={usage} model={selectedModel} modelInfo={selectedModelInfo} />
+        )}
         <PromptInput
           onSubmit={handleSubmit}
           draftKey={workspaceId}
@@ -1429,7 +1445,7 @@ function AgentModelMenu({
                             isCurrentAgent && model.id === selectedModel ? "bg-accent" : "",
                           )}
                         >
-                          <span className="text-sm font-medium">{model.name}</span>
+                          <ModelLine model={model} />
                           {model.description && (
                             <span className="text-xs text-muted-foreground">
                               {model.description}
@@ -1464,7 +1480,7 @@ function AgentModelMenu({
                   model.id === selectedModel ? "bg-accent" : "",
                 )}
               >
-                <span className="text-sm font-medium">{model.name}</span>
+                <ModelLine model={model} />
                 {model.description && (
                   <span className="text-xs text-muted-foreground">{model.description}</span>
                 )}
@@ -1489,15 +1505,23 @@ function relativeTime(ms: number): string {
 }
 
 // Approximate context window per model. Fallback for the chat context meter
-// when an adapter doesn't report `maxContextTokens` live. Claude Code adapter
+// when an adapter doesn't report `maxContextTokens` live and the picker
+// doesn't supply a `contextWindow` on the ModelInfo. Claude Code adapter
 // always passes the SDK's `getContextUsage().maxTokens`, so this map is
 // fallback-only for Claude; Codex/Gemini/Cursor SDKs don't expose a context
 // window field, so they rely on this map directly.
+//
+// Order matters: `getContextWindow` walks entries with the longest key first
+// so "claude-opus-4-7[1m]" matches before "claude-opus-4-7".
 const MODEL_CONTEXT_WINDOWS: Record<string, number> = {
-  // Claude — Opus 4.7, Opus 4.6, and Sonnet 4.6 default to 1M GA at standard
-  // pricing. Haiku 4.5 stays at 200k.
-  "claude-opus-4-7": 1_000_000,
-  "claude-opus-4-6": 1_000_000,
+  // Claude — Opus 4.x ships a 200k default and a separate [1m] long-context
+  // tier. Sonnet 4.6 is 1M GA at standard pricing (the [1m] suffix is a
+  // legacy alias). Haiku 4.5 stays at 200k.
+  "claude-opus-4-7[1m]": 1_000_000,
+  "claude-opus-4-6[1m]": 1_000_000,
+  "claude-opus-4-7": 200_000,
+  "claude-opus-4-6": 200_000,
+  "claude-sonnet-4-6[1m]": 1_000_000,
   "claude-sonnet-4-6": 1_000_000,
   "claude-haiku-4-5": 200_000,
   // OpenAI — GPT-5 family runs at 400k inside Codex CLI (the Responses API
@@ -1512,9 +1536,11 @@ const MODEL_CONTEXT_WINDOWS: Record<string, number> = {
 
 function getContextWindow(model: string | undefined): number {
   if (!model) return 200_000;
-  // Try exact match, then prefix match (e.g. "claude-sonnet-4-6-20250101").
   if (MODEL_CONTEXT_WINDOWS[model]) return MODEL_CONTEXT_WINDOWS[model];
-  for (const [key, value] of Object.entries(MODEL_CONTEXT_WINDOWS)) {
+  // Prefix match — sort by descending key length so longer/more specific
+  // keys win (e.g. "claude-opus-4-7[1m]" before "claude-opus-4-7").
+  const entries = Object.entries(MODEL_CONTEXT_WINDOWS).sort(([a], [b]) => b.length - a.length);
+  for (const [key, value] of entries) {
     if (model.startsWith(key)) return value;
   }
   return 200_000;
@@ -1526,12 +1552,37 @@ function formatTokens(n: number): string {
   return String(n);
 }
 
+/** Compact context-window label, e.g. 200000 → "200k", 1_000_000 → "1M". */
+function formatCtxWindow(n: number): string {
+  if (n >= 1_000_000) {
+    const m = n / 1_000_000;
+    return `${Number.isInteger(m) ? m.toFixed(0) : m.toFixed(1)}M`;
+  }
+  if (n >= 1_000) return `${Math.round(n / 1_000)}k`;
+  return String(n);
+}
+
+function ModelLine({ model }: { model: ModelInfo }) {
+  return (
+    <span className="flex w-full items-baseline justify-between gap-2">
+      <span className="text-sm font-medium">{model.name}</span>
+      {model.contextWindow !== undefined && (
+        <span className="text-[10px] uppercase tabular-nums text-muted-foreground">
+          {formatCtxWindow(model.contextWindow)} ctx
+        </span>
+      )}
+    </span>
+  );
+}
+
 function ContextMeter({
   usage,
   model,
+  modelInfo,
 }: {
   usage: UsageData | undefined;
   model: string | undefined;
+  modelInfo?: ModelInfo;
 }) {
   // Adapters compute context size with provider-aware semantics and pass it
   // through `contextTokens`. Only fall back to summation for legacy snapshots
@@ -1542,10 +1593,11 @@ function ContextMeter({
   // `legacyContextSize` uses the `provider` discriminator (with a
   // cacheCreationTokens-presence fallback for old snapshots).
   const contextSize = usage ? (usage.contextTokens ?? legacyContextSize(usage)) : 0;
-  // Prefer the SDK-reported max (e.g. Claude's auto-compact-aware limit).
-  // Fall back to the static model→window map for providers that don't
-  // report it (Codex, Gemini, etc.).
-  const window = usage?.maxContextTokens ?? getContextWindow(model);
+  // Window denominator priority:
+  //   1. SDK-reported `maxContextTokens` (Claude only, auto-compact-aware)
+  //   2. `modelInfo.contextWindow` from the adapter's listModels()
+  //   3. Static MODEL_CONTEXT_WINDOWS map keyed by id prefix
+  const window = usage?.maxContextTokens ?? modelInfo?.contextWindow ?? getContextWindow(model);
   const pct = Math.min(100, (contextSize / window) * 100);
   const danger = pct >= 85;
   const warn = !danger && pct >= 65;

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -10,6 +10,9 @@ import {
   DropdownMenuLabel,
   DropdownMenuSeparator,
   DropdownMenuTrigger,
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
   Tooltip,
   TooltipContent,
   TooltipTrigger,
@@ -1259,9 +1262,6 @@ export function ChatView({
 
       <div className="mx-auto w-full max-w-3xl shrink-0 px-3 lg:px-4 pt-2 pb-4 standalone:pb-[env(safe-area-inset-bottom)]">
         <TaskListWidget tasks={taskMap} workspaceId={workspaceId} />
-        {contextMeterEnabled && (
-          <ContextMeter usage={usage} model={selectedModel} modelInfo={selectedModelInfo} />
-        )}
         <PromptInput
           onSubmit={handleSubmit}
           draftKey={workspaceId}
@@ -1278,6 +1278,18 @@ export function ChatView({
           <PromptInputActions>
             <div className="flex items-center gap-0.5">
               <PromptInputAttach />
+              {supportsSessionListing && (
+                <SessionHistoryMenu
+                  workspaceId={workspaceId}
+                  chatId={chatId}
+                  activeSessionId={activeSessionId ?? sessionIdRef.current}
+                  onSelectSession={handleSelectSession}
+                  onNewSession={handleNewSession}
+                />
+              )}
+              {contextMeterEnabled && (
+                <ContextMeter usage={usage} model={selectedModel} modelInfo={selectedModelInfo} />
+              )}
               {(agentGroups.length > 0 || models.length > 0) && (
                 <AgentModelMenu
                   agentGroups={agentGroups}
@@ -1292,21 +1304,8 @@ export function ChatView({
               {modes.length > 0 && (
                 <ModeMenu modes={modes} selected={selectedMode} onSelect={handleModeSelect} />
               )}
-              {supportsSessionListing && (
-                <SessionHistoryMenu
-                  workspaceId={workspaceId}
-                  chatId={chatId}
-                  activeSessionId={activeSessionId ?? sessionIdRef.current}
-                  onSelectSession={handleSelectSession}
-                  onNewSession={handleNewSession}
-                />
-              )}
             </div>
-            <PromptInputSubmit
-              status={status}
-              onStop={handleStop}
-              queueCount={queuedMessages.length}
-            />
+            <PromptInputSubmit status={status} onStop={handleStop} />
           </PromptInputActions>
         </PromptInput>
       </div>
@@ -1342,7 +1341,7 @@ function ModeMenu({
           <DropdownMenuTrigger asChild>
             <button
               type="button"
-              className="inline-flex items-center gap-1 rounded-md px-2 py-1 text-xs font-medium text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+              className="inline-flex items-center gap-1 rounded-md px-1.5 py-1 text-xs font-medium text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
             >
               <ModeIcon modeId={current?.id ?? ""} className="size-3" />
               {current?.name ?? "Mode"}
@@ -1405,7 +1404,7 @@ function AgentModelMenu({
           type="button"
           disabled={disabled}
           className={cn(
-            "inline-flex items-center gap-1 rounded-md px-2 py-1 text-xs font-medium text-muted-foreground transition-colors hover:bg-accent hover:text-foreground",
+            "inline-flex items-center gap-1 rounded-md px-1.5 py-1 text-xs font-medium text-muted-foreground transition-colors hover:bg-accent hover:text-foreground",
             disabled && "opacity-50 cursor-not-allowed",
           )}
         >
@@ -1575,6 +1574,12 @@ function ModelLine({ model }: { model: ModelInfo }) {
   );
 }
 
+// Donut geometry — 24×24 viewBox keeps the SVG aligned with `size-4`
+// (16px) Tailwind utility while leaving enough whitespace for a 3-unit
+// stroke without clipping. Radius 9, stroke 3 → circumference ≈ 56.55.
+const DONUT_RADIUS = 9;
+const DONUT_CIRCUMFERENCE = 2 * Math.PI * DONUT_RADIUS;
+
 function ContextMeter({
   usage,
   model,
@@ -1599,24 +1604,81 @@ function ContextMeter({
   //   3. Static MODEL_CONTEXT_WINDOWS map keyed by id prefix
   const window = usage?.maxContextTokens ?? modelInfo?.contextWindow ?? getContextWindow(model);
   const pct = Math.min(100, (contextSize / window) * 100);
+  const pctRounded = Math.round(pct);
   const danger = pct >= 85;
   const warn = !danger && pct >= 65;
-  const barColor = danger ? "bg-destructive" : warn ? "bg-amber-500" : "bg-primary/60";
+  // Monochrome gray progression — the donut sits among other muted-foreground
+  // affordances in PromptInputActions, so it should read as a quiet status
+  // glyph rather than a colored alert. Higher usage = darker shade.
+  const progressColor = danger
+    ? "stroke-foreground"
+    : warn
+      ? "stroke-muted-foreground"
+      : "stroke-muted-foreground/60";
+  // Empty arc would render as a full ring at strokeDashoffset = circumference,
+  // so dot-treat the 0% case explicitly to match a "nothing yet" affordance.
+  const dashOffset = pct <= 0 ? DONUT_CIRCUMFERENCE : DONUT_CIRCUMFERENCE * (1 - pct / 100);
+
+  // Popover (controlled) instead of Tooltip so the breakdown is reachable on
+  // touch devices where hover doesn't fire reliably. On desktop we still want
+  // the lightweight hover-to-peek feel, so `onPointerEnter`/`onPointerLeave`
+  // open/close the popover when the input is a mouse. Touch and pen taps fall
+  // through to Popover's built-in click toggle.
+  const [open, setOpen] = useState(false);
 
   return (
-    <Tooltip>
-      <TooltipTrigger asChild>
-        <div className="mb-1 flex items-center gap-2 px-1 text-[11px] text-muted-foreground">
-          <span className="tabular-nums">
-            {formatTokens(contextSize)} / {formatTokens(window)}
-          </span>
-          <div className="h-1 flex-1 overflow-hidden rounded-full bg-border">
-            <div className={cn("h-full transition-all", barColor)} style={{ width: `${pct}%` }} />
-          </div>
-          <span className="tabular-nums">{Math.round(pct)}%</span>
-        </div>
-      </TooltipTrigger>
-      <TooltipContent>
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <button
+          type="button"
+          // Match `SessionHistoryMenu`'s button shell so the donut sits
+          // visually on the same row of affordances inside PromptInputActions.
+          aria-label={`Context window: ${pctRounded}% of ${formatTokens(window)}`}
+          className="inline-flex items-center justify-center rounded-md px-1.5 py-1 text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+          onPointerEnter={(e) => {
+            if (e.pointerType === "mouse") setOpen(true);
+          }}
+          onPointerLeave={(e) => {
+            if (e.pointerType === "mouse") setOpen(false);
+          }}
+        >
+          <svg viewBox="0 0 24 24" className="size-5 -rotate-90 shrink-0" aria-hidden="true">
+            <circle
+              cx="12"
+              cy="12"
+              r={DONUT_RADIUS}
+              fill="none"
+              className="stroke-muted-foreground/25"
+              strokeWidth="3"
+            />
+            <circle
+              cx="12"
+              cy="12"
+              r={DONUT_RADIUS}
+              fill="none"
+              className={cn("transition-all", progressColor)}
+              strokeWidth="3"
+              strokeLinecap="round"
+              strokeDasharray={DONUT_CIRCUMFERENCE}
+              strokeDashoffset={dashOffset}
+            />
+          </svg>
+        </button>
+      </PopoverTrigger>
+      <PopoverContent
+        // Keep the popover open while the mouse is over its content (otherwise
+        // hovering off the trigger into the popover would close it before the
+        // user can read it). Touch users dismiss via tap-outside / Escape.
+        onPointerEnter={(e) => {
+          if (e.pointerType === "mouse") setOpen(true);
+        }}
+        onPointerLeave={(e) => {
+          if (e.pointerType === "mouse") setOpen(false);
+        }}
+        className="w-auto p-2"
+        side="top"
+        align="end"
+      >
         <div className="space-y-0.5 text-xs">
           {usage ? (
             <>
@@ -1636,15 +1698,15 @@ function ContextMeter({
                   <div>Total processed: {usage.totalProcessedTokens.toLocaleString()}</div>
                 )}
               <div className="mt-1 border-t pt-1">
-                Context: {contextSize.toLocaleString()} / {window.toLocaleString()}
+                Context: {contextSize.toLocaleString()} / {window.toLocaleString()} ({pctRounded}%)
               </div>
             </>
           ) : (
             <div>Context window: {window.toLocaleString()} tokens</div>
           )}
         </div>
-      </TooltipContent>
-    </Tooltip>
+      </PopoverContent>
+    </Popover>
   );
 }
 
@@ -1714,9 +1776,9 @@ function SessionHistoryMenu({
           <DropdownMenuTrigger asChild>
             <button
               type="button"
-              className="inline-flex items-center justify-center rounded-md px-2 py-1 text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+              className="inline-flex items-center justify-center rounded-md px-1.5 py-1 text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
             >
-              <Clock className="size-3" />
+              <Clock className="size-4" />
             </button>
           </DropdownMenuTrigger>
         </TooltipTrigger>

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -212,6 +212,13 @@ interface AgentGroup {
   defaultModel?: string;
 }
 
+interface UsageData {
+  inputTokens: number;
+  outputTokens: number;
+  cacheReadTokens?: number;
+  cacheCreationTokens?: number;
+}
+
 interface ChatViewProps {
   workspaceId: string;
   chatId: string;
@@ -269,6 +276,7 @@ export function ChatView({
   // shows on the first render rather than briefly flashing the empty state.
   const [loadingHistory, setLoadingHistory] = useState(!!initialSessionId);
   const [hasMore, setHasMore] = useState(false);
+  const [usage, setUsage] = useState<UsageData | undefined>(undefined);
   const [loadingOlder, setLoadingOlder] = useState(false);
   const scrollHeightBeforePrependRef = useRef<number | null>(null);
   const sentinelRef = useRef<HTMLDivElement>(null);
@@ -485,6 +493,20 @@ export function ChatView({
         const sid = (dataPart.data as { sessionId: string }).sessionId;
         sessionIdRef.current = sid;
         onActiveSessionChange?.(sid);
+      } else if (
+        dataPart.type === "data-usage" &&
+        dataPart.data != null &&
+        typeof dataPart.data === "object"
+      ) {
+        const data = dataPart.data as Partial<UsageData>;
+        if (typeof data.inputTokens === "number" && typeof data.outputTokens === "number") {
+          setUsage({
+            inputTokens: data.inputTokens,
+            outputTokens: data.outputTokens,
+            cacheReadTokens: data.cacheReadTokens,
+            cacheCreationTokens: data.cacheCreationTokens,
+          });
+        }
       }
     },
   });
@@ -809,6 +831,7 @@ export function ChatView({
       onActiveSessionChange?.(sessionId);
       setMessages([]);
       setQueuedMessages([]);
+      setUsage(undefined);
       trpc.queue.clear.mutate({ workspaceId, chatId }).catch(() => {});
       onShowSessionListChange(false);
       await loadMessages(sessionId);
@@ -837,6 +860,7 @@ export function ChatView({
     onActiveSessionChange?.(undefined);
     setMessages([]);
     setQueuedMessages([]);
+    setUsage(undefined);
     trpc.queue.clear.mutate({ workspaceId, chatId }).catch(() => {});
     onShowSessionListChange(false);
   }, [
@@ -1166,6 +1190,7 @@ export function ChatView({
 
       <div className="mx-auto w-full max-w-3xl shrink-0 px-3 lg:px-4 pt-2 pb-4 standalone:pb-[env(safe-area-inset-bottom)]">
         <TaskListWidget tasks={taskMap} workspaceId={workspaceId} />
+        <ContextMeter usage={usage} model={selectedModel} />
         <PromptInput
           onSubmit={handleSubmit}
           draftKey={workspaceId}
@@ -1406,6 +1431,93 @@ function relativeTime(ms: number): string {
   if (days < 30) return `${days}d ago`;
   const months = Math.floor(days / 30);
   return `${months}mo ago`;
+}
+
+// Approximate context window per model. Used for the chat context meter.
+// Falls back to 200k for unknown models — meter still shows raw counts.
+const MODEL_CONTEXT_WINDOWS: Record<string, number> = {
+  // Claude family
+  "claude-opus-4-7": 1_000_000,
+  "claude-opus-4-6": 200_000,
+  "claude-sonnet-4-6": 200_000,
+  "claude-haiku-4-5": 200_000,
+  // OpenAI
+  "gpt-5": 400_000,
+  "gpt-4.1": 1_000_000,
+  "gpt-4o": 128_000,
+  // Gemini
+  "gemini-2.5-pro": 2_000_000,
+  "gemini-2.5-flash": 1_000_000,
+};
+
+function getContextWindow(model: string | undefined): number {
+  if (!model) return 200_000;
+  // Try exact match, then prefix match (e.g. "claude-sonnet-4-6-20250101").
+  if (MODEL_CONTEXT_WINDOWS[model]) return MODEL_CONTEXT_WINDOWS[model];
+  for (const [key, value] of Object.entries(MODEL_CONTEXT_WINDOWS)) {
+    if (model.startsWith(key)) return value;
+  }
+  return 200_000;
+}
+
+function formatTokens(n: number): string {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+  if (n >= 1_000) return `${(n / 1_000).toFixed(n >= 10_000 ? 0 : 1)}k`;
+  return String(n);
+}
+
+function ContextMeter({
+  usage,
+  model,
+}: {
+  usage: UsageData | undefined;
+  model: string | undefined;
+}) {
+  const contextSize = usage
+    ? usage.inputTokens + (usage.cacheReadTokens ?? 0) + (usage.cacheCreationTokens ?? 0)
+    : 0;
+  const window = getContextWindow(model);
+  const pct = Math.min(100, (contextSize / window) * 100);
+  const danger = pct >= 85;
+  const warn = !danger && pct >= 65;
+  const barColor = danger ? "bg-destructive" : warn ? "bg-amber-500" : "bg-primary/60";
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <div className="mb-1 flex items-center gap-2 px-1 text-[11px] text-muted-foreground">
+          <span className="tabular-nums">
+            {formatTokens(contextSize)} / {formatTokens(window)}
+          </span>
+          <div className="h-1 flex-1 overflow-hidden rounded-full bg-border">
+            <div className={cn("h-full transition-all", barColor)} style={{ width: `${pct}%` }} />
+          </div>
+          <span className="tabular-nums">{Math.round(pct)}%</span>
+        </div>
+      </TooltipTrigger>
+      <TooltipContent>
+        <div className="space-y-0.5 text-xs">
+          {usage ? (
+            <>
+              <div>Input: {usage.inputTokens.toLocaleString()}</div>
+              <div>Output: {usage.outputTokens.toLocaleString()}</div>
+              {usage.cacheReadTokens !== undefined && (
+                <div>Cache read: {usage.cacheReadTokens.toLocaleString()}</div>
+              )}
+              {usage.cacheCreationTokens !== undefined && (
+                <div>Cache write: {usage.cacheCreationTokens.toLocaleString()}</div>
+              )}
+              <div className="mt-1 border-t pt-1">
+                Context: {contextSize.toLocaleString()} / {window.toLocaleString()}
+              </div>
+            </>
+          ) : (
+            <div>Context window: {window.toLocaleString()} tokens</div>
+          )}
+        </div>
+      </TooltipContent>
+    </Tooltip>
+  );
 }
 
 interface SessionHistoryItem {

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -213,10 +213,19 @@ interface AgentGroup {
 }
 
 interface UsageData {
+  /** Provider that produced this snapshot. Drives legacy context-size math. */
+  provider?: "claude" | "codex" | "gemini" | "opencode" | "cursor";
   inputTokens: number;
   outputTokens: number;
   cacheReadTokens?: number;
   cacheCreationTokens?: number;
+  reasoningOutputTokens?: number;
+  /** Provider-aware total context tokens (preferred over summing fields). */
+  contextTokens?: number;
+  /** Cumulative processed tokens for the session/thread when available. */
+  totalProcessedTokens?: number;
+  /** Authoritative model context window from the agent SDK. */
+  maxContextTokens?: number;
 }
 
 interface ChatViewProps {
@@ -500,11 +509,26 @@ export function ChatView({
       ) {
         const data = dataPart.data as Partial<UsageData>;
         if (typeof data.inputTokens === "number" && typeof data.outputTokens === "number") {
-          setUsage({
+          const next: UsageData = {
+            provider: data.provider,
             inputTokens: data.inputTokens,
             outputTokens: data.outputTokens,
             cacheReadTokens: data.cacheReadTokens,
             cacheCreationTokens: data.cacheCreationTokens,
+            reasoningOutputTokens: data.reasoningOutputTokens,
+            contextTokens: data.contextTokens,
+            totalProcessedTokens: data.totalProcessedTokens,
+            maxContextTokens: data.maxContextTokens,
+          };
+          // SSE gap-fill can replay older usage chunks on reconnect. Prefer
+          // monotonic totalProcessedTokens when present so context may shrink
+          // after compaction; older providers fall back to context size.
+          setUsage((prev) => {
+            const shouldUseNext =
+              prev?.totalProcessedTokens !== undefined && next.totalProcessedTokens !== undefined
+                ? next.totalProcessedTokens >= prev.totalProcessedTokens
+                : usageContextSize(next) >= usageContextSize(prev);
+            return shouldUseNext ? next : prev;
           });
         }
       }
@@ -658,12 +682,27 @@ export function ChatView({
           chatId,
           sessionId,
         });
-        setMessages(data.messages as UIMessage[]);
+        setMessages(data.messages as unknown as UIMessage[]);
         lastEventIdRef.current = data.lastEventId ?? undefined;
         firstEventIdRef.current = data.firstEventId ?? undefined;
         firstMessageIndexRef.current =
           (data as { firstMessageIndex?: number | null }).firstMessageIndex ?? undefined;
         setHasMore(data.hasMore);
+        // Re-hydrate the context meter from the persisted snapshot so it
+        // survives task completion and page refreshes.
+        if (data.lastUsage) {
+          setUsage({
+            provider: data.lastUsage.provider,
+            inputTokens: data.lastUsage.inputTokens,
+            outputTokens: data.lastUsage.outputTokens,
+            cacheReadTokens: data.lastUsage.cacheReadTokens,
+            cacheCreationTokens: data.lastUsage.cacheCreationTokens,
+            reasoningOutputTokens: data.lastUsage.reasoningOutputTokens,
+            contextTokens: data.lastUsage.contextTokens,
+            totalProcessedTokens: data.lastUsage.totalProcessedTokens,
+            maxContextTokens: data.lastUsage.maxContextTokens,
+          });
+        }
       } finally {
         setLoadingHistory(false);
       }
@@ -705,7 +744,7 @@ export function ChatView({
           scrollHeightBeforePrependRef.current = scrollEl.scrollHeight;
         }
 
-        setMessages((prev) => [...(data.messages as UIMessage[]), ...prev]);
+        setMessages((prev) => [...(data.messages as unknown as UIMessage[]), ...prev]);
         firstEventIdRef.current = data.firstEventId ?? undefined;
         firstMessageIndexRef.current =
           (data as { firstMessageIndex?: number | null }).firstMessageIndex ?? undefined;
@@ -1473,10 +1512,19 @@ function ContextMeter({
   usage: UsageData | undefined;
   model: string | undefined;
 }) {
-  const contextSize = usage
-    ? usage.inputTokens + (usage.cacheReadTokens ?? 0) + (usage.cacheCreationTokens ?? 0)
-    : 0;
-  const window = getContextWindow(model);
+  // Adapters compute context size with provider-aware semantics and pass it
+  // through `contextTokens`. Only fall back to summation for legacy snapshots
+  // that predate that field. Provider semantics differ:
+  //   • Claude: `inputTokens` is the *uncached* portion → must add cache.
+  //   • Codex/OpenAI: `inputTokens` is the full prompt (already includes
+  //     cached) → adding `cacheReadTokens` would double-count.
+  // `legacyContextSize` uses the `provider` discriminator (with a
+  // cacheCreationTokens-presence fallback for old snapshots).
+  const contextSize = usage ? (usage.contextTokens ?? legacyContextSize(usage)) : 0;
+  // Prefer the SDK-reported max (e.g. Claude's auto-compact-aware limit).
+  // Fall back to the static model→window map for providers that don't
+  // report it (Codex, Gemini, etc.).
+  const window = usage?.maxContextTokens ?? getContextWindow(model);
   const pct = Math.min(100, (contextSize / window) * 100);
   const danger = pct >= 85;
   const warn = !danger && pct >= 65;
@@ -1507,6 +1555,13 @@ function ContextMeter({
               {usage.cacheCreationTokens !== undefined && (
                 <div>Cache write: {usage.cacheCreationTokens.toLocaleString()}</div>
               )}
+              {usage.reasoningOutputTokens !== undefined && (
+                <div>Reasoning output: {usage.reasoningOutputTokens.toLocaleString()}</div>
+              )}
+              {usage.totalProcessedTokens !== undefined &&
+                usage.totalProcessedTokens > contextSize && (
+                  <div>Total processed: {usage.totalProcessedTokens.toLocaleString()}</div>
+                )}
               <div className="mt-1 border-t pt-1">
                 Context: {contextSize.toLocaleString()} / {window.toLocaleString()}
               </div>
@@ -1518,6 +1573,31 @@ function ContextMeter({
       </TooltipContent>
     </Tooltip>
   );
+}
+
+function usageContextSize(usage: UsageData | undefined): number {
+  if (!usage) return 0;
+  return usage.contextTokens ?? legacyContextSize(usage);
+}
+
+/**
+ * Backward-compat fallback for usage snapshots that lack `contextTokens`.
+ * Uses `provider` when set; falls back to `cacheCreationTokens` presence as
+ * a Claude detector for snapshots persisted before the provider field
+ * existed. Claude `inputTokens` excludes cached content (must add cache
+ * fields); other providers report the full prompt.
+ */
+function legacyContextSize(usage: UsageData): number {
+  const isClaude = usage.provider === "claude" || usage.cacheCreationTokens !== undefined;
+  if (isClaude) {
+    return (
+      usage.inputTokens +
+      (usage.cacheReadTokens ?? 0) +
+      (usage.cacheCreationTokens ?? 0) +
+      (usage.reasoningOutputTokens ?? 0)
+    );
+  }
+  return usage.inputTokens + (usage.reasoningOutputTokens ?? 0);
 }
 
 interface SessionHistoryItem {

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -1,5 +1,5 @@
 import { useChat } from "@ai-sdk/react";
-import { AgentIcon } from "@band-app/dashboard-core";
+import { AgentIcon, useExperimentalContextMeter } from "@band-app/dashboard-core";
 import {
   Badge,
   cn,
@@ -286,6 +286,7 @@ export function ChatView({
   const [loadingHistory, setLoadingHistory] = useState(!!initialSessionId);
   const [hasMore, setHasMore] = useState(false);
   const [usage, setUsage] = useState<UsageData | undefined>(undefined);
+  const [contextMeterEnabled] = useExperimentalContextMeter();
   const [loadingOlder, setLoadingOlder] = useState(false);
   const scrollHeightBeforePrependRef = useRef<number | null>(null);
   const sentinelRef = useRef<HTMLDivElement>(null);
@@ -395,6 +396,21 @@ export function ChatView({
   const [userModelOverride, setUserModelOverride] = useState<string | undefined>();
   // Effective model: user override takes precedence, then agent default
   const selectedModel = userModelOverride ?? agentDefaultModel;
+
+  // Drop the SDK-reported `maxContextTokens` when the model changes — that
+  // value was for the prior model and would otherwise stick until the next
+  // turn refreshes it (e.g. switching Sonnet 1M → Haiku 200k would still
+  // show the 1M denominator). Falling back to undefined lets ContextMeter
+  // use the static MODEL_CONTEXT_WINDOWS entry for the new model in the
+  // meantime.
+  useEffect(() => {
+    if (!selectedModel) return;
+    setUsage((prev) => {
+      if (!prev || prev.maxContextTokens === undefined) return prev;
+      const { maxContextTokens: _drop, ...rest } = prev;
+      return rest;
+    });
+  }, [selectedModel]);
 
   useEffect(() => {
     const modelsP = trpc.models.listAll
@@ -1229,7 +1245,7 @@ export function ChatView({
 
       <div className="mx-auto w-full max-w-3xl shrink-0 px-3 lg:px-4 pt-2 pb-4 standalone:pb-[env(safe-area-inset-bottom)]">
         <TaskListWidget tasks={taskMap} workspaceId={workspaceId} />
-        <ContextMeter usage={usage} model={selectedModel} />
+        {contextMeterEnabled && <ContextMeter usage={usage} model={selectedModel} />}
         <PromptInput
           onSubmit={handleSubmit}
           draftKey={workspaceId}
@@ -1472,20 +1488,25 @@ function relativeTime(ms: number): string {
   return `${months}mo ago`;
 }
 
-// Approximate context window per model. Used for the chat context meter.
-// Falls back to 200k for unknown models — meter still shows raw counts.
+// Approximate context window per model. Fallback for the chat context meter
+// when an adapter doesn't report `maxContextTokens` live. Claude Code adapter
+// always passes the SDK's `getContextUsage().maxTokens`, so this map is
+// fallback-only for Claude; Codex/Gemini/Cursor SDKs don't expose a context
+// window field, so they rely on this map directly.
 const MODEL_CONTEXT_WINDOWS: Record<string, number> = {
-  // Claude family
+  // Claude — Opus 4.7, Opus 4.6, and Sonnet 4.6 default to 1M GA at standard
+  // pricing. Haiku 4.5 stays at 200k.
   "claude-opus-4-7": 1_000_000,
-  "claude-opus-4-6": 200_000,
-  "claude-sonnet-4-6": 200_000,
+  "claude-opus-4-6": 1_000_000,
+  "claude-sonnet-4-6": 1_000_000,
   "claude-haiku-4-5": 200_000,
-  // OpenAI
+  // OpenAI — GPT-5 family runs at 400k inside Codex CLI (the Responses API
+  // tier is 1M but Band shells out to the codex binary which caps at 400k).
   "gpt-5": 400_000,
   "gpt-4.1": 1_000_000,
   "gpt-4o": 128_000,
-  // Gemini
-  "gemini-2.5-pro": 2_000_000,
+  // Gemini 2.5 Pro and Flash are both 1M (~1,048,576).
+  "gemini-2.5-pro": 1_000_000,
   "gemini-2.5-flash": 1_000_000,
 };
 

--- a/apps/web/src/components/ai-elements/prompt-input.tsx
+++ b/apps/web/src/components/ai-elements/prompt-input.tsx
@@ -1,7 +1,7 @@
 import type { SelectionToChatDetail } from "@band-app/dashboard-core";
-import { Badge, cn } from "@band-app/ui";
+import { cn } from "@band-app/ui";
 import type { ChatStatus } from "ai";
-import { ArrowUpIcon, Clock, FileIcon, Loader2, Paperclip, SquareIcon, X } from "lucide-react";
+import { ArrowUpIcon, FileIcon, Loader2, Paperclip, SquareIcon, X } from "lucide-react";
 import type {
   ComponentProps,
   DragEvent,
@@ -406,13 +406,15 @@ export const PromptInputAttach = ({ className, ...props }: PromptInputAttachProp
       <button
         type="button"
         className={cn(
-          "inline-flex size-8 lg:size-7 shrink-0 items-center justify-center rounded text-muted-foreground transition-colors hover:bg-muted hover:text-foreground",
+          // Match the icon-button shell used by SessionHistoryMenu / ModeMenu /
+          // AgentModelMenu in the action row so all affordances line up.
+          "inline-flex shrink-0 items-center justify-center rounded-md px-1.5 py-1 text-muted-foreground transition-colors hover:bg-accent hover:text-foreground",
           className,
         )}
         onClick={() => fileInputRef.current?.click()}
         {...props}
       >
-        <Paperclip className="size-5 lg:size-4" />
+        <Paperclip className="size-4" />
       </button>
     </>
   );
@@ -503,14 +505,12 @@ export const PromptInputTextarea = ({
 export type PromptInputSubmitProps = ComponentProps<"button"> & {
   status?: ChatStatus;
   onStop?: () => void;
-  queueCount?: number;
 };
 
 export const PromptInputSubmit = ({
   className,
   status,
   onStop,
-  queueCount,
   ...props
 }: PromptInputSubmitProps) => {
   const { hasContent } = useContext(PromptInputContext);
@@ -520,12 +520,6 @@ export const PromptInputSubmit = ({
 
   return (
     <div className="flex items-center gap-1">
-      {queueCount != null && queueCount > 0 && (
-        <Badge variant="secondary" className="text-xs tabular-nums">
-          <Clock className="size-3" />
-          {queueCount}
-        </Badge>
-      )}
       {isStreaming && (
         <button
           type="button"

--- a/apps/web/src/lib/convert-events.ts
+++ b/apps/web/src/lib/convert-events.ts
@@ -150,6 +150,7 @@ export function convertEventsToUIMessages(events: SessionEventRecord[]): UIMessa
 
       case "data-session":
       case "data-result":
+      case "data-usage":
       case "finish-step":
       case "finish":
       case "start-step":

--- a/apps/web/src/lib/task-runner.ts
+++ b/apps/web/src/lib/task-runner.ts
@@ -516,6 +516,23 @@ async function runTask(chatId: string, task: InternalTask) {
           break;
         }
 
+        case "usage": {
+          broadcast(chatId, {
+            type: "data-usage" as UIMessageChunk["type"],
+            data: {
+              inputTokens: event.inputTokens,
+              outputTokens: event.outputTokens,
+              ...(event.cacheReadTokens !== undefined && {
+                cacheReadTokens: event.cacheReadTokens,
+              }),
+              ...(event.cacheCreationTokens !== undefined && {
+                cacheCreationTokens: event.cacheCreationTokens,
+              }),
+            },
+          } as UIMessageChunk);
+          break;
+        }
+
         case "session-result": {
           endText();
 

--- a/apps/web/src/lib/task-runner.ts
+++ b/apps/web/src/lib/task-runner.ts
@@ -92,17 +92,55 @@ interface InternalTask extends TaskInfo {
 const TASKS_KEY = Symbol.for("band.task-runner.tasks");
 const LISTENERS_KEY = Symbol.for("band.task-runner.listeners");
 const BUFFERS_KEY = Symbol.for("band.task-runner.sessionBuffers");
+const USAGE_KEY = Symbol.for("band.task-runner.sessionUsage");
 
 const g = globalThis as unknown as Record<symbol, unknown>;
 if (!g[TASKS_KEY]) g[TASKS_KEY] = new Map<string, InternalTask>();
 if (!g[LISTENERS_KEY]) g[LISTENERS_KEY] = new Map<string, Set<Listener>>();
 if (!g[BUFFERS_KEY]) g[BUFFERS_KEY] = new Map<string, SessionBuffer>();
+if (!g[USAGE_KEY]) g[USAGE_KEY] = new Map<string, SessionUsage>();
 
 /** Tasks keyed by chatId — one running task per chat pane. */
 const tasks = g[TASKS_KEY] as Map<string, InternalTask>;
 /** Event listeners keyed by chatId. */
 const listeners = g[LISTENERS_KEY] as Map<string, Set<Listener>>;
 const sessionBuffers = g[BUFFERS_KEY] as Map<string, SessionBuffer>;
+/**
+ * Latest token-usage snapshot per session. Survives task completion so the
+ * chat UI's context meter still shows accumulated context after the agent
+ * stops streaming. Cleared when the session is replaced (session-id-resolved
+ * remap) or implicitly when a new chat is created. Stored in-memory only.
+ *
+ * Bounded by `MAX_SESSION_USAGE` via insertion-order LRU eviction so a
+ * long-running server doesn't accumulate per-session entries forever.
+ */
+const sessionUsage = g[USAGE_KEY] as Map<string, SessionUsage>;
+const MAX_SESSION_USAGE = 1000;
+
+/** Bounded-LRU set. JS Map preserves insertion order, so deleting the first
+ * key drops the oldest. Re-inserting an existing key bumps it to MRU. */
+function lruSet<K, V>(map: Map<K, V>, key: K, value: V, cap: number): void {
+  if (map.has(key)) map.delete(key);
+  map.set(key, value);
+  while (map.size > cap) {
+    const oldest = map.keys().next().value;
+    if (oldest === undefined) break;
+    map.delete(oldest);
+  }
+}
+
+export interface SessionUsage {
+  /** Provider that produced this snapshot. Drives context-size arithmetic. */
+  provider?: "claude" | "codex" | "gemini" | "opencode" | "cursor";
+  inputTokens: number;
+  outputTokens: number;
+  cacheReadTokens?: number;
+  cacheCreationTokens?: number;
+  reasoningOutputTokens?: number;
+  contextTokens?: number;
+  totalProcessedTokens?: number;
+  maxContextTokens?: number;
+}
 
 function persistTask(task: InternalTask): void {
   const workspace = resolveWorkspace(task.workspaceId);
@@ -517,16 +555,60 @@ async function runTask(chatId: string, task: InternalTask) {
         }
 
         case "usage": {
+          // Persist the latest usage for this session so the UI can re-hydrate
+          // the context meter after the task completes or the page reloads.
+          // Prefer monotonic totalProcessedTokens when available. That lets
+          // current context shrink after compaction while still ignoring older
+          // replayed snapshots. Older providers fall back to a context high
+          // water mark.
+          if (task.sessionId) {
+            const prev = sessionUsage.get(task.sessionId);
+            const shouldStore =
+              prev?.totalProcessedTokens !== undefined && event.totalProcessedTokens !== undefined
+                ? event.totalProcessedTokens >= prev.totalProcessedTokens
+                : usageContextSize(event) >= usageContextSize(prev);
+            if (shouldStore) {
+              lruSet(
+                sessionUsage,
+                task.sessionId,
+                {
+                  provider: event.provider,
+                  inputTokens: event.inputTokens,
+                  outputTokens: event.outputTokens,
+                  cacheReadTokens: event.cacheReadTokens,
+                  cacheCreationTokens: event.cacheCreationTokens,
+                  reasoningOutputTokens: event.reasoningOutputTokens,
+                  contextTokens: event.contextTokens,
+                  totalProcessedTokens: event.totalProcessedTokens,
+                  maxContextTokens: event.maxContextTokens,
+                },
+                MAX_SESSION_USAGE,
+              );
+            }
+          }
           broadcast(chatId, {
             type: "data-usage" as UIMessageChunk["type"],
             data: {
               inputTokens: event.inputTokens,
               outputTokens: event.outputTokens,
+              ...(event.provider !== undefined && { provider: event.provider }),
               ...(event.cacheReadTokens !== undefined && {
                 cacheReadTokens: event.cacheReadTokens,
               }),
               ...(event.cacheCreationTokens !== undefined && {
                 cacheCreationTokens: event.cacheCreationTokens,
+              }),
+              ...(event.reasoningOutputTokens !== undefined && {
+                reasoningOutputTokens: event.reasoningOutputTokens,
+              }),
+              ...(event.contextTokens !== undefined && {
+                contextTokens: event.contextTokens,
+              }),
+              ...(event.totalProcessedTokens !== undefined && {
+                totalProcessedTokens: event.totalProcessedTokens,
+              }),
+              ...(event.maxContextTokens !== undefined && {
+                maxContextTokens: event.maxContextTokens,
               }),
             },
           } as UIMessageChunk);
@@ -583,6 +665,14 @@ async function runTask(chatId: string, task: InternalTask) {
           if (oldBuf) {
             sessionBuffers.set(event.resolvedSessionId, oldBuf);
             sessionBuffers.delete(event.previousSessionId);
+          }
+
+          // Migrate the latest usage snapshot too, so the context meter
+          // survives the ID swap.
+          const oldUsage = sessionUsage.get(event.previousSessionId);
+          if (oldUsage) {
+            lruSet(sessionUsage, event.resolvedSessionId, oldUsage, MAX_SESSION_USAGE);
+            sessionUsage.delete(event.previousSessionId);
           }
 
           if (task.sessionId === event.previousSessionId) {
@@ -679,6 +769,37 @@ export function getTask(chatId: string): TaskInfo | null {
  */
 export function getSessionBuffer(sessionId: string): SessionBuffer | undefined {
   return sessionBuffers.get(sessionId);
+}
+
+/**
+ * Compute context size for monotonic comparison only (not for display). Used
+ * by the SSE replay guard that throws away stale chunks. Adapters are
+ * expected to populate `contextTokens` directly; the summation fallback is
+ * provider-aware: `cacheCreationTokens` is Claude-only, so its presence
+ * signals Claude semantics where `inputTokens` excludes cached content.
+ */
+function usageContextSize(usage: SessionUsage | undefined): number {
+  if (!usage) return 0;
+  if (usage.contextTokens !== undefined) return usage.contextTokens;
+  // Provider-driven legacy fallback. Claude `inputTokens` excludes cached
+  // content → must add cache fields. Other providers report full prompt.
+  // Pre-provider snapshots use `cacheCreationTokens` presence as a
+  // backward-compatible Claude detector.
+  const isClaude = usage.provider === "claude" || usage.cacheCreationTokens !== undefined;
+  if (isClaude) {
+    return (
+      usage.inputTokens +
+      (usage.cacheReadTokens ?? 0) +
+      (usage.cacheCreationTokens ?? 0) +
+      (usage.reasoningOutputTokens ?? 0)
+    );
+  }
+  return usage.inputTokens + (usage.reasoningOutputTokens ?? 0);
+}
+
+/** Get the latest persisted usage snapshot for a session, if any. */
+export function getSessionUsage(sessionId: string): SessionUsage | undefined {
+  return sessionUsage.get(sessionId);
 }
 
 export function subscribe(chatId: string, listener: Listener): () => void {

--- a/apps/web/src/mcp/server.ts
+++ b/apps/web/src/mcp/server.ts
@@ -22,7 +22,7 @@ interface ProcedureInfo {
 function discoverProcedures(): ProcedureInfo[] {
   const procedures: ProcedureInfo[] = [];
   // appRouter._def.procedures is a flat Record<"namespace.method", AnyProcedure>
-  const procRecord = (appRouter._def as Record<string, unknown>).procedures as Record<
+  const procRecord = (appRouter._def as unknown as Record<string, unknown>).procedures as Record<
     string,
     // biome-ignore lint/suspicious/noExplicitAny: tRPC internal structure
     any

--- a/apps/web/src/trpc/router.ts
+++ b/apps/web/src/trpc/router.ts
@@ -86,7 +86,14 @@ import {
   upsertWorkspaceStatus,
   worktreesDir,
 } from "../lib/state";
-import { abortTask, cancelTask, getTask, submitTask, TaskConflictError } from "../lib/task-runner";
+import {
+  abortTask,
+  cancelTask,
+  getSessionUsage,
+  getTask,
+  submitTask,
+  TaskConflictError,
+} from "../lib/task-runner";
 import { listTasks, loadTask } from "../lib/task-store";
 import { loadWorkspaceTerminalConfig } from "../lib/terminal-config";
 import {
@@ -1533,6 +1540,9 @@ const sessionsRouter = t.router({
     )
     .query(async ({ input }) => {
       const pageSize = input.limit ?? 100;
+      // Latest usage snapshot — included on the initial page only so the
+      // chat UI can re-hydrate the context meter without a separate query.
+      const lastUsage = input.beforeEventId ? null : (getSessionUsage(input.sessionId) ?? null);
 
       // Try in-memory session buffer first (only for non-JSONL pagination).
       // When the client is paginating via beforeMessageIndex we're explicitly
@@ -1560,6 +1570,7 @@ const sessionsRouter = t.router({
               lastEventId,
               firstMessageIndex: null,
               hasMore: hasMoreInBuffer,
+              lastUsage,
             };
           }
 
@@ -1591,6 +1602,7 @@ const sessionsRouter = t.router({
                   lastEventId,
                   firstMessageIndex: jsonl.firstMessageIndex,
                   hasMore: jsonl.hasMore,
+                  lastUsage,
                 };
               }
             }
@@ -1604,6 +1616,7 @@ const sessionsRouter = t.router({
             lastEventId,
             firstMessageIndex: null,
             hasMore: false,
+            lastUsage,
           };
         }
       }
@@ -1632,6 +1645,7 @@ const sessionsRouter = t.router({
         lastEventId: null,
         firstMessageIndex: jsonl.firstMessageIndex,
         hasMore: jsonl.hasMore,
+        lastUsage,
       };
     }),
 });

--- a/apps/web/tests/fake-agent.mjs
+++ b/apps/web/tests/fake-agent.mjs
@@ -4,16 +4,25 @@
  * Fake agent binary that speaks the Claude Agent SDK stdin/stdout protocol.
  *
  * Reads FAKE_AGENT_SCENARIO env var pointing to a JSON file containing an
- * array of SDK messages. Outputs them as JSONL to stdout, then exits.
+ * array of SDK messages. Outputs them as JSONL to stdout, then waits for the
+ * SDK to close our stdin before exiting.
  *
  * Handles the SDK's bidirectional protocol:
- * - control_request from SDK (e.g. "initialize"): auto-responds with success
+ * - control_request from SDK (e.g. "initialize", "get_context_usage"):
+ *   auto-responds with success and an empty payload
  * - control_response from SDK (response to our control_request): resolves
  *   any pending _wait_for_stdin waiter
  *
  * Supports a special `{ _wait_for_stdin: true }` directive that pauses output
  * until a control_response is received on stdin (used for testing interactive
  * tool callbacks like canUseTool / AskUserQuestion).
+ *
+ * IMPORTANT: we don't exit immediately after emitting the scenario. Real
+ * adapters may send `control_request`s *after* the terminal `result` event
+ * (e.g. claude-code's `getContextUsage()` call). Exiting early would make
+ * those requests hang because there's no agent left to reply. Instead, we
+ * keep the process alive and exit when stdin EOFs, which the SDK does on
+ * shutdown.
  */
 
 import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
@@ -43,6 +52,9 @@ let stdinBuffer = "";
 
 process.stdin.resume();
 process.stdin.setEncoding("utf-8");
+// Exit when the SDK closes our stdin. Until then we stay alive so we can
+// answer late control_requests like `get_context_usage`.
+process.stdin.on("end", () => process.exit(exitCode));
 process.stdin.on("data", (chunk) => {
 	stdinBuffer += chunk;
 	let newlineIdx;
@@ -109,5 +121,14 @@ process.stdin.on("data", (chunk) => {
 		}
 		process.stdout.write(JSON.stringify(msg) + "\n");
 	}
-	process.exit(exitCode);
+	if (exitCode !== 0) {
+		// Crash simulation — tests that pin FAKE_AGENT_EXIT_CODE to a
+		// non-zero value want the agent to die now (e.g. simulating a
+		// binary segfault). Don't keep the process alive in that case.
+		process.exit(exitCode);
+	}
+	// Otherwise keep the process alive. The SDK may still send
+	// control_requests (e.g. a `getContextUsage()` triggered by the terminal
+	// `result` event); exiting before responding would hang the SDK promise.
+	// The stdin 'end' listener handles shutdown when the SDK is done with us.
 })();

--- a/packages/coding-agent/src/adapters/claude-code.ts
+++ b/packages/coding-agent/src/adapters/claude-code.ts
@@ -102,6 +102,38 @@ function encodeProjectDir(absDir: string): string {
 
 const SESSION_TAIL_BYTES = 64 * 1024;
 
+interface CumulativeUsage {
+  input: number;
+  output: number;
+  cacheRead: number;
+  cacheCreation: number;
+}
+
+/**
+ * Per-session cumulative usage counters, persisted across `runSession`
+ * invocations so `totalProcessedTokens` is monotonic across a continuing
+ * conversation. Module-scoped (lives for the lifetime of the process); not
+ * durable across server restarts.
+ *
+ * Bounded by `MAX_CUMULATIVE_SESSIONS` via simple insertion-order LRU eviction
+ * to prevent unbounded growth in long-running servers.
+ */
+const cumulativeUsageBySession = new Map<string, CumulativeUsage>();
+const MAX_CUMULATIVE_SESSIONS = 500;
+
+/** Set into a bounded LRU map. JS Map preserves insertion order, so deleting
+ * the first key drops the oldest. Re-inserting an existing key bumps it to
+ * MRU. */
+function lruSet<K, V>(map: Map<K, V>, key: K, value: V, cap: number): void {
+  if (map.has(key)) map.delete(key);
+  map.set(key, value);
+  while (map.size > cap) {
+    const oldest = map.keys().next().value;
+    if (oldest === undefined) break;
+    map.delete(oldest);
+  }
+}
+
 // Read the most recent `last-prompt` record from a session JSONL file by
 // scanning the last 64 KB. The CLI's /resume picker uses this latest
 // prompt as the session title, so we surface the same string here.
@@ -288,6 +320,57 @@ export class ClaudeCodeAdapter implements CodingAgent {
       hasEmittedTextSinceLastUser: false,
     };
 
+    // Cumulative session totals — persisted in `cumulativeUsageBySession`
+    // keyed by sessionId so they survive `runSession` boundaries. New sessions
+    // start at zero; resumed sessions pick up where the prior run left off.
+    // This makes `totalProcessedTokens` truly monotonic across the whole
+    // session and lets the task-runner monotonic guard rehydrate correctly.
+    let currentSessionId = sessionId ?? "";
+    const initialCumulative = currentSessionId
+      ? cumulativeUsageBySession.get(currentSessionId)
+      : undefined;
+    let cumulativeInput = initialCumulative?.input ?? 0;
+    let cumulativeOutput = initialCumulative?.output ?? 0;
+    let cumulativeCacheRead = initialCumulative?.cacheRead ?? 0;
+    let cumulativeCacheCreation = initialCumulative?.cacheCreation ?? 0;
+
+    const persistCumulative = () => {
+      if (!currentSessionId) return;
+      lruSet(
+        cumulativeUsageBySession,
+        currentSessionId,
+        {
+          input: cumulativeInput,
+          output: cumulativeOutput,
+          cacheRead: cumulativeCacheRead,
+          cacheCreation: cumulativeCacheCreation,
+        },
+        MAX_CUMULATIVE_SESSIONS,
+      );
+    };
+
+    // Migrate stored cumulative under a newly-resolved sessionId. Called when
+    // the SDK reports a session_id different from the one we initialised
+    // with — typically the first `system.init` for a brand-new session.
+    const adoptSessionId = (newSid: string) => {
+      if (!newSid || newSid === currentSessionId) return;
+      const prevStored = currentSessionId
+        ? cumulativeUsageBySession.get(currentSessionId)
+        : undefined;
+      if (prevStored) {
+        lruSet(cumulativeUsageBySession, newSid, prevStored, MAX_CUMULATIVE_SESSIONS);
+        cumulativeUsageBySession.delete(currentSessionId);
+      }
+      currentSessionId = newSid;
+      persistCumulative();
+    };
+
+    // Most recent canonical context snapshot from `getContextUsage()`.
+    // Reused on the terminal `result` event so the final usage payload
+    // reports the same window size the UI just rendered, instead of the
+    // accumulated-across-API-calls number SDK puts on `result.usage`.
+    let lastKnownContext: { contextTokens: number; maxContextTokens?: number } | undefined;
+
     try {
       for await (const message of conversation) {
         log.debug(
@@ -298,7 +381,118 @@ export class ClaudeCodeAdapter implements CodingAgent {
           "sdk message",
         );
 
+        // Adopt SDK-reported sessionId as soon as it's known so cumulatives
+        // get persisted under the right key. Applies to brand-new sessions
+        // (no `sessionId` param) and to any rare ID changes.
+        const rawSid = (message as { session_id?: string | number | null }).session_id;
+        if (rawSid != null) {
+          adoptSessionId(String(rawSid));
+        }
+
+        // Handle the terminal `result` event's usage *before* delegating to
+        // the mapper so the usage event lands ahead of any text-delta /
+        // session-result the mapper emits for the same message. SDK's
+        // `result.usage` is the accumulated total for this turn — drive
+        // `totalProcessedTokens` from it; carry context-size from the most
+        // recent `getContextUsage()` call so the meter doesn't briefly
+        // jump to the inflated accumulated number.
+        if (message.type === "result") {
+          const resultUsage = (
+            message as {
+              usage?: {
+                input_tokens?: number;
+                output_tokens?: number;
+                cache_read_input_tokens?: number;
+                cache_creation_input_tokens?: number;
+              };
+            }
+          ).usage;
+          if (resultUsage) {
+            const inputTokens = resultUsage.input_tokens ?? 0;
+            const outputTokens = resultUsage.output_tokens ?? 0;
+            const cacheReadTokens = resultUsage.cache_read_input_tokens ?? 0;
+            const cacheCreationTokens = resultUsage.cache_creation_input_tokens ?? 0;
+            cumulativeInput += inputTokens;
+            cumulativeOutput += outputTokens;
+            cumulativeCacheRead += cacheReadTokens;
+            cumulativeCacheCreation += cacheCreationTokens;
+            persistCumulative();
+
+            // If no prior main-thread assistant message ran getContextUsage()
+            // (e.g. tool-only turn or early termination), fetch a snapshot now
+            // so the terminal usage event still carries an accurate context
+            // size instead of forcing the UI onto the per-call summation
+            // fallback (which under-counts: it omits system prompt, MCP
+            // tools, and memory-file overhead).
+            if (!lastKnownContext) {
+              try {
+                const ctx = await conversation.getContextUsage();
+                lastKnownContext = {
+                  contextTokens: ctx.totalTokens,
+                  maxContextTokens: ctx.maxTokens,
+                };
+              } catch (err) {
+                log.warn({ err }, "getContextUsage failed on result; emitting without snapshot");
+              }
+            }
+
+            yield {
+              type: "usage",
+              provider: "claude",
+              inputTokens,
+              outputTokens,
+              cacheReadTokens,
+              cacheCreationTokens,
+              contextTokens: lastKnownContext?.contextTokens,
+              maxContextTokens: lastKnownContext?.maxContextTokens,
+              totalProcessedTokens:
+                cumulativeInput + cumulativeOutput + cumulativeCacheRead + cumulativeCacheCreation,
+            };
+          }
+        }
+
         yield* mapClaudeCodeEvent(message, state);
+
+        // After each main-thread assistant message, ask the SDK for the
+        // canonical context-window breakdown (same number Claude Code's
+        // `/context` HUD displays). It includes system prompt, MCP tools,
+        // memory files, and message history overhead — far more accurate
+        // than summing per-call API usage. Skip subagent messages and
+        // non-assistant messages. On failure, log and skip — falling back
+        // to per-message summation drifts upward across multi-tool turns
+        // and is worse than no update.
+        if (
+          message.type === "assistant" &&
+          (message as { parent_tool_use_id?: string | null }).parent_tool_use_id == null
+        ) {
+          try {
+            const ctx = await conversation.getContextUsage();
+            lastKnownContext = {
+              contextTokens: ctx.totalTokens,
+              maxContextTokens: ctx.maxTokens,
+            };
+            // Mid-turn emission ticks the context meter without inflating the
+            // tooltip's per-field counters: input/output/cache reflect the
+            // last *completed* turn's cumulative totals (frozen between
+            // result events), while contextTokens is a live SDK snapshot.
+            // Surfacing `ctx.apiUsage` here would show single-API-call
+            // values that look nonsensical next to a 50k-token context.
+            yield {
+              type: "usage",
+              provider: "claude",
+              inputTokens: cumulativeInput,
+              outputTokens: cumulativeOutput,
+              cacheReadTokens: cumulativeCacheRead,
+              cacheCreationTokens: cumulativeCacheCreation,
+              contextTokens: ctx.totalTokens,
+              maxContextTokens: ctx.maxTokens,
+              totalProcessedTokens:
+                cumulativeInput + cumulativeOutput + cumulativeCacheRead + cumulativeCacheCreation,
+            };
+          } catch (err) {
+            log.warn({ err }, "getContextUsage failed; skipping usage emission");
+          }
+        }
       }
       log.info("conversation generator done");
     } catch (err) {
@@ -588,18 +782,10 @@ function* mapClaudeCodeEvent(
             };
           }
         | undefined;
-      // Emit a usage snapshot for the latest assistant message so the UI
-      // context meter ticks after every LLM round-trip — not just at the
-      // final `result` event.
-      if (msg?.usage) {
-        yield {
-          type: "usage",
-          inputTokens: msg.usage.input_tokens ?? 0,
-          outputTokens: msg.usage.output_tokens ?? 0,
-          cacheReadTokens: msg.usage.cache_read_input_tokens ?? 0,
-          cacheCreationTokens: msg.usage.cache_creation_input_tokens ?? 0,
-        };
-      }
+      // Note: per-assistant usage is emitted by the caller via
+      // `getContextUsage()` so the meter reflects the SDK's full context
+      // accounting (system prompt, MCP tools, memory files). Emitting
+      // here too would double-broadcast on every assistant message.
       const content = msg?.content;
       if (Array.isArray(content)) {
         // Pre-populate toolNames for all visible tool_use blocks so that
@@ -693,23 +879,12 @@ function* mapClaudeCodeEvent(
       const numTurns = (message.num_turns as number) ?? 0;
       const costUsd = (message.total_cost_usd as number) ?? 0;
 
-      const usage = message.usage as
-        | {
-            input_tokens?: number;
-            output_tokens?: number;
-            cache_read_input_tokens?: number;
-            cache_creation_input_tokens?: number;
-          }
-        | undefined;
-      if (usage) {
-        yield {
-          type: "usage",
-          inputTokens: usage.input_tokens ?? 0,
-          outputTokens: usage.output_tokens ?? 0,
-          cacheReadTokens: usage.cache_read_input_tokens ?? 0,
-          cacheCreationTokens: usage.cache_creation_input_tokens ?? 0,
-        };
-      }
+      // Note: usage for the terminal `result` event is emitted by the
+      // caller (runSession's outer loop) before delegating to this mapper,
+      // so it can carry the cached `lastKnownContext` snapshot and the
+      // running cumulative `totalProcessedTokens`. Emitting here would
+      // double-broadcast and report the inflated accumulated number as
+      // current context size.
 
       // Fallback: if the final assistant text was never streamed via
       // intermediate `assistant` events (e.g. the SDK jumped straight

--- a/packages/coding-agent/src/adapters/claude-code.ts
+++ b/packages/coding-agent/src/adapters/claude-code.ts
@@ -675,6 +675,24 @@ function* mapClaudeCodeEvent(
       const numTurns = (message.num_turns as number) ?? 0;
       const costUsd = (message.total_cost_usd as number) ?? 0;
 
+      const usage = message.usage as
+        | {
+            input_tokens?: number;
+            output_tokens?: number;
+            cache_read_input_tokens?: number;
+            cache_creation_input_tokens?: number;
+          }
+        | undefined;
+      if (usage) {
+        yield {
+          type: "usage",
+          inputTokens: usage.input_tokens ?? 0,
+          outputTokens: usage.output_tokens ?? 0,
+          cacheReadTokens: usage.cache_read_input_tokens ?? 0,
+          cacheCreationTokens: usage.cache_creation_input_tokens ?? 0,
+        };
+      }
+
       // Fallback: if the final assistant text was never streamed via
       // intermediate `assistant` events (e.g. the SDK jumped straight
       // from an empty-text placeholder to the `result` event), emit

--- a/packages/coding-agent/src/adapters/claude-code.ts
+++ b/packages/coding-agent/src/adapters/claude-code.ts
@@ -580,8 +580,26 @@ function* mapClaudeCodeEvent(
               name?: string;
               input?: Record<string, unknown>;
             }>;
+            usage?: {
+              input_tokens?: number;
+              output_tokens?: number;
+              cache_read_input_tokens?: number;
+              cache_creation_input_tokens?: number;
+            };
           }
         | undefined;
+      // Emit a usage snapshot for the latest assistant message so the UI
+      // context meter ticks after every LLM round-trip — not just at the
+      // final `result` event.
+      if (msg?.usage) {
+        yield {
+          type: "usage",
+          inputTokens: msg.usage.input_tokens ?? 0,
+          outputTokens: msg.usage.output_tokens ?? 0,
+          cacheReadTokens: msg.usage.cache_read_input_tokens ?? 0,
+          cacheCreationTokens: msg.usage.cache_creation_input_tokens ?? 0,
+        };
+      }
       const content = msg?.content;
       if (Array.isArray(content)) {
         // Pre-populate toolNames for all visible tool_use blocks so that

--- a/packages/coding-agent/src/adapters/claude-code.ts
+++ b/packages/coding-agent/src/adapters/claude-code.ts
@@ -633,31 +633,54 @@ export class ClaudeCodeAdapter implements CodingAgent {
     return [
       {
         id: "claude-sonnet-4-6",
-        name: "Default (recommended)",
-        description: "Use the default model (currently Sonnet 4.6) · $3/$15 per Mtok",
+        name: "Sonnet 4.6",
+        description: "Balanced default for everyday work",
+        contextWindow: claudeContextForId("claude-sonnet-4-6"),
       },
       {
         id: "claude-sonnet-4-6[1m]",
-        name: "Sonnet (1M context)",
-        description: "Sonnet 4.6 for long sessions · $6/$22.50 per Mtok",
+        name: "Sonnet 4.6 (1M)",
+        description: "Long-context tier for large sessions",
+        contextWindow: 1_000_000,
       },
       {
         id: "claude-opus-4-7",
-        name: "Opus",
-        description: "Opus 4.7 · Most capable for complex work · $5/$25 per Mtok",
+        name: "Opus 4.7",
+        description: "Most capable for complex work",
+        contextWindow: claudeContextForId("claude-opus-4-7"),
       },
       {
         id: "claude-opus-4-7[1m]",
-        name: "Opus (1M context)",
-        description: "Opus 4.7 for long sessions · $10/$37.50 per Mtok",
+        name: "Opus 4.7 (1M)",
+        description: "Most capable, long-context tier",
+        contextWindow: 1_000_000,
       },
       {
         id: "claude-haiku-4-5-20251001",
-        name: "Haiku",
-        description: "Haiku 4.5 · Fastest for quick answers · $1/$5 per Mtok",
+        name: "Haiku 4.5",
+        description: "Fastest for quick answers",
+        contextWindow: claudeContextForId("claude-haiku-4-5-20251001"),
       },
     ];
   }
+}
+
+/**
+ * Approximate context window per Claude model id. Mirrors the static map in
+ * the web meter so SDK-discovered models also surface a window estimate.
+ * The runtime `getContextUsage()` value still wins when present.
+ *
+ *   • [1m] suffix    → 1M long-context tier
+ *   • Sonnet 4.x     → 1M (GA at standard pricing, no premium)
+ *   • Opus 4.x       → 200k default; the 1M tier requires the [1m] id
+ *   • Haiku 4.x      → 200k
+ */
+function claudeContextForId(id: string): number | undefined {
+  if (id.includes("[1m]")) return 1_000_000;
+  if (id.startsWith("claude-haiku")) return 200_000;
+  if (id.startsWith("claude-opus")) return 200_000;
+  if (id.startsWith("claude-sonnet")) return 1_000_000;
+  return undefined;
 }
 
 function mapModelInfo(info: ModelInfo): AgentModel {
@@ -665,6 +688,7 @@ function mapModelInfo(info: ModelInfo): AgentModel {
     id: info.value,
     name: info.displayName,
     description: info.description,
+    contextWindow: claudeContextForId(info.value),
   };
 }
 

--- a/packages/coding-agent/src/adapters/codex.ts
+++ b/packages/coding-agent/src/adapters/codex.ts
@@ -23,6 +23,36 @@ import type {
 
 const log = createLogger("coding-agent:codex");
 
+interface CumulativeUsage {
+  input: number;
+  output: number;
+  reasoningOutput: number;
+}
+
+/**
+ * Per-thread cumulative usage counters, persisted across `runSession`
+ * invocations so `totalProcessedTokens` is monotonic across a continuing
+ * Codex thread. Module-scoped (lifetime-of-process); not durable across
+ * server restarts.
+ *
+ * Bounded by `MAX_CUMULATIVE_SESSIONS` via insertion-order LRU eviction
+ * to prevent unbounded growth in long-running servers.
+ */
+const cumulativeUsageBySession = new Map<string, CumulativeUsage>();
+const MAX_CUMULATIVE_SESSIONS = 500;
+
+/** Bounded-LRU set. JS Map preserves insertion order, so deleting the first
+ * key drops the oldest. Re-inserting an existing key bumps it to MRU. */
+function lruSet<K, V>(map: Map<K, V>, key: K, value: V, cap: number): void {
+  if (map.has(key)) map.delete(key);
+  map.set(key, value);
+  while (map.size > cap) {
+    const oldest = map.keys().next().value;
+    if (oldest === undefined) break;
+    map.delete(oldest);
+  }
+}
+
 /**
  * Codex adapter — uses the `@openai/codex-sdk` TypeScript SDK which wraps the
  * Codex CLI binary and exchanges JSONL events over stdin/stdout.
@@ -141,11 +171,49 @@ export class CodexAdapter implements CodingAgent {
 
     const startMs = Date.now();
     let turnCount = 0;
-    let totalInputTokens = 0;
-    let totalOutputTokens = 0;
     // Track the actual thread ID from the SDK — sessionId param may be
     // undefined for new sessions.
     let actualSessionId = sessionId ?? "";
+
+    // Cumulative thread totals — persisted in `cumulativeUsageBySession`
+    // keyed by thread id so they survive `runSession` boundaries. New threads
+    // start at zero; resumed threads pick up where the prior run left off.
+    const initialCumulative = actualSessionId
+      ? cumulativeUsageBySession.get(actualSessionId)
+      : undefined;
+    let totalInputTokens = initialCumulative?.input ?? 0;
+    let totalOutputTokens = initialCumulative?.output ?? 0;
+    let totalReasoningOutputTokens = initialCumulative?.reasoningOutput ?? 0;
+
+    const persistCumulative = () => {
+      if (!actualSessionId) return;
+      lruSet(
+        cumulativeUsageBySession,
+        actualSessionId,
+        {
+          input: totalInputTokens,
+          output: totalOutputTokens,
+          reasoningOutput: totalReasoningOutputTokens,
+        },
+        MAX_CUMULATIVE_SESSIONS,
+      );
+    };
+
+    // Migrate stored cumulative under a newly-resolved thread id. Called when
+    // `thread.started` reports a thread_id different from the one we
+    // initialised with — typically for brand-new threads.
+    const adoptSessionId = (newSid: string) => {
+      if (!newSid || newSid === actualSessionId) return;
+      const prevStored = actualSessionId
+        ? cumulativeUsageBySession.get(actualSessionId)
+        : undefined;
+      if (prevStored) {
+        lruSet(cumulativeUsageBySession, newSid, prevStored, MAX_CUMULATIVE_SESSIONS);
+        cumulativeUsageBySession.delete(actualSessionId);
+      }
+      actualSessionId = newSid;
+      persistCumulative();
+    };
 
     const runStreamedStartMs = Date.now();
     log.info("calling thread.runStreamed");
@@ -179,6 +247,10 @@ export class CodexAdapter implements CodingAgent {
     const toolNames = new Map<string, string>();
     // Track emitted text length per item to compute deltas on item.updated
     const emittedTextLengths = new Map<string, number>();
+    // Buffer terminal turn state — emit a single session-result *after* the
+    // iterator exhausts so multi-turn sessions don't yield duplicate finishes.
+    let lastTurnOutcome: "completed" | "failed" | null = null;
+    let lastTurnError: string | null = null;
 
     try {
       for await (const event of { [Symbol.asyncIterator]: () => iterator }) {
@@ -187,7 +259,8 @@ export class CodexAdapter implements CodingAgent {
         switch (event.type) {
           // ── Session lifecycle ──────────────────────────────────────────
           case "thread.started": {
-            actualSessionId = event.thread_id ?? sessionId ?? "";
+            const resolvedSid = event.thread_id ?? sessionId ?? "";
+            adoptSessionId(resolvedSid);
             log.info(
               { threadId: event.thread_id, sessionIdParam: sessionId, actualSessionId },
               "codex thread.started",
@@ -222,35 +295,37 @@ export class CodexAdapter implements CodingAgent {
           }
 
           case "turn.completed": {
+            const reasoningOutputTokens = event.usage.reasoning_output_tokens ?? 0;
+            const contextTokens =
+              event.usage.input_tokens + event.usage.output_tokens + reasoningOutputTokens;
             totalInputTokens += event.usage.input_tokens;
             totalOutputTokens += event.usage.output_tokens;
+            totalReasoningOutputTokens += reasoningOutputTokens;
+            persistCumulative();
+            // OpenAI Responses API: `input_tokens` is the full prompt sent to
+            // the model for this turn (already inclusive of cached content).
+            // `cached_input_tokens` is a subset for visibility only. Match the
+            // t3code-style split: current window usage is the latest turn's
+            // total, while totalProcessedTokens is cumulative session work.
             yield {
               type: "usage",
+              provider: "codex",
               inputTokens: event.usage.input_tokens,
               outputTokens: event.usage.output_tokens,
+              cacheReadTokens: event.usage.cached_input_tokens,
+              reasoningOutputTokens,
+              contextTokens,
+              totalProcessedTokens:
+                totalInputTokens + totalOutputTokens + totalReasoningOutputTokens,
             };
-            yield {
-              type: "session-result",
-              success: true,
-              sessionId: actualSessionId,
-              durationMs: Date.now() - startMs,
-              numTurns: turnCount,
-              costUsd: 0,
-              errors: [],
-            };
+            lastTurnOutcome = "completed";
+            lastTurnError = null;
             break;
           }
 
           case "turn.failed": {
-            yield {
-              type: "session-result",
-              success: false,
-              sessionId: actualSessionId,
-              durationMs: Date.now() - startMs,
-              numTurns: turnCount,
-              costUsd: 0,
-              errors: [event.error.message],
-            };
+            lastTurnOutcome = "failed";
+            lastTurnError = event.error.message;
             break;
           }
 
@@ -269,11 +344,25 @@ export class CodexAdapter implements CodingAgent {
           turnCount,
           totalInputTokens,
           totalOutputTokens,
+          totalReasoningOutputTokens,
           actualSessionId,
           elapsedMs: Date.now() - startMs,
         },
         "codex stream done — all events consumed",
       );
+
+      // Emit a single terminal session-result reflecting the last turn outcome.
+      if (lastTurnOutcome !== null) {
+        yield {
+          type: "session-result",
+          success: lastTurnOutcome === "completed",
+          sessionId: actualSessionId,
+          durationMs: Date.now() - startMs,
+          numTurns: turnCount,
+          costUsd: 0,
+          errors: lastTurnError ? [lastTurnError] : [],
+        };
+      }
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
       log.error({ err, cwd: this.workspaceDir }, "codex stream error");

--- a/packages/coding-agent/src/adapters/codex.ts
+++ b/packages/coding-agent/src/adapters/codex.ts
@@ -225,6 +225,11 @@ export class CodexAdapter implements CodingAgent {
             totalInputTokens += event.usage.input_tokens;
             totalOutputTokens += event.usage.output_tokens;
             yield {
+              type: "usage",
+              inputTokens: event.usage.input_tokens,
+              outputTokens: event.usage.output_tokens,
+            };
+            yield {
               type: "session-result",
               success: true,
               sessionId: actualSessionId,

--- a/packages/coding-agent/src/adapters/codex.ts
+++ b/packages/coding-agent/src/adapters/codex.ts
@@ -295,11 +295,22 @@ export class CodexAdapter implements CodingAgent {
           }
 
           case "turn.completed": {
-            const reasoningOutputTokens = event.usage.reasoning_output_tokens ?? 0;
-            const contextTokens =
-              event.usage.input_tokens + event.usage.output_tokens + reasoningOutputTokens;
-            totalInputTokens += event.usage.input_tokens;
-            totalOutputTokens += event.usage.output_tokens;
+            // Codex CLI versions vary: some omit individual usage fields. Coerce
+            // each to 0 so a missing field doesn't NaN the broadcast (ChatView
+            // silently drops data-usage chunks without numeric inputTokens).
+            const usage = event.usage ?? {
+              input_tokens: 0,
+              output_tokens: 0,
+              cached_input_tokens: 0,
+              reasoning_output_tokens: 0,
+            };
+            const inputTokens = usage.input_tokens ?? 0;
+            const outputTokens = usage.output_tokens ?? 0;
+            const cachedInputTokens = usage.cached_input_tokens ?? 0;
+            const reasoningOutputTokens = usage.reasoning_output_tokens ?? 0;
+            const contextTokens = inputTokens + outputTokens + reasoningOutputTokens;
+            totalInputTokens += inputTokens;
+            totalOutputTokens += outputTokens;
             totalReasoningOutputTokens += reasoningOutputTokens;
             persistCumulative();
             // OpenAI Responses API: `input_tokens` is the full prompt sent to
@@ -307,12 +318,23 @@ export class CodexAdapter implements CodingAgent {
             // `cached_input_tokens` is a subset for visibility only. Match the
             // t3code-style split: current window usage is the latest turn's
             // total, while totalProcessedTokens is cumulative session work.
+            log.debug(
+              {
+                inputTokens,
+                outputTokens,
+                cachedInputTokens,
+                reasoningOutputTokens,
+                contextTokens,
+                totalProcessed: totalInputTokens + totalOutputTokens + totalReasoningOutputTokens,
+              },
+              "codex usage emitted",
+            );
             yield {
               type: "usage",
               provider: "codex",
-              inputTokens: event.usage.input_tokens,
-              outputTokens: event.usage.output_tokens,
-              cacheReadTokens: event.usage.cached_input_tokens,
+              inputTokens,
+              outputTokens,
+              cacheReadTokens: cachedInputTokens,
               reasoningOutputTokens,
               contextTokens,
               totalProcessedTokens:

--- a/packages/coding-agent/src/adapters/codex.ts
+++ b/packages/coding-agent/src/adapters/codex.ts
@@ -453,12 +453,42 @@ function resolveCodexBinary(): string | undefined {
 
 // ─── Models ─────────────────────────────────────────────────────────────────
 
+// All GPT-5 family models cap at 400k tokens inside the Codex CLI tier
+// (Plus / Pro / Business / Enterprise / Edu / Go). The Responses API tier
+// goes higher (1M for 5.5) but Band shells out to the codex binary.
+const CODEX_CTX = 400_000;
+
 const CODEX_MODELS: AgentModel[] = [
-  { id: "gpt-5.5", name: "GPT-5.5", description: "Flagship frontier model" },
-  { id: "gpt-5.4", name: "GPT-5.4", description: "Previous flagship model" },
-  { id: "gpt-5.4-mini", name: "GPT-5.4 Mini", description: "Fast, efficient mini model" },
-  { id: "gpt-5.3-codex", name: "GPT-5.3 Codex", description: "Coding-optimized model" },
-  { id: "gpt-5.2-codex", name: "GPT-5.2 Codex", description: "Previous coding-optimized model" },
+  {
+    id: "gpt-5.5",
+    name: "GPT-5.5",
+    description: "Flagship frontier model",
+    contextWindow: CODEX_CTX,
+  },
+  {
+    id: "gpt-5.4",
+    name: "GPT-5.4",
+    description: "Previous flagship model",
+    contextWindow: CODEX_CTX,
+  },
+  {
+    id: "gpt-5.4-mini",
+    name: "GPT-5.4 Mini",
+    description: "Fast, efficient mini model",
+    contextWindow: CODEX_CTX,
+  },
+  {
+    id: "gpt-5.3-codex",
+    name: "GPT-5.3 Codex",
+    description: "Coding-optimized model",
+    contextWindow: CODEX_CTX,
+  },
+  {
+    id: "gpt-5.2-codex",
+    name: "GPT-5.2 Codex",
+    description: "Previous coding-optimized model",
+    contextWindow: CODEX_CTX,
+  },
 ];
 
 // ─── Skills ─────────────────────────────────────────────────────────────────

--- a/packages/coding-agent/src/adapters/cursor-cli.ts
+++ b/packages/coding-agent/src/adapters/cursor-cli.ts
@@ -161,6 +161,9 @@ export class CursorCliAdapter implements CodingAgent {
   }
 
   listModels(): AgentModel[] {
+    // Cursor "auto" routes among multiple backends — context window varies by
+    // chosen model. No SDK-side reporting; leave undefined so the meter
+    // falls back to the static MODEL_CONTEXT_WINDOWS default (200k).
     return [{ id: "auto", name: "Auto", description: "Cursor chooses the best model" }];
   }
 }

--- a/packages/coding-agent/src/adapters/gemini-cli.ts
+++ b/packages/coding-agent/src/adapters/gemini-cli.ts
@@ -198,8 +198,18 @@ export class GeminiCliAdapter implements CodingAgent {
 
   listModels(): AgentModel[] {
     return [
-      { id: "gemini-2.5-pro", name: "Gemini 2.5 Pro", description: "Most capable" },
-      { id: "gemini-2.5-flash", name: "Gemini 2.5 Flash", description: "Fast and efficient" },
+      {
+        id: "gemini-2.5-pro",
+        name: "Gemini 2.5 Pro",
+        description: "Most capable",
+        contextWindow: 1_000_000,
+      },
+      {
+        id: "gemini-2.5-flash",
+        name: "Gemini 2.5 Flash",
+        description: "Fast and efficient",
+        contextWindow: 1_000_000,
+      },
     ];
   }
 }

--- a/packages/coding-agent/src/adapters/openai-codex.ts
+++ b/packages/coding-agent/src/adapters/openai-codex.ts
@@ -172,8 +172,13 @@ export class OpenAICodexAdapter implements CodingAgent {
 
   listModels(): AgentModel[] {
     return [
-      { id: "codex-mini", name: "Codex Mini", description: "Fast and efficient" },
-      { id: "o4-mini", name: "o4-mini" },
+      {
+        id: "codex-mini",
+        name: "Codex Mini",
+        description: "Fast and efficient",
+        contextWindow: 200_000,
+      },
+      { id: "o4-mini", name: "o4-mini", contextWindow: 200_000 },
     ];
   }
 }

--- a/packages/coding-agent/src/adapters/opencode.ts
+++ b/packages/coding-agent/src/adapters/opencode.ts
@@ -112,6 +112,13 @@ export class OpenCodeAdapter implements CodingAgent {
         stderrChunks.push(chunk.toString());
       });
 
+      // Register the close listener *before* iterating stdout so a fast-exit
+      // (process closes before the readline loop starts/finishes draining)
+      // can't fire 'close' without a subscriber and leave us with exit code 0.
+      const exitCodePromise = new Promise<number>((resolve) => {
+        child.on("close", (code) => resolve(code ?? 0));
+      });
+
       const rl = createInterface({ input: child.stdout });
 
       try {
@@ -179,9 +186,7 @@ export class OpenCodeAdapter implements CodingAgent {
           }
         }
 
-        lastExitCode = await new Promise<number>((resolve) => {
-          child.on("close", (code) => resolve(code ?? 0));
-        });
+        lastExitCode = await exitCodePromise;
         lastStderr = stderrChunks.join("");
 
         if (!gotOutput && effectiveSessionId && attempt < maxAttempts) {

--- a/packages/coding-agent/src/events.ts
+++ b/packages/coding-agent/src/events.ts
@@ -47,21 +47,71 @@ export interface ErrorEvent {
   message: string;
 }
 
+/** Identifies which provider produced a UsageEvent so consumers can apply
+ * provider-aware semantics without sniffing optional fields. */
+export type UsageProvider = "claude" | "codex" | "gemini" | "opencode" | "cursor";
+
 /**
  * Token usage for the most recent turn. Adapters emit this when usage info
  * is available so the UI can show context-window pressure.
  *
- * For Claude-family agents, `inputTokens` is the prompt size for the latest
- * turn (which approximates current context size, since the full conversation
- * is resent each turn). `cacheReadTokens` and `cacheCreationTokens` count
- * cached prompt content. For Codex/Gemini, only input/output are populated.
+ * Provider semantics differ:
+ *   • Claude — on `result` events `inputTokens` is the *uncached* prompt
+ *     portion of the latest API round-trip; cached portions appear in
+ *     `cacheReadTokens` / `cacheCreationTokens`, and total context ≈ sum of
+ *     all three. Mid-turn (per-assistant) emissions freeze input/output/cache
+ *     at the *previous* turn's cumulative totals so tooltip values stay
+ *     coherent while `contextTokens` ticks live from the SDK.
+ *   • Codex / OpenAI Responses API — `inputTokens` is the *full* prompt size
+ *     for the turn (already inclusive of cached content). `cacheReadTokens`
+ *     reports the cached subset for tooltip display only; do not sum. Codex
+ *     also populates `reasoningOutputTokens`, `contextTokens`, and
+ *     `totalProcessedTokens`.
+ *
+ * Adapters MUST set `contextTokens` to the computed context size for their
+ * provider so the UI can render the meter without knowing per-provider
+ * arithmetic. UIs should prefer `contextTokens` and only fall back to the
+ * legacy summation (driven by `provider`) for snapshots that predate that
+ * field.
  */
 export interface UsageEvent {
   type: "usage";
+  /**
+   * Provider that produced this snapshot. Drives provider-aware UI logic
+   * (legacy context summation, tooltip rendering). Optional for backward
+   * compatibility with snapshots persisted before this field existed; new
+   * adapters MUST set it.
+   */
+  provider?: UsageProvider;
   inputTokens: number;
   outputTokens: number;
   cacheReadTokens?: number;
+  /**
+   * Claude-only: tokens written into the prompt cache on this round-trip.
+   * Non-Claude adapters MUST leave this `undefined`.
+   */
   cacheCreationTokens?: number;
+  reasoningOutputTokens?: number;
+  /** Total tokens currently in the model's context window (provider-aware). */
+  contextTokens?: number;
+  /**
+   * Cumulative tokens processed by this session/thread when available.
+   * Monotonic across `runSession` boundaries within a single process —
+   * adapters persist running totals keyed by session id so a continuing
+   * conversation never resets to zero. Not durable across server restarts.
+   *
+   * For Codex/OpenAI this approximates billed prompt+output tokens (each
+   * turn's full prompt is counted, so prior history is recounted across
+   * turns by design); for Claude it is the API-reported cumulative.
+   */
+  totalProcessedTokens?: number;
+  /**
+   * Effective max context window the agent is operating against. When set,
+   * the UI should prefer this over a hard-coded model→window map (e.g.
+   * Claude SDK's `getContextUsage().maxTokens` reflects the auto-compact
+   * threshold).
+   */
+  maxContextTokens?: number;
 }
 
 /**

--- a/packages/coding-agent/src/events.ts
+++ b/packages/coding-agent/src/events.ts
@@ -48,6 +48,23 @@ export interface ErrorEvent {
 }
 
 /**
+ * Token usage for the most recent turn. Adapters emit this when usage info
+ * is available so the UI can show context-window pressure.
+ *
+ * For Claude-family agents, `inputTokens` is the prompt size for the latest
+ * turn (which approximates current context size, since the full conversation
+ * is resent each turn). `cacheReadTokens` and `cacheCreationTokens` count
+ * cached prompt content. For Codex/Gemini, only input/output are populated.
+ */
+export interface UsageEvent {
+  type: "usage";
+  inputTokens: number;
+  outputTokens: number;
+  cacheReadTokens?: number;
+  cacheCreationTokens?: number;
+}
+
+/**
  * Emitted when the agent resolves the real session ID after a run.
  * Some agents (e.g. OpenCode) create their own session IDs internally.
  * The adapter emits session-start with a temporary ID early (so the UI
@@ -69,4 +86,5 @@ export type AgentEvent =
   | FileEvent
   | SessionResultEvent
   | SessionIdResolvedEvent
+  | UsageEvent
   | ErrorEvent;

--- a/packages/coding-agent/src/types.ts
+++ b/packages/coding-agent/src/types.ts
@@ -72,6 +72,8 @@ export interface AgentModel {
   id: string;
   name: string;
   description?: string;
+  /** Approximate max input context window in tokens (e.g. 200000, 1_000_000). */
+  contextWindow?: number;
 }
 
 export interface RunSessionOptions {

--- a/packages/coding-agent/tests/codex-adapter.test.ts
+++ b/packages/coding-agent/tests/codex-adapter.test.ts
@@ -82,13 +82,13 @@ describe("CodexAdapter", () => {
 
   it("passes model via startThread, not constructor config", async () => {
     _test.setEvents([{ type: "thread.started", thread_id: "t1" }]);
-    const adapter = new CodexAdapter(makeConfig({ model: "gpt-5-codex" }));
+    const adapter = new CodexAdapter(makeConfig({ model: "gpt-5.5" }));
     await collectEvents(adapter.runSession("hello"));
     assert.equal(_test.constructorCalls.length, 1);
     // Model is no longer passed via constructor config (avoids double-passing)
     assert.equal(_test.constructorCalls[0].config, undefined);
     // Model is passed via startThread options instead
-    assert.equal(_test.startThreadCalls[0].opts?.model, "gpt-5-codex");
+    assert.equal(_test.startThreadCalls[0].opts?.model, "gpt-5.5");
   });
 
   it("passes executablePath as codexPathOverride", async () => {
@@ -464,11 +464,28 @@ describe("CodexAdapter", () => {
       { type: "turn.started" },
       {
         type: "turn.completed",
-        usage: { input_tokens: 1000, cached_input_tokens: 200, output_tokens: 500 },
+        usage: {
+          input_tokens: 1000,
+          cached_input_tokens: 200,
+          output_tokens: 500,
+          reasoning_output_tokens: 50,
+        },
       },
     ]);
     const adapter = new CodexAdapter(makeConfig());
     const events = await collectEvents(adapter.runSession("plan"));
+
+    const usage = events.find((e) => e.type === "usage") as
+      | {
+          contextTokens: number;
+          totalProcessedTokens?: number;
+          reasoningOutputTokens?: number;
+        }
+      | undefined;
+    assert.ok(usage);
+    assert.equal(usage.contextTokens, 1550);
+    assert.equal(usage.totalProcessedTokens, 1550);
+    assert.equal(usage.reasoningOutputTokens, 50);
 
     const result = events.find((e) => e.type === "session-result") as {
       success: boolean;
@@ -666,6 +683,7 @@ describe("CodexAdapter", () => {
       "tool-result",
       "text-delta",
       // item.completed for agent_message emits no delta (already fully streamed)
+      "usage",
       "session-result",
     ]);
 
@@ -680,8 +698,18 @@ describe("CodexAdapter", () => {
     const toolResult = events[3] as { output: string };
     assert.equal(toolResult.output, "# My Project\nHello world");
 
+    // Verify usage carries context size
+    const usageEvent = events[5] as {
+      inputTokens: number;
+      contextTokens?: number;
+      totalProcessedTokens?: number;
+    };
+    assert.equal(usageEvent.inputTokens, 500);
+    assert.equal(usageEvent.contextTokens, 700);
+    assert.equal(usageEvent.totalProcessedTokens, 700);
+
     // Verify session-result
-    const sessionResult = events[5] as {
+    const sessionResult = events[6] as {
       success: boolean;
       numTurns: number;
     };

--- a/packages/dashboard-core/src/adapter.ts
+++ b/packages/dashboard-core/src/adapter.ts
@@ -39,7 +39,9 @@ export interface DashboardAdapter {
   updateSettings(settings: Settings): Promise<void>;
 
   // Models (for agent configuration)
-  listModels?(agentId?: string): Promise<{ id: string; name: string; description?: string }[]>;
+  listModels?(
+    agentId?: string,
+  ): Promise<{ id: string; name: string; description?: string; contextWindow?: number }[]>;
 
   // Event subscriptions (return unsubscribe fn)
   subscribeAgentStatus(

--- a/packages/dashboard-core/src/adapters/web.ts
+++ b/packages/dashboard-core/src/adapters/web.ts
@@ -107,9 +107,14 @@ export class WebDashboardAdapter implements DashboardAdapter {
 
   async listModels(
     agentId?: string,
-  ): Promise<{ id: string; name: string; description?: string }[]> {
+  ): Promise<{ id: string; name: string; description?: string; contextWindow?: number }[]> {
     const data = await this.trpc.models.list.query({ agentId });
-    return data.models as { id: string; name: string; description?: string }[];
+    return data.models as {
+      id: string;
+      name: string;
+      description?: string;
+      contextWindow?: number;
+    }[];
   }
 
   private statusHandlers = new Set<(data: SSEEvent) => void>();

--- a/packages/dashboard-core/src/components/SettingsPage.tsx
+++ b/packages/dashboard-core/src/components/SettingsPage.tsx
@@ -53,6 +53,16 @@ interface Props {
   onOpenChange: (open: boolean) => void;
 }
 
+/** Compact context-window label, e.g. 200000 → "200k", 1_000_000 → "1M". */
+function formatCtxWindow(n: number): string {
+  if (n >= 1_000_000) {
+    const m = n / 1_000_000;
+    return `${Number.isInteger(m) ? m.toFixed(0) : m.toFixed(1)}M`;
+  }
+  if (n >= 1_000) return `${Math.round(n / 1_000)}k`;
+  return String(n);
+}
+
 export function SettingsPage({ open, onOpenChange }: Props) {
   const { settings } = useSettingsQuery();
   const updateSettingsMutation = useUpdateSettings();
@@ -75,7 +85,7 @@ export function SettingsPage({ open, onOpenChange }: Props) {
   const [enableLSP, setEnableLSP] = useState(settings.enableLSP ?? false);
   const [selectedTheme, setSelectedTheme] = useState<Theme>(settings.theme ?? "system");
   const [agentModels, setAgentModels] = useState<
-    Record<string, { id: string; name: string; description?: string }[]>
+    Record<string, { id: string; name: string; description?: string; contextWindow?: number }[]>
   >({});
   // Experimental flags live in localStorage (per-device) rather than the
   // settings store, so they don't participate in `isDirty` / Save.
@@ -483,7 +493,14 @@ export function SettingsPage({ open, onOpenChange }: Props) {
                                 <SelectItem value={MODEL_DEFAULT_SENTINEL}>Default</SelectItem>
                                 {models.map((m) => (
                                   <SelectItem key={m.id} value={m.id}>
-                                    {m.name}
+                                    <span className="flex w-full items-baseline justify-between gap-2">
+                                      <span>{m.name}</span>
+                                      {m.contextWindow !== undefined && (
+                                        <span className="text-[10px] uppercase tabular-nums text-muted-foreground">
+                                          {formatCtxWindow(m.contextWindow)} ctx
+                                        </span>
+                                      )}
+                                    </span>
                                   </SelectItem>
                                 ))}
                               </SelectContent>

--- a/packages/dashboard-core/src/components/SettingsPage.tsx
+++ b/packages/dashboard-core/src/components/SettingsPage.tsx
@@ -26,6 +26,7 @@ import { useEffect, useMemo, useState } from "react";
 import { useAdapter, useCapabilities } from "../context";
 import { useUpdateSettings } from "../hooks/use-settings-mutations";
 import { useSettingsQuery } from "../hooks/use-settings-query";
+import { useExperimentalContextMeter } from "../lib/experimental-flags";
 import { playSound, SOUNDS, type SoundId } from "../lib/sounds";
 import type { CodingAgentDefinition, CodingAgentType, LabelDefinition, Theme } from "../types";
 import { AgentIcon } from "./agent-icons";
@@ -76,6 +77,9 @@ export function SettingsPage({ open, onOpenChange }: Props) {
   const [agentModels, setAgentModels] = useState<
     Record<string, { id: string; name: string; description?: string }[]>
   >({});
+  // Experimental flags live in localStorage (per-device) rather than the
+  // settings store, so they don't participate in `isDirty` / Save.
+  const [contextMeterEnabled, setContextMeterEnabled] = useExperimentalContextMeter();
 
   const adapter = useAdapter();
 
@@ -569,6 +573,24 @@ export function SettingsPage({ open, onOpenChange }: Props) {
                   id="auto-start-tunnel"
                   checked={autoStartTunnel}
                   onCheckedChange={setAutoStartTunnel}
+                />
+              </SettingsRow>
+            </SettingsSection>
+
+            {/* ── Experimental ───────────────────────────────── */}
+            <SettingsSection
+              title="Experimental"
+              description="Unstable features that may change or break between releases. Stored per device — not synced across the workspace."
+            >
+              <SettingsRow
+                htmlFor="exp-context-meter"
+                label="Context window meter"
+                description="Show a context-usage donut next to the session-history button. Token counting accuracy varies by provider — disable if numbers look wrong."
+              >
+                <Switch
+                  id="exp-context-meter"
+                  checked={contextMeterEnabled}
+                  onCheckedChange={setContextMeterEnabled}
                 />
               </SettingsRow>
             </SettingsSection>

--- a/packages/dashboard-core/src/components/SettingsPage.tsx
+++ b/packages/dashboard-core/src/components/SettingsPage.tsx
@@ -392,6 +392,17 @@ export function SettingsPage({ open, onOpenChange }: Props) {
                   </Select>
                 </SettingsRow>
               )}
+              <SettingsRow
+                htmlFor="agents-context-meter"
+                label="Context window meter"
+                description="Show a context-usage donut next to the session-history button in the chat input. Token counting accuracy varies by agent — disable if numbers look wrong."
+              >
+                <Switch
+                  id="agents-context-meter"
+                  checked={contextMeterEnabled}
+                  onCheckedChange={setContextMeterEnabled}
+                />
+              </SettingsRow>
               <Accordion type="multiple" className="w-full">
                 {KNOWN_AGENTS.map((known) => {
                   const agent = codingAgents.find((a) => a.type === known.type);
@@ -590,24 +601,6 @@ export function SettingsPage({ open, onOpenChange }: Props) {
                   id="auto-start-tunnel"
                   checked={autoStartTunnel}
                   onCheckedChange={setAutoStartTunnel}
-                />
-              </SettingsRow>
-            </SettingsSection>
-
-            {/* ── Experimental ───────────────────────────────── */}
-            <SettingsSection
-              title="Experimental"
-              description="Unstable features that may change or break between releases. Stored per device — not synced across the workspace."
-            >
-              <SettingsRow
-                htmlFor="exp-context-meter"
-                label="Context window meter"
-                description="Show a context-usage donut next to the session-history button. Token counting accuracy varies by provider — disable if numbers look wrong."
-              >
-                <Switch
-                  id="exp-context-meter"
-                  checked={contextMeterEnabled}
-                  onCheckedChange={setContextMeterEnabled}
                 />
               </SettingsRow>
             </SettingsSection>

--- a/packages/dashboard-core/src/components/WorkspacePickerDialog.tsx
+++ b/packages/dashboard-core/src/components/WorkspacePickerDialog.tsx
@@ -16,13 +16,14 @@ import { useProjects } from "../hooks/use-projects";
 import { getRecentWorkspaceOrder, recordWorkspaceAccess } from "../lib/recent-workspaces";
 import { toWorkspaceId } from "../lib/workspace-id";
 import { useDashboardStore } from "../stores/index";
+import type { AgentInfo } from "../types";
 import { AgentStatusIndicator } from "./AgentStatusIndicator";
 
 interface WorkspaceEntry {
   workspaceId: string;
   projectName: string;
   branch: string;
-  agent?: { status: string } | null;
+  agent?: AgentInfo;
 }
 
 interface WorkspacePickerDialogProps {
@@ -60,7 +61,7 @@ export function WorkspacePickerDialog({ open, onOpenChange }: WorkspacePickerDia
           workspaceId,
           projectName: project.name,
           branch: worktree.branch,
-          agent: statuses[workspaceId]?.agent ?? worktree.agent,
+          agent: statuses.get(workspaceId)?.agent,
         });
       }
     }

--- a/packages/dashboard-core/src/index.ts
+++ b/packages/dashboard-core/src/index.ts
@@ -79,6 +79,10 @@ export {
 } from "./lib/codemirror-setup";
 export type { CommandRegistryDeps, PaletteCommand } from "./lib/command-registry";
 export { buildCommands, formatShortcut, isMacPlatform } from "./lib/command-registry";
+export {
+  EXPERIMENTAL_FLAG_KEYS,
+  useExperimentalContextMeter,
+} from "./lib/experimental-flags";
 export { getFileIcon } from "./lib/file-icon";
 export { type FileLocation, formatFileLocation, parseFileLocation } from "./lib/file-location";
 export { type FilePreviewType, getFilePreviewType } from "./lib/file-type";

--- a/packages/dashboard-core/src/lib/experimental-flags.ts
+++ b/packages/dashboard-core/src/lib/experimental-flags.ts
@@ -1,0 +1,54 @@
+import { useCallback, useEffect, useState } from "react";
+
+/**
+ * Per-device, opt-in flags for unstable features. Stored in localStorage so
+ * they survive reloads but don't sync across devices — matches the spirit of
+ * "experimental: turn on if you want to try it."
+ */
+export const EXPERIMENTAL_FLAG_KEYS = {
+  contextMeter: "band.experimental.context-meter",
+} as const;
+
+type FlagKey = (typeof EXPERIMENTAL_FLAG_KEYS)[keyof typeof EXPERIMENTAL_FLAG_KEYS];
+
+function readFlag(key: FlagKey): boolean {
+  if (typeof window === "undefined") return false;
+  return window.localStorage.getItem(key) === "true";
+}
+
+function writeFlag(key: FlagKey, value: boolean): void {
+  if (typeof window === "undefined") return;
+  window.localStorage.setItem(key, value ? "true" : "false");
+  window.dispatchEvent(new CustomEvent("band:experimental-flag-change", { detail: { key } }));
+}
+
+function useExperimentalFlag(key: FlagKey): [boolean, (value: boolean) => void] {
+  const [enabled, setEnabled] = useState<boolean>(() => readFlag(key));
+
+  useEffect(() => {
+    const sync = (e: Event) => {
+      if (e instanceof CustomEvent && e.detail?.key !== key) return;
+      setEnabled(readFlag(key));
+    };
+    window.addEventListener("band:experimental-flag-change", sync);
+    window.addEventListener("storage", sync);
+    return () => {
+      window.removeEventListener("band:experimental-flag-change", sync);
+      window.removeEventListener("storage", sync);
+    };
+  }, [key]);
+
+  const set = useCallback(
+    (value: boolean) => {
+      writeFlag(key, value);
+      setEnabled(value);
+    },
+    [key],
+  );
+
+  return [enabled, set];
+}
+
+export function useExperimentalContextMeter(): [boolean, (value: boolean) => void] {
+  return useExperimentalFlag(EXPERIMENTAL_FLAG_KEYS.contextMeter);
+}


### PR DESCRIPTION
## Summary

Cherry-picks the context-meter feature chain from `develop` and reshapes the UI to fit `main`'s layout.

- **Token-usage tracking** — adapters emit provider-aware usage (`contextTokens`, `totalProcessedTokens`, `maxContextTokens`) with provider discriminator. Claude pulls canonical context size from `getContextUsage()` (system prompt + MCP + memory). Codex tracks cumulative input/output/reasoning across turns. Both persist running totals per session via bounded LRU so the meter stays monotonic across `runSession` boundaries.
- **Server-side persistence** — `task-runner` keeps the latest `SessionUsage` snapshot per session in a 1000-entry LRU; tRPC `sessions.messages` returns it as `lastUsage` on the initial page so the meter rehydrates after task completion or page refresh.
- **UI redesign** — instead of the horizontal bar above the prompt, the meter now lives inline in the chat input as a small SVG donut next to the session-history button. Hover (desktop) or tap (touch) opens a Popover with the full breakdown — input/output, cache read/write, reasoning, total processed, and `Context: x / window (pct%)`.
- **Per-model context windows** — adapters' `listModels()` now surfaces a `contextWindow` field. The settings model picker shows it (e.g. \`200k ctx\`), and the meter denominator uses SDK-reported \`maxContextTokens\` → \`modelInfo.contextWindow\` → static map fallback.
- **Settings** — context-meter toggle lives under **Coding Agents** (rather than its own Experimental section), matching the new card-based settings layout.
- **Action-row polish** — uniform icon sizing (\`size-4\`, donut \`size-5\`), tighter padding (\`px-1.5\`), reordered (icons-first / labels-last), removed the queued-messages badge from the submit button.

## Commits

- \`feat(chat)\`: track and surface per-turn token usage with context meter
- \`fix(chat)\`: emit usage from each assistant message so context meter updates mid-turn
- \`feat(chat)\`: provider-aware context meter with cumulative usage tracking
- \`feat(settings)\`: gate context meter behind experimental flag
- \`feat(models)\`: surface contextWindow per model across pickers and meter
- \`feat(chat)\`: redesign context meter as donut, tighten action row

Will squash-merge.

## Test plan

- [ ] Toggle **Coding Agents → Context window meter** off/on; donut appears/disappears next to the session-history button.
- [ ] Send a message with Claude Code; donut fills with cumulative usage and ticks live mid-turn.
- [ ] Hover the donut on desktop — Popover opens with input/output/cache/total breakdown and \`Context: x / window (pct%)\`.
- [ ] Tap the donut on mobile (touch) — same Popover opens; tap outside or Escape dismisses.
- [ ] Refresh the page mid-session; meter rehydrates from the tRPC \`lastUsage\` snapshot.
- [ ] Switch model from Sonnet (1M) to Haiku (200k); denominator updates immediately, percentage rebases.
- [ ] Open the per-agent model picker in Settings; each model row shows \`{ctx-size} ctx\` (e.g. \`1M ctx\`, \`200k ctx\`).
- [ ] Submit a queued message while one is running; the queued bubble still renders above the prompt (the count badge in the submit area is intentionally gone).

🤖 Generated with [Claude Code](https://claude.com/claude-code)