### PR TITLE
feat(cli): add band-start and band-loop skill templates

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,13 +38,15 @@ The web server (`apps/web`) handles **data, state, and background processes** on
 
 ## Band CLI Skills
 
-The Band CLI ships **four domain-specific skills**, each generated from its own template in `apps/cli/skills/` plus the CLI schema:
+The Band CLI ships **six domain-specific skills**, each generated from its own template in `apps/cli/skills/` plus the CLI schema:
 
 - `band.md` → `band/SKILL.md` — workspaces, projects, cronjobs, tunnel, settings, schema, notify, generate-skills.
 - `band-chat.md` → `band-chat/SKILL.md` — chat panes (`band chats ...`).
 - `band-terminal.md` → `band-terminal/SKILL.md` — terminal sessions (`band terminals ...`).
 - `band-browser.md` → `band-browser/SKILL.md` — browser tabs (`band browsers ...`).
+- `band-start.md` → `band-start/SKILL.md` — kickoff flow: create a workspace and submit the first agent task (`band workspaces create --prompt ...`) with Jira/GitHub ticket auto-detection and branch-name generation.
+- `band-loop.md` → `band-loop/SKILL.md` — schedule a recurring agent prompt against a workspace via `band cronjobs`, with an optional self-deleting "stop when criteria is met" wrapper. Native answer for users who would otherwise reach for Claude Code's `/loop`.
 
