### PR TITLE
feat(desktop): bundle Band CLI sidecar in Electron build (#364)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,5 @@ screenshots/
 .last-run.json
 apps/dashboard/src-tauri/binaries/*
 !apps/dashboard/src-tauri/binaries/.gitkeep
+apps/desktop/binaries/*
+!apps/desktop/binaries/.gitkeep

--- a/apps/desktop/electron-builder.yml
+++ b/apps/desktop/electron-builder.yml
@@ -1,0 +1,37 @@
+# electron-builder configuration for the Band desktop shell.
+#
+# Phase 7 of the Tauri → Electron migration (issue #364) — this file currently
+# only declares the resources that need to be bundled (web server output and
+# the Band CLI sidecar). Phase 8 will fill in the remaining packaging targets,
+# code-signing, and notarisation.
+#
+# Cross-references:
+#   - Tauri sidecar:   apps/dashboard/src-tauri/tauri.conf.json (`externalBin`).
+#   - Web bundle path: apps/desktop/src/main/services/web-paths.ts.
+#   - CLI bundle path: apps/desktop/src/main/services/cli-paths.ts.
+
+appId: app.getband.agent
+productName: Band
+
+# `extraResources` files are copied verbatim into the packaged app's
+# `Resources/` directory (`Band.app/Contents/Resources/` on macOS,
+# `resources/` next to the executable on Linux/Windows). Both entries match
+# the runtime resolvers in `services/web-paths.ts` and `services/cli-paths.ts`,
+# which read `process.resourcesPath` in packaged builds.
+extraResources:
+  # Bundled web server. Mirrors the Tauri `bundle.resources` map that ships
+  # `apps/web/dist/` into `Resources/web/`.
+  - from: ../web/dist
+    to: web/dist
+  # Bundled CLI sidecar. Populated by `apps/desktop/scripts/copy-cli-binary.mjs`
+  # before electron-builder runs (see root `build:cli:desktop`). The runtime
+  # path resolver expects this exact relative location.
+  - from: binaries/band
+    to: binaries/band
+
+# Limit the JS bundle shipped inside the .asar to the compiled main + preload
+# output and the package manifest. Source TypeScript and tsconfig files are
+# excluded so the asar stays small.
+files:
+  - dist/**/*
+  - package.json

--- a/apps/desktop/scripts/copy-cli-binary.mjs
+++ b/apps/desktop/scripts/copy-cli-binary.mjs
@@ -1,0 +1,55 @@
+#!/usr/bin/env node
+
+/**
+ * Copy the host-built Band CLI binary into `apps/desktop/binaries/band` so
+ * `electron-builder` can ship it as an `extraResource` (mirrors the Tauri
+ * `externalBin: ["binaries/band"]` pattern in `apps/dashboard/src-tauri/
+ * tauri.conf.json`).
+ *
+ * Phase 7 of the Tauri → Electron migration (issue #364). Phase 8 (electron-
+ * builder packaging) will invoke this from the build pipeline; in the meantime
+ * the root `build:cli:desktop` script calls it after `cargo build --release`.
+ *
+ * Resolution order for the source binary:
+ *   1. `apps/cli/target/release/band` — preferred (matches `pnpm build:cli`).
+ *   2. `apps/cli/target/debug/band`   — fallback (matches `pnpm build:cli:dev`).
+ *
+ * On Windows, `band.exe` is used. On every platform a single binary is copied
+ * (the host triple is implied by the build that produced it). This is
+ * deliberately simpler than the Tauri sidecar's per-triple naming convention
+ * because `electron-builder` resolves resources by relative path at runtime,
+ * not by host triple at packaging time.
+ *
+ * Exits non-zero if no source binary is found, so the caller (e.g. CI) can
+ * surface the missing-build error before electron-builder runs.
+ */
+
+import { copyFileSync, existsSync, mkdirSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(__dirname, "..", "..", "..");
+
+const exe = process.platform === "win32" ? "band.exe" : "band";
+const candidates = [
+  resolve(repoRoot, "apps/cli/target/release", exe),
+  resolve(repoRoot, "apps/cli/target/debug", exe),
+];
+
+const source = candidates.find((p) => existsSync(p));
+if (!source) {
+  console.error(
+    `[copy-cli-binary] No CLI binary found. Build it first with:\n` +
+      `  pnpm --filter @band-app/cli build       # release\n` +
+      `  pnpm --filter @band-app/cli build:dev   # debug\n\n` +
+      `Searched:\n${candidates.map((p) => `  - ${p}`).join("\n")}`,
+  );
+  process.exit(1);
+}
+
+const destDir = resolve(__dirname, "..", "binaries");
+const dest = resolve(destDir, exe);
+mkdirSync(destDir, { recursive: true });
+copyFileSync(source, dest);
+console.log(`[copy-cli-binary] ${source} → ${dest}`);

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -142,6 +142,11 @@ async function bootstrap(): Promise<void> {
     webDir: state.webDir,
     managed: state.managed,
     browserManager: state.browserManager,
+    cliPaths: {
+      isPackaged: app.isPackaged,
+      resourcesPath: process.resourcesPath,
+      appPath: app.getAppPath(),
+    },
   });
 
   state.mainWindow.on("close", () => {

--- a/apps/desktop/src/main/ipc/macos-shell.ts
+++ b/apps/desktop/src/main/ipc/macos-shell.ts
@@ -17,6 +17,8 @@ import { homedir } from "node:os";
 import { join } from "node:path";
 import { type BrowserWindow, dialog, shell } from "electron";
 
+import { type CliPathOptions, resolveCliBinary } from "../services/cli-paths.js";
+
 const NOT_SUPPORTED = "Not supported on this platform";
 
 // ---------------------------------------------------------------------------
@@ -113,12 +115,37 @@ export async function openWithApp(path: string, appName: string): Promise<void> 
  * Create a symlink with administrator privileges. Pops a macOS password
  * dialog via osascript. Direct port of the Rust impl, including the same
  * single-quote escaping (replace `'` with `'\''` then JSON-quote).
+ *
+ * `paths` carries the host context so the handler can resolve the bundled
+ * sidecar (issue #364): in packaged builds the binary lives at
+ * `process.resourcesPath/binaries/band` regardless of what the renderer
+ * supplies, so we trust the resolver over the renderer's argument. In dev,
+ * we fall through to the renderer-supplied path because the web server's
+ * own `findCliBinary` already knows how to locate the cargo target.
+ *
+ * Resolving in the main process keeps the symlink target inside the trust
+ * boundary of the desktop shell — the renderer can't trick us into linking
+ * `/usr/local/bin/band` to an attacker-controlled path.
  */
-export async function installCli(binaryPath: string, symlinkPath: string): Promise<void> {
+export async function installCli(
+  binaryPath: string,
+  symlinkPath: string,
+  paths?: CliPathOptions,
+): Promise<void> {
   if (process.platform !== "darwin") {
     throw new Error(NOT_SUPPORTED);
   }
-  const escapedBinary = binaryPath.replaceAll("'", "'\\''");
+  // In packaged mode the bundled sidecar is the only trustworthy source.
+  // In dev we accept the renderer-supplied path (web server already
+  // resolved a cargo target) but still prefer the resolver if it finds a
+  // local cargo build — keeps behaviour consistent across `pnpm dev:desktop`
+  // and a packaged `Band.app`.
+  const resolved = paths ? resolveCliBinary(paths) : null;
+  const sourcePath = paths?.isPackaged
+    ? (resolved ?? throwMissingBundledBinary())
+    : (resolved ?? binaryPath);
+
+  const escapedBinary = sourcePath.replaceAll("'", "'\\''");
   const escapedSymlink = symlinkPath.replaceAll("'", "'\\''");
   const cmd = `ln -sf '${escapedBinary}' '${escapedSymlink}'`;
   // The osascript `do shell script` string is double-quote delimited, so we
@@ -146,6 +173,18 @@ export async function installCli(binaryPath: string, symlinkPath: string): Promi
       reject(new Error(`Failed to install CLI: ${stderr || "unknown error"}`));
     });
   });
+}
+
+/**
+ * Bail out when a packaged build is missing the bundled CLI binary. This is
+ * a deployment error (`build:cli:desktop` was skipped before
+ * `electron-builder`) — there is no useful fallback in a sandboxed `.app`.
+ */
+function throwMissingBundledBinary(): never {
+  throw new Error(
+    "Bundled CLI binary not found in the packaged app. " +
+      "Run `pnpm build:cli:desktop` before electron-builder.",
+  );
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/desktop/src/main/ipc/register.ts
+++ b/apps/desktop/src/main/ipc/register.ts
@@ -25,6 +25,7 @@ import type {
   OpenWithAppArgs,
   RevealInFinderArgs,
 } from "../../shared/types.js";
+import type { CliPathOptions } from "../services/cli-paths.js";
 import { type ManagedProcess, webserverStart, webserverStop } from "../services/web-server.js";
 import { browserHandlers } from "./browser.js";
 import {
@@ -42,6 +43,13 @@ export interface RegisterOptions {
   webDir: string;
   managed: ManagedProcess;
   browserManager: BrowserViewManager;
+  /**
+   * Host paths used by the bundled-CLI resolver in `installCli` (issue #364).
+   * `app.isPackaged`, `process.resourcesPath`, and `app.getAppPath()` from
+   * the bootstrap. Captured at registration time so the IPC handler can
+   * resolve the sidecar binary inside the trust boundary.
+   */
+  cliPaths: CliPathOptions;
 }
 
 /**
@@ -80,7 +88,7 @@ export function registerIpc(opts: RegisterOptions): () => void {
   handle(Channels.checkAppExists, (args: CheckAppExistsArgs) => checkAppExists(args.appName));
   handle(Channels.openWithApp, (args: OpenWithAppArgs) => openWithApp(args.path, args.appName));
   handle(Channels.installCli, (args: InstallCliArgs) =>
-    installCli(args.binaryPath, args.symlinkPath),
+    installCli(args.binaryPath, args.symlinkPath, opts.cliPaths),
   );
   handle(Channels.openExternal, (args: OpenExternalArgs) => openExternal(args.url));
 

--- a/apps/desktop/src/main/services/cli-paths.ts
+++ b/apps/desktop/src/main/services/cli-paths.ts
@@ -1,0 +1,69 @@
+/**
+ * Resolve the bundled Band CLI binary path.
+ *
+ * Mirrors `apps/desktop/src/main/services/web-paths.ts` for the CLI sidecar
+ * shipped via `electron-builder`'s `extraResources` (Phase 7 of the Tauri →
+ * Electron migration, issue #364). The Tauri equivalent is the `externalBin`
+ * resolution that lands the per-host-triple `band-<triple>` binary in
+ * `Band.app/Contents/MacOS/band`; we simplify to a single host-built binary
+ * shipped under `Resources/binaries/band` because `electron-builder` doesn't
+ * use the `band-<triple>` naming convention.
+ *
+ *   - In dev (Electron run from the repo): walk up from `appPath` to find
+ *     `apps/cli/target/{release,debug}/band`. Prefer release; fall back to
+ *     debug so `pnpm dev:desktop` (which runs `pnpm build:cli:dev`) works.
+ *   - In a packaged app: `process.resourcesPath/binaries/band` — matches the
+ *     `extraResources` entry in `apps/desktop/electron-builder.yml`.
+ *
+ * The path is *not* used directly by the install_cli IPC handler in
+ * `macos-shell.ts` to symlink — it is the source we trust over whatever
+ * binary path the renderer (web server) supplies. See the handler for the
+ * security-conscious override semantics.
+ */
+
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+
+export interface CliPathOptions {
+  /** True when running inside a packaged Electron build. */
+  isPackaged: boolean;
+  /** `process.resourcesPath` — only used when packaged. */
+  resourcesPath?: string;
+  /** `app.getAppPath()` — used in dev to walk up to the repo root. */
+  appPath?: string;
+}
+
+/** Filename of the CLI binary on disk (Windows uses `.exe`). */
+const BINARY_NAME = process.platform === "win32" ? "band.exe" : "band";
+
+/** Relative path within `Resources/` produced by electron-builder. */
+const PACKAGED_REL_PATH = join("binaries", BINARY_NAME);
+
+/**
+ * Resolve the absolute path to the bundled CLI binary, or `null` when no
+ * candidate exists on disk. The caller decides whether a missing binary is
+ * fatal (e.g. `installCli`) or a hint to fall back to the renderer-supplied
+ * path (e.g. legacy code paths that pre-date the sidecar).
+ */
+export function resolveCliBinary(opts: CliPathOptions): string | null {
+  if (opts.isPackaged) {
+    if (!opts.resourcesPath) return null;
+    const path = join(opts.resourcesPath, PACKAGED_REL_PATH);
+    return existsSync(path) ? path : null;
+  }
+
+  // Dev: walk up from app.getAppPath() looking for apps/cli/target/{release,debug}/band.
+  // Bounded depth so we fail loudly rather than crawling the whole disk.
+  const start = opts.appPath ?? process.cwd();
+  let current = start;
+  for (let i = 0; i < 8; i++) {
+    for (const profile of ["release", "debug"] as const) {
+      const candidate = join(current, "apps", "cli", "target", profile, BINARY_NAME);
+      if (existsSync(candidate)) return candidate;
+    }
+    const parent = join(current, "..");
+    if (parent === current) break;
+    current = parent;
+  }
+  return null;
+}

--- a/apps/desktop/tests/cli-paths.test.ts
+++ b/apps/desktop/tests/cli-paths.test.ts
@@ -1,0 +1,124 @@
+/**
+ * Integration test for resolveCliBinary.
+ *
+ * The function locates the bundled Band CLI sidecar:
+ *   - Packaged: <resourcesPath>/binaries/band
+ *   - Dev:      walks up from `appPath` to apps/cli/target/{release,debug}/band
+ *
+ * We construct real directory trees in tmp and assert the resolution.
+ */
+
+import { strict as assert } from "node:assert";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, test } from "node:test";
+
+import { resolveCliBinary } from "../src/main/services/cli-paths.ts";
+
+const BINARY_NAME = process.platform === "win32" ? "band.exe" : "band";
+
+describe("resolveCliBinary", () => {
+  test("packaged: returns resourcesPath/binaries/band when present", async () => {
+    const resources = await mkdtemp(join(tmpdir(), "band-cli-paths-pkg-"));
+    try {
+      const binDir = join(resources, "binaries");
+      await mkdir(binDir, { recursive: true });
+      await writeFile(join(binDir, BINARY_NAME), "// fake binary");
+
+      const resolved = resolveCliBinary({
+        isPackaged: true,
+        resourcesPath: resources,
+      });
+      assert.equal(resolved, join(binDir, BINARY_NAME));
+    } finally {
+      await rm(resources, { recursive: true, force: true });
+    }
+  });
+
+  test("packaged: returns null when binary missing", async () => {
+    const resources = await mkdtemp(join(tmpdir(), "band-cli-paths-pkg-missing-"));
+    try {
+      const resolved = resolveCliBinary({
+        isPackaged: true,
+        resourcesPath: resources,
+      });
+      assert.equal(resolved, null);
+    } finally {
+      await rm(resources, { recursive: true, force: true });
+    }
+  });
+
+  test("packaged: returns null when resourcesPath omitted", () => {
+    const resolved = resolveCliBinary({ isPackaged: true });
+    assert.equal(resolved, null);
+  });
+
+  test("dev: walks up from appPath to release cargo target", async () => {
+    const repo = await mkdtemp(join(tmpdir(), "band-cli-paths-dev-rel-"));
+    try {
+      // Lay out: repo/apps/desktop/dist/main and repo/apps/cli/target/release/band
+      await mkdir(join(repo, "apps", "desktop", "dist", "main"), { recursive: true });
+      const releaseDir = join(repo, "apps", "cli", "target", "release");
+      await mkdir(releaseDir, { recursive: true });
+      await writeFile(join(releaseDir, BINARY_NAME), "// fake release binary");
+
+      const resolved = resolveCliBinary({
+        isPackaged: false,
+        appPath: join(repo, "apps", "desktop", "dist", "main"),
+      });
+      assert.equal(resolved, join(releaseDir, BINARY_NAME));
+    } finally {
+      await rm(repo, { recursive: true, force: true });
+    }
+  });
+
+  test("dev: prefers release over debug when both exist", async () => {
+    const repo = await mkdtemp(join(tmpdir(), "band-cli-paths-dev-pref-"));
+    try {
+      await mkdir(join(repo, "apps", "desktop"), { recursive: true });
+      const releaseDir = join(repo, "apps", "cli", "target", "release");
+      const debugDir = join(repo, "apps", "cli", "target", "debug");
+      await mkdir(releaseDir, { recursive: true });
+      await mkdir(debugDir, { recursive: true });
+      await writeFile(join(releaseDir, BINARY_NAME), "// release");
+      await writeFile(join(debugDir, BINARY_NAME), "// debug");
+
+      const resolved = resolveCliBinary({
+        isPackaged: false,
+        appPath: join(repo, "apps", "desktop"),
+      });
+      assert.equal(resolved, join(releaseDir, BINARY_NAME));
+    } finally {
+      await rm(repo, { recursive: true, force: true });
+    }
+  });
+
+  test("dev: falls back to debug when only debug exists", async () => {
+    const repo = await mkdtemp(join(tmpdir(), "band-cli-paths-dev-dbg-"));
+    try {
+      await mkdir(join(repo, "apps", "desktop"), { recursive: true });
+      const debugDir = join(repo, "apps", "cli", "target", "debug");
+      await mkdir(debugDir, { recursive: true });
+      await writeFile(join(debugDir, BINARY_NAME), "// debug");
+
+      const resolved = resolveCliBinary({
+        isPackaged: false,
+        appPath: join(repo, "apps", "desktop"),
+      });
+      assert.equal(resolved, join(debugDir, BINARY_NAME));
+    } finally {
+      await rm(repo, { recursive: true, force: true });
+    }
+  });
+
+  test("dev: returns null when no binary is found anywhere up the tree", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "band-cli-paths-dev-missing-"));
+    try {
+      const resolved = resolveCliBinary({ isPackaged: false, appPath: dir });
+      assert.equal(resolved, null);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/apps/web/src/lib/cli.ts
+++ b/apps/web/src/lib/cli.ts
@@ -36,9 +36,9 @@ export function findCliBinary(): string | null {
   }
 
   // --- Strategy B: Tauri sidecar binary in macOS .app bundle ---
-  // When running inside Band.app, the CLI sidecar lives next to the main
-  // executable at .app/Contents/MacOS/band.  The web server's cwd is
-  // .app/Contents/Resources/web/, so walk up to Contents/MacOS.
+  // When running inside Band.app (Tauri shell), the CLI sidecar lives next
+  // to the main executable at .app/Contents/MacOS/band. The web server's
+  // cwd is .app/Contents/Resources/web/, so walk up to Contents/MacOS.
   if (platform() === "darwin") {
     const macOsCandidates = [
       // From cwd (Resources/web/) → Contents/MacOS/band
@@ -53,6 +53,30 @@ export function findCliBinary(): string | null {
       } catch {
         // Continue
       }
+    }
+  }
+
+  // --- Strategy C: Electron extraResources layout (issue #364) ---
+  // electron-builder ships the sidecar at <Resources>/binaries/band on every
+  // platform. The web server runs as a child of the main process with cwd
+  // set to <Resources>/web/dist by `services/web-server.ts`, so the sidecar
+  // is one level up and across into `binaries/`. We try both the cwd-based
+  // and module-relative paths so the resolution survives a future change to
+  // the spawn cwd (the import.meta.dirname path matches the bundled file's
+  // installed location).
+  const exe = platform() === "win32" ? "band.exe" : "band";
+  const electronCandidates = [
+    // From cwd (<Resources>/web/dist) → <Resources>/binaries/band
+    resolve(process.cwd(), "..", "..", "binaries", exe),
+    // From the bundled dist file (<Resources>/web/dist/...) → <Resources>/binaries/band
+    resolve(import.meta.dirname, "..", "..", "..", "binaries", exe),
+  ];
+  for (const p of electronCandidates) {
+    try {
+      lstatSync(p);
+      return p;
+    } catch {
+      // Continue
     }
   }
 
@@ -77,10 +101,15 @@ export async function checkCli(): Promise<CliStatus> {
       return "NotInstalled";
     }
 
-    // Accept our own cargo build output OR the Tauri sidecar binary
+    // Accept our own cargo build output OR the Tauri/Electron sidecar
+    // binaries. Tauri ships the sidecar at .app/Contents/MacOS/band; the
+    // Electron shell (issue #364) ships it as an extraResource at
+    // <Resources>/binaries/band — that path is platform-agnostic, so the
+    // matcher just looks for the trailing `/binaries/band` segment.
     const isCargoBuild = target.includes(join("apps", "cli", "target"));
-    const isSidecar = target.includes(join("Contents", "MacOS", "band"));
-    if (!isCargoBuild && !isSidecar) {
+    const isTauriSidecar = target.includes(join("Contents", "MacOS", "band"));
+    const isElectronSidecar = target.endsWith(join("binaries", "band"));
+    if (!isCargoBuild && !isTauriSidecar && !isElectronSidecar) {
       return "ConflictingBinary";
     }
     return "Installed";

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "build:web": "pnpm --filter @band-app/server build",
     "build:cli": "pnpm --filter @band-app/cli build && mkdir -p apps/dashboard/src-tauri/binaries && cp apps/cli/target/release/band \"apps/dashboard/src-tauri/binaries/band-$(rustc -vV | sed -n 's/host: //p')\"",
     "build:cli:dev": "pnpm --filter @band-app/cli build:dev && mkdir -p apps/dashboard/src-tauri/binaries && cp apps/cli/target/debug/band \"apps/dashboard/src-tauri/binaries/band-$(rustc -vV | sed -n 's/host: //p')\"",
+    "build:cli:desktop": "pnpm --filter @band-app/cli build && node apps/desktop/scripts/copy-cli-binary.mjs",
     "test": "pnpm --filter @band-app/server test && cargo test --manifest-path apps/cli/Cargo.toml && pnpm build:cli && mkdir -p apps/web/dist && touch apps/web/dist/start-server.mjs && cargo test --manifest-path apps/dashboard/src-tauri/Cargo.toml; rm -rf apps/web/dist; pnpm --filter @band-app/desktop test",
     "lint": "biome check . && cargo clippy --manifest-path apps/cli/Cargo.toml -- -D warnings && cargo clippy --manifest-path apps/dashboard/src-tauri/Cargo.toml -- -D warnings",
     "lint:fix": "biome check --fix . && cargo clippy --manifest-path apps/cli/Cargo.toml --fix --allow-dirty && cargo clippy --manifest-path apps/dashboard/src-tauri/Cargo.toml --fix --allow-dirty",


### PR DESCRIPTION
## Summary

Phase 7 of the Tauri → Electron migration (#306). Adds the plumbing to ship the Band CLI binary inside the packaged Electron app so the existing \`install_cli\` admin-prompt symlink flow works in \`Band.app\` without a separate install step — parity with Tauri's \`externalBin: [\"binaries/band\"]\`.

- **Bundling**: new \`apps/desktop/electron-builder.yml\` declares the bundled web server and CLI sidecar as \`extraResources\`. \`apps/desktop/scripts/copy-cli-binary.mjs\` copies the host-built \`apps/cli/target/{release,debug}/band\` into \`apps/desktop/binaries/\` for electron-builder to pick up.
- **Build script**: root \`build:cli:desktop\` mirrors \`build:cli\` for the desktop layout. Phase 8 will wire it into the packaging pipeline.
- **Runtime resolver**: new \`services/cli-paths.ts\` resolves the bundled binary from \`process.resourcesPath/binaries/band\` in packaged builds and from the cargo target in dev (mirrors the \`web-paths.ts\` pattern). \`installCli\` now trusts its own resolver over the renderer-supplied path in packaged mode, keeping the symlink target inside the main-process trust boundary.
- **Renderer-side awareness**: \`apps/web/src/lib/cli.ts\` — \`findCliBinary\` gains an Electron strategy that looks at \`<Resources>/binaries/band\`; \`checkCli\` recognises the new sidecar layout as a valid install target.
- **Tests**: integration tests for \`resolveCliBinary\` covering packaged hit/miss, dev release-over-debug preference, dev miss.

## Out of scope

Cross-compilation for non-host triples; Phase 8 packaging targets / signing / notarisation; and the macOS admin-password prompt (already done in Phase 2).

## Test plan

- [x] \`pnpm --filter @band-app/desktop build\` — clean
- [x] \`pnpm --filter @band-app/desktop test\` — 26 tests pass (7 new \`resolveCliBinary\` cases)
- [x] \`pnpm biome check .\` — clean across 332 files
- [x] \`pnpm --filter @band-app/server build\` — clean
- [x] \`node apps/desktop/scripts/copy-cli-binary.mjs\` (no source) exits non-zero with a \"build it first\" hint

Closes #364

🤖 Generated with [Claude Code](https://claude.com/claude-code)