### PR TITLE
Address PR #374 review: atomic preview-pin + enableFilePreviewTabs setting

### DIFF
--- a/apps/web/src/components/CodeBrowserView.tsx
+++ b/apps/web/src/components/CodeBrowserView.tsx
@@ -196,12 +196,10 @@ export function CodeBrowserView({
   const fileTabs = useFileTabs(workspaceId);
   const tabState = useTabState(workspaceId);
 
-  // Mirror tab state for synchronous reads inside callbacks. Lets the
-  // preview-open helper stay stable across tab changes, so callbacks
-  // built on top (handleSelectFile, navigateToEntry) don't churn deps
-  // and re-trigger downstream LSP/keyboard effects.
-  const openTabsRef = useRef(fileTabs.openTabs);
-  openTabsRef.current = fileTabs.openTabs;
+  // Mirror tab-state callbacks behind refs. `openPreviewWithGuard` is
+  // memoised on `fileTabs.openTabPreview` alone — these refs let it read
+  // the latest isDirty / removeFile without churning its dep array (which
+  // would re-trigger downstream LSP / keyboard effects every render).
   const isDirtyRef = useRef(tabState.isDirty);
   isDirtyRef.current = tabState.isDirty;
   const removeFileRef = useRef(tabState.removeFile);
@@ -513,7 +511,9 @@ export function CodeBrowserView({
     prevFileRef.current = file;
   }, [file]);
 
-  // Handle externally triggered file open (Quick Open, Search, chat links)
+  // Handle externally triggered file open (Quick Open, Search, chat links).
+  // These are explicit user intentions to open a file — pin the destination
+  // so it isn't silently replaced by the next single-click in the tree.
   // biome-ignore lint/correctness/useExhaustiveDependencies: editorHistory.push is stable (ref-based)
   useEffect(() => {
     if (openFilePath) {
@@ -523,7 +523,7 @@ export function CodeBrowserView({
         line: loc.line ?? 1,
         column: loc.column,
       });
-      fileTabs.openTab(loc.filePath);
+      fileTabs.openTabPinned(loc.filePath);
       setViewFilePath(loc.filePath);
       setViewLine(loc.line);
       setViewLineEnd(loc.lineEnd);
@@ -580,45 +580,64 @@ export function CodeBrowserView({
     search.handleCloseSearch();
   }, [viewFilePath]);
 
-  // Open a file in the preview slot, pinning any dirty preview tab first
-  // (so unsaved edits are never silently dropped) and releasing editor
-  // state for the evicted preview to keep memory bounded. Reads tab state
-  // through refs so the callback identity stays stable across tab changes.
+  // Open a file in the preview slot. `openTabPreview` pins a dirty preview
+  // in place before evicting (single atomic setState updater) so unsaved
+  // edits are never silently dropped. We release editor state for the
+  // evicted (clean) preview to keep memory bounded.
   const openPreviewWithGuard = useCallback(
     (filePath: string) => {
-      const previewTab = openTabsRef.current.find((t) => t.isPreview);
-      if (
-        previewTab &&
-        previewTab.filePath !== filePath &&
-        isDirtyRef.current(previewTab.filePath)
-      ) {
-        fileTabs.pinTab(previewTab.filePath);
-      }
-      const evicted = fileTabs.openTabPreview(filePath);
+      const evicted = fileTabs.openTabPreview(filePath, isDirtyRef.current);
       if (evicted && evicted !== filePath) {
         delete savedEditorStatesRef.current[evicted];
         removeFileRef.current(evicted);
       }
     },
-    [fileTabs.pinTab, fileTabs.openTabPreview],
+    [fileTabs.openTabPreview],
   );
 
+  // Preview-tab behavior is opt-out via the `enableFilePreviewTabs` setting.
+  // The setting defaults to true, matching the PR's new default; when the
+  // user disables it, single-click reverts to the pre-PR pinned-open
+  // behavior. Double-click and edit-auto-pin paths remain functional in
+  // either mode — they're no-ops when there's no preview slot to operate on.
+  const previewTabsEnabled = settings.enableFilePreviewTabs ?? true;
   const handleSelectFile = useCallback(
     (filePath: string) => {
-      pushDepartureAndArrival({ filePath });
-      openPreviewWithGuard(filePath);
+      // History push is deduped by useEditorHistory's proximity check
+      // (same file + close line), so skipping here when the target equals
+      // the current view file just keeps the call site simple — but the
+      // pin/preview branch still needs to run.
+      const isSameFile = filePath === viewFilePath;
+      if (!isSameFile) pushDepartureAndArrival({ filePath });
+      if (previewTabsEnabled) {
+        openPreviewWithGuard(filePath);
+      } else {
+        fileTabs.openTabPinned(filePath);
+      }
       setViewFilePath(filePath);
       setViewLine(undefined);
       setViewLineEnd(undefined);
       setViewColumn(undefined);
       onSelectFile?.(filePath);
     },
-    [onSelectFile, pushDepartureAndArrival, openPreviewWithGuard],
+    [
+      onSelectFile,
+      pushDepartureAndArrival,
+      openPreviewWithGuard,
+      fileTabs.openTabPinned,
+      previewTabsEnabled,
+      viewFilePath,
+    ],
   );
 
   const handleSelectFilePinned = useCallback(
     (filePath: string) => {
-      pushDepartureAndArrival({ filePath });
+      // A double-click on a file in the tree fires `onClick` twice plus
+      // `onDoubleClick` once — so handleSelectFile has already pushed the
+      // navigation and the file is now the current view. Skipping the
+      // push when the target is unchanged keeps history sane on
+      // double-click (and on rapid same-file re-clicks generally).
+      if (filePath !== viewFilePath) pushDepartureAndArrival({ filePath });
       fileTabs.openTabPinned(filePath);
       setViewFilePath(filePath);
       setViewLine(undefined);
@@ -626,7 +645,7 @@ export function CodeBrowserView({
       setViewColumn(undefined);
       onSelectFile?.(filePath);
     },
-    [onSelectFile, pushDepartureAndArrival, fileTabs.openTabPinned],
+    [onSelectFile, pushDepartureAndArrival, fileTabs.openTabPinned, viewFilePath],
   );
 
   const handleBack = useCallback(() => {
@@ -777,7 +796,10 @@ export function CodeBrowserView({
     };
   }, [handleEditorGoBack, handleEditorGoForward]);
 
-  // Listen for LSP cross-file navigation events (e.g., go-to-definition)
+  // Listen for LSP cross-file navigation events (e.g., go-to-definition).
+  // Go-to-definition is an explicit user intent to land on the target — pin
+  // the destination so the next single-click in the tree doesn't silently
+  // replace the file the user just navigated to.
   useEffect(() => {
     const handleLspNavigate = (e: Event) => {
       const detail = (e as CustomEvent).detail;
@@ -785,7 +807,7 @@ export function CodeBrowserView({
         pushDepartureAndArrival({ filePath: detail.filePath });
         // Use skipFileEffectRef to prevent the route change from clobbering nav
         skipFileEffectRef.current = true;
-        fileTabs.openTab(detail.filePath);
+        fileTabs.openTabPinned(detail.filePath);
         setViewFilePath(detail.filePath);
         setViewLine(undefined);
         setViewLineEnd(undefined);
@@ -798,7 +820,7 @@ export function CodeBrowserView({
 
     window.addEventListener("band:lsp-navigate", handleLspNavigate);
     return () => window.removeEventListener("band:lsp-navigate", handleLspNavigate);
-  }, [pushDepartureAndArrival, fileTabs.openTab, onSelectFile]);
+  }, [pushDepartureAndArrival, fileTabs.openTabPinned, onSelectFile]);
 
   // Ctrl+Tab / Ctrl+Shift+Tab to switch between file tabs
   useEffect(() => {

--- a/apps/web/src/hooks/useFileTabs.ts
+++ b/apps/web/src/hooks/useFileTabs.ts
@@ -21,10 +21,20 @@ export interface UseFileTabsReturn {
   openTab: (filePath: string) => void;
   /**
    * Open as a preview tab — replaces any existing preview tab.
-   * Returns the path of the evicted preview tab (if any) so caller can
-   * release its associated editor state / localStorage entries.
+   *
+   * If `isDirty` is provided and the current preview tab is dirty, the
+   * dirty preview is pinned in place (so unsaved edits are never lost)
+   * and the new file is appended as the new preview. Pinning and the
+   * new-preview append happen inside a single setState call so they are
+   * atomic with respect to React's batching — callers can rely on the
+   * returned `evicted` path being safe to discard.
+   *
+   * Returns the path of the evicted preview tab (if any) so the caller
+   * can release its associated editor state / localStorage entries.
+   * Returns null when the preview was pinned (dirty case), when the
+   * file is already open, or when no preview tab existed.
    */
-  openTabPreview: (filePath: string) => string | null;
+  openTabPreview: (filePath: string, isDirty?: (path: string) => boolean) => string | null;
   /** Force-open a pinned tab — creates if missing, pins if existing preview. */
   openTabPinned: (filePath: string) => void;
   /** Convert an existing preview tab into a pinned tab. */
@@ -95,9 +105,16 @@ export function useFileTabs(workspaceId: string): UseFileTabsReturn {
     return saved?.active ?? null;
   });
 
-  // Mirror of openTabs for synchronous reads inside callbacks. Lets us avoid
-  // mutating closure variables from inside setState updaters (which React
-  // documents as unsafe under StrictMode / future concurrent rendering).
+  // Mirror of the React-committed `openTabs` plus any direct-value update
+  // we've just dispatched in the same synchronous tick. Updating this ref
+  // immediately after a `setOpenTabs(next)` call lets consecutive calls in
+  // the same tick see the up-to-date state without waiting for a render.
+  //
+  // We only read this ref inside `openTabPreview`, the one operation that
+  // must atomically decide between "pin the dirty preview and append" vs
+  // "evict the clean preview and replace" — packaging both branches into a
+  // single direct-value setState avoids the original pin-vs-replace race
+  // that arose when those two transitions were issued as separate setStates.
   const openTabsRef = useRef(openTabs);
   openTabsRef.current = openTabs;
 
@@ -150,29 +167,52 @@ export function useFileTabs(workspaceId: string): UseFileTabsReturn {
     setActiveTabPathState(filePath);
   }, []);
 
-  const openTabPreview = useCallback((filePath: string): string | null => {
-    const prev = openTabsRef.current;
-    const existingIdx = prev.findIndex((t) => t.filePath === filePath);
-    // If file already open (preview or pinned), just activate it.
-    if (existingIdx !== -1) {
+  const openTabPreview = useCallback(
+    (filePath: string, isDirty?: (path: string) => boolean): string | null => {
+      const prev = openTabsRef.current;
+
+      // Already open (preview or pinned) — just activate, no eviction.
+      if (prev.some((t) => t.filePath === filePath)) {
+        setActiveTabPathState(filePath);
+        return null;
+      }
+
+      const previewIdx = prev.findIndex((t) => t.isPreview);
+      let evicted: string | null = null;
+      let next: FileTab[];
+
+      if (previewIdx === -1) {
+        // No existing preview — append a new preview tab.
+        next = [...prev, { filePath, isPreview: true }];
+      } else {
+        const previewPath = prev[previewIdx].filePath;
+        const draft = prev.slice();
+        if (isDirty?.(previewPath)) {
+          // Dirty preview — pin it in place and append the new preview.
+          // Combining pin + append in ONE setState call (vs. the previous
+          // pinTab() + setOpenTabs() pair) is what makes the transition
+          // atomic with respect to React's batching: there's no longer
+          // any direct-value setState that can overwrite a queued pin
+          // updater. The dirty file's tab survives and its editedContent
+          // is never silently dropped by the eviction cleanup below.
+          draft[previewIdx] = { filePath: previewPath };
+          next = [...draft, { filePath, isPreview: true }];
+        } else {
+          // Clean preview — replace it. Caller may release editor state
+          // for the evicted path.
+          evicted = previewPath;
+          draft[previewIdx] = { filePath, isPreview: true };
+          next = draft;
+        }
+      }
+
+      openTabsRef.current = next;
+      setOpenTabs(next);
       setActiveTabPathState(filePath);
-      return null;
-    }
-    // Replace the existing preview tab if any, otherwise append.
-    const previewIdx = prev.findIndex((t) => t.isPreview);
-    let evicted: string | null = null;
-    let next: FileTab[];
-    if (previewIdx !== -1) {
-      evicted = prev[previewIdx].filePath;
-      next = prev.slice();
-      next[previewIdx] = { filePath, isPreview: true };
-    } else {
-      next = [...prev, { filePath, isPreview: true }];
-    }
-    setOpenTabs(next);
-    setActiveTabPathState(filePath);
-    return evicted;
-  }, []);
+      return evicted;
+    },
+    [],
+  );
 
   const pinTab = useCallback((filePath: string) => {
     setOpenTabs((prev) => {

--- a/apps/web/tests/useFileTabs.test.ts
+++ b/apps/web/tests/useFileTabs.test.ts
@@ -1,0 +1,310 @@
+// @vitest-environment jsdom
+import { createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { act } from "react-dom/test-utils";
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { type UseFileTabsReturn, useFileTabs } from "../src/hooks/useFileTabs";
+
+beforeAll(() => {
+  (globalThis as Record<string, unknown>).IS_REACT_ACT_ENVIRONMENT = true;
+});
+
+// ---------------------------------------------------------------------------
+// Minimal renderHook utility — avoids adding @testing-library/react
+// ---------------------------------------------------------------------------
+function renderHook(workspaceId: string): {
+  result: { current: UseFileTabsReturn };
+  unmount: () => void;
+} {
+  const result = { current: undefined as unknown as UseFileTabsReturn };
+  let root: Root;
+
+  function TestComponent() {
+    result.current = useFileTabs(workspaceId);
+    return null;
+  }
+
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+
+  act(() => {
+    root = createRoot(container);
+    root.render(createElement(TestComponent));
+  });
+
+  return {
+    result,
+    unmount: () => {
+      act(() => {
+        root.unmount();
+      });
+      container.remove();
+    },
+  };
+}
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+afterEach(() => {
+  localStorage.clear();
+});
+
+// ---------------------------------------------------------------------------
+// Basic open / pin / close
+// ---------------------------------------------------------------------------
+describe("useFileTabs — basic operations", () => {
+  it("starts empty", () => {
+    const { result, unmount } = renderHook("ws-1");
+    expect(result.current.openTabs).toEqual([]);
+    expect(result.current.activeTabPath).toBeNull();
+    unmount();
+  });
+
+  it("openTab creates a pinned tab and activates it", () => {
+    const { result, unmount } = renderHook("ws-1");
+    act(() => {
+      result.current.openTab("a.ts");
+    });
+    expect(result.current.openTabs).toEqual([{ filePath: "a.ts" }]);
+    expect(result.current.activeTabPath).toBe("a.ts");
+    unmount();
+  });
+
+  it("openTabPreview creates a preview tab", () => {
+    const { result, unmount } = renderHook("ws-1");
+    act(() => {
+      result.current.openTabPreview("a.ts");
+    });
+    expect(result.current.openTabs).toEqual([{ filePath: "a.ts", isPreview: true }]);
+    expect(result.current.activeTabPath).toBe("a.ts");
+    unmount();
+  });
+
+  it("openTabPreview replaces an existing preview tab (clean preview)", () => {
+    const { result, unmount } = renderHook("ws-1");
+    let evicted: string | null = "unset";
+    act(() => {
+      result.current.openTabPreview("a.ts");
+    });
+    act(() => {
+      evicted = result.current.openTabPreview("b.ts");
+    });
+    expect(result.current.openTabs).toEqual([{ filePath: "b.ts", isPreview: true }]);
+    expect(result.current.activeTabPath).toBe("b.ts");
+    expect(evicted).toBe("a.ts");
+    unmount();
+  });
+
+  it("openTabPreview returns null when file is already open", () => {
+    const { result, unmount } = renderHook("ws-1");
+    act(() => {
+      result.current.openTab("a.ts");
+    });
+    let evicted: string | null = "unset";
+    act(() => {
+      evicted = result.current.openTabPreview("a.ts");
+    });
+    expect(result.current.openTabs).toEqual([{ filePath: "a.ts" }]);
+    expect(evicted).toBeNull();
+    unmount();
+  });
+
+  it("pinTab converts a preview tab into a pinned tab", () => {
+    const { result, unmount } = renderHook("ws-1");
+    act(() => {
+      result.current.openTabPreview("a.ts");
+    });
+    act(() => {
+      result.current.pinTab("a.ts");
+    });
+    expect(result.current.openTabs).toEqual([{ filePath: "a.ts" }]);
+    unmount();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Dirty-preview race — the bug PR #374 introduces and we now guard against
+// ---------------------------------------------------------------------------
+describe("useFileTabs — dirty-preview guard (PR #374 fix)", () => {
+  it("pins a dirty preview tab in place when a new preview is opened", () => {
+    const { result, unmount } = renderHook("ws-1");
+
+    // Open a preview tab and mark it dirty
+    act(() => {
+      result.current.openTabPreview("dirty.ts");
+    });
+    const isDirty = (path: string) => path === "dirty.ts";
+
+    // Single-click on another file — dirty preview must be pinned, not evicted
+    let evicted: string | null = "unset";
+    act(() => {
+      evicted = result.current.openTabPreview("other.ts", isDirty);
+    });
+
+    // dirty.ts should be pinned (no longer a preview), other.ts is the new preview
+    expect(result.current.openTabs).toEqual([
+      { filePath: "dirty.ts" }, // pinned
+      { filePath: "other.ts", isPreview: true },
+    ]);
+    expect(result.current.activeTabPath).toBe("other.ts");
+    // Nothing was evicted — the dirty file stays around
+    expect(evicted).toBeNull();
+    unmount();
+  });
+
+  it("evicts a clean preview tab when isDirty returns false", () => {
+    const { result, unmount } = renderHook("ws-1");
+
+    act(() => {
+      result.current.openTabPreview("clean.ts");
+    });
+    const isDirty = () => false;
+
+    let evicted: string | null = "unset";
+    act(() => {
+      evicted = result.current.openTabPreview("other.ts", isDirty);
+    });
+
+    // clean.ts is gone, other.ts is the new preview
+    expect(result.current.openTabs).toEqual([{ filePath: "other.ts", isPreview: true }]);
+    expect(evicted).toBe("clean.ts");
+    unmount();
+  });
+
+  it("evicts a clean preview tab when isDirty is omitted", () => {
+    const { result, unmount } = renderHook("ws-1");
+
+    act(() => {
+      result.current.openTabPreview("clean.ts");
+    });
+
+    let evicted: string | null = "unset";
+    act(() => {
+      evicted = result.current.openTabPreview("other.ts");
+    });
+
+    expect(result.current.openTabs).toEqual([{ filePath: "other.ts", isPreview: true }]);
+    expect(evicted).toBe("clean.ts");
+    unmount();
+  });
+
+  it("does not consult isDirty when no preview tab exists", () => {
+    const { result, unmount } = renderHook("ws-1");
+    let isDirtyCalled = false;
+    const isDirty = () => {
+      isDirtyCalled = true;
+      return true;
+    };
+
+    let evicted: string | null = "unset";
+    act(() => {
+      evicted = result.current.openTabPreview("first.ts", isDirty);
+    });
+
+    expect(result.current.openTabs).toEqual([{ filePath: "first.ts", isPreview: true }]);
+    expect(evicted).toBeNull();
+    expect(isDirtyCalled).toBe(false);
+    unmount();
+  });
+
+  it("does not consult isDirty for the file being opened", () => {
+    const { result, unmount } = renderHook("ws-1");
+    act(() => {
+      result.current.openTab("already-open.ts");
+    });
+
+    const calls: string[] = [];
+    const isDirty = (path: string) => {
+      calls.push(path);
+      return false;
+    };
+
+    act(() => {
+      result.current.openTabPreview("already-open.ts", isDirty);
+    });
+
+    // The already-open early-return path skips the preview lookup entirely.
+    expect(calls).toEqual([]);
+    unmount();
+  });
+
+  it("simulates the session-restore race: dirty preview survives first single-click", () => {
+    // This is the scenario the PR fix targets: a dirty preview tab is
+    // restored from localStorage on mount, and the user's FIRST single-click
+    // on another file happens before any keystroke would have pinned it.
+
+    // Seed localStorage with a preview tab
+    localStorage.setItem(
+      "band-open-tabs:ws-1",
+      JSON.stringify({
+        tabs: [{ filePath: "restored-preview.ts", isPreview: true }],
+        active: "restored-preview.ts",
+      }),
+    );
+
+    const { result, unmount } = renderHook("ws-1");
+    expect(result.current.openTabs).toEqual([{ filePath: "restored-preview.ts", isPreview: true }]);
+
+    // The user has unsaved edits in restored-preview.ts (loaded from tab-state).
+    // First single-click on another file — without the dirty guard, restored
+    // -preview.ts would be silently evicted along with its edits.
+    const isDirty = (path: string) => path === "restored-preview.ts";
+
+    let evicted: string | null = "unset";
+    act(() => {
+      evicted = result.current.openTabPreview("other.ts", isDirty);
+    });
+
+    expect(result.current.openTabs).toEqual([
+      { filePath: "restored-preview.ts" }, // pinned, not evicted
+      { filePath: "other.ts", isPreview: true },
+    ]);
+    expect(evicted).toBeNull();
+    unmount();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// openTabPinned semantics — pins a preview, no-op on already-pinned
+// ---------------------------------------------------------------------------
+describe("useFileTabs — openTabPinned", () => {
+  it("creates a pinned tab when the file is not open", () => {
+    const { result, unmount } = renderHook("ws-1");
+    act(() => {
+      result.current.openTabPinned("a.ts");
+    });
+    expect(result.current.openTabs).toEqual([{ filePath: "a.ts" }]);
+    expect(result.current.activeTabPath).toBe("a.ts");
+    unmount();
+  });
+
+  it("pins an existing preview tab", () => {
+    const { result, unmount } = renderHook("ws-1");
+    act(() => {
+      result.current.openTabPreview("a.ts");
+    });
+    act(() => {
+      result.current.openTabPinned("a.ts");
+    });
+    expect(result.current.openTabs).toEqual([{ filePath: "a.ts" }]);
+    unmount();
+  });
+
+  it("is a no-op (state-wise) on an already-pinned tab, but activates", () => {
+    const { result, unmount } = renderHook("ws-1");
+    act(() => {
+      result.current.openTab("a.ts");
+      result.current.openTab("b.ts");
+    });
+    expect(result.current.activeTabPath).toBe("b.ts");
+
+    act(() => {
+      result.current.openTabPinned("a.ts");
+    });
+    expect(result.current.openTabs).toEqual([{ filePath: "a.ts" }, { filePath: "b.ts" }]);
+    expect(result.current.activeTabPath).toBe("a.ts");
+    unmount();
+  });
+});

--- a/packages/dashboard-core/src/components/FileBrowser.tsx
+++ b/packages/dashboard-core/src/components/FileBrowser.tsx
@@ -6,9 +6,16 @@ import type { FileEntry } from "../types";
 
 interface FileBrowserProps {
   workspaceId: string;
-  /** Single-click on a file. Defaults to a "preview" open if onOpenFilePinned is also provided. */
+  /**
+   * Called on single-click on a file. The caller decides whether this
+   * opens as a preview or pinned tab (this component just emits the
+   * event with the file path).
+   */
   onOpenFile: (path: string) => void;
-  /** Double-click on a file — opens as a pinned (persistent) tab. Optional. */
+  /**
+   * Called on double-click on a file. Optional — when provided, the
+   * caller typically opens the file as a pinned (persistent) tab.
+   */
   onOpenFilePinned?: (path: string) => void;
   /** Compact mode for sidebar use — smaller items */
   compact?: boolean;

--- a/packages/dashboard-core/src/components/SettingsPage.tsx
+++ b/packages/dashboard-core/src/components/SettingsPage.tsx
@@ -83,6 +83,9 @@ export function SettingsPage({ open, onOpenChange }: Props) {
   const [labels, setLabels] = useState<LabelDefinition[]>(settings.labels ?? []);
   const [autoStartTunnel, setAutoStartTunnel] = useState(settings.autoStartTunnel ?? false);
   const [enableLSP, setEnableLSP] = useState(settings.enableLSP ?? false);
+  const [enableFilePreviewTabs, setEnableFilePreviewTabs] = useState(
+    settings.enableFilePreviewTabs ?? true,
+  );
   const [maxCachedWorkspaces, setMaxCachedWorkspaces] = useState(
     settings.maxCachedWorkspaces?.toString() ?? "",
   );
@@ -126,6 +129,7 @@ export function SettingsPage({ open, onOpenChange }: Props) {
     if (JSON.stringify(labels) !== JSON.stringify(settings.labels ?? [])) return true;
     if (autoStartTunnel !== (settings.autoStartTunnel ?? false)) return true;
     if (enableLSP !== (settings.enableLSP ?? false)) return true;
+    if (enableFilePreviewTabs !== (settings.enableFilePreviewTabs ?? true)) return true;
     if (maxCachedWorkspaces !== (settings.maxCachedWorkspaces?.toString() ?? "")) return true;
     if (selectedTheme !== (settings.theme ?? "system")) return true;
     return false;
@@ -139,6 +143,7 @@ export function SettingsPage({ open, onOpenChange }: Props) {
     labels,
     autoStartTunnel,
     enableLSP,
+    enableFilePreviewTabs,
     maxCachedWorkspaces,
     selectedTheme,
     settings,
@@ -154,6 +159,7 @@ export function SettingsPage({ open, onOpenChange }: Props) {
     setLabels(settings.labels ?? []);
     setAutoStartTunnel(settings.autoStartTunnel ?? false);
     setEnableLSP(settings.enableLSP ?? false);
+    setEnableFilePreviewTabs(settings.enableFilePreviewTabs ?? true);
     setMaxCachedWorkspaces(settings.maxCachedWorkspaces?.toString() ?? "");
     setSelectedTheme(settings.theme ?? "system");
   }, [
@@ -165,6 +171,7 @@ export function SettingsPage({ open, onOpenChange }: Props) {
     settings.labels,
     settings.autoStartTunnel,
     settings.enableLSP,
+    settings.enableFilePreviewTabs,
     settings.maxCachedWorkspaces,
     settings.theme,
   ]);
@@ -202,6 +209,10 @@ export function SettingsPage({ open, onOpenChange }: Props) {
       tokenSecret: settings.tokenSecret,
       autoStartTunnel: autoStartTunnel || undefined,
       enableLSP: enableLSP || undefined,
+      // Default is true — only persist when explicitly disabled so we
+      // never serialise the default and a future change of default still
+      // applies to users who haven't touched this setting.
+      enableFilePreviewTabs: enableFilePreviewTabs ? undefined : false,
       maxCachedWorkspaces: parsedMaxCachedWorkspaces,
       theme: selectedTheme,
     });
@@ -294,6 +305,17 @@ export function SettingsPage({ open, onOpenChange }: Props) {
                 description="Enable hover type info and go-to-definition in the code browser. Currently supports TypeScript and JavaScript. Uses additional memory per workspace."
               >
                 <Switch id="enable-lsp" checked={enableLSP} onCheckedChange={setEnableLSP} />
+              </SettingsRow>
+              <SettingsRow
+                htmlFor="enable-file-preview-tabs"
+                label="Preview tabs (single-click open)"
+                description="Single-click a file in the tree to open it in a temporary preview tab. Double-click or edit to keep it open."
+              >
+                <Switch
+                  id="enable-file-preview-tabs"
+                  checked={enableFilePreviewTabs}
+                  onCheckedChange={setEnableFilePreviewTabs}
+                />
               </SettingsRow>
               <SettingsRow
                 variant="responsive"

--- a/packages/dashboard-core/src/types.ts
+++ b/packages/dashboard-core/src/types.ts
@@ -129,6 +129,14 @@ export interface Settings {
   tokenSecret?: string;
   autoStartTunnel?: boolean;
   enableLSP?: boolean;
+  /**
+   * When true (default), single-clicking a file in the tree opens it in a
+   * shared "preview" tab slot (italic title) that is replaced by the next
+   * single-click. Double-click or editing pins the tab. When false, every
+   * single-click opens the file as a pinned tab (pre-PR behavior).
+   * @default true
+   */
+  enableFilePreviewTabs?: boolean;
   theme?: Theme;
   /**
    * Maximum number of workspace dockview instances kept alive in memory at


### PR DESCRIPTION
## Summary

Stacked on top of #374. Addresses the review feedback for the preview-tab feature.

- **Fix dirty-preview race in `openPreviewWithGuard`.** The old code issued `pinTab(updater)` followed by `setOpenTabs(value)`; React 18 batching let the direct-value call overwrite the queued updater, silently evicting the dirty preview tab and dropping the user's unsaved edits — mostly latent because every keystroke auto-pins, but reproducible on session-restore of a dirty preview tab. Move the pin-or-evict decision into `openTabPreview` so it commits as a single `setOpenTabs(next)` call.
- **Add `enableFilePreviewTabs` setting (default `true`).** When disabled, single-click in the tree opens files as pinned tabs (pre-PR behavior). Wired through `Settings` types, `SettingsPage` UI, and `CodeBrowserView.handleSelectFile`.
- **Smaller review items**:
  - Reworded `FileBrowser` `onOpenFile` JSDoc so the caller (not the component) owns preview vs pinned semantics.
  - Skipped `pushDepartureAndArrival` in `handleSelectFile` / `handleSelectFilePinned` when the target equals the current view file — double-clicks no longer push three history entries.
  - Quick Open / chat link / LSP cross-file nav now use `openTabPinned` so explicit user intents stick rather than living in the preview slot.
- Added `useFileTabs.test.ts` (15 tests) covering the pin-on-dirty path, including a localStorage-restore scenario that reproduces the original race.

## Test plan

- [x] `pnpm exec vitest run` — all 455 tests pass (incl. new `useFileTabs.test.ts`)
- [x] `pnpm exec biome check .` — clean
- [x] `pnpm build:web` — builds successfully
- [x] Pre-push hook (biome, cargo fmt/clippy, knip, jscpd) passed
- [ ] Manual: toggle Settings → Preview tabs off, single-click a file in the tree, confirm it opens pinned
- [ ] Manual: with preview tabs on, open a dirty preview, restart the workspace, single-click another file, confirm the dirty file is pinned (not evicted) and edits survive
- [ ] Manual: double-click a file in the tree, navigate forward/back, confirm only one history entry was added

🤖 Generated with [Claude Code](https://claude.com/claude-code)