### PR TITLE
perf: throttle branch-status poller and terminal title poll

### DIFF
--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -19,6 +19,7 @@ import { BrowserViewManager } from "../browser/view-manager.js";
 import { resolveAppIcon } from "./icon.js";
 import { registerIpc } from "./ipc/register.js";
 import { installAppMenu } from "./menu.js";
+import { type ActivityMonitorHandle, startActivityMonitor } from "./services/activity-monitor.js";
 import { dashLog, logToFile } from "./services/log.js";
 import { killPort } from "./services/port.js";
 import { getConfiguredPort } from "./services/settings.js";
@@ -33,6 +34,7 @@ interface AppState {
   browserManager: BrowserViewManager | null;
   unregisterIpc: (() => void) | null;
   cancelStartupUpdateCheck: (() => void) | null;
+  activityMonitor: ActivityMonitorHandle | null;
   cleanedUp: boolean;
   port: number;
   /** Empty string in dev mode where we don't own the server. */
@@ -45,6 +47,7 @@ const state: AppState = {
   browserManager: null,
   unregisterIpc: null,
   cancelStartupUpdateCheck: null,
+  activityMonitor: null,
   cleanedUp: false,
   port: getConfiguredPort(),
   webDir: "",
@@ -95,6 +98,7 @@ async function cleanupOnce(): Promise<void> {
   // Cancel any pending startup update check so its dialog doesn't pop up
   // mid-shutdown (the 10s delay can outlive Cmd+Q on a quick quit).
   state.cancelStartupUpdateCheck?.();
+  state.activityMonitor?.stop();
   state.unregisterIpc?.();
   state.browserManager?.destroyAll();
   await state.managed.kill();
@@ -160,6 +164,14 @@ async function bootstrap(): Promise<void> {
   // in unpacked dev runs (`!app.isPackaged`) — see updater.ts.
   state.cancelStartupUpdateCheck = scheduleStartupCheck(app.isPackaged, {
     parentWindow: state.mainWindow,
+  });
+
+  // Watch focus + AC/battery state and tell the web server to widen the
+  // branch-status poller interval whenever the user isn't actively using
+  // Band. Best-effort; failures are logged but don't block startup.
+  state.activityMonitor = startActivityMonitor({
+    mainWindow: state.mainWindow,
+    port: state.port,
   });
 
   state.mainWindow.on("close", () => {

--- a/apps/desktop/src/main/services/activity-monitor.ts
+++ b/apps/desktop/src/main/services/activity-monitor.ts
@@ -1,0 +1,136 @@
+/**
+ * Drives the web server's `services.setActivity` mutation based on local
+ * window focus + AC/battery state.
+ *
+ * The branch-status poller (apps/web/src/lib/branch-status-poller.ts) keeps
+ * shelling out to git/gh on a 5 s tick by default. That's wasted energy when
+ * the window is unfocused or the laptop is on battery, so the desktop shell
+ * notifies the server to widen the interval:
+ *
+ *   focused && !onBattery  → "active"      (5 s git / 30 s CI — original)
+ *   focused &&  onBattery  → "idle"        (30 s git / 3 min CI)
+ *  !focused && !onBattery  → "idle"        (30 s git / 3 min CI)
+ *  !focused &&  onBattery  → "background"  (60 s git / 10 min CI)
+ *
+ * Failures are logged but never thrown — this is a best-effort optimization
+ * and the server defaults to "active" if nothing ever calls it.
+ */
+
+import { type BrowserWindow, powerMonitor } from "electron";
+import { dashLog } from "./log.js";
+import { getConfiguredPort, tryGetToken } from "./settings.js";
+
+type ActivityLevel = "active" | "idle" | "background";
+
+const DEBOUNCE_MS = 250;
+const REQUEST_TIMEOUT_MS = 2_000;
+
+export interface ActivityMonitorOptions {
+  mainWindow: BrowserWindow;
+  /** Override the configured port (defaults to settings.json / 3456). */
+  port?: number;
+}
+
+export interface ActivityMonitorHandle {
+  /** Remove all listeners. The window's listeners auto-release on close, but
+   *  powerMonitor's are global and need explicit teardown. */
+  stop: () => void;
+}
+
+function computeActivity(focused: boolean, onBattery: boolean): ActivityLevel {
+  if (focused && !onBattery) return "active";
+  if (!focused && onBattery) return "background";
+  return "idle";
+}
+
+async function postActivity(port: number, activity: ActivityLevel): Promise<void> {
+  const token = tryGetToken();
+  if (!token) {
+    // Server may not have written settings.json yet (during startup). Skip —
+    // the next state change will retry.
+    return;
+  }
+  try {
+    const res = await fetch(`http://127.0.0.1:${port}/trpc/services.setActivity`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Cookie: `band_token=${token}`,
+      },
+      body: JSON.stringify({ activity }),
+      signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+    });
+    if (!res.ok) {
+      dashLog(`activity-monitor: setActivity(${activity}) → HTTP ${res.status}`);
+    }
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    dashLog(`activity-monitor: setActivity(${activity}) failed: ${msg}`);
+  }
+}
+
+/**
+ * Wire focus + powerMonitor listeners and POST every transition to the web
+ * server. Returns a teardown handle.
+ */
+export function startActivityMonitor(opts: ActivityMonitorOptions): ActivityMonitorHandle {
+  const port = opts.port ?? getConfiguredPort();
+
+  let focused = opts.mainWindow.isFocused();
+  let onBattery = powerMonitor.isOnBatteryPower();
+  let lastSent: ActivityLevel | null = null;
+  let debounceTimer: NodeJS.Timeout | null = null;
+
+  const flush = (): void => {
+    debounceTimer = null;
+    const next = computeActivity(focused, onBattery);
+    if (next === lastSent) return;
+    lastSent = next;
+    void postActivity(port, next);
+  };
+
+  /** Coalesce rapid focus/blur transitions (e.g. cmd-tab through windows). */
+  const schedule = (): void => {
+    if (debounceTimer) return;
+    debounceTimer = setTimeout(flush, DEBOUNCE_MS);
+  };
+
+  const onFocus = () => {
+    focused = true;
+    schedule();
+  };
+  const onBlur = () => {
+    focused = false;
+    schedule();
+  };
+  const onAc = () => {
+    onBattery = false;
+    schedule();
+  };
+  const onBatt = () => {
+    onBattery = true;
+    schedule();
+  };
+
+  opts.mainWindow.on("focus", onFocus);
+  opts.mainWindow.on("blur", onBlur);
+  powerMonitor.on("on-ac", onAc);
+  powerMonitor.on("on-battery", onBatt);
+
+  // Send initial state so the server isn't stuck at "active" if Band launched
+  // into the background or on battery.
+  schedule();
+
+  return {
+    stop: () => {
+      if (debounceTimer) {
+        clearTimeout(debounceTimer);
+        debounceTimer = null;
+      }
+      opts.mainWindow.off("focus", onFocus);
+      opts.mainWindow.off("blur", onBlur);
+      powerMonitor.off("on-ac", onAc);
+      powerMonitor.off("on-battery", onBatt);
+    },
+  };
+}

--- a/apps/web/src/lib/branch-status-poller.ts
+++ b/apps/web/src/lib/branch-status-poller.ts
@@ -25,11 +25,34 @@ interface WorkspaceInfo {
   projectPath: string;
 }
 
-const POLL_INTERVAL_MS = 5000;
-const CI_POLL_TICKS = 6; // every 6th tick = 30s
+/**
+ * Activity level controls how aggressively we poll git/CI status. The Electron
+ * main process drives this via the `services.setActivity` tRPC mutation when
+ * the window gains/loses focus or the laptop transitions on/off battery —
+ * see `apps/desktop/src/main/services/activity-monitor.ts`. Other clients
+ * (CLI, web-only deployments) can leave it at the default `"active"`.
+ */
+export type ActivityLevel = "active" | "idle" | "background";
+
+interface IntervalConfig {
+  /** Base tick period in ms — fires `getGitStatus` for every workspace. */
+  pollMs: number;
+  /** Every Nth tick also runs `git fetch --all` + the batched CI query. */
+  ciTicks: number;
+}
+
+const INTERVALS: Record<ActivityLevel, IntervalConfig> = {
+  // 5 s git / 30 s CI — the original cadence, used when the user is actively looking at the UI on AC power.
+  active: { pollMs: 5_000, ciTicks: 6 },
+  // 30 s git / 3 min CI — window unfocused OR on battery (but not both).
+  idle: { pollMs: 30_000, ciTicks: 6 },
+  // 60 s git / 10 min CI — window unfocused AND on battery.
+  background: { pollMs: 60_000, ciTicks: 10 },
+};
 
 let pollerTimer: ReturnType<typeof setInterval> | null = null;
 let tickCount = 0;
+let currentActivity: ActivityLevel = "active";
 
 // Cache repo info per project path within a single CI poll tick.
 // Cleared on each CI tick so transferred repos or new remotes are picked up.
@@ -233,7 +256,7 @@ async function getBatchedCIStatuses(workspaces: WorkspaceInfo[]): Promise<Map<st
 
 async function pollTick() {
   tickCount++;
-  const isCITick = tickCount % CI_POLL_TICKS === 0;
+  const isCITick = tickCount % INTERVALS[currentActivity].ciTicks === 0;
 
   if (tickCount === 1 || isCITick) {
     await syncWorktrees().catch((err) => console.error("syncWorktrees error:", err));
@@ -330,7 +353,7 @@ export function startBranchStatusPoller() {
 
   pollerTimer = setInterval(() => {
     pollTick().catch((err) => console.error("Branch status poll error:", err));
-  }, POLL_INTERVAL_MS);
+  }, INTERVALS[currentActivity].pollMs);
 }
 
 export function stopBranchStatusPoller() {
@@ -338,4 +361,28 @@ export function stopBranchStatusPoller() {
     clearInterval(pollerTimer);
     pollerTimer = null;
   }
+}
+
+/**
+ * Update the activity level. If the poller is currently running it is
+ * rescheduled with the new base interval; `tickCount` is reset so the new CI
+ * cadence is honoured immediately rather than being dragged out by a stale
+ * counter from the previous level.
+ *
+ * No-op when the level is unchanged.
+ */
+export function setPollerActivity(activity: ActivityLevel): void {
+  if (activity === currentActivity) return;
+  currentActivity = activity;
+  if (pollerTimer) {
+    clearInterval(pollerTimer);
+    tickCount = 0;
+    pollerTimer = setInterval(() => {
+      pollTick().catch((err) => console.error("Branch status poll error:", err));
+    }, INTERVALS[activity].pollMs);
+  }
+}
+
+export function getPollerActivity(): ActivityLevel {
+  return currentActivity;
 }

--- a/apps/web/src/lib/terminal-ws.ts
+++ b/apps/web/src/lib/terminal-ws.ts
@@ -130,6 +130,10 @@ function attachSession(
 
   // Poll the PTY foreground process name and send title updates (text/JSON frames).
   // This mimics how iTerm detects the running command without relying on OSC sequences.
+  // 3 s is a deliberate trade-off: a 1 s poll picked up `cd`/`vim` transitions
+  // ~2 s sooner but kept the event loop awake at 1 Hz for every open terminal,
+  // which compounds when several PTYs are open. 3 s is fast enough that title
+  // updates still feel near-instant to a user reading the change.
   let lastProcess = "";
   const processInterval = setInterval(() => {
     try {
@@ -143,7 +147,7 @@ function attachSession(
     } catch {
       // pty.process can throw if the process has exited
     }
-  }, 1000);
+  }, 3000);
 
   // PTY exit -> close WebSocket
   const exitDisposable = session.pty.onExit(({ exitCode }) => {

--- a/apps/web/src/trpc/router.ts
+++ b/apps/web/src/trpc/router.ts
@@ -11,6 +11,7 @@ import type { UIMessage } from "ai";
 import { Cron } from "croner";
 import { z } from "zod";
 import { createMetadataAgent, getOrCreateAgent, replaceAgent } from "../lib/agent-pool";
+import { getPollerActivity, setPollerActivity } from "../lib/branch-status-poller";
 import {
   deleteBrowserLayout,
   getBrowserLayout,
@@ -1816,6 +1817,16 @@ const servicesRouter = t.router({
     log.debug({ result }, "services.health result");
     return result;
   }),
+  // Activity level controls how often the branch-status poller fires.
+  // Driven by the Electron main process based on window focus + power state.
+  // See `apps/desktop/src/main/services/activity-monitor.ts`.
+  setActivity: publicProcedure
+    .input(z.object({ activity: z.enum(["active", "idle", "background"]) }))
+    .mutation(({ input }) => {
+      setPollerActivity(input.activity);
+      return { activity: input.activity };
+    }),
+  getActivity: publicProcedure.query(() => ({ activity: getPollerActivity() })),
 });
 
 // ---------------------------------------------------------------------------

--- a/apps/web/tests/trpc.test.ts
+++ b/apps/web/tests/trpc.test.ts
@@ -1033,6 +1033,53 @@ describe("tRPC — system checks", () => {
 });
 
 // ---------------------------------------------------------------------------
+// services router — activity level
+// ---------------------------------------------------------------------------
+
+describe("tRPC — services activity", () => {
+  let server: ServerHandle;
+  let tmpHome: string;
+
+  beforeAll(async () => {
+    tmpHome = createTmpHome();
+    seedState(tmpHome, { projects: [] });
+    seedSettings(tmpHome, { tokenSecret: DEFAULT_TOKEN });
+    server = await startServer({ tmpHome });
+  });
+
+  afterAll(async () => {
+    await server.close();
+    rmSync(tmpHome, { recursive: true, force: true });
+  });
+
+  it("services.getActivity defaults to 'active'", async () => {
+    const res = await trpcQuery(server.url, "services.getActivity");
+    expect(res.status).toBe(200);
+    const data = await trpcData<{ activity: string }>(res);
+    expect(data.activity).toBe("active");
+  });
+
+  it("services.setActivity accepts each valid level and getActivity reflects it", async () => {
+    for (const activity of ["idle", "background", "active"] as const) {
+      const setRes = await trpcMutate(server.url, "services.setActivity", { activity });
+      expect(setRes.status).toBe(200);
+      const setData = await trpcData<{ activity: string }>(setRes);
+      expect(setData.activity).toBe(activity);
+
+      const getRes = await trpcQuery(server.url, "services.getActivity");
+      expect(getRes.status).toBe(200);
+      const getData = await trpcData<{ activity: string }>(getRes);
+      expect(getData.activity).toBe(activity);
+    }
+  });
+
+  it("services.setActivity rejects an unknown activity", async () => {
+    const res = await trpcMutate(server.url, "services.setActivity", { activity: "asleep" });
+    expect(res.status).toBe(400);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Auth enforcement on tRPC endpoints
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Reduces idle/background battery drain from Band's two highest-frequency continuous workloads.

- **Branch-status poller** now has an `ActivityLevel` (`active` / `idle` / `background`) controllable at runtime via `services.setActivity` tRPC. The Electron shell drives it from window focus + `powerMonitor` AC/battery state (debounced 250 ms). Foreground/AC behaviour is unchanged; idle/battery widens the cadence by 6–20×.

  | Level      | Git status | CI / fetch |
  | ---------- | ---------- | ---------- |
  | active     | 5 s        | 30 s       |
  | idle       | 30 s       | 3 min      |
  | background | 60 s       | 10 min     |

- **Terminal title poll** dropped from 1 s → 3 s. The 1 s rate kept the event loop awake at 1 Hz for every open PTY for a barely-noticeable latency win.

CLI / web-only deployments are unaffected — the server defaults to `active` if nothing ever calls the API.

## Test plan

- [x] New integration tests in `apps/web/tests/trpc.test.ts` cover default activity, valid transitions, and invalid input rejection (3 new tests, full file: 64/64 pass)
- [x] Web `tsc --noEmit` clean for changed files (two pre-existing errors in `state.ts` / `task-store.ts` are on main)
- [x] Desktop `pnpm build` clean (typechecks `tsconfig.main.json` + `tsconfig.preload.json`)
- [x] Biome check clean for all modified files
- [ ] Manual smoke: launch Band, switch focus / unplug AC, observe activity flips in `~/.band/server.log` and `git fetch` cadence widening

🤖 Generated with [Claude Code](https://claude.com/claude-code)