### PR TITLE
feat(web): enable terminal tab in mobile view

### DIFF
--- a/apps/web/src/components/TerminalPanel.tsx
+++ b/apps/web/src/components/TerminalPanel.tsx
@@ -149,6 +149,42 @@ export function TerminalPanel({
       terminalRef.current = terminal;
       fitAddonRef.current = fitAddon;
 
+      // Mobile touch scrolling. xterm renders `.xterm-screen` (canvas/dom) on top
+      // of the scrollable `.xterm-viewport`, so touches on the visible terminal
+      // never reach the scroll layer in iOS Safari and native finger-scroll fails.
+      // Translate vertical touch drags into `terminal.scrollLines()` calls so the
+      // user can pull up/down to scroll back through history.
+      const containerEl = containerRef.current!;
+      let lastTouchY: number | null = null;
+      const onTouchStart = (e: TouchEvent) => {
+        lastTouchY = e.touches.length === 1 ? e.touches[0].clientY : null;
+      };
+      const onTouchMove = (e: TouchEvent) => {
+        if (e.touches.length !== 1 || lastTouchY === null) return;
+        const currentY = e.touches[0].clientY;
+        const deltaY = lastTouchY - currentY;
+        // Estimate the cell height from the rendered viewport so the scroll
+        // speed matches finger movement at any font size / DPR.
+        const viewport = containerEl.querySelector(".xterm-viewport") as HTMLElement | null;
+        const cellHeight =
+          viewport && terminal.rows > 0 ? viewport.clientHeight / terminal.rows : 17;
+        const lineDelta = Math.trunc(deltaY / cellHeight);
+        if (lineDelta !== 0) {
+          terminal.scrollLines(lineDelta);
+          // Carry the unconsumed sub-line remainder into the next move so
+          // slow drags still accumulate instead of being rounded away.
+          lastTouchY = currentY + (deltaY - lineDelta * cellHeight);
+          e.preventDefault();
+        }
+      };
+      const onTouchEnd = () => {
+        lastTouchY = null;
+      };
+      containerEl.addEventListener("touchstart", onTouchStart, { passive: true });
+      containerEl.addEventListener("touchmove", onTouchMove, { passive: false });
+      containerEl.addEventListener("touchend", onTouchEnd, { passive: true });
+      containerEl.addEventListener("touchcancel", onTouchEnd, { passive: true });
+
       // Connect WebSocket
       const proto = location.protocol === "https:" ? "wss:" : "ws:";
       const ws = new WebSocket(
@@ -238,6 +274,10 @@ export function TerminalPanel({
       cleanup = () => {
         themeObserver.disconnect();
         resizeObserver.disconnect();
+        containerEl.removeEventListener("touchstart", onTouchStart);
+        containerEl.removeEventListener("touchmove", onTouchMove);
+        containerEl.removeEventListener("touchend", onTouchEnd);
+        containerEl.removeEventListener("touchcancel", onTouchEnd);
         ws.close();
         terminal.dispose();
         terminalRef.current = null;

--- a/apps/web/src/routes/workspace.$workspaceId.tsx
+++ b/apps/web/src/routes/workspace.$workspaceId.tsx
@@ -90,6 +90,7 @@ function useActiveTab(workspaceId: string): WorkspaceTab {
   const prefix = `/workspace/${workspaceId}`;
   if (pathname.startsWith(`${prefix}/changes`)) return "diff";
   if (pathname.startsWith(`${prefix}/code`)) return "code";
+  if (pathname.startsWith(`${prefix}/terminal`)) return "terminal";
   return "chat";
 }
 
@@ -323,6 +324,7 @@ function MobileWorkspaceLayout({
     chat: `/workspace/${encodedId}`,
     diff: `/workspace/${encodedId}/changes`,
     code: `/workspace/${encodedId}/code`,
+    terminal: `/workspace/${encodedId}/terminal`,
   };
 
   return (
@@ -347,17 +349,18 @@ function MobileWorkspaceLayout({
           }}
         >
           {isDesktop && <DesktopDragRegion />}
-          <header className="flex shrink-0 items-center gap-3 border-b border-border/50 px-4 py-3 pt-[max(0.75rem,env(safe-area-inset-top))]">
+          <header className="flex h-[calc(2.5rem+env(safe-area-inset-top))] shrink-0 items-center gap-2 border-b border-border/50 px-3 pt-[env(safe-area-inset-top)]">
             <button
               type="button"
               onClick={handleBack}
-              className="inline-flex size-8 items-center justify-center rounded-md hover:bg-accent"
+              className="inline-flex size-7 shrink-0 items-center justify-center rounded-md hover:bg-accent"
             >
               <ArrowLeft className="size-4" />
             </button>
             <div className="min-w-0 flex-1">
-              <h1 className="truncate text-sm font-semibold">{workspaceId}</h1>
+              <h1 className="truncate text-center text-sm font-semibold">{workspaceId}</h1>
             </div>
+            <div aria-hidden="true" className="size-7 shrink-0" />
           </header>
           <WorkspaceTabNav
             activeTab={activeTab}

--- a/packages/dashboard-core/src/components/WorkspaceTabNav.tsx
+++ b/packages/dashboard-core/src/components/WorkspaceTabNav.tsx
@@ -1,6 +1,6 @@
-import { FolderOpen, GitCompare, MessageSquare } from "lucide-react";
+import { FolderOpen, GitCompare, MessageSquare, TerminalSquare } from "lucide-react";
 
-export type WorkspaceTab = "chat" | "diff" | "code";
+export type WorkspaceTab = "chat" | "diff" | "code" | "terminal";
 
 interface WorkspaceTabNavProps {
   activeTab: WorkspaceTab;
@@ -14,6 +14,7 @@ const tabs: { id: WorkspaceTab; label: string; icon: typeof MessageSquare }[] = 
   { id: "chat", label: "Chat", icon: MessageSquare },
   { id: "diff", label: "Changes", icon: GitCompare },
   { id: "code", label: "Files", icon: FolderOpen },
+  { id: "terminal", label: "Terminal", icon: TerminalSquare },
 ];
 
 export function WorkspaceTabNav({
@@ -30,7 +31,7 @@ export function WorkspaceTabNav({
         const badge = tab.id === "diff" && diffFileCount != null && diffFileCount > 0;
         const href = tabHrefs?.[tab.id];
 
-        const className = `flex flex-1 items-center justify-center gap-2 py-2.5 text-sm font-medium transition-colors ${
+        const className = `flex flex-1 items-center justify-center gap-1.5 py-2.5 text-sm font-medium transition-colors ${
           isActive
             ? "border-b-2 border-foreground text-foreground"
             : "text-muted-foreground hover:text-foreground"
@@ -39,7 +40,6 @@ export function WorkspaceTabNav({
         const content = (
           <>
             <Icon className="size-4" />
-            {tab.label}
             {badge && (
               <span className="inline-flex h-5 min-w-5 items-center justify-center rounded-full bg-blue-500/20 text-blue-600 dark:text-blue-400 px-1.5 text-xs font-medium">
                 {diffFileCount}
@@ -50,7 +50,13 @@ export function WorkspaceTabNav({
 
         if (href) {
           return (
-            <a key={tab.id} href={href} className={className}>
+            <a
+              key={tab.id}
+              href={href}
+              className={className}
+              aria-label={tab.label}
+              title={tab.label}
+            >
               {content}
             </a>
           );
@@ -62,6 +68,8 @@ export function WorkspaceTabNav({
             type="button"
             onClick={() => onTabChange?.(tab.id)}
             className={className}
+            aria-label={tab.label}
+            title={tab.label}
           >
             {content}
           </button>


### PR DESCRIPTION
## Summary

Enables the terminal pane on mobile-sized viewports as a fourth tab in the existing mobile workspace nav, plus a few mobile-header polishes and a touch-scrolling fix for xterm.

- **Terminal tab on mobile** — adds `terminal` to `WorkspaceTab` and the mobile `tabHrefs`/`useActiveTab`. The route `/workspace/$id/terminal` already existed for desktop dockview; mobile now routes to the same `DockviewTerminalContainer`.
- **Icon-only mobile tab nav** — drops the text labels from `WorkspaceTabNav` so four tabs fit comfortably; keeps the diff-count badge and exposes labels via `aria-label` / `title`.
- **Smaller, centered mobile header** — workspace header is now 40px tall (plus iOS safe-area inset above), and the workspace name is centered using a balanced invisible spacer on the right.
- **Touch-drag scrolling in TerminalPanel** — xterm renders `.xterm-screen` on top of `.xterm-viewport`, so finger-scroll on iOS never reaches the scroll layer. Translates single-finger vertical drags into `terminal.scrollLines()` calls with sub-line remainder carry-over for smooth slow drags.

## Test plan

- [ ] In Chrome DevTools mobile mode (or iOS Simulator Safari), open a workspace and verify four tabs render: Chat | Changes | Files | Terminal
- [ ] Tap the Terminal tab — `DockviewTerminalContainer` mounts and an interactive shell appears
- [ ] Drag up/down on the terminal — history scrolls; the page itself does not scroll
- [ ] Mobile header is 40px tall, back arrow on the left, workspace name visually centered, truncates with ellipsis on long names
- [ ] Resize past 1024px — desktop dockview layout still works as before (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)