### PR TITLE
Fix Diff tab and add compare-branch picker

### DIFF
--- a/apps/web/src/trpc/router.ts
+++ b/apps/web/src/trpc/router.ts
@@ -685,12 +685,64 @@ const workspaceRouter = t.router({
       return { config };
     }),
 
+  listBranches: publicProcedure
+    .input(z.object({ workspaceId: z.string() }))
+    .query(async ({ input }) => {
+      const workspace = resolveWorkspace(input.workspaceId);
+      if (!workspace) {
+        throw new Error("Workspace not found");
+      }
+
+      const cwd = workspace.worktree.path;
+      const defaultBranch = workspace.project.defaultBranch;
+
+      let headBranch: string | null = null;
+      try {
+        headBranch = (await execGit(["rev-parse", "--abbrev-ref", "HEAD"], cwd)).trim();
+      } catch {
+        // No commits yet
+      }
+
+      let branches: string[] = [];
+      try {
+        const output = await execGit(
+          ["for-each-ref", "--format=%(refname:short)", "refs/heads/"],
+          cwd,
+        );
+        branches = output
+          .trim()
+          .split("\n")
+          .map((b) => b.trim())
+          .filter(Boolean);
+      } catch {
+        // No branches
+      }
+
+      // Exclude HEAD branch (you don't compare against yourself); ensure default present.
+      const filtered = branches.filter((b) => b !== headBranch);
+      if (!filtered.includes(defaultBranch)) {
+        filtered.unshift(defaultBranch);
+      } else {
+        // Move defaultBranch to the front for stable ordering.
+        const idx = filtered.indexOf(defaultBranch);
+        filtered.splice(idx, 1);
+        filtered.unshift(defaultBranch);
+      }
+
+      return {
+        branches: filtered,
+        defaultBranch,
+        headBranch: headBranch ?? defaultBranch,
+      };
+    }),
+
   getDiff: publicProcedure
     .input(
       z.object({
         workspaceId: z.string(),
         contextLines: z.number().int().min(0).max(99999).optional(),
         diffMode: z.enum(["uncommitted", "branch"]).optional(),
+        compareBranch: z.string().optional(),
       }),
     )
     .query(async ({ input }) => {
@@ -701,6 +753,8 @@ const workspaceRouter = t.router({
 
       const cwd = workspace.worktree.path;
       const defaultBranch = workspace.project.defaultBranch;
+      const compareBranch =
+        input.diffMode === "uncommitted" ? defaultBranch : (input.compareBranch ?? defaultBranch);
 
       let headBranch: string;
       try {
@@ -720,7 +774,7 @@ const workspaceRouter = t.router({
         }
       } else {
         try {
-          mergeBase = (await execGit(["merge-base", defaultBranch, "HEAD"], cwd)).trim();
+          mergeBase = (await execGit(["merge-base", compareBranch, "HEAD"], cwd)).trim();
         } catch {
           mergeBase = (await execGit(["hash-object", "-t", "tree", "/dev/null"], cwd)).trim();
         }
@@ -789,7 +843,7 @@ const workspaceRouter = t.router({
       return {
         diff,
         stats: { filesChanged, insertions, deletions },
-        baseBranch: defaultBranch,
+        baseBranch: compareBranch,
         headBranch,
         fileStatuses,
       };
@@ -800,6 +854,7 @@ const workspaceRouter = t.router({
       z.object({
         workspaceId: z.string(),
         diffMode: z.enum(["uncommitted", "branch"]).optional(),
+        compareBranch: z.string().optional(),
       }),
     )
     .query(async ({ input }) => {
@@ -810,6 +865,8 @@ const workspaceRouter = t.router({
 
       const cwd = workspace.worktree.path;
       const defaultBranch = workspace.project.defaultBranch;
+      const compareBranch =
+        input.diffMode === "uncommitted" ? defaultBranch : (input.compareBranch ?? defaultBranch);
 
       let headBranch: string;
       try {
@@ -829,7 +886,7 @@ const workspaceRouter = t.router({
         }
       } else {
         try {
-          mergeBase = (await execGit(["merge-base", defaultBranch, "HEAD"], cwd)).trim();
+          mergeBase = (await execGit(["merge-base", compareBranch, "HEAD"], cwd)).trim();
         } catch {
           mergeBase = (await execGit(["hash-object", "-t", "tree", "/dev/null"], cwd)).trim();
         }
@@ -883,7 +940,7 @@ const workspaceRouter = t.router({
 
       return {
         stats: { filesChanged, insertions, deletions },
-        baseBranch: defaultBranch,
+        baseBranch: compareBranch,
         headBranch,
         fileStatuses,
         mergeBase,
@@ -948,6 +1005,7 @@ const workspaceRouter = t.router({
         workspaceId: z.string(),
         filePath: z.string(),
         diffMode: z.enum(["uncommitted", "branch"]),
+        compareBranch: z.string().optional(),
       }),
     )
     .mutation(async ({ input }) => {
@@ -978,9 +1036,9 @@ const workspaceRouter = t.router({
           ref = (await execGit(["hash-object", "-t", "tree", "/dev/null"], cwd)).trim();
         }
       } else {
-        const defaultBranch = workspace.project.defaultBranch;
+        const compareBranch = input.compareBranch ?? workspace.project.defaultBranch;
         try {
-          ref = (await execGit(["merge-base", defaultBranch, "HEAD"], cwd)).trim();
+          ref = (await execGit(["merge-base", compareBranch, "HEAD"], cwd)).trim();
         } catch {
           ref = (await execGit(["hash-object", "-t", "tree", "/dev/null"], cwd)).trim();
         }

--- a/packages/dashboard-core/src/adapter.ts
+++ b/packages/dashboard-core/src/adapter.ts
@@ -74,20 +74,33 @@ export interface DashboardAdapter {
     workspaceId: string,
     contextLines?: number,
     diffMode?: DiffMode,
+    compareBranch?: string,
   ): Promise<WorkspaceDiff>;
-  getWorkspaceDiffSummary?(workspaceId: string, diffMode?: DiffMode): Promise<WorkspaceDiffSummary>;
+  getWorkspaceDiffSummary?(
+    workspaceId: string,
+    diffMode?: DiffMode,
+    compareBranch?: string,
+  ): Promise<WorkspaceDiffSummary>;
   getFileDiff?(
     workspaceId: string,
     filePath: string,
     mergeBase: string,
     contextLines?: number,
   ): Promise<FileDiffResult>;
+  listWorkspaceBranches?(
+    workspaceId: string,
+  ): Promise<{ branches: string[]; defaultBranch: string; headBranch: string }>;
   listWorkspaceFiles?(workspaceId: string, path: string): Promise<FileListResult>;
   getWorkspaceFile?(workspaceId: string, path: string): Promise<FileContentResult>;
   saveWorkspaceFile?(workspaceId: string, path: string, content: string): Promise<void>;
 
   /** Revert a single file to its original state, discarding all changes. */
-  revertFile?(workspaceId: string, filePath: string, diffMode: string): Promise<void>;
+  revertFile?(
+    workspaceId: string,
+    filePath: string,
+    diffMode: string,
+    compareBranch?: string,
+  ): Promise<void>;
 
   /** Get a URL for raw file content (images, PDFs, etc.) */
   getWorkspaceFileUrl?(workspaceId: string, path: string): string;

--- a/packages/dashboard-core/src/adapters/web.ts
+++ b/packages/dashboard-core/src/adapters/web.ts
@@ -225,22 +225,36 @@ export class WebDashboardAdapter implements DashboardAdapter {
     workspaceId: string,
     contextLines?: number,
     diffMode?: DiffMode,
+    compareBranch?: string,
   ): Promise<WorkspaceDiff> {
     return (await this.trpc.workspace.getDiff.query({
       workspaceId,
       contextLines,
       diffMode,
+      compareBranch,
     })) as WorkspaceDiff;
   }
 
   async getWorkspaceDiffSummary(
     workspaceId: string,
     diffMode?: DiffMode,
+    compareBranch?: string,
   ): Promise<WorkspaceDiffSummary> {
     return (await this.trpc.workspace.getDiffSummary.query({
       workspaceId,
       diffMode,
+      compareBranch,
     })) as WorkspaceDiffSummary;
+  }
+
+  async listWorkspaceBranches(
+    workspaceId: string,
+  ): Promise<{ branches: string[]; defaultBranch: string; headBranch: string }> {
+    return (await this.trpc.workspace.listBranches.query({ workspaceId })) as {
+      branches: string[];
+      defaultBranch: string;
+      headBranch: string;
+    };
   }
 
   async getFileDiff(
@@ -269,8 +283,18 @@ export class WebDashboardAdapter implements DashboardAdapter {
     await this.trpc.workspace.saveFile.mutate({ workspaceId, path, content });
   }
 
-  async revertFile(workspaceId: string, filePath: string, diffMode: string): Promise<void> {
-    await this.trpc.workspace.revertFile.mutate({ workspaceId, filePath, diffMode });
+  async revertFile(
+    workspaceId: string,
+    filePath: string,
+    diffMode: string,
+    compareBranch?: string,
+  ): Promise<void> {
+    await this.trpc.workspace.revertFile.mutate({
+      workspaceId,
+      filePath,
+      diffMode: diffMode as "uncommitted" | "branch",
+      compareBranch,
+    });
   }
 
   getWorkspaceFileUrl(workspaceId: string, path: string): string {

--- a/packages/dashboard-core/src/components/DiffView.tsx
+++ b/packages/dashboard-core/src/components/DiffView.tsx
@@ -81,6 +81,28 @@ function storeDiffMode(mode: DiffMode) {
   } catch {}
 }
 
+const COMPARE_BRANCH_KEY_PREFIX = "band:diff-compare-branch:";
+
+function getStoredCompareBranch(workspaceId: string): string | null {
+  try {
+    return localStorage.getItem(COMPARE_BRANCH_KEY_PREFIX + workspaceId);
+  } catch {
+    return null;
+  }
+}
+
+function storeCompareBranch(workspaceId: string, branch: string | null) {
+  try {
+    if (branch) {
+      localStorage.setItem(COMPARE_BRANCH_KEY_PREFIX + workspaceId, branch);
+    } else {
+      localStorage.removeItem(COMPARE_BRANCH_KEY_PREFIX + workspaceId);
+    }
+  } catch {}
+}
+
+const UNCOMMITTED_VALUE = "__uncommitted__";
+
 const EXPAND_ALL_KEY = "band:diff-expand-all";
 
 function getStoredExpandAll(): boolean {
@@ -819,6 +841,10 @@ export function DiffView({
   const [viewMode, setViewModeState] = useState<ViewMode>(getStoredViewMode);
   const [diffMode, setDiffModeState] = useState<DiffMode>(getStoredDiffMode);
   const [expandAll, setExpandAllState] = useState(getStoredExpandAll);
+  const [compareBranch, setCompareBranchState] = useState<string | null>(() =>
+    getStoredCompareBranch(workspaceId),
+  );
+  const [availableBranches, setAvailableBranches] = useState<string[]>([]);
   const setViewMode = useCallback((mode: ViewMode) => {
     setViewModeState(mode);
     storeViewMode(mode);
@@ -827,6 +853,45 @@ export function DiffView({
     setDiffModeState(mode);
     storeDiffMode(mode);
   }, []);
+  const setCompareBranch = useCallback(
+    (branch: string | null) => {
+      setCompareBranchState(branch);
+      storeCompareBranch(workspaceId, branch);
+    },
+    [workspaceId],
+  );
+
+  // Reload stored compareBranch when workspace changes
+  useEffect(() => {
+    setCompareBranchState(getStoredCompareBranch(workspaceId));
+  }, [workspaceId]);
+
+  // Fetch list of branches for the workspace
+  useEffect(() => {
+    const listWorkspaceBranches = adapter.listWorkspaceBranches;
+    if (!listWorkspaceBranches) return;
+    let cancelled = false;
+    listWorkspaceBranches
+      .call(adapter, workspaceId)
+      .then((result) => {
+        if (cancelled) return;
+        setAvailableBranches(result.branches);
+        // Drop the stored selection if it no longer exists in the workspace
+        setCompareBranchState((current) => {
+          if (current && !result.branches.includes(current)) {
+            storeCompareBranch(workspaceId, null);
+            return null;
+          }
+          return current;
+        });
+      })
+      .catch(() => {
+        if (!cancelled) setAvailableBranches([]);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [adapter, workspaceId]);
   const setExpandAll = useCallback((v: boolean) => {
     setExpandAllState(v);
     storeExpandAll(v);
@@ -1085,7 +1150,7 @@ export function DiffView({
       if (!revertFile) return;
 
       revertFile
-        .call(adapter, workspaceId, filename, diffMode)
+        .call(adapter, workspaceId, filename, diffMode, compareBranch ?? undefined)
         .then(() => {
           // Remove from diff cache
           setDiffCache((prev) => {
@@ -1101,7 +1166,7 @@ export function DiffView({
           console.error("Failed to revert file:", err);
         });
     },
-    [adapter, workspaceId, diffMode],
+    [adapter, workspaceId, diffMode, compareBranch],
   );
 
   // -------------------------------------------------------------------------
@@ -1123,7 +1188,7 @@ export function DiffView({
 
     const fetchSummary = (forceRefresh = false) => {
       getWorkspaceDiffSummary
-        .call(adapter, workspaceId, diffMode)
+        .call(adapter, workspaceId, diffMode, compareBranch ?? undefined)
         .then((result) => {
           if (!cancelled) {
             const fingerprint = JSON.stringify({
@@ -1205,7 +1270,41 @@ export function DiffView({
       fetchSummaryRef.current = null;
       unsubscribe?.();
     };
-  }, [adapter, workspaceId, active, onStatsChange, diffMode, fetchFileDiff]);
+  }, [adapter, workspaceId, active, onStatsChange, diffMode, compareBranch, fetchFileDiff]);
+
+  // ---------------------------------------------------------------------------
+  // Diff target dropdown — combines diff mode + branch selection into one menu
+  // ---------------------------------------------------------------------------
+  const branchOptions =
+    availableBranches.length > 0 ? availableBranches : baseBranch ? [baseBranch] : [];
+  const selectedBranch = compareBranch ?? branchOptions[0] ?? baseBranch ?? null;
+  const diffSelectValue =
+    diffMode === "uncommitted" ? UNCOMMITTED_VALUE : (selectedBranch ?? UNCOMMITTED_VALUE);
+
+  const handleDiffSelectChange = (value: string) => {
+    if (value === UNCOMMITTED_VALUE) {
+      setDiffMode("uncommitted");
+    } else {
+      setDiffMode("branch");
+      setCompareBranch(value);
+    }
+  };
+
+  const renderDiffSelect = () => (
+    <Select value={diffSelectValue} onValueChange={handleDiffSelectChange}>
+      <SelectTrigger className="h-7 w-auto gap-1 rounded-md border-border/50 bg-muted/50 px-2.5 text-xs">
+        <SelectValue />
+      </SelectTrigger>
+      <SelectContent>
+        <SelectItem value={UNCOMMITTED_VALUE}>Uncommitted</SelectItem>
+        {branchOptions.map((branch) => (
+          <SelectItem key={branch} value={branch}>
+            {branch}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  );
 
   if (loading) {
     return (
@@ -1227,15 +1326,7 @@ export function DiffView({
     return (
       <div className="flex h-full flex-col overflow-hidden">
         <div className="flex shrink-0 items-center justify-end border-b border-border px-4 py-2">
-          <Select value={diffMode} onValueChange={(v) => setDiffMode(v as DiffMode)}>
-            <SelectTrigger className="h-7 w-auto gap-1 rounded-md border-border/50 bg-muted/50 px-2.5 text-xs">
-              <SelectValue />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value="uncommitted">Uncommitted</SelectItem>
-              <SelectItem value="branch">{baseBranch ?? "base"}</SelectItem>
-            </SelectContent>
-          </Select>
+          {renderDiffSelect()}
         </div>
         <div className="flex flex-1 items-center justify-center text-sm text-muted-foreground">
           No changes
@@ -1354,15 +1445,7 @@ export function DiffView({
                 <ChevronsUpDown className="size-3.5" />
               )}
             </button>
-            <Select value={diffMode} onValueChange={(v) => setDiffMode(v as DiffMode)}>
-              <SelectTrigger className="h-7 w-auto gap-1 rounded-md border-border/50 bg-muted/50 px-2.5 text-xs">
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="uncommitted">Uncommitted</SelectItem>
-                <SelectItem value="branch">{baseBranch ?? "base"}</SelectItem>
-              </SelectContent>
-            </Select>
+            {renderDiffSelect()}
             <div className="hidden items-center rounded-md border border-border/50 bg-muted/50 md:flex">
               <button
                 type="button"


### PR DESCRIPTION
## PO Summary

Diff tab in workspace dashboard now lets you pick which branch to compare against (e.g. `main`, `develop`, any other local branch), instead of always comparing to the project's default branch. The Uncommitted view still works as before. Selection persists per workspace.

## Test plan

- [ ] Open workspace → Diff tab
- [ ] Switch dropdown between Uncommitted and a branch — confirm file list and stats update
- [ ] Pick a non-default branch — confirm diff is computed against `merge-base(<picked>, HEAD)`
- [ ] Reload workspace — confirm picked branch is restored
- [ ] Switch workspaces — confirm selection is per-workspace
- [ ] Revert a file in branch-compare mode — confirm revert uses the picked branch as ref