### PR TITLE
Redesign Diff tab + add compare-branch picker

### DIFF
--- a/apps/web/src/trpc/router.ts
+++ b/apps/web/src/trpc/router.ts
@@ -683,12 +683,64 @@ const workspaceRouter = t.router({
       return { config };
     }),
 
+  listBranches: publicProcedure
+    .input(z.object({ workspaceId: z.string() }))
+    .query(async ({ input }) => {
+      const workspace = resolveWorkspace(input.workspaceId);
+      if (!workspace) {
+        throw new Error("Workspace not found");
+      }
+
+      const cwd = workspace.worktree.path;
+      const defaultBranch = workspace.project.defaultBranch;
+
+      let headBranch: string | null = null;
+      try {
+        headBranch = (await execGit(["rev-parse", "--abbrev-ref", "HEAD"], cwd)).trim();
+      } catch {
+        // No commits yet
+      }
+
+      let branches: string[] = [];
+      try {
+        const output = await execGit(
+          ["for-each-ref", "--format=%(refname:short)", "refs/heads/"],
+          cwd,
+        );
+        branches = output
+          .trim()
+          .split("\n")
+          .map((b) => b.trim())
+          .filter(Boolean);
+      } catch {
+        // No branches
+      }
+
+      // Exclude HEAD branch (you don't compare against yourself); ensure default present.
+      const filtered = branches.filter((b) => b !== headBranch);
+      if (!filtered.includes(defaultBranch)) {
+        filtered.unshift(defaultBranch);
+      } else {
+        // Move defaultBranch to the front for stable ordering.
+        const idx = filtered.indexOf(defaultBranch);
+        filtered.splice(idx, 1);
+        filtered.unshift(defaultBranch);
+      }
+
+      return {
+        branches: filtered,
+        defaultBranch,
+        headBranch: headBranch ?? defaultBranch,
+      };
+    }),
+
   getDiff: publicProcedure
     .input(
       z.object({
         workspaceId: z.string(),
         contextLines: z.number().int().min(0).max(99999).optional(),
         diffMode: z.enum(["uncommitted", "branch"]).optional(),
+        compareBranch: z.string().optional(),
       }),
     )
     .query(async ({ input }) => {
@@ -699,6 +751,8 @@ const workspaceRouter = t.router({
 
       const cwd = workspace.worktree.path;
       const defaultBranch = workspace.project.defaultBranch;
+      const compareBranch =
+        input.diffMode === "uncommitted" ? defaultBranch : (input.compareBranch ?? defaultBranch);
 
       let headBranch: string;
       try {
@@ -718,7 +772,7 @@ const workspaceRouter = t.router({
         }
       } else {
         try {
-          mergeBase = (await execGit(["merge-base", defaultBranch, "HEAD"], cwd)).trim();
+          mergeBase = (await execGit(["merge-base", compareBranch, "HEAD"], cwd)).trim();
         } catch {
           mergeBase = (await execGit(["hash-object", "-t", "tree", "/dev/null"], cwd)).trim();
         }
@@ -787,7 +841,7 @@ const workspaceRouter = t.router({
       return {
         diff,
         stats: { filesChanged, insertions, deletions },
-        baseBranch: defaultBranch,
+        baseBranch: compareBranch,
         headBranch,
         fileStatuses,
       };
@@ -798,6 +852,7 @@ const workspaceRouter = t.router({
       z.object({
         workspaceId: z.string(),
         diffMode: z.enum(["uncommitted", "branch"]).optional(),
+        compareBranch: z.string().optional(),
       }),
     )
     .query(async ({ input }) => {
@@ -808,6 +863,8 @@ const workspaceRouter = t.router({
 
       const cwd = workspace.worktree.path;
       const defaultBranch = workspace.project.defaultBranch;
+      const compareBranch =
+        input.diffMode === "uncommitted" ? defaultBranch : (input.compareBranch ?? defaultBranch);
 
       let headBranch: string;
       try {
@@ -827,7 +884,7 @@ const workspaceRouter = t.router({
         }
       } else {
         try {
-          mergeBase = (await execGit(["merge-base", defaultBranch, "HEAD"], cwd)).trim();
+          mergeBase = (await execGit(["merge-base", compareBranch, "HEAD"], cwd)).trim();
         } catch {
           mergeBase = (await execGit(["hash-object", "-t", "tree", "/dev/null"], cwd)).trim();
         }
@@ -881,7 +938,7 @@ const workspaceRouter = t.router({
 
       return {
         stats: { filesChanged, insertions, deletions },
-        baseBranch: defaultBranch,
+        baseBranch: compareBranch,
         headBranch,
         fileStatuses,
         mergeBase,
@@ -946,6 +1003,7 @@ const workspaceRouter = t.router({
         workspaceId: z.string(),
         filePath: z.string(),
         diffMode: z.enum(["uncommitted", "branch"]),
+        compareBranch: z.string().optional(),
       }),
     )
     .mutation(async ({ input }) => {
@@ -976,9 +1034,9 @@ const workspaceRouter = t.router({
           ref = (await execGit(["hash-object", "-t", "tree", "/dev/null"], cwd)).trim();
         }
       } else {
-        const defaultBranch = workspace.project.defaultBranch;
+        const compareBranch = input.compareBranch ?? workspace.project.defaultBranch;
         try {
-          ref = (await execGit(["merge-base", defaultBranch, "HEAD"], cwd)).trim();
+          ref = (await execGit(["merge-base", compareBranch, "HEAD"], cwd)).trim();
         } catch {
           ref = (await execGit(["hash-object", "-t", "tree", "/dev/null"], cwd)).trim();
         }

--- a/apps/web/src/trpc/router.ts
+++ b/apps/web/src/trpc/router.ts
@@ -673,6 +673,123 @@ const LANG_MAP: Record<string, string> = {
   ".diff": "diff",
 };
 
+// ---------------------------------------------------------------------------
+// Workspace diff helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Branch names accepted by diff/revert procedures. Forbids leading `-` so the
+ * value can't be interpreted by git as a flag (e.g. `--upload-pack=`, `--exec=`)
+ * when it lands in `git merge-base <branch> HEAD` or `git checkout <branch> -- file`.
+ * The trpc server is local-only, but `execFile` doesn't pass through a shell, so
+ * a leading-dash check is enough to close the only realistic injection vector.
+ */
+const compareBranchSchema = z
+  .string()
+  .min(1)
+  .regex(/^[^-]/, "branch name must not start with '-'")
+  .optional();
+
+const EMPTY_TREE_ARGS = ["hash-object", "-t", "tree", "/dev/null"];
+
+interface DiffContext {
+  /** Resolved compare branch — defaults to project default. */
+  compareBranch: string;
+  /** Current branch name, or `defaultBranch` if HEAD is detached / unborn. */
+  headBranch: string;
+  /** Commit/tree to diff against. */
+  mergeBase: string;
+}
+
+/**
+ * Resolves the `(headBranch, mergeBase, compareBranch)` triple shared by
+ * `getDiff`, `getDiffSummary`, and `revertFile`. Falls back to the empty tree
+ * when the workspace has no commits yet (so brand-new repos don't 500).
+ */
+async function resolveDiffContext(
+  cwd: string,
+  defaultBranch: string,
+  diffMode: "uncommitted" | "branch",
+  compareBranchInput: string | undefined,
+): Promise<DiffContext> {
+  const compareBranch =
+    diffMode === "uncommitted" ? defaultBranch : (compareBranchInput ?? defaultBranch);
+
+  let headBranch: string;
+  try {
+    headBranch = (await execGit(["rev-parse", "--abbrev-ref", "HEAD"], cwd)).trim();
+  } catch {
+    headBranch = defaultBranch;
+  }
+
+  let mergeBase: string;
+  if (diffMode === "uncommitted") {
+    try {
+      mergeBase = (await execGit(["rev-parse", "HEAD"], cwd)).trim();
+    } catch {
+      mergeBase = (await execGit(EMPTY_TREE_ARGS, cwd)).trim();
+    }
+  } else {
+    try {
+      mergeBase = (await execGit(["merge-base", compareBranch, "HEAD"], cwd)).trim();
+    } catch {
+      mergeBase = (await execGit(EMPTY_TREE_ARGS, cwd)).trim();
+    }
+  }
+
+  return { compareBranch, headBranch, mergeBase };
+}
+
+/** Parses the trailing summary line of `git diff --stat`. */
+function parseDiffStatSummary(statOutput: string): {
+  filesChanged: number;
+  insertions: number;
+  deletions: number;
+} {
+  const statLines = statOutput.trim().split("\n");
+  const summaryLine = statLines[statLines.length - 1] || "";
+
+  const filesMatch = summaryLine.match(/(\d+)\s+files?\s+changed/);
+  const insertMatch = summaryLine.match(/(\d+)\s+insertions?\(\+\)/);
+  const deleteMatch = summaryLine.match(/(\d+)\s+deletions?\(-\)/);
+
+  return {
+    filesChanged: filesMatch ? Number.parseInt(filesMatch[1], 10) : 0,
+    insertions: insertMatch ? Number.parseInt(insertMatch[1], 10) : 0,
+    deletions: deleteMatch ? Number.parseInt(deleteMatch[1], 10) : 0,
+  };
+}
+
+/** Builds the `path -> status code` map from `git diff --name-status`. */
+function parseFileStatuses(nameStatusOutput: string): Record<string, string> {
+  const fileStatuses: Record<string, string> = {};
+  for (const line of nameStatusOutput.trim().split("\n").filter(Boolean)) {
+    const parts = line.split("\t");
+    const statusCode = parts[0][0];
+    if (statusCode === "R" && parts[2]) {
+      fileStatuses[parts[2]] = "R";
+    } else if (parts[1]) {
+      fileStatuses[parts[1]] = statusCode;
+    }
+  }
+  return fileStatuses;
+}
+
+/** Reads an untracked file as the lines that would appear in a synthesized diff. */
+async function readUntrackedFileLines(cwd: string, file: string): Promise<string[] | null> {
+  try {
+    const content = await readFile(join(cwd, file), "utf-8");
+    const lines = content.split("\n");
+    if (lines.length > 0 && lines[lines.length - 1] === "") {
+      lines.pop();
+    }
+    return lines;
+  } catch {
+    // Skip binary or unreadable files
+    return null;
+  }
+}
+
 const workspaceRouter = t.router({
   getTerminalConfig: publicProcedure
     .input(z.object({ workspaceId: z.string() }))
@@ -698,7 +815,7 @@ const workspaceRouter = t.router({
       try {
         headBranch = (await execGit(["rev-parse", "--abbrev-ref", "HEAD"], cwd)).trim();
       } catch {
-        // No commits yet
+        // No commits yet — leave headBranch null
       }
 
       let branches: string[] = [];
@@ -712,18 +829,21 @@ const workspaceRouter = t.router({
           .split("\n")
           .map((b) => b.trim())
           .filter(Boolean);
-      } catch {
-        // No branches
+      } catch (err) {
+        log.error(
+          `listBranches: for-each-ref failed for ${cwd}: ${err instanceof Error ? err.message : err}`,
+        );
       }
 
-      // Exclude HEAD branch (you don't compare against yourself); ensure default present.
+      // Drop the current branch (you don't compare against yourself) and pin
+      // the default branch to the front. When you're on the default branch,
+      // skip the re-add — comparing main↔main is a no-op and confusing.
       const filtered = branches.filter((b) => b !== headBranch);
-      if (!filtered.includes(defaultBranch)) {
-        filtered.unshift(defaultBranch);
-      } else {
-        // Move defaultBranch to the front for stable ordering.
+      if (defaultBranch !== headBranch) {
         const idx = filtered.indexOf(defaultBranch);
-        filtered.splice(idx, 1);
+        if (idx >= 0) {
+          filtered.splice(idx, 1);
+        }
         filtered.unshift(defaultBranch);
       }
 
@@ -740,7 +860,7 @@ const workspaceRouter = t.router({
         workspaceId: z.string(),
         contextLines: z.number().int().min(0).max(99999).optional(),
         diffMode: z.enum(["uncommitted", "branch"]).optional(),
-        compareBranch: z.string().optional(),
+        compareBranch: compareBranchSchema,
       }),
     )
     .query(async ({ input }) => {
@@ -751,32 +871,12 @@ const workspaceRouter = t.router({
 
       const cwd = workspace.worktree.path;
       const defaultBranch = workspace.project.defaultBranch;
-      const compareBranch =
-        input.diffMode === "uncommitted" ? defaultBranch : (input.compareBranch ?? defaultBranch);
-
-      let headBranch: string;
-      try {
-        headBranch = (await execGit(["rev-parse", "--abbrev-ref", "HEAD"], cwd)).trim();
-      } catch {
-        // No commits yet — HEAD doesn't exist
-        headBranch = defaultBranch;
-      }
-
-      let mergeBase: string;
-      if (input.diffMode === "uncommitted") {
-        try {
-          mergeBase = (await execGit(["rev-parse", "HEAD"], cwd)).trim();
-        } catch {
-          // No commits yet — diff against the empty tree so all staged files appear as new
-          mergeBase = (await execGit(["hash-object", "-t", "tree", "/dev/null"], cwd)).trim();
-        }
-      } else {
-        try {
-          mergeBase = (await execGit(["merge-base", compareBranch, "HEAD"], cwd)).trim();
-        } catch {
-          mergeBase = (await execGit(["hash-object", "-t", "tree", "/dev/null"], cwd)).trim();
-        }
-      }
+      const { compareBranch, headBranch, mergeBase } = await resolveDiffContext(
+        cwd,
+        defaultBranch,
+        input.diffMode ?? "branch",
+        input.compareBranch,
+      );
 
       const diffArgs = ["diff"];
       if (input.contextLines !== undefined) {
@@ -786,62 +886,37 @@ const workspaceRouter = t.router({
       let diff = await execGit(diffArgs, cwd);
 
       const statOutput = await execGit(["diff", "--stat", mergeBase], cwd);
-      const statLines = statOutput.trim().split("\n");
-      const summaryLine = statLines[statLines.length - 1] || "";
+      const stats = parseDiffStatSummary(statOutput);
 
-      let filesChanged = 0;
-      let insertions = 0;
-      let deletions = 0;
-
-      const filesMatch = summaryLine.match(/(\d+)\s+files?\s+changed/);
-      const insertMatch = summaryLine.match(/(\d+)\s+insertions?\(\+\)/);
-      const deleteMatch = summaryLine.match(/(\d+)\s+deletions?\(-\)/);
-
-      if (filesMatch) filesChanged = Number.parseInt(filesMatch[1], 10);
-      if (insertMatch) insertions = Number.parseInt(insertMatch[1], 10);
-      if (deleteMatch) deletions = Number.parseInt(deleteMatch[1], 10);
-
-      const fileStatuses: Record<string, string> = {};
       const nameStatusOutput = await execGit(["diff", "--name-status", mergeBase], cwd);
-      for (const line of nameStatusOutput.trim().split("\n").filter(Boolean)) {
-        const parts = line.split("\t");
-        const statusCode = parts[0][0];
-        if (statusCode === "R" && parts[2]) {
-          fileStatuses[parts[2]] = "R";
-        } else if (parts[1]) {
-          fileStatuses[parts[1]] = statusCode;
-        }
-      }
+      const fileStatuses = parseFileStatuses(nameStatusOutput);
 
       const untrackedOutput = await execGit(["ls-files", "--others", "--exclude-standard"], cwd);
       const untrackedFiles = untrackedOutput.trim().split("\n").filter(Boolean);
 
       for (const file of untrackedFiles) {
-        try {
-          const content = await readFile(join(cwd, file), "utf-8");
-          const lines = content.split("\n");
-          if (lines.length > 0 && lines[lines.length - 1] === "") {
-            lines.pop();
-          }
-          diff += `diff --git a/${file} b/${file}\n`;
-          diff += "new file mode 100644\n";
-          diff += "--- /dev/null\n";
-          diff += `+++ b/${file}\n`;
-          diff += `@@ -0,0 +1,${lines.length} @@\n`;
-          diff += lines.map((l) => `+${l}`).join("\n");
-          diff += "\n";
-          filesChanged++;
-          insertions += lines.length;
-          fileStatuses[file] = "U";
-        } catch {
-          // Skip binary or unreadable files
-        }
+        const lines = await readUntrackedFileLines(cwd, file);
+        if (lines === null) continue;
+        diff += `diff --git a/${file} b/${file}\n`;
+        diff += "new file mode 100644\n";
+        diff += "--- /dev/null\n";
+        diff += `+++ b/${file}\n`;
+        diff += `@@ -0,0 +1,${lines.length} @@\n`;
+        diff += lines.map((l) => `+${l}`).join("\n");
+        diff += "\n";
+        stats.filesChanged++;
+        stats.insertions += lines.length;
+        fileStatuses[file] = "U";
       }
 
       return {
         diff,
-        stats: { filesChanged, insertions, deletions },
-        baseBranch: compareBranch,
+        stats,
+        // `compareBranch` is the branch we diffed against (the user's pick, or
+        // the project default). `defaultBranch` is the project default. They
+        // diverge once a non-default branch is picked.
+        compareBranch,
+        defaultBranch,
         headBranch,
         fileStatuses,
       };
@@ -852,7 +927,7 @@ const workspaceRouter = t.router({
       z.object({
         workspaceId: z.string(),
         diffMode: z.enum(["uncommitted", "branch"]).optional(),
-        compareBranch: z.string().optional(),
+        compareBranch: compareBranchSchema,
       }),
     )
     .query(async ({ input }) => {
@@ -863,82 +938,34 @@ const workspaceRouter = t.router({
 
       const cwd = workspace.worktree.path;
       const defaultBranch = workspace.project.defaultBranch;
-      const compareBranch =
-        input.diffMode === "uncommitted" ? defaultBranch : (input.compareBranch ?? defaultBranch);
-
-      let headBranch: string;
-      try {
-        headBranch = (await execGit(["rev-parse", "--abbrev-ref", "HEAD"], cwd)).trim();
-      } catch {
-        // No commits yet — HEAD doesn't exist
-        headBranch = defaultBranch;
-      }
-
-      let mergeBase: string;
-      if (input.diffMode === "uncommitted") {
-        try {
-          mergeBase = (await execGit(["rev-parse", "HEAD"], cwd)).trim();
-        } catch {
-          // No commits yet — diff against the empty tree so all staged files appear as new
-          mergeBase = (await execGit(["hash-object", "-t", "tree", "/dev/null"], cwd)).trim();
-        }
-      } else {
-        try {
-          mergeBase = (await execGit(["merge-base", compareBranch, "HEAD"], cwd)).trim();
-        } catch {
-          mergeBase = (await execGit(["hash-object", "-t", "tree", "/dev/null"], cwd)).trim();
-        }
-      }
+      const { compareBranch, headBranch, mergeBase } = await resolveDiffContext(
+        cwd,
+        defaultBranch,
+        input.diffMode ?? "branch",
+        input.compareBranch,
+      );
 
       const statOutput = await execGit(["diff", "--stat", mergeBase], cwd);
-      const statLines = statOutput.trim().split("\n");
-      const summaryLine = statLines[statLines.length - 1] || "";
+      const stats = parseDiffStatSummary(statOutput);
 
-      let filesChanged = 0;
-      let insertions = 0;
-      let deletions = 0;
-
-      const filesMatch = summaryLine.match(/(\d+)\s+files?\s+changed/);
-      const insertMatch = summaryLine.match(/(\d+)\s+insertions?\(\+\)/);
-      const deleteMatch = summaryLine.match(/(\d+)\s+deletions?\(-\)/);
-
-      if (filesMatch) filesChanged = Number.parseInt(filesMatch[1], 10);
-      if (insertMatch) insertions = Number.parseInt(insertMatch[1], 10);
-      if (deleteMatch) deletions = Number.parseInt(deleteMatch[1], 10);
-
-      const fileStatuses: Record<string, string> = {};
       const nameStatusOutput = await execGit(["diff", "--name-status", mergeBase], cwd);
-      for (const line of nameStatusOutput.trim().split("\n").filter(Boolean)) {
-        const parts = line.split("\t");
-        const statusCode = parts[0][0];
-        if (statusCode === "R" && parts[2]) {
-          fileStatuses[parts[2]] = "R";
-        } else if (parts[1]) {
-          fileStatuses[parts[1]] = statusCode;
-        }
-      }
+      const fileStatuses = parseFileStatuses(nameStatusOutput);
 
       const untrackedOutput = await execGit(["ls-files", "--others", "--exclude-standard"], cwd);
       const untrackedFiles = untrackedOutput.trim().split("\n").filter(Boolean);
 
       for (const file of untrackedFiles) {
-        try {
-          const content = await readFile(join(cwd, file), "utf-8");
-          const lines = content.split("\n");
-          if (lines.length > 0 && lines[lines.length - 1] === "") {
-            lines.pop();
-          }
-          filesChanged++;
-          insertions += lines.length;
-          fileStatuses[file] = "U";
-        } catch {
-          // Skip binary or unreadable files
-        }
+        const lines = await readUntrackedFileLines(cwd, file);
+        if (lines === null) continue;
+        stats.filesChanged++;
+        stats.insertions += lines.length;
+        fileStatuses[file] = "U";
       }
 
       return {
-        stats: { filesChanged, insertions, deletions },
-        baseBranch: compareBranch,
+        stats,
+        compareBranch,
+        defaultBranch,
         headBranch,
         fileStatuses,
         mergeBase,
@@ -1003,7 +1030,7 @@ const workspaceRouter = t.router({
         workspaceId: z.string(),
         filePath: z.string(),
         diffMode: z.enum(["uncommitted", "branch"]),
-        compareBranch: z.string().optional(),
+        compareBranch: compareBranchSchema,
       }),
     )
     .mutation(async ({ input }) => {
@@ -1025,22 +1052,14 @@ const workspaceRouter = t.router({
         return { ok: true };
       }
 
-      // Resolve the reference commit for the diff mode
-      let ref: string;
-      if (diffMode === "uncommitted") {
-        try {
-          ref = (await execGit(["rev-parse", "HEAD"], cwd)).trim();
-        } catch {
-          ref = (await execGit(["hash-object", "-t", "tree", "/dev/null"], cwd)).trim();
-        }
-      } else {
-        const compareBranch = input.compareBranch ?? workspace.project.defaultBranch;
-        try {
-          ref = (await execGit(["merge-base", compareBranch, "HEAD"], cwd)).trim();
-        } catch {
-          ref = (await execGit(["hash-object", "-t", "tree", "/dev/null"], cwd)).trim();
-        }
-      }
+      // Reuse the shared resolver so the reference commit matches what
+      // getDiff/getDiffSummary computed — otherwise revert can drift.
+      const { mergeBase: ref } = await resolveDiffContext(
+        cwd,
+        workspace.project.defaultBranch,
+        diffMode,
+        input.compareBranch,
+      );
 
       // Determine the tracked file status from the diff
       const nameStatusOutput = await execGit(["diff", "--name-status", ref, "--", filePath], cwd);

--- a/apps/web/tests/trpc.test.ts
+++ b/apps/web/tests/trpc.test.ts
@@ -648,11 +648,13 @@ describe("tRPC — workspace operations", () => {
     const data = await trpcData<{
       diff: string;
       stats: { filesChanged: number; insertions: number; deletions: number };
-      baseBranch: string;
+      compareBranch: string;
+      defaultBranch: string;
       headBranch: string;
       fileStatuses: Record<string, string>;
     }>(res);
-    expect(data.baseBranch).toBe("main");
+    expect(data.compareBranch).toBe("main");
+    expect(data.defaultBranch).toBe("main");
     expect(data.headBranch).toBe("main");
   });
 
@@ -690,6 +692,152 @@ describe("tRPC — workspace operations", () => {
       workspaceId: "nonexistent-main",
     });
     expect(res.status).toBe(500);
+  });
+
+  // -- workspace.listBranches --
+
+  it("workspace.listBranches returns branches with default first and current excluded", async () => {
+    // feature-1 worktree should already exist from earlier tests in this describe block.
+    const res = await trpcQuery(server.url, "workspace.listBranches", {
+      workspaceId: "repo-feature-1",
+    });
+    expect(res.status).toBe(200);
+    const data = await trpcData<{
+      branches: string[];
+      defaultBranch: string;
+      headBranch: string;
+    }>(res);
+
+    expect(data.defaultBranch).toBe("main");
+    expect(data.headBranch).toBe("feature-1");
+    expect(data.branches).toContain("main");
+    expect(data.branches[0]).toBe("main");
+    // Current branch should not appear in the list (you don't compare against yourself).
+    expect(data.branches).not.toContain("feature-1");
+  });
+
+  it("workspace.listBranches omits default when on the default branch", async () => {
+    // On the default branch, comparing against `main` is a no-op, so the
+    // server skips re-adding it to the list.
+    const res = await trpcQuery(server.url, "workspace.listBranches", {
+      workspaceId: "repo-main",
+    });
+    expect(res.status).toBe(200);
+    const data = await trpcData<{
+      branches: string[];
+      defaultBranch: string;
+      headBranch: string;
+    }>(res);
+
+    expect(data.defaultBranch).toBe("main");
+    expect(data.headBranch).toBe("main");
+    expect(data.branches).not.toContain("main");
+  });
+
+  // -- workspace.getDiff with compareBranch --
+
+  it("workspace.getDiff with non-default compareBranch uses merge-base of that branch", async () => {
+    // Set up: create `develop` from main, add a commit on develop, switch back
+    // to main, add a commit there. Then on a feature branch off main, the diff
+    // against `develop` should NOT include the main-only commit (because the
+    // merge-base of develop and HEAD is the original main tip).
+    git(repoPath, ["branch", "develop"]);
+    writeFileSync(join(repoPath, "develop-only.txt"), "develop\n");
+    git(repoPath, ["add", "develop-only.txt"]);
+    git(repoPath, ["commit", "-m", "develop commit"]);
+    git(repoPath, ["branch", "-f", "develop", "HEAD"]);
+    git(repoPath, ["reset", "--hard", "HEAD~1"]);
+
+    // Create a fresh feature workspace off main.
+    const createRes = await trpcMutate(server.url, "workspaces.create", {
+      project: "repo",
+      branch: "feature-cmp",
+    });
+    expect(createRes.status).toBe(200);
+    const createData = await trpcData<{ path: string }>(createRes);
+    const featurePath = createData.path;
+
+    // Add a commit on the feature branch.
+    writeFileSync(join(featurePath, "feature-only.txt"), "feature\n");
+    git(featurePath, ["add", "feature-only.txt"]);
+    git(featurePath, ["commit", "-m", "feature commit"]);
+
+    // Diff against `develop` — should include feature-only.txt and develop-only.txt.
+    const developRes = await trpcQuery(server.url, "workspace.getDiff", {
+      workspaceId: "repo-feature-cmp",
+      diffMode: "branch",
+      compareBranch: "develop",
+    });
+    expect(developRes.status).toBe(200);
+    const developData = await trpcData<{
+      compareBranch: string;
+      defaultBranch: string;
+      fileStatuses: Record<string, string>;
+    }>(developRes);
+    expect(developData.compareBranch).toBe("develop");
+    expect(developData.defaultBranch).toBe("main");
+    // develop has a file main doesn't have, so diffing HEAD against merge-base(develop, HEAD)
+    // shows feature-only.txt as added (relative to the common ancestor).
+    expect(developData.fileStatuses["feature-only.txt"]).toBe("A");
+
+    // Diff against `main` — same merge-base in this setup, so the result matches.
+    const mainRes = await trpcQuery(server.url, "workspace.getDiff", {
+      workspaceId: "repo-feature-cmp",
+      diffMode: "branch",
+      compareBranch: "main",
+    });
+    expect(mainRes.status).toBe(200);
+    const mainData = await trpcData<{ compareBranch: string }>(mainRes);
+    expect(mainData.compareBranch).toBe("main");
+  });
+
+  it("workspace.getDiff rejects compareBranch starting with '-'", async () => {
+    // Defense-in-depth against branch names that git would treat as flags
+    // (e.g. `--upload-pack=`, `--exec=`).
+    const res = await trpcQuery(server.url, "workspace.getDiff", {
+      workspaceId: "repo-feature-cmp",
+      diffMode: "branch",
+      compareBranch: "--exec=bad",
+    });
+    expect(res.status).toBe(400);
+  });
+
+  // -- workspace.revertFile with compareBranch --
+
+  it("workspace.revertFile uses compareBranch when in branch mode", async () => {
+    // Use the feature-cmp workspace from the previous test. Modify a file
+    // that exists on the merge-base of `develop`/HEAD, then revert in
+    // branch mode against `develop` — it should restore the file.
+    const listRes = await trpcQuery(server.url, "projects.list");
+    const listData = await trpcData<{
+      projects: Array<{ worktrees: Array<{ branch: string; path: string }> }>;
+    }>(listRes);
+    const featureCmp = listData.projects[0].worktrees.find((wt) => wt.branch === "feature-cmp");
+    expect(featureCmp).toBeDefined();
+
+    // Modify README.md (which exists at the merge-base).
+    writeFileSync(join(featureCmp!.path, "README.md"), "# Modified\n");
+    git(featureCmp!.path, ["add", "README.md"]);
+    git(featureCmp!.path, ["commit", "-m", "modify readme"]);
+
+    const revertRes = await trpcMutate(server.url, "workspace.revertFile", {
+      workspaceId: "repo-feature-cmp",
+      filePath: "README.md",
+      diffMode: "branch",
+      compareBranch: "develop",
+    });
+    expect(revertRes.status).toBe(200);
+    const revertData = await trpcData<{ ok: boolean }>(revertRes);
+    expect(revertData.ok).toBe(true);
+
+    // After revert, the working tree should match the merge-base content.
+    const fileRes = await trpcQuery(server.url, "workspace.getFile", {
+      workspaceId: "repo-feature-cmp",
+      path: "README.md",
+    });
+    expect(fileRes.status).toBe(200);
+    const fileData = await trpcData<{ content: string }>(fileRes);
+    expect(fileData.content).toBe("# My Project\n");
   });
 
   // -- workspaces.runScript --

--- a/knip.json
+++ b/knip.json
@@ -41,7 +41,9 @@
         "tests/loader.mjs",
         "scripts/*.mjs"
       ],
-      "project": ["src/**/*.{ts,cts}", "tests/**/*.{ts,mjs}", "scripts/**/*.mjs"]
+      "project": ["src/**/*.{ts,cts}", "tests/**/*.{ts,mjs}", "scripts/**/*.mjs"],
+      "ignoreBinaries": ["tsc", "electron", "electron-builder"],
+      "ignoreDependencies": ["electron-builder"]
     },
     "apps/website": {
       "entry": ["src/**/*.{astro,ts,tsx}"],

--- a/packages/dashboard-core/src/adapter.ts
+++ b/packages/dashboard-core/src/adapter.ts
@@ -98,7 +98,7 @@ export interface DashboardAdapter {
   revertFile?(
     workspaceId: string,
     filePath: string,
-    diffMode: string,
+    diffMode: DiffMode,
     compareBranch?: string,
   ): Promise<void>;
 

--- a/packages/dashboard-core/src/adapter.ts
+++ b/packages/dashboard-core/src/adapter.ts
@@ -74,20 +74,33 @@ export interface DashboardAdapter {
     workspaceId: string,
     contextLines?: number,
     diffMode?: DiffMode,
+    compareBranch?: string,
   ): Promise<WorkspaceDiff>;
-  getWorkspaceDiffSummary?(workspaceId: string, diffMode?: DiffMode): Promise<WorkspaceDiffSummary>;
+  getWorkspaceDiffSummary?(
+    workspaceId: string,
+    diffMode?: DiffMode,
+    compareBranch?: string,
+  ): Promise<WorkspaceDiffSummary>;
   getFileDiff?(
     workspaceId: string,
     filePath: string,
     mergeBase: string,
     contextLines?: number,
   ): Promise<FileDiffResult>;
+  listWorkspaceBranches?(
+    workspaceId: string,
+  ): Promise<{ branches: string[]; defaultBranch: string; headBranch: string }>;
   listWorkspaceFiles?(workspaceId: string, path: string): Promise<FileListResult>;
   getWorkspaceFile?(workspaceId: string, path: string): Promise<FileContentResult>;
   saveWorkspaceFile?(workspaceId: string, path: string, content: string): Promise<void>;
 
   /** Revert a single file to its original state, discarding all changes. */
-  revertFile?(workspaceId: string, filePath: string, diffMode: string): Promise<void>;
+  revertFile?(
+    workspaceId: string,
+    filePath: string,
+    diffMode: string,
+    compareBranch?: string,
+  ): Promise<void>;
 
   /** Get a URL for raw file content (images, PDFs, etc.) */
   getWorkspaceFileUrl?(workspaceId: string, path: string): string;

--- a/packages/dashboard-core/src/adapters/web.ts
+++ b/packages/dashboard-core/src/adapters/web.ts
@@ -286,13 +286,13 @@ export class WebDashboardAdapter implements DashboardAdapter {
   async revertFile(
     workspaceId: string,
     filePath: string,
-    diffMode: string,
+    diffMode: DiffMode,
     compareBranch?: string,
   ): Promise<void> {
     await this.trpc.workspace.revertFile.mutate({
       workspaceId,
       filePath,
-      diffMode: diffMode as "uncommitted" | "branch",
+      diffMode,
       compareBranch,
     });
   }

--- a/packages/dashboard-core/src/adapters/web.ts
+++ b/packages/dashboard-core/src/adapters/web.ts
@@ -225,22 +225,36 @@ export class WebDashboardAdapter implements DashboardAdapter {
     workspaceId: string,
     contextLines?: number,
     diffMode?: DiffMode,
+    compareBranch?: string,
   ): Promise<WorkspaceDiff> {
     return (await this.trpc.workspace.getDiff.query({
       workspaceId,
       contextLines,
       diffMode,
+      compareBranch,
     })) as WorkspaceDiff;
   }
 
   async getWorkspaceDiffSummary(
     workspaceId: string,
     diffMode?: DiffMode,
+    compareBranch?: string,
   ): Promise<WorkspaceDiffSummary> {
     return (await this.trpc.workspace.getDiffSummary.query({
       workspaceId,
       diffMode,
+      compareBranch,
     })) as WorkspaceDiffSummary;
+  }
+
+  async listWorkspaceBranches(
+    workspaceId: string,
+  ): Promise<{ branches: string[]; defaultBranch: string; headBranch: string }> {
+    return (await this.trpc.workspace.listBranches.query({ workspaceId })) as {
+      branches: string[];
+      defaultBranch: string;
+      headBranch: string;
+    };
   }
 
   async getFileDiff(
@@ -269,8 +283,18 @@ export class WebDashboardAdapter implements DashboardAdapter {
     await this.trpc.workspace.saveFile.mutate({ workspaceId, path, content });
   }
 
-  async revertFile(workspaceId: string, filePath: string, diffMode: string): Promise<void> {
-    await this.trpc.workspace.revertFile.mutate({ workspaceId, filePath, diffMode });
+  async revertFile(
+    workspaceId: string,
+    filePath: string,
+    diffMode: string,
+    compareBranch?: string,
+  ): Promise<void> {
+    await this.trpc.workspace.revertFile.mutate({
+      workspaceId,
+      filePath,
+      diffMode: diffMode as "uncommitted" | "branch",
+      compareBranch,
+    });
   }
 
   getWorkspaceFileUrl(workspaceId: string, path: string): string {

--- a/packages/dashboard-core/src/components/DiffView.tsx
+++ b/packages/dashboard-core/src/components/DiffView.tsx
@@ -81,6 +81,28 @@ function storeDiffMode(mode: DiffMode) {
   } catch {}
 }
 
+const COMPARE_BRANCH_KEY_PREFIX = "band:diff-compare-branch:";
+
+function getStoredCompareBranch(workspaceId: string): string | null {
+  try {
+    return localStorage.getItem(COMPARE_BRANCH_KEY_PREFIX + workspaceId);
+  } catch {
+    return null;
+  }
+}
+
+function storeCompareBranch(workspaceId: string, branch: string | null) {
+  try {
+    if (branch) {
+      localStorage.setItem(COMPARE_BRANCH_KEY_PREFIX + workspaceId, branch);
+    } else {
+      localStorage.removeItem(COMPARE_BRANCH_KEY_PREFIX + workspaceId);
+    }
+  } catch {}
+}
+
+const UNCOMMITTED_VALUE = "__uncommitted__";
+
 const EXPAND_ALL_KEY = "band:diff-expand-all";
 
 function getStoredExpandAll(): boolean {
@@ -819,6 +841,10 @@ export function DiffView({
   const [viewMode, setViewModeState] = useState<ViewMode>(getStoredViewMode);
   const [diffMode, setDiffModeState] = useState<DiffMode>(getStoredDiffMode);
   const [expandAll, setExpandAllState] = useState(getStoredExpandAll);
+  const [compareBranch, setCompareBranchState] = useState<string | null>(() =>
+    getStoredCompareBranch(workspaceId),
+  );
+  const [availableBranches, setAvailableBranches] = useState<string[]>([]);
   const setViewMode = useCallback((mode: ViewMode) => {
     setViewModeState(mode);
     storeViewMode(mode);
@@ -827,6 +853,45 @@ export function DiffView({
     setDiffModeState(mode);
     storeDiffMode(mode);
   }, []);
+  const setCompareBranch = useCallback(
+    (branch: string | null) => {
+      setCompareBranchState(branch);
+      storeCompareBranch(workspaceId, branch);
+    },
+    [workspaceId],
+  );
+
+  // Reload stored compareBranch when workspace changes
+  useEffect(() => {
+    setCompareBranchState(getStoredCompareBranch(workspaceId));
+  }, [workspaceId]);
+
+  // Fetch list of branches for the workspace
+  useEffect(() => {
+    const listWorkspaceBranches = adapter.listWorkspaceBranches;
+    if (!listWorkspaceBranches) return;
+    let cancelled = false;
+    listWorkspaceBranches
+      .call(adapter, workspaceId)
+      .then((result) => {
+        if (cancelled) return;
+        setAvailableBranches(result.branches);
+        // Drop the stored selection if it no longer exists in the workspace
+        setCompareBranchState((current) => {
+          if (current && !result.branches.includes(current)) {
+            storeCompareBranch(workspaceId, null);
+            return null;
+          }
+          return current;
+        });
+      })
+      .catch(() => {
+        if (!cancelled) setAvailableBranches([]);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [adapter, workspaceId]);
   const setExpandAll = useCallback((v: boolean) => {
     setExpandAllState(v);
     storeExpandAll(v);
@@ -1085,7 +1150,7 @@ export function DiffView({
       if (!revertFile) return;
 
       revertFile
-        .call(adapter, workspaceId, filename, diffMode)
+        .call(adapter, workspaceId, filename, diffMode, compareBranch ?? undefined)
         .then(() => {
           // Remove from diff cache
           setDiffCache((prev) => {
@@ -1101,7 +1166,7 @@ export function DiffView({
           console.error("Failed to revert file:", err);
         });
     },
-    [adapter, workspaceId, diffMode],
+    [adapter, workspaceId, diffMode, compareBranch],
   );
 
   // -------------------------------------------------------------------------
@@ -1123,7 +1188,7 @@ export function DiffView({
 
     const fetchSummary = (forceRefresh = false) => {
       getWorkspaceDiffSummary
-        .call(adapter, workspaceId, diffMode)
+        .call(adapter, workspaceId, diffMode, compareBranch ?? undefined)
         .then((result) => {
           if (!cancelled) {
             const fingerprint = JSON.stringify({
@@ -1205,7 +1270,41 @@ export function DiffView({
       fetchSummaryRef.current = null;
       unsubscribe?.();
     };
-  }, [adapter, workspaceId, active, onStatsChange, diffMode, fetchFileDiff]);
+  }, [adapter, workspaceId, active, onStatsChange, diffMode, compareBranch, fetchFileDiff]);
+
+  // ---------------------------------------------------------------------------
+  // Diff target dropdown — combines diff mode + branch selection into one menu
+  // ---------------------------------------------------------------------------
+  const branchOptions =
+    availableBranches.length > 0 ? availableBranches : baseBranch ? [baseBranch] : [];
+  const selectedBranch = compareBranch ?? branchOptions[0] ?? baseBranch ?? null;
+  const diffSelectValue =
+    diffMode === "uncommitted" ? UNCOMMITTED_VALUE : (selectedBranch ?? UNCOMMITTED_VALUE);
+
+  const handleDiffSelectChange = (value: string) => {
+    if (value === UNCOMMITTED_VALUE) {
+      setDiffMode("uncommitted");
+    } else {
+      setDiffMode("branch");
+      setCompareBranch(value);
+    }
+  };
+
+  const renderDiffSelect = () => (
+    <Select value={diffSelectValue} onValueChange={handleDiffSelectChange}>
+      <SelectTrigger className="h-7 w-auto gap-1 rounded-md border-border/50 bg-muted/50 px-2.5 text-xs">
+        <SelectValue />
+      </SelectTrigger>
+      <SelectContent>
+        <SelectItem value={UNCOMMITTED_VALUE}>Uncommitted</SelectItem>
+        {branchOptions.map((branch) => (
+          <SelectItem key={branch} value={branch}>
+            {branch}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  );
 
   if (loading) {
     return (
@@ -1227,15 +1326,7 @@ export function DiffView({
     return (
       <div className="flex h-full flex-col overflow-hidden">
         <div className="flex shrink-0 items-center justify-end border-b border-border px-4 py-2">
-          <Select value={diffMode} onValueChange={(v) => setDiffMode(v as DiffMode)}>
-            <SelectTrigger className="h-7 w-auto gap-1 rounded-md border-border/50 bg-muted/50 px-2.5 text-xs">
-              <SelectValue />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value="uncommitted">Uncommitted</SelectItem>
-              <SelectItem value="branch">{baseBranch ?? "base"}</SelectItem>
-            </SelectContent>
-          </Select>
+          {renderDiffSelect()}
         </div>
         <div className="flex flex-1 items-center justify-center text-sm text-muted-foreground">
           No changes
@@ -1354,15 +1445,7 @@ export function DiffView({
                 <ChevronsUpDown className="size-3.5" />
               )}
             </button>
-            <Select value={diffMode} onValueChange={(v) => setDiffMode(v as DiffMode)}>
-              <SelectTrigger className="h-7 w-auto gap-1 rounded-md border-border/50 bg-muted/50 px-2.5 text-xs">
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="uncommitted">Uncommitted</SelectItem>
-                <SelectItem value="branch">{baseBranch ?? "base"}</SelectItem>
-              </SelectContent>
-            </Select>
+            {renderDiffSelect()}
             <div className="hidden items-center rounded-md border border-border/50 bg-muted/50 md:flex">
               <button
                 type="button"

--- a/packages/dashboard-core/src/components/DiffView.tsx
+++ b/packages/dashboard-core/src/components/DiffView.tsx
@@ -2,6 +2,7 @@ import {
   Select,
   SelectContent,
   SelectItem,
+  SelectSeparator,
   SelectTrigger,
   SelectValue,
   Tooltip,
@@ -13,6 +14,7 @@ import { SearchQuery } from "@codemirror/search";
 import { EditorState, RangeSetBuilder, Text } from "@codemirror/state";
 import { Decoration, EditorView, lineNumbers, WidgetType } from "@codemirror/view";
 import {
+  ArrowRight,
   Check,
   ChevronsDownUp,
   ChevronsUpDown,
@@ -850,6 +852,10 @@ export function DiffView({
     const stored = getStoredCompareBranch(workspaceId);
     return stored ? [stored] : [];
   });
+  // The project's default branch, fetched via listWorkspaceBranches. We track
+  // it independently of the diff summary so the dropdown can pin the default
+  // (e.g. `main`) to the top section even before the summary loads.
+  const [availableDefaultBranch, setAvailableDefaultBranch] = useState<string | null>(null);
   const compareBranchRef = useRef(compareBranch);
   compareBranchRef.current = compareBranch;
   const setViewMode = useCallback((mode: ViewMode) => {
@@ -873,6 +879,7 @@ export function DiffView({
     const stored = getStoredCompareBranch(workspaceId);
     setCompareBranchState(stored);
     setAvailableBranches(stored ? [stored] : []);
+    setAvailableDefaultBranch(null);
   }, [workspaceId]);
 
   // Fetch the list of branches and refresh on branch-status SSE events so a
@@ -889,6 +896,7 @@ export function DiffView({
         .then((result) => {
           if (cancelled) return;
           setAvailableBranches(result.branches);
+          setAvailableDefaultBranch(result.defaultBranch);
           // Drop the stored selection if it no longer exists. Read the latest
           // value from a ref so this stays a pure check (no side effects in
           // the setState updater) and avoids stale-closure issues.
@@ -1300,18 +1308,36 @@ export function DiffView({
   }, [adapter, workspaceId, active, onStatsChange, diffMode, compareBranch, fetchFileDiff]);
 
   // ---------------------------------------------------------------------------
-  // Diff target dropdown — combines diff mode + branch selection into one menu
+  // Diff target dropdown — combines diff mode + branch selection into one menu.
+  // Top section: target branch (current pick), then the project's default
+  // branch (if different from target), then Uncommitted. Below the separator
+  // we list every other branch alphabetically. Pinning both target + default
+  // to the top keeps the two most common compare targets one click away.
   // ---------------------------------------------------------------------------
   const summaryCompareBranch = summary?.compareBranch ?? null;
+  const defaultBranch = summary?.defaultBranch ?? availableDefaultBranch ?? null;
   const branchOptions =
     availableBranches.length > 0
       ? availableBranches
       : summaryCompareBranch
         ? [summaryCompareBranch]
         : [];
-  const selectedBranch = compareBranch ?? branchOptions[0] ?? summaryCompareBranch;
+  const targetBranch = compareBranch ?? branchOptions[0] ?? summaryCompareBranch;
+
+  // Branches pinned above the separator. Order matters in the rendered list.
+  const topSectionBranches: string[] = [];
+  if (targetBranch) {
+    topSectionBranches.push(targetBranch);
+  }
+  if (defaultBranch && defaultBranch !== targetBranch && branchOptions.includes(defaultBranch)) {
+    topSectionBranches.push(defaultBranch);
+  }
+  const otherBranches = branchOptions
+    .filter((b) => !topSectionBranches.includes(b))
+    .sort((a, b) => a.localeCompare(b));
+
   const diffSelectValue =
-    diffMode === "uncommitted" ? UNCOMMITTED_VALUE : (selectedBranch ?? UNCOMMITTED_VALUE);
+    diffMode === "uncommitted" ? UNCOMMITTED_VALUE : (targetBranch ?? UNCOMMITTED_VALUE);
 
   const handleDiffSelectChange = (value: string) => {
     if (value === UNCOMMITTED_VALUE) {
@@ -1324,12 +1350,18 @@ export function DiffView({
 
   const renderDiffSelect = () => (
     <Select value={diffSelectValue} onValueChange={handleDiffSelectChange}>
-      <SelectTrigger className="h-7 w-auto gap-1 rounded-md border-border/50 bg-muted/50 px-2.5 text-xs">
+      <SelectTrigger className="h-6 w-auto gap-1 rounded-md border-0 bg-transparent px-1.5 text-xs font-medium text-foreground shadow-none hover:bg-accent">
         <SelectValue />
       </SelectTrigger>
       <SelectContent>
+        {topSectionBranches.map((branch) => (
+          <SelectItem key={branch} value={branch}>
+            {branch}
+          </SelectItem>
+        ))}
         <SelectItem value={UNCOMMITTED_VALUE}>Uncommitted</SelectItem>
-        {branchOptions.map((branch) => (
+        {otherBranches.length > 0 && <SelectSeparator />}
+        {otherBranches.map((branch) => (
           <SelectItem key={branch} value={branch}>
             {branch}
           </SelectItem>
@@ -1354,14 +1386,48 @@ export function DiffView({
     );
   }
 
+  // Ghost-style classes shared across every toolbar action button. Variants
+  // for the segmented view-mode toggle differ slightly because the active
+  // segment uses `bg-accent` on its own, without the hover transition.
+  const ghostBtnClass =
+    "hidden size-7 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent hover:text-foreground md:inline-flex";
+  const ghostBtnAlwaysClass =
+    "inline-flex size-7 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent hover:text-foreground";
+
+  /** File-tree toggle — always visible on desktop, hidden on mobile. */
+  const renderSidebarToggle = () => (
+    <button
+      type="button"
+      onClick={() => setSidebarOpen(!sidebarOpen)}
+      className={ghostBtnClass}
+      title={sidebarOpen ? "Hide file tree" : "Show file tree"}
+      aria-label={sidebarOpen ? "Hide file tree" : "Show file tree"}
+      aria-pressed={sidebarOpen}
+    >
+      <PanelLeft className="size-3.5" />
+    </button>
+  );
+
+  /** Inline branch indicator: `<head> → <dropdown>` rendered next to the stats. */
+  const renderBranchIndicator = (headBranchLabel: string | null | undefined) => (
+    <div className="hidden items-center gap-1.5 text-xs text-muted-foreground sm:flex">
+      {headBranchLabel && (
+        <>
+          <span className="font-medium text-foreground">{headBranchLabel}</span>
+          <ArrowRight className="size-3" aria-hidden />
+        </>
+      )}
+      {renderDiffSelect()}
+    </div>
+  );
+
   if (!summary || summary.stats.filesChanged === 0) {
     return (
       <div className="flex h-full flex-col overflow-hidden">
-        <div className="flex shrink-0 items-center justify-end border-b border-border px-4 py-2">
-          {renderDiffSelect()}
-        </div>
-        <div className="flex flex-1 items-center justify-center text-sm text-muted-foreground">
-          No changes
+        <div className="flex h-8 shrink-0 items-center gap-3 border-b border-border pl-2 pr-3">
+          {renderSidebarToggle()}
+          <span className="text-sm text-muted-foreground">No changes</span>
+          {renderBranchIndicator(summary?.headBranch)}
         </div>
       </div>
     );
@@ -1380,16 +1446,8 @@ export function DiffView({
           className="hidden shrink-0 flex-col md:flex"
           style={{ width: sidebarWidth }}
         >
-          <div className="flex h-8 shrink-0 items-center justify-between border-b border-border px-3">
+          <div className="flex h-8 shrink-0 items-center border-b border-border px-3">
             <span className="text-xs font-medium text-muted-foreground">Files</span>
-            <button
-              type="button"
-              onClick={() => setSidebarOpen(false)}
-              className="rounded p-0.5 text-muted-foreground hover:bg-accent/50 hover:text-foreground"
-              title="Hide file tree"
-            >
-              <PanelLeft className="size-3.5" />
-            </button>
           </div>
           <div className="min-h-0 flex-1 overflow-y-auto py-1">
             <ChangesFileTree
@@ -1411,65 +1469,37 @@ export function DiffView({
 
       {/* RIGHT: Main content (toolbar + file list) */}
       <div className="flex min-w-0 flex-1 flex-col overflow-hidden">
-        <div className="flex shrink-0 items-center justify-between border-b border-border px-4 py-2">
-          <div className="flex items-center gap-3">
-            {/* Sidebar toggle — only visible on desktop when sidebar is closed */}
-            {!sidebarOpen && (
-              <button
-                type="button"
-                onClick={() => setSidebarOpen(true)}
-                className="hidden items-center rounded-md border border-border/50 bg-muted/50 px-2 py-1 text-xs text-muted-foreground transition-colors hover:text-foreground md:inline-flex"
-                title="Show file tree"
-              >
-                <PanelLeft className="size-3.5" />
-              </button>
-            )}
-            <div>
-              <div className="text-sm text-muted-foreground">
-                <span className="font-medium text-foreground">{summary.stats.filesChanged}</span>{" "}
-                {summary.stats.filesChanged === 1 ? "file" : "files"} changed
-                {summary.stats.insertions > 0 && (
-                  <span className="ml-2 text-green-600 dark:text-green-400">
-                    +{summary.stats.insertions}
-                  </span>
-                )}
-                {summary.stats.deletions > 0 && (
-                  <span className="ml-1 text-red-600 dark:text-red-400">
-                    -{summary.stats.deletions}
-                  </span>
-                )}
-              </div>
-              <div className="mt-0.5 text-xs text-muted-foreground">
-                {summary.compareBranch} &larr; {summary.headBranch}
-              </div>
-            </div>
+        <div className="flex h-8 shrink-0 items-center justify-between gap-3 border-b border-border pl-2 pr-3">
+          <div className="flex min-w-0 items-center gap-1.5">
+            {renderSidebarToggle()}
+            {renderBranchIndicator(summary.headBranch)}
           </div>
-          <div className="flex items-center gap-2">
+          <div className="flex items-center gap-1">
             <button
               type="button"
               onClick={() => fetchSummaryRef.current?.(true)}
-              className="inline-flex items-center rounded-md border border-border/50 bg-muted/50 px-2 py-1 text-xs text-muted-foreground transition-colors hover:text-foreground"
+              className={ghostBtnAlwaysClass}
               title="Reload changes"
+              aria-label="Reload changes"
             >
               <RefreshCw className="size-3.5" />
             </button>
             <button
               type="button"
               onClick={search.handleOpenSearch}
-              className="inline-flex items-center rounded-md border border-border/50 bg-muted/50 px-2 py-1 text-xs text-muted-foreground transition-colors hover:text-foreground"
+              className={ghostBtnAlwaysClass}
               title="Find in changes (⌘F)"
+              aria-label="Find in changes"
             >
               <Search className="size-3.5" />
             </button>
             <button
               type="button"
               onClick={() => setExpandAll(!expandAll)}
-              className={`inline-flex items-center rounded-md border border-border/50 px-2 py-1 text-xs transition-colors ${
-                expandAll
-                  ? "bg-accent text-foreground"
-                  : "bg-muted/50 text-muted-foreground hover:text-foreground"
-              }`}
+              className={`${ghostBtnAlwaysClass} ${expandAll ? "bg-accent text-foreground" : ""}`}
               title={expandAll ? "Collapse all files" : "Expand all files"}
+              aria-label={expandAll ? "Collapse all files" : "Expand all files"}
+              aria-pressed={expandAll}
             >
               {expandAll ? (
                 <ChevronsDownUp className="size-3.5" />
@@ -1477,29 +1507,24 @@ export function DiffView({
                 <ChevronsUpDown className="size-3.5" />
               )}
             </button>
-            {renderDiffSelect()}
-            <div className="hidden items-center rounded-md border border-border/50 bg-muted/50 md:flex">
+            <div className="hidden items-center md:flex">
               <button
                 type="button"
                 onClick={() => setViewMode("unified")}
-                className={`inline-flex items-center gap-1 rounded-l-md px-2 py-1 text-xs transition-colors ${
-                  viewMode === "unified"
-                    ? "bg-accent text-foreground"
-                    : "text-muted-foreground hover:text-foreground"
-                }`}
+                className={`${ghostBtnAlwaysClass} ${viewMode === "unified" ? "bg-accent text-foreground" : ""}`}
                 title="Unified view"
+                aria-label="Unified view"
+                aria-pressed={viewMode === "unified"}
               >
                 <Rows2 className="size-3.5" />
               </button>
               <button
                 type="button"
                 onClick={() => setViewMode("split")}
-                className={`inline-flex items-center gap-1 rounded-r-md px-2 py-1 text-xs transition-colors ${
-                  viewMode === "split"
-                    ? "bg-accent text-foreground"
-                    : "text-muted-foreground hover:text-foreground"
-                }`}
+                className={`${ghostBtnAlwaysClass} ${viewMode === "split" ? "bg-accent text-foreground" : ""}`}
                 title="Split view"
+                aria-label="Split view"
+                aria-pressed={viewMode === "split"}
               >
                 <Columns2 className="size-3.5" />
               </button>
@@ -1542,6 +1567,21 @@ export function DiffView({
               />
             ))}
           </div>
+        </div>
+        {/* Bottom status bar — totals for the current diff */}
+        <div className="flex h-8 shrink-0 items-center border-t border-border px-3 text-sm text-muted-foreground">
+          <span className="font-medium text-foreground">{summary.stats.filesChanged}</span>
+          <span className="ml-1">
+            {summary.stats.filesChanged === 1 ? "file" : "files"} changed
+          </span>
+          {summary.stats.insertions > 0 && (
+            <span className="ml-2 text-green-600 dark:text-green-400">
+              +{summary.stats.insertions}
+            </span>
+          )}
+          {summary.stats.deletions > 0 && (
+            <span className="ml-1 text-red-600 dark:text-red-400">-{summary.stats.deletions}</span>
+          )}
         </div>
       </div>
     </div>

--- a/packages/dashboard-core/src/components/DiffView.tsx
+++ b/packages/dashboard-core/src/components/DiffView.tsx
@@ -826,7 +826,6 @@ export function DiffView({
   const adapter = useAdapter();
   const [summary, setSummary] = useState<WorkspaceDiffSummary | null>(null);
   const summaryRef = useRef<WorkspaceDiffSummary | null>(null);
-  const [baseBranch, setBaseBranch] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
   const fetchSummaryRef = useRef<((force?: boolean) => void) | null>(null);
@@ -844,7 +843,15 @@ export function DiffView({
   const [compareBranch, setCompareBranchState] = useState<string | null>(() =>
     getStoredCompareBranch(workspaceId),
   );
-  const [availableBranches, setAvailableBranches] = useState<string[]>([]);
+  // Seed `availableBranches` with the persisted selection so the picker shows
+  // the stored branch immediately on mount, instead of flashing empty until
+  // listWorkspaceBranches resolves.
+  const [availableBranches, setAvailableBranches] = useState<string[]>(() => {
+    const stored = getStoredCompareBranch(workspaceId);
+    return stored ? [stored] : [];
+  });
+  const compareBranchRef = useRef(compareBranch);
+  compareBranchRef.current = compareBranch;
   const setViewMode = useCallback((mode: ViewMode) => {
     setViewModeState(mode);
     storeViewMode(mode);
@@ -861,37 +868,58 @@ export function DiffView({
     [workspaceId],
   );
 
-  // Reload stored compareBranch when workspace changes
+  // Reload stored compareBranch + reseed availableBranches when workspace changes
   useEffect(() => {
-    setCompareBranchState(getStoredCompareBranch(workspaceId));
+    const stored = getStoredCompareBranch(workspaceId);
+    setCompareBranchState(stored);
+    setAvailableBranches(stored ? [stored] : []);
   }, [workspaceId]);
 
-  // Fetch list of branches for the workspace
+  // Fetch the list of branches and refresh on branch-status SSE events so a
+  // `git checkout -b` from another tool (terminal, IDE) is reflected without
+  // a full reload.
   useEffect(() => {
     const listWorkspaceBranches = adapter.listWorkspaceBranches;
     if (!listWorkspaceBranches) return;
     let cancelled = false;
-    listWorkspaceBranches
-      .call(adapter, workspaceId)
-      .then((result) => {
-        if (cancelled) return;
-        setAvailableBranches(result.branches);
-        // Drop the stored selection if it no longer exists in the workspace
-        setCompareBranchState((current) => {
+
+    const fetchBranches = () => {
+      listWorkspaceBranches
+        .call(adapter, workspaceId)
+        .then((result) => {
+          if (cancelled) return;
+          setAvailableBranches(result.branches);
+          // Drop the stored selection if it no longer exists. Read the latest
+          // value from a ref so this stays a pure check (no side effects in
+          // the setState updater) and avoids stale-closure issues.
+          const current = compareBranchRef.current;
           if (current && !result.branches.includes(current)) {
-            storeCompareBranch(workspaceId, null);
-            return null;
+            setCompareBranch(null);
           }
-          return current;
+        })
+        .catch(() => {
+          // Leave existing availableBranches in place on error — the server
+          // logs the underlying failure in listBranches.
         });
-      })
-      .catch(() => {
-        if (!cancelled) setAvailableBranches([]);
+    };
+
+    fetchBranches();
+
+    let unsubscribe: (() => void) | undefined;
+    if (active) {
+      unsubscribe = adapter.subscribeStatusEvents((event) => {
+        const data = event as SSEEvent;
+        if (data.kind === "branch-status" && data.workspaceId === workspaceId) {
+          fetchBranches();
+        }
       });
+    }
+
     return () => {
       cancelled = true;
+      unsubscribe?.();
     };
-  }, [adapter, workspaceId]);
+  }, [adapter, workspaceId, active, setCompareBranch]);
   const setExpandAll = useCallback((v: boolean) => {
     setExpandAllState(v);
     storeExpandAll(v);
@@ -1207,7 +1235,6 @@ export function DiffView({
             // re-rendering the entire file list with identical content.
             if (dataChanged) {
               setSummary(result);
-              setBaseBranch(result.baseBranch);
             }
             setError(null);
 
@@ -1275,9 +1302,14 @@ export function DiffView({
   // ---------------------------------------------------------------------------
   // Diff target dropdown — combines diff mode + branch selection into one menu
   // ---------------------------------------------------------------------------
+  const summaryCompareBranch = summary?.compareBranch ?? null;
   const branchOptions =
-    availableBranches.length > 0 ? availableBranches : baseBranch ? [baseBranch] : [];
-  const selectedBranch = compareBranch ?? branchOptions[0] ?? baseBranch ?? null;
+    availableBranches.length > 0
+      ? availableBranches
+      : summaryCompareBranch
+        ? [summaryCompareBranch]
+        : [];
+  const selectedBranch = compareBranch ?? branchOptions[0] ?? summaryCompareBranch;
   const diffSelectValue =
     diffMode === "uncommitted" ? UNCOMMITTED_VALUE : (selectedBranch ?? UNCOMMITTED_VALUE);
 
@@ -1408,7 +1440,7 @@ export function DiffView({
                 )}
               </div>
               <div className="mt-0.5 text-xs text-muted-foreground">
-                {summary.baseBranch} &larr; {summary.headBranch}
+                {summary.compareBranch} &larr; {summary.headBranch}
               </div>
             </div>
           </div>

--- a/packages/dashboard-core/src/types.ts
+++ b/packages/dashboard-core/src/types.ts
@@ -166,7 +166,10 @@ export type DiffMode = "uncommitted" | "branch";
 export interface WorkspaceDiff {
   diff: string;
   stats: { filesChanged: number; insertions: number; deletions: number };
-  baseBranch: string;
+  /** Branch the diff was computed against — user's pick, or defaults to `defaultBranch`. */
+  compareBranch: string;
+  /** The project's default branch (e.g. `main`). Always present, regardless of `compareBranch`. */
+  defaultBranch: string;
   headBranch: string;
   fileStatuses: Record<string, FileStatus>;
 }
@@ -192,7 +195,10 @@ export interface FileContentResult {
 
 export interface WorkspaceDiffSummary {
   stats: { filesChanged: number; insertions: number; deletions: number };
-  baseBranch: string;
+  /** Branch the diff was computed against — user's pick, or defaults to `defaultBranch`. */
+  compareBranch: string;
+  /** The project's default branch (e.g. `main`). Always present, regardless of `compareBranch`. */
+  defaultBranch: string;
   headBranch: string;
   fileStatuses: Record<string, FileStatus>;
   mergeBase: string;


### PR DESCRIPTION
## Summary

Builds on top of #360 (Marko's compare-branch picker work) and addresses every point from the [PR review](https://github.com/band-app/band/pull/360#issuecomment-) plus a series of UX iterations on the Diff tab toolbar.

This PR can supersede #360 — it includes all of marsicdev's commits (rebased onto current `main`), follow-up fixes for each review point, and the redesigned toolbar.

## What changed

### Original feature (preserved from #360)
- Per-workspace compare-branch picker — diff against any local branch, not just the project default
- New `workspace.listBranches` tRPC endpoint backing the dropdown
- Selection persists per workspace in localStorage

### Review fixes
- **Validation:** new `compareBranchSchema` (`z.string().regex(/^[^-]/)`) prevents branch names starting with `-` from being interpreted as git flags in `merge-base` / `checkout`
- **API rename:** `baseBranch` → `compareBranch`, plus a new `defaultBranch` companion field — the old name's semantics changed under #360 and the new pair is honest about which is which
- **`listBranches` edge case:** stop re-adding the default branch when you're already on it (it produced a no-op compare option identical to "Uncommitted")
- **Refactor:** extracted `resolveDiffContext` / `parseDiffStatSummary` / `parseFileStatuses` / `readUntrackedFileLines` helpers — `getDiff`, `getDiffSummary`, and `revertFile` now share merge-base resolution and can't drift
- **Branch list refresh:** subscribes to `branch-status` SSE events so a `git checkout -b` from another tool updates the dropdown without reload
- **State hygiene:** moved the `localStorage` write out of the `setCompareBranchState` updater (read-from-ref pattern); seeded `availableBranches` from storage on mount so the picker doesn't flash empty
- **Type tightening:** `DashboardAdapter.revertFile` is `DiffMode` instead of `string` — drops a runtime cast in `WebDashboardAdapter`
- **Server logging:** `listBranches` now logs `for-each-ref` failures instead of swallowing them silently
- **Tests:** 5 new integration tests cover the new endpoint, `compareBranch` routing, validation rejection, default-branch-on-default-branch behaviour, and `revertFile` against a non-default branch

### Toolbar redesign
- Single `h-8` toolbar (was two-line) matching the file-tree sidebar header
- Inline `<headBranch> → <dropdown>` indicator (replaces the `compare ← head` second line)
- Stats moved to a new `h-8` status bar at the bottom of the changes panel
- Branch dropdown reordered: **target → default branch → Uncommitted → separator → other branches alphabetically**. Pinning both the current pick and the project default keeps the two most common compare targets one click away.
- Ghost-style toolbar buttons (no border / muted-bg) with hover affordance
- Single file-tree toggle in the toolbar (always visible on desktop, hidden on mobile) — removed the redundant button from the sidebar header

### Build hygiene
- `chore(knip)`: silence false-positive "unlisted binaries" / "unused devDep" for `apps/desktop`'s `tsc` / `electron` / `electron-builder`. The Electron migration on `main` had left `pnpm knip` failing on the pre-push hook; this unblocks pushes.

## Commits

```
4f9cf70 chore(knip): silence false positives for apps/desktop
cab6acf refactor(diff): redesign Diff tab toolbar and branch picker
40881f3 refactor(diff): address PR review feedback
88ba837 fix(diff): repair diff tab rendering   ← #360, replayed
```

## Test plan

- [ ] Open workspace → Diff tab
- [ ] Switch dropdown between Uncommitted / default / a non-default branch — confirm file list and stats update
- [ ] Pick a non-default branch — confirm diff is computed against `merge-base(<picked>, HEAD)`
- [ ] Reload workspace — confirm picked branch is restored from storage
- [ ] Switch workspaces — confirm selection is per-workspace
- [ ] Revert a file in branch-compare mode — confirm revert uses the picked branch as ref
- [ ] Create a branch from a terminal while the diff tab is open — confirm it appears in the dropdown without reload
- [ ] Try to send `compareBranch: "--exec=foo"` — confirm 400 from validation
- [ ] Toggle the file-tree from the toolbar button — confirm the sidebar opens/closes from the same control regardless of state

🤖 Generated with [Claude Code](https://claude.com/claude-code)