### PR TITLE
feat(web): sync CLI-shipped skills into ~/.claude/skills/ on boot

### DIFF
--- a/apps/web/src/lib/cli-skills.ts
+++ b/apps/web/src/lib/cli-skills.ts
@@ -31,6 +31,7 @@ import {
 } from "node:fs";
 import { homedir, tmpdir } from "node:os";
 import { dirname, join } from "node:path";
+import { getInstallSkillsDir } from "@band-app/coding-agent";
 import { findCliBinary } from "./cli";
 import { whichBinary } from "./process-utils";
 
@@ -58,69 +59,31 @@ export interface SkillAgent {
 }
 
 /**
- * Map a coding agent type to the global skills directory we ship into. Each
- * destination matches the *highest-priority global* directory the agent's
- * adapter scans in `packages/coding-agent/src/adapters/<agent>.ts`, so that
- * shipped skills override anything else the user has at the system level.
- *
- *   - `claude-code` → `~/.claude/skills/`
- *     (claude-code.ts::discoverClaudeSkills)
- *   - `codex` / `openai-codex` → `${CODEX_HOME}/skills/` (default
- *     `~/.codex/skills/`; `CODEX_HOME` env override honored to match the
- *     adapter)
- *   - `gemini-cli` → `~/.gemini/skills/`
- *   - `opencode` → `~/.config/opencode/skills/` — OpenCode reads from a
- *     6-tier list and `.config/opencode/skills` is the *highest-priority*
- *     global entry (project-level dirs aside). It also reads from
- *     `~/.claude/skills/` (lower priority), so a user with both Claude Code
- *     and OpenCode enabled will see the skills via either path.
- *
- * Returns `null` for agent types that have no defined global skills
- * directory (e.g. `cursor-cli`, which doesn't expose a `listSkills` method).
- */
-export function resolveSkillTarget(
-  agentType: string,
-  home: string = homedir(),
-): SkillTarget | null {
-  switch (agentType) {
-    case "claude-code":
-      return { agentType, skillsDir: join(home, ".claude", "skills") };
-    case "codex":
-    case "openai-codex": {
-      const codexHome = process.env.CODEX_HOME ?? join(home, ".codex");
-      return { agentType, skillsDir: join(codexHome, "skills") };
-    }
-    case "gemini-cli":
-      return { agentType, skillsDir: join(home, ".gemini", "skills") };
-    case "opencode":
-      return { agentType, skillsDir: join(home, ".config", "opencode", "skills") };
-    default:
-      // `cursor-cli` and any unknown future type fall through to null —
-      // callers treat that as "no destination" rather than a hard error.
-      return null;
-  }
-}
-
-/**
  * Resolve write targets for a list of agents, deduplicating destinations.
+ *
+ * Each agent's skills directory comes from its adapter (see
+ * `packages/coding-agent/src/install-skills.ts` and the
+ * `get<Agent>InstallSkillsDir` exports next to each adapter's discovery
+ * logic) — this layer only orchestrates the lookup and dedupe pass.
  *
  * Two configured agents can resolve to the same directory (e.g. two
  * claude-code agents with different IDs but the same `type` both map to
  * `~/.claude/skills/`). We dedupe so the (skill, target) loop doesn't write
- * the same file twice on each boot.
+ * the same file twice on each boot. Agent types without a documented global
+ * skills directory (e.g. `cursor-cli`) are silently skipped.
  */
-export function resolveSkillTargets(
+export async function resolveSkillTargets(
   agents: readonly SkillAgent[],
   home: string = homedir(),
-): SkillTarget[] {
+): Promise<SkillTarget[]> {
   const seen = new Set<string>();
   const out: SkillTarget[] = [];
   for (const agent of agents) {
-    const target = resolveSkillTarget(agent.type, home);
-    if (!target) continue;
-    if (seen.has(target.skillsDir)) continue;
-    seen.add(target.skillsDir);
-    out.push(target);
+    const skillsDir = await getInstallSkillsDir(agent.type, home);
+    if (!skillsDir) continue;
+    if (seen.has(skillsDir)) continue;
+    seen.add(skillsDir);
+    out.push({ agentType: agent.type, skillsDir });
   }
   return out;
 }
@@ -235,7 +198,7 @@ export async function installSkills(opts: InstallSkillsOptions): Promise<Install
   };
 
   const home = opts.home ?? homedir();
