### PR TITLE
fix(release): read current version from latest git tag

### DIFF
--- a/scripts/bump-version.mjs
+++ b/scripts/bump-version.mjs
@@ -71,8 +71,20 @@ function parseArgs() {
 }
 
 function getCurrentVersion() {
-  const pkg = JSON.parse(readFileSync(resolve(ROOT, "package.json"), "utf8"));
-  return pkg.version;
+  // Prefer the latest git tag as the source of truth: the release workflow
+  // bumps package.json files only on the runner and never commits them back
+  // to main, so the in-repo package.json versions can lag behind the actual
+  // released versions. Fall back to package.json only when no tags exist.
+  try {
+    const tag = execSync("git describe --tags --abbrev=0", {
+      cwd: ROOT,
+      encoding: "utf8",
+    }).trim();
+    return tag.replace(/^v/, "");
+  } catch {
+    const pkg = JSON.parse(readFileSync(resolve(ROOT, "package.json"), "utf8"));
+    return pkg.version;
+  }
 }
 
 function bumpVersion(current, type) {


### PR DESCRIPTION
## Summary

- Fixes `release.yml` aborting at the *Verify tag does not exist* step when triggered with no inputs (failing run: https://github.com/band-app/band/actions/runs/25390634725).
- The release workflow bumps `package.json` files only on the runner and never commits them back to `main`, so every in-repo `package.json` stays pinned at `0.1.0` while git tags advance (`v0.1.1`, `v0.2.0`, `v0.3.0`, `v0.3.1`, ...). `bump-version.mjs --from-commits` therefore proposed `v0.2.0` again, which already exists.
- Read the latest git tag in `getCurrentVersion()` and fall back to `package.json` only when no tags exist. This makes "what's the current version?" deterministic and aligns with what the `Verify tag does not exist` check enforces.

Out of scope: changing the release workflow to commit bumped `package.json` files back to `main`. Leaving them at `0.1.0` is fine now that the script no longer treats them as the source of truth.

## Test plan

- [x] `node scripts/bump-version.mjs --from-commits --dry-run` → uses latest tag (`v0.3.1`) as current version (no `feat:` commits since, so patch → `0.3.2`).
- [x] `node scripts/bump-version.mjs --bump patch --dry-run` → `0.3.1 → 0.3.2`.
- [x] `node scripts/bump-version.mjs --version 0.5.0 --dry-run` → `0.3.1 → 0.5.0`.
- [ ] Next `workflow_dispatch` of Release with empty inputs proposes `v0.4.0` (or whatever the next un-tagged version is) and clears the *Verify tag does not exist* step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)