### PR TITLE
fix(terminal): restore mobile touch + focus on WebGL renderer

### DIFF
--- a/apps/web/src/components/TerminalPanel.tsx
+++ b/apps/web/src/components/TerminalPanel.tsx
@@ -231,6 +231,27 @@ export function TerminalPanel({
         try {
           const addon = new XWebglAddon({ customGlyphs: true });
           terminal.loadAddon(addon);
+          // The WebGL addon appends a <canvas> to `.xterm-screen` and only sets
+          // width/height — no `pointer-events` or `touch-action`. That canvas
+          // sits on top of `.xterm-helper-textarea`, the hidden element xterm.js
+          // uses to receive keyboard focus and synthesize taps. On iOS Safari
+          // the opaque canvas swallows every touch: taps never reach the helper
+          // textarea (so the soft keyboard never appears), our drag-to-scroll
+          // handler doesn't fire reliably, and long-press selection is dead.
+          // The canvas is purely a render target — it never needs DOM events —
+          // so disable pointer/touch handling on it. We re-run this on every
+          // `attachWebGL()` invocation so the `onContextLoss` recovery path
+          // (which appends a fresh canvas) doesn't reintroduce the regression.
+          const screenEl = containerRef.current?.querySelector(
+            ".xterm-screen",
+          ) as HTMLElement | null;
+          const webglCanvas = screenEl?.querySelector(
+            ":scope > canvas:last-of-type",
+          ) as HTMLCanvasElement | null;
+          if (webglCanvas) {
+            webglCanvas.style.pointerEvents = "none";
+            webglCanvas.style.touchAction = "none";
+          }
           webglAddonRef.current = addon;
           webglContextLossDisposable?.dispose();
           webglContextLossDisposable = addon.onContextLoss(() => {
@@ -336,6 +357,53 @@ export function TerminalPanel({
       containerEl.addEventListener("touchend", onTouchEnd, { passive: true });
       containerEl.addEventListener("touchcancel", onTouchEnd, { passive: true });
 
+      // Mobile focus-on-tap. Disabling `pointer-events` on the WebGL canvas
+      // (see `attachWebGL` above) lets touches reach `.xterm-screen`, but
+      // xterm.js's built-in click→focus path doesn't reliably re-engage the
+      // iOS soft keyboard in two scenarios:
+      //   1. Split terminals — tapping another panel needs to move focus to
+      //      that panel's `.xterm-helper-textarea`, but the synthesized click
+      //      via the canvas+pointer-events-none layout doesn't always trigger
+      //      xterm's internal focus call.
+      //   2. After the user taps "Done" on the soft keyboard, the textarea is
+      //      blurred. iOS only re-opens the keyboard when `.focus()` is called
+      //      synchronously inside a user gesture.
+      // Bind our own touchstart/touchend that explicitly calls
+      // `terminal.focus()` on taps (touches that release within ~10px of where
+      // they started). Larger movements are scroll drags handled by the scroll
+      // handler above — we deliberately skip focus there so a flick-to-scroll
+      // doesn't accidentally pop the keyboard.
+      let tapStartX: number | null = null;
+      let tapStartY: number | null = null;
+      const onTapStart = (e: TouchEvent) => {
+        if (e.touches.length === 1) {
+          tapStartX = e.touches[0].clientX;
+          tapStartY = e.touches[0].clientY;
+        } else {
+          tapStartX = null;
+          tapStartY = null;
+        }
+      };
+      const onTapEnd = (e: TouchEvent) => {
+        const startX = tapStartX;
+        const startY = tapStartY;
+        tapStartX = null;
+        tapStartY = null;
+        if (startX === null || startY === null || e.changedTouches.length !== 1) return;
+        const dx = Math.abs(e.changedTouches[0].clientX - startX);
+        const dy = Math.abs(e.changedTouches[0].clientY - startY);
+        if (dx < 10 && dy < 10) {
+          terminal.focus();
+        }
+      };
+      const onTapCancel = () => {
+        tapStartX = null;
+        tapStartY = null;
+      };
+      containerEl.addEventListener("touchstart", onTapStart, { passive: true });
+      containerEl.addEventListener("touchend", onTapEnd, { passive: true });
+      containerEl.addEventListener("touchcancel", onTapCancel, { passive: true });
+
       // Connect WebSocket
       const proto = location.protocol === "https:" ? "wss:" : "ws:";
       const ws = new WebSocket(
@@ -431,6 +499,9 @@ export function TerminalPanel({
         containerEl.removeEventListener("touchmove", onTouchMove);
         containerEl.removeEventListener("touchend", onTouchEnd);
         containerEl.removeEventListener("touchcancel", onTouchEnd);
+        containerEl.removeEventListener("touchstart", onTapStart);
+        containerEl.removeEventListener("touchend", onTapEnd);
+        containerEl.removeEventListener("touchcancel", onTapCancel);
         ws.close();
         // `terminal.dispose()` cascades to all loaded addons (including the
         // WebGL addon if present), so we don't need to dispose it manually.


### PR DESCRIPTION
## Summary

- After commit 91e15d0 switched xterm.js to `@xterm/addon-webgl`, the WebGL canvas absorbed every touch on iOS Safari — taps never reached `.xterm-helper-textarea`, so the soft keyboard never appeared, drag-to-scroll didn't fire, and long-press selection was dead.
- Set `pointer-events: none` and `touch-action: none` on the WebGL canvas inside `attachWebGL()`, so the fix re-applies on every `onContextLoss` reattach. The canvas is purely a render target and never needs DOM events.
- xterm.js's internal click→focus path didn't reliably re-engage iOS when switching focus between split terminals or re-opening the keyboard after Done, so added a small touchstart/touchend tap detector that calls `terminal.focus()` synchronously inside the user gesture for releases within ~10px of touchstart. Larger movements remain scroll drags, handled by the untouched existing scroll handler.

## Test plan

Per `CLAUDE.md`, this project uses integration tests and does not allow mocked unit tests for DOM event flow, so verification is manual on iOS Safari (or desktop Safari with touch emulation):

- [ ] WebGL on (Settings → Terminal → GPU-accelerated rendering = on): tap terminal → soft keyboard appears, prompt cursor focused
- [ ] Type → characters reach the PTY
- [ ] Drag up/down → scrollback scrolls
- [ ] Long-press a word → iOS selection bubble appears
- [ ] Split terminal: tap the other panel → focus moves to it, keyboard follows
- [ ] Tap Done on keyboard → keyboard hides; tap terminal again → keyboard re-appears
- [ ] WebGL OFF, reload → DOM renderer still works on mobile (regression check; we only touched the WebGL path)
- [ ] WebGL on: simulate context loss via `WEBGL_lose_context.loseContext()`; after reattach, all the above still work (exercises the recursive `attachWebGL()` path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)