### PR TITLE
ci: add Claude PR review workflow gated on collaborator status

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,0 +1,105 @@
+name: Claude PR Review
+
+# Automated review of pull requests by Anthropic's Claude.
+#
+# WHY pull_request (and NOT pull_request_target):
+#   - pull_request runs against the PR head, which is what we want to review.
+#   - pull_request from forks does NOT receive repository secrets (per GitHub
+#     policy), so even without our author check the ANTHROPIC_API_KEY would
+#     never be exposed to a fork's checked-out code. The author_association
+#     gate below is therefore a *budget / noise* control — not a credential
+#     boundary. Forks already cannot read the key.
+#   - pull_request_target would run against the base ref WITH secrets exposed.
+#     That is the well-known "pwn request" attack pattern. Don't switch to it.
+#
+# WHY the author_association gate:
+#   - Without it we would burn API credits on every drive-by fork PR. Costs
+#     and review noise are both unbounded. We only auto-review PRs from people
+#     already trusted with the repo (OWNER / MEMBER / COLLABORATOR).
+#   - Outside contributors come back as CONTRIBUTOR or NONE and are skipped.
+#     Dependabot reports as NONE; if you want Claude to review dependabot PRs,
+#     add `|| github.actor == 'dependabot[bot]'` to the gate.
+#   - DO NOT loosen this gate without team discussion. The check lives at the
+#     job level, not just the step level, so the runner never spins up for
+#     skipped PRs.
+#
+# OPTIONAL EXTENSION — issue_comment trigger:
+#   To let collaborators re-run the review by commenting `/claude review` on a
+#   PR, add `issue_comment: types: [created]` to `on:` and an `issues: write`
+#   permission, and extend the `if:` with a parallel branch that uses
+#   `github.event.comment.author_association` (different field) plus
+#   `startsWith(github.event.comment.body, '/claude review')`. The gate is
+#   *critical* there because issue_comment runs in the base repo context with
+#   secrets exposed.
+#
+# REQUIRED REPO SECRET:
+#   CLAUDE_CODE_OAUTH_TOKEN — generated locally by running `claude setup-token`
+#   while signed into a Claude Pro / Max account, then added at
+#   Settings → Secrets and variables → Actions → New repository secret.
+#   Usage bills against the token holder's Claude subscription quota (not a
+#   metered API account), so if PR volume grows, watch quota and consider
+#   switching to `anthropic_api_key` with a metered key instead.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+# Cancel an in-flight review when a new commit lands on the same PR so a
+# rapid re-push doesn't double-bill the API.
+concurrency:
+  group: claude-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+# Minimum permissions the action needs to read the diff and post a review.
+# Do NOT add id-token, actions: write, or other broad scopes unless the
+# action's docs explicitly require them for a feature you're using.
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  review:
+    name: Claude review
+    runs-on: ubuntu-latest
+
+    # Budget gate — see header comment. OWNER / MEMBER / COLLABORATOR are the
+    # three "trusted" author_association values; everything else (CONTRIBUTOR,
+    # FIRST_TIME_CONTRIBUTOR, FIRST_TIMER, NONE, MANNEQUIN) is skipped.
+    if: >
+      contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'),
+               github.event.pull_request.author_association)
+
+    steps:
+      - name: Checkout PR head
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude review
+        # Pinned to the v1 stable tag of the official Anthropic action.
+        # See https://github.com/anthropics/claude-code-action/releases — bump
+        # this deliberately when reviewing release notes; do not pin to @main.
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          prompt: |
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ github.event.pull_request.number }}
+
+            Please review this pull request. The PR branch is checked out in
+            the working directory; you can also use `gh pr diff` and
+            `gh pr view` for context.
+
+            Focus on:
+            - Correctness and obvious bugs.
+            - Security and credential handling.
+            - Test coverage. This repo prefers integration tests over mocked
+              unit tests — see CLAUDE.md and CONTRIBUTING.md for the rules.
+            - Adherence to existing patterns in the codebase.
+            - Performance regressions in hot paths.
+
+            Use inline review comments for specific findings (cite line
+            numbers). Use a single top-level comment for the overall summary.
+            Be specific and actionable; skip generic praise.
+          claude_args: |
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -51,17 +51,22 @@ concurrency:
   cancel-in-progress: true
 
 # Minimum permissions the action needs.