-Each template's frontmatter has a `commands:` field listing comma-separated CLI command-name prefixes; the generator filters the schema by those prefixes so each skill ships only its domain's commands. The split improves trigger precision and keeps each generated SKILL.md scoped to one task type (issue #331).
+Reference-shaped templates (e.g. `band`, `band-chat`, `band-terminal`, `band-browser`) have a `commands:` frontmatter field listing comma-separated CLI command-name prefixes, plus a `<!-- COMMANDS -->` placeholder in the body; the generator filters the schema by those prefixes and splices the rendered Commands section into the placeholder. Workflow-shaped templates (e.g. `band-start`, `band-loop`) are self-contained recipes — they omit both `commands:` and the placeholder, and the generator emits the template body verbatim. The split improves trigger precision and keeps each generated SKILL.md scoped to one task type (issue #331).
 
-Run `band generate-skills --output-dir apps/cli/skills` to regenerate all four skills, then copy each `<name>/SKILL.md` to `~/.claude/skills/<name>/SKILL.md`.
+Run `band generate-skills --output-dir apps/cli/skills` to regenerate all six skills, then copy each `<name>/SKILL.md` to `~/.claude/skills/<name>/SKILL.md`.

--- a/apps/cli/skills/band-loop.md
+++ b/apps/cli/skills/band-loop.md
@@ -1,0 +1,252 @@
+---
+name: band-loop
+version: 0.1.0
+description: Schedule a recurring prompt against a Band workspace's coding agent via a cronjob, with an optional self-deleting "stop when criteria is met" wrapper. Use when the user wants to "loop on X every 10m", "keep retrying until Y", "poll the deploy every 5 minutes", "check in every hour until tests pass", "run this prompt on a recurring interval", or otherwise asks for an iterative/repeating agent task. Wraps `band cronjobs create` so the agent re-runs the same prompt on a fixed cadence (default 10m), and optionally appends a stop-condition that makes the agent delete its own cronjob with `band cronjobs delete` when done. Caps loop lifetime at 7 days by default to match the safety horizon Claude Code's built-in `/loop` uses.
+allowed-tools: Bash
+argument-hint: <prompt> [--every <duration>] [--until <stop condition>] [--max-iterations <n>]
+---
+
+# Band Loop
+
+Recurring agent tasks via `band cronjobs`. The agent fires on a cron schedule against a target workspace's active chat, optionally checks a stop condition each iteration, and deletes its own cronjob when the condition is met.
+
+This is the **native answer** for users who reach for Claude Code's built-in `/loop`: that command is gated behind `scheduledTasksEnabled`, which is always `false` in SDK / Band sessions. `band cronjobs` runs server-side and survives session restarts.
+
+This skill is focused on the **scheduled-loop pattern**. For broader operations see the sibling skills:
+
+- **`band`** — workspaces, projects, tunnel, settings (also documents `band cronjobs` for general CRUD).
+- **`band-start`** — create a new workspace and kick off the first agent task.
+- **`band-chat`** — chat panes inside a workspace (the loop's prompt is dispatched to a chat).
+
+## Prerequisites
+
+- The Band server must be running (started by the Band dashboard app).
+- A target workspace must exist (use **`band-start`** to create one first if needed).
+
+## JSON Output
+
+All commands support `--output json` (or `BAND_OUTPUT=json` env var) for structured output.
+
+- **Success**: JSON object to stdout, exit code 0
+- **Error**: `{"error": "message"}` to stderr, exit code 1
+
+## Workflow
+
+### 1. Resolve the loop target
+
+A cronjob is scoped to either a **project** or a **workspace**. For an agent loop you almost always want **workspace scope** so the prompt fires into the same chat over and over:
+
+```sh
+# Auto-detect the workspace ID from cwd
+ws_id=$(band workspaces list --output json \
+  | jq -r --arg cwd "$PWD" '.workspaces[] | select(.path == $cwd) | .id' \
+  | head -1)
+```
+
+If the user is outside a workspace cwd, ask them which workspace to target (or run `band workspaces list` and pick one).
+
+### 2. Parse the interval into a cron expression
+
+Accept human durations (`5m`, `10m`, `1h`, `6h`, `1d`). Default is `10m`. Map to a standard 5-field cron expression in the server's local timezone:
+
+| Duration | Cron expression  | Meaning              |
+| -------- | ---------------- | -------------------- |
+| `5m`     | `*/5 * * * *`    | every 5 minutes      |
+| `10m`    | `*/10 * * * *`   | every 10 minutes     |
+| `15m`    | `*/15 * * * *`   | every 15 minutes     |
+| `30m`    | `*/30 * * * *`   | every 30 minutes     |
+| `1h`     | `7 * * * *`      | hourly at :07        |
+| `6h`     | `0 */6 * * *`    | every 6 hours        |
+| `1d`     | `0 9 * * *`      | daily at 09:00       |
+
+> **Tip:** for "hourly" or coarser cadences, prefer minute offsets that aren't `:00` or `:30` — every loop in the fleet that lands on `:00` thunders together. Pick a non-round minute like `:07` or `:23` when the user's request is approximate.
+
+If the user passes a literal cron expression (5 whitespace-separated tokens), use it as-is.
+
+### 3. Compose the iteration prompt
+
+Two flavours:
+
+**A. Open-ended loop** — no stop condition. The cronjob just fires the prompt every interval until the user (or the 7-day cap) stops it.
+
+The iteration prompt is the user's prompt verbatim.
+
+**B. Ends-when-done loop** — the user gave a stop condition. Wrap the prompt so the agent **self-deletes** the cronjob once the condition is met:
+
+```text
+<user prompt>
+
+---
+STOP CONDITION: <user's stop condition>
+
+After completing your work this iteration, evaluate the stop condition.
+- If the stop condition is met, run this shell command to terminate the loop:
+
+      band cronjobs delete <key> <cronjob_id>
+
+- If the stop condition is NOT met, do nothing extra — the next iteration
+  fires automatically on schedule.
+
+This is iteration of a recurring loop. Do not assume previous iterations
+ran successfully; re-check state at the start of each run.
+```
+
+The `<key>` and `<cronjob_id>` placeholders must be substituted after the cronjob is created (see step 5 — we don't know the ID until then).
+
+### 4. Create the cronjob
+
+`band cronjobs create` requires `--name`, `--prompt`, and `--cron`. For workspace-scoped loops, set `--scope workspace` and pass the workspace ID twice (once positionally as `key`, once as `--workspace-id`):
+
+```sh
+job=$(band cronjobs create "$ws_id" \
+  --scope workspace \
+  --workspace-id "$ws_id" \
+  --name "Loop: <short summary>" \
+  --cron "*/10 * * * *" \
+  --prompt "<placeholder — will be updated in step 5>" \
+  --output json)
+
+cronjob_id=$(echo "$job" | jq -r .id)
+```
+
+### 5. Patch the prompt with the cronjob ID (ends-when-done flavour only)
+
+For the open-ended flavour, skip this step — the prompt from step 4 is already final.
+
+For the ends-when-done flavour, substitute the now-known `cronjob_id` into the wrapped prompt and update the cronjob:
+
+```sh
+final_prompt="<user prompt>
+
+---
+STOP CONDITION: <stop condition>
+
+After completing your work, if the stop condition is met, run:
+
+    band cronjobs delete $ws_id $cronjob_id
+
+Otherwise do nothing extra — the next iteration fires on schedule."
+
+band cronjobs update "$ws_id" "$cronjob_id" --prompt "$final_prompt"
+```
+
+### 6. Enforce a safety cap
+
+Cronjobs have no built-in TTL. Apply a 7-day cap to match Claude Code's `/loop` horizon — schedule yourself a reminder, or include the cap directly in the wrapped prompt so the agent self-deletes after a date threshold:
+
+```text
+SAFETY: If the current date is on or after <YYYY-MM-DD + 7 days>, treat
+the loop as expired and run `band cronjobs delete <key> <cronjob_id>`
+regardless of the stop condition.
+```
+
+For an explicit `--max-iterations <n>` cap, ask the agent to count iterations in a known file inside the worktree (e.g. `.band/loop-iterations`) and exit when the count reaches `n`.
+
+### 7. Report the result
+
+Tell the user:
+
+- The cronjob ID (`cj_...`) and the cron expression that was scheduled.
+- The next firing time (best-effort — compute from the cron expression).
+- That the loop will auto-delete when the stop condition is met (if applicable) or at the 7-day cap.
+- How to inspect and abort manually:
+
+  ```sh
+  band cronjobs list --workspace <ws_id>
+  band cronjobs trigger <key> <cronjob_id>   # fire it once right now
+  band cronjobs delete  <key> <cronjob_id>   # stop the loop
+  ```
+
+- That the agent's output for each iteration streams to the workspace's chat — tail it with:
+
+  ```sh
+  cd <workspace-path>
+  band chats watch
+  ```
+
+## Examples
+
+### Open-ended loop, every 10 minutes
+
+User input: `Loop on improving test coverage in this workspace every 10 minutes`
+
+1. Resolve `ws_id` from cwd.
+2. Interval `10m` → cron `*/10 * * * *`.
+3. Iteration prompt is the user prompt verbatim.
+4. Create cronjob:
+
+   ```sh
+   band cronjobs create "$ws_id" \
+     --scope workspace --workspace-id "$ws_id" \
+     --name "Loop: improve test coverage" \
+     --cron "*/10 * * * *" \
+     --prompt "Improve test coverage in this workspace. Pick the lowest-coverage file each iteration and add tests; commit when green."
+   ```
+
+5. Report cronjob ID, schedule, and `band chats watch` instructions.
+
+### Ends-when-done loop, hourly
+
+User input: `Every hour, check whether the deploy in #ops-deploys turned green. Stop once it's green.`
+
+1. Resolve `ws_id` from cwd (or ask).
+2. Interval `1h` → cron `7 * * * *` (off-zero minute).
+3. Create the cronjob with a placeholder prompt and capture the ID:
+
+   ```sh
+   job=$(band cronjobs create "$ws_id" \
+     --scope workspace --workspace-id "$ws_id" \
+     --name "Loop: poll deploy until green" \
+     --cron "7 * * * *" \
+     --prompt "<placeholder>" \
+     --output json)
+   cronjob_id=$(echo "$job" | jq -r .id)
+   ```
+
+4. Patch with the wrapped, self-deleting prompt:
+
+   ```sh
+   band cronjobs update "$ws_id" "$cronjob_id" --prompt "Check whether the deploy in #ops-deploys turned green.
+
+   ---
+   STOP CONDITION: deploy status is 'green' or 'success'.
+
+   After completing your work, if the stop condition is met, run:
+
+       band cronjobs delete $ws_id $cronjob_id
+
+   Otherwise do nothing extra — the next iteration fires on schedule.
+
+   SAFETY: If the current date is on or after $(date -v+7d +%Y-%m-%d), run
+   the same delete command regardless of the stop condition."
+   ```
+
+5. Report cronjob ID, the 1-hour cadence, and that the loop self-terminates on green or after 7 days.
+
+### Cancel a loop early
+
+```sh
+# Find the cronjob
+band cronjobs list --workspace "$ws_id"
+
+# Delete it
+band cronjobs delete "$ws_id" cj_1234567890
+```
+
+## Invariants
+
+- The cronjob's `--prompt` is what the agent sees on every firing — keep it self-contained (no shell variables, no implicit "previous iteration" context).
+- Workspace-scoped cronjobs (`--scope workspace --workspace-id <ws_id>`) dispatch into the workspace's active chat. Project-scoped ones don't.
+- The self-deleting pattern requires the agent itself to run `band cronjobs delete` — the cron engine has no built-in stop condition. The agent needs `band` on its `PATH` (true by default after `band` is installed).
+- Cap loop lifetime at **7 days** unless the user explicitly overrides — same horizon as Claude Code's `/loop`.
+- For an iteration-count cap, the agent must persist a counter to a file inside the worktree (cronjobs are stateless across runs).
+
+## Cross-references
+
+- General `band cronjobs` CRUD (list / update / trigger / delete) is also documented under the **`band`** skill.
+- To send a one-off message to a chat instead of a recurring one, use **`band-chat`** (`band chats send`).
+- To create the workspace the loop runs against, see **`band-start`**.
+
+## Configuration
+
+See the `band` skill for environment variables (`BAND_SERVER_URL`, `BAND_TOKEN`, `BAND_OUTPUT`, `BAND_HOME`).

--- a/apps/cli/skills/band-start.md
+++ b/apps/cli/skills/band-start.md
@@ -1,0 +1,262 @@
+---
+name: band-start
+version: 0.1.0
+description: Kick off work on a new feature, bug fix, or task in a fresh Band workspace. Use when the user describes a piece of work and wants an agent to start on it — "start working on X", "create a workspace and implement Y", "kick off a task for ABCD-1234", "spin up a worktree to fix #42". Auto-detects the project from the cwd, parses any Jira (e.g. `ABCD-1234`) or GitHub (`#123`) ticket reference out of the prompt, fetches richer context with `acli` / `gh`, picks a Conventional Commits branch prefix (`feat/`, `fix/`, or `chore/`) based on the work, generates a kebab-case branch name, and creates the workspace with `--prompt` so the agent starts immediately.
+allowed-tools: Bash
+argument-hint: <prompt describing what to work on>
+---
+
+# Start a Band Workspace
+
+Creates a Band workspace (git worktree) and submits a task to the coding agent in a single step. The only required input is the **prompt** — a natural-language description of what the agent should work on. This skill figures out the project, branch name, and any ticket context automatically.
+
+This skill is focused on the **kickoff flow**. For broader operations see the sibling skills:
+
+- **`band`** — workspaces, projects, cronjobs, tunnel, settings.
+- **`band-chat`** — chat panes inside a workspace (`band chats send/watch/...`).
+- **`band-loop`** — schedule a recurring prompt against a workspace (`band cronjobs ...`).
+- **`band-terminal`** — terminal sessions inside a workspace.
+- **`band-browser`** — browser tabs inside a workspace.
+
+## Prerequisites
+
+- The Band server must be running (started by the Band dashboard app). Connects to `http://localhost:3456` by default.
+- The target project must be registered with Band (`band projects list` to check).
+- Optional: `acli` for Jira ticket lookups, `gh` for GitHub issue lookups. Missing tools are non-fatal — the skill falls back to using the prompt as-is.
+
+## JSON Output
+
+All commands support `--output json` (or `BAND_OUTPUT=json` env var) for structured output.
+
+- **Success**: JSON object to stdout, exit code 0
+- **Error**: `{"error": "message"}` to stderr, exit code 1
+
+## Workflow
+
+### 1. Determine the project
+
+Match the current working directory against the registered Band projects:
+
+```sh
+band projects list --output json | jq -r '.projects[] | "\(.name)\t\(.path)"'
+```
+
+Pick the project whose `path` is the cwd or one of its ancestors. If no match or the cwd is ambiguous (multiple registered projects under the same root), ask the user to pick one.
+
+### 2. Detect a ticket reference in the prompt
+
+Scan the prompt for either format:
+
+- **Jira ticket** — `^[A-Z][A-Z0-9]+-\d+$` anywhere in the prompt (e.g. `ABCD-1234`, `WXYZ-567`). Letters-dash-numbers.
+- **GitHub issue** — `#\d+` (e.g. `#42`) or a full GitHub issue URL (e.g. `https://github.com/<owner>/<repo>/issues/123`).
+
+If neither is found and you still want to disambiguate which ticket system the project uses, check the git remote:
+
+```sh
+git -C <project-path> remote get-url origin
+```
+
+A `github.com` remote → assume GitHub Issues. Anything else → assume Jira.
+
+### 3. Fetch ticket context (only if a reference is present)
+
+**For Jira tickets:**
+
+```sh
+acli jira workitem view <TICKET-KEY> --fields summary,description
+```
+
+**For GitHub issues:**
+
+```sh
+gh issue view <issue-number> --repo <owner/repo>
+```
+
+Use the fetched title and description to:
+
+- Build a richer prompt for the coding agent (append as additional context).
+- Generate a more descriptive branch name summary.
+
+If the CLI tool is not available, the command fails, or no ticket reference was found, **skip this step entirely** and work with the prompt as given. Never block on ticket fetching.
+
+### 4. Generate the branch name
+
+The branch name MUST start with a Conventional Commits-style prefix, then be all lowercase, kebab-case.
+
+**Pick the prefix** by classifying the work:
+
+| Prefix    | When to pick                                                                            |
+| --------- | --------------------------------------------------------------------------------------- |
+| `feat/`   | New user-visible functionality (adding a feature, screen, command, API endpoint).       |
+| `fix/`    | Bug fix — restoring broken behavior, correcting a regression, patching incorrect logic. |
+| `chore/`  | Everything else: deps, refactors, tests, docs, tooling, CI, internal cleanup.           |
+
+When the prompt doesn't clearly fit `feat/` or `fix/`, **default to `chore/`** — it's the catch-all. Never produce a branch without a prefix.
+
+**Compose the branch** as `<prefix>/<rest>`, where `<rest>` is:
+
+| Reference type | `<rest>` format                       | Example                       |
+| -------------- | ------------------------------------- | ----------------------------- |
+| Jira ticket    | `<ticket-key>-<2-3-word-summary>`     | `feat/abcd-1234-add-labels`   |
+| GitHub issue   | `<issue-number>-<2-3-word-summary>`   | `feat/42-dark-mode`           |
+| No ticket      | `<2-3-word-summary>`                  | `fix/login-redirect`          |
+
+Good examples:
+
+- `feat/abcd-1234-add-labels` (new feature, Jira ticket)
+- `fix/wxyz-567-login-redirect` (bug fix, Jira ticket)
+- `feat/42-dark-mode` (new feature, GitHub issue)
+- `fix/login-redirect` (bug fix, no ticket)
+- `chore/bump-deps` (maintenance, no ticket)
+- `chore/refactor-auth-module` (refactor, no ticket)
+
+Bad examples (do NOT produce these):
+
+- `feature/add-labels` — use `feat/`, not `feature/`.
+- `abcd-1234-add-labels` — missing the `feat/` / `fix/` / `chore/` prefix.
+- `ABCD-1234` — missing prefix and summary; not lowercase.
+- `feat/abcd-1234-implement-the-new-feature-for-adding-labels-to-items` — too long; cap the summary at 2–3 words.
+- `feat/fix/login-redirect` — exactly one prefix; if it's a fix, use `fix/`.
+
+### 5. Compose the agent prompt
+
+- Start with the user's original prompt verbatim.
+- If you fetched ticket info in step 3, append a section with the ticket title and description so the agent has the full context.
+
+### 6. Create the workspace
+
+Always pass `--prompt` so the agent starts immediately — never create a workspace and then separately call `band chats send`. Capture the worktree path from `--output json` (the create response is shaped `{"path": "..."}`):
+
+```sh
+ws_path=$(band workspaces create <project> <branch> \
+  --prompt "<composed prompt>" \
+  --output json | jq -r .path)
+```
+
+`workspaces create` is idempotent — creating an existing workspace just returns its path, so re-running with the same arguments is safe.
+
+### 7. Resolve the workspace ID and chat pane
+
+`band workspaces create` doesn't return the workspace ID, only the path. Look it up by path from `band workspaces list` (the list response uses the field name `workspaceId`):
+
+```sh
+ws_id=$(band workspaces list --output json \
+  | jq -r --arg path "$ws_path" '.workspaces[] | select(.path == $path) | .workspaceId')
+```
+
+`--prompt` lazy-creates a chat pane for the agent task. Look up that pane's ID so you can print a fully-resolved watch command (no `<chat-id>` placeholders):
+
+```sh
+chat_id=$(band chats list "$ws_id" --output json | jq -r '.chats[0].id')
+```
+
+If `chat_id` comes back as `null` or empty (rare race — the chat hasn't registered yet), retry once after a brief pause. If it still doesn't resolve, fall back to the cwd-auto-resolved form: `band chats watch` run from inside `$ws_path` picks the first chat pane automatically.
+
+### 8. Report the result
+
+Print a one-line summary that includes:
+
+- The branch name and the **worktree path** (`$ws_path`).
+- The **fully-substituted watch command** the user can copy to a new shell — e.g. literal `band chats watch chat_8f2a1`, not `band chats watch <chat-id>`. Substitute the real `chat_id` from step 7.
+
+Do **not** invoke `band chats watch` yourself — the command streams indefinitely until the agent finishes, which would block this session. Just print the resolved command and let the user run it in their own shell when they're ready.
+
+If the user wants only the agent's textual deltas instead of raw NDJSON, see the `band-chat` skill for `jq` filter recipes.
+
+## Examples
+
+### Jira ticket (feature)
+
+User input: `Start working on ABCD-1234 to add labels to the chat messages`
+
+1. Detect Jira ticket `ABCD-1234`.
+2. Fetch context: `acli jira workitem view ABCD-1234 --fields summary,description`.
+3. Classify: adding labels → new functionality → `feat/`.
+4. Branch: `feat/abcd-1234-add-labels`.
+5. Compose prompt: user input + Jira summary/description.
+6. Create the workspace and resolve the chat ID:
+
+   ```sh
+   ws_path=$(band workspaces create my-app feat/abcd-1234-add-labels \
+     --prompt "Add labels to the chat messages.
+
+   Jira ticket ABCD-1234: <summary>
+   <description>" \
+     --output json | jq -r .path)
+
+   ws_id=$(band workspaces list --output json \
+     | jq -r --arg path "$ws_path" '.workspaces[] | select(.path == $path) | .workspaceId')
+
+   chat_id=$(band chats list "$ws_id" --output json | jq -r '.chats[0].id')
+   ```
+
+7. Report — the printed watch command must use the **resolved** `chat_id`, e.g. literal `band chats watch chat_8f2a1`. Do not invoke `band chats watch` yourself; just give the user the copy-pasteable command.
+
+### GitHub issue (bug fix)
+
+User input: `Kick off #42 — the login button redirects in a loop`
+
+1. Detect GitHub issue `#42`.
+2. Fetch context: `gh issue view 42 --repo owner/repo`.
+3. Classify: broken behavior → `fix/`.
+4. Branch: `fix/42-login-redirect`.
+5. Compose prompt: user input + GitHub issue body.
+6. Create the workspace and resolve the chat ID:
+
+   ```sh
+   ws_path=$(band workspaces create my-app fix/42-login-redirect \
+     --prompt "The login button redirects in a loop.
+
+   GitHub issue #42: <title>
+   <body>" \
+     --output json | jq -r .path)
+
+   ws_id=$(band workspaces list --output json \
+     | jq -r --arg path "$ws_path" '.workspaces[] | select(.path == $path) | .workspaceId')
+
+   chat_id=$(band chats list "$ws_id" --output json | jq -r '.chats[0].id')
+   ```
+
+7. Print the watch command with the **resolved** chat ID (e.g. literal `band chats watch chat_8f2a1`) for the user to run in their own shell.
+
+### No ticket reference (maintenance)
+
+User input: `Spin up a workspace to bump all the dependencies and refresh the lockfile`
+
+1. No ticket pattern matches → skip step 3.
+2. Classify: not user-visible, not a bug → `chore/`.
+3. Branch: `chore/bump-deps`.
+4. Create the workspace and resolve the chat ID:
+
+   ```sh
+   ws_path=$(band workspaces create my-app chore/bump-deps \
+     --prompt "Spin up a workspace to bump all the dependencies and refresh the lockfile" \
+     --output json | jq -r .path)
+
+   ws_id=$(band workspaces list --output json \
+     | jq -r --arg path "$ws_path" '.workspaces[] | select(.path == $path) | .workspaceId')
+
+   chat_id=$(band chats list "$ws_id" --output json | jq -r '.chats[0].id')
+   ```
+
+5. Print the watch command with the **resolved** chat ID (e.g. literal `band chats watch chat_8f2a1`) for the user to run in their own shell.
+
+## Invariants
+
+- **Always pass `--prompt`** on `workspaces create` so the agent starts in one step. Never create-then-send as two CLI calls.
+- Branch names start with a Conventional Commits prefix (`feat/`, `fix/`, or `chore/`), then are lowercase kebab-case, optionally including a Jira key (`abcd-1234-`) or GitHub issue number (`42-`).
+- When the work doesn't clearly fit `feat/` or `fix/`, default to `chore/`. Never omit the prefix.
+- Skip ticket fetching when the relevant CLI (`acli`, `gh`) is missing or the lookup fails — the kickoff should still succeed.
+- `workspaces create` is idempotent — re-running with the same project/branch returns the existing worktree path.
+- **Always resolve the chat ID and print `band chats watch <resolved-id>`** as the final step. The printed copy-paste command must contain the literal resolved ID (e.g. `band chats watch chat_8f2a1`), never a `<chat-id>` placeholder. Do not invoke `band chats watch` yourself — it streams indefinitely and would block the session.
+- `workspaces create` returns `{"path": "..."}` only — there is no `id` field. The workspace ID is `workspaceId` in `band workspaces list --output json`, looked up by matching `path`.
+
+## Cross-references
+
+- For sending follow-up messages to the agent after kickoff, see **`band-chat`** (`band chats send`).
+- For recurring or follow-up scheduled prompts against the same workspace, see **`band-loop`**.
+- For workspace cleanup (`band workspaces remove`), project management (`band projects add/remove`), and tunnel control, see **`band`**.
+
+## Configuration
+
+See the `band` skill for environment variables (`BAND_SERVER_URL`, `BAND_TOKEN`, `BAND_OUTPUT`, `BAND_HOME`).

--- a/apps/cli/src/skills.rs
+++ b/apps/cli/src/skills.rs
@@ -3,18 +3,30 @@ use std::fmt::Write;
 use std::fs;
 use std::path::Path;
 
-/// Domain-specific skill templates with `<!-- COMMANDS -->` placeholders.
+/// Skill templates rendered by `band generate-skills`.
 ///
-/// Each template has a `commands:` frontmatter field that lists the
-/// space-separated command-name prefixes from the CLI schema that should be
-/// embedded into that skill's COMMANDS section. Splitting the monolithic
-/// skill into focused per-domain skills improves trigger precision and keeps
-/// each generated SKILL.md scoped to one task type (issue #331).
+/// Two shapes are supported:
+///
+/// 1. **Reference-shaped** (e.g. `band`, `band-chat`) — the template body
+///    contains a `<!-- COMMANDS -->` placeholder, and the `commands:`
+///    frontmatter field lists the comma-separated command-name prefixes from
+///    the CLI schema that should be embedded into that skill's auto-generated
+///    Commands section.
+/// 2. **Workflow-shaped** (e.g. `band-start`, `band-loop`) — the template
+///    body contains no `<!-- COMMANDS -->` placeholder; the skill is a
+///    self-contained recipe rather than a command reference. Such templates
+///    may omit the `commands:` frontmatter field entirely.
+///
+/// Splitting the monolithic skill into focused per-domain skills improves
+/// trigger precision and keeps each generated SKILL.md scoped to one task
+/// type (issue #331).
 const SKILL_TEMPLATES: &[(&str, &str)] = &[
     ("band", include_str!("../skills/band.md")),
     ("band-chat", include_str!("../skills/band-chat.md")),
     ("band-terminal", include_str!("../skills/band-terminal.md")),
     ("band-browser", include_str!("../skills/band-browser.md")),
+    ("band-start", include_str!("../skills/band-start.md")),
+    ("band-loop", include_str!("../skills/band-loop.md")),
 ];
 
 pub fn generate_skills(output_dir: &str, filter: Option<&str>) -> Result<CommandResult, String> {
@@ -34,27 +46,44 @@ pub fn generate_skills(output_dir: &str, filter: Option<&str>) -> Result<Command
             .unwrap_or_else(|| (*default_name).to_string());
         let description = parse_frontmatter_field(template, "description").unwrap_or_default();
         let prefixes = parse_command_prefixes(template);
+        let has_placeholder = template.contains(COMMANDS_PLACEHOLDER);
 
         if !matches_filter(&name, filter) {
             continue;
         }
 
-        if prefixes.is_empty() {
-            return Err(format!(
-                "Skill template '{name}' is missing a non-empty 'commands:' frontmatter field"
-            ));
+        // `commands:` frontmatter and the `<!-- COMMANDS -->` placeholder are
+        // a pair: reference-shaped skills need both, workflow-shaped skills
+        // need neither. Reject mismatches so a template can't silently lose
+        // its rendered Commands section through a typo.
+        match (has_placeholder, prefixes.is_empty()) {
+            (true, true) => {
+                return Err(format!(
+                    "Skill template '{name}' has '<!-- COMMANDS -->' placeholder but is missing a non-empty 'commands:' frontmatter field"
+                ));
+            }
+            (false, false) => {
+                return Err(format!(
+                    "Skill template '{name}' declares 'commands:' frontmatter ({prefixes:?}) but has no '<!-- COMMANDS -->' placeholder in the body"
+                ));
+            }
+            _ => {}
         }
 
-        let matched: Vec<&serde_json::Value> = commands
-            .iter()
-            .filter(|c| {
-                c["name"]
-                    .as_str()
-                    .is_some_and(|cn| matches_any_prefix(cn, &prefixes))
-            })
-            .collect();
+        let matched: Vec<&serde_json::Value> = if prefixes.is_empty() {
+            Vec::new()
+        } else {
+            commands
+                .iter()
+                .filter(|c| {
+                    c["name"]
+                        .as_str()
+                        .is_some_and(|cn| matches_any_prefix(cn, &prefixes))
+                })
+                .collect()
+        };
 
-        if matched.is_empty() {
+        if has_placeholder && matched.is_empty() {
             return Err(format!(
                 "Skill template '{name}' matched no commands from the schema (prefixes: {prefixes:?})"
             ));

--- a/apps/cli/tests/integration.rs
+++ b/apps/cli/tests/integration.rs
@@ -2417,14 +2417,21 @@ fn frontmatter_field<'a>(skill: &'a str, key: &'a str) -> Option<&'a str> {
 }
 
 #[test]
-fn generate_skills_emits_all_four_domain_skills() {
+fn generate_skills_emits_all_domain_skills() {
     let tmp = tempfile::tempdir().expect("create tempdir");
     let out = tmp.path();
 
     let output = band_offline(&["generate-skills", "--output-dir", out.to_str().unwrap()]);
     assert!(output.status.success(), "stderr: {}", stderr(&output));
 
-    for name in ["band", "band-chat", "band-terminal", "band-browser"] {
+    for name in [
+        "band",
+        "band-chat",
+        "band-terminal",
+        "band-browser",
+        "band-start",
+        "band-loop",
+    ] {
         let path = out.join(name).join("SKILL.md");
         assert!(
             path.exists(),
@@ -2442,7 +2449,14 @@ fn generate_skills_each_skill_has_non_empty_description() {
     let output = band_offline(&["generate-skills", "--output-dir", out.to_str().unwrap()]);
     assert!(output.status.success(), "stderr: {}", stderr(&output));
 
-    for name in ["band", "band-chat", "band-terminal", "band-browser"] {
+    for name in [
+        "band",
+        "band-chat",
+        "band-terminal",
+        "band-browser",
+        "band-start",
+        "band-loop",
+    ] {
         let skill = read_skill(out, name);
         let desc = frontmatter_field(&skill, "description")
             .unwrap_or_else(|| panic!("{name} has no description"));
@@ -2471,6 +2485,20 @@ fn generate_skills_each_skill_has_non_empty_description() {
                 assert!(
                     !lower.contains(" chat ") && !lower.contains("terminal"),
                     "{name} description leaks other domains: {desc}"
+                );
+            }
+            "band-start" => {
+                // band-start's trigger keywords cover kickoff/workspace creation.
+                assert!(
+                    lower.contains("workspace") || lower.contains("kick off"),
+                    "{name}: {desc}"
+                );
+            }
+            "band-loop" => {
+                // band-loop's trigger keywords cover recurring scheduling.
+                assert!(
+                    lower.contains("recurring") || lower.contains("cronjob"),
+                    "{name}: {desc}"
                 );
             }
             _ => {}
@@ -2666,6 +2694,8 @@ fn generate_skills_filter_limits_to_one_skill() {
     assert!(!out.join("band").join("SKILL.md").exists());
     assert!(!out.join("band-terminal").join("SKILL.md").exists());
     assert!(!out.join("band-browser").join("SKILL.md").exists());
+    assert!(!out.join("band-start").join("SKILL.md").exists());
+    assert!(!out.join("band-loop").join("SKILL.md").exists());
 }
 
 #[test]
@@ -2686,19 +2716,30 @@ fn generate_skills_json_output_lists_generated_skills() {
     let skills = json["skills"].as_array().expect("skills array");
     let names: Vec<&str> = skills.iter().map(|s| s["name"].as_str().unwrap()).collect();
 
-    assert_eq!(names.len(), 4, "expected 4 skills, got {names:?}");
-    assert!(names.contains(&"band"));
-    assert!(names.contains(&"band-chat"));
-    assert!(names.contains(&"band-terminal"));
-    assert!(names.contains(&"band-browser"));
+    // Reference-shaped skills must report at least one command. Workflow-
+    // shaped skills (band-start, band-loop) are self-contained recipes that
+    // omit the `commands:` frontmatter, so their commandCount is 0 by design.
+    let workflow_skills: &[&str] = &["band-start", "band-loop"];
 
-    // Every skill must report at least one command.
+    assert_eq!(names.len(), 6, "expected 6 skills, got {names:?}");
+    for expected in [
+        "band",
+        "band-chat",
+        "band-terminal",
+        "band-browser",
+        "band-start",
+        "band-loop",
+    ] {
+        assert!(names.contains(&expected), "missing skill: {expected}");
+    }
+
     for skill in skills {
+        let name = skill["name"].as_str().unwrap_or("?");
         let count = skill["commandCount"].as_u64().unwrap_or(0);
-        assert!(
-            count > 0,
-            "skill {} has no commands",
-            skill["name"].as_str().unwrap_or("?")
-        );
+        if workflow_skills.contains(&name) {
+            assert_eq!(count, 0, "workflow skill {name} unexpectedly has commands");
+        } else {
+            assert!(count > 0, "reference skill {name} has no commands");
+        }
     }
 }

--- a/apps/web/src/lib/cli-skills.ts
+++ b/apps/web/src/lib/cli-skills.ts
@@ -1,8 +1,9 @@
 /**
  * Sync the CLI-shipped skills (`band`, `band-chat`, `band-terminal`,
- * `band-browser`) into the user's global coding-agent skill directory so the
- * skills become discoverable to the agent right after install / auto-update,
- * without the user having to manually `cp` each SKILL.md after every release.
+ * `band-browser`, `band-start`, `band-loop`) into the user's global
+ * coding-agent skill directory so the skills become discoverable to the agent
+ * right after install / auto-update, without the user having to manually `cp`
+ * each SKILL.md after every release.
  *
  * The skills are not shipped as loose files in the packaged Electron build —
  * they're baked into the Rust `band` binary via `include_str!` (see
@@ -38,8 +39,15 @@ import { findCliBinary } from "./cli";
 import { whichBinary } from "./process-utils";
 import { loadSettings } from "./state";
 
-/** The four skills `band generate-skills` emits. */
-export const BAND_SKILL_NAMES = ["band", "band-chat", "band-terminal", "band-browser"] as const;
+/** The six skills `band generate-skills` emits. */
+export const BAND_SKILL_NAMES = [
+  "band",
+  "band-chat",
+  "band-terminal",
+  "band-browser",
+  "band-start",
+  "band-loop",
+] as const;
 
 const SKILL_FILE = "SKILL.md";
 

--- a/apps/web/tests/cli-skills.test.ts
+++ b/apps/web/tests/cli-skills.test.ts
@@ -28,7 +28,14 @@ import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
 import { findBandBinary } from "../src/lib/cli-skills";
 import { closeDb } from "../src/lib/db/connection";
 
-const SKILL_NAMES = ["band", "band-chat", "band-terminal", "band-browser"] as const;
+const SKILL_NAMES = [
+  "band",
+  "band-chat",
+  "band-terminal",
+  "band-browser",
+  "band-start",
+  "band-loop",
+] as const;
 
 /**
  * Reuse the same resolver the production code uses so we exercise the real
@@ -160,7 +167,7 @@ describe.skipIf(!bandBinaryReachable())("CLI skills sync (ensureSkillsInstalled)
     if (tmp) rmSync(tmp, { recursive: true, force: true });
   });
 
-  it("writes all four CLI skills into ~/.claude/skills/<name>/SKILL.md on first run", async () => {
+  it("writes every CLI skill into ~/.claude/skills/<name>/SKILL.md on first run", async () => {
     expect(bandBinary, "band binary must be resolvable for this suite").not.toBeNull();
     const { runFirstTimeSetup } = await import("../src/lib/setup");
     await runFirstTimeSetup();
@@ -263,9 +270,9 @@ describe.skipIf(!bandBinaryReachable())("CLI skills sync (ensureSkillsInstalled)
       }
     }
 
-    // 4 agents × 4 skills = 16 freshly written files (each test gets a new
+    // 4 agents × N skills freshly written files (each test gets a new
     // tmp HOME via beforeEach, so nothing should already exist).
-    expect(result.written.length).toBe(16);
+    expect(result.written.length).toBe(4 * SKILL_NAMES.length);
     expect(result.unchanged.length).toBe(0);
   });
 
@@ -325,7 +332,7 @@ describe.skipIf(!bandBinaryReachable())("CLI skills sync (ensureSkillsInstalled)
 
     expect(existsSync(join(process.env.HOME!, ".claude", "skills", "band", "SKILL.md"))).toBe(true);
     expect(existsSync(join(process.env.HOME!, ".codex", "skills", "band", "SKILL.md"))).toBe(false);
-    expect(result.written.length).toBe(SKILL_NAMES.length); // 4 — only claude-code wrote
+    expect(result.written.length).toBe(SKILL_NAMES.length); // only claude-code wrote
   });
 
   it("skips agents with no command override when the default binary isn't on PATH", async () => {

--- a/apps/web/tests/slash-commands.test.ts
+++ b/apps/web/tests/slash-commands.test.ts
@@ -4,6 +4,7 @@ import { createServer } from "node:net";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { BAND_SKILL_NAMES } from "../src/lib/cli-skills";
 import { seedSettings, seedState } from "./helpers/seed-state";
 import { SERVER_RUNTIME, SERVER_SCRIPT } from "./helpers/server-runtime";
 
@@ -16,8 +17,11 @@ const DEFAULT_TOKEN = "slash-test-token";
  * lays down on every boot for any HOME that has Claude Code in its codingAgents
  * settings. We filter these out of the slash-commands assertions so the tests
  * remain focused on the skills *they* seed.
+ *
+ * Sourced from `BAND_SKILL_NAMES` (the canonical list in `lib/cli-skills.ts`)
+ * so adding a new shipped skill doesn't require touching this filter too.
  */
-const AUTO_INSTALLED_SKILL_NAMES = new Set(["band", "band-chat", "band-terminal", "band-browser"]);
+const AUTO_INSTALLED_SKILL_NAMES = new Set<string>(BAND_SKILL_NAMES);
 
 function withoutAutoInstalled<T extends { name: string }>(skills: T[]): T[] {
   return skills.filter((s) => !AUTO_INSTALLED_SKILL_NAMES.has(s.name));


### PR DESCRIPTION
## Summary

Adds two new domain-specific skills to the Band CLI's skill family, bringing the shipped set from four to six.

- **`band-start`** — kickoff flow. Auto-detects the project from cwd, parses Jira (`ABCD-1234`) / GitHub (`#42`) ticket references, fetches richer context via `acli` / `gh`, picks a Conventional Commits branch prefix (`feat/` / `fix/` / `chore/`), and creates the workspace with `--prompt` so the agent starts in one step. Then looks up the workspace ID via `band workspaces list` (the create response only returns `{"path": "..."}`) and the chat ID via `band chats list`, and prints a fully-substituted `band chats watch chat_abc` command for the user to run.
- **`band-loop`** — recurring agent prompts via `band cronjobs`. Default 10m cadence, accepts `5m` / `1h` / `1d` / raw cron. Two flavours: open-ended, and a self-deleting "stop when criteria is met" wrapper that has the agent run `band cronjobs delete` itself once the condition fires. 7-day safety cap. Native answer for users who would otherwise reach for Claude Code's `/loop` (which is gated on `scheduledTasksEnabled = true`, always false in SDK / Band sessions).

Both are **workflow-shaped** rather than reference-shaped — self-contained recipes, no auto-generated Commands section. The Rust generator (`apps/cli/src/skills.rs`) now supports both shapes: a template without `<!-- COMMANDS -->` may omit the `commands:` frontmatter, and the body is emitted verbatim. A paired-validation rule rejects templates that declare one but not the other so a typo can't silently drop a reference skill's Commands section.

`BAND_SKILL_NAMES` in `apps/web/src/lib/cli-skills.ts` (and the test mirror in `apps/web/tests/cli-skills.test.ts`) grows from four to six. The three existing Rust integration tests in `apps/cli/tests/integration.rs` are extended to cover the new skills, and the JSON-output test splits its per-skill command-count assertion so reference skills still require `> 0` commands while workflow skills must report exactly `0`. CLAUDE.md is updated to list six skills and describe the new template-shape split.

## Test plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy --manifest-path apps/cli/Cargo.toml -- -D warnings` clean (matches `.husky/pre-push`)
- [x] `cargo test --test integration -- skills` — all 8 `generate_skills_*` tests pass (existing 5 + the 3 extended ones)
- [x] `band generate-skills --output-dir apps/cli/skills` emits all six SKILL.md files: reference skills with their auto-generated Commands section, workflow skills verbatim with `0 command(s)` reported
- [x] Pre-push hook (biome, fmt, clippy, knip, jscpd) passed during `git push`
- [ ] CI green
- [ ] `apps/web/tests/cli-skills.test.ts` integration tests will only pick up the new templates once the installed `/usr/local/bin/band` symlink (or the bundled desktop sidecar) is rebuilt off this branch — known dev-loop limitation called out in earlier iterations of this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)