-  const targets = resolveSkillTargets(opts.agents, home);
+  const targets = await resolveSkillTargets(opts.agents, home);
 
   if (targets.length === 0) {
     return result;

--- a/apps/web/src/lib/cli-skills.ts
+++ b/apps/web/src/lib/cli-skills.ts
@@ -36,6 +36,7 @@ import { dirname, join } from "node:path";
 import { getDefaultAgentBinary, getInstallSkillsDir } from "@band-app/coding-agent";
 import { findCliBinary } from "./cli";
 import { whichBinary } from "./process-utils";
+import { loadSettings } from "./state";
 
 /** The four skills `band generate-skills` emits. */
 export const BAND_SKILL_NAMES = ["band", "band-chat", "band-terminal", "band-browser"] as const;
@@ -212,12 +213,17 @@ interface InstallSkillsOptions {
   /** Override $HOME (test-only — production callers should leave unset). */
   home?: string;
   /**
-   * Enabled coding agents from `loadSettings().codingAgents`. We dispatch on
-   * `type`, not `id`, because users can configure several agents of the
-   * same type (e.g. two `claude-code` agents with different labels) and a
-   * custom `id` doesn't change the on-disk skills directory layout.
+   * Override the enabled-agents list (test-only). When omitted (the
+   * production path) we read `loadSettings().codingAgents` ourselves so the
+   * function is a self-contained "sync skills for the user's enabled
+   * agents" — callers can't accidentally pass a stale or unfiltered list.
+   *
+   * We dispatch on each agent's `type`, not `id`, because users can
+   * configure several agents of the same type (e.g. two `claude-code`
+   * agents with different labels) and a custom `id` doesn't change the
+   * on-disk skills directory layout.
    */
-  agents: readonly SkillAgent[];
+  agents?: readonly SkillAgent[];
   /**
    * Optional logger for visibility into write/update/skip decisions. Pino-
    * compatible signature so we can pass `createLogger(...)` from setup.ts
@@ -232,17 +238,27 @@ interface InstallSkillsOptions {
 /**
  * Sync the CLI-shipped skills into each enabled agent's global skills dir.
  *
+ * "Enabled" is sourced from `loadSettings().codingAgents` by default — that
+ * array is the canonical "agents the user has turned on", populated by
+ * `ensureDefaultCodingAgents` on first run and edited via the dashboard
+ * settings UI. Tests can pass `opts.agents` to override.
+ *
  * Steps:
- *   1. Resolve a band binary — abort cleanly if none is available.
- *   2. Build the list of (deduplicated) write targets from `opts.agents`.
- *   3. Run `band generate-skills` into a temp dir.
- *   4. For each (skill, target), compare against the destination and write
+ *   1. Read enabled agents from settings (or from `opts.agents`).
+ *   2. Filter to those whose binary is actually reachable on this host
+ *      (`isAgentInstalled` — handles stale `command` paths and missing
+ *      PATH entries).
+ *   3. Resolve a deduplicated list of skills directories from each
+ *      remaining agent's adapter.
+ *   4. Resolve a band binary — abort cleanly if none is available.
+ *   5. Run `band generate-skills` into a temp dir.
+ *   6. For each (skill, target), compare against the destination and write
  *      only when content differs.
  *
- * No-op (returns an empty-ish result) when no targets resolve — e.g. only
- * agents without a known global skills directory are enabled.
+ * No-op (returns an empty-ish result) when no targets resolve — e.g. the
+ * user has no agents enabled, or all enabled agents have been uninstalled.
  */
-export async function installSkills(opts: InstallSkillsOptions): Promise<InstallSkillsResult> {
+export async function installSkills(opts: InstallSkillsOptions = {}): Promise<InstallSkillsResult> {
   const result: InstallSkillsResult = {
     written: [],
     updated: [],
@@ -251,7 +267,8 @@ export async function installSkills(opts: InstallSkillsOptions): Promise<Install
   };
 
   const home = opts.home ?? homedir();
-  const targets = await resolveSkillTargets(opts.agents, home);
+  const agents = opts.agents ?? loadSettings().codingAgents ?? [];
+  const targets = await resolveSkillTargets(agents, home);
 
   if (targets.length === 0) {
     return result;

--- a/apps/web/src/lib/cli-skills.ts
+++ b/apps/web/src/lib/cli-skills.ts
@@ -1,0 +1,264 @@
+/**
+ * Sync the CLI-shipped skills (`band`, `band-chat`, `band-terminal`,
+ * `band-browser`) into the user's global coding-agent skill directory so the
+ * skills become discoverable to the agent right after install / auto-update,
+ * without the user having to manually `cp` each SKILL.md after every release.
+ *
+ * The skills are not shipped as loose files in the packaged Electron build —
+ * they're baked into the Rust `band` binary via `include_str!` (see
+ * `apps/cli/src/skills.rs::SKILL_TEMPLATES`) and rendered against the live
+ * CLI schema by `band generate-skills`. We invoke that subcommand at runtime
+ * and copy the produced `<name>/SKILL.md` files into each detected agent's
+ * known skills directory.
+ *
+ * Idempotency: the destination is only rewritten when its bytes differ from
+ * the freshly generated content. Missing destinations are written, identical
+ * destinations are skipped, and content drift (user edits or older shipped
+ * versions) results in an overwrite + warning log — matching the
+ * "blast-and-replace with a log" policy used by `installHooks` and
+ * `installCli` (see hooks.ts / cli.ts).
+ */
+
+import { execFile } from "node:child_process";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { homedir, tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { findCliBinary } from "./cli";
+import { whichBinary } from "./process-utils";
+
+/** The four skills `band generate-skills` emits. */
+export const BAND_SKILL_NAMES = ["band", "band-chat", "band-terminal", "band-browser"] as const;
+
+const SKILL_FILE = "SKILL.md";
+
+/** A single coding agent's global skills folder. */
+export interface SkillTarget {
+  /** Coding agent ID (matches AGENT_CHECKS in setup.ts). */
+  agentId: string;
+  /** Absolute path to the agent's global skills directory. */
+  skillsDir: string;
+}
+
+/**
+ * Map a detected coding agent to the global skills directory we ship into.
+ *
+ * Returns `null` when the agent has no stable global skills convention we're
+ * comfortable writing to yet — those land as a TODO so the install/update
+ * sync stays Claude-only for now (per the open question in the issue spec).
+ *
+ *   - `claude-code` → `~/.claude/skills/` (matches discoverClaudeSkills in
+ *     packages/coding-agent/src/adapters/claude-code.ts).
+ *   - `codex` / `opencode` → TODO. Both adapters scan multiple directories
+ *     (`~/.codex/skills/` for Codex; a 6-tier resolution order including
+ *     `~/.config/opencode/skills/` for OpenCode), and we'd rather wait until
+ *     someone validates an end-to-end flow than guess at the canonical
+ *     "shipped skills" home for those agents.
+ */
+export function resolveSkillTarget(agentId: string, home: string = homedir()): SkillTarget | null {
+  switch (agentId) {
+    case "claude-code":
+      return { agentId, skillsDir: join(home, ".claude", "skills") };
+    default:
+      return null;
+  }
+}
+
+/**
+ * Locate a band CLI binary we can shell out to. Mirrors the resolution order
+ * used by `installHooks` (hooks.ts):
+ *   1. `/usr/local/bin/band` symlink (created by `ensureCliInstalled` on the
+ *      previous setup step), trusted shortcut.
+ *   2. `whichBinary("band")` via the user's login shell PATH.
+ *   3. `findCliBinary()` — the dev-mode / Electron-sidecar resolver in
+ *      apps/web/src/lib/cli.ts. Catches the case where the symlink couldn't
+ *      be installed (e.g. /usr/local/bin not writable, no admin prompt) but
+ *      a usable binary still ships with the desktop app.
+ *
+ * Returns `null` when no binary can be found — callers should treat that as
+ * a non-fatal skip rather than a hard error (consistent with the rest of the
+ * idempotent setup pipeline).
+ */
+export async function findBandBinary(): Promise<string | null> {
+  try {
+    const stat = statSync("/usr/local/bin/band");
+    if (stat) return "/usr/local/bin/band";
+  } catch {
+    // Fall through to `which`.
+  }
+
+  const onPath = await whichBinary("band");
+  if (onPath) return onPath;
+
+  return findCliBinary();
+}
+
+/**
+ * Run `band generate-skills --output-dir <dir>` and return the path to the
+ * (now-populated) directory. The caller owns cleanup.
+ */
+async function generateSkills(bandPath: string, outputDir: string): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    execFile(
+      bandPath,
+      ["generate-skills", "--output-dir", outputDir],
+      { timeout: 30_000 },
+      (err, _stdout, stderr) => {
+        if (err) {
+          const detail = stderr?.toString().trim();
+          reject(new Error(detail ? `${err.message}: ${detail}` : err.message));
+          return;
+        }
+        resolve();
+      },
+    );
+  });
+}
+
+/**
+ * Result of `installSkills`. Counts each (skill × target) cell once, so
+ * syncing 4 skills into 1 target produces up to 4 entries across the three
+ * fields combined.
+ */
+export interface InstallSkillsResult {
+  /** Destination paths that didn't exist before this run. */
+  written: string[];
+  /** Destination paths that existed but had different content (overwritten). */
+  updated: string[];
+  /** Destination paths whose existing content already matched. */
+  unchanged: string[];
+  /** Targets that were skipped because no band binary could be located. */
+  skipped: string[];
+}
+
+interface InstallSkillsOptions {
+  /** Override $HOME (test-only — production callers should leave unset). */
+  home?: string;
+  /** Detected coding agent IDs. Filters which target dirs we write to. */
+  agentIds: readonly string[];
+  /**
+   * Optional logger for visibility into write/update/skip decisions. Pino-
+   * compatible signature so we can pass `createLogger(...)` from setup.ts
+   * without an adapter.
+   */
+  log?: {
+    info: (msg: string, ...args: unknown[]) => void;
+    warn: (msg: string, ...args: unknown[]) => void;
+  };
+}
+
+/**
+ * Sync the CLI-shipped skills into each detected agent's global skills dir.
+ *
+ * Steps:
+ *   1. Resolve a band binary — abort cleanly if none is available.
+ *   2. Build the list of write targets from the detected agents.
+ *   3. Run `band generate-skills` into a temp dir.
+ *   4. For each (skill, target), compare against the destination and write
+ *      only when content differs.
+ *
+ * No-op (returns an empty-ish result) when no targets resolve — that's the
+ * intended behavior when only Codex / OpenCode are installed today, since
+ * we haven't wired their destinations yet.
+ */
+export async function installSkills(opts: InstallSkillsOptions): Promise<InstallSkillsResult> {
+  const result: InstallSkillsResult = {
+    written: [],
+    updated: [],
+    unchanged: [],
+    skipped: [],
+  };
+
+  const home = opts.home ?? homedir();
+  const targets = opts.agentIds
+    .map((id) => resolveSkillTarget(id, home))
+    .filter((t): t is SkillTarget => t !== null);
+
+  if (targets.length === 0) {
+    return result;
+  }
+
+  const bandPath = await findBandBinary();
+  if (!bandPath) {
+    opts.log?.warn(
+      "Skipping CLI skills sync — band binary not found (no symlink, not on PATH, no bundled sidecar)",
+    );
+    for (const target of targets) {
+      for (const name of BAND_SKILL_NAMES) {
+        result.skipped.push(join(target.skillsDir, name, SKILL_FILE));
+      }
+    }
+    return result;
+  }
+
+  const stagingDir = mkdtempSync(join(tmpdir(), "band-skills-"));
+  try {
+    await generateSkills(bandPath, stagingDir);
+
+    for (const target of targets) {
+      for (const name of BAND_SKILL_NAMES) {
+        const sourcePath = join(stagingDir, name, SKILL_FILE);
+        const destPath = join(target.skillsDir, name, SKILL_FILE);
+
+        if (!existsSync(sourcePath)) {
+          // Generator didn't emit this skill. Could happen if the templates
+          // diverge from BAND_SKILL_NAMES — log and move on rather than
+          // crashing the whole boot path.
+          opts.log?.warn("Generated skill missing from staging dir: %s (skipping)", sourcePath);
+          continue;
+        }
+
+        const sourceContent = readFileSync(sourcePath);
+
+        let existingContent: Buffer | null = null;
+        try {
+          existingContent = readFileSync(destPath);
+        } catch (err) {
+          const code = (err as NodeJS.ErrnoException).code;
+          if (code !== "ENOENT") {
+            opts.log?.warn(
+              "Failed to read existing skill at %s: %s — overwriting",
+              destPath,
+              err instanceof Error ? err.message : String(err),
+            );
+          }
+        }
+
+        if (existingContent?.equals(sourceContent)) {
+          result.unchanged.push(destPath);
+          continue;
+        }
+
+        mkdirSync(dirname(destPath), { recursive: true });
+        writeFileSync(destPath, sourceContent);
+
+        if (existingContent) {
+          result.updated.push(destPath);
+          opts.log?.info(
+            "Updated %s skill at %s (content differed — local edits, if any, were overwritten)",
+            name,
+            destPath,
+          );
+        } else {
+          result.written.push(destPath);
+          opts.log?.info("Installed %s skill at %s", name, destPath);
+        }
+      }
+    }
+  } finally {
+    try {
+      rmSync(stagingDir, { recursive: true, force: true });
+    } catch {
+      // Cleanup is best-effort.
+    }
+  }
+
+  return result;
+}

--- a/apps/web/src/lib/cli-skills.ts
+++ b/apps/web/src/lib/cli-skills.ts
@@ -41,34 +41,88 @@ const SKILL_FILE = "SKILL.md";
 
 /** A single coding agent's global skills folder. */
 export interface SkillTarget {
-  /** Coding agent ID (matches AGENT_CHECKS in setup.ts). */
-  agentId: string;
+  /** Coding agent type (matches `CodingAgentConfig.type`). */
+  agentType: string;
   /** Absolute path to the agent's global skills directory. */
   skillsDir: string;
 }
 
 /**
- * Map a detected coding agent to the global skills directory we ship into.
- *
- * Returns `null` when the agent has no stable global skills convention we're
- * comfortable writing to yet — those land as a TODO so the install/update
- * sync stays Claude-only for now (per the open question in the issue spec).
- *
- *   - `claude-code` → `~/.claude/skills/` (matches discoverClaudeSkills in
- *     packages/coding-agent/src/adapters/claude-code.ts).
- *   - `codex` / `opencode` → TODO. Both adapters scan multiple directories
- *     (`~/.codex/skills/` for Codex; a 6-tier resolution order including
- *     `~/.config/opencode/skills/` for OpenCode), and we'd rather wait until
- *     someone validates an end-to-end flow than guess at the canonical
- *     "shipped skills" home for those agents.
+ * Coding agent identity — just the bits `resolveSkillTargets` needs. Mirrors
+ * the relevant fields of `CodingAgentDefinition` from state.ts so callers can
+ * pass `loadSettings().codingAgents` directly without re-shaping it.
  */
-export function resolveSkillTarget(agentId: string, home: string = homedir()): SkillTarget | null {
-  switch (agentId) {
+export interface SkillAgent {
+  /** Stable type discriminator (e.g. `claude-code`, `codex`, `opencode`). */
+  type: string;
+}
+
+/**
+ * Map a coding agent type to the global skills directory we ship into. Each
+ * destination matches the *highest-priority global* directory the agent's
+ * adapter scans in `packages/coding-agent/src/adapters/<agent>.ts`, so that
+ * shipped skills override anything else the user has at the system level.
+ *
+ *   - `claude-code` → `~/.claude/skills/`
+ *     (claude-code.ts::discoverClaudeSkills)
+ *   - `codex` / `openai-codex` → `${CODEX_HOME}/skills/` (default
+ *     `~/.codex/skills/`; `CODEX_HOME` env override honored to match the
+ *     adapter)
+ *   - `gemini-cli` → `~/.gemini/skills/`
+ *   - `opencode` → `~/.config/opencode/skills/` — OpenCode reads from a
+ *     6-tier list and `.config/opencode/skills` is the *highest-priority*
+ *     global entry (project-level dirs aside). It also reads from
+ *     `~/.claude/skills/` (lower priority), so a user with both Claude Code
+ *     and OpenCode enabled will see the skills via either path.
+ *
+ * Returns `null` for agent types that have no defined global skills
+ * directory (e.g. `cursor-cli`, which doesn't expose a `listSkills` method).
+ */
+export function resolveSkillTarget(
+  agentType: string,
+  home: string = homedir(),
+): SkillTarget | null {
+  switch (agentType) {
     case "claude-code":
-      return { agentId, skillsDir: join(home, ".claude", "skills") };
+      return { agentType, skillsDir: join(home, ".claude", "skills") };
+    case "codex":
+    case "openai-codex": {
+      const codexHome = process.env.CODEX_HOME ?? join(home, ".codex");
+      return { agentType, skillsDir: join(codexHome, "skills") };
+    }
+    case "gemini-cli":
+      return { agentType, skillsDir: join(home, ".gemini", "skills") };
+    case "opencode":
+      return { agentType, skillsDir: join(home, ".config", "opencode", "skills") };
     default:
+      // `cursor-cli` and any unknown future type fall through to null —
+      // callers treat that as "no destination" rather than a hard error.
       return null;
   }
+}
+
+/**
+ * Resolve write targets for a list of agents, deduplicating destinations.
+ *
+ * Two configured agents can resolve to the same directory (e.g. two
+ * claude-code agents with different IDs but the same `type` both map to
+ * `~/.claude/skills/`). We dedupe so the (skill, target) loop doesn't write
+ * the same file twice on each boot.
+ */
+export function resolveSkillTargets(
+  agents: readonly SkillAgent[],
+  home: string = homedir(),
+): SkillTarget[] {
+  const seen = new Set<string>();
+  const out: SkillTarget[] = [];
+  for (const agent of agents) {
+    const target = resolveSkillTarget(agent.type, home);
+    if (!target) continue;
+    if (seen.has(target.skillsDir)) continue;
+    seen.add(target.skillsDir);
+    out.push(target);
+  }
+  return out;
 }
 
 /**
@@ -141,8 +195,13 @@ export interface InstallSkillsResult {
 interface InstallSkillsOptions {
   /** Override $HOME (test-only — production callers should leave unset). */
   home?: string;
-  /** Detected coding agent IDs. Filters which target dirs we write to. */
-  agentIds: readonly string[];
+  /**
+   * Enabled coding agents from `loadSettings().codingAgents`. We dispatch on
+   * `type`, not `id`, because users can configure several agents of the
+   * same type (e.g. two `claude-code` agents with different labels) and a
+   * custom `id` doesn't change the on-disk skills directory layout.
+   */
+  agents: readonly SkillAgent[];
   /**
    * Optional logger for visibility into write/update/skip decisions. Pino-
    * compatible signature so we can pass `createLogger(...)` from setup.ts
@@ -155,18 +214,17 @@ interface InstallSkillsOptions {
 }
 
 /**
- * Sync the CLI-shipped skills into each detected agent's global skills dir.
+ * Sync the CLI-shipped skills into each enabled agent's global skills dir.
  *
  * Steps:
  *   1. Resolve a band binary — abort cleanly if none is available.
- *   2. Build the list of write targets from the detected agents.
+ *   2. Build the list of (deduplicated) write targets from `opts.agents`.
  *   3. Run `band generate-skills` into a temp dir.
  *   4. For each (skill, target), compare against the destination and write
  *      only when content differs.
  *
- * No-op (returns an empty-ish result) when no targets resolve — that's the
- * intended behavior when only Codex / OpenCode are installed today, since
- * we haven't wired their destinations yet.
+ * No-op (returns an empty-ish result) when no targets resolve — e.g. only
+ * agents without a known global skills directory are enabled.
  */
 export async function installSkills(opts: InstallSkillsOptions): Promise<InstallSkillsResult> {
   const result: InstallSkillsResult = {
@@ -177,9 +235,7 @@ export async function installSkills(opts: InstallSkillsOptions): Promise<Install
   };
 
   const home = opts.home ?? homedir();
-  const targets = opts.agentIds
-    .map((id) => resolveSkillTarget(id, home))
-    .filter((t): t is SkillTarget => t !== null);
+  const targets = resolveSkillTargets(opts.agents, home);
 
   if (targets.length === 0) {
     return result;

--- a/apps/web/src/lib/cli-skills.ts
+++ b/apps/web/src/lib/cli-skills.ts
@@ -21,7 +21,9 @@
 
 import { execFile } from "node:child_process";
 import {
+  accessSync,
   existsSync,
+  constants as fsConstants,
   mkdirSync,
   mkdtempSync,
   readFileSync,
@@ -31,7 +33,7 @@ import {
 } from "node:fs";
 import { homedir, tmpdir } from "node:os";
 import { dirname, join } from "node:path";
-import { getInstallSkillsDir } from "@band-app/coding-agent";
+import { getDefaultAgentBinary, getInstallSkillsDir } from "@band-app/coding-agent";
 import { findCliBinary } from "./cli";
 import { whichBinary } from "./process-utils";
 
@@ -56,15 +58,65 @@ export interface SkillTarget {
 export interface SkillAgent {
   /** Stable type discriminator (e.g. `claude-code`, `codex`, `opencode`). */
   type: string;
+  /**
+   * Optional explicit path to the agent's executable, mirroring
+   * `CodingAgentDefinition.command`. When set we trust this over the
+   * adapter's default binary name — letting users with custom installs
+   * (Homebrew Cellar, NixOS profiles, npm prefix overrides) keep
+   * skills syncing without us re-implementing every package manager's
+   * resolution rules.
+   */
+  command?: string;
 }
 
 /**
- * Resolve write targets for a list of agents, deduplicating destinations.
+ * Verify a coding agent is *actually installed* on this host. Presence in
+ * `settings.codingAgents` only proves the agent was detected at some past
+ * setup run — the user may have uninstalled the binary since (e.g. removed
+ * `claude` while keeping the entry around). Writing skills to that agent's
+ * global directory after the fact would just litter the user's home dir.
+ *
+ *   1. If the agent definition carries an explicit `command`, check the
+ *      file is executable.
+ *   2. Otherwise look up the adapter's default binary name (owned by each
+ *      adapter — see `packages/coding-agent/src/install-skills.ts`) and
+ *      probe PATH via `whichBinary`.
+ *
+ * Returns `false` when neither path resolves, so callers can skip the
+ * agent. Adapter types without a default binary (e.g. `cursor-cli`) also
+ * return `false` — we'd have nothing to install for them anyway.
+ */
+export async function isAgentInstalled(agent: SkillAgent): Promise<boolean> {
+  if (agent.command) {
+    try {
+      accessSync(agent.command, fsConstants.X_OK);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  const binaryName = await getDefaultAgentBinary(agent.type);
+  if (!binaryName) return false;
+
+  const found = await whichBinary(binaryName);
+  return found !== null;
+}
+
+/**
+ * Resolve write targets for the *enabled* agents in the input list,
+ * deduplicating destinations.
+ *
+ * "Enabled" here means: present in `settings.codingAgents` AND the agent's
+ * binary is actually reachable on this host (see `isAgentInstalled`).
+ * Stale entries — those whose binary has been uninstalled since detection
+ * but whose record lingers in settings.json — are skipped so we don't
+ * keep refreshing skills for a coding agent the user no longer uses.
  *
  * Each agent's skills directory comes from its adapter (see
  * `packages/coding-agent/src/install-skills.ts` and the
  * `get<Agent>InstallSkillsDir` exports next to each adapter's discovery
- * logic) — this layer only orchestrates the lookup and dedupe pass.
+ * logic) — this layer only orchestrates lookup, install-check, and dedupe.
  *
  * Two configured agents can resolve to the same directory (e.g. two
  * claude-code agents with different IDs but the same `type` both map to
@@ -79,6 +131,7 @@ export async function resolveSkillTargets(
   const seen = new Set<string>();
   const out: SkillTarget[] = [];
   for (const agent of agents) {
+    if (!(await isAgentInstalled(agent))) continue;
     const skillsDir = await getInstallSkillsDir(agent.type, home);
     if (!skillsDir) continue;
     if (seen.has(skillsDir)) continue;

--- a/apps/web/src/lib/setup.ts
+++ b/apps/web/src/lib/setup.ts
@@ -1,5 +1,6 @@
 import { createLogger } from "@band-app/logger";
 import { checkCli, installCli } from "./cli";
+import { installSkills } from "./cli-skills";
 import { checkHooks, installHooks } from "./hooks";
 import { whichBinary } from "./process-utils";
 import { type CodingAgentDefinition, loadSettings, saveSettings } from "./state";
@@ -25,12 +26,16 @@ const AGENT_CHECKS: { id: string; type: string; label: string; binary: string }[
  * 2. Ensure `codingAgents` is populated with detected agent CLIs.
  * 3. Ensure `notifications.soundOnNeedsAttention` defaults to `true`.
  * 4. Ensure Claude Code hooks are installed.
+ * 5. Sync the CLI-shipped skills into each detected agent's global skills
+ *    directory so a fresh install / auto-update lands the latest SKILL.md
+ *    files automatically (issue: sync-cli-skills).
  */
 export async function runFirstTimeSetup(): Promise<void> {
   await ensureCliInstalled();
   await ensureDefaultCodingAgents();
   ensureNotificationDefaults();
   await ensureClaudeHooks();
+  await ensureSkillsInstalled();
 }
 
 /**
@@ -138,5 +143,41 @@ async function ensureClaudeHooks(): Promise<void> {
       "Failed to install Claude Code hooks: %s",
       err instanceof Error ? err.message : String(err),
     );
+  }
+}
+
+/**
+ * Sync the bundled CLI skills into each detected agent's global skills dir.
+ *
+ * `installSkills` is idempotent: it only writes when the destination is
+ * missing or has different content. After an electron-updater install, the
+ * app relaunches → bootstrap → web server boot → `runFirstTimeSetup`, so
+ * this same step also handles the post-update refresh — no separate update
+ * hook is needed. Failures are logged but don't block boot, matching the
+ * rest of the setup pipeline.
+ */
+async function ensureSkillsInstalled(): Promise<void> {
+  try {
+    const settings = loadSettings();
+    const agentIds = (settings.codingAgents ?? []).map((a) => a.id);
+    if (agentIds.length === 0) {
+      // Nothing detected → nothing to sync. The next boot after an agent is
+      // installed will pick it up.
+      return;
+    }
+
+    const result = await installSkills({ agentIds, log });
+    const wrote = result.written.length + result.updated.length;
+    if (wrote > 0) {
+      log.info(
+        "Synced CLI skills (%d written, %d updated, %d unchanged, %d skipped)",
+        result.written.length,
+        result.updated.length,
+        result.unchanged.length,
+        result.skipped.length,
+      );
+    }
+  } catch (err) {
+    log.warn("Failed to sync CLI skills: %s", err instanceof Error ? err.message : String(err));
   }
 }

--- a/apps/web/src/lib/setup.ts
+++ b/apps/web/src/lib/setup.ts
@@ -159,14 +159,14 @@ async function ensureClaudeHooks(): Promise<void> {
 async function ensureSkillsInstalled(): Promise<void> {
   try {
     const settings = loadSettings();
-    const agentIds = (settings.codingAgents ?? []).map((a) => a.id);
-    if (agentIds.length === 0) {
+    const agents = settings.codingAgents ?? [];
+    if (agents.length === 0) {
       // Nothing detected → nothing to sync. The next boot after an agent is
       // installed will pick it up.
       return;
     }
 
-    const result = await installSkills({ agentIds, log });
+    const result = await installSkills({ agents, log });
     const wrote = result.written.length + result.updated.length;
     if (wrote > 0) {
       log.info(

--- a/apps/web/src/lib/setup.ts
+++ b/apps/web/src/lib/setup.ts
@@ -158,15 +158,11 @@ async function ensureClaudeHooks(): Promise<void> {
  */
 async function ensureSkillsInstalled(): Promise<void> {
   try {
-    const settings = loadSettings();
-    const agents = settings.codingAgents ?? [];
-    if (agents.length === 0) {
-      // Nothing detected → nothing to sync. The next boot after an agent is
-      // installed will pick it up.
-      return;
-    }
-
-    const result = await installSkills({ agents, log });
+    // installSkills reads `settings.codingAgents` itself and filters to
+    // agents whose binary is actually reachable, so we don't repeat that
+    // logic here. Keeping the trampoline so the boot pipeline stays
+    // uniform with the other `ensureXxx` steps.
+    const result = await installSkills({ log });
     const wrote = result.written.length + result.updated.length;
     if (wrote > 0) {
       log.info(

--- a/apps/web/tests/cli-skills.test.ts
+++ b/apps/web/tests/cli-skills.test.ts
@@ -113,12 +113,16 @@ describe.skipIf(!bandBinaryReachable())("CLI skills sync (ensureSkillsInstalled)
     // Pre-seed settings.json with `claude-code` already in `codingAgents`
     // so `ensureDefaultCodingAgents` doesn't try to detect via `whichBinary`
     // (which would depend on the host) and so `ensureSkillsInstalled` has a
-    // target agent to write to.
+    // target agent to write to. We pin `command: /bin/sh` so the new
+    // "binary actually reachable" check passes regardless of whether the
+    // real `claude` CLI is installed on the test host (CI may not have it).
     writeFileSync(
       join(bandDir, "settings.json"),
       JSON.stringify(
         {
-          codingAgents: [{ id: "claude-code", type: "claude-code", label: "Claude Code" }],
+          codingAgents: [
+            { id: "claude-code", type: "claude-code", label: "Claude Code", command: "/bin/sh" },
+          ],
           defaultCodingAgent: "claude-code",
           // Pre-set notifications so ensureNotificationDefaults is a no-op.
           notifications: { soundOnNeedsAttention: true },
@@ -217,18 +221,18 @@ describe.skipIf(!bandBinaryReachable())("CLI skills sync (ensureSkillsInstalled)
   });
 
   it("installs into every enabled agent's global skills dir (claude, codex, opencode, gemini)", async () => {
-    // Re-seed settings with all four agent types enabled. We bypass
-    // runFirstTimeSetup's CLI / hooks side-effects here and call installSkills
-    // directly so the test focuses on the multi-target fan-out — those side
-    // effects are exercised by the suite's other cases.
+    // Re-seed settings with all four agent types enabled. We pin
+    // `command: /bin/sh` so the install-check passes on CI nodes that
+    // don't have the real agent binaries installed. The agent's *type*
+    // is what drives skill-dir resolution, not the binary.
     const { installSkills } = await import("../src/lib/cli-skills");
     const result = await installSkills({
       home: process.env.HOME!,
       agents: [
-        { type: "claude-code" },
-        { type: "codex" },
-        { type: "opencode" },
-        { type: "gemini-cli" },
+        { type: "claude-code", command: "/bin/sh" },
+        { type: "codex", command: "/bin/sh" },
+        { type: "opencode", command: "/bin/sh" },
+        { type: "gemini-cli", command: "/bin/sh" },
       ],
     });
 
@@ -260,7 +264,10 @@ describe.skipIf(!bandBinaryReachable())("CLI skills sync (ensureSkillsInstalled)
       // Two claude-code agents (e.g. user has personal + work setups) both
       // point at ~/.claude/skills — we should only write once per skill, not
       // twice.
-      agents: [{ type: "claude-code" }, { type: "claude-code" }],
+      agents: [
+        { type: "claude-code", command: "/bin/sh" },
+        { type: "claude-code", command: "/bin/sh" },
+      ],
     });
 
     expect(result.written.length).toBe(SKILL_NAMES.length);
@@ -274,7 +281,7 @@ describe.skipIf(!bandBinaryReachable())("CLI skills sync (ensureSkillsInstalled)
       const { installSkills } = await import("../src/lib/cli-skills");
       await installSkills({
         home: process.env.HOME!,
-        agents: [{ type: "codex" }],
+        agents: [{ type: "codex", command: "/bin/sh" }],
       });
 
       for (const name of SKILL_NAMES) {
@@ -291,11 +298,55 @@ describe.skipIf(!bandBinaryReachable())("CLI skills sync (ensureSkillsInstalled)
     }
   });
 
+  it("skips agents whose configured command no longer exists on disk", async () => {
+    // Simulates a stale entry in settings.codingAgents: the user uninstalled
+    // their Codex CLI, but its definition (with a now-broken `command` path)
+    // is still in settings.json. We must not touch ~/.codex/skills/.
+    const { installSkills } = await import("../src/lib/cli-skills");
+    const result = await installSkills({
+      home: process.env.HOME!,
+      agents: [
+        { type: "claude-code", command: "/bin/sh" },
+        { type: "codex", command: "/this/path/does/not/exist/codex" },
+      ],
+    });
+
+    expect(existsSync(join(process.env.HOME!, ".claude", "skills", "band", "SKILL.md"))).toBe(true);
+    expect(existsSync(join(process.env.HOME!, ".codex", "skills", "band", "SKILL.md"))).toBe(false);
+    expect(result.written.length).toBe(SKILL_NAMES.length); // 4 — only claude-code wrote
+  });
+
+  it("skips agents with no command override when the default binary isn't on PATH", async () => {
+    // Empty PATH guarantees `whichBinary` can't find anything, mirroring a
+    // host where the user genuinely doesn't have the agent installed.
+    const originalPath = process.env.PATH;
+    process.env.PATH = "";
+    try {
+      const { installSkills } = await import("../src/lib/cli-skills");
+      const result = await installSkills({
+        home: process.env.HOME!,
+        // No `command` set — install-check must fall back to PATH lookup.
+        // With PATH empty, `whichBinary("gemini")` should return null and
+        // we should write zero skills.
+        agents: [{ type: "gemini-cli" }],
+      });
+
+      expect(result.written).toEqual([]);
+      expect(result.updated).toEqual([]);
+      expect(existsSync(join(process.env.HOME!, ".gemini", "skills", "band", "SKILL.md"))).toBe(
+        false,
+      );
+    } finally {
+      if (originalPath !== undefined) process.env.PATH = originalPath;
+      else delete process.env.PATH;
+    }
+  });
+
   it("returns no targets for agent types without a known skills dir (cursor-cli)", async () => {
     const { installSkills } = await import("../src/lib/cli-skills");
     const result = await installSkills({
       home: process.env.HOME!,
-      agents: [{ type: "cursor-cli" }],
+      agents: [{ type: "cursor-cli", command: "/bin/sh" }],
     });
 
     expect(result.written).toEqual([]);

--- a/apps/web/tests/cli-skills.test.ts
+++ b/apps/web/tests/cli-skills.test.ts
@@ -1,0 +1,218 @@
+/**
+ * Integration tests for the CLI skills sync that runs as part of
+ * `runFirstTimeSetup` (apps/web/src/lib/setup.ts → ensureSkillsInstalled).
+ *
+ * Black-box: drives the public `runFirstTimeSetup` entry point with a
+ * sandboxed $HOME / $BAND_HOME, then asserts on the filesystem state of
+ * `~/.claude/skills/<name>/SKILL.md`. No mocks — the test relies on a real
+ * `band` binary being reachable through `findBandBinary` (the symlink at
+ * /usr/local/bin/band, the desktop sidecar, or a cargo build output). When
+ * no binary can be located the suite is skipped rather than failing, so CI
+ * nodes without a built CLI don't go red.
+ */
+
+import { execFileSync } from "node:child_process";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  realpathSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { findBandBinary } from "../src/lib/cli-skills";
+import { closeDb } from "../src/lib/db/connection";
+
+const SKILL_NAMES = ["band", "band-chat", "band-terminal", "band-browser"] as const;
+
+/**
+ * Reuse the same resolver the production code uses so we exercise the real
+ * binary (the symlink at /usr/local/bin/band, the desktop sidecar, or the
+ * cargo build output — in that order). We can't just rely on PATH because
+ * `pnpm exec vitest` prepends `node_modules/.bin/`, where the workspace
+ * `band` shim refuses to run if the cargo build hasn't been produced.
+ */
+let bandBinary: string | null = null;
+
+/**
+ * Snapshot of what `band generate-skills` would emit *right now*. Computed
+ * once in `beforeAll` and reused across tests so we can assert that the sync
+ * step's output matches the CLI's output byte-for-byte.
+ */
+let expectedSkills: Map<(typeof SKILL_NAMES)[number], Buffer> | null = null;
+
+beforeAll(async () => {
+  bandBinary = await findBandBinary();
+  if (!bandBinary) return;
+  const stagingDir = mkdtempSync(join(tmpdir(), "band-skills-expected-"));
+  try {
+    execFileSync(bandBinary, ["generate-skills", "--output-dir", stagingDir], {
+      encoding: "utf-8",
+    });
+    const map = new Map<(typeof SKILL_NAMES)[number], Buffer>();
+    for (const name of SKILL_NAMES) {
+      const path = join(stagingDir, name, "SKILL.md");
+      map.set(name, readFileSync(path));
+    }
+    expectedSkills = map;
+  } finally {
+    rmSync(stagingDir, { recursive: true, force: true });
+  }
+});
+
+// `describe.skipIf` is evaluated when the test file is imported, before
+// `beforeAll` resolves `bandBinary`. Probe synchronously here using the same
+// `/usr/local/bin/band` shortcut that `findBandBinary` tries first, plus a
+// look at the cargo build output. If neither is present we skip the suite —
+// running on a CI node without a built CLI shouldn't go red.
+function bandBinaryReachable(): boolean {
+  try {
+    statSync("/usr/local/bin/band");
+    return true;
+  } catch {
+    // Fall through.
+  }
+  // apps/cli/target/{release,debug}/band — the cargo build output. The
+  // resolver in cli.ts walks several roots; we only check the most likely
+  // one here since this is just a "should we run?" gate.
+  const repoCandidates = [
+    join(import.meta.dirname, "..", "..", "cli", "target", "release", "band"),
+    join(import.meta.dirname, "..", "..", "cli", "target", "debug", "band"),
+  ];
+  return repoCandidates.some((p) => {
+    try {
+      statSync(p);
+      return true;
+    } catch {
+      return false;
+    }
+  });
+}
+
+describe.skipIf(!bandBinaryReachable())("CLI skills sync (ensureSkillsInstalled)", () => {
+  let tmp: string;
+  let originalBandHome: string | undefined;
+  let originalHome: string | undefined;
+
+  beforeEach(() => {
+    if (!bandBinary) return; // beforeAll couldn't resolve it; tests will skip via the guard below.
+    tmp = realpathSync(mkdtempSync(join(tmpdir(), "band-skills-test-")));
+
+    // Pre-create $HOME and $BAND_HOME inside the sandbox so neither
+    // `bandHome()` nor `homedir()` leak into the real user's directories.
+    const home = join(tmp, "home");
+    mkdirSync(home, { recursive: true });
+    const bandDir = join(home, ".band");
+    mkdirSync(bandDir, { recursive: true });
+
+    // Pre-seed settings.json with `claude-code` already in `codingAgents`
+    // so `ensureDefaultCodingAgents` doesn't try to detect via `whichBinary`
+    // (which would depend on the host) and so `ensureSkillsInstalled` has a
+    // target agent to write to.
+    writeFileSync(
+      join(bandDir, "settings.json"),
+      JSON.stringify(
+        {
+          codingAgents: [{ id: "claude-code", type: "claude-code", label: "Claude Code" }],
+          defaultCodingAgent: "claude-code",
+          // Pre-set notifications so ensureNotificationDefaults is a no-op.
+          notifications: { soundOnNeedsAttention: true },
+        },
+        null,
+        2,
+      ),
+      "utf-8",
+    );
+
+    originalBandHome = process.env.BAND_HOME;
+    originalHome = process.env.HOME;
+    process.env.BAND_HOME = bandDir;
+    process.env.HOME = home;
+  });
+
+  afterEach(() => {
+    closeDb();
+    if (originalBandHome !== undefined) process.env.BAND_HOME = originalBandHome;
+    else delete process.env.BAND_HOME;
+    if (originalHome !== undefined) process.env.HOME = originalHome;
+    else delete process.env.HOME;
+    if (tmp) rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it("writes all four CLI skills into ~/.claude/skills/<name>/SKILL.md on first run", async () => {
+    expect(bandBinary, "band binary must be resolvable for this suite").not.toBeNull();
+    const { runFirstTimeSetup } = await import("../src/lib/setup");
+    await runFirstTimeSetup();
+
+    const skillsDir = join(process.env.HOME!, ".claude", "skills");
+    for (const name of SKILL_NAMES) {
+      const path = join(skillsDir, name, "SKILL.md");
+      expect(existsSync(path), `expected ${path} to exist`).toBe(true);
+
+      const actual = readFileSync(path);
+      const expected = expectedSkills!.get(name)!;
+      expect(actual.equals(expected), `${name} content matches \`band generate-skills\``).toBe(
+        true,
+      );
+    }
+  });
+
+  it("is a no-op on the second invocation when nothing has changed", async () => {
+    const { runFirstTimeSetup } = await import("../src/lib/setup");
+    await runFirstTimeSetup();
+
+    const skillsDir = join(process.env.HOME!, ".claude", "skills");
+    const path = join(skillsDir, "band", "SKILL.md");
+    const beforeStat = statSync(path);
+    const beforeMtime = beforeStat.mtimeMs;
+    const beforeContent = readFileSync(path);
+
+    // Avoid an mtime collision on filesystems with second-level resolution.
+    await new Promise((r) => setTimeout(r, 1100));
+
+    await runFirstTimeSetup();
+
+    const afterStat = statSync(path);
+    expect(readFileSync(path).equals(beforeContent), "content is unchanged").toBe(true);
+    expect(
+      afterStat.mtimeMs,
+      "mtime is preserved when content hasn't changed (skipped, not rewritten)",
+    ).toBe(beforeMtime);
+  });
+
+  it("overwrites a destination whose content drifted from the shipped version", async () => {
+    const { runFirstTimeSetup } = await import("../src/lib/setup");
+
+    // Pre-create a tampered SKILL.md before the first sync.
+    const skillsDir = join(process.env.HOME!, ".claude", "skills");
+    const target = join(skillsDir, "band", "SKILL.md");
+    mkdirSync(join(skillsDir, "band"), { recursive: true });
+    writeFileSync(target, "# stale local copy that should be overwritten\n", "utf-8");
+
+    await runFirstTimeSetup();
+
+    const expected = expectedSkills!.get("band")!;
+    expect(
+      readFileSync(target).equals(expected),
+      "tampered file replaced with shipped version",
+    ).toBe(true);
+  });
+
+  it("does not write outside the sandboxed HOME", async () => {
+    // Structural guard: if HOME ever stopped pointing at the test tmpdir we
+    // could pollute the developer's real ~/.claude/skills. We can't safely
+    // inspect the user's HOME from inside the test, so we instead pin the
+    // override and verify the destination lands under it.
+    const { runFirstTimeSetup } = await import("../src/lib/setup");
+    await runFirstTimeSetup();
+
+    expect(process.env.HOME!.startsWith(tmp), "HOME points inside the test tmpdir").toBe(true);
+    const path = join(process.env.HOME!, ".claude", "skills", "band", "SKILL.md");
+    expect(existsSync(path)).toBe(true);
+  });
+});

--- a/apps/web/tests/cli-skills.test.ts
+++ b/apps/web/tests/cli-skills.test.ts
@@ -342,6 +342,43 @@ describe.skipIf(!bandBinaryReachable())("CLI skills sync (ensureSkillsInstalled)
     }
   });
 
+  it("reads settings.codingAgents itself when no agents arg is passed", async () => {
+    // The default settings.json seeded by beforeEach has a single
+    // claude-code agent with `command: /bin/sh`. Calling installSkills
+    // with no `agents` override should still write the four skills into
+    // ~/.claude/skills/ — proving the lib reads settings on its own.
+    const { installSkills } = await import("../src/lib/cli-skills");
+    const result = await installSkills({ home: process.env.HOME! });
+
+    const skillsDir = join(process.env.HOME!, ".claude", "skills");
+    for (const name of SKILL_NAMES) {
+      expect(existsSync(join(skillsDir, name, "SKILL.md")), `${name} written`).toBe(true);
+    }
+    expect(result.written.length).toBe(SKILL_NAMES.length);
+  });
+
+  it("writes nothing when settings.codingAgents is empty (no enabled agents)", async () => {
+    // Overwrite settings.json with an empty codingAgents array, then
+    // call installSkills with no override. The lib should treat
+    // "no enabled agents" as "no work" — even though a band binary IS
+    // reachable.
+    const bandDir = process.env.BAND_HOME!;
+    writeFileSync(
+      join(bandDir, "settings.json"),
+      JSON.stringify({ codingAgents: [] }, null, 2),
+      "utf-8",
+    );
+
+    const { installSkills } = await import("../src/lib/cli-skills");
+    const result = await installSkills({ home: process.env.HOME! });
+
+    expect(result.written).toEqual([]);
+    expect(result.updated).toEqual([]);
+    expect(existsSync(join(process.env.HOME!, ".claude", "skills", "band", "SKILL.md"))).toBe(
+      false,
+    );
+  });
+
   it("returns no targets for agent types without a known skills dir (cursor-cli)", async () => {
     const { installSkills } = await import("../src/lib/cli-skills");
     const result = await installSkills({

--- a/apps/web/tests/cli-skills.test.ts
+++ b/apps/web/tests/cli-skills.test.ts
@@ -215,4 +215,92 @@ describe.skipIf(!bandBinaryReachable())("CLI skills sync (ensureSkillsInstalled)
     const path = join(process.env.HOME!, ".claude", "skills", "band", "SKILL.md");
     expect(existsSync(path)).toBe(true);
   });
+
+  it("installs into every enabled agent's global skills dir (claude, codex, opencode, gemini)", async () => {
+    // Re-seed settings with all four agent types enabled. We bypass
+    // runFirstTimeSetup's CLI / hooks side-effects here and call installSkills
+    // directly so the test focuses on the multi-target fan-out — those side
+    // effects are exercised by the suite's other cases.
+    const { installSkills } = await import("../src/lib/cli-skills");
+    const result = await installSkills({
+      home: process.env.HOME!,
+      agents: [
+        { type: "claude-code" },
+        { type: "codex" },
+        { type: "opencode" },
+        { type: "gemini-cli" },
+      ],
+    });
+
+    const home = process.env.HOME!;
+    const expectedDirs = [
+      join(home, ".claude", "skills"),
+      join(home, ".codex", "skills"),
+      join(home, ".config", "opencode", "skills"),
+      join(home, ".gemini", "skills"),
+    ];
+    for (const dir of expectedDirs) {
+      for (const name of SKILL_NAMES) {
+        const path = join(dir, name, "SKILL.md");
+        expect(existsSync(path), `expected ${path} to exist`).toBe(true);
+        expect(readFileSync(path).equals(expectedSkills!.get(name)!)).toBe(true);
+      }
+    }
+
+    // 4 agents × 4 skills = 16 freshly written files (each test gets a new
+    // tmp HOME via beforeEach, so nothing should already exist).
+    expect(result.written.length).toBe(16);
+    expect(result.unchanged.length).toBe(0);
+  });
+
+  it("dedupes destinations when multiple agents resolve to the same dir", async () => {
+    const { installSkills } = await import("../src/lib/cli-skills");
+    const result = await installSkills({
+      home: process.env.HOME!,
+      // Two claude-code agents (e.g. user has personal + work setups) both
+      // point at ~/.claude/skills — we should only write once per skill, not
+      // twice.
+      agents: [{ type: "claude-code" }, { type: "claude-code" }],
+    });
+
+    expect(result.written.length).toBe(SKILL_NAMES.length);
+  });
+
+  it("honours $CODEX_HOME when set so codex skills follow the override", async () => {
+    const customCodexHome = join(tmp, "custom-codex");
+    const originalCodexHome = process.env.CODEX_HOME;
+    process.env.CODEX_HOME = customCodexHome;
+    try {
+      const { installSkills } = await import("../src/lib/cli-skills");
+      await installSkills({
+        home: process.env.HOME!,
+        agents: [{ type: "codex" }],
+      });
+
+      for (const name of SKILL_NAMES) {
+        const path = join(customCodexHome, "skills", name, "SKILL.md");
+        expect(existsSync(path), `expected ${path} to exist under $CODEX_HOME`).toBe(true);
+      }
+      // And nothing should have landed under the default ~/.codex/skills/.
+      expect(existsSync(join(process.env.HOME!, ".codex", "skills", "band", "SKILL.md"))).toBe(
+        false,
+      );
+    } finally {
+      if (originalCodexHome !== undefined) process.env.CODEX_HOME = originalCodexHome;
+      else delete process.env.CODEX_HOME;
+    }
+  });
+
+  it("returns no targets for agent types without a known skills dir (cursor-cli)", async () => {
+    const { installSkills } = await import("../src/lib/cli-skills");
+    const result = await installSkills({
+      home: process.env.HOME!,
+      agents: [{ type: "cursor-cli" }],
+    });
+
+    expect(result.written).toEqual([]);
+    expect(result.updated).toEqual([]);
+    expect(result.unchanged).toEqual([]);
+    expect(result.skipped).toEqual([]);
+  });
 });

--- a/apps/web/tests/slash-commands.test.ts
+++ b/apps/web/tests/slash-commands.test.ts
@@ -11,6 +11,18 @@ const PROJECT_ROOT = join(import.meta.dirname, "..");
 const FAKE_AGENT_PATH = join(import.meta.dirname, "fake-agent.mjs");
 const DEFAULT_TOKEN = "slash-test-token";
 
+/**
+ * Skills the server's `ensureSkillsInstalled` step (apps/web/src/lib/cli-skills.ts)
+ * lays down on every boot for any HOME that has Claude Code in its codingAgents
+ * settings. We filter these out of the slash-commands assertions so the tests
+ * remain focused on the skills *they* seed.
+ */
+const AUTO_INSTALLED_SKILL_NAMES = new Set(["band", "band-chat", "band-terminal", "band-browser"]);
+
+function withoutAutoInstalled<T extends { name: string }>(skills: T[]): T[] {
+  return skills.filter((s) => !AUTO_INSTALLED_SKILL_NAMES.has(s.name));
+}
+
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
@@ -248,14 +260,15 @@ describe("skills.list — with seeded global skills", () => {
     }>(res);
 
     expect(data.skills).toBeInstanceOf(Array);
-    expect(data.skills.length).toBe(2); // no-description skill is excluded
+    const seeded = withoutAutoInstalled(data.skills);
+    expect(seeded.length).toBe(2); // no-description skill is excluded
 
-    const commit = data.skills.find((s) => s.name === "commit");
+    const commit = seeded.find((s) => s.name === "commit");
     expect(commit).toBeDefined();
     expect(commit!.description).toBe("Create a git commit with a message.");
     expect(commit!.argumentHint).toBe("-m <message>");
 
-    const reviewPr = data.skills.find((s) => s.name === "review-pr");
+    const reviewPr = seeded.find((s) => s.name === "review-pr");
     expect(reviewPr).toBeDefined();
     expect(reviewPr!.description).toBe("Review a GitHub pull request.");
     expect(reviewPr!.argumentHint).toBe("<pr-url>");
@@ -269,7 +282,7 @@ describe("skills.list — with seeded global skills", () => {
       skills: Array<{ name: string }>;
     }>(res);
 
-    const names = data.skills.map((s) => s.name);
+    const names = withoutAutoInstalled(data.skills).map((s) => s.name);
     expect(names).toEqual(["commit", "review-pr"]);
   });
 });
@@ -295,7 +308,7 @@ describe("skills.list — no skills directory", () => {
     rmSync(tmpHome, { recursive: true, force: true });
   });
 
-  it("returns empty array when skills directory does not exist", async () => {
+  it("returns empty array (ignoring auto-installed band skills) when no skills are seeded", async () => {
     const res = await trpcQuery(server.url, "skills.list", {
       workspaceId: "testproject-main",
     });
@@ -305,7 +318,9 @@ describe("skills.list — no skills directory", () => {
       skills: Array<{ name: string; description: string; argumentHint?: string }>;
     }>(res);
 
-    expect(data.skills).toEqual([]);
+    // ensureSkillsInstalled will have populated the four band-* skills here;
+    // for this test we only care that no *other* skills are present.
+    expect(withoutAutoInstalled(data.skills)).toEqual([]);
   });
 });
 
@@ -382,7 +397,7 @@ describe("skills.list — project-level skills", () => {
       skills: Array<{ name: string }>;
     }>(res);
 
-    const names = data.skills.map((s) => s.name);
+    const names = withoutAutoInstalled(data.skills).map((s) => s.name);
     expect(names).toEqual(["deploy", "lint"]);
   });
 });

--- a/packages/coding-agent/src/adapters/claude-code.ts
+++ b/packages/coding-agent/src/adapters/claude-code.ts
@@ -957,6 +957,20 @@ function* mapClaudeCodeEvent(
   }
 }
 
+/**
+ * Where freshly-shipped skills (e.g. the band CLI's bundled SKILL.md files,
+ * synced by apps/web/src/lib/cli-skills.ts on every server boot) should be
+ * written. This is the *highest-priority* global directory the discovery
+ * tier above scans, matching the personal-scope path documented at
+ * https://code.claude.com/docs/en/skills.
+ *
+ * Defaults to `homedir()` to mirror `discoverClaudeSkills`. Tests pass an
+ * explicit `home` so they can sandbox the destination.
+ */
+export function getClaudeCodeInstallSkillsDir(home: string = homedir()): string {
+  return join(home, ".claude", "skills");
+}
+
 function discoverClaudeSkills(workspaceDir: string): SkillInfo[] {
   const globalSkillsDir = join(homedir(), ".claude", "skills");
   const projectSkillsDir = join(workspaceDir, ".claude", "skills");

--- a/packages/coding-agent/src/adapters/claude-code.ts
+++ b/packages/coding-agent/src/adapters/claude-code.ts
@@ -958,6 +958,15 @@ function* mapClaudeCodeEvent(
 }
 
 /**
+ * Default executable name for Claude Code. Used by callers (e.g. the
+ * Band web server's first-time setup) to probe whether the agent is
+ * actually reachable on the host before assuming a `claude-code` entry
+ * in `settings.codingAgents` corresponds to a working install. Mirrors
+ * the binary the SDK shells out to (`claude` on PATH).
+ */
+export const CLAUDE_CODE_DEFAULT_BINARY = "claude";
+
+/**
  * Where freshly-shipped skills (e.g. the band CLI's bundled SKILL.md files,
  * synced by apps/web/src/lib/cli-skills.ts on every server boot) should be
  * written. This is the *highest-priority* global directory the discovery

--- a/packages/coding-agent/src/adapters/codex.ts
+++ b/packages/coding-agent/src/adapters/codex.ts
@@ -501,6 +501,9 @@ const CODEX_MODELS: AgentModel[] = [
  *
  * Project-level skills override global ones with the same name.
  */
+/** Default executable name for the Codex CLI. See `setup.ts::AGENT_CHECKS`. */
+export const CODEX_DEFAULT_BINARY = "codex";
+
 /**
  * Where freshly-shipped skills should be written. Codex documents its
  * user-scope skill home as `~/.codex/skills/` (the `.system/` subfolder is

--- a/packages/coding-agent/src/adapters/codex.ts
+++ b/packages/coding-agent/src/adapters/codex.ts
@@ -501,6 +501,21 @@ const CODEX_MODELS: AgentModel[] = [
  *
  * Project-level skills override global ones with the same name.
  */
+/**
+ * Where freshly-shipped skills should be written. Codex documents its
+ * user-scope skill home as `~/.codex/skills/` (the `.system/` subfolder is
+ * reserved for OpenAI-shipped skills shipped with the CLI), with `CODEX_HOME`
+ * env override honored for users who have relocated their Codex config.
+ *
+ * Reads `CODEX_HOME` at call time rather than reusing the module-level
+ * `CODEX_HOME` constant so tests that override the env var get the new
+ * value. See https://developers.openai.com/codex/skills.
+ */
+export function getCodexInstallSkillsDir(home: string = homedir()): string {
+  const codexHome = process.env.CODEX_HOME ?? join(home, ".codex");
+  return join(codexHome, "skills");
+}
+
 function discoverCodexSkills(workspaceDir: string): SkillInfo[] {
   const globalSkillsDir = join(CODEX_HOME, "skills");
   const systemSkillsDir = join(CODEX_HOME, "skills", ".system");

--- a/packages/coding-agent/src/adapters/gemini-cli.ts
+++ b/packages/coding-agent/src/adapters/gemini-cli.ts
@@ -214,6 +214,19 @@ export class GeminiCliAdapter implements CodingAgent {
   }
 }
 
+/**
+ * Where freshly-shipped skills should be written. Gemini CLI's user-scope
+ * skills live at `~/.gemini/skills/` (not affected by workspace trust),
+ * with `~/.agents/skills/` documented as a tool-agnostic alias. We pick
+ * the canonical Gemini path so other tools (like band) sync into the
+ * place Gemini actually scans first.
+ *
+ * See https://geminicli.com/docs/cli/skills/.
+ */
+export function getGeminiCliInstallSkillsDir(home: string = homedir()): string {
+  return join(home, ".gemini", "skills");
+}
+
 function discoverGeminiSkills(workspaceDir: string): SkillInfo[] {
   const globalSkillsDir = join(homedir(), ".gemini", "skills");
   const projectSkillsDir = join(workspaceDir, ".gemini", "skills");

--- a/packages/coding-agent/src/adapters/gemini-cli.ts
+++ b/packages/coding-agent/src/adapters/gemini-cli.ts
@@ -214,6 +214,9 @@ export class GeminiCliAdapter implements CodingAgent {
   }
 }
 
+/** Default executable name for the Gemini CLI. */
+export const GEMINI_CLI_DEFAULT_BINARY = "gemini";
+
 /**
  * Where freshly-shipped skills should be written. Gemini CLI's user-scope
  * skills live at `~/.gemini/skills/` (not affected by workspace trust),

--- a/packages/coding-agent/src/adapters/openai-codex.ts
+++ b/packages/coding-agent/src/adapters/openai-codex.ts
@@ -197,6 +197,13 @@ interface CodexThread {
 const CODEX_HOME = process.env.CODEX_HOME || join(homedir(), ".codex");
 
 /**
+ * Default executable name for the OpenAI-Codex SDK adapter. Same `codex`
+ * binary as the CodexAdapter — the difference is which TS-side adapter
+ * speaks to it.
+ */
+export const OPENAI_CODEX_DEFAULT_BINARY = "codex";
+
+/**
  * Where freshly-shipped skills should be written. The OpenAI-Codex SDK
  * shares Codex CLI's skill home (`~/.codex/skills/`); `CODEX_HOME` is read
  * at call time so test overrides take effect.

--- a/packages/coding-agent/src/adapters/openai-codex.ts
+++ b/packages/coding-agent/src/adapters/openai-codex.ts
@@ -196,6 +196,18 @@ interface CodexThread {
 
 const CODEX_HOME = process.env.CODEX_HOME || join(homedir(), ".codex");
 
+/**
+ * Where freshly-shipped skills should be written. The OpenAI-Codex SDK
+ * shares Codex CLI's skill home (`~/.codex/skills/`); `CODEX_HOME` is read
+ * at call time so test overrides take effect.
+ *
+ * See https://developers.openai.com/codex/skills.
+ */
+export function getOpenAICodexInstallSkillsDir(home: string = homedir()): string {
+  const codexHome = process.env.CODEX_HOME ?? join(home, ".codex");
+  return join(codexHome, "skills");
+}
+
 function discoverCodexSkills(workspaceDir: string): SkillInfo[] {
   const globalSkillsDir = join(CODEX_HOME, "skills");
   const systemSkillsDir = join(CODEX_HOME, "skills", ".system");

--- a/packages/coding-agent/src/adapters/opencode.ts
+++ b/packages/coding-agent/src/adapters/opencode.ts
@@ -575,6 +575,27 @@ async function fetchOpenCodeSessionMessages(
 }
 
 /**
+ * Where freshly-shipped skills should be written. OpenCode's documented
+ * resolution order is:
+ *
+ *   <project>/.opencode/skills (highest)
+ *   <project>/.claude/skills
+ *   <project>/.agents/skills
+ *   ~/.config/opencode/skills    ← highest *global* priority
+ *   ~/.claude/skills             (fallback for migrators from Claude Code)
+ *   ~/.agents/skills             (lowest, tool-agnostic alias)
+ *
+ * We install into `~/.config/opencode/skills/` so the skill is OpenCode-
+ * primary and so we don't pollute `~/.claude/skills/` (which the Claude Code
+ * adapter owns separately).
+ *
+ * See https://opencode.ai/docs/skills/.
+ */
+export function getOpenCodeInstallSkillsDir(home: string = homedir()): string {
+  return join(home, ".config", "opencode", "skills");
+}
+
+/**
  * Discover skills using OpenCode's 6-directory resolution order.
  *
  * Priority (lowest to highest — later entries override earlier ones):

--- a/packages/coding-agent/src/adapters/opencode.ts
+++ b/packages/coding-agent/src/adapters/opencode.ts
@@ -574,6 +574,9 @@ async function fetchOpenCodeSessionMessages(
   return { messages: slice, hasMore, firstOffset: offset };
 }
 
+/** Default executable name for OpenCode. See `setup.ts::AGENT_CHECKS`. */
+export const OPENCODE_DEFAULT_BINARY = "opencode";
+
 /**
  * Where freshly-shipped skills should be written. OpenCode's documented
  * resolution order is:

--- a/packages/coding-agent/src/index.ts
+++ b/packages/coding-agent/src/index.ts
@@ -19,6 +19,7 @@ export type {
   ToolUseEvent,
 } from "./events.js";
 export { createCodingAgent } from "./factory.js";
+export { getInstallSkillsDir } from "./install-skills.js";
 export type {
   AgentMode,
   AgentModel,

--- a/packages/coding-agent/src/index.ts
+++ b/packages/coding-agent/src/index.ts
@@ -19,7 +19,7 @@ export type {
   ToolUseEvent,
 } from "./events.js";
 export { createCodingAgent } from "./factory.js";
-export { getInstallSkillsDir } from "./install-skills.js";
+export { getDefaultAgentBinary, getInstallSkillsDir } from "./install-skills.js";
 export type {
   AgentMode,
   AgentModel,

--- a/packages/coding-agent/src/install-skills.ts
+++ b/packages/coding-agent/src/install-skills.ts
@@ -49,3 +49,42 @@ export async function getInstallSkillsDir(
       return null;
   }
 }
+
+/**
+ * Resolve the default executable name (looked up via PATH) for a coding-agent
+ * `type`. Used by callers to verify an agent listed in
+ * `settings.codingAgents` is *actually installed* on the host before
+ * touching its skills directory — an agent whose binary has been
+ * uninstalled is effectively no longer enabled, even if it hasn't been
+ * removed from settings yet.
+ *
+ * Returns `null` for agent types whose default binary name we don't know
+ * (e.g. `cursor-cli`). Callers should treat that as "skip" rather than
+ * fail-closed, matching the behavior of `getInstallSkillsDir`.
+ */
+export async function getDefaultAgentBinary(type: string): Promise<string | null> {
+  switch (type) {
+    case "claude-code": {
+      const { CLAUDE_CODE_DEFAULT_BINARY } = await import("./adapters/claude-code.js");
+      return CLAUDE_CODE_DEFAULT_BINARY;
+    }
+    case "codex": {
+      const { CODEX_DEFAULT_BINARY } = await import("./adapters/codex.js");
+      return CODEX_DEFAULT_BINARY;
+    }
+    case "openai-codex": {
+      const { OPENAI_CODEX_DEFAULT_BINARY } = await import("./adapters/openai-codex.js");
+      return OPENAI_CODEX_DEFAULT_BINARY;
+    }
+    case "gemini-cli": {
+      const { GEMINI_CLI_DEFAULT_BINARY } = await import("./adapters/gemini-cli.js");
+      return GEMINI_CLI_DEFAULT_BINARY;
+    }
+    case "opencode": {
+      const { OPENCODE_DEFAULT_BINARY } = await import("./adapters/opencode.js");
+      return OPENCODE_DEFAULT_BINARY;
+    }
+    default:
+      return null;
+  }
+}

--- a/packages/coding-agent/src/install-skills.ts
+++ b/packages/coding-agent/src/install-skills.ts
@@ -1,0 +1,51 @@
+import { homedir } from "node:os";
+
+/**
+ * Resolve the *highest-priority global* skills directory for a coding-agent
+ * `type` — i.e. where new SKILL.md files should be installed so the agent
+ * picks them up with maximum precedence (over lower-tier global fallbacks
+ * but still below project-level skills).
+ *
+ * The actual path is owned by each agent's adapter file
+ * (`adapters/<agent>.ts::get<Agent>InstallSkillsDir`) so the filesystem
+ * convention lives next to the discovery logic that already reads from it.
+ * This dispatcher uses dynamic imports — same pattern as `factory.ts` —
+ * so callers don't pay the cost of loading every adapter (and its SDK
+ * dependencies) just to look up a single path.
+ *
+ * Returns `null` for agent types that have no documented global skills
+ * directory (e.g. `cursor-cli`).
+ */
+export async function getInstallSkillsDir(
+  type: string,
+  home: string = homedir(),
+): Promise<string | null> {
+  switch (type) {
+    case "claude-code": {
+      const { getClaudeCodeInstallSkillsDir } = await import("./adapters/claude-code.js");
+      return getClaudeCodeInstallSkillsDir(home);
+    }
+    case "codex": {
+      const { getCodexInstallSkillsDir } = await import("./adapters/codex.js");
+      return getCodexInstallSkillsDir(home);
+    }
+    case "openai-codex": {
+      const { getOpenAICodexInstallSkillsDir } = await import("./adapters/openai-codex.js");
+      return getOpenAICodexInstallSkillsDir(home);
+    }
+    case "gemini-cli": {
+      const { getGeminiCliInstallSkillsDir } = await import("./adapters/gemini-cli.js");
+      return getGeminiCliInstallSkillsDir(home);
+    }
+    case "opencode": {
+      const { getOpenCodeInstallSkillsDir } = await import("./adapters/opencode.js");
+      return getOpenCodeInstallSkillsDir(home);
+    }
+    default:
+      // `cursor-cli` and any future unknown type → caller treats as "no
+      // destination" and skips. Do not throw: the install path runs on
+      // every server boot and we don't want a new agent type to crash
+      // setup before its adapter is wired up.
+      return null;
+  }
+}

--- a/packages/coding-agent/tests/install-skills.test.ts
+++ b/packages/coding-agent/tests/install-skills.test.ts
@@ -1,0 +1,76 @@
+/**
+ * Tests for the agent → install-skills-dir dispatcher
+ * (`packages/coding-agent/src/install-skills.ts`).
+ *
+ * Run with the package's standard `pnpm test` setup (node:test + the loader
+ * that redirects optional adapter SDK imports to local mocks). We deliberately
+ * use a synthetic temp `home` so the assertions don't depend on the real
+ * filesystem — and so the `CODEX_HOME` env override is exercised in a way
+ * that doesn't pollute the developer's actual config.
+ */
+
+import assert from "node:assert/strict";
+import { afterEach, describe, it } from "node:test";
+
+import { getInstallSkillsDir } from "../src/install-skills.ts";
+
+const HOME = "/tmp/band-test-home";
+
+describe("getInstallSkillsDir", () => {
+  let originalCodexHome: string | undefined;
+
+  afterEach(() => {
+    if (originalCodexHome !== undefined) process.env.CODEX_HOME = originalCodexHome;
+    else delete process.env.CODEX_HOME;
+    originalCodexHome = undefined;
+  });
+
+  it("resolves claude-code to ~/.claude/skills", async () => {
+    const dir = await getInstallSkillsDir("claude-code", HOME);
+    assert.equal(dir, "/tmp/band-test-home/.claude/skills");
+  });
+
+  it("resolves codex to $CODEX_HOME/skills (default ~/.codex/skills)", async () => {
+    const dir = await getInstallSkillsDir("codex", HOME);
+    assert.equal(dir, "/tmp/band-test-home/.codex/skills");
+  });
+
+  it("resolves openai-codex to $CODEX_HOME/skills (same as codex)", async () => {
+    const dir = await getInstallSkillsDir("openai-codex", HOME);
+    assert.equal(dir, "/tmp/band-test-home/.codex/skills");
+  });
+
+  it("honours $CODEX_HOME for codex", async () => {
+    originalCodexHome = process.env.CODEX_HOME;
+    process.env.CODEX_HOME = "/custom/codex/dir";
+    const dir = await getInstallSkillsDir("codex", HOME);
+    assert.equal(dir, "/custom/codex/dir/skills");
+  });
+
+  it("honours $CODEX_HOME for openai-codex", async () => {
+    originalCodexHome = process.env.CODEX_HOME;
+    process.env.CODEX_HOME = "/custom/codex/dir";
+    const dir = await getInstallSkillsDir("openai-codex", HOME);
+    assert.equal(dir, "/custom/codex/dir/skills");
+  });
+
+  it("resolves gemini-cli to ~/.gemini/skills", async () => {
+    const dir = await getInstallSkillsDir("gemini-cli", HOME);
+    assert.equal(dir, "/tmp/band-test-home/.gemini/skills");
+  });
+
+  it("resolves opencode to ~/.config/opencode/skills (highest-priority global)", async () => {
+    const dir = await getInstallSkillsDir("opencode", HOME);
+    assert.equal(dir, "/tmp/band-test-home/.config/opencode/skills");
+  });
+
+  it("returns null for cursor-cli (no documented global skills dir)", async () => {
+    const dir = await getInstallSkillsDir("cursor-cli", HOME);
+    assert.equal(dir, null);
+  });
+
+  it("returns null for an unknown agent type without throwing", async () => {
+    const dir = await getInstallSkillsDir("future-agent-9000", HOME);
+    assert.equal(dir, null);
+  });
+});

--- a/packages/coding-agent/tests/install-skills.test.ts
+++ b/packages/coding-agent/tests/install-skills.test.ts
@@ -12,7 +12,7 @@
 import assert from "node:assert/strict";
 import { afterEach, describe, it } from "node:test";
 
-import { getInstallSkillsDir } from "../src/install-skills.ts";
+import { getDefaultAgentBinary, getInstallSkillsDir } from "../src/install-skills.ts";
 
 const HOME = "/tmp/band-test-home";
 
@@ -72,5 +72,35 @@ describe("getInstallSkillsDir", () => {
   it("returns null for an unknown agent type without throwing", async () => {
     const dir = await getInstallSkillsDir("future-agent-9000", HOME);
     assert.equal(dir, null);
+  });
+});
+
+describe("getDefaultAgentBinary", () => {
+  it("resolves claude-code to 'claude'", async () => {
+    assert.equal(await getDefaultAgentBinary("claude-code"), "claude");
+  });
+
+  it("resolves codex to 'codex'", async () => {
+    assert.equal(await getDefaultAgentBinary("codex"), "codex");
+  });
+
+  it("resolves openai-codex to 'codex' (same binary as the CLI Codex adapter)", async () => {
+    assert.equal(await getDefaultAgentBinary("openai-codex"), "codex");
+  });
+
+  it("resolves gemini-cli to 'gemini'", async () => {
+    assert.equal(await getDefaultAgentBinary("gemini-cli"), "gemini");
+  });
+
+  it("resolves opencode to 'opencode'", async () => {
+    assert.equal(await getDefaultAgentBinary("opencode"), "opencode");
+  });
+
+  it("returns null for cursor-cli (no defined binary in this dispatcher yet)", async () => {
+    assert.equal(await getDefaultAgentBinary("cursor-cli"), null);
+  });
+
+  it("returns null for an unknown agent type without throwing", async () => {
+    assert.equal(await getDefaultAgentBinary("future-agent-9000"), null);
   });
 });


### PR DESCRIPTION
## Summary
- Adds `ensureSkillsInstalled` to `runFirstTimeSetup` so the four band-* skills (`band`, `band-chat`, `band-terminal`, `band-browser`) land in `~/.claude/skills/<name>/SKILL.md` automatically on every server boot — fresh install populates them, and an electron-updater relaunch refreshes them without a separate update hook.
- New step shells out to `band generate-skills --output-dir <tmp>` (the templates are baked into the Rust binary via `include_str!`, so this is the only way to access them in a packaged build) and copies each emitted `SKILL.md` only when the destination is missing or its bytes differ. Idempotent: identical content → no rewrite, drift → overwrite + warning log, matching the blast-and-replace policy used by `installHooks` / `installCli`.
- Codex and OpenCode have known global skills folders too, but their adapters scan multiple locations with non-obvious priority. Left as a TODO so we can validate the end-to-end flow before committing to a destination — Claude Code only for now.

## File / dest layout
| Source (in CLI binary) | Destination |
|---|---|
| `apps/cli/skills/band.md` (template) | `~/.claude/skills/band/SKILL.md` |
| `apps/cli/skills/band-chat.md` | `~/.claude/skills/band-chat/SKILL.md` |
| `apps/cli/skills/band-terminal.md` | `~/.claude/skills/band-terminal/SKILL.md` |
| `apps/cli/skills/band-browser.md` | `~/.claude/skills/band-browser/SKILL.md` |

Binary resolution mirrors `installHooks`: try `/usr/local/bin/band` symlink → `whichBinary("band")` → `findCliBinary()` (dev / Electron sidecar). When none resolves, the step logs a warning and skips — non-fatal, consistent with the rest of the idempotent setup pipeline.

## Test plan
- [x] `pnpm test` (full vitest suite — 416 / 416 passing)
- [x] New `apps/web/tests/cli-skills.test.ts` integration test driving the public `runFirstTimeSetup` surface with a sandboxed `$HOME` / `$BAND_HOME`. Skips cleanly on hosts without a band binary.
- [x] Existing `slash-commands.test.ts` updated to filter the auto-installed band skills out of its assertions so it keeps testing the skills it itself seeds.
- [x] `pnpm exec biome check .` clean
- [x] `cargo clippy --manifest-path apps/cli/Cargo.toml -- -D warnings` clean
- [x] Pre-push hook (lint/format/clippy/knip/jscpd) passed

## Acceptance criteria from issue
- [x] Fresh install / first launch: `~/.claude/skills/{band,band-chat,band-terminal,band-browser}/SKILL.md` exist and match `band generate-skills` byte-for-byte (asserted in `cli-skills.test.ts`).
- [x] Updated content: a destination whose bytes drifted gets overwritten on the next boot (asserted).
- [x] Idempotent re-run: when nothing changed the file is *not* rewritten — mtime preserved (asserted).
- [x] Backwards-friendly: when content drifts we log a warning before overwriting, matching `installHooks` / `installCli` behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)