### PR TITLE
ci: cache pnpm/playwright/next + bump Node to 24 LTS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,8 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
+          cache: 'pnpm'
 
       - name: Build CLI
         run: cargo build --release --manifest-path apps/cli/Cargo.toml
@@ -92,11 +93,27 @@ jobs:
       - name: Lint (cargo clippy — CLI)
         run: cargo clippy --manifest-path apps/cli/Cargo.toml -- -D warnings
 
+      - name: Cache Next.js build
+        uses: actions/cache@v5
+        with:
+          path: apps/web/.next/cache
+          key: nextjs-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}-${{ hashFiles('apps/web/**/*.[jt]s', 'apps/web/**/*.[jt]sx') }}
+          restore-keys: |
+            nextjs-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}-
+            nextjs-${{ runner.os }}-
+
       - name: Build web (needed by tests)
         run: pnpm build:web
 
       - name: Test (web)
         run: pnpm --filter @band-app/server test
+
+      - name: Cache Playwright browsers
+        uses: actions/cache@v5
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: playwright-${{ runner.os }}-
 
       - name: Install Playwright Chromium
         run: pnpm --filter @band-app/server exec playwright install --with-deps chromium
@@ -145,7 +162,8 @@ jobs:
         if: steps.changes.outputs.changed == 'true'
         uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
+          cache: 'pnpm'
 
       - name: Install dependencies
         if: steps.changes.outputs.changed == 'true'


### PR DESCRIPTION
## PO Summary

CI runs faster on every push. Re-uses already-downloaded dependencies (pnpm packages, Playwright browser, Next.js build artifacts) instead of fetching them from scratch each time. Also moves the Node runtime from version 22 to 24 (the current Active LTS) so we stay on a supported release.

## Changes

- `actions/setup-node@v6` now uses `cache: 'pnpm'` — pnpm store restored across runs (biggest single win for `pnpm install` time).
- New cache step for Playwright browsers (`~/.cache/ms-playwright`) keyed on `pnpm-lock.yaml` so Chromium isn't re-downloaded each run.
- New cache step for Next.js build (`apps/web/.next/cache`) so incremental builds reuse prior artifacts.
- Node version bumped `22 → 24` in both `check` and `deploy-docs` jobs.

## Test plan

- [ ] CI green on this PR (validates Node 24 + caches behave on a real run)
- [ ] Compare run duration vs. recent main runs once cache warms (2nd run)
- [ ] Confirm Playwright/Next.js cache keys hit on subsequent push without lockfile change