### PR TITLE
feat(desktop): wire electron-updater (#363 phase 6)

### DIFF
--- a/apps/desktop/electron-builder.yml
+++ b/apps/desktop/electron-builder.yml
@@ -1,17 +1,27 @@
 # electron-builder configuration for the Band desktop shell.
 #
-# Phase 7 of the Tauri → Electron migration (issue #364) — this file currently
-# only declares the resources that need to be bundled (web server output and
-# the Band CLI sidecar). Phase 8 will fill in the remaining packaging targets,
-# code-signing, and notarisation.
+# Built up across the Tauri → Electron migration:
+#   - Phase 7 (#364): web bundle + CLI sidecar `extraResources`, asar `files`.
+#   - Phase 6 (#363): GitHub `publish` block + macOS code-signing scaffold so
+#     `electron-updater` (apps/desktop/src/main/updater.ts) can pick up
+#     releases from `band-app/band` and verify signatures.
+#   - Phase 8 (TBD):  remaining packaging targets, signing key wiring, and
+#     notarisation.
 #
 # Cross-references:
-#   - Tauri sidecar:   apps/dashboard/src-tauri/tauri.conf.json (`externalBin`).
-#   - Web bundle path: apps/desktop/src/main/services/web-paths.ts.
-#   - CLI bundle path: apps/desktop/src/main/services/cli-paths.ts.
+#   - Tauri sidecar:        apps/dashboard/src-tauri/tauri.conf.json (`externalBin`).
+#   - Tauri updater config: apps/dashboard/src-tauri/tauri.prod.conf.json (pubkey, endpoints).
+#   - Web bundle path:      apps/desktop/src/main/services/web-paths.ts.
+#   - CLI bundle path:      apps/desktop/src/main/services/cli-paths.ts.
+#   - Updater logic:        apps/desktop/src/main/updater.ts.
 
 appId: app.getband.agent
 productName: Band
+copyright: Copyright © 2026 Band Contributors
+
+directories:
+  buildResources: build
+  output: dist-builder
 
 # `extraResources` files are copied verbatim into the packaged app's
 # `Resources/` directory (`Band.app/Contents/Resources/` on macOS,
@@ -35,3 +45,46 @@ extraResources:
 files:
   - dist/**/*
   - package.json
+
+# Publish to the existing GitHub releases endpoint. The Tauri shell pointed
+# its updater at `https://github.com/band-app/band/releases/latest/download/latest.json`
+# (see tauri.prod.conf.json); the electron-updater equivalent is the GitHub
+# provider, which fetches `latest-mac.yml` / `latest.yml` from the same
+# release. The repo coordinates are pinned here so the generated
+# `app-update.yml` doesn't drift if `package.json#repository` ever changes.
+publish:
+  provider: github
+  owner: band-app
+  repo: band
+  # Channel left at default ("latest"); updater.ts overrides at runtime if
+  # we ever ship beta channels.
+
+mac:
+  category: public.app-category.developer-tools
+  minimumSystemVersion: "11.0"
+  hardenedRuntime: true
+  gatekeeperAssess: false
+  # Signing is handled by Phase 8 / ops; CSC_LINK + CSC_KEY_PASSWORD env vars
+  # drive code signing in CI. Locally builds run unsigned.
+  entitlements: build/entitlements.mac.plist
+  entitlementsInherit: build/entitlements.mac.plist
+  target:
+    - target: dmg
+      arch:
+        - x64
+        - arm64
+    - target: zip
+      arch:
+        - x64
+        - arm64
+
+dmg:
+  writeUpdateInfo: true
+
+# Signing key configuration for auto-updates: electron-updater verifies the
+# downloaded artifact against the certificate the .app was signed with on
+# macOS, and against `publisherName` on Windows. The minisign keypair Tauri
+# used (TAURI_SIGNING_PRIVATE_KEY / pubkey in tauri.prod.conf.json) does not
+# apply here — electron-updater piggy-backs on platform code signing instead.
+# The legacy minisign artifacts can stay in the same GitHub release for
+# backward compatibility with users still on the Tauri shell.

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -19,5 +19,8 @@
     "electron": "^33.0.0",
     "electron-builder": "^25.0.0",
     "typescript": "^5.7.0"
+  },
+  "dependencies": {
+    "electron-updater": "^6.8.3"
   }
 }

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -24,6 +24,7 @@ import { killPort } from "./services/port.js";
 import { getConfiguredPort } from "./services/settings.js";
 import { resolveWebDir } from "./services/web-paths.js";
 import { ensureWebserverRunning, ManagedProcess } from "./services/web-server.js";
