### PR TITLE
Dockview v6 edge groups: projects panel + fullscreen-aware title bar

### DIFF
--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -165,6 +165,14 @@ async function bootstrap(): Promise<void> {
   state.mainWindow.on("close", () => {
     void cleanupOnce();
   });
+
+  // Forward macOS native fullscreen state to the renderer so the title bar
+  // can drop the 80px traffic-light offset when the controls are hidden.
+  const sendFullscreen = (fs: boolean) => {
+    state.mainWindow?.webContents.send("window-fullscreen-changed", fs);
+  };
+  state.mainWindow.on("enter-full-screen", () => sendFullscreen(true));
+  state.mainWindow.on("leave-full-screen", () => sendFullscreen(false));
 }
 
 app.on("window-all-closed", () => {

--- a/apps/desktop/src/main/ipc/register.ts
+++ b/apps/desktop/src/main/ipc/register.ts
@@ -71,6 +71,7 @@ export function registerIpc(opts: RegisterOptions): () => void {
     webserverStop({ webDir: opts.webDir, managed: opts.managed }),
   );
   handle(Channels.getAppTitle, () => getAppTitle());
+  handle(Channels.getWindowFullscreen, () => opts.mainWindow.isFullScreen());
 
   // ---- macOS shell ----
   // Args are camelCase because they're forwarded to the handlers as typed

--- a/apps/desktop/src/main/menu.ts
+++ b/apps/desktop/src/main/menu.ts
@@ -144,9 +144,11 @@ export function buildAppMenu(): Menu {
       accelerator: "CmdOrCtrl+-",
       click: () => evalInFocused("if(window.__bandZoom)window.__bandZoom('out')"),
     },
+    // Zoom-reset deliberately has no accelerator: CmdOrCtrl+0 is owned by
+    // the dashboard's "All projects" label filter (see DashboardShell).
+    // Reset is still reachable here via menu click.
     {
       label: "Actual Size",
-      accelerator: "CmdOrCtrl+0",
       click: () => evalInFocused("if(window.__bandZoom)window.__bandZoom('reset')"),
     },
     { type: "separator" },

--- a/apps/desktop/src/preload/index.cts
+++ b/apps/desktop/src/preload/index.cts
@@ -38,6 +38,7 @@ const ALLOWED_INVOKE_CHANNELS = new Set<string>([
   "webserver_start",
   "webserver_stop",
   "get_app_title",
+  "get_window_fullscreen",
   // Phase 2 — macOS shell + open_external
   "pick_folder",
   "reveal_in_finder",
@@ -60,7 +61,11 @@ const ALLOWED_INVOKE_CHANNELS = new Set<string>([
   "browser_show_all_for_workspace",
 ]);
 
-const ALLOWED_EVENT_NAMES = new Set<string>(["browser-url-changed", "browser-title-changed"]);
+const ALLOWED_EVENT_NAMES = new Set<string>([
+  "browser-url-changed",
+  "browser-title-changed",
+  "window-fullscreen-changed",
+]);
 
 type Unlisten = () => void;
 

--- a/apps/desktop/src/shared/ipc-channels.ts
+++ b/apps/desktop/src/shared/ipc-channels.ts
@@ -12,6 +12,7 @@ export const Channels = {
   webserverStart: "webserver_start",
   webserverStop: "webserver_stop",
   getAppTitle: "get_app_title",
+  getWindowFullscreen: "get_window_fullscreen",
 
   // macOS shell bridges + open_external
   pickFolder: "pick_folder",
@@ -41,6 +42,7 @@ export type ChannelName = (typeof Channels)[keyof typeof Channels];
 export const Events = {
   browserUrlChanged: "browser-url-changed",
   browserTitleChanged: "browser-title-changed",
+  windowFullscreenChanged: "window-fullscreen-changed",
 } as const;
 
 export type EventName = (typeof Events)[keyof typeof Events];

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -72,7 +72,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "croner": "^10.0.1",
-    "dockview": "^5.2.0",
+    "dockview": "^6.0.6",
     "drizzle-kit": "1.0.0-rc.1",
     "drizzle-orm": "1.0.0-rc.1",
     "esbuild": "^0.25.0",

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -1463,6 +1463,10 @@ export function ChatView({
             placeholder="Type a message..."
             onEscape={handleEscape}
             onPreviousMessage={getLastUserMessage}
+            // Shift+Tab toggles Edit/Plan mode, but only while the chat
+            // input has focus — the same band:toggle-mode listener picks
+            // up palette invocations as well.
+            onShiftTab={() => window.dispatchEvent(new CustomEvent("band:toggle-mode"))}
           />
           <PromptInputActions>
             <div className="flex items-center gap-0.5">

--- a/apps/web/src/components/CodeBrowserView.tsx
+++ b/apps/web/src/components/CodeBrowserView.tsx
@@ -256,6 +256,25 @@ export function CodeBrowserView({
     return () => ro.disconnect();
   }, []);
 
+  // Listen for the workspace-level ⇧⌘E "focus Files" event. Scope the
+  // focus to this CodeBrowserView's subtree (containerRef), so multi-
+  // workspace setups don't fight — only the visible instance's focus
+  // actually applies (offsetParent === null on hidden ones is a no-op).
+  // Prefer the currently-active file row (data-band-active); fall back
+  // to the first focusable button in the tree if nothing is selected.
+  useEffect(() => {
+    const handler = () => {
+      const root = containerRef.current;
+      if (!root || root.offsetParent === null) return;
+      const target =
+        root.querySelector<HTMLElement>("[data-band-active]") ??
+        root.querySelector<HTMLElement>("button");
+      target?.focus({ preventScroll: true });
+    };
+    window.addEventListener("band:focus-files", handler);
+    return () => window.removeEventListener("band:focus-files", handler);
+  }, []);
+
   // Use the mobile toggle layout when EITHER the viewport is narrow (real
   // mobile) OR the container is narrower than 600px (narrow dockview panel).
   const useMobileLayout = !isDesktop || (containerWidth !== null && containerWidth < 600);

--- a/apps/web/src/components/CodeBrowserView.tsx
+++ b/apps/web/src/components/CodeBrowserView.tsx
@@ -840,7 +840,13 @@ export function CodeBrowserView({
   // -------------------------------------------------------------------------
   // Wrapped in a measured container so the ResizeObserver can track width.
   return (
-    <div ref={containerRef} className="h-full">
+    // h-full + w-full + overflow-hidden + min-w-0 is required so that
+    // CodeMirror's wide intrinsic content (long unwrapped lines, scrollable
+    // horizontally) doesn't propagate up through the flex chain into
+    // dockview's content container, which has min-height:0 but not
+    // min-width:0 and would otherwise be pushed wider than its allocated
+    // group slot — visibly shoving the right-edge tab strip off-screen.
+    <div ref={containerRef} className="h-full w-full min-w-0 overflow-hidden">
       {useMobileLayout ? (
         // Mobile / narrow container: toggle between file browser and viewer
         viewFilePath ? (
@@ -928,7 +934,7 @@ export function CodeBrowserView({
 
           {/* Right panel — file tabs + content */}
           <Panel id="file-viewer" minSize="20%">
-            <div className="relative flex h-full flex-col overflow-hidden">
+            <div className="relative flex h-full min-w-0 flex-col overflow-hidden">
               {/* Tab bar — owns the file-tree toggle now (auto-hides when narrow) */}
               <FileTabBar
                 workspacePath={workspacePath}
@@ -988,7 +994,7 @@ export function CodeBrowserView({
               />
 
               {/* File content */}
-              <div className="min-h-0 flex-1">
+              <div className="min-h-0 min-w-0 flex-1 overflow-hidden">
                 {viewFilePath ? (
                   <FileViewer
                     workspaceId={workspaceId}

--- a/apps/web/src/components/DesktopTitleBar.tsx
+++ b/apps/web/src/components/DesktopTitleBar.tsx
@@ -8,8 +8,9 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@band-app/ui";
-import { ChevronLeft, ChevronRight, PanelLeft, PanelTop } from "lucide-react";
-import { useEffect, useState } from "react";
+import { ChevronLeft, ChevronRight, Menu, PanelTop } from "lucide-react";
+import { type ReactNode, useEffect, useState } from "react";
+import { useIsFullscreen } from "../hooks/useIsFullscreen";
 import { invoke as desktopInvoke } from "../lib/desktop-ipc";
 import { isDesktop } from "../lib/is-desktop";
 import { EditorPicker } from "./EditorPicker";
@@ -32,10 +33,6 @@ export interface PanelItem {
 interface DesktopTitleBarProps {
   /** Static title. If omitted, fetches the app title from the desktop shell. */
   title?: string;
-  /** Callback to toggle the sidebar. When provided, a toggle button is shown. */
-  onToggleSidebar?: () => void;
-  /** Whether the sidebar is currently collapsed. */
-  sidebarCollapsed?: boolean;
   /** Active workspace name to display prominently. */
   workspaceName?: string;
   /** The workspace path for open-in / copy-path actions. */
@@ -56,13 +53,15 @@ interface DesktopTitleBarProps {
   canGoBack?: boolean;
   /** Whether forward navigation is currently available (enables/disables the button). */
   canGoForward?: boolean;
+  /** Items rendered inside the global hamburger dropdown (left of back/forward).
+   *  Pass DropdownMenu items (Tasks, Cronjobs, Settings, …). When undefined,
+   *  the hamburger button is not rendered. */
+  menuItems?: ReactNode;
 }
 
 /** Draggable desktop title bar that works with external-URL Electron webviews. */
 export function DesktopTitleBar({
   title,
-  onToggleSidebar,
-  sidebarCollapsed,
   workspaceName,
   workspacePath,
   onCopyPath,
@@ -73,8 +72,12 @@ export function DesktopTitleBar({
   onGoForward,
   canGoBack,
   canGoForward,
+  menuItems,
 }: DesktopTitleBarProps) {
   const [appTitle, setAppTitle] = useState(title ?? "Band");
+  // macOS native fullscreen hides the traffic lights — used below to drop
+  // the 80px left offset reserved for them.
+  const isFullscreen = useIsFullscreen();
 
   useEffect(() => {
     if (title) return;
@@ -94,22 +97,33 @@ export function DesktopTitleBar({
       className="h-[38px] shrink-0 flex items-center justify-center relative border-b border-border"
       style={DRAG_STYLE}
     >
-      {(onToggleSidebar || onGoBack || onGoForward) && (
+      {(onGoBack || onGoForward || menuItems) && (
         <div
           // Desktop: leave 80px clear for the macOS traffic lights.
           // Web: no traffic lights exist, so park the controls near the edge.
-          className={`absolute ${isDesktop ? "left-[80px]" : "left-2"} top-1/2 -translate-y-1/2 flex items-center gap-0.5 pointer-events-auto`}
+          className={`absolute ${isDesktop && !isFullscreen ? "left-[80px]" : "left-2"} top-1/2 -translate-y-1/2 flex items-center gap-0.5 pointer-events-auto`}
           style={NO_DRAG_STYLE}
         >
-          {onToggleSidebar && (
-            <button
-              type="button"
-              onClick={onToggleSidebar}
-              className="flex items-center justify-center rounded p-1 text-muted-foreground hover:text-foreground hover:bg-accent/50 transition-colors"
-              title={sidebarCollapsed ? "Show sidebar" : "Hide sidebar"}
-            >
-              <PanelLeft className="size-5" />
-            </button>
+          {menuItems && (
+            <DropdownMenu>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <DropdownMenuTrigger asChild>
+                    <button
+                      type="button"
+                      className="flex items-center justify-center rounded p-1 text-muted-foreground hover:text-foreground hover:bg-accent/50 transition-colors"
+                      aria-label="Menu"
+                    >
+                      <Menu className="size-5" />
+                    </button>
+                  </DropdownMenuTrigger>
+                </TooltipTrigger>
+                <TooltipContent side="bottom" className="text-xs">
+                  More
+                </TooltipContent>
+              </Tooltip>
+              <DropdownMenuContent align="start">{menuItems}</DropdownMenuContent>
+            </DropdownMenu>
           )}
           {(onGoBack || onGoForward) && (
             <>

--- a/apps/web/src/components/DockviewBrowserContainer.tsx
+++ b/apps/web/src/components/DockviewBrowserContainer.tsx
@@ -561,6 +561,30 @@ export function DockviewBrowserContainer({
     return () => window.removeEventListener("keydown", handler, true);
   }, [visible, closeTab, handleSplit, handleAddTab]);
 
+  // Listen for the workspace-level ⇧⌘B "focus Browser" event. Scoped
+  // to this container's subtree via containerRef. The native webview
+  // can't be focused from React, so we focus the URL input instead —
+  // which matches what users typically want (start typing → type a
+  // new URL or search query). The visibility gate (offsetParent on
+  // the container ref) means inactive workspaces' calls are no-ops.
+  useEffect(() => {
+    const handler = () => {
+      const root = containerRef.current;
+      if (!root || root.offsetParent === null) return;
+      // Prefer the visible address bar (multiple are mounted while
+      // the user has multiple browser tabs open inside the panel).
+      const inputs = root.querySelectorAll<HTMLInputElement>('input[placeholder^="Enter URL"]');
+      for (const input of inputs) {
+        if (input.offsetParent !== null) {
+          input.focus({ preventScroll: true });
+          return;
+        }
+      }
+    };
+    window.addEventListener("band:focus-browser", handler);
+    return () => window.removeEventListener("band:focus-browser", handler);
+  }, []);
+
   // Sync dockview panels when browsers are created/removed externally (e.g. CLI).
   useEffect(() => {
     return adapter.subscribeStatusEvents((event) => {

--- a/apps/web/src/components/DockviewWorkspaceLayout.tsx
+++ b/apps/web/src/components/DockviewWorkspaceLayout.tsx
@@ -64,10 +64,10 @@ const PANEL_ICONS: Record<string, React.FC<{ className?: string }>> = {
 };
 
 const PANEL_SHORTCUTS: Record<string, string> = {
-  changes: "⌘E",
-  files: "⌘G",
-  terminal: "⌘J",
-  browser: "⌘B",
+  changes: "⇧⌘G",
+  files: "⇧⌘E",
+  terminal: "⌃`",
+  browser: "⇧⌘B",
 };
 
 // ---------------------------------------------------------------------------
@@ -822,6 +822,19 @@ export const DockviewWorkspaceLayout = memo(function DockviewWorkspaceLayout({
         return;
       }
 
+      // Ctrl+` (not Cmd+`) → Terminal panel. Handled here, ahead of the
+      // mod gate, because we want to hijack even when xterm has focus
+      // (otherwise the backtick would be typed into the shell). Matches
+      // VS Code's "Toggle Terminal" binding.
+      if (e.ctrlKey && !e.metaKey && e.key === "`") {
+        e.preventDefault();
+        e.stopPropagation();
+        if (!hiddenPanelsRef.current.includes("terminal")) {
+          apiRef.current?.getPanel("terminal")?.api.setActive();
+        }
+        return;
+      }
+
       // Ctrl+Tab → next file tab
       if (e.key === "Tab" && e.ctrlKey && !e.shiftKey) {
         e.preventDefault();
@@ -866,20 +879,20 @@ export const DockviewWorkspaceLayout = memo(function DockviewWorkspaceLayout({
         } else {
           window.dispatchEvent(new CustomEvent("band:find-in-file"));
         }
-      } else if (key === "e" && !e.shiftKey && api) {
+      } else if (key === "g" && e.shiftKey && api) {
+        // ⇧⌘G → Changes (matches VS Code "Show Source Control")
         e.preventDefault();
         if (!hiddenPanelsRef.current.includes("changes")) api.getPanel("changes")?.api.setActive();
-      } else if (key === "j" && !e.shiftKey && api) {
-        e.preventDefault();
-        if (!hiddenPanelsRef.current.includes("terminal"))
-          api.getPanel("terminal")?.api.setActive();
-      } else if (key === "g" && !e.shiftKey && api) {
+      } else if (key === "e" && e.shiftKey && api) {
+        // ⇧⌘E → Files (matches VS Code "Show Explorer")
         e.preventDefault();
         if (!hiddenPanelsRef.current.includes("files")) api.getPanel("files")?.api.setActive();
-      } else if (key === "b" && !e.shiftKey && api) {
+      } else if (key === "b" && e.shiftKey && api) {
+        // ⇧⌘B → Browser
         e.preventDefault();
         if (!hiddenPanelsRef.current.includes("browser")) api.getPanel("browser")?.api.setActive();
-      } else if (key === "b" && e.shiftKey && api) {
+      } else if (key === "b" && !e.shiftKey && api) {
+        // ⌘B → toggle Projects sidebar (matches VS Code "Toggle Primary Side Bar")
         e.preventDefault();
         const left = api.groups.find((g) => g.id === EDGE_GROUP_IDS.left);
         if (left) {

--- a/apps/web/src/components/DockviewWorkspaceLayout.tsx
+++ b/apps/web/src/components/DockviewWorkspaceLayout.tsx
@@ -16,6 +16,7 @@ import {
   DockviewReact,
   type DockviewReadyEvent,
   type DockviewTheme,
+  type IDockviewHeaderActionsProps,
   type IDockviewPanelHeaderProps,
   type IDockviewPanelProps,
 } from "dockview";
@@ -24,7 +25,9 @@ import {
   Folders,
   GitCompare,
   Globe,
+  Maximize2,
   MessageSquare,
+  Minimize2,
   Terminal as TerminalIcon,
 } from "lucide-react";
 import { lazy, memo, Suspense, useCallback, useEffect, useMemo, useRef, useState } from "react";
@@ -366,6 +369,62 @@ const components: Record<string, React.FunctionComponent<IDockviewPanelProps<any
 const tabComponents: Record<string, React.FunctionComponent<IDockviewPanelHeaderProps>> = {
   badge: BadgeTab,
 };
+
+// ---------------------------------------------------------------------------
+// Right-side header actions — adds a maximize/restore toggle to the tab strip
+// of every center (grid) group. Hidden on edge groups (projects / future
+// right + bottom edges) where maximize doesn't make sense.
+// ---------------------------------------------------------------------------
+
+const MainGroupRightActions = memo(function MainGroupRightActions(
+  props: IDockviewHeaderActionsProps,
+) {
+  // location.type === "grid" means a real center group; "edge" / "floating" /
+  // "popout" are all skipped. Default to "grid" if dockview omits the field
+  // (older builds) so the button still shows on the main layout.
+  const isGridGroup = (props.location?.type ?? "grid") === "grid";
+
+  // Track maximize state via the container event so the icon flips when the
+  // user toggles via another path (e.g. drag-restore, future keyboard shortcut).
+  // group.api.isMaximized() returns true only when *this* group is the
+  // maximized one — global enough that we don't need a separate
+  // hasMaximizedGroup() check.
+  const [isMaximized, setIsMaximized] = useState(() => props.api.isMaximized());
+  useEffect(() => {
+    const refresh = () => setIsMaximized(props.api.isMaximized());
+    refresh();
+    const d = props.containerApi.onDidMaximizedGroupChange(refresh);
+    return () => d.dispose();
+  }, [props.api, props.containerApi]);
+
+  if (!isGridGroup) return null;
+
+  const Icon = isMaximized ? Minimize2 : Maximize2;
+  const label = isMaximized ? "Restore" : "Maximize";
+
+  return (
+    <div className="flex h-full items-center px-1">
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <button
+            type="button"
+            aria-label={label}
+            onClick={() => {
+              if (props.api.isMaximized()) props.api.exitMaximized();
+              else props.api.maximize();
+            }}
+            className="inline-flex size-7 items-center justify-center rounded text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+          >
+            <Icon className="size-3.5" />
+          </button>
+        </TooltipTrigger>
+        <TooltipContent side="bottom" className="text-xs">
+          {label}
+        </TooltipContent>
+      </Tooltip>
+    </div>
+  );
+});
 
 // ---------------------------------------------------------------------------
 // Diff file count hook (polls every 15s)
@@ -1410,6 +1469,7 @@ export const DockviewWorkspaceLayout = memo(function DockviewWorkspaceLayout({
           components={components}
           tabComponents={tabComponents}
           defaultTabComponent={DefaultTab}
+          rightHeaderActionsComponent={MainGroupRightActions}
           onReady={onReady}
         />
       </div>

--- a/apps/web/src/components/DockviewWorkspaceLayout.tsx
+++ b/apps/web/src/components/DockviewWorkspaceLayout.tsx
@@ -64,6 +64,7 @@ const PANEL_ICONS: Record<string, React.FC<{ className?: string }>> = {
 };
 
 const PANEL_SHORTCUTS: Record<string, string> = {
+  chat: "⌃⌘I",
   changes: "⇧⌘G",
   files: "⇧⌘E",
   terminal: "⌃`",
@@ -835,6 +836,31 @@ export const DockviewWorkspaceLayout = memo(function DockviewWorkspaceLayout({
         return;
       }
 
+      // Ctrl+0 (not Cmd+0) → focus Projects in the left edge group.
+      // Matches VS Code's "Focus Side Bar" binding. Like ⌃`, handled in
+      // an early branch so it hijacks even when xterm has focus.
+      // Three-step flow:
+      //   1. Expand the left edge group if collapsed (so there's
+      //      something visible to focus).
+      //   2. Activate the projects panel (in case the left edge
+      //      hosts other tabs in the future).
+      //   3. Dispatch band:focus-projects on the next microtask;
+      //      DashboardShell listens and moves keyboard focus into
+      //      its [tabindex=-1] project-list root.
+      if (e.ctrlKey && !e.metaKey && e.key === "0") {
+        e.preventDefault();
+        e.stopPropagation();
+        const dvApi = apiRef.current;
+        if (!dvApi) return;
+        const left = dvApi.groups.find((g) => g.id === EDGE_GROUP_IDS.left);
+        if (left?.api.isCollapsed()) left.api.expand();
+        dvApi.getPanel("projects")?.api.setActive();
+        queueMicrotask(() => {
+          window.dispatchEvent(new CustomEvent("band:focus-projects"));
+        });
+        return;
+      }
+
       // Ctrl+Tab → next file tab
       if (e.key === "Tab" && e.ctrlKey && !e.shiftKey) {
         e.preventDefault();
@@ -879,6 +905,12 @@ export const DockviewWorkspaceLayout = memo(function DockviewWorkspaceLayout({
         } else {
           window.dispatchEvent(new CustomEvent("band:find-in-file"));
         }
+      } else if (key === "i" && e.ctrlKey && e.metaKey && api) {
+        // ⌃⌘I → Chat (matches VS Code "Toggle Chat")
+        // Both Ctrl AND Cmd held — distinguished from any plain ⌘I /
+        // ⌃I combo (neither of which we currently bind).
+        e.preventDefault();
+        if (!hiddenPanelsRef.current.includes("chat")) api.getPanel("chat")?.api.setActive();
       } else if (key === "g" && e.shiftKey && api) {
         // ⇧⌘G → Changes (matches VS Code "Show Source Control")
         e.preventDefault();

--- a/apps/web/src/components/DockviewWorkspaceLayout.tsx
+++ b/apps/web/src/components/DockviewWorkspaceLayout.tsx
@@ -1,6 +1,7 @@
 import {
   buildCommands,
   CommandPaletteDialog,
+  DashboardShell,
   type DiffStats,
   DiffView,
   parseFileLocation,
@@ -20,6 +21,7 @@ import {
 } from "dockview";
 import {
   FolderOpen,
+  Folders,
   GitCompare,
   Globe,
   MessageSquare,
@@ -34,6 +36,7 @@ import { useWsActive } from "../lib/workspace-visibility-store";
 import { CodeBrowserView } from "./CodeBrowserView";
 import { DockviewBrowserContainer } from "./DockviewBrowserContainer";
 import { DockviewChatContainer } from "./DockviewChatContainer";
+import { useAnyToolbarDialogOpen } from "./ToolbarButtons";
 
 // ---------------------------------------------------------------------------
 // Custom dockview theme – prevents the default themeAbyss from being applied
@@ -49,6 +52,7 @@ const bandTheme: DockviewTheme = {
 // ---------------------------------------------------------------------------
 
 const PANEL_ICONS: Record<string, React.FC<{ className?: string }>> = {
+  projects: Folders,
   chat: MessageSquare,
   changes: GitCompare,
   files: FolderOpen,
@@ -109,11 +113,42 @@ interface TerminalParams {
 // Panel wrapper components
 // ---------------------------------------------------------------------------
 
+/** Empty-state shown by every workspace-scoped panel when no workspace is
+ *  selected (i.e. the index route mounts DockviewWorkspaceLayout with
+ *  workspaceId="" so the layout shape matches /workspace/$id). */
+function NoWorkspaceMessage({ Icon }: { Icon: React.FC<{ className?: string }> }) {
+  return (
+    <div className="flex h-full items-center justify-center">
+      <div className="flex flex-col items-center gap-3 text-center px-8">
+        <Icon className="size-8 text-muted-foreground/30" />
+        <p className="text-sm text-muted-foreground">Select a workspace to get started</p>
+      </div>
+    </div>
+  );
+}
+
+function ProjectsPanelComponent() {
+  // DashboardShell is workspace-agnostic — it shows the global project list.
+  // We mount one instance per workspace's dockview (via DockviewInstanceManager),
+  // which is wasteful: useStatusWatcher / useBranchStatusWatcher /
+  // useSetupStatusWatcher each open a parallel subscription per copy. They
+  // funnel into the same Zustand store so it's idempotent, but a follow-up
+  // should hoist those watchers to <AppShell> and let DashboardShell read
+  // from the store.
+  // hideMenu suppresses DashboardShell's in-shell hamburger overflow menu —
+  // the global DesktopTitleBar in __root.tsx already exposes the same
+  // Tasks / Cronjobs / Settings entries via its own dropdown, so the
+  // duplicate menu inside the panel is just noise. ToolbarOverflowMenuItems
+  // is no longer needed here since the only consumer was that menu.
+  return <DashboardShell hideTitleBar={isDesktop} hideMenu />;
+}
+
 function ChatPanelComponent({ params, api }: IDockviewPanelProps<ChatParams>) {
   // Track physical visibility (not focus/active state).
   // In a split layout, the Chat panel remains visible when another panel
   // (Changes, Files, Terminal) is focused.  `isVisible` is only false when
-  // the panel is behind another tab in a tabbed group.
+  // the panel is behind another tab in a tabbed group, or when its edge
+  // group is collapsed (dockview reports !isVisible in both cases).
   const [isVisible, setIsVisible] = useState(api.isVisible);
   const wsActive = useWsActive(params.workspaceId ?? "");
 
@@ -124,10 +159,9 @@ function ChatPanelComponent({ params, api }: IDockviewPanelProps<ChatParams>) {
 
   const visible = wsActive && isVisible;
 
-  // Don't render until workspaceId is injected — during layout sync fromJSON
-  // recreates panels with empty params before injectParams runs a tick later.
-  // Rendering with undefined workspaceId would cause draft/session state issues.
-  if (!params.workspaceId) return null;
+  // No workspace selected (index route mounts the layout with workspaceId="")
+  // — show a hint that prompts the user to pick a project.
+  if (!params.workspaceId) return <NoWorkspaceMessage Icon={MessageSquare} />;
 
   return (
     <DockviewChatContainer workspaceId={params.workspaceId} visible={visible} wsActive={wsActive} />
@@ -135,7 +169,7 @@ function ChatPanelComponent({ params, api }: IDockviewPanelProps<ChatParams>) {
 }
 
 function ChangesPanelComponent({ params }: IDockviewPanelProps<ChangesParams>) {
-  if (!params.workspaceId) return null;
+  if (!params.workspaceId) return <NoWorkspaceMessage Icon={GitCompare} />;
   return (
     <DiffView
       workspaceId={params.workspaceId}
@@ -148,7 +182,7 @@ function ChangesPanelComponent({ params }: IDockviewPanelProps<ChangesParams>) {
 }
 
 function FilesPanelComponent({ params }: IDockviewPanelProps<FilesParams>) {
-  if (!params.workspaceId) return null;
+  if (!params.workspaceId) return <NoWorkspaceMessage Icon={FolderOpen} />;
   return (
     <CodeBrowserView
       workspaceId={params.workspaceId}
@@ -175,7 +209,7 @@ function TerminalPanelComponent({ params, api }: IDockviewPanelProps<TerminalPar
 
   const visible = wsActive && isVisible;
 
-  if (!params.workspaceId) return null;
+  if (!params.workspaceId) return <NoWorkspaceMessage Icon={TerminalIcon} />;
 
   return (
     <Suspense fallback={null}>
@@ -304,7 +338,7 @@ function BrowserPanelComponent({ params, api }: IDockviewPanelProps<BrowserParam
 
   const visible = wsActive && isVisible;
 
-  if (!params.workspaceId) return null;
+  if (!params.workspaceId) return <NoWorkspaceMessage Icon={Globe} />;
 
   return (
     <DockviewBrowserContainer
@@ -321,6 +355,7 @@ function BrowserPanelComponent({ params, api }: IDockviewPanelProps<BrowserParam
 
 // biome-ignore lint/suspicious/noExplicitAny: dockview requires generic panel props
 const components: Record<string, React.FunctionComponent<IDockviewPanelProps<any>>> = {
+  projects: ProjectsPanelComponent,
   chat: ChatPanelComponent,
   changes: ChangesPanelComponent,
   files: FilesPanelComponent,
@@ -364,7 +399,7 @@ function useDiffFileCount(workspaceId: string, isActive: boolean): number {
 // ---------------------------------------------------------------------------
 
 /** All panels that must always be present in the layout. */
-const REQUIRED_PANEL_IDS = ["chat", "changes", "files", "terminal", "browser"] as const;
+const REQUIRED_PANEL_IDS = ["projects", "chat", "changes", "files", "terminal", "browser"] as const;
 
 // ---------------------------------------------------------------------------
 // Layout persistence: shared structure + per-workspace active tabs
@@ -375,8 +410,17 @@ const REQUIRED_PANEL_IDS = ["chat", "changes", "files", "terminal", "browser"] a
 // each group) is stored per-workspace so that switching workspaces doesn't
 // clobber the user's tab focus.
 
-const GLOBAL_LAYOUT_KEY = "band:dockview-layout";
+const GLOBAL_LAYOUT_KEY = "band:dockview-layout-v6";
 const ACTIVE_STATE_KEY_PREFIX = "band:dockview-active:";
+
+// Edge group ids — pinned to the four sides of the layout. Empty edge groups
+// auto-collapse out of view; users drag panels onto a side to dock there.
+const EDGE_GROUP_IDS = {
+  left: "edge-left",
+  right: "edge-right",
+  bottom: "edge-bottom",
+} as const;
+type EdgeDirection = keyof typeof EDGE_GROUP_IDS;
 
 /** Per-workspace active-tab state: which group is focused and which tab is
  *  shown in each tabbed group. */
@@ -776,6 +820,13 @@ export const DockviewWorkspaceLayout = memo(function DockviewWorkspaceLayout({
       } else if (key === "b" && !e.shiftKey && api) {
         e.preventDefault();
         if (!hiddenPanelsRef.current.includes("browser")) api.getPanel("browser")?.api.setActive();
+      } else if (key === "b" && e.shiftKey && api) {
+        e.preventDefault();
+        const left = api.groups.find((g) => g.id === EDGE_GROUP_IDS.left);
+        if (left) {
+          if (left.api.isCollapsed()) left.api.expand();
+          else left.api.collapse();
+        }
       } else if (key === "-") {
         e.preventDefault();
         window.dispatchEvent(new CustomEvent("band:editor-go-back"));
@@ -879,6 +930,7 @@ export const DockviewWorkspaceLayout = memo(function DockviewWorkspaceLayout({
         api.getPanel("chat");
 
       const titleMap: Record<string, string> = {
+        projects: "Projects",
         chat: "Chat",
         changes: "Changes",
         files: "Files",
@@ -896,6 +948,20 @@ export const DockviewWorkspaceLayout = memo(function DockviewWorkspaceLayout({
 
       if (panelId === "changes") {
         opts.tabComponent = "badge";
+      }
+
+      // Projects has its own home in the left edge group — make sure that
+      // edge exists, then dock the panel there.
+      if (panelId === "projects") {
+        try {
+          if (!api.groups.some((g) => g.id === "edge-left")) {
+            api.addEdgeGroup("left", { id: "edge-left" });
+          }
+        } catch {}
+        opts.position = { referenceGroup: "edge-left", direction: "within" };
+        // biome-ignore lint/suspicious/noExplicitAny: dynamic panel options
+        api.addPanel(opts as any);
+        return;
       }
 
       // Place chat to the left; everything else as a tab alongside an existing panel
@@ -916,6 +982,14 @@ export const DockviewWorkspaceLayout = memo(function DockviewWorkspaceLayout({
     (api: DockviewApi) => {
       const hidden = hiddenPanelsRef.current;
 
+      // Center panels first. Chat is the very first panel — without it,
+      // every later addPanel that references chat would have no anchor,
+      // and dockview's `addPanel` without an explicit position falls back
+      // to `referenceGroup = activeGroup, target = 'within'`, so creating
+      // the left edge group + projects up front would make `edge-left`
+      // the active group and pull every subsequent center panel into it.
+      // Edge group + projects panel are added at the end (see below) once
+      // the center is built.
       api.addPanel({
         id: "chat",
         component: "chat",
@@ -1007,6 +1081,30 @@ export const DockviewWorkspaceLayout = memo(function DockviewWorkspaceLayout({
       try {
         api.getPanel("chat")?.api.setSize({ width: api.width * 0.5 });
       } catch {}
+
+      // Now that the center grid is built, drop projects into the left
+      // edge group as its default home. The edge starts expanded
+      // (no `collapsed` option) so projects is visible at first paint;
+      // empty right/bottom edges added later in onReady stay collapsed.
+      // initialSize matches SIDEBAR_MIN_SIZE ("15rem" = 240px) from
+      // apps/web/src/lib/sidebar-width.ts — the historical min width of
+      // the project list panel — so the project list opens with a
+      // legible width on first load instead of dockview's default 200px.
+      // addEdgeGroup is idempotent here via the existence guard —
+      // onReady's edge-group sweep below also ensures left/right/bottom
+      // exist (so this just gets us the slot for projects to dock into).
+      try {
+        if (!api.groups.some((g) => g.id === "edge-left")) {
+          api.addEdgeGroup("left", { id: "edge-left", initialSize: 240 });
+        }
+      } catch {}
+      api.addPanel({
+        id: "projects",
+        component: "projects",
+        title: "Projects",
+        params: { workspaceId },
+        position: { referenceGroup: "edge-left", direction: "within" },
+      });
     },
     [workspaceId],
   );
@@ -1016,6 +1114,13 @@ export const DockviewWorkspaceLayout = memo(function DockviewWorkspaceLayout({
   const onReady = useCallback(
     (event: DockviewReadyEvent) => {
       apiRef.current = event.api;
+
+      // Drop orphaned keys from the old custom-collapse system (replaced by
+      // dockview's built-in edge groups). Harmless if they're already absent.
+      try {
+        localStorage.removeItem("band:collapsed-groups");
+        localStorage.removeItem("band:group-expanded-widths");
+      } catch {}
 
       // Try to restore a saved layout
       let restored = false;
@@ -1048,6 +1153,43 @@ export const DockviewWorkspaceLayout = memo(function DockviewWorkspaceLayout({
         if (panel) {
           event.api.removePanel(panel);
         }
+      }
+
+      // Drop the legacy top edge group if it was persisted by an earlier
+      // build of this branch — there's no panel that wants to dock there
+      // and an always-present empty top strip eats vertical space.
+      try {
+        if (event.api.getEdgeGroup("top")) event.api.removeEdgeGroup("top");
+      } catch {}
+
+      // Ensure left / right / bottom edge groups exist as drop targets.
+      // Done AFTER buildDefaultLayout intentionally — addPanel without an
+      // explicit position falls back to `referenceGroup = activeGroup` plus
+      // `target = 'within'`. If we pre-created edge groups and then projects
+      // landed in edge-left (making it the active group), the next
+      // chat/changes/etc would all stack into edge-left. By adding edges
+      // last, the default layout builds in a clean grid and panels keep
+      // their intended positions.
+      // addEdgeGroup is not idempotent — id check guards re-runs after
+      // fromJSON which auto-creates edge groups it sees in saved JSON.
+      for (const direction of Object.keys(EDGE_GROUP_IDS) as EdgeDirection[]) {
+        const id = EDGE_GROUP_IDS[direction];
+        if (!event.api.groups.some((g) => g.id === id)) {
+          try {
+            event.api.addEdgeGroup(direction, { id, collapsed: true });
+          } catch {}
+        }
+      }
+
+      // Hide empty edge groups so the resting layout shows no edge strips
+      // at all. The drag-visibility effect below toggles them back on while
+      // a panel/group is being dragged so the user has somewhere to drop.
+      for (const direction of Object.keys(EDGE_GROUP_IDS) as EdgeDirection[]) {
+        const id = EDGE_GROUP_IDS[direction];
+        try {
+          const group = event.api.groups.find((g) => g.id === id);
+          event.api.setEdgeGroupVisible(direction, !!group && group.panels.length > 0);
+        } catch {}
       }
 
       // After restore, inject live callback references
@@ -1162,13 +1304,84 @@ export const DockviewWorkspaceLayout = memo(function DockviewWorkspaceLayout({
     });
   }, [isActive]);
 
+  // Show empty edge groups only while a panel/group drag is in progress.
+  // Resting state: empty edges are hidden so they don't take up space.
+  // During drag: empty edges become visible drop targets. Edges with
+  // panels are always visible regardless of drag state.
+  // Gate on isActive so only the foreground workspace responds to drags.
+  useEffect(() => {
+    if (!isActive) return;
+    const api = apiRef.current;
+    if (!api) return;
+
+    let isDragging = false;
+
+    const refresh = () => {
+      for (const direction of Object.keys(EDGE_GROUP_IDS) as EdgeDirection[]) {
+        const id = EDGE_GROUP_IDS[direction];
+        const group = api.groups.find((g) => g.id === id);
+        if (!group) continue;
+        const isEmpty = group.panels.length === 0;
+        try {
+          api.setEdgeGroupVisible(direction, isDragging || !isEmpty);
+        } catch {}
+      }
+    };
+
+    const startDrag = () => {
+      isDragging = true;
+      refresh();
+    };
+    const endDrag = () => {
+      isDragging = false;
+      refresh();
+    };
+
+    // Establish the resting state on activation.
+    refresh();
+
+    // Drag start — show all empty edges as drop targets.
+    const d1 = api.onWillDragPanel(startDrag);
+    const d2 = api.onWillDragGroup(startDrag);
+
+    // Drag end — needs multiple signals because HTML5 `dragend` does not
+    // dispatch when the drag source element is removed from the DOM during
+    // drop handling, which is exactly what dockview does for inter-group
+    // moves. Coverage:
+    //  - onDidMovePanel:   panel moved between groups (success drop into edge / center)
+    //  - onDidRemovePanel: source group lost a panel (panel pulled out of an edge)
+    //  - document `drop` in capture phase: any drop, fires before source removal
+    //  - document `dragend`: cancel cases (no panel moved, source still in DOM)
+    const d3 = api.onDidMovePanel(endDrag);
+    const d4 = api.onDidRemovePanel(endDrag);
+
+    const onDragEndNative = () => endDrag();
+    document.addEventListener("drop", onDragEndNative, true);
+    document.addEventListener("dragend", onDragEndNative, true);
+
+    return () => {
+      d1.dispose();
+      d2.dispose();
+      d3.dispose();
+      d4.dispose();
+      document.removeEventListener("drop", onDragEndNative, true);
+      document.removeEventListener("dragend", onDragEndNative, true);
+    };
+  }, [isActive]);
+
   // Hide all browser webviews when a dialog is open (z-ordering: native
   // webviews render on top of the React DOM, so they would cover dialogs).
   // With multi-tab browsers, we hide/show ALL webviews for this workspace.
+  // Also reacts to global toolbar dialogs (Tasks, Cronjobs, Tunnel, Prereq).
+  const toolbarDialogOpen = useAnyToolbarDialogOpen();
   useEffect(() => {
     if (!isDesktop) return;
     const isDialogOpen =
-      quickOpenOpen || searchFilesOpen || workspacePickerOpen || commandPaletteOpen;
+      quickOpenOpen ||
+      searchFilesOpen ||
+      workspacePickerOpen ||
+      commandPaletteOpen ||
+      toolbarDialogOpen;
 
     if (isDialogOpen) {
       desktopInvoke("browser_hide_all_for_workspace", { workspaceId }).catch(() => {});
@@ -1179,7 +1392,14 @@ export const DockviewWorkspaceLayout = memo(function DockviewWorkspaceLayout({
         desktopInvoke("browser_show_all_for_workspace", { workspaceId }).catch(() => {});
       }
     }
-  }, [quickOpenOpen, searchFilesOpen, workspacePickerOpen, commandPaletteOpen, workspaceId]);
+  }, [
+    quickOpenOpen,
+    searchFilesOpen,
+    workspacePickerOpen,
+    commandPaletteOpen,
+    toolbarDialogOpen,
+    workspaceId,
+  ]);
 
   return (
     <>

--- a/apps/web/src/components/DockviewWorkspaceLayout.tsx
+++ b/apps/web/src/components/DockviewWorkspaceLayout.tsx
@@ -903,14 +903,15 @@ export const DockviewWorkspaceLayout = memo(function DockviewWorkspaceLayout({
         }
         if (active.api.isMaximized()) active.api.exitMaximized();
         else active.api.maximize();
-      } else if (key === "-") {
-        e.preventDefault();
-        window.dispatchEvent(new CustomEvent("band:editor-go-back"));
-      } else if (key === "_") {
-        // Ctrl+Shift+- produces key="_" (underscore) in the browser
-        e.preventDefault();
-        window.dispatchEvent(new CustomEvent("band:editor-go-forward"));
       }
+      // Note: editor history navigation (band:editor-go-back / -forward) is
+      // not bound to a keyboard shortcut. The previous binding was Cmd+- /
+      // Cmd+Shift+-, but that key is permanently claimed by the desktop
+      // View menu's Zoom Out accelerator (apps/desktop/src/main/menu.ts),
+      // so the binding never fired. Workspace-level back/forward (Cmd+[ /
+      // Cmd+]) is wired separately in useNavigationHistory; in-Files-tab
+      // history can still be triggered from the back/forward arrow buttons
+      // in the FileViewer toolbar or via the Command Palette.
     };
     window.addEventListener("keydown", handler, true);
     return () => window.removeEventListener("keydown", handler, true);

--- a/apps/web/src/components/DockviewWorkspaceLayout.tsx
+++ b/apps/web/src/components/DockviewWorkspaceLayout.tsx
@@ -832,6 +832,9 @@ export const DockviewWorkspaceLayout = memo(function DockviewWorkspaceLayout({
         e.stopPropagation();
         if (!hiddenPanelsRef.current.includes("terminal")) {
           apiRef.current?.getPanel("terminal")?.api.setActive();
+          queueMicrotask(() => {
+            window.dispatchEvent(new CustomEvent("band:focus-terminal"));
+          });
         }
         return;
       }
@@ -839,14 +842,10 @@ export const DockviewWorkspaceLayout = memo(function DockviewWorkspaceLayout({
       // Ctrl+0 (not Cmd+0) → focus Projects in the left edge group.
       // Matches VS Code's "Focus Side Bar" binding. Like ⌃`, handled in
       // an early branch so it hijacks even when xterm has focus.
-      // Three-step flow:
-      //   1. Expand the left edge group if collapsed (so there's
-      //      something visible to focus).
-      //   2. Activate the projects panel (in case the left edge
-      //      hosts other tabs in the future).
-      //   3. Dispatch band:focus-projects on the next microtask;
-      //      DashboardShell listens and moves keyboard focus into
-      //      its [tabindex=-1] project-list root.
+      // Three-step flow: expand left edge if collapsed, activate the
+      // projects panel, dispatch band:focus-projects on the next
+      // microtask so DashboardShell's listener focuses [tabindex=-1]
+      // after React commits the setActive change.
       if (e.ctrlKey && !e.metaKey && e.key === "0") {
         e.preventDefault();
         e.stopPropagation();
@@ -910,19 +909,39 @@ export const DockviewWorkspaceLayout = memo(function DockviewWorkspaceLayout({
         // Both Ctrl AND Cmd held — distinguished from any plain ⌘I /
         // ⌃I combo (neither of which we currently bind).
         e.preventDefault();
-        if (!hiddenPanelsRef.current.includes("chat")) api.getPanel("chat")?.api.setActive();
+        if (!hiddenPanelsRef.current.includes("chat")) {
+          api.getPanel("chat")?.api.setActive();
+          queueMicrotask(() => {
+            window.dispatchEvent(new CustomEvent("band:focus-chat"));
+          });
+        }
       } else if (key === "g" && e.shiftKey && api) {
         // ⇧⌘G → Changes (matches VS Code "Show Source Control")
         e.preventDefault();
-        if (!hiddenPanelsRef.current.includes("changes")) api.getPanel("changes")?.api.setActive();
+        if (!hiddenPanelsRef.current.includes("changes")) {
+          api.getPanel("changes")?.api.setActive();
+          queueMicrotask(() => {
+            window.dispatchEvent(new CustomEvent("band:focus-changes"));
+          });
+        }
       } else if (key === "e" && e.shiftKey && api) {
         // ⇧⌘E → Files (matches VS Code "Show Explorer")
         e.preventDefault();
-        if (!hiddenPanelsRef.current.includes("files")) api.getPanel("files")?.api.setActive();
+        if (!hiddenPanelsRef.current.includes("files")) {
+          api.getPanel("files")?.api.setActive();
+          queueMicrotask(() => {
+            window.dispatchEvent(new CustomEvent("band:focus-files"));
+          });
+        }
       } else if (key === "b" && e.shiftKey && api) {
         // ⇧⌘B → Browser
         e.preventDefault();
-        if (!hiddenPanelsRef.current.includes("browser")) api.getPanel("browser")?.api.setActive();
+        if (!hiddenPanelsRef.current.includes("browser")) {
+          api.getPanel("browser")?.api.setActive();
+          queueMicrotask(() => {
+            window.dispatchEvent(new CustomEvent("band:focus-browser"));
+          });
+        }
       } else if (key === "b" && !e.shiftKey && api) {
         // ⌘B → toggle Projects sidebar (matches VS Code "Toggle Primary Side Bar")
         e.preventDefault();

--- a/apps/web/src/components/DockviewWorkspaceLayout.tsx
+++ b/apps/web/src/components/DockviewWorkspaceLayout.tsx
@@ -419,7 +419,10 @@ const MainGroupRightActions = memo(function MainGroupRightActions(
           </button>
         </TooltipTrigger>
         <TooltipContent side="bottom" className="text-xs">
-          {label}
+          {label}{" "}
+          <kbd className="ml-1.5 rounded border border-popover-foreground/25 bg-popover-foreground/10 px-1 py-0.5 font-mono text-[14px]">
+            ⇧⌘M
+          </kbd>
         </TooltipContent>
       </Tooltip>
     </div>
@@ -886,6 +889,20 @@ export const DockviewWorkspaceLayout = memo(function DockviewWorkspaceLayout({
           if (left.api.isCollapsed()) left.api.expand();
           else left.api.collapse();
         }
+      } else if (key === "m" && e.shiftKey && api) {
+        // Toggle maximize for the active group. Edge groups (Projects /
+        // future right+bottom edges) are skipped — maximize only makes
+        // sense for center grid groups. If a *different* group is already
+        // maximized, exit that first so the user can never get stuck.
+        e.preventDefault();
+        const active = api.activeGroup;
+        if (!active) return;
+        if (active.api.location.type !== "grid") {
+          if (api.hasMaximizedGroup()) api.exitMaximizedGroup();
+          return;
+        }
+        if (active.api.isMaximized()) active.api.exitMaximized();
+        else active.api.maximize();
       } else if (key === "-") {
         e.preventDefault();
         window.dispatchEvent(new CustomEvent("band:editor-go-back"));

--- a/apps/web/src/components/DockviewWorkspaceLayout.tsx
+++ b/apps/web/src/components/DockviewWorkspaceLayout.tsx
@@ -807,14 +807,11 @@ export const DockviewWorkspaceLayout = memo(function DockviewWorkspaceLayout({
       // handled at the app level when the terminal has focus.
       const terminalFocused = document.activeElement?.closest(".xterm") != null;
 
-      // Shift+Tab → toggle mode (Edit/Plan) — skip when terminal focused
-      if (e.key === "Tab" && e.shiftKey && !e.ctrlKey && !e.metaKey) {
-        if (terminalFocused) return;
-        e.preventDefault();
-        e.stopPropagation();
-        window.dispatchEvent(new CustomEvent("band:toggle-mode"));
-        return;
-      }
+      // Note: Shift+Tab toggles Edit/Plan mode only when the chat input
+      // (PromptInputTextarea) has focus — wired inside that component, not
+      // globally. A global handler would hijack the standard "focus
+      // previous element" Tab behaviour everywhere else (form fields,
+      // dialogs, the command palette), which broke accessibility flows.
 
       // Ctrl+R (not Cmd+R) → workspace picker — skip when terminal focused
       if (e.ctrlKey && !e.metaKey && e.key.toLowerCase() === "r" && !e.shiftKey) {

--- a/apps/web/src/components/TerminalPanel.tsx
+++ b/apps/web/src/components/TerminalPanel.tsx
@@ -266,6 +266,19 @@ export function TerminalPanel({
     }
   }, [visible]);
 
+  // Listen for the workspace-level ⌃` "focus Terminal" event. Many
+  // TerminalPanel instances may exist (one per terminal session × one
+  // per workspace) — the visibility gate ensures only the active
+  // session in the active workspace actually grabs focus.
+  useEffect(() => {
+    const handler = () => {
+      if (!visible) return;
+      terminalRef.current?.focus();
+    };
+    window.addEventListener("band:focus-terminal", handler);
+    return () => window.removeEventListener("band:focus-terminal", handler);
+  }, [visible]);
+
   return (
     <div className="relative h-full w-full">
       <div ref={containerRef} className="absolute inset-2 overflow-hidden" />

--- a/apps/web/src/components/ToolbarButtons.tsx
+++ b/apps/web/src/components/ToolbarButtons.tsx
@@ -13,9 +13,19 @@ interface ToolbarOverflowContextValue {
   openTunnel: () => void;
   /** Tunnel state hint for the menu item (so we can show running/error coloring). */
   tunnelStatus: "idle" | "running" | "error";
+  /** True when any toolbar dialog (Tasks, Cronjobs, Tunnel, Prereq) is open.
+   *  DockviewWorkspaceLayout merges this with its own dialog state to hide
+   *  Electron BrowserView webviews that would otherwise render on top. */
+  anyDialogOpen: boolean;
 }
 
 const ToolbarOverflowContext = createContext<ToolbarOverflowContextValue | null>(null);
+
+/** Read whether any toolbar overflow dialog is open. Returns false when no
+ *  provider is mounted (mobile/web fallback). */
+export function useAnyToolbarDialogOpen(): boolean {
+  return useContext(ToolbarOverflowContext)?.anyDialogOpen ?? false;
+}
 
 /**
  * Owns the dialog state for the toolbar overflow menu (Tasks, Cronjobs, Mobile access).
@@ -52,9 +62,12 @@ export function ToolbarOverflowProvider({ children }: { children: ReactNode }) {
       ? "running"
       : "idle";
 
+  const anyDialogOpen =
+    showTasksDialog || showCronjobsDialog || showTunnelDialog || showPrereq;
+
   const value = useMemo(
-    () => ({ openTasks, openCronjobs, openTunnel, tunnelStatus }),
-    [openTasks, openCronjobs, openTunnel, tunnelStatus],
+    () => ({ openTasks, openCronjobs, openTunnel, tunnelStatus, anyDialogOpen }),
+    [openTasks, openCronjobs, openTunnel, tunnelStatus, anyDialogOpen],
   );
 
   return (

--- a/apps/web/src/components/ToolbarButtons.tsx
+++ b/apps/web/src/components/ToolbarButtons.tsx
@@ -62,8 +62,7 @@ export function ToolbarOverflowProvider({ children }: { children: ReactNode }) {
       ? "running"
       : "idle";
 
-  const anyDialogOpen =
-    showTasksDialog || showCronjobsDialog || showTunnelDialog || showPrereq;
+  const anyDialogOpen = showTasksDialog || showCronjobsDialog || showTunnelDialog || showPrereq;
 
   const value = useMemo(
     () => ({ openTasks, openCronjobs, openTunnel, tunnelStatus, anyDialogOpen }),

--- a/apps/web/src/components/ai-elements/prompt-input.tsx
+++ b/apps/web/src/components/ai-elements/prompt-input.tsx
@@ -489,6 +489,22 @@ export const PromptInputTextarea = ({
     el.style.height = `${Math.min(el.scrollHeight, MAX_HEIGHT)}px`;
   }, [inputValue, textareaRef]);
 
+  // Listen for the workspace-level ⌃⌘I "focus Chat" event. Multiple
+  // PromptInputTextarea instances may be mounted (one per chat session
+  // across one or more workspaces) — only the visible one's
+  // offsetParent is non-null, so only that instance's focus() call has
+  // any visible effect. The others are no-ops.
+  useEffect(() => {
+    const handler = () => {
+      const el = textareaRef.current;
+      if (el && el.offsetParent !== null) {
+        el.focus({ preventScroll: true });
+      }
+    };
+    window.addEventListener("band:focus-chat", handler);
+    return () => window.removeEventListener("band:focus-chat", handler);
+  }, [textareaRef]);
+
   return (
     <div className="relative">
       <textarea

--- a/apps/web/src/components/ai-elements/prompt-input.tsx
+++ b/apps/web/src/components/ai-elements/prompt-input.tsx
@@ -427,6 +427,10 @@ export type PromptInputTextareaProps = HTMLAttributes<HTMLTextAreaElement> & {
   onEscape?: () => void;
   /** Called when ArrowUp is pressed on an empty input. Return the previous message text to load it, or undefined to do nothing. */
   onPreviousMessage?: () => string | undefined;
+  /** Called when Shift+Tab is pressed inside the textarea. When provided,
+   *  the default focus-previous behaviour is suppressed. Used by the host
+   *  to toggle Edit/Plan mode. */
+  onShiftTab?: () => void;
 };
 
 export const PromptInputTextarea = ({
@@ -434,6 +438,7 @@ export const PromptInputTextarea = ({
   placeholder = "Type a message...",
   onEscape,
   onPreviousMessage,
+  onShiftTab,
   ...props
 }: PromptInputTextareaProps) => {
   const [isComposing, setIsComposing] = useState(false);
@@ -451,6 +456,11 @@ export const PromptInputTextarea = ({
         if (isTouchDevice) return;
         e.preventDefault();
         e.currentTarget.form?.requestSubmit();
+      } else if (e.key === "Tab" && e.shiftKey && onShiftTab) {
+        // Suppress default focus-previous so the cursor stays in the
+        // textarea — host uses this to toggle a contextual mode picker.
+        e.preventDefault();
+        onShiftTab();
       } else if (e.key === "Escape") {
         onEscape?.();
       } else if (e.key === "ArrowUp" && onPreviousMessage) {
@@ -464,7 +474,7 @@ export const PromptInputTextarea = ({
         }
       }
     },
-    [isComposing, onEscape, onPreviousMessage, setTextareaValue],
+    [isComposing, onEscape, onPreviousMessage, onShiftTab, setTextareaValue],
   );
 
   // JS fallback for auto-resize when CSS field-sizing-content is not supported

--- a/apps/web/src/hooks/useIsFullscreen.ts
+++ b/apps/web/src/hooks/useIsFullscreen.ts
@@ -1,0 +1,37 @@
+import { useEffect, useState } from "react";
+import { invoke as desktopInvoke, listen as desktopListen } from "../lib/desktop-ipc";
+import { isDesktop } from "../lib/is-desktop";
+
+/**
+ * Tracks the Electron BrowserWindow's macOS native fullscreen state.
+ * Returns false outside the desktop shell. The main process forwards
+ * enter-/leave-full-screen events; this hook also runs an initial query.
+ */
+export function useIsFullscreen(): boolean {
+  const [isFullscreen, setIsFullscreen] = useState(false);
+
+  useEffect(() => {
+    if (!isDesktop) return;
+    let unlisten: (() => void) | null = null;
+    let cancelled = false;
+    desktopInvoke<boolean>("get_window_fullscreen")
+      .then((fs) => {
+        if (!cancelled) setIsFullscreen(fs);
+      })
+      .catch(() => {});
+    desktopListen<boolean>("window-fullscreen-changed", ({ payload }) => {
+      setIsFullscreen(payload);
+    })
+      .then((off) => {
+        if (cancelled) off();
+        else unlisten = off;
+      })
+      .catch(() => {});
+    return () => {
+      cancelled = true;
+      unlisten?.();
+    };
+  }, []);
+
+  return isFullscreen;
+}

--- a/apps/web/src/hooks/useZoom.ts
+++ b/apps/web/src/hooks/useZoom.ts
@@ -1,18 +1,22 @@
 import { useEffect } from "react";
 import { isDesktop } from "../lib/is-desktop";
-import { zoomIn, zoomOut, zoomReset } from "../lib/zoom";
+import { zoomIn, zoomOut } from "../lib/zoom";
 
 /**
  * Browser-mode keyboard shortcut handler for zoom.
  *
- * Registers Cmd+= (zoom in), Cmd+- (zoom out), and Cmd+0 (reset).
+ * Registers Cmd+= (zoom in) and Cmd+- (zoom out). Cmd+0 is intentionally
+ * NOT bound — that combo is owned by the dashboard's "All projects" label
+ * filter (see DashboardShell). Reset is still reachable via the desktop
+ * View menu's "Actual Size" item.
+ *
  * Only active outside the desktop shell — when running inside Electron the
  * native View menu accelerators intercept these keys before they reach the
  * webview (see `apps/desktop/src/main/menu.ts`).
  */
 export function useZoom(): void {
   useEffect(() => {
-    // In a desktop shell, the View menu accelerators handle Cmd+=/Cmd+-/Cmd+0
+    // In a desktop shell, the View menu accelerators handle Cmd+= / Cmd+-
     // before they reach the webview, so skip the JS listener.
     if (isDesktop) return;
 
@@ -33,14 +37,6 @@ export function useZoom(): void {
         e.preventDefault();
         e.stopPropagation();
         zoomOut();
-        return;
-      }
-
-      // Cmd+0 → reset zoom
-      if (e.key === "0") {
-        e.preventDefault();
-        e.stopPropagation();
-        zoomReset();
       }
     };
 

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -1,6 +1,5 @@
 import {
   DashboardProvider,
-  DashboardShell,
   useDashboardStore,
   useSettingsQuery,
   useUpdateSettings,
@@ -10,7 +9,7 @@ import {
   NativeShellCapabilities,
 } from "@band-app/dashboard-core/adapters/desktop";
 import { WebCapabilities, WebDashboardAdapter } from "@band-app/dashboard-core/adapters/web";
-import { TooltipProvider } from "@band-app/ui";
+import { DropdownMenuItem, TooltipProvider } from "@band-app/ui";
 import {
   createRootRoute,
   HeadContent,
@@ -25,10 +24,10 @@ import {
   GitCompare,
   Globe,
   MessageSquare,
+  Settings as SettingsIcon,
   Terminal as TerminalIcon,
 } from "lucide-react";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { Group, Panel, Separator, usePanelRef } from "react-resizable-panels";
+import { useCallback, useEffect, useMemo } from "react";
 import { DesktopTitleBar, type PanelItem } from "../components/DesktopTitleBar";
 import { DockviewInstanceManager } from "../components/DockviewInstanceManager";
 import { ToolbarOverflowMenuItems, ToolbarOverflowProvider } from "../components/ToolbarButtons";
@@ -37,12 +36,6 @@ import { useNavigationHistory } from "../hooks/useNavigationHistory";
 import { useZoom } from "../hooks/useZoom";
 import { isDesktop } from "../lib/is-desktop";
 import { parseWorkspaceFromPath } from "../lib/parse-workspace";
-import {
-  loadSidebarWidth,
-  SIDEBAR_MAX_SIZE,
-  SIDEBAR_MIN_SIZE,
-  saveSidebarWidth,
-} from "../lib/sidebar-width";
 import { applyZoomLevel, loadZoomLevel, zoomIn, zoomOut, zoomReset } from "../lib/zoom";
 import "../styles/globals.css";
 
@@ -219,37 +212,6 @@ function AppShell() {
   // in the desktop shell the View menu accelerators handle these keys)
   useZoom();
 
-  // Resizable sidebar: load persisted width and skip the first layout callback
-  // (react-resizable-panels fires it on mount with a computed layout that may
-  // differ from the default before the container has its final CSS dimensions).
-  const savedWidth = loadSidebarWidth();
-  const defaultLayout = savedWidth ? { sidebar: savedWidth, main: 100 - savedWidth } : undefined;
-  const skipFirstLayoutCallback = useRef(true);
-  const handleSidebarResize = useCallback((layout: Record<string, number>) => {
-    if (skipFirstLayoutCallback.current) {
-      skipFirstLayoutCallback.current = false;
-      return;
-    }
-    if (layout.sidebar != null) {
-      saveSidebarWidth(layout.sidebar);
-    }
-  }, []);
-
-  // Collapsible sidebar (desktop title bar toggle)
-  const sidebarPanelRef = usePanelRef();
-  const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
-  const toggleSidebar = useCallback(() => {
-    const panel = sidebarPanelRef.current;
-    if (!panel) return;
-    if (panel.isCollapsed()) {
-      panel.expand();
-    } else {
-      panel.collapse();
-    }
-  }, [sidebarPanelRef]);
-  const handleSidebarCollapse = useCallback(() => setSidebarCollapsed(true), []);
-  const handleSidebarExpand = useCallback(() => setSidebarCollapsed(false), []);
-
   // Derive active workspace from pathname for title bar display
   const activeWorkspaceId = parseWorkspaceFromPath(pathname);
 
@@ -307,8 +269,21 @@ function AppShell() {
     <ToolbarOverflowProvider>
       <div className="flex flex-col h-full w-full overflow-hidden bg-background text-foreground">
         <DesktopTitleBar
-          onToggleSidebar={toggleSidebar}
-          sidebarCollapsed={sidebarCollapsed}
+          menuItems={
+            <>
+              <ToolbarOverflowMenuItems />
+              <DropdownMenuItem
+                onClick={() => {
+                  const fn = (window as unknown as { __bandOpenSettings?: () => void })
+                    .__bandOpenSettings;
+                  fn?.();
+                }}
+              >
+                <SettingsIcon className="size-4" />
+                Settings
+              </DropdownMenuItem>
+            </>
+          }
           workspaceName={activeWorkspaceId ?? undefined}
           workspacePath={activeWorkspaceId ? workspacePath : undefined}
           onCopyPath={activeWorkspaceId ? handleCopyPath : undefined}
@@ -321,39 +296,10 @@ function AppShell() {
           canGoForward={navigationHistory.canGoForward}
         />
         <div className="flex-1 min-h-0 overflow-hidden">
-          <Group
-            orientation="horizontal"
-            defaultLayout={defaultLayout}
-            onLayoutChanged={handleSidebarResize}
-          >
-            <Panel
-              id="sidebar"
-              defaultSize={SIDEBAR_MIN_SIZE}
-              minSize={SIDEBAR_MIN_SIZE}
-              maxSize={SIDEBAR_MAX_SIZE}
-              collapsible
-              collapsedSize="0%"
-              panelRef={sidebarPanelRef}
-              onResize={(size) => {
-                if (size.asPercentage === 0) handleSidebarCollapse();
-                else handleSidebarExpand();
-              }}
-            >
-              <div className="h-full border-r border-border overflow-hidden">
-                <DashboardShell
-                  toolbarMenuItems={<ToolbarOverflowMenuItems />}
-                  hideTitleBar={isDesktop}
-                />
-              </div>
-            </Panel>
-            <Separator className="w-[3px] bg-transparent hover:bg-accent-foreground/20 active:bg-accent-foreground/30 transition-colors cursor-col-resize" />
-            <Panel id="main" minSize="20%">
-              <div className="h-full min-w-0 overflow-hidden relative">
-                <Outlet />
-                <DockviewInstanceManager />
-              </div>
-            </Panel>
-          </Group>
+          <div className="h-full min-w-0 overflow-hidden relative">
+            <Outlet />
+            <DockviewInstanceManager />
+          </div>
         </div>
       </div>
     </ToolbarOverflowProvider>

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -224,10 +224,10 @@ function AppShell() {
   const panelItems: PanelItem[] = useMemo(
     () => [
       { id: "chat", label: "Chat", icon: MessageSquare },
-      { id: "changes", label: "Changes", icon: GitCompare, shortcut: "⌘E" },
-      { id: "files", label: "Files", icon: FolderOpen, shortcut: "⌘G" },
-      { id: "terminal", label: "Terminal", icon: TerminalIcon, shortcut: "⌘J" },
-      ...(isDesktop ? [{ id: "browser", label: "Browser", icon: Globe, shortcut: "⌘B" }] : []),
+      { id: "changes", label: "Changes", icon: GitCompare, shortcut: "⇧⌘G" },
+      { id: "files", label: "Files", icon: FolderOpen, shortcut: "⇧⌘E" },
+      { id: "terminal", label: "Terminal", icon: TerminalIcon, shortcut: "⌃`" },
+      ...(isDesktop ? [{ id: "browser", label: "Browser", icon: Globe, shortcut: "⇧⌘B" }] : []),
     ],
     [],
   );

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -223,7 +223,7 @@ function AppShell() {
   // Panel items for the title bar panel switcher dropdown
   const panelItems: PanelItem[] = useMemo(
     () => [
-      { id: "chat", label: "Chat", icon: MessageSquare },
+      { id: "chat", label: "Chat", icon: MessageSquare, shortcut: "⌃⌘I" },
       { id: "changes", label: "Changes", icon: GitCompare, shortcut: "⇧⌘G" },
       { id: "files", label: "Files", icon: FolderOpen, shortcut: "⇧⌘E" },
       { id: "terminal", label: "Terminal", icon: TerminalIcon, shortcut: "⌃`" },

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -1,6 +1,6 @@
 import { createFileRoute } from "@tanstack/react-router";
-import { MessageSquare } from "lucide-react";
 import { DashboardView } from "../components/DashboardView";
+import { DockviewWorkspaceLayout } from "../components/DockviewWorkspaceLayout";
 import { useIsDesktop } from "../hooks/useIsDesktop";
 import { isDesktop } from "../lib/is-desktop";
 
@@ -13,16 +13,17 @@ function DashboardPage() {
   // Desktop split layout is active inside the desktop shell or in a wide browser window.
   const useDesktopLayout = isWideScreen || isDesktop;
 
-  // Desktop: sidebar is rendered by root layout, just show empty state
+  // Desktop: render the SAME dockview shell as the workspace route, just with
+  // no active workspace. The Projects panel (workspace-agnostic — it's the
+  // global project list) renders in the left edge group. The center panels
+  // (Chat / Changes / Files / Terminal / Browser) all short-circuit to null
+  // when params.workspaceId is empty, so the center groups exist
+  // structurally (matching the workspace layout) but render no content
+  // until the user picks a project. Workspace-id "" gates saveLayout via
+  // isActiveRef.current = useWsActive("") = false, so layout edits made
+  // on this route don't pollute the shared band:dockview-layout-v6 key.
   if (useDesktopLayout) {
-    return (
-      <div className="flex h-full items-center justify-center">
-        <div className="flex flex-col items-center gap-3 text-center px-8">
-          <MessageSquare className="size-8 text-muted-foreground/30" />
-          <p className="text-sm text-muted-foreground">Select a workspace to get started</p>
-        </div>
-      </div>
-    );
+    return <DockviewWorkspaceLayout workspaceId="" />;
   }
 
   // Mobile / narrow browser: full-screen dashboard shell

--- a/apps/web/src/styles/dockview-theme.css
+++ b/apps/web/src/styles/dockview-theme.css
@@ -34,8 +34,11 @@
   --dv-drag-over-background-color: oklch(0.5 0.1 250 / 0.25);
   --dv-drag-over-border-color: var(--ring);
 
-  /* Tab sizing */
-  --dv-tabs-and-actions-container-height: 40px;
+  /* Tab sizing — controls the main-axis dimension of every
+   *  .dv-tabs-and-actions-container in the band-themed dockview:
+   *  height for top/bottom-header (horizontal) strips, width for
+   *  left/right-header (vertical edge) strips. */
+  --dv-tabs-and-actions-container-height: 36px;
   --dv-tabs-and-actions-container-font-size: 13px;
 
   /* Sash (resize handle between panels) */
@@ -70,9 +73,52 @@
   box-shadow: none;
 }
 
-/* Border below the tabs container */
+/* Allow the panel content container to shrink below its intrinsic content
+ * width. Dockview-core sets min-height:0 on .dv-content-container (correct
+ * for top-header groups whose main axis is vertical) but not min-width:0.
+ * In edge groups with header on the left/right (flex-direction: row), the
+ * main axis is horizontal — without min-width:0 a flex item defaults to
+ * min-width:auto and refuses to shrink below intrinsic child width, which
+ * lets long project names / file paths push the panel wider than its
+ * allocated edge slot and clip past the right boundary. */
+.dockview-theme-band .dv-content-container {
+  min-width: 0;
+}
+
+/* Border between the tabs container and the panel content. The default
+ * rule below targets the most common case (header on top → border on the
+ * bottom of the strip). The three overrides below cover the other header
+ * positions used by edge groups (left edge → vertical strip on the left;
+ * right edge → vertical strip on the right; bottom edge → horizontal
+ * strip at the bottom). Without these the strip blurs into the content. */
 .dockview-theme-band .dv-tabs-and-actions-container {
   border-bottom: 1px solid var(--border);
+}
+.dockview-theme-band .dv-groupview.dv-groupview-header-bottom > .dv-tabs-and-actions-container {
+  border-bottom: none;
+  border-top: 1px solid var(--border);
+}
+.dockview-theme-band .dv-groupview.dv-groupview-header-left > .dv-tabs-and-actions-container {
+  border-bottom: none;
+  border-right: 1px solid var(--border);
+}
+.dockview-theme-band .dv-groupview.dv-groupview-header-right > .dv-tabs-and-actions-container {
+  border-bottom: none;
+  border-left: 1px solid var(--border);
+}
+
+/* Suppress the inter-view separator when the preceding view is hidden
+ * (e.g. an empty edge group with setEdgeGroupVisible(false)).
+ * Without this, the ::before pseudo-element on a non-first .dv-view
+ * still renders at left:0 of itself, and when the previous view has
+ * size 0 it lands at the very edge of the dockview component, producing
+ * a phantom 1px line that doubles up with neighbouring borders.
+ * The .visible class is toggled by splitview's setVisible() in
+ * dockview-core/.../splitview/viewItem.js. */
+.dv-split-view-container.dv-separator-border > .dv-view-container
+  > .dv-view:not(.visible)
+  + .dv-view::before {
+  content: none;
 }
 
 /* More horizontal padding in each tab */

--- a/apps/website/src/pages/docs/flexible-layout.astro
+++ b/apps/website/src/pages/docs/flexible-layout.astro
@@ -76,8 +76,10 @@ import DocsLayout from "../../layouts/DocsLayout.astro";
 
   <ul>
     <li><kbd>⌘B</kbd> &mdash; toggle <strong>Projects sidebar</strong>.</li>
-    <li><kbd>⇧⌘E</kbd> &mdash; show <strong>Files</strong>.</li>
+    <li><kbd>⌃0</kbd> &mdash; focus <strong>Projects</strong> (matches VS Code <em>Focus Side Bar</em>).</li>
+    <li><kbd>⌃⌘I</kbd> &mdash; show <strong>Chat</strong>.</li>
     <li><kbd>⇧⌘G</kbd> &mdash; show <strong>Changes</strong>.</li>
+    <li><kbd>⇧⌘E</kbd> &mdash; show <strong>Files</strong>.</li>
     <li><kbd>⌃`</kbd> &mdash; show <strong>Terminal</strong>.</li>
     <li><kbd>⇧⌘B</kbd> &mdash; show <strong>Browser</strong>.</li>
   </ul>

--- a/apps/website/src/pages/docs/flexible-layout.astro
+++ b/apps/website/src/pages/docs/flexible-layout.astro
@@ -75,10 +75,11 @@ import DocsLayout from "../../layouts/DocsLayout.astro";
   <p>The default keyboard shortcuts are:</p>
 
   <ul>
-    <li><kbd>⌘E</kbd> &mdash; toggle <strong>Changes</strong>.</li>
-    <li><kbd>⌘G</kbd> &mdash; toggle <strong>Files</strong>.</li>
-    <li><kbd>⌘J</kbd> &mdash; toggle <strong>Terminal</strong>.</li>
-    <li><kbd>⌘B</kbd> &mdash; toggle <strong>Browser</strong>.</li>
+    <li><kbd>⌘B</kbd> &mdash; toggle <strong>Projects sidebar</strong>.</li>
+    <li><kbd>⇧⌘E</kbd> &mdash; show <strong>Files</strong>.</li>
+    <li><kbd>⇧⌘G</kbd> &mdash; show <strong>Changes</strong>.</li>
+    <li><kbd>⌃`</kbd> &mdash; show <strong>Terminal</strong>.</li>
+    <li><kbd>⇧⌘B</kbd> &mdash; show <strong>Browser</strong>.</li>
   </ul>
 
   <p>

--- a/packages/dashboard-core/src/components/ChangesFileTree.tsx
+++ b/packages/dashboard-core/src/components/ChangesFileTree.tsx
@@ -53,6 +53,10 @@ function ChangesTreeNode({
       <button
         ref={isActive ? btnRef : undefined}
         type="button"
+        // data-band-active marks this button so the workspace-level
+        // ⇧⌘G "focus Changes" handler can target it from outside the
+        // file tree.
+        data-band-active={isActive ? "true" : undefined}
         onClick={handleClick}
         className={`flex h-[26px] w-full items-center gap-1 pr-3 text-left text-xs ${
           isActive ? "bg-accent text-accent-foreground" : "hover:bg-accent/50"

--- a/packages/dashboard-core/src/components/CommandPaletteDialog.tsx
+++ b/packages/dashboard-core/src/components/CommandPaletteDialog.tsx
@@ -46,7 +46,9 @@ export function CommandPaletteDialog({ open, onOpenChange, commands }: CommandPa
               {commands.map((cmd) => (
                 <CommandItem key={cmd.id} value={cmd.label} onSelect={() => handleSelect(cmd)}>
                   <span className="text-sm">{cmd.label}</span>
-                  <CommandShortcut>{formatShortcut(cmd.shortcut)}</CommandShortcut>
+                  {cmd.shortcut && (
+                    <CommandShortcut>{formatShortcut(cmd.shortcut)}</CommandShortcut>
+                  )}
                 </CommandItem>
               ))}
             </CommandGroup>

--- a/packages/dashboard-core/src/components/DashboardShell.tsx
+++ b/packages/dashboard-core/src/components/DashboardShell.tsx
@@ -28,7 +28,7 @@ import {
   Tag,
   X,
 } from "lucide-react";
-import { type ReactNode, useCallback, useEffect, useMemo, useState } from "react";
+import { type ReactNode, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useCliSetup } from "../hooks/use-cli-setup";
 import { useHooksSetup } from "../hooks/use-hooks-setup";
 import { useProjects } from "../hooks/use-projects";
@@ -124,6 +124,23 @@ export function DashboardShell({ toolbarMenuItems, hideTitleBar, hideMenu }: Das
     };
   }, []);
 
+  // Listen for ⌃0 (Focus Side Bar) — the keyboard handler in the workspace
+  // layout expands the left edge group and dispatches this event; we move
+  // keyboard focus into the project list so arrow keys can navigate it.
+  // Multi-workspace note: every DashboardShell instance receives the
+  // event, but each focuses only its own subtree via rootRef. Inactive
+  // workspaces are display:none-hidden upstream, so focus() on their
+  // internal element is a no-op — only the visible instance wins.
+  const rootRef = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    const handler = () => {
+      const list = rootRef.current?.querySelector<HTMLElement>('[tabindex="-1"]');
+      list?.focus({ preventScroll: true });
+    };
+    window.addEventListener("band:focus-projects", handler);
+    return () => window.removeEventListener("band:focus-projects", handler);
+  }, []);
+
   // Keyboard shortcuts: Cmd+0 → all projects, Cmd+1..9 → nth label.
   // Skips when focus is in an editable element so it doesn't hijack typing.
   useEffect(() => {
@@ -157,6 +174,7 @@ export function DashboardShell({ toolbarMenuItems, hideTitleBar, hideMenu }: Das
 
   return (
     <div
+      ref={rootRef}
       className={cn(
         "w-full overflow-hidden flex flex-col bg-background text-foreground p-0",
         hideTitleBar ? "h-full" : "h-dvh",

--- a/packages/dashboard-core/src/components/DashboardShell.tsx
+++ b/packages/dashboard-core/src/components/DashboardShell.tsx
@@ -111,12 +111,12 @@ export function DashboardShell({ toolbarMenuItems, hideTitleBar, hideMenu }: Das
     [labelFilter, labels],
   );
 
-  // The desktop shell's native menu (Cmd+,) calls `window.__bandOpenSettings()`
-  // via webview.eval / executeJavaScript — same pattern as the zoom menu.
-  // Register the global so the menu can pop the in-app dialog instead of
-  // spawning a separate window.
+  // The desktop shell's native menu (Cmd+,) and the in-app DesktopTitleBar
+  // hamburger both call `window.__bandOpenSettings()` to pop this dialog.
+  // The native-menu path goes via webview.eval / executeJavaScript — same
+  // pattern as the zoom menu. Register the global unconditionally so the
+  // hamburger works in the browser too (E2E + web shell).
   useEffect(() => {
-    if (!isDesktop) return;
     const globalKey = "__bandOpenSettings";
     (window as unknown as Record<string, unknown>)[globalKey] = () => setShowSettingsDialog(true);
     return () => {

--- a/packages/dashboard-core/src/components/DashboardShell.tsx
+++ b/packages/dashboard-core/src/components/DashboardShell.tsx
@@ -1,5 +1,6 @@
 import {
   Button,
+  cn,
   Dialog,
   DialogContent,
   DialogDescription,
@@ -16,7 +17,17 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@band-app/ui";
-import { Check, FolderPlus, Menu, Pencil, Plus, Settings, Tag, X } from "lucide-react";
+import {
+  Check,
+  FolderPlus,
+  Menu,
+  MoreVertical,
+  Pencil,
+  Plus,
+  Settings,
+  Tag,
+  X,
+} from "lucide-react";
 import { type ReactNode, useCallback, useEffect, useMemo, useState } from "react";
 import { useCliSetup } from "../hooks/use-cli-setup";
 import { useHooksSetup } from "../hooks/use-hooks-setup";
@@ -38,6 +49,11 @@ interface DashboardShellProps {
   toolbarMenuItems?: ReactNode;
   /** Hide the desktop title bar (e.g. when the parent renders a full-width one). */
   hideTitleBar?: boolean;
+  /** Suppress the in-shell hamburger overflow menu. Used when this shell is
+   *  embedded under a global title bar that already exposes the same items
+   *  (Tasks / Cronjobs / Settings / …). Edit-list moves to a 3-dot menu next
+   *  to the Add-project button. */
+  hideMenu?: boolean;
 }
 
 // Desktop-shell detection. The Electron preload
@@ -61,7 +77,7 @@ async function desktopInvoke<T>(cmd: string, args?: Record<string, unknown>): Pr
   throw new Error(`desktopInvoke('${cmd}') called outside the desktop shell`);
 }
 
-export function DashboardShell({ toolbarMenuItems, hideTitleBar }: DashboardShellProps) {
+export function DashboardShell({ toolbarMenuItems, hideTitleBar, hideMenu }: DashboardShellProps) {
   const { projects, isLoading: loading } = useProjects();
   const { settings } = useSettingsQuery();
   const labels = settings.labels ?? [];
@@ -141,7 +157,11 @@ export function DashboardShell({ toolbarMenuItems, hideTitleBar }: DashboardShel
 
   return (
     <div
-      className={`${hideTitleBar ? "h-full" : "h-dvh"} w-full overflow-hidden flex flex-col bg-background text-foreground p-0 ${isDesktop ? "" : "pt-[env(safe-area-inset-top)]"}`}
+      className={cn(
+        "w-full overflow-hidden flex flex-col bg-background text-foreground p-0",
+        hideTitleBar ? "h-full" : "h-dvh",
+        !isDesktop && "pt-[env(safe-area-inset-top)]",
+      )}
     >
       {isDesktop && !hideTitleBar && (
         <div
@@ -154,102 +174,131 @@ export function DashboardShell({ toolbarMenuItems, hideTitleBar }: DashboardShel
         </div>
       )}
 
-      <div className="flex h-10 shrink-0 items-center justify-between border-b border-border px-2">
-        <div className="flex min-w-0 items-center gap-1">
-          <DropdownMenu>
-            <Tooltip>
-              <TooltipTrigger asChild>
+      <div className="flex h-9 shrink-0 items-center justify-between border-b border-border">
+        <div className="flex min-w-0 items-center">
+          <div className="flex items-center gap-1 pl-2">
+            {!hideMenu && (
+              <DropdownMenu>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <DropdownMenuTrigger asChild>
+                      <Button
+                        size="icon-sm"
+                        variant="ghost"
+                        className="text-muted-foreground"
+                        aria-label="Menu"
+                      >
+                        <Menu className="size-5" />
+                      </Button>
+                    </DropdownMenuTrigger>
+                  </TooltipTrigger>
+                  <TooltipContent side="bottom">More</TooltipContent>
+                </Tooltip>
+                <DropdownMenuContent align="start">
+                  <DropdownMenuItem onClick={() => setEditMode((v) => !v)}>
+                    <Pencil className="size-4" />
+                    {editMode ? "Done editing" : "Edit list"}
+                  </DropdownMenuItem>
+                  {toolbarMenuItems}
+                  <DropdownMenuItem onClick={handleSettingsClick}>
+                    <Settings className="size-4" />
+                    Settings
+                  </DropdownMenuItem>
+                </DropdownMenuContent>
+              </DropdownMenu>
+            )}
+            {labels.length > 0 && (
+              <DropdownMenu>
                 <DropdownMenuTrigger asChild>
                   <Button
-                    size="icon-sm"
+                    size="sm"
                     variant="ghost"
-                    className="text-muted-foreground"
-                    aria-label="Menu"
+                    className={`min-w-0 text-sm h-7 px-2 gap-1.5 ${labelFilter ? "bg-accent text-accent-foreground" : "text-muted-foreground"}`}
                   >
-                    <Menu className="size-5" />
+                    {activeLabel ? (
+                      <>
+                        <span
+                          className="size-2.5 rounded-full shrink-0"
+                          style={{ backgroundColor: activeLabel.color }}
+                        />
+                        <span className="truncate">{activeLabel.name}</span>
+                      </>
+                    ) : (
+                      <>
+                        <Tag className="size-3.5 shrink-0" />
+                        <span className="truncate">All</span>
+                      </>
+                    )}
                   </Button>
                 </DropdownMenuTrigger>
-              </TooltipTrigger>
-              <TooltipContent side="bottom">More</TooltipContent>
-            </Tooltip>
-            <DropdownMenuContent align="start">
-              <DropdownMenuItem onClick={() => setEditMode((v) => !v)}>
-                <Pencil className="size-4" />
-                {editMode ? "Done editing" : "Edit list"}
-              </DropdownMenuItem>
-              {toolbarMenuItems}
-              <DropdownMenuItem onClick={handleSettingsClick}>
-                <Settings className="size-4" />
-                Settings
-              </DropdownMenuItem>
-            </DropdownMenuContent>
-          </DropdownMenu>
-          {labels.length > 0 && (
-            <DropdownMenu>
-              <DropdownMenuTrigger asChild>
-                <Button
-                  size="sm"
-                  variant="ghost"
-                  className={`min-w-0 text-sm h-8 px-2 gap-1.5 ${labelFilter ? "bg-accent text-accent-foreground" : "text-muted-foreground"}`}
-                >
-                  {activeLabel ? (
-                    <>
-                      <span
-                        className="size-2.5 rounded-full shrink-0"
-                        style={{ backgroundColor: activeLabel.color }}
-                      />
-                      <span className="truncate">{activeLabel.name}</span>
-                    </>
-                  ) : (
-                    <>
-                      <Tag className="size-5 shrink-0" />
-                      <span className="truncate">All</span>
-                    </>
-                  )}
-                </Button>
-              </DropdownMenuTrigger>
-              <DropdownMenuContent align="start">
-                <DropdownMenuItem onClick={() => setLabelFilter(null)}>
-                  <Tag className="size-3.5 shrink-0 mr-2 text-muted-foreground" />
-                  <span className="truncate">All</span>
-                  {!labelFilter && <Check className="size-3 ml-2 shrink-0" />}
-                  <span className="ml-auto pl-3 text-xs text-muted-foreground tracking-widest">
-                    ⌘0
-                  </span>
-                </DropdownMenuItem>
-                {labels.map((lbl, idx) => (
-                  <DropdownMenuItem key={lbl.id} onClick={() => setLabelFilter(lbl.id)}>
-                    <span
-                      className="size-2.5 rounded-full shrink-0 mr-2"
-                      style={{ backgroundColor: lbl.color }}
-                    />
-                    <span className="truncate">{lbl.name}</span>
-                    {labelFilter === lbl.id && <Check className="size-3 ml-2 shrink-0" />}
-                    {idx < 9 && (
-                      <span className="ml-auto pl-3 text-xs text-muted-foreground tracking-widest">
-                        ⌘{idx + 1}
-                      </span>
-                    )}
+                <DropdownMenuContent align="start">
+                  <DropdownMenuItem onClick={() => setLabelFilter(null)}>
+                    <Tag className="size-3.5 shrink-0 mr-2 text-muted-foreground" />
+                    <span className="truncate">All</span>
+                    {!labelFilter && <Check className="size-3 ml-2 shrink-0" />}
+                    <span className="ml-auto pl-3 text-xs text-muted-foreground tracking-widest">
+                      ⌘0
+                    </span>
                   </DropdownMenuItem>
-                ))}
-              </DropdownMenuContent>
-            </DropdownMenu>
-          )}
+                  {labels.map((lbl, idx) => (
+                    <DropdownMenuItem key={lbl.id} onClick={() => setLabelFilter(lbl.id)}>
+                      <span
+                        className="size-2.5 rounded-full shrink-0 mr-2"
+                        style={{ backgroundColor: lbl.color }}
+                      />
+                      <span className="truncate">{lbl.name}</span>
+                      {labelFilter === lbl.id && <Check className="size-3 ml-2 shrink-0" />}
+                      {idx < 9 && (
+                        <span className="ml-auto pl-3 text-xs text-muted-foreground tracking-widest">
+                          ⌘{idx + 1}
+                        </span>
+                      )}
+                    </DropdownMenuItem>
+                  ))}
+                </DropdownMenuContent>
+              </DropdownMenu>
+            )}
+          </div>
         </div>
-        <div className="flex items-center gap-1">
+        <div className="flex items-center gap-1 pr-2">
           <Tooltip>
             <TooltipTrigger asChild>
               <Button
-                size="icon-sm"
+                size="icon-xs"
                 variant="ghost"
                 className="text-muted-foreground"
                 onClick={() => setShowAddDialog(true)}
               >
-                <Plus className="size-5" />
+                <Plus className="size-4" />
               </Button>
             </TooltipTrigger>
             <TooltipContent side="bottom">Add project</TooltipContent>
           </Tooltip>
+          {hideMenu && (
+            <DropdownMenu>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <DropdownMenuTrigger asChild>
+                    <Button
+                      size="icon-xs"
+                      variant="ghost"
+                      className="text-muted-foreground"
+                      aria-label="More actions"
+                    >
+                      <MoreVertical className="size-4" />
+                    </Button>
+                  </DropdownMenuTrigger>
+                </TooltipTrigger>
+                <TooltipContent side="bottom">More</TooltipContent>
+              </Tooltip>
+              <DropdownMenuContent align="end">
+                <DropdownMenuItem onClick={() => setEditMode((v) => !v)}>
+                  <Pencil className="size-4" />
+                  {editMode ? "Done editing" : "Edit list"}
+                </DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
+          )}
         </div>
       </div>
 

--- a/packages/dashboard-core/src/components/DiffView.tsx
+++ b/packages/dashboard-core/src/components/DiffView.tsx
@@ -980,6 +980,31 @@ export function DiffView({
   const scrollContainerRef = useRef<HTMLDivElement>(null);
 
   // -------------------------------------------------------------------------
+  // Root ref — used for the workspace-level ⇧⌘G "focus Changes" handler
+  // to scope its querySelector to this DiffView instance.
+  // -------------------------------------------------------------------------
+  const rootRef = useRef<HTMLDivElement>(null);
+
+  // Listen for ⇧⌘G "focus Changes". Multiple workspaces' DiffViews
+  // are mounted simultaneously; the offsetParent check filters down
+  // to the visible instance. Prefer the active file row
+  // (data-band-active marked in ChangesFileTree); fall back to the
+  // first focusable button inside the [data-diff-sidebar] tree.
+  useEffect(() => {
+    const handler = () => {
+      const root = rootRef.current;
+      if (!root || root.offsetParent === null) return;
+      const sidebar = root.querySelector<HTMLElement>("[data-diff-sidebar]") ?? root;
+      const target =
+        sidebar.querySelector<HTMLElement>("[data-band-active]") ??
+        sidebar.querySelector<HTMLElement>("button");
+      target?.focus({ preventScroll: true });
+    };
+    window.addEventListener("band:focus-changes", handler);
+    return () => window.removeEventListener("band:focus-changes", handler);
+  }, []);
+
+  // -------------------------------------------------------------------------
   // Find-in-diff state
   // -------------------------------------------------------------------------
   const editorViewsRef = useRef<Map<string, EditorView[]>>(new Map());
@@ -1469,7 +1494,7 @@ export function DiffView({
   filenamesRef.current = filenames;
 
   return (
-    <div className="@container/diff flex h-full overflow-hidden">
+    <div ref={rootRef} className="@container/diff flex h-full overflow-hidden">
       {/* LEFT: File tree sidebar — auto-hides when this view's container
           becomes too narrow to fit both the tree and useful diff content. */}
       {sidebarOpen && (

--- a/packages/dashboard-core/src/components/FileBrowser.tsx
+++ b/packages/dashboard-core/src/components/FileBrowser.tsx
@@ -91,6 +91,11 @@ function TreeNode({
       <button
         ref={isSelected ? selectedRef : undefined}
         type="button"
+        // data-band-active marks this button so the workspace-level
+        // ⇧⌘E "focus Files" handler can target it from outside the
+        // FileBrowser without depending on the brittle Tailwind class
+        // pair below.
+        data-band-active={isSelected ? "true" : undefined}
         onClick={handleClick}
         className={`flex w-full items-center text-left hover:bg-accent/50 ${
           compact ? "h-[26px] gap-1 pr-3 text-xs" : "h-[30px] gap-1.5 pr-4 text-sm"

--- a/packages/dashboard-core/src/components/FileViewer.tsx
+++ b/packages/dashboard-core/src/components/FileViewer.tsx
@@ -289,7 +289,11 @@ export function FileViewer({
   }, [isDirty, onBack]);
 
   return (
-    <div className="flex h-full flex-col overflow-hidden">
+    // min-w-0 prevents intrinsic-width content (CodeMirror's long unwrapped
+    // lines, in particular) from forcing this box wider than its allocated
+    // flex slot, which would propagate up and shove neighbouring layout
+    // (e.g. the right-edge tab strip) off-screen.
+    <div className="flex h-full min-w-0 flex-col overflow-hidden">
       {/* Title bar — full version (mobile / non-tab views) */}
       {!hideTitleBar && (
         <div className="flex h-9 shrink-0 items-center gap-2 border-b border-border/50 px-3">
@@ -400,7 +404,7 @@ export function FileViewer({
       {toolbar}
 
       {/* Content area */}
-      <div className="min-h-0 flex-1 overflow-hidden">
+      <div className="min-h-0 min-w-0 flex-1 overflow-hidden">
         {loading && (
           <div className="flex h-32 items-center justify-center text-sm text-muted-foreground">
             Loading...

--- a/packages/dashboard-core/src/lib/command-registry.ts
+++ b/packages/dashboard-core/src/lib/command-registry.ts
@@ -142,9 +142,11 @@ export function buildCommands(deps: CommandRegistryDeps): PaletteCommand[] {
       action: () => window.dispatchEvent(new CustomEvent("band:editor-go-forward")),
     },
     {
+      // No shortcut advertised: Shift+Tab is wired only inside the chat
+      // input (PromptInputTextarea), so it isn't a globally-applicable
+      // binding. The chat's mode dropdown shows the ⇧Tab hint in-context.
       id: "toggle-mode",
       label: "Toggle Edit/Plan Mode",
-      shortcut: "Shift+Tab",
       action: () => window.dispatchEvent(new CustomEvent("band:toggle-mode")),
     },
   ];

--- a/packages/dashboard-core/src/lib/command-registry.ts
+++ b/packages/dashboard-core/src/lib/command-registry.ts
@@ -69,6 +69,7 @@ export function formatShortcut(shortcut: string): string {
   if (mac) {
     return shortcut
       .replace(/Cmd\+/g, "⌘")
+      .replace(/Ctrl\+/g, "⌃")
       .replace(/Shift\+/g, "⇧")
       .replace(/Alt\+/g, "⌥");
   }
@@ -107,25 +108,25 @@ export function buildCommands(deps: CommandRegistryDeps): PaletteCommand[] {
     {
       id: "show-changes",
       label: "Show Changes",
-      shortcut: "Cmd+E",
+      shortcut: "Cmd+Shift+G",
       action: () => activatePanel(deps, "changes"),
     },
     {
       id: "show-terminal",
       label: "Show Terminal",
-      shortcut: "Cmd+J",
+      shortcut: "Ctrl+`",
       action: () => activatePanel(deps, "terminal"),
     },
     {
       id: "show-files",
       label: "Show Files",
-      shortcut: "Cmd+G",
+      shortcut: "Cmd+Shift+E",
       action: () => activatePanel(deps, "files"),
     },
     {
       id: "show-browser",
       label: "Show Browser",
-      shortcut: "Cmd+B",
+      shortcut: "Cmd+Shift+B",
       action: () => activatePanel(deps, "browser"),
     },
     {

--- a/packages/dashboard-core/src/lib/command-registry.ts
+++ b/packages/dashboard-core/src/lib/command-registry.ts
@@ -73,7 +73,11 @@ export function formatShortcut(shortcut: string): string {
       .replace(/Shift\+/g, "⇧")
       .replace(/Alt\+/g, "⌥");
   }
-  return shortcut.replace(/Cmd\+/g, "Ctrl+");
+  // Non-Mac: collapse "Ctrl+Cmd+X" → "Ctrl+X" first so we don't end up
+  // with the redundant "Ctrl+Ctrl+X" after the Cmd→Ctrl substitution.
+  // (No native Cmd-equivalent on Win/Linux; the binding falls through
+  // to plain Ctrl in those environments.)
+  return shortcut.replace(/Ctrl\+Cmd\+/g, "Ctrl+").replace(/Cmd\+/g, "Ctrl+");
 }
 
 // ---------------------------------------------------------------------------
@@ -106,6 +110,12 @@ export function buildCommands(deps: CommandRegistryDeps): PaletteCommand[] {
       action: () => deps.findInFile(),
     },
     {
+      id: "show-chat",
+      label: "Show Chat",
+      shortcut: "Ctrl+Cmd+I",
+      action: () => activatePanel(deps, "chat"),
+    },
+    {
       id: "show-changes",
       label: "Show Changes",
       shortcut: "Cmd+Shift+G",
@@ -128,6 +138,23 @@ export function buildCommands(deps: CommandRegistryDeps): PaletteCommand[] {
       label: "Show Browser",
       shortcut: "Cmd+Shift+B",
       action: () => activatePanel(deps, "browser"),
+    },
+    {
+      // ⌃0 — focuses keyboard into the Projects list. The direct
+      // keyboard handler in DockviewWorkspaceLayout also expands the
+      // left edge group if it's collapsed; this palette path just
+      // activates the panel and dispatches the focus event. If the
+      // sidebar happens to be collapsed when invoked from the palette,
+      // press ⌘B first.
+      id: "focus-projects",
+      label: "Focus Projects",
+      shortcut: "Ctrl+0",
+      action: () => {
+        activatePanel(deps, "projects");
+        queueMicrotask(() => {
+          window.dispatchEvent(new CustomEvent("band:focus-projects"));
+        });
+      },
     },
     {
       // No keyboard shortcut: Cmd+- is reserved by the desktop View menu's

--- a/packages/dashboard-core/src/lib/command-registry.ts
+++ b/packages/dashboard-core/src/lib/command-registry.ts
@@ -15,11 +15,12 @@ export interface PaletteCommand {
   /** Human-readable label shown in the palette. */
   label: string;
   /**
-   * Canonical keyboard shortcut string.
+   * Canonical keyboard shortcut string. Optional — palette-only commands
+   * with no keybinding can omit it.
    * Use `Cmd+` for the platform modifier (⌘ on Mac, Ctrl elsewhere).
    * Examples: `"Cmd+P"`, `"Cmd+Shift+F"`, `"Shift+Tab"`.
    */
-  shortcut: string;
+  shortcut?: string;
   /** Callback executed when the command is selected. */
   action: () => void;
 }
@@ -128,15 +129,16 @@ export function buildCommands(deps: CommandRegistryDeps): PaletteCommand[] {
       action: () => activatePanel(deps, "browser"),
     },
     {
+      // No keyboard shortcut: Cmd+- is reserved by the desktop View menu's
+      // Zoom Out accelerator. Reachable via the back/forward arrows in the
+      // FileViewer toolbar and via this palette entry.
       id: "editor-go-back",
       label: "Go Back",
-      shortcut: "Cmd+-",
       action: () => window.dispatchEvent(new CustomEvent("band:editor-go-back")),
     },
     {
       id: "editor-go-forward",
       label: "Go Forward",
-      shortcut: "Cmd+Shift+-",
       action: () => window.dispatchEvent(new CustomEvent("band:editor-go-forward")),
     },
     {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -176,8 +176,8 @@ importers:
         specifier: ^10.0.1
         version: 10.0.1
       dockview:
-        specifier: ^5.2.0
-        version: 5.2.0(react@19.2.4)
+        specifier: ^6.0.6
+        version: 6.0.6(react@19.2.4)
       drizzle-kit:
         specifier: 1.0.0-rc.1
         version: 1.0.0-rc.1
@@ -4182,11 +4182,11 @@ packages:
     os: [darwin]
     hasBin: true
 
-  dockview-core@5.2.0:
-    resolution: {integrity: sha512-Gib8yhK2Ng7w47ASvbUZ7GdhBYbeXEflbIDxf/vobdQBMrN/QXmPaouSsSSkEx5YH0N8ap8GYljfvqjug7h5Fg==}
+  dockview-core@6.0.6:
+    resolution: {integrity: sha512-d7MA42recquehve/52nC3yIbnFBHicRNbkHYX7bFepw3TlQF0XRHEOBnyYIT9OlVLkVRkv7aEOy5yIzZw5wyyA==}
 
-  dockview@5.2.0:
-    resolution: {integrity: sha512-Eh+SWt+AydcyeVmYkwP+Yxax0XpYSQfXsc4Rad9k+6QEddkSCn4hcjsdxp9lLsw/CaMy39jHawbDVxPMC4kvTg==}
+  dockview@6.0.6:
+    resolution: {integrity: sha512-NLhW6J7T5aUhNHAct9c67TmaLej7Tp4f6jY43Ke/Ibs7sNXEGGNtAncg2d/mSjX5uM92BIMXzqZxkkWAFxQI+w==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
@@ -11500,11 +11500,11 @@ snapshots:
       verror: 1.10.1
     optional: true
 
-  dockview-core@5.2.0: {}
+  dockview-core@6.0.6: {}
 
-  dockview@5.2.0(react@19.2.4):
+  dockview@6.0.6(react@19.2.4):
     dependencies:
-      dockview-core: 5.2.0
+      dockview-core: 6.0.6
       react: 19.2.4
 
   doctypes@1.1.0: {}


### PR DESCRIPTION
## Summary

- Upgrade `dockview` 5.2 → 6.0 and rebuild the layout around its native edge groups.
- Move the project list out of the `react-resizable-panels` sidebar in `__root.tsx` and into a Projects panel docked in dockview's left edge group. The same `DockviewWorkspaceLayout` now also renders on the index route (with `workspaceId=""`), so the empty-state shell matches the workspace shell.
- Empty edge groups (left/right/bottom) hide at rest and become visible drop targets only while a panel/group is being dragged.
- `DesktopTitleBar` gains a hamburger dropdown exposing Tasks / Cronjobs / Tunnel / Settings (replacing the old sidebar toggle). ⇧⌘B now collapses the left edge group.
- New `get_window_fullscreen` IPC channel + `useIsFullscreen` hook so the title bar drops the 80px traffic-light offset when macOS hides the controls.
- Bumped persisted layout key to `band:dockview-layout-v6` and dropped the orphaned `band:collapsed-groups` / `band:group-expanded-widths` keys from the previous custom-collapse system.
- `DashboardShell` gains a `hideMenu` prop for the embedded panel use; its edit-list action moves to a 3-dot button next to Add-project.
- Added `min-w-0` / `overflow-hidden` to `CodeBrowserView` and `FileViewer` so CodeMirror's intrinsic content width can no longer push the panel wider than its allocated edge slot and shove the right-edge tab strip off-screen.
- Theme: border styling for header-left/right/bottom variants and a fix for a phantom separator that appeared next to hidden edge views.

## Test plan

- [ ] Launch the desktop shell — Projects panel is docked in the left edge group with a sensible default width
- [ ] Drag the Chat tab to the right edge — the right edge appears as a drop target during the drag, then stays visible because it now contains a panel
- [ ] Drag the same panel back out — the right edge collapses out of view at rest
- [ ] Toggle macOS native fullscreen — the title bar's hamburger / back / forward controls slide left to fill the now-vacant traffic-light area, then back to `left-[80px]` on exit
- [ ] ⇧⌘B collapses / expands the left edge group
- [ ] Hamburger dropdown in the title bar opens Tasks / Cronjobs / Tunnel / Settings dialogs; the active webview hides behind each dialog
- [ ] Open a long, unwrapped source file in the Files panel — horizontal scroll stays inside the editor and does not push the right-edge tab strip off-screen
- [ ] Reload — layout is restored from `band:dockview-layout-v6`; the legacy `band:collapsed-groups` and `band:group-expanded-widths` keys are removed from `localStorage`
- [ ] Index route (no workspace) renders the same dockview shell with empty-state messages in each panel, and edits on this route do not pollute the saved layout

🤖 Generated with [Claude Code](https://claude.com/claude-code)