### PR TITLE
feat(web): queued messages — images, edit, drag-reorder; fix multi-image direct send

### DIFF
--- a/apps/web/src/api/task-stream.ts
+++ b/apps/web/src/api/task-stream.ts
@@ -12,7 +12,7 @@ import {
   subscribe as subscribeTask,
   TaskConflictError,
 } from "../lib/task-runner";
-import { saveUploadedFiles } from "../lib/upload-utils";
+import { saveUploadedFilesDetailed } from "../lib/upload-utils";
 
 const log = createLogger("task-stream");
 
@@ -232,13 +232,25 @@ async function handlePost(
     createChat(workspaceId, { id: chatId, name: "Chat", agent: codingAgentId });
   }
 
-  // Handle file uploads
+  // Handle file uploads — write each attachment to ~/.band/uploads/
+  // and build (a) a path list to inject into the agent prompt and
+  // (b) a display-only metadata array, with /api/uploads/{name} URLs,
+  // that we hand to submitTask so the user-message broadcast (and
+  // therefore the persisted session JSONL) carries the file parts.
+  // Without (b), reloading the session would re-render the user
+  // bubble as text-only and lose any attached images.
   let agentPrompt: string | undefined;
+  let displayFiles: { mediaType: string; url: string; filename?: string }[] | undefined;
   if (files && files.length > 0) {
-    const savedPaths = await saveUploadedFiles(files);
-    if (savedPaths.length > 0) {
-      const fileList = savedPaths.map((p) => `- ${p}`).join("\n");
+    const saved = await saveUploadedFilesDetailed(files);
+    if (saved.length > 0) {
+      const fileList = saved.map((s) => `- ${s.path}`).join("\n");
       agentPrompt = `I'm sharing these files with you:\n${fileList}\n\n${prompt}`;
+      displayFiles = saved.map((s) => ({
+        mediaType: s.mediaType,
+        url: `/api/uploads/${s.storedName}`,
+        filename: s.originalName,
+      }));
     }
   }
 
@@ -250,6 +262,7 @@ async function handlePost(
       prompt,
       sessionId,
       agentPrompt,
+      displayFiles,
       maxTurns,
       mode,
       model,

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -2,7 +2,13 @@ import { useChat } from "@ai-sdk/react";
 import { AgentIcon, useExperimentalContextMeter } from "@band-app/dashboard-core";
 import {
   Badge,
+  Button,
   cn,
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuGroup,
@@ -14,10 +20,26 @@ import {
   Popover,
   PopoverContent,
   PopoverTrigger,
+  Textarea,
   Tooltip,
   TooltipContent,
   TooltipTrigger,
 } from "@band-app/ui";
+import {
+  closestCenter,
+  DndContext,
+  type DragEndEvent,
+  PointerSensor,
+  useSensor,
+  useSensors,
+} from "@dnd-kit/core";
+import {
+  arrayMove,
+  SortableContext,
+  useSortable,
+  verticalListSortingStrategy,
+} from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
 import type { UIMessage } from "ai";
 import { getToolName, isToolUIPart } from "ai";
 import {
@@ -26,6 +48,7 @@ import {
   Clock,
   CodeXml,
   GitBranch,
+  GripHorizontal,
   Loader2,
   Plus,
   ScrollText,
@@ -173,8 +196,15 @@ type UIMessageParts = ReturnType<
   typeof import("@ai-sdk/react").useChat
 >["messages"][number]["parts"];
 
+interface QueuedFilePart {
+  mediaType: string;
+  url: string;
+  filename?: string;
+}
+
 type QueueSegment = {
   userPrompt: string | null;
+  userFiles?: QueuedFilePart[];
   parts: UIMessageParts;
 };
 
@@ -194,8 +224,11 @@ function splitMessageAtQueueBoundaries(parts: UIMessageParts): QueueSegment[] {
     if (part.type === "data-prompt") {
       // Finish current segment and start a new one
       segments.push(current);
+      const data = (part as { type: string; data: { text: string; files?: QueuedFilePart[] } })
+        .data;
       current = {
-        userPrompt: (part as { type: string; data: { text: string } }).data.text,
+        userPrompt: data.text,
+        userFiles: data.files,
         parts: [],
       };
       continue;
@@ -483,7 +516,12 @@ export function ChatView({
     [chatId],
   );
 
-  const [queuedMessages, setQueuedMessages] = useState<string[]>([]);
+  interface QueuedMessageView {
+    id: string;
+    text: string;
+    files?: QueuedFilePart[];
+  }
+  const [queuedMessages, setQueuedMessages] = useState<QueuedMessageView[]>([]);
 
   // Subscribe to queue state changes via a dedicated tRPC subscription.
   // The backend pushes the full queue array on every change (push, shift,
@@ -492,7 +530,7 @@ export function ChatView({
     const subscription = trpc.queue.stream.subscribe(
       { workspaceId, chatId },
       {
-        onData(data: { messages: string[] }) {
+        onData(data: { messages: QueuedMessageView[] }) {
           setQueuedMessages(data.messages);
         },
       },
@@ -1009,9 +1047,43 @@ export function ChatView({
   }, [visible, wsActive, handleNewSession]);
 
   const queueMessage = useCallback(
-    (text: string) => {
-      setQueuedMessages((prev) => [...prev, text]);
-      trpc.queue.push.mutate({ workspaceId, chatId, text }).catch(() => {});
+    async (message: PromptInputMessage) => {
+      // Convert browser File[] to base64 data URLs so they can be
+      // serialized through tRPC. Files are uploaded to disk only when
+      // the queued message is drained (server-side).
+      const files = await Promise.all(
+        (message.files ?? []).map(
+          (file): Promise<QueuedFilePart> =>
+            new Promise((resolve, reject) => {
+              const reader = new FileReader();
+              reader.onload = () => {
+                resolve({
+                  mediaType: file.type,
+                  url: reader.result as string,
+                  filename: file.name,
+                });
+              };
+              reader.onerror = () => reject(reader.error);
+              reader.readAsDataURL(file);
+            }),
+        ),
+      );
+
+      // Optimistic update with a temporary id; subscription corrects when
+      // the server's response arrives.
+      const tempId = `temp-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+      setQueuedMessages((prev) => [
+        ...prev,
+        { id: tempId, text: message.text, files: files.length > 0 ? files : undefined },
+      ]);
+      trpc.queue.push
+        .mutate({
+          workspaceId,
+          chatId,
+          text: message.text,
+          ...(files.length > 0 && { files }),
+        })
+        .catch(() => {});
     },
     [workspaceId, chatId],
   );
@@ -1023,7 +1095,7 @@ export function ChatView({
       if (isStreaming) {
         // Agent is busy — queue the message on the backend.
         // Optimistic update for instant feedback; subscription corrects if needed.
-        queueMessage(message.text);
+        await queueMessage(message);
         return;
       }
 
@@ -1032,7 +1104,7 @@ export function ChatView({
       try {
         const { task } = await trpc.tasks.get.query({ workspaceId, chatId });
         if (task && task.status === "running") {
-          queueMessage(message.text);
+          await queueMessage(message);
           return;
         }
       } catch {
@@ -1046,16 +1118,55 @@ export function ChatView({
   );
 
   const handleCancelQueued = useCallback(
-    (text: string) => {
+    (id: string) => {
       // Optimistic update for instant feedback; subscription corrects if needed.
-      setQueuedMessages((prev) => {
-        const idx = prev.indexOf(text);
-        if (idx === -1) return prev;
-        const messages = [...prev.slice(0, idx), ...prev.slice(idx + 1)];
+      setQueuedMessages((prev) => prev.filter((m) => m.id !== id));
+      trpc.queue.remove.mutate({ workspaceId, chatId, id }).catch(() => {});
+    },
+    [workspaceId, chatId],
+  );
 
-        return messages;
+  const handleEditQueued = useCallback(
+    (id: string, text: string) => {
+      // Optimistic update for instant feedback; subscription corrects if needed.
+      setQueuedMessages((prev) => prev.map((m) => (m.id === id ? { ...m, text } : m)));
+      trpc.queue.update.mutate({ workspaceId, chatId, id, text }).catch(() => {});
+    },
+    [workspaceId, chatId],
+  );
+
+  // Pointer sensor with a small activation distance so a click on the
+  // drag handle (or anywhere) doesn't accidentally start a drag —
+  // the user has to actually move a few pixels first.
+  const dndSensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 4 } }),
+  );
+
+  const handleReorderQueued = useCallback(
+    (event: DragEndEvent) => {
+      const { active, over } = event;
+      if (!over || active.id === over.id) return;
+      setQueuedMessages((prev) => {
+        const oldIdx = prev.findIndex((m) => m.id === active.id);
+        const newIdx = prev.findIndex((m) => m.id === over.id);
+        if (oldIdx === -1 || newIdx === -1) return prev;
+        const reordered = arrayMove(prev, oldIdx, newIdx);
+        // Persist the new order. queue.set replaces the whole queue;
+        // the subscription will broadcast the same shape back so the
+        // optimistic state and the server stay in sync.
+        trpc.queue.set
+          .mutate({
+            workspaceId,
+            chatId,
+            messages: reordered.map((m) => ({
+              id: m.id,
+              text: m.text,
+              ...(m.files && m.files.length > 0 && { files: m.files }),
+            })),
+          })
+          .catch(() => {});
+        return reordered;
       });
-      trpc.queue.remove.mutate({ workspaceId, chatId, text }).catch(() => {});
     },
     [workspaceId, chatId],
   );
@@ -1251,6 +1362,12 @@ export function ChatView({
                     {segment.userPrompt && (
                       <Message from="user">
                         <MessageContent>
+                          {segment.userFiles?.map((file, fileIdx) => (
+                            <MessageFilePart
+                              key={`${message.id}-${segKey}-userfile-${fileIdx}`}
+                              part={{ type: "file", ...file }}
+                            />
+                          ))}
                           <MessageResponse>{segment.userPrompt}</MessageResponse>
                         </MessageContent>
                       </Message>
@@ -1305,9 +1422,29 @@ export function ChatView({
               </MessageContent>
             </Message>
           )}
-          {queuedMessages.map((text) => (
-            <QueuedMessageBubble key={text} text={text} onCancel={() => handleCancelQueued(text)} />
-          ))}
+          {queuedMessages.length > 0 && (
+            <DndContext
+              sensors={dndSensors}
+              collisionDetection={closestCenter}
+              onDragEnd={handleReorderQueued}
+            >
+              <SortableContext
+                items={queuedMessages.map((m) => m.id)}
+                strategy={verticalListSortingStrategy}
+              >
+                {queuedMessages.map((m) => (
+                  <QueuedMessageBubble
+                    key={m.id}
+                    id={m.id}
+                    text={m.text}
+                    files={m.files}
+                    onCancel={() => handleCancelQueued(m.id)}
+                    onEdit={(newText) => handleEditQueued(m.id, newText)}
+                  />
+                ))}
+              </SortableContext>
+            </DndContext>
+          )}
         </ConversationContent>
         <ConversationScrollButton />
       </Conversation>
@@ -1882,26 +2019,123 @@ function SessionHistoryMenu({
   );
 }
 
-function QueuedMessageBubble({ text, onCancel }: { text: string; onCancel: () => void }) {
+function QueuedMessageBubble({
+  id,
+  text,
+  files,
+  onCancel,
+  onEdit,
+}: {
+  id: string;
+  text: string;
+  files?: QueuedFilePart[];
+  onCancel: () => void;
+  onEdit: (text: string) => void;
+}) {
+  const [editing, setEditing] = useState(false);
+  const [draft, setDraft] = useState(text);
+
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
+    id,
+  });
+  const sortableStyle = {
+    transform: CSS.Translate.toString(transform),
+    transition,
+    opacity: isDragging ? 0.4 : undefined,
+  };
+
+  // When the dialog opens, reset the draft to the latest text. We don't
+  // sync continuously so the user's in-progress edits aren't clobbered
+  // if the queue subscription pushes an unchanged update mid-edit.
+  const openEditor = useCallback(() => {
+    setDraft(text);
+    setEditing(true);
+  }, [text]);
+
+  const handleSave = useCallback(() => {
+    const next = draft.trim();
+    if (!next) return;
+    if (next !== text) onEdit(next);
+    setEditing(false);
+  }, [draft, text, onEdit]);
+
   return (
-    <div className="group is-user flex w-full max-w-[90%] flex-col gap-2 ml-auto justify-end opacity-60">
-      <div className="flex min-w-0 max-w-full flex-col gap-2 break-words text-base ml-auto w-fit rounded-md bg-secondary px-4 py-3 text-foreground">
-        <MessageResponse>{text}</MessageResponse>
-        <div className="flex items-center justify-end gap-2 mt-1">
-          <Badge variant="outline" className="text-xs text-muted-foreground">
-            <Clock className="size-3" />
-            Queued
-          </Badge>
+    <>
+      <div
+        ref={setNodeRef}
+        style={sortableStyle}
+        className="group is-user flex w-full max-w-[90%] flex-col items-end ml-auto justify-end opacity-60"
+      >
+        <div className="flex min-w-0 max-w-full w-fit flex-col overflow-hidden rounded-md bg-secondary text-foreground">
+          {/* Drag handle pinned to the top border — separate from the
+              bubble body so click-to-edit doesn't conflict with reorder
+              gestures. Acts as a visual "grip" rail across the top. */}
           <button
             type="button"
-            onClick={onCancel}
-            className="inline-flex items-center gap-1 rounded px-1.5 py-0.5 text-xs text-muted-foreground transition-colors hover:bg-destructive/10 hover:text-destructive"
+            {...attributes}
+            {...listeners}
+            aria-label="Reorder queued message"
+            className="flex w-full items-center justify-center border-b border-border/30 bg-muted/30 py-0.5 text-muted-foreground/60 cursor-grab touch-none transition-colors hover:bg-muted/50 hover:text-muted-foreground active:cursor-grabbing"
           >
-            <X className="size-3" />
-            Cancel
+            <GripHorizontal className="size-3.5" />
           </button>
+          <div className="flex flex-col gap-2 break-words text-sm px-3 py-2">
+            {files?.map((file, idx) => (
+              <MessageFilePart key={`queued-file-${idx}`} part={{ type: "file", ...file }} />
+            ))}
+            <button
+              type="button"
+              onClick={openEditor}
+              className="-mx-1 cursor-pointer rounded px-1 text-left transition-colors hover:bg-foreground/5"
+              title="Click to edit"
+            >
+              <MessageResponse className="text-sm">{text}</MessageResponse>
+            </button>
+            <div className="flex items-center justify-end gap-2 mt-1">
+              <Badge variant="outline" className="text-xs text-muted-foreground">
+                <Clock className="size-3" />
+                Queued
+              </Badge>
+              <button
+                type="button"
+                onClick={onCancel}
+                className="inline-flex items-center gap-1 rounded px-1.5 py-0.5 text-xs text-muted-foreground transition-colors hover:bg-destructive/10 hover:text-destructive"
+              >
+                <X className="size-3" />
+                Cancel
+              </button>
+            </div>
+          </div>
         </div>
       </div>
-    </div>
+
+      <Dialog open={editing} onOpenChange={setEditing}>
+        <DialogContent className="sm:max-w-[480px]">
+          <DialogHeader>
+            <DialogTitle>Edit queued message</DialogTitle>
+          </DialogHeader>
+          <Textarea
+            value={draft}
+            onChange={(e) => setDraft(e.target.value)}
+            className="min-h-[120px] text-sm"
+            autoFocus
+            onKeyDown={(e) => {
+              if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
+                e.preventDefault();
+                handleSave();
+              }
+            }}
+          />
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setEditing(false)}>
+              Cancel
+            </Button>
+            <Button onClick={handleSave} disabled={!draft.trim()}>
+              Save
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
   );
 }

--- a/apps/web/src/lib/convert-events.ts
+++ b/apps/web/src/lib/convert-events.ts
@@ -104,25 +104,57 @@ export function convertEventsToUIMessages(events: SessionEventRecord[]): UIMessa
       case "user-message": {
         // Initial user prompt — broadcast at task start so the buffer
         // includes the user message (not just assistant chunks).
+        // Files attached at submit time are reconstructed as `file`
+        // parts so the bubble re-renders with images on reload.
         flushText();
         currentAssistant = null;
+        const userParts: UIMessageParts = [{ type: "text", text: chunk.text as string }];
+        const userFiles = chunk.files as
+          | { mediaType: string; url: string; filename?: string }[]
+          | undefined;
+        if (Array.isArray(userFiles)) {
+          for (const f of userFiles) {
+            userParts.push({
+              type: "file",
+              mediaType: f.mediaType,
+              url: f.url,
+              ...(f.filename && { filename: f.filename }),
+            } as UIMessageParts[number]);
+          }
+        }
         messages.push({
           id: crypto.randomUUID(),
           role: "user",
-          parts: [{ type: "text", text: chunk.text as string }],
+          parts: userParts,
         });
         break;
       }
 
       case "data-prompt": {
-        // Queue boundary: finalize current assistant, insert user message
+        // Queue boundary: finalize current assistant, insert user message.
+        // The chunk may carry file metadata for attachments uploaded with
+        // the queued message; reconstruct them as `file` parts.
         flushText();
         currentAssistant = null;
-        const data = chunk.data as { text: string };
+        const data = chunk.data as {
+          text: string;
+          files?: { mediaType: string; url: string; filename?: string }[];
+        };
+        const promptParts: UIMessageParts = [{ type: "text", text: data.text }];
+        if (Array.isArray(data.files)) {
+          for (const f of data.files) {
+            promptParts.push({
+              type: "file",
+              mediaType: f.mediaType,
+              url: f.url,
+              ...(f.filename && { filename: f.filename }),
+            } as UIMessageParts[number]);
+          }
+        }
         messages.push({
           id: crypto.randomUUID(),
           role: "user",
-          parts: [{ type: "text", text: data.text }],
+          parts: promptParts,
         });
         break;
       }

--- a/apps/web/src/lib/queued-message-store.ts
+++ b/apps/web/src/lib/queued-message-store.ts
@@ -6,24 +6,45 @@
  * completes, the task-runner pops the next message and auto-starts
  * a new task. The frontend only pushes to and renders the queue.
  *
+ * Each queued message can carry file attachments (images, PDFs, etc.)
+ * encoded as base64 data URLs — the same shape the live transport
+ * uses when posting to /api/tasks/:chatId/stream. Files are uploaded
+ * to disk only when the message is drained and submitted as a real
+ * task, mirroring the immediate-submit code path in task-stream.ts.
+ *
  * Uses the globalThis Symbol pattern (same as task-runner.ts) to
  * ensure a single shared map across multiple bundles.
  */
+
+import { randomUUID } from "node:crypto";
+
+export interface QueuedFile {
+  mediaType: string;
+  url: string;
+  filename?: string;
+}
+
+export interface QueuedMessage {
+  /** Stable identifier so the client can cancel a specific entry by id. */
+  id: string;
+  text: string;
+  files?: QueuedFile[];
+}
 
 const QUEUED_KEY = Symbol.for("band.queued-messages");
 const LISTENERS_KEY = Symbol.for("band.queued-messages.listeners");
 
 const g = globalThis as unknown as Record<symbol, unknown>;
-if (!g[QUEUED_KEY]) g[QUEUED_KEY] = new Map<string, string[]>();
+if (!g[QUEUED_KEY]) g[QUEUED_KEY] = new Map<string, QueuedMessage[]>();
 if (!g[LISTENERS_KEY]) g[LISTENERS_KEY] = new Set<QueueListener>();
 
-const store = g[QUEUED_KEY] as Map<string, string[]>;
+const store = g[QUEUED_KEY] as Map<string, QueuedMessage[]>;
 const queueListeners = g[LISTENERS_KEY] as Set<QueueListener>;
 
-type QueueListener = (chatId: string, messages: string[]) => void;
+type QueueListener = (chatId: string, messages: QueuedMessage[]) => void;
 
 function notify(chatId: string): void {
-  const messages = [...(store.get(chatId) ?? [])];
+  const messages = (store.get(chatId) ?? []).map(cloneMessage);
   for (const listener of queueListeners) {
     try {
       listener(chatId, messages);
@@ -31,6 +52,14 @@ function notify(chatId: string): void {
       // listener may have been removed
     }
   }
+}
+
+function cloneMessage(msg: QueuedMessage): QueuedMessage {
+  return {
+    id: msg.id,
+    text: msg.text,
+    files: msg.files ? msg.files.map((f) => ({ ...f })) : undefined,
+  };
 }
 
 /** Subscribe to queue state changes. Returns an unsubscribe function. */
@@ -41,53 +70,92 @@ export function subscribeQueue(listener: QueueListener): () => void {
   };
 }
 
-/** Append a queued message for a chat pane. */
-export function pushQueuedMessage(chatId: string, text: string): void {
-  const msgs = store.get(chatId);
-  if (msgs) {
-    msgs.push(text);
-  } else {
-    store.set(chatId, [text]);
-  }
-  notify(chatId);
+export interface PushQueuedMessageInput {
+  text: string;
+  files?: QueuedFile[];
 }
 
-/** Replace the entire queue for a chat pane. */
-export function setQueuedMessages(chatId: string, texts: string[]): void {
-  if (texts.length === 0) {
+/**
+ * Append a queued message for a chat pane. Returns the stored message
+ * (including the generated id) so callers can reference it later.
+ */
+export function pushQueuedMessage(chatId: string, input: PushQueuedMessageInput): QueuedMessage {
+  const message: QueuedMessage = {
+    id: randomUUID(),
+    text: input.text,
+    files: input.files && input.files.length > 0 ? input.files.map((f) => ({ ...f })) : undefined,
+  };
+  const msgs = store.get(chatId);
+  if (msgs) {
+    msgs.push(message);
+  } else {
+    store.set(chatId, [message]);
+  }
+  notify(chatId);
+  return cloneMessage(message);
+}
+
+/**
+ * Replace the entire queue for a chat pane. Each input message may
+ * provide its own id; otherwise a new one is generated.
+ */
+export function setQueuedMessages(
+  chatId: string,
+  messages: (PushQueuedMessageInput & { id?: string })[],
+): void {
+  if (messages.length === 0) {
     store.delete(chatId);
   } else {
-    store.set(chatId, [...texts]);
+    const stored: QueuedMessage[] = messages.map((m) => ({
+      id: m.id ?? randomUUID(),
+      text: m.text,
+      files: m.files && m.files.length > 0 ? m.files.map((f) => ({ ...f })) : undefined,
+    }));
+    store.set(chatId, stored);
   }
   notify(chatId);
 }
 
 /** Retrieve all queued messages for a chat pane (empty array if none). */
-export function getQueuedMessages(chatId: string): string[] {
-  return store.get(chatId) ?? [];
+export function getQueuedMessages(chatId: string): QueuedMessage[] {
+  return (store.get(chatId) ?? []).map(cloneMessage);
 }
 
 /**
  * Remove and return the first queued message for a chat pane, or null
  * if the queue is empty.
  */
-export function shiftQueuedMessage(chatId: string): string | null {
+export function shiftQueuedMessage(chatId: string): QueuedMessage | null {
   const msgs = store.get(chatId);
   if (!msgs || msgs.length === 0) return null;
   const first = msgs.shift()!;
   if (msgs.length === 0) store.delete(chatId);
   notify(chatId);
-  return first;
+  return cloneMessage(first);
 }
 
 /**
- * Remove the first occurrence of a message matching `text` from the queue.
- * Returns true if a message was removed.
+ * Replace the text of the queued message with the given id. Files
+ * (if any) are preserved. Returns true if a message was updated.
  */
-export function removeQueuedMessage(chatId: string, text: string): boolean {
+export function updateQueuedMessage(chatId: string, id: string, text: string): boolean {
   const msgs = store.get(chatId);
   if (!msgs) return false;
-  const idx = msgs.indexOf(text);
+  const idx = msgs.findIndex((m) => m.id === id);
+  if (idx === -1) return false;
+  msgs[idx] = { ...msgs[idx], text };
+  notify(chatId);
+  return true;
+}
+
+/**
+ * Remove the queued message with the given id. Returns true if a
+ * message was removed.
+ */
+export function removeQueuedMessage(chatId: string, id: string): boolean {
+  const msgs = store.get(chatId);
+  if (!msgs) return false;
+  const idx = msgs.findIndex((m) => m.id === id);
   if (idx === -1) return false;
   msgs.splice(idx, 1);
   if (msgs.length === 0) store.delete(chatId);

--- a/apps/web/src/lib/task-chat-transport.ts
+++ b/apps/web/src/lib/task-chat-transport.ts
@@ -146,12 +146,15 @@ export class TaskChatTransport implements ChatTransport<UIMessage> {
       signal: controller.signal,
     });
 
-    // Handle conflict — task is already running, queue the message instead
+    // Handle conflict — task is already running, queue the message instead.
+    // Files are queued as base64 data URLs (same shape sent above) so the
+    // task-runner can upload them when the queued message is drained.
     if (response.status === 409) {
       await trpc.queue.push.mutate({
         workspaceId: this.workspaceId,
         chatId: this.chatId,
         text: userText,
+        ...(files.length > 0 && { files }),
       });
       return new ReadableStream<UIMessageChunk>({
         start(controller) {

--- a/apps/web/src/lib/task-runner.ts
+++ b/apps/web/src/lib/task-runner.ts
@@ -9,6 +9,7 @@ import { createPendingInput, rejectAllPendingInputs } from "./pending-inputs";
 import { shiftQueuedMessage } from "./queued-message-store";
 import { bandHome, upsertWorkspaceStatus } from "./state";
 import { generateTaskId, markTaskFailed, saveTask } from "./task-store";
+import { saveUploadedFilesDetailed } from "./upload-utils";
 import { emit as emitStatusEvent } from "./watcher";
 import { resolveWorkspace } from "./workspace";
 
@@ -57,12 +58,32 @@ export interface TaskInfo {
   firstEventId?: number;
 }
 
+/**
+ * File attachment metadata to display alongside the user prompt. Stored
+ * on the task so the initial `user-message` broadcast can carry the file
+ * parts — without these, the session JSONL (and any future reload from
+ * it) would render the user's bubble as text-only and lose the images.
+ */
+export interface DisplayFile {
+  mediaType: string;
+  url: string;
+  filename?: string;
+}
+
 export interface SubmitTaskOptions {
   workspaceId: string;
   chatId: string;
   prompt: string;
   sessionId?: string;
   agentPrompt?: string;
+  /**
+   * Optional file attachments to broadcast as part of the user-message
+   * chunk so direct (non-queued) messages survive a session reload with
+   * their attached files intact. Each url should already be a stable
+   * server-served URL (e.g. /api/uploads/{name}); embedding raw data
+   * URLs here is allowed but bloats the persisted JSONL.
+   */
+  displayFiles?: DisplayFile[];
   maxTurns?: number;
   mode?: string;
   model?: string;
@@ -85,6 +106,7 @@ const MAX_BUFFER_SIZE = 2000;
 interface InternalTask extends TaskInfo {
   taskRecordId: string;
   agentPrompt: string;
+  displayFiles?: DisplayFile[];
 }
 
 // Use globalThis to ensure a single shared state across multiple bundles
@@ -209,6 +231,7 @@ export function submitTask(options: SubmitTaskOptions): TaskInfo {
     prompt,
     sessionId,
     agentPrompt,
+    displayFiles,
     maxTurns,
     mode,
     model,
@@ -236,6 +259,7 @@ export function submitTask(options: SubmitTaskOptions): TaskInfo {
     prompt,
     taskRecordId,
     agentPrompt: agentPrompt ?? prompt,
+    displayFiles: displayFiles && displayFiles.length > 0 ? displayFiles : undefined,
     maxTurns,
     mode,
     model,
@@ -467,9 +491,15 @@ async function runTask(chatId: string, task: InternalTask) {
           // is set and broadcast() stores it in the session buffer.
           // Uses "user-message" (not "data-prompt") so the live stream ignores
           // it — useChat already has the user message in its state.
+          // Include any uploaded file metadata so reloading the session
+          // from the JSONL re-renders the user bubble with its images.
           broadcast(chatId, {
             type: "user-message",
             text: task.prompt,
+            ...(task.displayFiles &&
+              task.displayFiles.length > 0 && {
+                files: task.displayFiles,
+              }),
           } as unknown as UIMessageChunk);
           break;
         }
@@ -729,16 +759,42 @@ async function runTask(chatId: string, task: InternalTask) {
     const queued = shiftQueuedMessage(chatId);
     if (queued) {
       try {
+        // Upload any attached files to disk so the agent can read them.
+        // Mirrors the immediate-submit path in api/task-stream.ts.
+        let agentPrompt: string | undefined;
+        let displayFiles: DisplayFile[] | undefined;
+        if (queued.files && queued.files.length > 0) {
+          const saved = await saveUploadedFilesDetailed(queued.files);
+          if (saved.length > 0) {
+            const fileList = saved.map((s) => `- ${s.path}`).join("\n");
+            agentPrompt = `I'm sharing these files with you:\n${fileList}\n\n${queued.text}`;
+            // Replace the bulky base64 data URLs with stable
+            // /api/uploads/* references for the persisted bubble — the
+            // bytes already live on disk, no need to embed them again
+            // in the SSE event / session JSONL.
+            displayFiles = saved.map((s) => ({
+              mediaType: s.mediaType,
+              url: `/api/uploads/${s.storedName}`,
+              filename: s.originalName,
+            }));
+          }
+        }
+
         // Emit the queued user prompt so the client can render it as a
-        // user message bubble between assistant responses.
+        // user message bubble between assistant responses. Include any
+        // file attachments so they show up in the bubble too.
         broadcast(chatId, {
           type: "data-prompt" as UIMessageChunk["type"],
-          data: { text: queued },
+          data: {
+            text: queued.text,
+            ...(displayFiles && displayFiles.length > 0 && { files: displayFiles }),
+          },
         } as UIMessageChunk);
         submitTask({
           workspaceId: task.workspaceId,
           chatId,
-          prompt: queued,
+          prompt: queued.text,
+          agentPrompt,
           sessionId: task.sessionId,
         });
         autoStarted = true;

--- a/apps/web/src/lib/upload-utils.ts
+++ b/apps/web/src/lib/upload-utils.ts
@@ -8,25 +8,62 @@ export interface FilePart {
   filename?: string;
 }
 
-export async function saveUploadedFiles(fileParts: FilePart[]): Promise<string[]> {
+export interface SavedFile {
+  /** Absolute path on disk where the file was written. */
+  path: string;
+  /** The leaf filename used on disk (also the URL component under /api/uploads/). */
+  storedName: string;
+  mediaType: string;
+  /** Original filename supplied by the client, if any. */
+  originalName?: string;
+}
+
+/**
+ * Persist data-URL-encoded file uploads to ~/.band/uploads/ and return
+ * metadata for each one.
+ *
+ * Multiple files in the same submission are guaranteed to land on
+ * distinct paths even when their original filenames collide (e.g. two
+ * clipboard pastes both named "image.png") — we include both the
+ * submission timestamp and a per-file index in the on-disk filename.
+ */
+export async function saveUploadedFilesDetailed(fileParts: FilePart[]): Promise<SavedFile[]> {
   const uploadDir = join(bandHome(), "uploads");
   await mkdir(uploadDir, { recursive: true });
 
-  const savedPaths: string[] = [];
+  // Capture the timestamp once for the whole batch — combined with the
+  // per-iteration index this gives a unique on-disk name even when
+  // two files share the original filename.
+  const baseTimestamp = Date.now();
+  const saved: SavedFile[] = [];
 
-  for (const part of fileParts) {
+  for (let i = 0; i < fileParts.length; i++) {
+    const part = fileParts[i];
     const dataUrlMatch = part.url.match(/^data:[^;]+;base64,(.+)$/);
     if (!dataUrlMatch) continue;
 
     const buffer = Buffer.from(dataUrlMatch[1], "base64");
-    const timestamp = Date.now();
-    const filename = part.filename || `file-${timestamp}`;
-    const safeName = `${timestamp}-${filename.replace(/[^a-zA-Z0-9._-]/g, "_")}`;
-    const filePath = join(uploadDir, safeName);
+    const filename = part.filename || `file-${baseTimestamp}`;
+    const safeOriginal = filename.replace(/[^a-zA-Z0-9._-]/g, "_");
+    const storedName = `${baseTimestamp}-${i}-${safeOriginal}`;
+    const filePath = join(uploadDir, storedName);
 
     await writeFile(filePath, buffer);
-    savedPaths.push(filePath);
+    saved.push({
+      path: filePath,
+      storedName,
+      mediaType: part.mediaType,
+      originalName: part.filename,
+    });
   }
 
-  return savedPaths;
+  return saved;
+}
+
+/**
+ * Backwards-compatible thin wrapper that returns just the on-disk paths.
+ */
+export async function saveUploadedFiles(fileParts: FilePart[]): Promise<string[]> {
+  const saved = await saveUploadedFilesDetailed(fileParts);
+  return saved.map((f) => f.path);
 }

--- a/apps/web/src/trpc/router.ts
+++ b/apps/web/src/trpc/router.ts
@@ -64,10 +64,12 @@ import {
   clearQueuedMessages,
   getQueuedMessages,
   pushQueuedMessage,
+  type QueuedMessage,
   removeQueuedMessage,
   setQueuedMessages,
   shiftQueuedMessage,
   subscribeQueue,
+  updateQueuedMessage,
 } from "../lib/queued-message-store";
 import { getSessionEventsBefore, getSessionEventsTail } from "../lib/session-store";
 import { runSetup } from "../lib/setup-runner";
@@ -2485,13 +2487,26 @@ const browsersRouter = t.router({
 // Queue (persisted queued messages)
 // ---------------------------------------------------------------------------
 
+const queuedFileSchema = z.object({
+  mediaType: z.string(),
+  url: z.string(),
+  filename: z.string().optional(),
+});
+
 const queueRouter = t.router({
   push: publicProcedure
-    .input(z.object({ workspaceId: z.string(), chatId: z.string().optional(), text: z.string() }))
+    .input(
+      z.object({
+        workspaceId: z.string(),
+        chatId: z.string().optional(),
+        text: z.string(),
+        files: z.array(queuedFileSchema).optional(),
+      }),
+    )
     .mutation(({ input }) => {
       const chatId = input.chatId ?? getOrCreateDefaultChat(input.workspaceId).id;
-      pushQueuedMessage(chatId, input.text);
-      return { ok: true, messages: getQueuedMessages(chatId) };
+      const message = pushQueuedMessage(chatId, { text: input.text, files: input.files });
+      return { ok: true, message, messages: getQueuedMessages(chatId) };
     }),
 
   set: publicProcedure
@@ -2499,13 +2514,19 @@ const queueRouter = t.router({
       z.object({
         workspaceId: z.string(),
         chatId: z.string().optional(),
-        messages: z.array(z.string()),
+        messages: z.array(
+          z.object({
+            id: z.string().optional(),
+            text: z.string(),
+            files: z.array(queuedFileSchema).optional(),
+          }),
+        ),
       }),
     )
     .mutation(({ input }) => {
       const chatId = input.chatId ?? getOrCreateDefaultChat(input.workspaceId).id;
       setQueuedMessages(chatId, input.messages);
-      return { ok: true };
+      return { ok: true, messages: getQueuedMessages(chatId) };
     }),
 
   get: publicProcedure
@@ -2517,19 +2538,34 @@ const queueRouter = t.router({
     }),
 
   remove: publicProcedure
-    .input(z.object({ workspaceId: z.string(), chatId: z.string().optional(), text: z.string() }))
+    .input(z.object({ workspaceId: z.string(), chatId: z.string().optional(), id: z.string() }))
     .mutation(({ input }) => {
       const chatId = input.chatId ?? getOrCreateDefaultChat(input.workspaceId).id;
-      removeQueuedMessage(chatId, input.text);
-      return { ok: true, messages: getQueuedMessages(chatId) };
+      const removed = removeQueuedMessage(chatId, input.id);
+      return { ok: true, removed, messages: getQueuedMessages(chatId) };
+    }),
+
+  update: publicProcedure
+    .input(
+      z.object({
+        workspaceId: z.string(),
+        chatId: z.string().optional(),
+        id: z.string(),
+        text: z.string(),
+      }),
+    )
+    .mutation(({ input }) => {
+      const chatId = input.chatId ?? getOrCreateDefaultChat(input.workspaceId).id;
+      const updated = updateQueuedMessage(chatId, input.id, input.text);
+      return { ok: true, updated, messages: getQueuedMessages(chatId) };
     }),
 
   shift: publicProcedure
     .input(z.object({ workspaceId: z.string(), chatId: z.string().optional() }))
     .mutation(({ input }) => {
       const chatId = input.chatId ?? getOrCreateDefaultChat(input.workspaceId).id;
-      const text = shiftQueuedMessage(chatId);
-      return { text };
+      const message = shiftQueuedMessage(chatId);
+      return { message };
     }),
 
   clear: publicProcedure
@@ -2545,7 +2581,7 @@ const queueRouter = t.router({
     .subscription(async function* (opts) {
       const chatId = opts.input.chatId ?? getOrCreateDefaultChat(opts.input.workspaceId).id;
 
-      type Update = { messages: string[] };
+      type Update = { messages: QueuedMessage[] };
       const queue: Update[] = [];
       let resolve: (() => void) | null = null;
 

--- a/apps/web/tests/file-sharing.test.ts
+++ b/apps/web/tests/file-sharing.test.ts
@@ -1,5 +1,5 @@
 import { spawn } from "node:child_process";
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { createServer } from "node:net";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -617,5 +617,158 @@ describe("Task stream — Write to workspace does NOT emit file event", () => {
     expect(eventTypes).toContain("tool-input-available");
     expect(eventTypes).toContain("tool-output-available");
     expect(eventTypes).not.toContain("file");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Direct submit — multiple file attachments in one message
+// ---------------------------------------------------------------------------
+
+/**
+ * 1×1 pixel PNGs with distinct payloads so we can verify each one was
+ * written to disk separately (and the "same filename → same path"
+ * collision in saveUploadedFiles doesn't lose data).
+ */
+const PNG_RED_DATA_URL =
+  "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8/5+hHgAHggJ/PchI7wAAAABJRU5ErkJggg==";
+const PNG_BLUE_DATA_URL =
+  "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPj/HwADAgH/eL9GtQAAAABJRU5ErkJggg==";
+
+function decodeDataUrlBytes(url: string): Buffer {
+  const m = url.match(/^data:[^;]+;base64,(.+)$/);
+  if (!m) throw new Error("not a base64 data URL");
+  return Buffer.from(m[1], "base64");
+}
+
+describe("Task stream — multiple files in a single direct message", () => {
+  let server: ServerHandle;
+  let tmpHome: string;
+  const WORKSPACE_ID = "testproject-main";
+
+  beforeAll(async () => {
+    tmpHome = createTmpHome();
+    seedState(tmpHome, createDefaultState(tmpHome));
+
+    // Quick scenario — we don't care about the agent output, only that
+    // the SSE pipeline ran end-to-end (file uploads + user-message).
+    const scenarioPath = writeScenario(tmpHome, [
+      { type: "system", subtype: "init", session_id: "multi-file-session" },
+      { type: "assistant", message: { content: [{ type: "text", text: "ok" }] } },
+      {
+        type: "result",
+        subtype: "success",
+        session_id: "multi-file-session",
+        duration_ms: 50,
+        num_turns: 1,
+        total_cost_usd: 0,
+      },
+    ]);
+
+    seedSettings(tmpHome, {
+      tokenSecret: DEFAULT_TOKEN,
+      codingAgents: [
+        { id: "claude-code", type: "claude-code", label: "Claude Code", command: FAKE_AGENT_PATH },
+      ],
+    });
+
+    server = await startServer({ tmpHome, scenarioPath });
+  });
+
+  afterAll(async () => {
+    await server.close();
+    rmSync(tmpHome, { recursive: true, force: true });
+  });
+
+  it("writes each file to a distinct path even when filenames collide", async () => {
+    const chatId = `direct-multifile-${Date.now()}`;
+    const response = await fetch(`${server.url}/api/tasks/${encodeURIComponent(chatId)}/stream`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", ...defaultHeaders },
+      body: JSON.stringify({
+        workspaceId: WORKSPACE_ID,
+        prompt: "compare these screenshots",
+        files: [
+          { mediaType: "image/png", url: PNG_RED_DATA_URL, filename: "screenshot.png" },
+          // Intentionally same filename to exercise the collision path.
+          { mediaType: "image/png", url: PNG_BLUE_DATA_URL, filename: "screenshot.png" },
+        ],
+      }),
+    });
+    expect(response.status).toBe(200);
+    await parseSSEStream(response); // drain to completion
+
+    // Both files must land on disk as distinct entries with their
+    // original payloads preserved — no overwrite.
+    const uploadsDir = join(tmpHome, ".band", "uploads");
+    const written = readdirSync(uploadsDir).filter((f) => f.endsWith("screenshot.png"));
+    expect(written.length).toBe(2);
+
+    const payloads = written.map((name) => readFileSync(join(uploadsDir, name)));
+    const expectedRed = decodeDataUrlBytes(PNG_RED_DATA_URL);
+    const expectedBlue = decodeDataUrlBytes(PNG_BLUE_DATA_URL);
+    const matchesRed = payloads.some((p) => p.equals(expectedRed));
+    const matchesBlue = payloads.some((p) => p.equals(expectedBlue));
+    expect(matchesRed).toBe(true);
+    expect(matchesBlue).toBe(true);
+  });
+
+  it("user-message SSE chunk carries every attached file for replay", async () => {
+    const chatId = `direct-userfiles-${Date.now()}`;
+    const response = await fetch(`${server.url}/api/tasks/${encodeURIComponent(chatId)}/stream`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", ...defaultHeaders },
+      body: JSON.stringify({
+        workspaceId: WORKSPACE_ID,
+        prompt: "look at these",
+        files: [
+          { mediaType: "image/png", url: PNG_RED_DATA_URL, filename: "a.png" },
+          { mediaType: "image/png", url: PNG_BLUE_DATA_URL, filename: "b.png" },
+        ],
+      }),
+    });
+    expect(response.status).toBe(200);
+    const events = await parseSSEStream(response);
+
+    // user-message is filtered out by task-stream's UI chunk projection
+    // before the SSE response, so we instead verify it round-trips by
+    // reading session events back via the tRPC sessions.messages endpoint.
+    const sessionId = "multi-file-session";
+    const msgsRes = await fetch(
+      `${server.url}/trpc/sessions.messages?input=${encodeURIComponent(
+        JSON.stringify({ workspaceId: WORKSPACE_ID, chatId, sessionId }),
+      )}`,
+      { headers: defaultHeaders },
+    );
+    expect(msgsRes.status).toBe(200);
+    const msgsBody = (await msgsRes.json()) as {
+      result: {
+        data: {
+          messages: {
+            role: string;
+            parts: { type: string; mediaType?: string; url?: string; filename?: string }[];
+          }[];
+        };
+      };
+    };
+    const userMessages = msgsBody.result.data.messages.filter((m) => m.role === "user");
+    expect(userMessages.length).toBeGreaterThanOrEqual(1);
+    // The previous test in this describe shares the same session_id (the
+    // fake-agent scenario uses a fixed value), so multiple user messages
+    // accumulate in the buffer — the one we just submitted is the last.
+    const lastUser = userMessages[userMessages.length - 1];
+    // The replayed user message should have both file parts in addition
+    // to the text — this is the regression we're guarding against.
+    const fileParts = lastUser.parts.filter((p) => p.type === "file");
+    expect(fileParts.length).toBe(2);
+    const filenames = fileParts.map((p) => p.filename).sort();
+    expect(filenames).toEqual(["a.png", "b.png"]);
+    // URLs should reference /api/uploads/* (server-served), not raw
+    // base64 — that's how reload-time rendering finds the bytes.
+    for (const part of fileParts) {
+      expect(part.url).toMatch(/^\/api\/uploads\//);
+    }
+
+    // Also sanity-check that finish was emitted on the SSE stream.
+    expect(events.some((e) => e.event === "finish")).toBe(true);
   });
 });

--- a/apps/web/tests/queue-drain.test.ts
+++ b/apps/web/tests/queue-drain.test.ts
@@ -1,5 +1,5 @@
 import { spawn } from "node:child_process";
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readdirSync, rmSync, writeFileSync } from "node:fs";
 import { createServer } from "node:net";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -283,7 +283,7 @@ describe("queue auto-drain — single queued message", () => {
 
     // 4. Verify the queue is now empty (message was consumed)
     const queueRes = await trpcQuery(server.url, "queue.get", { workspaceId });
-    const queueData = await trpcData<{ messages: string[] }>(queueRes);
+    const queueData = await trpcData<{ messages: { id: string; text: string }[] }>(queueRes);
     expect(queueData.messages).toEqual([]);
 
     // 5. Verify the last task that ran was the queued one
@@ -409,8 +409,8 @@ describe("queue auto-drain — failed task does not drain queue", () => {
 
     // 5. Verify queue still has the message (it was NOT consumed)
     const queueRes = await trpcQuery(server.url, "queue.get", { workspaceId });
-    const queueData = await trpcData<{ messages: string[] }>(queueRes);
-    expect(queueData.messages).toEqual(["should stay queued"]);
+    const queueData = await trpcData<{ messages: { id: string; text: string }[] }>(queueRes);
+    expect(queueData.messages.map((m) => m.text)).toEqual(["should stay queued"]);
 
     // Cleanup
     await trpcMutate(server.url, "queue.clear", { workspaceId });
@@ -505,7 +505,7 @@ describe("stream stays alive across auto-drained tasks (SSE)", () => {
 
     // 5. Queue should be empty
     const queueRes = await trpcQuery(server.url, "queue.get", { workspaceId });
-    const queueData = await trpcData<{ messages: string[] }>(queueRes);
+    const queueData = await trpcData<{ messages: { id: string; text: string }[] }>(queueRes);
     expect(queueData.messages).toEqual([]);
   });
 });
@@ -581,8 +581,8 @@ describe("queue.shift — pops the first message", () => {
   it("returns null when queue is empty", async () => {
     const res = await trpcMutate(server.url, "queue.shift", { workspaceId: "testproject-main" });
     expect(res.status).toBe(200);
-    const data = await trpcData<{ text: string | null }>(res);
-    expect(data.text).toBeNull();
+    const data = await trpcData<{ message: { text: string } | null }>(res);
+    expect(data.message).toBeNull();
   });
 
   it("pops the first message and leaves the rest", async () => {
@@ -595,13 +595,13 @@ describe("queue.shift — pops the first message", () => {
 
     // Shift the first
     const shiftRes = await trpcMutate(server.url, "queue.shift", { workspaceId });
-    const shiftData = await trpcData<{ text: string | null }>(shiftRes);
-    expect(shiftData.text).toBe("first");
+    const shiftData = await trpcData<{ message: { id: string; text: string } | null }>(shiftRes);
+    expect(shiftData.message?.text).toBe("first");
 
     // Verify remaining
     const getRes = await trpcQuery(server.url, "queue.get", { workspaceId });
-    const getData = await trpcData<{ messages: string[] }>(getRes);
-    expect(getData.messages).toEqual(["second", "third"]);
+    const getData = await trpcData<{ messages: { id: string; text: string }[] }>(getRes);
+    expect(getData.messages.map((m) => m.text)).toEqual(["second", "third"]);
 
     // Cleanup
     await trpcMutate(server.url, "queue.clear", { workspaceId });
@@ -711,7 +711,98 @@ describe("queue auto-drain — late queue push", () => {
 
     // 4. Queue is drained
     const queueRes = await trpcQuery(server.url, "queue.get", { workspaceId });
-    const queueData = await trpcData<{ messages: string[] }>(queueRes);
+    const queueData = await trpcData<{ messages: { id: string; text: string }[] }>(queueRes);
     expect(queueData.messages).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Queue auto-drain — queued message with image attachment
+// ---------------------------------------------------------------------------
+
+describe("queue auto-drain — queued message with images", () => {
+  let server: ServerHandle;
+  let tmpHome: string;
+
+  beforeAll(async () => {
+    tmpHome = createTmpHome();
+    seedState(tmpHome, createDefaultState(tmpHome));
+
+    const scenarioPath = writeScenario(tmpHome, quickSuccessScenario());
+    seedSettings(tmpHome, defaultSettings());
+
+    server = await startServer({ tmpHome, scenarioPath });
+  });
+
+  afterAll(async () => {
+    await server.close();
+    rmSync(tmpHome, { recursive: true, force: true });
+  });
+
+  it("preserves files when queueing and uploads them on drain", async () => {
+    const workspaceId = "testproject-main";
+    const chatId = `test-queue-files-${Date.now()}`;
+
+    // 1×1 transparent PNG as base64 data URL (the same shape the
+    // browser would produce after FileReader.readAsDataURL).
+    const dataUrl =
+      "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=";
+
+    // 1. Pre-load the queue with a message that has a file attachment
+    await trpcMutate(server.url, "queue.push", {
+      workspaceId,
+      chatId,
+      text: "describe this image",
+      files: [
+        {
+          mediaType: "image/png",
+          url: dataUrl,
+          filename: "pixel.png",
+        },
+      ],
+    });
+
+    // Sanity check: the queued message round-trips with its file metadata
+    const queueBefore = await trpcQuery(server.url, "queue.get", { workspaceId, chatId });
+    const queueBeforeData = await trpcData<{
+      messages: { id: string; text: string; files?: { filename?: string; url: string }[] }[];
+    }>(queueBefore);
+    expect(queueBeforeData.messages).toHaveLength(1);
+    expect(queueBeforeData.messages[0].files).toHaveLength(1);
+    expect(queueBeforeData.messages[0].files![0].filename).toBe("pixel.png");
+
+    // 2. Submit the first task — its completion should drain the queued one
+    const response = await fetch(`${server.url}/api/tasks/${encodeURIComponent(chatId)}/stream`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", ...defaultHeaders },
+      body: JSON.stringify({ workspaceId, prompt: "first task" }),
+    });
+    expect(response.status).toBe(200);
+    const events = await parseSSEStream(response);
+
+    // 3. The data-prompt event for the queued message includes the file payload
+    const promptEvents = events.filter((e) => e.event === "data-prompt");
+    expect(promptEvents.length).toBe(1);
+    const promptData = (
+      promptEvents[0].data as {
+        data: { text: string; files?: { mediaType: string; filename?: string; url: string }[] };
+      }
+    ).data;
+    expect(promptData.text).toBe("describe this image");
+    expect(promptData.files).toHaveLength(1);
+    expect(promptData.files![0].filename).toBe("pixel.png");
+    expect(promptData.files![0].mediaType).toBe("image/png");
+
+    // 4. The queue should be drained
+    const queueRes = await trpcQuery(server.url, "queue.get", { workspaceId, chatId });
+    const queueData = await trpcData<{ messages: { id: string; text: string }[] }>(queueRes);
+    expect(queueData.messages).toEqual([]);
+
+    // 5. The attached image should be saved to ~/.band/uploads/
+    //    (mirrors the immediate-submit code path in api/task-stream.ts)
+    const uploadsDir = join(tmpHome, ".band", "uploads");
+    const files = readdirSync(uploadsDir);
+    const matching = files.filter((f) => f.endsWith("pixel.png"));
+    expect(matching.length).toBeGreaterThanOrEqual(1);
   });
 });

--- a/apps/web/tests/queue.test.ts
+++ b/apps/web/tests/queue.test.ts
@@ -20,6 +20,18 @@ interface ServerHandle {
   close: () => Promise<void>;
 }
 
+interface QueuedFile {
+  mediaType: string;
+  url: string;
+  filename?: string;
+}
+
+interface QueuedMessage {
+  id: string;
+  text: string;
+  files?: QueuedFile[];
+}
+
 function createTmpHome(): string {
   const tmp = realpathSync(mkdtempSync(join(tmpdir(), "band-queue-test-")));
   const bandDir = join(tmp, ".band");
@@ -192,7 +204,7 @@ describe("tRPC — queue CRUD", () => {
   it("returns empty array when no queued messages exist", async () => {
     const res = await trpcQuery(server.url, "queue.get", { workspaceId: "proj-main" });
     expect(res.status).toBe(200);
-    const data = await trpcData<{ messages: string[] }>(res);
+    const data = await trpcData<{ messages: QueuedMessage[] }>(res);
     expect(data.messages).toEqual([]);
   });
 
@@ -202,15 +214,55 @@ describe("tRPC — queue CRUD", () => {
       text: "fix the bug",
     });
     expect(res.status).toBe(200);
-    const data = await trpcData<{ ok: boolean }>(res);
+    const data = await trpcData<{ ok: boolean; message: QueuedMessage }>(res);
     expect(data.ok).toBe(true);
+    expect(data.message.text).toBe("fix the bug");
+    expect(typeof data.message.id).toBe("string");
+    expect(data.message.files).toBeUndefined();
 
     const getRes = await trpcQuery(server.url, "queue.get", { workspaceId: "proj-main" });
-    const getData = await trpcData<{ messages: string[] }>(getRes);
-    expect(getData.messages).toEqual(["fix the bug"]);
+    const getData = await trpcData<{ messages: QueuedMessage[] }>(getRes);
+    expect(getData.messages.map((m) => m.text)).toEqual(["fix the bug"]);
+  });
+
+  it("pushes a queued message with file attachments", async () => {
+    await trpcMutate(server.url, "queue.clear", { workspaceId: "proj-main" });
+
+    const file: QueuedFile = {
+      mediaType: "image/png",
+      // 1×1 transparent PNG
+      url: "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=",
+      filename: "pixel.png",
+    };
+
+    const res = await trpcMutate(server.url, "queue.push", {
+      workspaceId: "proj-main",
+      text: "review this image",
+      files: [file],
+    });
+    expect(res.status).toBe(200);
+    const data = await trpcData<{ ok: boolean; message: QueuedMessage }>(res);
+    expect(data.message.text).toBe("review this image");
+    expect(data.message.files).toHaveLength(1);
+    expect(data.message.files![0]).toMatchObject({
+      mediaType: "image/png",
+      filename: "pixel.png",
+    });
+    expect(data.message.files![0].url).toBe(file.url);
+
+    const getRes = await trpcQuery(server.url, "queue.get", { workspaceId: "proj-main" });
+    const getData = await trpcData<{ messages: QueuedMessage[] }>(getRes);
+    expect(getData.messages).toHaveLength(1);
+    expect(getData.messages[0].files).toHaveLength(1);
+    expect(getData.messages[0].files![0].filename).toBe("pixel.png");
+
+    // cleanup
+    await trpcMutate(server.url, "queue.clear", { workspaceId: "proj-main" });
   });
 
   it("pushes multiple messages and preserves order", async () => {
+    await trpcMutate(server.url, "queue.clear", { workspaceId: "proj-main" });
+    await trpcMutate(server.url, "queue.push", { workspaceId: "proj-main", text: "first" });
     await trpcMutate(server.url, "queue.push", {
       workspaceId: "proj-main",
       text: "add tests",
@@ -221,20 +273,20 @@ describe("tRPC — queue CRUD", () => {
     });
 
     const res = await trpcQuery(server.url, "queue.get", { workspaceId: "proj-main" });
-    const data = await trpcData<{ messages: string[] }>(res);
-    expect(data.messages).toEqual(["fix the bug", "add tests", "update docs"]);
+    const data = await trpcData<{ messages: QueuedMessage[] }>(res);
+    expect(data.messages.map((m) => m.text)).toEqual(["first", "add tests", "update docs"]);
   });
 
   it("replaces the entire queue via queue.set", async () => {
     const res = await trpcMutate(server.url, "queue.set", {
       workspaceId: "proj-main",
-      messages: ["new first", "new second"],
+      messages: [{ text: "new first" }, { text: "new second" }],
     });
     expect(res.status).toBe(200);
 
     const getRes = await trpcQuery(server.url, "queue.get", { workspaceId: "proj-main" });
-    const getData = await trpcData<{ messages: string[] }>(getRes);
-    expect(getData.messages).toEqual(["new first", "new second"]);
+    const getData = await trpcData<{ messages: QueuedMessage[] }>(getRes);
+    expect(getData.messages.map((m) => m.text)).toEqual(["new first", "new second"]);
   });
 
   it("queue.set with empty array clears the queue", async () => {
@@ -244,43 +296,168 @@ describe("tRPC — queue CRUD", () => {
     });
 
     const res = await trpcQuery(server.url, "queue.get", { workspaceId: "proj-main" });
-    const data = await trpcData<{ messages: string[] }>(res);
+    const data = await trpcData<{ messages: QueuedMessage[] }>(res);
     expect(data.messages).toEqual([]);
   });
 
-  it("removes a single message by value via queue.remove", async () => {
+  it("reorders messages via queue.set, preserving ids and files", async () => {
+    // Seed three messages, the middle one with a file attachment.
+    await trpcMutate(server.url, "queue.clear", { workspaceId: "proj-main" });
+    const pushA = await trpcMutate(server.url, "queue.push", {
+      workspaceId: "proj-main",
+      text: "alpha",
+    });
+    const pushB = await trpcMutate(server.url, "queue.push", {
+      workspaceId: "proj-main",
+      text: "bravo",
+      files: [
+        {
+          mediaType: "image/png",
+          url: "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=",
+          filename: "pixel.png",
+        },
+      ],
+    });
+    const pushC = await trpcMutate(server.url, "queue.push", {
+      workspaceId: "proj-main",
+      text: "charlie",
+    });
+    const a = (await trpcData<{ message: QueuedMessage }>(pushA)).message;
+    const b = (await trpcData<{ message: QueuedMessage }>(pushB)).message;
+    const c = (await trpcData<{ message: QueuedMessage }>(pushC)).message;
+
+    // Reorder to C, A, B (mirrors what a drag-end persists).
+    const setRes = await trpcMutate(server.url, "queue.set", {
+      workspaceId: "proj-main",
+      messages: [
+        { id: c.id, text: c.text },
+        { id: a.id, text: a.text },
+        { id: b.id, text: b.text, files: b.files },
+      ],
+    });
+    expect(setRes.status).toBe(200);
+
+    const getRes = await trpcQuery(server.url, "queue.get", { workspaceId: "proj-main" });
+    const getData = await trpcData<{ messages: QueuedMessage[] }>(getRes);
+    expect(getData.messages.map((m) => m.id)).toEqual([c.id, a.id, b.id]);
+    expect(getData.messages.map((m) => m.text)).toEqual(["charlie", "alpha", "bravo"]);
+    // File attachment survives the reorder
+    const reorderedB = getData.messages.find((m) => m.id === b.id);
+    expect(reorderedB?.files).toHaveLength(1);
+    expect(reorderedB?.files?.[0].filename).toBe("pixel.png");
+
+    // cleanup
+    await trpcMutate(server.url, "queue.clear", { workspaceId: "proj-main" });
+  });
+
+  it("removes a single message by id via queue.remove", async () => {
     // Seed: a, b, c
     await trpcMutate(server.url, "queue.clear", { workspaceId: "proj-main" });
     await trpcMutate(server.url, "queue.push", { workspaceId: "proj-main", text: "a" });
-    await trpcMutate(server.url, "queue.push", { workspaceId: "proj-main", text: "b" });
+    const pushB = await trpcMutate(server.url, "queue.push", {
+      workspaceId: "proj-main",
+      text: "b",
+    });
+    const pushBData = await trpcData<{ message: QueuedMessage }>(pushB);
     await trpcMutate(server.url, "queue.push", { workspaceId: "proj-main", text: "c" });
 
     const res = await trpcMutate(server.url, "queue.remove", {
       workspaceId: "proj-main",
-      text: "b",
+      id: pushBData.message.id,
     });
     expect(res.status).toBe(200);
+    const removeData = await trpcData<{ ok: boolean; removed: boolean }>(res);
+    expect(removeData.removed).toBe(true);
 
     const getRes = await trpcQuery(server.url, "queue.get", { workspaceId: "proj-main" });
-    const getData = await trpcData<{ messages: string[] }>(getRes);
-    expect(getData.messages).toEqual(["a", "c"]);
+    const getData = await trpcData<{ messages: QueuedMessage[] }>(getRes);
+    expect(getData.messages.map((m) => m.text)).toEqual(["a", "c"]);
 
     // cleanup
     await trpcMutate(server.url, "queue.clear", { workspaceId: "proj-main" });
   });
 
-  it("queue.remove only removes the first occurrence of a duplicate", async () => {
-    await trpcMutate(server.url, "queue.push", { workspaceId: "proj-main", text: "dup" });
-    await trpcMutate(server.url, "queue.push", { workspaceId: "proj-main", text: "dup" });
+  it("queue.remove of an unknown id returns removed=false", async () => {
+    await trpcMutate(server.url, "queue.push", { workspaceId: "proj-main", text: "x" });
 
-    await trpcMutate(server.url, "queue.remove", { workspaceId: "proj-main", text: "dup" });
-
-    const getRes = await trpcQuery(server.url, "queue.get", { workspaceId: "proj-main" });
-    const getData = await trpcData<{ messages: string[] }>(getRes);
-    expect(getData.messages).toEqual(["dup"]);
+    const res = await trpcMutate(server.url, "queue.remove", {
+      workspaceId: "proj-main",
+      id: "unknown-id",
+    });
+    expect(res.status).toBe(200);
+    const removeData = await trpcData<{ ok: boolean; removed: boolean }>(res);
+    expect(removeData.removed).toBe(false);
 
     // cleanup
     await trpcMutate(server.url, "queue.clear", { workspaceId: "proj-main" });
+  });
+
+  it("updates the text of a queued message via queue.update", async () => {
+    await trpcMutate(server.url, "queue.clear", { workspaceId: "proj-main" });
+    const pushRes = await trpcMutate(server.url, "queue.push", {
+      workspaceId: "proj-main",
+      text: "before",
+    });
+    const pushData = await trpcData<{ message: QueuedMessage }>(pushRes);
+
+    const updateRes = await trpcMutate(server.url, "queue.update", {
+      workspaceId: "proj-main",
+      id: pushData.message.id,
+      text: "after",
+    });
+    expect(updateRes.status).toBe(200);
+    const updateData = await trpcData<{ ok: boolean; updated: boolean }>(updateRes);
+    expect(updateData.updated).toBe(true);
+
+    const getRes = await trpcQuery(server.url, "queue.get", { workspaceId: "proj-main" });
+    const getData = await trpcData<{ messages: QueuedMessage[] }>(getRes);
+    expect(getData.messages).toHaveLength(1);
+    expect(getData.messages[0].id).toBe(pushData.message.id);
+    expect(getData.messages[0].text).toBe("after");
+
+    // cleanup
+    await trpcMutate(server.url, "queue.clear", { workspaceId: "proj-main" });
+  });
+
+  it("queue.update preserves file attachments", async () => {
+    await trpcMutate(server.url, "queue.clear", { workspaceId: "proj-main" });
+    const file: QueuedFile = {
+      mediaType: "image/png",
+      url: "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=",
+      filename: "pixel.png",
+    };
+    const pushRes = await trpcMutate(server.url, "queue.push", {
+      workspaceId: "proj-main",
+      text: "look at this",
+      files: [file],
+    });
+    const pushData = await trpcData<{ message: QueuedMessage }>(pushRes);
+
+    await trpcMutate(server.url, "queue.update", {
+      workspaceId: "proj-main",
+      id: pushData.message.id,
+      text: "actually, look at this image carefully",
+    });
+
+    const getRes = await trpcQuery(server.url, "queue.get", { workspaceId: "proj-main" });
+    const getData = await trpcData<{ messages: QueuedMessage[] }>(getRes);
+    expect(getData.messages[0].text).toBe("actually, look at this image carefully");
+    expect(getData.messages[0].files).toHaveLength(1);
+    expect(getData.messages[0].files![0].filename).toBe("pixel.png");
+
+    // cleanup
+    await trpcMutate(server.url, "queue.clear", { workspaceId: "proj-main" });
+  });
+
+  it("queue.update of an unknown id returns updated=false", async () => {
+    const res = await trpcMutate(server.url, "queue.update", {
+      workspaceId: "proj-main",
+      id: "unknown-id",
+      text: "irrelevant",
+    });
+    expect(res.status).toBe(200);
+    const data = await trpcData<{ ok: boolean; updated: boolean }>(res);
+    expect(data.updated).toBe(false);
   });
 
   it("clears all queued messages via queue.clear", async () => {
@@ -294,7 +471,7 @@ describe("tRPC — queue CRUD", () => {
     expect(clearData.ok).toBe(true);
 
     const getRes = await trpcQuery(server.url, "queue.get", { workspaceId: "proj-main" });
-    const getData = await trpcData<{ messages: string[] }>(getRes);
+    const getData = await trpcData<{ messages: QueuedMessage[] }>(getRes);
     expect(getData.messages).toEqual([]);
   });
 
@@ -311,23 +488,23 @@ describe("tRPC — queue CRUD", () => {
     await trpcMutate(server.url, "queue.push", { workspaceId: "ws-b", text: "msg-b1" });
 
     const resA = await trpcQuery(server.url, "queue.get", { workspaceId: "ws-a" });
-    const dataA = await trpcData<{ messages: string[] }>(resA);
-    expect(dataA.messages).toEqual(["msg-a1", "msg-a2"]);
+    const dataA = await trpcData<{ messages: QueuedMessage[] }>(resA);
+    expect(dataA.messages.map((m) => m.text)).toEqual(["msg-a1", "msg-a2"]);
 
     const resB = await trpcQuery(server.url, "queue.get", { workspaceId: "ws-b" });
-    const dataB = await trpcData<{ messages: string[] }>(resB);
-    expect(dataB.messages).toEqual(["msg-b1"]);
+    const dataB = await trpcData<{ messages: QueuedMessage[] }>(resB);
+    expect(dataB.messages.map((m) => m.text)).toEqual(["msg-b1"]);
 
     // Clearing one doesn't affect the other
     await trpcMutate(server.url, "queue.clear", { workspaceId: "ws-a" });
 
     const resA2 = await trpcQuery(server.url, "queue.get", { workspaceId: "ws-a" });
-    const dataA2 = await trpcData<{ messages: string[] }>(resA2);
+    const dataA2 = await trpcData<{ messages: QueuedMessage[] }>(resA2);
     expect(dataA2.messages).toEqual([]);
 
     const resB2 = await trpcQuery(server.url, "queue.get", { workspaceId: "ws-b" });
-    const dataB2 = await trpcData<{ messages: string[] }>(resB2);
-    expect(dataB2.messages).toEqual(["msg-b1"]);
+    const dataB2 = await trpcData<{ messages: QueuedMessage[] }>(resB2);
+    expect(dataB2.messages.map((m) => m.text)).toEqual(["msg-b1"]);
 
     // cleanup
     await trpcMutate(server.url, "queue.clear", { workspaceId: "ws-b" });
@@ -377,7 +554,7 @@ describe("tRPC — queue input validation", () => {
   });
 
   it("queue.set fails when workspaceId is missing", async () => {
-    const res = await trpcMutate(server.url, "queue.set", { messages: ["hello"] });
+    const res = await trpcMutate(server.url, "queue.set", { messages: [{ text: "hello" }] });
     expect(res.ok).toBe(false);
   });
 
@@ -393,6 +570,27 @@ describe("tRPC — queue input validation", () => {
 
   it("queue.clear fails when workspaceId is missing", async () => {
     const res = await trpcMutate(server.url, "queue.clear", {});
+    expect(res.ok).toBe(false);
+  });
+
+  it("queue.remove fails when id is missing", async () => {
+    const res = await trpcMutate(server.url, "queue.remove", { workspaceId: "proj-main" });
+    expect(res.ok).toBe(false);
+  });
+
+  it("queue.update fails when id is missing", async () => {
+    const res = await trpcMutate(server.url, "queue.update", {
+      workspaceId: "proj-main",
+      text: "x",
+    });
+    expect(res.ok).toBe(false);
+  });
+
+  it("queue.update fails when text is missing", async () => {
+    const res = await trpcMutate(server.url, "queue.update", {
+      workspaceId: "proj-main",
+      id: "some-id",
+    });
     expect(res.ok).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

- **Queued messages now support images and other file attachments** end-to-end: client → 409-queue → tRPC store → drain → upload → agent prompt → persisted user bubble.
- **Click any queued bubble to edit its text** in a popup (Cmd/Ctrl+Enter saves; files preserved).
- **Drag the top-border grip rail to reorder** the queue; new order persists via `queue.set`.
- **Two pre-existing bugs in the direct (non-queued) multi-image flow are fixed**:
  - `saveUploadedFiles` could overwrite a file with another that shared the same filename when both writes landed in the same millisecond. Now uses a `${baseTimestamp}-${i}-${name}` scheme.
  - The `user-message` chunk only carried text, so direct messages with images came back as text-only after a session reload. Now broadcasts and reconstructs file parts (with stable `/api/uploads/*` URLs) via a new `displayFiles` field on `submitTask` and an updated `convert-events.ts`.

## Test plan

- [x] `pnpm --filter @band-app/server build` clean
- [x] `npx biome check` clean (only pre-existing array-index-key warnings, no errors)
- [x] `vitest run tests/queue.test.ts tests/queue-drain.test.ts tests/file-sharing.test.ts` — 49 tests pass, including new coverage for:
  - queued message + image round-trip via `queue.push` / `queue.get`
  - `queue.update` preserving files; queue.update id/text validation
  - drag-reorder via `queue.set` preserving ids and files
  - direct multi-file submission writing each file to a distinct path on disk even with identical filenames
  - `user-message` SSE replay reconstructing file parts with `/api/uploads/*` URLs
- [ ] Manual: send a direct message with two `image.png` clipboard pastes — both render in the bubble, both persist after reload, both reach the agent at distinct paths.
- [ ] Manual: while a task runs, queue 3 messages (some with images), drag to reorder, edit one, then let them drain — order respected, edits applied, files reach the agent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)