### PR TITLE
feat(dashboard): collapsible projects/labels, drop edit-list mode

### DIFF
--- a/apps/website/src/pages/docs/projects.astro
+++ b/apps/website/src/pages/docs/projects.astro
@@ -54,16 +54,21 @@ band projects add /path/to/your/repo --label my-label</code></pre>
   </p>
   <ul>
     <li>Right-clicking the project name and selecting <strong>Remove from list</strong>.</li>
-    <li>Entering edit mode (via the settings menu) and clicking the trash icon next to the project.</li>
     <li>Using the CLI: <code>band projects remove &lt;name&gt;</code></li>
   </ul>
 
   <h2>Reordering Projects</h2>
   <p>
-    To reorder projects in the sidebar, open the settings menu and select <strong>Edit list</strong>.
-    This enables edit mode, which shows drag handles next to each project name. Drag projects
-    up or down to rearrange them. The new order is persisted automatically. Click
-    <strong>Done editing</strong> when finished.
+    Projects in the sidebar can be reordered by drag-and-drop. On desktop, click and drag a
+    project name up or down to rearrange. On mobile, press and hold a project until it lifts,
+    then drag it to the new position. The new order is persisted automatically.
+  </p>
+
+  <h2>Collapsing Projects</h2>
+  <p>
+    Click the chevron next to a project name to collapse or expand its workspaces. Collapse
+    state is remembered between reloads, so projects you rarely look at can stay tucked
+    away. Label section headers can be collapsed the same way.
   </p>
 
   <h2>Labels and Filtering</h2>
@@ -79,7 +84,7 @@ band projects add /path/to/your/repo --label my-label</code></pre>
     <li>When labels are defined, projects are visually grouped by label with colored section headers.</li>
   </ul>
   <p>
-    You can also drag projects between label groups in edit mode to reassign labels quickly.
+    You can also drag projects between label groups to reassign labels quickly.
   </p>
 
   <h2>Project Configuration</h2>

--- a/apps/website/src/pages/docs/remote-access.astro
+++ b/apps/website/src/pages/docs/remote-access.astro
@@ -74,7 +74,7 @@ sudo apt install cloudflared
   <figure class="my-8 mx-auto max-w-[12rem] overflow-hidden rounded-xl border border-border shadow-lg">
     <img
       src="/screenshot-tunnel-menu.png"
-      alt="The Band desktop app's hamburger menu showing Edit list, Tasks, Cronjobs, Start tunnel, and Settings options."
+      alt="The Band desktop app's hamburger menu showing Tasks, Cronjobs, Start tunnel, and Settings options."
       width="130"
       height="207"
       loading="lazy"

--- a/packages/dashboard-core/src/components/DashboardShell.tsx
+++ b/packages/dashboard-core/src/components/DashboardShell.tsx
@@ -17,19 +17,15 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@band-app/ui";
-import {
-  Check,
-  FolderPlus,
-  Menu,
-  MoreVertical,
-  Pencil,
-  Plus,
-  Settings,
-  Tag,
-  X,
-} from "lucide-react";
+import { Check, ChevronsDownUp, FolderPlus, Menu, Plus, Settings, Tag, X } from "lucide-react";
 import { type ReactNode, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useCliSetup } from "../hooks/use-cli-setup";
+import {
+  LABELS_COLLAPSE_KEY,
+  PROJECTS_COLLAPSE_KEY,
+  UNLABELED_KEY,
+  useCollapseState,
+} from "../hooks/use-collapse-state";
 import { useHooksSetup } from "../hooks/use-hooks-setup";
 import { useProjects } from "../hooks/use-projects";
 import { useSettingsQuery } from "../hooks/use-settings-query";
@@ -44,15 +40,14 @@ import { ProjectList } from "./ProjectList";
 import { SettingsPage } from "./SettingsPage";
 
 interface DashboardShellProps {
-  /** Extra menu items rendered inside the toolbar's overflow ("3 dots") dropdown,
-   *  appended after the built-in Edit/Settings entries. */
+  /** Extra menu items rendered inside the toolbar's overflow dropdown,
+   *  appended after the built-in Settings entry. */
   toolbarMenuItems?: ReactNode;
   /** Hide the desktop title bar (e.g. when the parent renders a full-width one). */
   hideTitleBar?: boolean;
   /** Suppress the in-shell hamburger overflow menu. Used when this shell is
    *  embedded under a global title bar that already exposes the same items
-   *  (Tasks / Cronjobs / Settings / …). Edit-list moves to a 3-dot menu next
-   *  to the Add-project button. */
+   *  (Tasks / Cronjobs / Settings / …). */
   hideMenu?: boolean;
 }
 