+import { scheduleStartupCheck } from "./updater.js";
 import { createMainWindow } from "./window.js";
 
 interface AppState {
@@ -31,6 +32,7 @@ interface AppState {
   managed: ManagedProcess;
   browserManager: BrowserViewManager | null;
   unregisterIpc: (() => void) | null;
+  cancelStartupUpdateCheck: (() => void) | null;
   cleanedUp: boolean;
   port: number;
   /** Empty string in dev mode where we don't own the server. */
@@ -42,6 +44,7 @@ const state: AppState = {
   managed: new ManagedProcess(),
   browserManager: null,
   unregisterIpc: null,
+  cancelStartupUpdateCheck: null,
   cleanedUp: false,
   port: getConfiguredPort(),
   webDir: "",
@@ -89,6 +92,9 @@ async function cleanupOnce(): Promise<void> {
   if (state.cleanedUp) return;
   state.cleanedUp = true;
 
+  // Cancel any pending startup update check so its dialog doesn't pop up
+  // mid-shutdown (the 10s delay can outlive Cmd+Q on a quick quit).
+  state.cancelStartupUpdateCheck?.();
   state.unregisterIpc?.();
   state.browserManager?.destroyAll();
   await state.managed.kill();
@@ -147,6 +153,14 @@ async function bootstrap(): Promise<void> {
       resourcesPath: process.resourcesPath,
       appPath: app.getAppPath(),
     },
+  });
+
+  // Auto-update check 10s after launch (matches the Tauri shell's
+  // `tokio::time::sleep(Duration::from_secs(10))` in lib.rs::run). No-op
+  // unless `BAND_UPDATER_ENABLED=1` is set AND we're in a packaged build —
+  // see updater.ts for the full gating.
+  state.cancelStartupUpdateCheck = scheduleStartupCheck(app.isPackaged, {
+    parentWindow: state.mainWindow,
   });
 
   state.mainWindow.on("close", () => {

--- a/apps/desktop/src/main/menu.ts
+++ b/apps/desktop/src/main/menu.ts
@@ -15,12 +15,13 @@
  * the Tauri shell uses (`webview.eval`); here we use Electron's
  * `executeJavaScript`.
  *
- * Phase 5 of issue #306. The "Check for Updates…" entry is still deferred
- * to Phase 6 (electron-updater).
+ * Phase 5 of issue #306 added everything except "Check for Updates…",
+ * which Phase 6 (issue #363) wires up here against `electron-updater`.
  */
 
 import { app, BrowserWindow, Menu, type MenuItemConstructorOptions } from "electron";
 import { dashLog } from "./services/log.js";
+import { checkForUpdate, UPDATER_ENABLED } from "./updater.js";
 
 /** Run JS in whichever window is focused, falling back to the main window. */
 function evalInFocused(js: string): void {
@@ -86,8 +87,26 @@ export function buildAppMenu(): Menu {
 
   const appName = app.name ?? "Band";
 
+  // Match the Tauri shell: when the updater is disabled (dev / unsigned
+  // local builds) the menu item is omitted entirely rather than greyed out.
+  // See lib.rs::run for the equivalent `if UPDATER_ENABLED { ... }` branch.
+  const updaterItems: MenuItemConstructorOptions[] = UPDATER_ENABLED
+    ? [
+        { type: "separator" },
+        {
+          label: "Check for Updates…",
+          click: () => {
+            void checkForUpdate(true).catch((err) => {
+              dashLog(`menu: check for updates failed: ${String(err)}`);
+            });
+          },
+        },
+      ]
+    : [];
+
   const bandSubmenu: MenuItemConstructorOptions[] = [
     { role: "about", label: `About ${appName}` },
+    ...updaterItems,
     { type: "separator" },
     { role: "services" },
     { type: "separator" },

--- a/apps/desktop/src/main/updater.ts
+++ b/apps/desktop/src/main/updater.ts
@@ -1,0 +1,352 @@
+/**
+ * Auto-updater. Direct port of
+ * `apps/dashboard/src-tauri/src/commands/updater.rs`, backed by
+ * `electron-updater` instead of `tauri-plugin-updater`.
+ *
+ * Parity goals (issue #363):
+ *   - Boot-time silent check: 10s after launch, mirroring the
+ *     `tokio::time::sleep(Duration::from_secs(10))` in lib.rs::run.
+ *   - Interactive "Check for Updates…" menu item: dialog when up-to-date,
+ *     dialog with Update/Later when an update exists, progress reporting
+ *     during download, restart on install.
+ *   - Same UPDATER_ENABLED gating: only active in CI release builds.
+ *
+ * Why electron-updater (not Squirrel.Mac directly): it shares the
+ * publish/feed semantics with `electron-builder`, generates the
+ * `app-update.yml` manifest baked into the .app, and matches the GitHub
+ * Releases hosting we already use. The legacy `latest.json` (minisign-signed,
+ * Tauri-format) stays in the same release for users still on the Tauri shell.
+ *
+ * The publish endpoint itself is configured in `electron-builder.yml`; the
+ * runtime simply calls `autoUpdater.checkForUpdates()` and reads the feed
+ * from the bundled `app-update.yml`.
+ *
+ * Implementation note — lazy electron imports: the top of this file
+ * deliberately avoids importing `electron` or `electron-updater` eagerly.
+ * Both packages bind to the running Electron binary at module-load time,
+ * so a plain `node` process loading `updater.ts` (e.g. our integration
+ * tests) would either get back `undefined` exports (in electron's case
+ * `index.js` returns a path string) or hard-fail (in electron-updater's
+ * case it imports `electron`). The runtime defaults are resolved inside
+ * the helper functions; tests inject a `CheckForUpdateDeps` and never
+ * touch the live modules.
+ */
+
+// Type-only imports erase at compile time — these don't trigger module
+// loading at runtime, even under plain Node.
+import type { BrowserWindow } from "electron";
+import { dashLog } from "./services/log.js";
+
+/**
+ * Whether the updater is enabled at runtime.
+ *
+ * Mirror of Tauri's `option_env!("TAURI_SIGNING_PRIVATE_KEY").is_some()`,
+ * which compiled the updater plugin out of dev/local builds. The Electron
+ * equivalent is environment-driven because `electron-updater` is always
+ * present in the bundle:
+ *
+ *   - In CI release builds, `BAND_UPDATER_ENABLED=1` is exported alongside
+ *     the code-signing variables (CSC_LINK / CSC_KEY_PASSWORD).
+ *   - In local builds and `pnpm dev:desktop`, the variable is unset, so we
+ *     short-circuit before touching `autoUpdater` (which would otherwise
+ *     log "skip checkForUpdates because application is not packed").
+ */
+export const UPDATER_ENABLED: boolean = process.env.BAND_UPDATER_ENABLED === "1";
+
+/**
+ * The subset of the `electron-updater` `AppUpdater` interface we use. Tests
+ * inject a fake satisfying this; production code passes the live singleton.
+ */
+export interface UpdaterLike {
+  checkForUpdates(): Promise<unknown>;
+  downloadUpdate(): Promise<unknown>;
+  quitAndInstall(): void;
+  on(event: "update-available", listener: (info: { version: string }) => void): void;
+  on(event: "update-not-available", listener: () => void): void;
+  on(event: "download-progress", listener: (info: ProgressInfo) => void): void;
+  on(event: "update-downloaded", listener: () => void): void;
+  on(event: "error", listener: (err: Error) => void): void;
+  removeAllListeners(event?: string): void;
+  autoDownload: boolean;
+  autoInstallOnAppQuit: boolean;
+}
+
+interface ProgressInfo {
+  percent: number;
+  bytesPerSecond: number;
+  transferred: number;
+  total: number;
+}
+
+/**
+ * Visible for tests. The default updater is the singleton from
+ * electron-updater; tests pass a fake to avoid touching the network.
+ */
+export interface CheckForUpdateDeps {
+  updater?: UpdaterLike;
+  /** Window to parent dialogs to. Falls back to no-parent dialogs. */
+  parentWindow?: BrowserWindow | null;
+  /** Override `autoUpdater.quitAndInstall` (used by interactive flow tests). */
+  restart?: () => void;
+  /** Override the info dialog (used in tests). */
+  showInfo?: (title: string, message: string) => Promise<void>;
+  /**
+   * Override the confirm dialog. Resolves true when the user clicks
+   * "Update", false otherwise.
+   */
+  showConfirm?: (title: string, message: string) => Promise<boolean>;
+}
+
+const ZERO_DEPS: Readonly<CheckForUpdateDeps> = Object.freeze({});
+
+/**
+ * Lazy-load the live `electron-updater` singleton. Only called when no
+ * `deps.updater` was supplied — i.e. in production. Tests never reach this.
+ */
+async function loadDefaultUpdater(): Promise<UpdaterLike> {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-imports
+  const mod = await import("electron-updater");
+  return mod.autoUpdater as unknown as UpdaterLike;
+}
+
+async function loadElectron(): Promise<typeof import("electron")> {
+  return import("electron");
+}
+
+async function defaultShowInfo(
+  parent: BrowserWindow | null,
+  title: string,
+  message: string,
+): Promise<void> {
+  const { dialog } = await loadElectron();
+  const opts = {
+    type: "info" as const,
+    title,
+    message,
+    buttons: ["OK"],
+    defaultId: 0,
+  };
+  if (parent) {
+    await dialog.showMessageBox(parent, opts);
+  } else {
+    await dialog.showMessageBox(opts);
+  }
+}
+
+async function defaultShowConfirm(
+  parent: BrowserWindow | null,
+  title: string,
+  message: string,
+): Promise<boolean> {
+  const { dialog } = await loadElectron();
+  const opts = {
+    type: "question" as const,
+    title,
+    message,
+    buttons: ["Update", "Later"],
+    defaultId: 0,
+    cancelId: 1,
+  };
+  const result = parent
+    ? await dialog.showMessageBox(parent, opts)
+    : await dialog.showMessageBox(opts);
+  return result.response === 0;
+}
+
+/**
+ * Check for updates and prompt the user to install if one is available.
+ *
+ * When `interactive` is true, a dialog is shown even when no update is found
+ * (used for the "Check for Updates…" menu item). When false, the check is
+ * silent unless an update exists (used for the automatic startup check).
+ *
+ * Mirror of `commands::updater::check_for_update` in updater.rs. The control
+ * flow there is request/response (`updater.check().await` returns the update
+ * descriptor); electron-updater is event-driven, so we wire one-shot
+ * listeners and bridge them back to the same linear flow here.
+ */
+export async function checkForUpdate(
+  interactive: boolean,
+  deps: CheckForUpdateDeps = ZERO_DEPS,
+): Promise<void> {
+  const parent = deps.parentWindow ?? null;
+  const showInfo = deps.showInfo ?? ((t, m) => defaultShowInfo(parent, t, m));
+  const showConfirm = deps.showConfirm ?? ((t, m) => defaultShowConfirm(parent, t, m));
+
+  let updater: UpdaterLike;
+  try {
+    updater = deps.updater ?? (await loadDefaultUpdater());
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    dashLog(`updater: failed to create updater: ${msg}`);
+    if (interactive) {
+      await showInfo("Update Error", `Failed to check for updates: ${msg}`);
+    }
+    return;
+  }
+
+  // We drive the download + install ourselves so we can show a confirmation
+  // dialog after `update-available` fires (matching Tauri's flow). With
+  // `autoDownload=false`, electron-updater emits `update-available` and
+  // stops; we then call `downloadUpdate()` after the user confirms.
+  updater.autoDownload = false;
+  updater.autoInstallOnAppQuit = false;
+
+  // Wire the event listeners against a single CheckForUpdates round-trip,
+  // then tear them all down before returning so a second invocation
+  // doesn't double-fire.
+  type Outcome =
+    | { kind: "available"; version: string }
+    | { kind: "not-available" }
+    | { kind: "error"; error: Error };
+
+  const result = await new Promise<Outcome>((resolve) => {
+    let settled = false;
+    const settle = (o: Outcome) => {
+      if (settled) return;
+      settled = true;
+      resolve(o);
+    };
+
+    updater.on("update-available", (info) => {
+      settle({ kind: "available", version: info.version });
+    });
+    updater.on("update-not-available", () => {
+      settle({ kind: "not-available" });
+    });
+    updater.on("error", (err) => {
+      settle({ kind: "error", error: err });
+    });
+
+    Promise.resolve(updater.checkForUpdates()).catch((err) => {
+      settle({
+        kind: "error",
+        error: err instanceof Error ? err : new Error(String(err)),
+      });
+    });
+  });
+
+  // We're going to add fresh listeners for the download phase below; clear
+  // the check-phase ones first so we don't accidentally re-handle them.
+  updater.removeAllListeners("update-available");
+  updater.removeAllListeners("update-not-available");
+  updater.removeAllListeners("error");
+
+  if (result.kind === "error") {
+    dashLog(`updater: check failed: ${result.error.message}`);
+    if (interactive) {
+      await showInfo("Update Error", "Failed to check for updates. Please try again later.");
+    }
+    return;
+  }
+
+  if (result.kind === "not-available") {
+    dashLog("updater: no update available");
+    if (interactive) {
+      await showInfo("No Updates Available", "You're running the latest version of Band.");
+    }
+    return;
+  }
+
+  const { version } = result;
+  dashLog(`updater: update available — v${version}`);
+
+  const accepted = await showConfirm(
+    "Update Available",
+    `Band v${version} is available. Would you like to download and install it now?`,
+  );
+  if (!accepted) {
+    return;
+  }
+
+  dashLog(`updater: downloading v${version}…`);
+
+  const installed = await new Promise<{ ok: true } | { ok: false; error: Error }>((resolve) => {
+    let settled = false;
+    const settle = (r: { ok: true } | { ok: false; error: Error }) => {
+      if (settled) return;
+      settled = true;
+      resolve(r);
+    };
+
+    updater.on("download-progress", (info) => {
+      // The Tauri version logs every chunk; electron-updater emits at a
+      // sensible interval (~every few hundred ms) so we just forward.
+      const transferred = Math.round(info.transferred);
+      const total = Math.round(info.total);
+      const pct = info.percent.toFixed(1);
+      dashLog(`updater: progress — ${transferred}/${total} bytes (${pct}%)`);
+    });
+    updater.on("update-downloaded", () => {
+      dashLog("updater: download finished, installing…");
+      settle({ ok: true });
+    });
+    updater.on("error", (err) => {
+      settle({ ok: false, error: err });
+    });
+
+    Promise.resolve(updater.downloadUpdate()).catch((err) => {
+      settle({
+        ok: false,
+        error: err instanceof Error ? err : new Error(String(err)),
+      });
+    });
+  });
+
+  // Same teardown reasoning as above.
+  updater.removeAllListeners("download-progress");
+  updater.removeAllListeners("update-downloaded");
+  updater.removeAllListeners("error");
+
+  if (!installed.ok) {
+    dashLog(`updater: install failed: ${installed.error.message}`);
+    await showInfo("Update Failed", `Failed to install the update: ${installed.error.message}`);
+    return;
+  }
+
+  dashLog(`updater: installed v${version}, restarting…`);
+  if (deps.restart) {
+    deps.restart();
+  } else {
+    // electron-updater's quitAndInstall handles the relaunch flow. It
+    // closes all windows, fires `before-quit`, then runs the installer.
+    updater.quitAndInstall();
+  }
+}
+
+/**
+ * Schedule the boot-time silent check. Mirrors the
+ * `tokio::time::sleep(Duration::from_secs(10))` in lib.rs::run: hold off
+ * 10s after launch so the dashboard is fully loaded before we hit the
+ * network.
+ *
+ * Returns a cancellation function so the caller can abort the pending check
+ * during shutdown (avoids a stray dialog popping up after Cmd+Q).
+ *
+ * `isPackaged` is supplied by the caller (typically `app.isPackaged`) so
+ * this module doesn't need to import `electron` eagerly. `delayMs` is
+ * overridable for tests; production always uses the 10s default to match
+ * Tauri.
+ */
+export function scheduleStartupCheck(
+  isPackaged: boolean,
+  deps: CheckForUpdateDeps & { delayMs?: number } = {},
+): () => void {
+  if (!UPDATER_ENABLED) {
+    return () => undefined;
+  }
+  // Skip in unpacked dev runs even if BAND_UPDATER_ENABLED is set —
+  // electron-updater refuses to operate without a packaged
+  // `app-update.yml` and would log a confusing warning every launch.
+  if (!isPackaged) {
+    return () => undefined;
+  }
+
+  const handle = setTimeout(() => {
+    void checkForUpdate(false, deps).catch((err) => {
+      dashLog(`updater: startup check threw: ${String(err)}`);
+    });
+  }, deps.delayMs ?? 10_000);
+
+  return () => clearTimeout(handle);
+}

--- a/apps/desktop/tests/updater.test.ts
+++ b/apps/desktop/tests/updater.test.ts
@@ -1,0 +1,387 @@
+/**
+ * Integration tests for the auto-updater logic.
+ *
+ * Per CLAUDE.md: black-box, no mocks of our own modules. The only thing we
+ * substitute is the third-party `electron-updater` singleton (out of our
+ * control + binds to the running Electron binary at module-load time —
+ * impractical in CI). The substitution is via dependency injection at the
+ * `checkForUpdate` call site, not a network or loader-level mock — so the
+ * production code under test is exactly the same code that ships.
+ *
+ * Each test drives a fresh `FakeUpdater` through the same event sequence
+ * the real `electron-updater` emits (`checking-for-update` →
+ * `update-available` / `update-not-available` / `error` → optionally
+ * `download-progress` ... → `update-downloaded`). Dialog interactions are
+ * captured as a list, and the install path replaces `quitAndInstall` with
+ * a `restart` callback so the test process doesn't actually exit.
+ *
+ * The startup-check schedule is exercised with a synthetic `delayMs: 0` so
+ * the suite runs in <1s.
+ */
+
+import { strict as assert } from "node:assert";
+import { afterEach, beforeEach, describe, test } from "node:test";
+import { setTimeout as delay } from "node:timers/promises";
+
+import { type CheckForUpdateDeps, checkForUpdate, type UpdaterLike } from "../src/main/updater.ts";
+
+// ---------------------------------------------------------------------------
+// FakeUpdater: same event surface as electron-updater's AppUpdater singleton
+// ---------------------------------------------------------------------------
+
+interface FakeUpdaterOptions {
+  /** Outcome to fire from `checkForUpdates`. Defaults to "not-available". */
+  checkOutcome?: "available" | "not-available" | "error";
+  /** Version to report in the `update-available` event. */
+  version?: string;
+  /** Error message for the "error" outcome. */
+  errorMessage?: string;
+  /** Outcome to fire from `downloadUpdate`. */
+  downloadOutcome?: "downloaded" | "error";
+  /** Error message for download failure. */
+  downloadErrorMessage?: string;
+}
+
+class FakeUpdater implements UpdaterLike {
+  autoDownload = true;
+  autoInstallOnAppQuit = true;
+  checkForUpdatesCalls = 0;
+  downloadUpdateCalls = 0;
+  quitAndInstallCalls = 0;
+  private listeners = new Map<string, Array<(...args: unknown[]) => void>>();
+  private opts: FakeUpdaterOptions;
+
+  constructor(opts: FakeUpdaterOptions = {}) {
+    this.opts = opts;
+  }
+
+  // biome-ignore lint/suspicious/noExplicitAny: matches the AppUpdater contract
+  on(event: string, listener: (...args: any[]) => void): void {
+    const arr = this.listeners.get(event) ?? [];
+    arr.push(listener);
+    this.listeners.set(event, arr);
+  }
+
+  removeAllListeners(event?: string): void {
+    if (event) this.listeners.delete(event);
+    else this.listeners.clear();
+  }
+
+  private emit(event: string, ...args: unknown[]): void {
+    const arr = this.listeners.get(event);
+    if (!arr) return;
+    for (const fn of arr) fn(...args);
+  }
+
+  async checkForUpdates(): Promise<unknown> {
+    this.checkForUpdatesCalls++;
+    // Simulate the async dispatch: real electron-updater emits the event
+    // off-microtask after the network round-trip completes.
+    await Promise.resolve();
+    const outcome = this.opts.checkOutcome ?? "not-available";
+    if (outcome === "available") {
+      this.emit("update-available", { version: this.opts.version ?? "1.2.3" });
+    } else if (outcome === "not-available") {
+      this.emit("update-not-available");
+    } else {
+      this.emit("error", new Error(this.opts.errorMessage ?? "boom"));
+    }
+    return null;
+  }
+
+  async downloadUpdate(): Promise<unknown> {
+    this.downloadUpdateCalls++;
+    await Promise.resolve();
+    if (this.opts.downloadOutcome === "error") {
+      this.emit("error", new Error(this.opts.downloadErrorMessage ?? "download failed"));
+      return [];
+    }
+    // Emit one progress tick so we can assert the listener path runs.
+    this.emit("download-progress", {
+      percent: 50,
+      bytesPerSecond: 1024,
+      transferred: 512,
+      total: 1024,
+    });
+    this.emit("update-downloaded");
+    return [];
+  }
+
+  quitAndInstall(): void {
+    this.quitAndInstallCalls++;
+  }
+}
+
+interface DialogCall {
+  kind: "info" | "confirm";
+  title: string;
+  message: string;
+}
+
+interface Recorder {
+  dialogs: DialogCall[];
+  restarts: number;
+  deps: CheckForUpdateDeps;
+}
+
+/** Builds a fresh deps bundle that records every dialog + restart call. */
+function recorder(updater: UpdaterLike, confirmAnswer = true): Recorder {
+  const dialogs: DialogCall[] = [];
+  let restarts = 0;
+  const deps: CheckForUpdateDeps = {
+    updater,
+    showInfo: async (title, message) => {
+      dialogs.push({ kind: "info", title, message });
+    },
+    showConfirm: async (title, message) => {
+      dialogs.push({ kind: "confirm", title, message });
+      return confirmAnswer;
+    },
+    restart: () => {
+      restarts++;
+    },
+  };
+  return {
+    dialogs,
+    get restarts() {
+      return restarts;
+    },
+    deps,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("checkForUpdate (silent / startup mode)", () => {
+  test("no update available — no dialog, no restart", async () => {
+    const updater = new FakeUpdater({ checkOutcome: "not-available" });
+    const rec = recorder(updater);
+
+    await checkForUpdate(false, rec.deps);
+
+    assert.equal(updater.checkForUpdatesCalls, 1);
+    assert.equal(updater.downloadUpdateCalls, 0);
+    assert.equal(rec.dialogs.length, 0);
+    assert.equal(rec.restarts, 0);
+  });
+
+  test("check error — silent, no dialog", async () => {
+    const updater = new FakeUpdater({
+      checkOutcome: "error",
+      errorMessage: "DNS lookup failed",
+    });
+    const rec = recorder(updater);
+
+    await checkForUpdate(false, rec.deps);
+
+    assert.equal(rec.dialogs.length, 0);
+    assert.equal(updater.downloadUpdateCalls, 0);
+  });
+
+  test("update available + accepted — downloads and restarts", async () => {
+    const updater = new FakeUpdater({
+      checkOutcome: "available",
+      version: "9.8.7",
+    });
+    const rec = recorder(updater, true);
+
+    await checkForUpdate(false, rec.deps);
+
+    // Confirm dialog fired with the version.
+    assert.equal(rec.dialogs.length, 1);
+    assert.equal(rec.dialogs[0]?.kind, "confirm");
+    assert.equal(rec.dialogs[0]?.title, "Update Available");
+    assert.match(rec.dialogs[0]?.message ?? "", /v9\.8\.7/);
+
+    assert.equal(updater.downloadUpdateCalls, 1);
+    assert.equal(rec.restarts, 1);
+    // We never call quitAndInstall when restart override is supplied.
+    assert.equal(updater.quitAndInstallCalls, 0);
+  });
+
+  test("update available + declined — no download, no restart", async () => {
+    const updater = new FakeUpdater({
+      checkOutcome: "available",
+      version: "1.0.1",
+    });
+    const rec = recorder(updater, false);
+
+    await checkForUpdate(false, rec.deps);
+
+    assert.equal(rec.dialogs.length, 1);
+    assert.equal(rec.dialogs[0]?.kind, "confirm");
+    assert.equal(updater.downloadUpdateCalls, 0);
+    assert.equal(rec.restarts, 0);
+  });
+
+  test("download fails — info dialog is shown", async () => {
+    const updater = new FakeUpdater({
+      checkOutcome: "available",
+      version: "2.0.0",
+      downloadOutcome: "error",
+      downloadErrorMessage: "checksum mismatch",
+    });
+    const rec = recorder(updater, true);
+
+    await checkForUpdate(false, rec.deps);
+
+    // 1 confirm + 1 info (failure)
+    assert.equal(rec.dialogs.length, 2);
+    assert.equal(rec.dialogs[1]?.kind, "info");
+    assert.equal(rec.dialogs[1]?.title, "Update Failed");
+    assert.match(rec.dialogs[1]?.message ?? "", /checksum mismatch/);
+    assert.equal(rec.restarts, 0);
+  });
+
+  test("autoDownload + autoInstallOnAppQuit are forced off", async () => {
+    const updater = new FakeUpdater({ checkOutcome: "not-available" });
+    updater.autoDownload = true;
+    updater.autoInstallOnAppQuit = true;
+    const rec = recorder(updater);
+
+    await checkForUpdate(false, rec.deps);
+
+    // We need to drive download + install ourselves so the user can confirm
+    // before we touch their bandwidth. Regression-guard against someone
+    // flipping these back to defaults.
+    assert.equal(updater.autoDownload, false);
+    assert.equal(updater.autoInstallOnAppQuit, false);
+  });
+});
+
+describe("checkForUpdate (interactive / menu mode)", () => {
+  test("no update available — info dialog says you're up to date", async () => {
+    const updater = new FakeUpdater({ checkOutcome: "not-available" });
+    const rec = recorder(updater);
+
+    await checkForUpdate(true, rec.deps);
+
+    assert.equal(rec.dialogs.length, 1);
+    assert.equal(rec.dialogs[0]?.kind, "info");
+    assert.equal(rec.dialogs[0]?.title, "No Updates Available");
+  });
+
+  test("check error — info dialog mentions the failure", async () => {
+    const updater = new FakeUpdater({
+      checkOutcome: "error",
+      errorMessage: "503 Service Unavailable",
+    });
+    const rec = recorder(updater);
+
+    await checkForUpdate(true, rec.deps);
+
+    assert.equal(rec.dialogs.length, 1);
+    assert.equal(rec.dialogs[0]?.kind, "info");
+    assert.equal(rec.dialogs[0]?.title, "Update Error");
+  });
+});
+
+describe("checkForUpdate listener teardown", () => {
+  test("two back-to-back checks don't double-fire on the second outcome", async () => {
+    const updater = new FakeUpdater({ checkOutcome: "not-available" });
+    const rec = recorder(updater);
+
+    await checkForUpdate(false, rec.deps);
+    await checkForUpdate(true, rec.deps);
+
+    // Only the second (interactive) call should have surfaced a dialog.
+    assert.equal(rec.dialogs.length, 1);
+    assert.equal(rec.dialogs[0]?.kind, "info");
+    assert.equal(rec.dialogs[0]?.title, "No Updates Available");
+    assert.equal(updater.checkForUpdatesCalls, 2);
+  });
+});
+
+describe("scheduleStartupCheck", () => {
+  // Each test below toggles BAND_UPDATER_ENABLED. Because it's read once at
+  // module init time, we re-import the module fresh per test via a dynamic
+  // import + a unique cache-busting query param.
+  let originalEnv: string | undefined;
+
+  beforeEach(() => {
+    originalEnv = process.env.BAND_UPDATER_ENABLED;
+  });
+  afterEach(() => {
+    if (originalEnv === undefined) delete process.env.BAND_UPDATER_ENABLED;
+    else process.env.BAND_UPDATER_ENABLED = originalEnv;
+  });
+
+  test("returns no-op when UPDATER_ENABLED is false (env unset)", async () => {
+    delete process.env.BAND_UPDATER_ENABLED;
+    const mod = await freshUpdaterModule();
+    const updater = new FakeUpdater({ checkOutcome: "available" });
+    const cancel = mod.scheduleStartupCheck(true, {
+      updater,
+      delayMs: 5,
+      showInfo: async () => undefined,
+      showConfirm: async () => false,
+    });
+
+    await delay(30);
+    cancel();
+    assert.equal(updater.checkForUpdatesCalls, 0);
+  });
+
+  test("returns no-op when not packaged, even with UPDATER_ENABLED=1", async () => {
+    process.env.BAND_UPDATER_ENABLED = "1";
+    const mod = await freshUpdaterModule();
+    const updater = new FakeUpdater({ checkOutcome: "available" });
+
+    mod.scheduleStartupCheck(false, {
+      updater,
+      delayMs: 5,
+      showInfo: async () => undefined,
+      showConfirm: async () => false,
+    });
+
+    await delay(30);
+    assert.equal(updater.checkForUpdatesCalls, 0);
+  });
+
+  test("fires checkForUpdate after delay when enabled + packaged", async () => {
+    process.env.BAND_UPDATER_ENABLED = "1";
+    const mod = await freshUpdaterModule();
+    const updater = new FakeUpdater({ checkOutcome: "not-available" });
+
+    mod.scheduleStartupCheck(true, {
+      updater,
+      delayMs: 10,
+      showInfo: async () => undefined,
+      showConfirm: async () => false,
+    });
+
+    // Just past the delay.
+    await delay(50);
+    assert.equal(updater.checkForUpdatesCalls, 1);
+  });
+
+  test("cancellation prevents the deferred check from running", async () => {
+    process.env.BAND_UPDATER_ENABLED = "1";
+    const mod = await freshUpdaterModule();
+    const updater = new FakeUpdater({ checkOutcome: "available" });
+
+    const cancel = mod.scheduleStartupCheck(true, {
+      updater,
+      delayMs: 50,
+      showInfo: async () => undefined,
+      showConfirm: async () => false,
+    });
+    cancel();
+
+    await delay(80);
+    assert.equal(updater.checkForUpdatesCalls, 0);
+  });
+});
+
+/**
+ * Force a fresh module load so `UPDATER_ENABLED` (evaluated at module init)
+ * picks up the current value of `process.env.BAND_UPDATER_ENABLED`. Node's
+ * ESM cache keys on resolved URL, so a unique query param sidesteps it.
+ */
+async function freshUpdaterModule(): Promise<typeof import("../src/main/updater.ts")> {
+  const url = new URL("../src/main/updater.ts", import.meta.url);
+  url.searchParams.set("t", String(Date.now()) + Math.random().toString(36).slice(2));
+  return import(url.href);
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -77,6 +77,10 @@ importers:
         version: 6.4.1(@types/node@22.19.13)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
 
   apps/desktop:
+    dependencies:
+      electron-updater:
+        specifier: ^6.8.3
+        version: 6.8.3
     devDependencies:
       '@types/node':
         specifier: ^22.19.13
@@ -3362,6 +3366,7 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+    deprecated: Potential CWE-502 - Update to 1.3.1 or higher
 
   '@vercel/oidc@3.1.0':
     resolution: {integrity: sha512-Fw28YZpRnA3cAHHDlkt7xQHiJ0fcL+NRcIqsocZQUSmbzeIKRpwttJjik5ZGanXP+vlA4SbTg+AbA3bP363l+w==}
@@ -3699,6 +3704,10 @@ packages:
 
   builder-util-runtime@9.2.10:
     resolution: {integrity: sha512-6p/gfG1RJSQeIbz8TK5aPNkoztgY1q5TgmGFMAXcY8itsGW6Y2ld1ALsZ5UJn8rog7hKF3zHx5iQbNQ8uLcRlw==}
+    engines: {node: '>=12.0.0'}
+
+  builder-util-runtime@9.5.1:
+    resolution: {integrity: sha512-qt41tMfgHTllhResqM5DcnHyDIWNgzHvuY2jDcYP9iaGpkWxTUzV6GQjDeLnlR1/DtdlcsWQbA7sByMpmJFTLQ==}
     engines: {node: '>=12.0.0'}
 
   builder-util@25.1.7:
@@ -4492,6 +4501,9 @@ packages:
 
   electron-to-chromium@1.5.307:
     resolution: {integrity: sha512-5z3uFKBWjiNR44nFcYdkcXjKMbg5KXNdciu7mhTPo9tB7NbqSNP2sSnGR+fqknZSCwKkBN+oxiiajWs4dT6ORg==}
+
+  electron-updater@6.8.3:
+    resolution: {integrity: sha512-Z6sgw3jgbikWKXei1ENdqFOxBP0WlXg3TtKfz0rgw2vIZFJUyI4pD7ZN7jrkm7EoMK+tcm/qTnPUdqfZukBlBQ==}
 
   electron@33.4.11:
     resolution: {integrity: sha512-xmdAs5QWRkInC7TpXGNvzo/7exojubk+72jn1oJL7keNeIlw7xNglf8TGtJtkR4rWC5FJq0oXiIXPS9BcK2Irg==}
@@ -5386,6 +5398,9 @@ packages:
   lodash.difference@4.5.0:
     resolution: {integrity: sha512-dS2j+W26TQ7taQBGN8Lbbq04ssV3emRw4NY58WErlTO29pIqS0HmoT5aJ9+TUQ1N3G+JOZSji4eugsWwGp9yPA==}
 
+  lodash.escaperegexp@4.1.2:
+    resolution: {integrity: sha512-TM9YBvyC84ZxE3rgfefxUWiQKLilstD6k7PTGt6wfbtXF8ixIJLOL3VYyV/z+ZiPLsVxAsKAFVwWlWeb2Y8Yyw==}
+
   lodash.flatten@4.4.0:
     resolution: {integrity: sha512-C5N2Z3DgnnKr0LOpv/hKCgKdb7ZZwafIrsesve6lmzvZIRZRGaZ/l6Q8+2W7NaT+ZwO3fFlSCzCzrDCFdJfZ4g==}
 
@@ -5394,6 +5409,10 @@ packages:
 
   lodash.isboolean@3.0.3:
     resolution: {integrity: sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==}
+
+  lodash.isequal@4.5.0:
+    resolution: {integrity: sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==}
+    deprecated: This package is deprecated. Use require('node:util').isDeepStrictEqual instead.
 
   lodash.isinteger@4.0.4:
     resolution: {integrity: sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==}
@@ -6791,6 +6810,9 @@ packages:
 
   tiny-invariant@1.3.3:
     resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
+
+  tiny-typed-emitter@2.1.0:
+    resolution: {integrity: sha512-qVtvMxeXbVej0cQWKqVSSAHmKZEHAvxdF8HEUBFWts8h+xEo5m/lEiPakuyZ3BnCBjOD8i24kzNOiOLLgsSxhA==}
 
   tiny-warning@1.0.3:
     resolution: {integrity: sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA==}
@@ -10991,6 +11013,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  builder-util-runtime@9.5.1:
+    dependencies:
+      debug: 4.4.3
+      sax: 1.6.0
+    transitivePeerDependencies:
+      - supports-color
+
   builder-util@25.1.7:
     dependencies:
       7zip-bin: 5.2.0
@@ -11780,6 +11809,19 @@ snapshots:
       - supports-color
 
   electron-to-chromium@1.5.307: {}
+
+  electron-updater@6.8.3:
+    dependencies:
+      builder-util-runtime: 9.5.1
+      fs-extra: 10.1.0
+      js-yaml: 4.1.1
+      lazy-val: 1.0.5
+      lodash.escaperegexp: 4.1.2
+      lodash.isequal: 4.5.0
+      semver: 7.7.4
+      tiny-typed-emitter: 2.1.0
+    transitivePeerDependencies:
+      - supports-color
 
   electron@33.4.11:
     dependencies:
@@ -12862,6 +12904,8 @@ snapshots:
 
   lodash.difference@4.5.0: {}
 
+  lodash.escaperegexp@4.1.2: {}
+
   lodash.flatten@4.4.0: {}
 
   lodash.includes@4.3.0:
@@ -12869,6 +12913,8 @@ snapshots:
 
   lodash.isboolean@3.0.3:
     optional: true
+
+  lodash.isequal@4.5.0: {}
 
   lodash.isinteger@4.0.4:
     optional: true
@@ -14819,6 +14865,8 @@ snapshots:
   tiny-inflate@1.0.3: {}
 
   tiny-invariant@1.3.3: {}
+
+  tiny-typed-emitter@2.1.0: {}
 
   tiny-warning@1.0.3: {}
 


### PR DESCRIPTION
## Summary
- Phase 6 of the Tauri → Electron migration (#306). Ports `apps/dashboard/src-tauri/src/commands/updater.rs` to TypeScript using `electron-updater`, at parity with the Tauri shell's auto-updater.
- Boot-time silent check fires 10s after launch; "Check for Updates…" menu item under the Band submenu drives the interactive flow (info dialog when up-to-date, Update/Later confirm when an update exists, progress logs, restart on install).
- `BAND_UPDATER_ENABLED=1` mirrors Tauri's `option_env!("TAURI_SIGNING_PRIVATE_KEY")` gate — only active in CI release builds.

## Changes
- `apps/desktop/package.json` — add `electron-updater@^6.8.3` runtime dep.
- `apps/desktop/src/main/updater.ts` (new) — bridges electron-updater's event-driven API back into Tauri's linear flow. Lazy-loads `electron` + `electron-updater` so the module is testable under plain Node.
- `apps/desktop/electron-builder.yml` — adds `publish` (GitHub provider, `band-app/band`), `directories`, `mac` (hardened runtime, dmg + zip targets, x64 + arm64), `dmg.writeUpdateInfo`, `copyright` on top of #364's Phase 7 sidecar config.
- `apps/desktop/src/main/index.ts` — wires `scheduleStartupCheck(app.isPackaged, ...)` after the main window is created; cancels the pending timer in `cleanupOnce`.
- `apps/desktop/src/main/menu.ts` — surfaces the deferred "Check for Updates…" item (gated on `UPDATER_ENABLED`).
- `apps/desktop/tests/updater.test.ts` (new) — 12 black-box integration tests via DI of a `FakeUpdater`: silent vs interactive, no-update / available / error / declined / download-fail, listener teardown across back-to-back checks, `scheduleStartupCheck` env+packaged gating.

## Out of scope
- GitHub releases pipeline / release artifacts (Phase 8).
- Signing-key migration (separate ops task).

## Test plan
- [x] `pnpm --filter @band-app/desktop build`
- [x] `pnpm --filter @band-app/desktop test` — 39 passing (12 new)
- [x] `pnpm exec biome check .` — clean
- [ ] CI green
- [ ] Manual smoke test in a packaged build with `BAND_UPDATER_ENABLED=1` (deferred to Phase 8)

🤖 Generated with [Claude Code](https://claude.com/claude-code)