-#   contents: read         — to fetch the PR head.
-#   pull-requests: write   — to post review comments.
-#   id-token: write        — claude-code-action@v1 mints its own GitHub App
-#                            token via OIDC at runtime; without this the
-#                            action fails with "Could not fetch an OIDC token".
-# Do NOT add `actions: write` or anything broader unless a future version of
-# the action's docs explicitly requires it.
+#   contents: read       — to fetch the PR head.
+#   pull-requests: write — to post review comments via the workflow's
+#                          auto-provisioned GITHUB_TOKEN (passed explicitly
+#                          to the action below). With github_token supplied,
+#                          the action does NOT require the Claude Code
+#                          GitHub App to be installed on the repo and does
+#                          not need id-token: write for an App-token OIDC
+#                          exchange. Trade-off: review comments are posted
+#                          as `github-actions[bot]` instead of `claude[bot]`.
+#                          If you'd rather have the claude[bot] identity,
+#                          install https://github.com/apps/claude on the
+#                          repo, drop the github_token input below, and
+#                          add `id-token: write` here.
 permissions:
   contents: read
   pull-requests: write
-  id-token: write
 
 jobs:
   review:
@@ -88,6 +93,10 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # Use the workflow's auto-provisioned token instead of the
+          # claude[bot] GitHub App. Avoids the App-install requirement;
+          # comments post as github-actions[bot]. See permissions comment.
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           prompt: |
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -51,7 +51,7 @@ concurrency:
   cancel-in-progress: true
 
 # Minimum permissions the action needs.
-#   contents: read       — read repo metadata via the GitHub API.
+#   contents: read       — to clone the PR head and fetch base for diff.
 #   pull-requests: write — to post review comments via the workflow's
 #                          auto-provisioned GITHUB_TOKEN (passed explicitly
 #                          to the action below). With github_token supplied,
@@ -83,13 +83,17 @@ jobs:
       contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'),
                github.event.pull_request.author_association)
 
-    # No checkout step: Claude only has the `gh pr diff` / `gh pr view`
-    # subcommands (see claude_args below) plus the GitHub inline-comment
-    # tool — no `Read` or general `Bash` — so a checked-out working
-    # directory would be inert. The action fetches PR context over the
-    # GitHub API using github_token. If you later grant Claude file-system
-    # access, add `actions/checkout@v6` back here.
+    # Checkout is required by the action itself — it runs
+    # `git fetch origin main` internally to compute diff context — even
+    # though Claude's tool palette (see claude_args below) is restricted
+    # to `gh pr diff` / `gh pr view` and the inline-comment MCP tool, with
+    # no `Read` or general `Bash` access to the checked-out tree.
     steps:
+      - name: Checkout PR head
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
       - name: Run Claude review
         # Pinned to the v1 stable tag of the official Anthropic action.
         # See https://github.com/anthropics/claude-code-action/releases — bump
@@ -105,8 +109,10 @@ jobs:
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ github.event.pull_request.number }}
 
-            Please review this pull request. Use `gh pr diff` and `gh pr view`
-            for the changes and PR metadata.
+            Please review this pull request. The repository is checked out
+            for the action's internal use, but your tool palette is
+            restricted to `gh pr diff` and `gh pr view` — use those for the
+            changes and PR metadata.
 
             Focus on:
             - Correctness and obvious bugs.

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -50,12 +50,18 @@ concurrency:
   group: claude-review-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
-# Minimum permissions the action needs to read the diff and post a review.
-# Do NOT add id-token, actions: write, or other broad scopes unless the
-# action's docs explicitly require them for a feature you're using.
+# Minimum permissions the action needs.
+#   contents: read         — to fetch the PR head.
+#   pull-requests: write   — to post review comments.
+#   id-token: write        — claude-code-action@v1 mints its own GitHub App
+#                            token via OIDC at runtime; without this the
+#                            action fails with "Could not fetch an OIDC token".
+# Do NOT add `actions: write` or anything broader unless a future version of
+# the action's docs explicitly requires it.
 permissions:
   contents: read
   pull-requests: write
+  id-token: write
 
 jobs:
   review:

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -5,8 +5,8 @@ name: Claude PR Review
 # WHY pull_request (and NOT pull_request_target):
 #   - pull_request runs against the PR head, which is what we want to review.
 #   - pull_request from forks does NOT receive repository secrets (per GitHub
-#     policy), so even without our author check the ANTHROPIC_API_KEY would
-#     never be exposed to a fork's checked-out code. The author_association
+#     policy), so even without our author check the CLAUDE_CODE_OAUTH_TOKEN
+#     would never be exposed to a fork's checked-out code. The author_association
 #     gate below is therefore a *budget / noise* control — not a credential
 #     boundary. Forks already cannot read the key.
 #   - pull_request_target would run against the base ref WITH secrets exposed.
@@ -51,7 +51,7 @@ concurrency:
   cancel-in-progress: true
 
 # Minimum permissions the action needs.
-#   contents: read       — to fetch the PR head.
+#   contents: read       — read repo metadata via the GitHub API.
 #   pull-requests: write — to post review comments via the workflow's
 #                          auto-provisioned GITHUB_TOKEN (passed explicitly
 #                          to the action below). With github_token supplied,