@@ -86,7 +81,6 @@ export function DashboardShell({ toolbarMenuItems, hideTitleBar, hideMenu }: Das
   const [showAddDialog, setShowAddDialog] = useState(false);
   const [showErrorDialog, setShowErrorDialog] = useState(false);
   const [showSettingsDialog, setShowSettingsDialog] = useState(false);
-  const [editMode, setEditMode] = useState(false);
   const [labelFilter, setLabelFilter] = useState<string | null>(null);
   const { state: hooksState, install: installHooks } = useHooksSetup();
   const { state: cliState, install: installCli } = useCliSetup();
@@ -105,6 +99,17 @@ export function DashboardShell({ toolbarMenuItems, hideTitleBar, hideMenu }: Das
   useSetupStatusWatcher();
 
   const handleSettingsClick = useCallback(() => setShowSettingsDialog(true), []);
+
+  // Collapse-all toolbar action: write every project name into the
+  // collapsed-projects set and every label id (plus the unlabeled sentinel)
+  // into the collapsed-labels set. The custom event dispatched by `setAll`
+  // pings every useCollapseState consumer so the list re-renders instantly.
+  const projectCollapse = useCollapseState(PROJECTS_COLLAPSE_KEY);
+  const labelCollapse = useCollapseState(LABELS_COLLAPSE_KEY);
+  const collapseAll = useCallback(() => {
+    projectCollapse.setAll(projects.map((p) => p.name));
+    labelCollapse.setAll([...labels.map((l) => l.id), UNLABELED_KEY]);
+  }, [projectCollapse, labelCollapse, projects, labels]);
 
   const activeLabel = useMemo(
     () => (labelFilter ? labels.find((l) => l.id === labelFilter) : null),
@@ -213,10 +218,6 @@ export function DashboardShell({ toolbarMenuItems, hideTitleBar, hideMenu }: Das
                   <TooltipContent side="bottom">More</TooltipContent>
                 </Tooltip>
                 <DropdownMenuContent align="start">
-                  <DropdownMenuItem onClick={() => setEditMode((v) => !v)}>
-                    <Pencil className="size-4" />
-                    {editMode ? "Done editing" : "Edit list"}
-                  </DropdownMenuItem>
                   {toolbarMenuItems}
                   <DropdownMenuItem onClick={handleSettingsClick}>
                     <Settings className="size-4" />
@@ -292,30 +293,21 @@ export function DashboardShell({ toolbarMenuItems, hideTitleBar, hideMenu }: Das
             </TooltipTrigger>
             <TooltipContent side="bottom">Add project</TooltipContent>
           </Tooltip>
-          {hideMenu && (
-            <DropdownMenu>
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <DropdownMenuTrigger asChild>
-                    <Button
-                      size="icon-xs"
-                      variant="ghost"
-                      className="text-muted-foreground"
-                      aria-label="More actions"
-                    >
-                      <MoreVertical className="size-4" />
-                    </Button>
-                  </DropdownMenuTrigger>
-                </TooltipTrigger>
-                <TooltipContent side="bottom">More</TooltipContent>
-              </Tooltip>
-              <DropdownMenuContent align="end">
-                <DropdownMenuItem onClick={() => setEditMode((v) => !v)}>
-                  <Pencil className="size-4" />
-                  {editMode ? "Done editing" : "Edit list"}
-                </DropdownMenuItem>
-              </DropdownMenuContent>
-            </DropdownMenu>
+          {projects.length > 0 && (
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  size="icon-xs"
+                  variant="ghost"
+                  className="text-muted-foreground"
+                  aria-label="Collapse all"
+                  onClick={collapseAll}
+                >
+                  <ChevronsDownUp className="size-4" />
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent side="bottom">Collapse all</TooltipContent>
+            </Tooltip>
           )}
         </div>
       </div>
@@ -331,7 +323,12 @@ export function DashboardShell({ toolbarMenuItems, hideTitleBar, hideMenu }: Das
           list?.focus({ preventScroll: true });
         }}
       >
-        <main className="overflow-hidden">
+        {/* No overflow-hidden here: when the project list grows past the
+            viewport, clipping main makes Radix's ScrollArea miss the
+            overflowing content and stop scroll-max early. The list still
+            keeps horizontal text truncation via min-w-0 + truncate on its
+            children. pb-3 gives the last row breathing room. */}
+        <main className="pb-3">
           {loading ? (
             <div className="flex items-center justify-center py-12">
               <Spinner className="size-5 text-muted-foreground" />
@@ -351,7 +348,7 @@ export function DashboardShell({ toolbarMenuItems, hideTitleBar, hideMenu }: Das
               </Button>
             </div>
           ) : (
-            <ProjectList labelFilter={labelFilter} editMode={editMode} />
+            <ProjectList labelFilter={labelFilter} />
           )}
         </main>
       </ScrollArea>

--- a/packages/dashboard-core/src/components/ProjectList.tsx
+++ b/packages/dashboard-core/src/components/ProjectList.tsx
@@ -18,7 +18,9 @@ import {
   type DragEndEvent,
   DragOverlay,
   type DragStartEvent,
-  PointerSensor,
+  MouseSensor,
+  TouchSensor,
+  useDndContext,
   useDroppable,
   useSensor,
   useSensors,
@@ -32,16 +34,22 @@ import {
 import { CSS } from "@dnd-kit/utilities";
 import {
   Check,
+  ChevronRight,
   Clipboard,
+  Folder,
   FolderOpen,
-  GripVertical,
   ListMinus,
   Plus,
   Tag,
-  Trash2,
 } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useCapabilities } from "../context";
+import {
+  LABELS_COLLAPSE_KEY,
+  PROJECTS_COLLAPSE_KEY,
+  UNLABELED_KEY,
+  useCollapseState,
+} from "../hooks/use-collapse-state";
 import {
   useRemoveProject,
   useRemoveWorkspace,
@@ -76,7 +84,8 @@ interface SortableProjectProps {
   onShowDeleteDialog: (info: DeleteDialogInfo) => void;
   focusedIndex: number;
   workspaceIndexStart: number;
-  editMode: boolean;
+  collapsed: boolean;
+  onToggleCollapse: (name: string) => void;
 }
 
 function SortableProject({
@@ -91,17 +100,24 @@ function SortableProject({
   onShowDeleteDialog,
   focusedIndex,
   workspaceIndexStart,
-  editMode,
+  collapsed,
+  onToggleCollapse,
 }: SortableProjectProps) {
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
     id: project.name,
-    disabled: !editMode,
   });
   const capabilities = useCapabilities();
+  // `active` is the currently-dragged item (or null when nothing is being
+  // dragged). We only honour dnd-kit's `transition` while a drag is in
+  // progress: that keeps the smooth slide-out-of-the-way animation while
+  // dragging, but on drop the transition disappears so items snap to their
+  // optimistic new positions instead of animating from old → new (which
+  // looks like the list "shifting" after the drop).
+  const { active } = useDndContext();
 
   const style = {
     transform: CSS.Translate.toString(transform),
-    transition,
+    transition: active ? transition : undefined,
     opacity: isDragging ? 0.5 : undefined,
   };
 
@@ -111,13 +127,35 @@ function SortableProject({
     <div ref={setNodeRef} style={style} className="min-w-0 px-2">
       <ContextMenu>
         <ContextMenuTrigger asChild>
-          <div className="flex items-center justify-between mb-0.5 px-1 select-none">
+          {/* The header is a click/tap-to-toggle target on both desktop and
+              mobile. We don't add tabIndex/keyboard handlers here because
+              keyboard navigation lives one level down (workspace cards).
+              Keyboard users can toggle collapse via the right-click context
+              menu's Collapse/Expand entry, which is reachable with Shift+F10
+              or the Menu key. */}
+          {/* biome-ignore lint/a11y/useKeyWithClickEvents: keyboard path is the context menu (see comment above) */}
+          <div
+            // touch-pan-y lets touch devices scroll the list vertically with
+            // a finger over the project header — the TouchSensor still gets
+            // long-presses (delay activation) but stops blocking page scroll.
+            className="group flex items-center justify-between mb-0.5 px-1 select-none touch-pan-y"
+            onClick={() => onToggleCollapse(project.name)}
+          >
+            {/* Drag listeners live on the title (folder icon + project name)
+                so the project name itself is the drag handle. The 8px
+                MouseSensor / 250ms TouchSensor thresholds mean a still
+                click/tap bubbles up to the outer onClick (which toggles
+                collapse) without starting a drag. */}
             <div
-              className={`flex items-center gap-2 min-w-0 ${editMode ? "cursor-grab touch-none" : ""}`}
-              {...(editMode ? { ...attributes, ...listeners } : {})}
+              className="flex items-center gap-2 min-w-0 cursor-grab"
+              {...attributes}
+              {...listeners}
             >
-              {editMode && <GripVertical className="size-4 shrink-0 text-muted-foreground" />}
-              <FolderOpen className="size-4 shrink-0 text-muted-foreground" />
+              {collapsed ? (
+                <Folder className="size-4 shrink-0 text-muted-foreground" />
+              ) : (
+                <FolderOpen className="size-4 shrink-0 text-muted-foreground" />
+              )}
               <Tooltip>
                 <TooltipTrigger asChild>
                   <h2 className="text-sm font-semibold text-foreground/80 truncate">
@@ -128,38 +166,30 @@ function SortableProject({
               </Tooltip>
             </div>
             <div className="flex items-center gap-1">
-              {editMode ? (
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <Button
-                      variant="ghost"
-                      size="icon-xs"
-                      className="text-destructive hover:text-destructive"
-                      onClick={() => removeProject(project.name)}
-                    >
-                      <Trash2 />
-                    </Button>
-                  </TooltipTrigger>
-                  <TooltipContent>Remove project</TooltipContent>
-                </Tooltip>
-              ) : (
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <Button
-                      variant="ghost"
-                      size="icon-xs"
-                      onClick={() => setWorkspaceDialog(project.name)}
-                    >
-                      <Plus />
-                    </Button>
-                  </TooltipTrigger>
-                  <TooltipContent>Add workspace</TooltipContent>
-                </Tooltip>
-              )}
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button
+                    variant="ghost"
+                    size="icon-xs"
+                    onPointerDown={(e) => e.stopPropagation()}
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      setWorkspaceDialog(project.name);
+                    }}
+                  >
+                    <Plus />
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent>Add workspace</TooltipContent>
+              </Tooltip>
             </div>
           </div>
         </ContextMenuTrigger>
         <ContextMenuContent>
+          <ContextMenuItem onClick={() => onToggleCollapse(project.name)}>
+            <ChevronRight className={collapsed ? "" : "rotate-90"} />
+            {collapsed ? "Expand" : "Collapse"}
+          </ContextMenuItem>
           {labels.length > 0 && (
             <ContextMenuSub>
               <ContextMenuSubTrigger>
@@ -208,65 +238,97 @@ function SortableProject({
         </ContextMenuContent>
       </ContextMenu>
 
-      <div className="flex flex-col gap-0.5 overflow-hidden">
-        {project.worktrees.length === 0 ? (
-          <p className="text-sm text-muted-foreground px-4 py-2">No workspaces yet</p>
-        ) : (
-          project.worktrees.map((wt) => {
-            const wsId = toWorkspaceId(project.name, wt.branch);
-            const currentIndex = workspaceIndex++;
-            return (
-              <WorkspaceCard
-                key={wt.branch}
-                worktree={wt}
-                projectName={project.name}
-                defaultBranch={project.defaultBranch}
-                status={statuses.get(wsId)}
-                branchStatus={branchStatuses.get(wsId)}
-                setupStatus={setupStatuses.get(wsId)}
-                isFocused={currentIndex === focusedIndex}
-                onShowDeleteDialog={onShowDeleteDialog}
-                editMode={editMode}
-              />
-            );
-          })
-        )}
-      </div>
+      {!collapsed && (
+        <div className="flex flex-col gap-0.5 overflow-hidden">
+          {project.worktrees.length === 0 ? (
+            <p className="text-sm text-muted-foreground px-4 py-2">No workspaces yet</p>
+          ) : (
+            project.worktrees.map((wt) => {
+              const wsId = toWorkspaceId(project.name, wt.branch);
+              const currentIndex = workspaceIndex++;
+              return (
+                <WorkspaceCard
+                  key={wt.branch}
+                  worktree={wt}
+                  projectName={project.name}
+                  defaultBranch={project.defaultBranch}
+                  status={statuses.get(wsId)}
+                  branchStatus={branchStatuses.get(wsId)}
+                  setupStatus={setupStatuses.get(wsId)}
+                  isFocused={currentIndex === focusedIndex}
+                  onShowDeleteDialog={onShowDeleteDialog}
+                />
+              );
+            })
+          )}
+        </div>
+      )}
     </div>
   );
 }
 
-function DroppableLabelHeader({ labelId, label }: { labelId: string; label: LabelDefinition }) {
+interface DroppableLabelHeaderProps {
+  labelId: string;
+  label: LabelDefinition;
+  collapsed: boolean;
+  onToggle: () => void;
+}
+
+function DroppableLabelHeader({ labelId, label, collapsed, onToggle }: DroppableLabelHeaderProps) {
   const { setNodeRef, isOver } = useDroppable({ id: `group:${labelId}` });
   return (
-    <div
+    <button
+      type="button"
       ref={setNodeRef}
-      className={`flex h-9 items-center gap-2 px-3 mb-0.5 transition-colors ${isOver ? "bg-primary/20" : "bg-accent"}`}
+      onClick={onToggle}
+      aria-expanded={!collapsed}
+      className={`flex h-9 w-full items-center gap-2 px-3 mb-0.5 text-left transition-colors hover:bg-primary/10 ${
+        isOver ? "bg-primary/20" : "bg-accent"
+      }`}
     >
       <span className="size-2.5 rounded-full shrink-0" style={{ backgroundColor: label.color }} />
       <span className="text-sm font-semibold text-foreground/80">{label.name}</span>
-    </div>
+      <ChevronRight
+        className={`ml-auto size-3.5 shrink-0 text-muted-foreground transition-transform ${
+          collapsed ? "" : "rotate-90"
+        }`}
+      />
+    </button>
   );
 }
 
-function DroppableUnlabeledHeader() {
+interface DroppableUnlabeledHeaderProps {
+  collapsed: boolean;
+  onToggle: () => void;
+}
+
+function DroppableUnlabeledHeader({ collapsed, onToggle }: DroppableUnlabeledHeaderProps) {
   const { setNodeRef, isOver } = useDroppable({ id: "group:__unlabeled" });
   return (
-    <div
+    <button
+      type="button"
       ref={setNodeRef}
-      className={`flex h-9 items-center gap-2 px-3 mb-0.5 transition-colors ${isOver ? "bg-primary/20" : "bg-accent"}`}
+      onClick={onToggle}
+      aria-expanded={!collapsed}
+      className={`flex h-9 w-full items-center gap-2 px-3 mb-0.5 text-left transition-colors hover:bg-primary/10 ${
+        isOver ? "bg-primary/20" : "bg-accent"
+      }`}
     >
       <span className="text-sm font-semibold text-foreground/80">Unlabeled</span>
-    </div>
+      <ChevronRight
+        className={`ml-auto size-3.5 shrink-0 text-muted-foreground transition-transform ${
+          collapsed ? "" : "rotate-90"
+        }`}
+      />
+    </button>
   );
 }
 
 interface ProjectListProps {
   labelFilter: string | null;
-  editMode: boolean;
 }
 
-export function ProjectList({ labelFilter, editMode }: ProjectListProps) {
+export function ProjectList({ labelFilter }: ProjectListProps) {
   const { projects } = useProjects();
   const { settings } = useSettingsQuery();
   const labels = settings.labels ?? [];
@@ -288,7 +350,18 @@ export function ProjectList({ labelFilter, editMode }: ProjectListProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const keyboardNavRef = useRef(false);
 
-  const sensors = useSensors(useSensor(PointerSensor, { activationConstraint: { distance: 8 } }));
+  const projectCollapse = useCollapseState(PROJECTS_COLLAPSE_KEY);
+  const labelCollapse = useCollapseState(LABELS_COLLAPSE_KEY);
+
+  // Two sensors so reorder works without an explicit "edit" toggle:
+  //  • MouseSensor — desktop pointers can drag immediately; an 8px distance
+  //    threshold avoids hijacking ordinary clicks on the project header.
+  //  • TouchSensor — touch devices require a long-press (250ms) before drag
+  //    activates so taps and scrolling still work normally on mobile.
+  const sensors = useSensors(
+    useSensor(MouseSensor, { activationConstraint: { distance: 8 } }),
+    useSensor(TouchSensor, { activationConstraint: { delay: 250, tolerance: 5 } }),
+  );
 
   const groups = useMemo(() => {
     if (labels.length === 0)
@@ -324,25 +397,38 @@ export function ProjectList({ labelFilter, editMode }: ProjectListProps) {
     return groups.filter((g) => g.labelId === labelFilter);
   }, [groups, labelFilter]);
 
-  const allWorkspaceIds = useMemo(
-    () =>
-      visibleGroups.flatMap((g) =>
-        g.projects.flatMap((p) => p.worktrees.map((wt) => toWorkspaceId(p.name, wt.branch))),
-      ),
-    [visibleGroups],
-  );
+  // Only count workspaces that are actually rendered — collapsed
+  // projects/labels hide their workspaces entirely, and keyboard arrow
+  // navigation must skip over them so focus never lands on something the
+  // user can't see.
+  const allWorkspaceIds = useMemo(() => {
+    const headerVisible = labels.length > 0 && !labelFilter;
+    return visibleGroups.flatMap((g) => {
+      const groupKey = g.labelId ?? UNLABELED_KEY;
+      if (headerVisible && labelCollapse.isCollapsed(groupKey)) return [];
+      return g.projects.flatMap((p) => {
+        if (projectCollapse.isCollapsed(p.name)) return [];
+        return p.worktrees.map((wt) => toWorkspaceId(p.name, wt.branch));
+      });
+    });
+  }, [visibleGroups, labels.length, labelFilter, labelCollapse, projectCollapse]);
 
   const workspaceIndexMap = useMemo(() => {
     const map = new Map<string, number>();
     let index = 0;
+    const headerVisible = labels.length > 0 && !labelFilter;
     for (const group of visibleGroups) {
+      const groupKey = group.labelId ?? UNLABELED_KEY;
+      if (headerVisible && labelCollapse.isCollapsed(groupKey)) continue;
       for (const project of group.projects) {
         map.set(project.name, index);
-        index += project.worktrees.length;
+        if (!projectCollapse.isCollapsed(project.name)) {
+          index += project.worktrees.length;
+        }
       }
     }
     return map;
-  }, [visibleGroups]);
+  }, [visibleGroups, labels.length, labelFilter, labelCollapse, projectCollapse]);
 
   useEffect(() => {
     if (keyboardNavRef.current) return;
@@ -494,46 +580,69 @@ export function ProjectList({ labelFilter, editMode }: ProjectListProps) {
           onDragEnd={handleDragEnd}
         >
           <SortableContext items={allProjectNames} strategy={verticalListSortingStrategy}>
-            {visibleGroups.map((group, groupIndex) => (
-              <div key={group.labelId ?? "__unlabeled"}>
-                {groupIndex > 0 && !labels.length && (
-                  <hr className="border-border mt-1 mb-0.5 mx-2" />
-                )}
-                {labels.length > 0 &&
-                  !labelFilter &&
-                  (group.label ? (
-                    <DroppableLabelHeader labelId={group.labelId!} label={group.label} />
-                  ) : (
-                    <DroppableUnlabeledHeader />
-                  ))}
-                {group.projects.map((project, index) => (
-                  <div key={project.name}>
-                    {index > 0 && <hr className="border-border mt-1 mb-0.5 mx-2" />}
-                    <SortableProject
-                      project={project}
-                      statuses={statuses}
-                      branchStatuses={branchStatuses}
-                      setupStatuses={setupStatuses}
-                      removeProject={(name) => removeProjectMutation.mutate(name)}
-                      updateProjectLabel={(name, label) =>
-                        updateProjectLabelMutation.mutate({ name, label })
-                      }
-                      labels={labels}
-                      setWorkspaceDialog={setWorkspaceDialog}
-                      onShowDeleteDialog={setDeleteDialog}
-                      focusedIndex={focusedIndex}
-                      workspaceIndexStart={workspaceIndexMap.get(project.name) ?? 0}
-                      editMode={editMode}
-                    />
-                  </div>
-                ))}
-              </div>
-            ))}
+            {visibleGroups.map((group, groupIndex) => {
+              const groupKey = group.labelId ?? UNLABELED_KEY;
+              // When a label filter is active we render a single group without
+              // a header, so honour the group's collapsed state only when the
+              // header is visible (otherwise users would have no way to expand
+              // it again). Same for the no-labels mode.
+              const headerVisible = labels.length > 0 && !labelFilter;
+              const groupCollapsed = headerVisible && labelCollapse.isCollapsed(groupKey);
+              return (
+                <div key={groupKey}>
+                  {groupIndex > 0 && !labels.length && (
+                    <hr className="border-border mt-1 mb-0.5 mx-2" />
+                  )}
+                  {headerVisible &&
+                    (group.label ? (
+                      <DroppableLabelHeader
+                        labelId={group.labelId!}
+                        label={group.label}
+                        collapsed={groupCollapsed}
+                        onToggle={() => labelCollapse.toggle(groupKey)}
+                      />
+                    ) : (
+                      <DroppableUnlabeledHeader
+                        collapsed={groupCollapsed}
+                        onToggle={() => labelCollapse.toggle(groupKey)}
+                      />
+                    ))}
+                  {!groupCollapsed &&
+                    group.projects.map((project, index) => (
+                      <div key={project.name}>
+                        {index > 0 && <hr className="border-border mt-1 mb-0.5 mx-2" />}
+                        <SortableProject
+                          project={project}
+                          statuses={statuses}
+                          branchStatuses={branchStatuses}
+                          setupStatuses={setupStatuses}
+                          removeProject={(name) => removeProjectMutation.mutate(name)}
+                          updateProjectLabel={(name, label) =>
+                            updateProjectLabelMutation.mutate({ name, label })
+                          }
+                          labels={labels}
+                          setWorkspaceDialog={setWorkspaceDialog}
+                          onShowDeleteDialog={setDeleteDialog}
+                          focusedIndex={focusedIndex}
+                          workspaceIndexStart={workspaceIndexMap.get(project.name) ?? 0}
+                          collapsed={projectCollapse.isCollapsed(project.name)}
+                          onToggleCollapse={projectCollapse.toggle}
+                        />
+                      </div>
+                    ))}
+                </div>
+              );
+            })}
           </SortableContext>
-          <DragOverlay>
+          {/* dropAnimation={null} disables dnd-kit's default snap-back. The
+              reorder mutation runs an optimistic update in onMutate, so when
+              the user releases we want the overlay to disappear instantly
+              and the list to look like the new order — not animate back to
+              the original drop position before re-rendering. */}
+          <DragOverlay dropAnimation={null}>
             {activeDragId ? (
               <div className="flex items-center gap-2 px-1 py-1 bg-background rounded shadow-lg border">
-                <FolderOpen className="size-3.5 shrink-0 text-muted-foreground" />
+                <Folder className="size-3.5 shrink-0 text-muted-foreground" />
                 <span className="text-sm font-semibold text-foreground">{activeDragId}</span>
               </div>
             ) : null}

--- a/packages/dashboard-core/src/components/WorkspaceCard.tsx
+++ b/packages/dashboard-core/src/components/WorkspaceCard.tsx
@@ -42,7 +42,6 @@ interface Props {
   setupStatus?: SetupStatus;
   isFocused?: boolean;
   onShowDeleteDialog: (info: DeleteDialogInfo) => void;
-  editMode?: boolean;
 }
 
 export const WorkspaceCard = memo(function WorkspaceCard({
@@ -54,7 +53,6 @@ export const WorkspaceCard = memo(function WorkspaceCard({
   setupStatus,
   isFocused,
   onShowDeleteDialog,
-  editMode,
 }: Props) {
   const cardRef = useRef<HTMLDivElement>(null);
   const capabilities = useCapabilities();
@@ -139,13 +137,11 @@ export const WorkspaceCard = memo(function WorkspaceCard({
             </TooltipTrigger>
             <TooltipContent side="top">{worktree.branch}</TooltipContent>
           </Tooltip>
-          {!editMode && (
-            <div className="hidden @[10rem]:flex group-hover:flex items-center gap-2 shrink-0 ml-auto pl-2">
-              <SetupStatusIndicator setup={setupStatus} />
-              {branchStatus && <GitStatusIndicator git={branchStatus.git} />}
-              {branchStatus && <CIStatusIndicator ci={branchStatus.ci} />}
-            </div>
-          )}
+          <div className="hidden @[10rem]:flex group-hover:flex items-center gap-2 shrink-0 ml-auto pl-2">
+            <SetupStatusIndicator setup={setupStatus} />
+            {branchStatus && <GitStatusIndicator git={branchStatus.git} />}
+            {branchStatus && <CIStatusIndicator ci={branchStatus.ci} />}
+          </div>
         </div>
       </ContextMenuTrigger>
       <ContextMenuContent>

--- a/packages/dashboard-core/src/hooks/use-collapse-state.ts
+++ b/packages/dashboard-core/src/hooks/use-collapse-state.ts
@@ -1,0 +1,105 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+
+/**
+ * Tracks which items in a collection are collapsed, persisting the set to
+ * localStorage so the state survives page reloads. Used by the project list
+ * to remember which projects and label groups the user has collapsed.
+ *
+ * The state is stored as a JSON-serialised array of string ids; missing keys
+ * mean "expanded" so brand-new projects/labels show up expanded by default.
+ */
+
+/** localStorage key for the collapsed-projects set (project names). */
+export const PROJECTS_COLLAPSE_KEY = "band.projects-list.collapsed-projects";
+/** localStorage key for the collapsed-label-groups set (label ids + UNLABELED_KEY). */
+export const LABELS_COLLAPSE_KEY = "band.projects-list.collapsed-labels";
+/** Sentinel id for the "Unlabeled" group — it has no real label.id. */
+export const UNLABELED_KEY = "__unlabeled";
+
+/** Custom event used to broadcast same-tab updates. The native `storage`
+ *  event only fires across tabs, so we dispatch this on every write. */
+const SYNC_EVENT = "band:collapse-state-change";
+
+function read(key: string): Set<string> {
+  if (typeof window === "undefined") return new Set();
+  try {
+    const raw = window.localStorage.getItem(key);
+    if (!raw) return new Set();
+    const parsed = JSON.parse(raw);
+    if (Array.isArray(parsed))
+      return new Set(parsed.filter((v): v is string => typeof v === "string"));
+  } catch {
+    // Corrupted entry — start fresh
+  }
+  return new Set();
+}
+
+function write(key: string, set: Set<string>): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(key, JSON.stringify([...set]));
+  } catch {
+    // localStorage full or unavailable — ignore
+  }
+  window.dispatchEvent(new CustomEvent(SYNC_EVENT, { detail: { key } }));
+}
+
+export interface CollapseState {
+  isCollapsed: (id: string) => boolean;
+  toggle: (id: string) => void;
+  /** Replace the entire collapsed set in one shot (used for collapse-all). */
+  setAll: (ids: Iterable<string>) => void;
+}
+
+export function useCollapseState(storageKey: string): CollapseState {
+  const [collapsed, setCollapsed] = useState<Set<string>>(() => read(storageKey));
+
+  // Sync across tabs *and* across same-tab consumers. The native `storage`
+  // event covers cross-tab; the SYNC_EVENT fires from `write` so a setAll
+  // call (e.g. from the toolbar's Collapse-all button) immediately re-renders
+  // every component that uses the same storage key.
+  useEffect(() => {
+    const sync = (e: Event) => {
+      if (e instanceof StorageEvent && e.key !== storageKey) return;
+      if (e instanceof CustomEvent && e.detail?.key !== storageKey) return;
+      setCollapsed(read(storageKey));
+    };
+    window.addEventListener("storage", sync);
+    window.addEventListener(SYNC_EVENT, sync);
+    return () => {
+      window.removeEventListener("storage", sync);
+      window.removeEventListener(SYNC_EVENT, sync);
+    };
+  }, [storageKey]);
+
+  const isCollapsed = useCallback((id: string) => collapsed.has(id), [collapsed]);
+
+  const toggle = useCallback(
+    (id: string) => {
+      setCollapsed((prev) => {
+        const next = new Set(prev);
+        if (next.has(id)) {
+          next.delete(id);
+        } else {
+          next.add(id);
+        }
+        write(storageKey, next);
+        return next;
+      });
+    },
+    [storageKey],
+  );
+
+  const setAll = useCallback(
+    (ids: Iterable<string>) => {
+      const next = new Set(ids);
+      write(storageKey, next);
+      setCollapsed(next);
+    },
+    [storageKey],
+  );
+
+  // Memoised so consumers can use the returned object as a useMemo/useEffect
+  // dependency without triggering work on every render.
+  return useMemo(() => ({ isCollapsed, toggle, setAll }), [isCollapsed, toggle, setAll]);
+}


### PR DESCRIPTION
## Summary
- Replace the explicit "Edit list" toggle with always-on reorder: MouseSensor (8px distance) on desktop and TouchSensor (250ms long-press) on mobile, so reorder works without any mode switch.
- Project rows and label groups can now be collapsed/expanded; state is persisted in localStorage and synced same-tab via a custom event so a new toolbar "Collapse all" button (next to Add project) re-renders instantly.
- Folder icon swaps Open/Closed with the collapse state. Mobile and desktop render the same header — click the title toggles, drag the title reorders.
- Reorder is optimistic (React Query `onMutate`), drop animation disabled, and sortable transitions only run while a drag is in progress so the list doesn't visibly shift after release.
- Removed `overflow-hidden` from `<main>` so the ScrollArea can measure the full list height when many groups are expanded.
- Updated `docs/projects.astro` and the `remote-access.astro` screenshot alt text to drop the Edit-list flow.

## Test plan
- [ ] Drag a project on desktop — order updates the moment you release, no fly-back animation, no post-drop shift.
- [ ] Long-press a project on mobile to drag; quick taps don't start a drag.
- [ ] Tap/click a project header — collapse/expand toggles; state survives reload.
- [ ] Right-click a project — Collapse/Expand item in the context menu still works (keyboard-accessible path).
- [ ] Click "Collapse all" in the toolbar — every project and label group collapses immediately.
- [ ] Expand all label groups with many projects — scroll reaches the very bottom (was previously clipped).
- [ ] Drag a project between label groups to reassign label.

🤖 Generated with [Claude Code](https://claude.com/claude-code)