@@ -72,6 +72,9 @@ jobs:
   review:
     name: Claude review
     runs-on: ubuntu-latest
+    # Hard cap so a runaway action doesn't hold the concurrency slot for
+    # hours or drain subscription quota. Reviews usually finish in <5 min.
+    timeout-minutes: 15
 
     # Budget gate — see header comment. OWNER / MEMBER / COLLABORATOR are the
     # three "trusted" author_association values; everything else (CONTRIBUTOR,
@@ -80,12 +83,13 @@ jobs:
       contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'),
                github.event.pull_request.author_association)
 
+    # No checkout step: Claude only has the `gh pr diff` / `gh pr view`
+    # subcommands (see claude_args below) plus the GitHub inline-comment
+    # tool — no `Read` or general `Bash` — so a checked-out working
+    # directory would be inert. The action fetches PR context over the
+    # GitHub API using github_token. If you later grant Claude file-system
+    # access, add `actions/checkout@v6` back here.
     steps:
-      - name: Checkout PR head
-        uses: actions/checkout@v6
-        with:
-          fetch-depth: 1
-
       - name: Run Claude review
         # Pinned to the v1 stable tag of the official Anthropic action.
         # See https://github.com/anthropics/claude-code-action/releases — bump
@@ -101,9 +105,8 @@ jobs:
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ github.event.pull_request.number }}
 
-            Please review this pull request. The PR branch is checked out in
-            the working directory; you can also use `gh pr diff` and
-            `gh pr view` for context.
+            Please review this pull request. Use `gh pr diff` and `gh pr view`
+            for the changes and PR metadata.
 
             Focus on:
             - Correctness and obvious bugs.
@@ -116,5 +119,5 @@ jobs:
             Use inline review comments for specific findings (cite line
             numbers). Use a single top-level comment for the overall summary.
             Be specific and actionable; skip generic praise.
-          claude_args: |
+          claude_args: |-
             --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -94,6 +94,10 @@ CI does not run automatically on fork PRs to keep costs under control. Here's ho
 3. The maintainer adds the `ci:approved` label to trigger CI.
 4. CI runs. If you push new commits, CI re-runs automatically while the label is present.
 
+## Automated Claude Reviews
+
+PRs opened by project collaborators (OWNER / MEMBER / COLLABORATOR on this repo) automatically receive an AI review from Anthropic's Claude via [`anthropics/claude-code-action`](https://github.com/anthropics/claude-code-action) — see [`.github/workflows/claude-review.yml`](.github/workflows/claude-review.yml). The review posts inline comments on findings plus a single top-level summary; it's advisory, not a required check, and a human reviewer is still expected to sign off. PRs from outside contributors / forks intentionally do **not** trigger the automated review (budget and noise control), and `pull_request` (rather than `pull_request_target`) is used so the `CLAUDE_CODE_OAUTH_TOKEN` secret is never exposed to fork code.
+
 ## What to Contribute
 
 - **Bug fixes** — check [open issues](https://github.com/band-app/band/issues) or report a new one.


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/claude-review.yml` which runs `anthropics/claude-code-action@v1` on `pull_request` (opened/synchronize/reopened) and posts an automated review.
- Gates the job at the **job level** on `author_association ∈ {OWNER, MEMBER, COLLABORATOR}` — outside contributors / forks are skipped (budget + noise control).
- Uses `pull_request`, NOT `pull_request_target`: fork PRs do not receive the `CLAUDE_CODE_OAUTH_TOKEN` secret per GitHub policy, so the author gate is a budget control, not a credential boundary. The header comment in the YAML spells this out so the next editor doesn't loosen it.
- Minimum permissions: `contents: read`, `pull-requests: write`. No `id-token`, no `actions: write`.
- Concurrency group cancels prior runs on the same PR so a quick re-push doesn't double-bill.
- Uses `claude_code_oauth_token` (Pro/Max subscription) — secret name is `CLAUDE_CODE_OAUTH_TOKEN`, generated via `claude setup-token`.
- Short "Automated Claude Reviews" paragraph added to `CONTRIBUTING.md`.

## Test plan

- [ ] Add `CLAUDE_CODE_OAUTH_TOKEN` repo secret (Settings → Secrets and variables → Actions).
- [ ] Confirm this PR triggers the Claude review job and a comment is posted (you are a collaborator, so the gate should pass).
- [ ] Push a follow-up commit and verify the concurrency group cancels the prior in-flight review.
- [ ] (Optional) Spot-check the YAML rationale by reading the header comment — anyone touching this file later should understand the security model without external context.

🤖 Generated with [Claude Code](https://claude.com/claude-code)