### PR TITLE
feat(file-browser): create / rename / delete / cut / copy / paste

### DIFF
--- a/apps/web/src/components/CodeBrowserView.tsx
+++ b/apps/web/src/components/CodeBrowserView.tsx
@@ -2,6 +2,7 @@ import {
   buildLspWsUrl,
   createLspExtension,
   FileBrowser,
+  type FileBrowserHandle,
   FileViewer,
   getFilePreviewType,
   getLspLanguageId,
@@ -20,13 +21,34 @@ import {
   useSearch,
   useSettingsQuery,
 } from "@band-app/dashboard-core";
-import { cn, Tooltip, TooltipContent, TooltipTrigger } from "@band-app/ui";
+import {
+  cn,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@band-app/ui";
 import type { Extension } from "@codemirror/state";
 import { cjk } from "@streamdown/cjk";
 import { code } from "@streamdown/code";
 import { math } from "@streamdown/math";
 import { mermaid } from "@streamdown/mermaid";
-import { ChevronLeft, ChevronRight, Code, Eye, File, Search, TextSearch } from "lucide-react";
+import {
+  ChevronLeft,
+  ChevronRight,
+  Code,
+  Eye,
+  File,
+  FilePlus,
+  FolderPlus,
+  MoreVertical,
+  Search,
+  TextSearch,
+} from "lucide-react";
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { Group, Panel, Separator, usePanelRef } from "react-resizable-panels";
 import { Streamdown } from "streamdown";
@@ -119,10 +141,6 @@ interface CodeBrowserViewProps {
   onFileOpened?: () => void;
   /** Reports a callback that triggers find-in-file search (null when unavailable) */
   onFindInFile?: (fn: (() => void) | null) => void;
-  /** Called to open the Quick Open dialog */
-  onQuickOpen?: () => void;
-  /** Called to open the Search in Files dialog */
-  onSearchFiles?: () => void;
 }
 
 // ---------------------------------------------------------------------------
@@ -130,50 +148,217 @@ interface CodeBrowserViewProps {
 // ---------------------------------------------------------------------------
 
 interface FileTreeToolbarProps {
-  onQuickOpen?: () => void;
-  onSearchFiles?: () => void;
+  onNewFile?: () => void;
+  onNewFolder?: () => void;
 }
 
-function FileTreeToolbar({ onQuickOpen, onSearchFiles }: FileTreeToolbarProps) {
+// Below this width (px), the toolbar collapses its action buttons into a
+// vertical 3-dots dropdown so the panel stays usable even when narrow.
+const TOOLBAR_COMPACT_BREAKPOINT = 200;
+
+/**
+ * Build a pointerup handler that mirrors a click for touch / pen pointers.
+ *
+ * iOS Safari swallows the synthetic click on a Tooltip-wrapped button's
+ * first tap — the OS treats the tap as a "show hover state" gesture for
+ * the tooltip, the tooltip flashes, and `onClick` never fires. Lifting on
+ * pointerup is reliable across pointer types: we run the action there for
+ * touch and pen, and `preventDefault()` stops the synthetic click from
+ * firing afterward so mouse-pointer clicks (which take the `onClick` path)
+ * don't double-trigger.
+ */
+const touchPointerUp = (fn?: () => void) => (e: React.PointerEvent<HTMLButtonElement>) => {
+  if (!fn || e.pointerType === "mouse") return;
+  e.preventDefault();
+  fn();
+};
+
+/**
+ * Open Quick Open via a window event. The active workspace layout
+ * (MobileWorkspaceLayout in `workspace.$workspaceId.tsx` or
+ * DockviewWorkspaceLayout when desktop) listens for this event and
+ * opens its locally-owned dialog. Using an event avoids threading the
+ * setter through a React context across multiple route levels, which
+ * proved unreliable in practice on the iOS Simulator.
+ */
+const fireOpenQuickOpen = () => window.dispatchEvent(new CustomEvent("band:open-quick-open"));
+const fireOpenSearchFiles = () => window.dispatchEvent(new CustomEvent("band:open-search-files"));
+
+function FileTreeToolbar({ onNewFile, onNewFolder }: FileTreeToolbarProps) {
+  const rootRef = useRef<HTMLDivElement>(null);
+  const [compact, setCompact] = useState(false);
+
+  useLayoutEffect(() => {
+    const el = rootRef.current;
+    if (!el) return;
+    setCompact(el.clientWidth < TOOLBAR_COMPACT_BREAKPOINT);
+  }, []);
+
+  useEffect(() => {
+    const el = rootRef.current;
+    if (!el) return;
+    const ro = new ResizeObserver((entries) => {
+      for (const entry of entries) {
+        setCompact(entry.contentRect.width < TOOLBAR_COMPACT_BREAKPOINT);
+      }
+    });
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, []);
+
+  // Defer the dropdown's menu actions until after the menu has fully
+  // closed — same trick the file-tree context menus use. Without this,
+  // selecting "New File" mounts the inline rename / new-entry input
+  // inside dashboard-core while Radix's FocusScope (still alive for
+  // the DropdownMenu's close transition) yanks focus back, and the
+  // input's own onBlur tears it down before it can take focus.
+  const pendingMenuAction = useRef<(() => void) | null>(null);
+  const queueMenuAction = useCallback((fn: () => void) => {
+    pendingMenuAction.current = fn;
+  }, []);
+  const flushMenuAction = useCallback((e: { preventDefault: () => void }) => {
+    e.preventDefault();
+    const fn = pendingMenuAction.current;
+    pendingMenuAction.current = null;
+    fn?.();
+  }, []);
+
   return (
-    <div className="flex h-9 shrink-0 items-center gap-0.5 border-b border-border/50 pl-3 pr-1.5">
+    <div
+      ref={rootRef}
+      className="flex h-9 shrink-0 items-center gap-0.5 border-b border-border/50 pl-3 pr-1.5"
+    >
       <span className="text-xs font-medium text-muted-foreground">Files</span>
       <div className="flex-1" />
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <button
-            type="button"
-            onClick={onQuickOpen}
-            className="inline-flex size-6 items-center justify-center rounded-md text-muted-foreground hover:bg-accent hover:text-foreground transition-colors"
+      {compact ? (
+        <DropdownMenu>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <DropdownMenuTrigger asChild>
+                <button
+                  type="button"
+                  aria-label="File tree actions"
+                  className="inline-flex size-6 items-center justify-center rounded-md text-muted-foreground hover:bg-accent hover:text-foreground transition-colors data-[state=open]:bg-accent data-[state=open]:text-foreground"
+                >
+                  <MoreVertical className="size-3.5" />
+                </button>
+              </DropdownMenuTrigger>
+            </TooltipTrigger>
+            <TooltipContent side="bottom" className="text-xs">
+              More
+            </TooltipContent>
+          </Tooltip>
+          <DropdownMenuContent
+            align="end"
+            className="min-w-[10rem]"
+            onCloseAutoFocus={flushMenuAction}
           >
-            <Search className="size-3.5" />
-          </button>
-        </TooltipTrigger>
-        <TooltipContent side="bottom" className="text-xs">
-          Quick Open{" "}
-          <kbd className="ml-1.5 rounded border border-popover-foreground/25 bg-popover-foreground/10 px-1 py-0.5 font-mono text-[14px]">
-            ⌘P
-          </kbd>
-        </TooltipContent>
-      </Tooltip>
+            {onNewFile && (
+              <DropdownMenuItem onSelect={() => queueMenuAction(onNewFile)}>
+                <FilePlus className="size-4" />
+                New File
+              </DropdownMenuItem>
+            )}
+            {onNewFolder && (
+              <DropdownMenuItem onSelect={() => queueMenuAction(onNewFolder)}>
+                <FolderPlus className="size-4" />
+                New Folder
+              </DropdownMenuItem>
+            )}
+            {(onNewFile || onNewFolder) && <DropdownMenuSeparator />}
+            <DropdownMenuItem onSelect={() => queueMenuAction(fireOpenQuickOpen)}>
+              <Search className="size-4" />
+              Quick Open
+              <kbd className="ml-auto rounded border border-popover-foreground/25 bg-popover-foreground/10 px-1 py-0.5 font-mono text-[10px]">
+                ⌘P
+              </kbd>
+            </DropdownMenuItem>
+            <DropdownMenuItem onSelect={() => queueMenuAction(fireOpenSearchFiles)}>
+              <TextSearch className="size-4" />
+              Search in Files
+              <kbd className="ml-auto rounded border border-popover-foreground/25 bg-popover-foreground/10 px-1 py-0.5 font-mono text-[10px]">
+                ⌘⇧F
+              </kbd>
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      ) : (
+        <>
+          {onNewFile && (
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <button
+                  type="button"
+                  onClick={onNewFile}
+                  onPointerUp={touchPointerUp(onNewFile)}
+                  className="inline-flex size-6 items-center justify-center rounded-md text-muted-foreground hover:bg-accent hover:text-foreground transition-colors"
+                >
+                  <FilePlus className="size-3.5" />
+                </button>
+              </TooltipTrigger>
+              <TooltipContent side="bottom" className="text-xs">
+                New File
+              </TooltipContent>
+            </Tooltip>
+          )}
 
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <button
-            type="button"
-            onClick={onSearchFiles}
-            className="inline-flex size-6 items-center justify-center rounded-md text-muted-foreground hover:bg-accent hover:text-foreground transition-colors"
-          >
-            <TextSearch className="size-3.5" />
-          </button>
-        </TooltipTrigger>
-        <TooltipContent side="bottom" className="text-xs">
-          Search in Files{" "}
-          <kbd className="ml-1.5 rounded border border-popover-foreground/25 bg-popover-foreground/10 px-1 py-0.5 font-mono text-[14px]">
-            ⌘⇧F
-          </kbd>
-        </TooltipContent>
-      </Tooltip>
+          {onNewFolder && (
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <button
+                  type="button"
+                  onClick={onNewFolder}
+                  onPointerUp={touchPointerUp(onNewFolder)}
+                  className="inline-flex size-6 items-center justify-center rounded-md text-muted-foreground hover:bg-accent hover:text-foreground transition-colors"
+                >
+                  <FolderPlus className="size-3.5" />
+                </button>
+              </TooltipTrigger>
+              <TooltipContent side="bottom" className="text-xs">
+                New Folder
+              </TooltipContent>
+            </Tooltip>
+          )}
+
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                type="button"
+                onClick={fireOpenQuickOpen}
+                onPointerUp={touchPointerUp(fireOpenQuickOpen)}
+                className="inline-flex size-6 items-center justify-center rounded-md text-muted-foreground hover:bg-accent hover:text-foreground transition-colors"
+              >
+                <Search className="size-3.5" />
+              </button>
+            </TooltipTrigger>
+            <TooltipContent side="bottom" className="text-xs">
+              Quick Open{" "}
+              <kbd className="ml-1.5 rounded border border-popover-foreground/25 bg-popover-foreground/10 px-1 py-0.5 font-mono text-[14px]">
+                ⌘P
+              </kbd>
+            </TooltipContent>
+          </Tooltip>
+
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                type="button"
+                onClick={fireOpenSearchFiles}
+                onPointerUp={touchPointerUp(fireOpenSearchFiles)}
+                className="inline-flex size-6 items-center justify-center rounded-md text-muted-foreground hover:bg-accent hover:text-foreground transition-colors"
+              >
+                <TextSearch className="size-3.5" />
+              </button>
+            </TooltipTrigger>
+            <TooltipContent side="bottom" className="text-xs">
+              Search in Files{" "}
+              <kbd className="ml-1.5 rounded border border-popover-foreground/25 bg-popover-foreground/10 px-1 py-0.5 font-mono text-[14px]">
+                ⌘⇧F
+              </kbd>
+            </TooltipContent>
+          </Tooltip>
+        </>
+      )}
     </div>
   );
 }
@@ -189,8 +374,6 @@ export function CodeBrowserView({
   openFilePath,
   onFileOpened,
   onFindInFile,
-  onQuickOpen,
-  onSearchFiles,
 }: CodeBrowserViewProps) {
   const isDesktop = useIsDesktop();
   const fileTabs = useFileTabs(workspaceId);
@@ -882,6 +1065,130 @@ export function CodeBrowserView({
   }, [fileTabs.activeTabPath, handleTabClose]);
 
   // -------------------------------------------------------------------------
+  // File tree imperative handle (drives "new file" / "new folder" from toolbar)
+  // -------------------------------------------------------------------------
+  const fileBrowserRef = useRef<FileBrowserHandle | null>(null);
+
+  const handleNewFile = useCallback(() => {
+    fileBrowserRef.current?.startNewFile();
+  }, []);
+  const handleNewFolder = useCallback(() => {
+    fileBrowserRef.current?.startNewFolder();
+  }, []);
+
+  // -------------------------------------------------------------------------
+  // Keep tabs + editor state in sync with rename / delete in the file tree.
+  // -------------------------------------------------------------------------
+
+  // Save the editor view's current state for the currently active tab.
+  // This needs to happen synchronously BEFORE the file path changes so
+  // we don't lose pending edits when the editor remounts on the new
+  // path. Returns a function that flushes the saved state to either
+  // the rewritten path (rename) or drops it (delete).
+  const flushActiveEditorState = useCallback(() => {
+    const view = editorViewRef.current;
+    const fp = viewFilePathRef.current;
+    if (!view || !fp) return null;
+    try {
+      const state = serializeEditorState(view);
+      return { path: fp, state };
+    } catch {
+      return null;
+    }
+  }, []);
+
+  const handlePathRenamed = useCallback(
+    (oldPath: string, newPath: string, _kind: "file" | "directory") => {
+      // Capture the live editor state for the active tab before any
+      // path rewriting so it survives the rename.
+      const flushed = flushActiveEditorState();
+
+      // Rewrite tab list and persisted per-tab state (editor state,
+      // view mode, edited content). Both handle exact and prefix-match
+      // semantics so directory renames cascade to descendant tabs.
+      fileTabs.renameFile(oldPath, newPath);
+      tabState.renameFile(oldPath, newPath);
+
+      // In-memory editor states keyed by path also need rewriting.
+      const oldPrefix = `${oldPath}/`;
+      const newStates: typeof savedEditorStatesRef.current = {};
+      for (const [key, value] of Object.entries(savedEditorStatesRef.current)) {
+        if (key === oldPath) {
+          newStates[newPath] = value;
+        } else if (key.startsWith(oldPrefix)) {
+          newStates[newPath + key.slice(oldPath.length)] = value;
+        } else {
+          newStates[key] = value;
+        }
+      }
+      // If we just captured the active editor's state, persist it
+      // under the renamed key so the editor restores cleanly when it
+      // remounts on the new path.
+      if (flushed) {
+        const rewritten =
+          flushed.path === oldPath
+            ? newPath
+            : flushed.path.startsWith(oldPrefix)
+              ? newPath + flushed.path.slice(oldPath.length)
+              : flushed.path;
+        newStates[rewritten] = flushed.state;
+        tabState.update(rewritten, {
+          editorState: flushed.state.editorState,
+          scrollTop: flushed.state.scrollTop,
+        });
+      }
+      savedEditorStatesRef.current = newStates;
+
+      // Sync the currently-viewed file path so the editor remounts on
+      // the new name (or the new descendant path).
+      if (viewFilePath === oldPath) {
+        skipFileEffectRef.current = true;
+        setViewFilePath(newPath);
+        onSelectFile?.(newPath);
+      } else if (viewFilePath.startsWith(oldPrefix)) {
+        const rewritten = newPath + viewFilePath.slice(oldPath.length);
+        skipFileEffectRef.current = true;
+        setViewFilePath(rewritten);
+        onSelectFile?.(rewritten);
+      }
+    },
+    [
+      fileTabs.renameFile,
+      tabState.renameFile,
+      tabState.update,
+      flushActiveEditorState,
+      viewFilePath,
+      onSelectFile,
+    ],
+  );
+
+  const handlePathDeleted = useCallback(
+    (path: string, _kind: "file" | "directory") => {
+      const prefix = `${path}/`;
+      // Drop in-memory editor state for any descendant.
+      for (const key of Object.keys(savedEditorStatesRef.current)) {
+        if (key === path || key.startsWith(prefix)) {
+          delete savedEditorStatesRef.current[key];
+        }
+      }
+      // Drop persisted per-tab state.
+      tabState.removePath(path);
+      // Drop tabs (this also adjusts activeTabPath if needed).
+      fileTabs.removePath(path);
+
+      // Clear the currently-viewed file if it sat inside the deleted tree.
+      if (viewFilePath === path || viewFilePath.startsWith(prefix)) {
+        setViewFilePath("");
+        setViewLine(undefined);
+        setViewLineEnd(undefined);
+        setViewColumn(undefined);
+        onSelectFile?.(null);
+      }
+    },
+    [fileTabs.removePath, tabState.removePath, viewFilePath, onSelectFile],
+  );
+
+  // -------------------------------------------------------------------------
   // Resizable file tree panel
   // -------------------------------------------------------------------------
   const treePanelRef = usePanelRef();
@@ -968,12 +1275,26 @@ export function CodeBrowserView({
             onEditedContentChange={handleEditedContentChange}
           />
         ) : (
-          <FileBrowser
-            workspaceId={workspaceId}
-            onOpenFile={handleSelectFile}
-            onOpenFilePinned={handleSelectFilePinned}
-            selectedFile={viewFilePath}
-          />
+          // Same toolbar-above-tree layout the desktop side-by-side uses,
+          // so New File / New Folder / Quick Open / Search in Files are
+          // reachable on touch without relying on the (undiscoverable)
+          // long-press → context menu. The toolbar already handles its
+          // own narrow-width collapse into a kebab, so this works at any
+          // mobile viewport.
+          <div className="flex h-full flex-col overflow-hidden">
+            <FileTreeToolbar onNewFile={handleNewFile} onNewFolder={handleNewFolder} />
+            <div className="min-h-0 flex-1 overflow-hidden">
+              <FileBrowser
+                ref={fileBrowserRef}
+                workspaceId={workspaceId}
+                onOpenFile={handleSelectFile}
+                onOpenFilePinned={handleSelectFilePinned}
+                selectedFile={viewFilePath}
+                onPathRenamed={handlePathRenamed}
+                onPathDeleted={handlePathDeleted}
+              />
+            </div>
+          </div>
         )
       ) : (
         // Desktop: side-by-side layout with resizable file tree
@@ -998,14 +1319,17 @@ export function CodeBrowserView({
             }}
           >
             <div className="flex h-full flex-col overflow-hidden border-r border-border">
-              <FileTreeToolbar onQuickOpen={onQuickOpen} onSearchFiles={onSearchFiles} />
+              <FileTreeToolbar onNewFile={handleNewFile} onNewFolder={handleNewFolder} />
               <div className="min-h-0 flex-1 overflow-hidden">
                 <FileBrowser
+                  ref={fileBrowserRef}
                   workspaceId={workspaceId}
                   onOpenFile={handleSelectFile}
                   onOpenFilePinned={handleSelectFilePinned}
                   compact
                   selectedFile={viewFilePath}
+                  onPathRenamed={handlePathRenamed}
+                  onPathDeleted={handlePathDeleted}
                 />
               </div>
             </div>

--- a/apps/web/src/components/DockviewWorkspaceLayout.tsx
+++ b/apps/web/src/components/DockviewWorkspaceLayout.tsx
@@ -106,8 +106,6 @@ interface FilesParams {
   onSelectFile: (filePath: string | null) => void;
   onFileOpened: () => void;
   onFindInFile: (fn: (() => void) | null) => void;
-  onQuickOpen: () => void;
-  onSearchFiles: () => void;
 }
 
 interface TerminalParams {
@@ -196,8 +194,6 @@ function FilesPanelComponent({ params }: IDockviewPanelProps<FilesParams>) {
       openFilePath={params.openFilePath}
       onFileOpened={params.onFileOpened}
       onFindInFile={params.onFindInFile}
-      onQuickOpen={params.onQuickOpen}
-      onSearchFiles={params.onSearchFiles}
     />
   );
 }
@@ -1063,6 +1059,22 @@ export const DockviewWorkspaceLayout = memo(function DockviewWorkspaceLayout({
     return () => window.removeEventListener("band:open-file", handler);
   }, [isActive]);
 
+  // Window-event triggers for the file-tree toolbar's Quick Open / Search
+  // in Files buttons. See workspace.$workspaceId.tsx for the rationale —
+  // a window event is more reliable than threading the setters through
+  // multiple layers of route-component context.
+  useEffect(() => {
+    if (!isActive) return;
+    const openQO = () => setQuickOpenOpen(true);
+    const openSF = () => setSearchFilesOpen(true);
+    window.addEventListener("band:open-quick-open", openQO);
+    window.addEventListener("band:open-search-files", openSF);
+    return () => {
+      window.removeEventListener("band:open-quick-open", openQO);
+      window.removeEventListener("band:open-search-files", openSF);
+    };
+  }, [isActive]);
+
   // Listen for panel activation events from the title bar panel switcher
   useEffect(() => {
     if (!isActive) return;
@@ -1098,8 +1110,6 @@ export const DockviewWorkspaceLayout = memo(function DockviewWorkspaceLayout({
         onSelectFile: handleSelectFile,
         onFileOpened: handleFileOpened,
         onFindInFile: setFindInFile,
-        onQuickOpen: () => setQuickOpenOpen(true),
-        onSearchFiles: () => setSearchFilesOpen(true),
       });
       api.getPanel("terminal")?.api.updateParameters({
         workspaceId,

--- a/apps/web/src/hooks/useFileTabs.ts
+++ b/apps/web/src/hooks/useFileTabs.ts
@@ -43,6 +43,19 @@ export interface UseFileTabsReturn {
   setActiveTab: (filePath: string) => void;
   closeOtherTabs: (filePath: string) => void;
   closeAllTabs: () => void;
+  /**
+   * Rename or move a file. Updates the tab whose path equals `oldPath`,
+   * and any descendant tab whose path starts with `oldPath + "/"` (used
+   * when the user renames a directory). The active tab pointer follows
+   * the renamed path automatically.
+   */
+  renameFile: (oldPath: string, newPath: string) => void;
+  /**
+   * Remove every tab whose path equals `path` or sits inside `path + "/"`.
+   * Used to keep tabs in sync when the user deletes a file or directory
+   * from the file browser.
+   */
+  removePath: (path: string) => void;
 }
 
 // ---------------------------------------------------------------------------
@@ -291,6 +304,80 @@ export function useFileTabs(workspaceId: string): UseFileTabsReturn {
     setActiveTabPathState(null);
   }, []);
 
+  // Helper: returns the rewritten path if `path` is `oldPath` itself or
+  // a descendant of `oldPath`. Returns null when it's outside the
+  // renamed subtree.
+  const rewritePath = useCallback(
+    (path: string, oldPath: string, newPath: string): string | null => {
+      if (path === oldPath) return newPath;
+      const prefix = `${oldPath}/`;
+      if (path.startsWith(prefix)) return newPath + path.slice(oldPath.length);
+      return null;
+    },
+    [],
+  );
+
+  const renameFile = useCallback(
+    (oldPath: string, newPath: string) => {
+      if (oldPath === newPath) return;
+      setOpenTabs((prev) => {
+        let changed = false;
+        const next = prev.map((tab) => {
+          const rewritten = rewritePath(tab.filePath, oldPath, newPath);
+          if (rewritten === null) return tab;
+          changed = true;
+          return tab.isPreview ? { filePath: rewritten, isPreview: true } : { filePath: rewritten };
+        });
+        return changed ? next : prev;
+      });
+      setActiveTabPathState((current) => {
+        if (current === null) return current;
+        const rewritten = rewritePath(current, oldPath, newPath);
+        return rewritten ?? current;
+      });
+    },
+    [rewritePath],
+  );
+
+  const removePath = useCallback((path: string) => {
+    const prefix = `${path}/`;
+    setOpenTabs((prev) => {
+      const next = prev.filter((tab) => tab.filePath !== path && !tab.filePath.startsWith(prefix));
+      if (next.length === prev.length) {
+        // Nothing to remove — still need to sync activeTabPath in case it
+        // was already cleared elsewhere.
+        return prev;
+      }
+      setActiveTabPathState((currentActive) => {
+        if (
+          currentActive !== null &&
+          (currentActive === path || currentActive.startsWith(prefix))
+        ) {
+          // Pick the tab that used to be just after the removed range,
+          // else the previous tab, else nothing.
+          if (next.length === 0) return null;
+          const removedIdx = prev.findIndex((t) => t.filePath === currentActive);
+          if (removedIdx === -1) return next[0].filePath;
+          // Find the surviving tab nearest to the removed slot.
+          // Search forward first.
+          for (let i = removedIdx; i < prev.length; i++) {
+            if (next.some((t) => t.filePath === prev[i].filePath)) {
+              return prev[i].filePath;
+            }
+          }
+          for (let i = removedIdx - 1; i >= 0; i--) {
+            if (next.some((t) => t.filePath === prev[i].filePath)) {
+              return prev[i].filePath;
+            }
+          }
+          return next[0].filePath;
+        }
+        return currentActive;
+      });
+      return next;
+    });
+  }, []);
+
   return {
     openTabs,
     activeTabPath,
@@ -302,5 +389,7 @@ export function useFileTabs(workspaceId: string): UseFileTabsReturn {
     setActiveTab,
     closeOtherTabs,
     closeAllTabs,
+    renameFile,
+    removePath,
   };
 }

--- a/apps/web/src/hooks/useTabState.ts
+++ b/apps/web/src/hooks/useTabState.ts
@@ -55,6 +55,17 @@ export interface UseTabStateReturn {
   isDirty: (filePath: string) => boolean;
   /** Remove all stored state for a file (e.g. when tab is closed). */
   removeFile: (filePath: string) => void;
+  /**
+   * Rename a stored file's state (and any descendants when `oldPath`
+   * was a directory). Used to keep persisted editor state in sync when
+   * the user renames a file/directory from the file browser.
+   */
+  renameFile: (oldPath: string, newPath: string) => void;
+  /**
+   * Remove stored state for `path` and anything sitting inside it.
+   * Used when a path is deleted from the file browser.
+   */
+  removePath: (path: string) => void;
 }
 
 export function useTabState(workspaceId: string): UseTabStateReturn {
@@ -107,5 +118,54 @@ export function useTabState(workspaceId: string): UseTabStateReturn {
     [workspaceId],
   );
 
-  return { get, update, getViewMode, setViewMode, isDirty, removeFile };
+  const renameFile = useCallback(
+    (oldPath: string, newPath: string) => {
+      if (oldPath === newPath) return;
+      const prefix = `${oldPath}/`;
+      let changed = false;
+      const next: Record<string, TabFileState> = {};
+      for (const [key, value] of Object.entries(stateRef.current)) {
+        if (key === oldPath) {
+          next[newPath] = value;
+          changed = true;
+        } else if (key.startsWith(prefix)) {
+          next[newPath + key.slice(oldPath.length)] = value;
+          changed = true;
+        } else {
+          next[key] = value;
+        }
+      }
+      if (changed) {
+        stateRef.current = next;
+        saveState(workspaceId, stateRef.current);
+      }
+    },
+    [workspaceId],
+  );
+
+  const removePath = useCallback(
+    (path: string) => {
+      const prefix = `${path}/`;
+      let changed = false;
+      for (const key of Object.keys(stateRef.current)) {
+        if (key === path || key.startsWith(prefix)) {
+          delete stateRef.current[key];
+          changed = true;
+        }
+      }
+      if (changed) saveState(workspaceId, stateRef.current);
+    },
+    [workspaceId],
+  );
+
+  return {
+    get,
+    update,
+    getViewMode,
+    setViewMode,
+    isDirty,
+    removeFile,
+    renameFile,
+    removePath,
+  };
 }

--- a/apps/web/src/routes/workspace.$workspaceId.tsx
+++ b/apps/web/src/routes/workspace.$workspaceId.tsx
@@ -1,6 +1,7 @@
 import {
   type DiffStats,
   QuickOpenDialog,
+  SearchFilesDialog,
   useDashboardStore,
   type WorkspaceTab,
   WorkspaceTabNav,
@@ -54,6 +55,11 @@ const FindInFileContext = createContext<FindInFileContextValue>({
 export function useFindInFileContext() {
   return useContext(FindInFileContext);
 }
+
+// (Removed CodeToolbarContext — the toolbar now dispatches `band:open-quick-open`
+// and `band:open-search-files` window events that this layout and
+// DockviewWorkspaceLayout each listen for. Context proved unreliable
+// to thread through multiple route levels on the iOS Simulator.)
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -272,6 +278,8 @@ function MobileWorkspaceLayout({
   // Quick Open state for file link clicks from chat
   const [quickOpenOpen, setQuickOpenOpen] = useState(false);
   const [quickOpenQuery, setQuickOpenQuery] = useState<string | undefined>(undefined);
+  // Search-in-Files state for the file-tree toolbar (mobile / non-dockview).
+  const [searchFilesOpen, setSearchFilesOpen] = useState(false);
 
   const handleOpenFile = useCallback(
     (filename: string) => {
@@ -294,6 +302,23 @@ function MobileWorkspaceLayout({
     };
     window.addEventListener("band:open-file", handler);
     return () => window.removeEventListener("band:open-file", handler);
+  }, []);
+
+  // Window-event triggers for the file-tree toolbar's Quick Open / Search
+  // in Files buttons. We use a window event (rather than threading the
+  // setters through a React Context) because the toolbar is rendered by
+  // CodeBrowserView several levels down the route tree, and routing the
+  // setter via context proved unreliable on the iOS Simulator's tree.
+  // The toolbar dispatches the event; this layout owns the dialog state.
+  useEffect(() => {
+    const openQO = () => setQuickOpenOpen(true);
+    const openSF = () => setSearchFilesOpen(true);
+    window.addEventListener("band:open-quick-open", openQO);
+    window.addEventListener("band:open-search-files", openSF);
+    return () => {
+      window.removeEventListener("band:open-quick-open", openQO);
+      window.removeEventListener("band:open-search-files", openSF);
+    };
   }, []);
 
   const handleSwitchAgent = useCallback(
@@ -380,6 +405,12 @@ function MobileWorkspaceLayout({
             onOpenFile={handleOpenFile}
             initialQuery={quickOpenQuery}
             autoOpen={quickOpenQuery != null}
+          />
+          <SearchFilesDialog
+            workspaceId={workspaceId}
+            open={searchFilesOpen}
+            onOpenChange={setSearchFilesOpen}
+            onOpenFile={handleOpenFile}
           />
         </div>
       </AgentSwitcherContext.Provider>

--- a/apps/web/src/trpc/router.ts
+++ b/apps/web/src/trpc/router.ts
@@ -1,8 +1,8 @@
 import { execFile, execFileSync } from "node:child_process";
 import { randomUUID } from "node:crypto";
 import { existsSync, mkdirSync, unlinkSync } from "node:fs";
-import { readdir, readFile, rm, stat, writeFile } from "node:fs/promises";
-import { basename, extname, join, resolve } from "node:path";
+import { cp, mkdir, readdir, readFile, rename, rm, stat, writeFile } from "node:fs/promises";
+import { basename, dirname, extname, join, resolve, sep } from "node:path";
 import { promisify } from "node:util";
 import { toWorkspaceId } from "@band-app/dashboard-core";
 import { createLogger } from "@band-app/logger";
@@ -1397,6 +1397,278 @@ const workspaceRouter = t.router({
       await writeFile(target, input.content, "utf-8");
 
       return { ok: true };
+    }),
+
+  createFile: publicProcedure
+    .input(
+      z.object({
+        workspaceId: z.string(),
+        path: z.string().min(1),
+        content: z.string().default(""),
+      }),
+    )
+    .mutation(async ({ input }) => {
+      const workspace = resolveWorkspace(input.workspaceId);
+      if (!workspace) {
+        throw new Error("Workspace not found");
+      }
+
+      const root = workspace.worktree.path;
+      const target = resolve(join(root, input.path));
+
+      if (!target.startsWith(root) || target === root) {
+        throw new Error("Invalid path");
+      }
+
+      if (existsSync(target)) {
+        throw new Error("A file or directory already exists at this path");
+      }
+
+      const parent = dirname(target);
+      if (!existsSync(parent)) {
+        throw new Error("Parent directory does not exist");
+      }
+      const parentStat = await stat(parent);
+      if (!parentStat.isDirectory()) {
+        throw new Error("Parent is not a directory");
+      }
+
+      await writeFile(target, input.content, { encoding: "utf-8", flag: "wx" });
+
+      return { ok: true };
+    }),
+
+  createDirectory: publicProcedure
+    .input(
+      z.object({
+        workspaceId: z.string(),
+        path: z.string().min(1),
+      }),
+    )
+    .mutation(async ({ input }) => {
+      const workspace = resolveWorkspace(input.workspaceId);
+      if (!workspace) {
+        throw new Error("Workspace not found");
+      }
+
+      const root = workspace.worktree.path;
+      const target = resolve(join(root, input.path));
+
+      if (!target.startsWith(root) || target === root) {
+        throw new Error("Invalid path");
+      }
+
+      if (existsSync(target)) {
+        throw new Error("A file or directory already exists at this path");
+      }
+
+      const parent = dirname(target);
+      if (!existsSync(parent)) {
+        throw new Error("Parent directory does not exist");
+      }
+      const parentStat = await stat(parent);
+      if (!parentStat.isDirectory()) {
+        throw new Error("Parent is not a directory");
+      }
+
+      await mkdir(target);
+
+      return { ok: true };
+    }),
+
+  deletePath: publicProcedure
+    .input(
+      z.object({
+        workspaceId: z.string(),
+        path: z.string().min(1),
+      }),
+    )
+    .mutation(async ({ input }) => {
+      const workspace = resolveWorkspace(input.workspaceId);
+      if (!workspace) {
+        throw new Error("Workspace not found");
+      }
+
+      const root = workspace.worktree.path;
+      const target = resolve(join(root, input.path));
+
+      if (!target.startsWith(root) || target === root) {
+        throw new Error("Invalid path");
+      }
+
+      // Refuse to delete the .git metadata folder — destroying it would
+      // corrupt the worktree.
+      const relative = target.slice(root.length + 1);
+      if (relative === ".git" || relative.startsWith(".git/")) {
+        throw new Error("Refusing to delete .git internals");
+      }
+
+      let entryStat: Awaited<ReturnType<typeof stat>>;
+      try {
+        entryStat = await stat(target);
+      } catch {
+        throw new Error("Path does not exist");
+      }
+
+      // `rm` with `recursive` handles both files and directories. We pass
+      // it unconditionally so callers don't need to know the entry kind.
+      await rm(target, { recursive: true, force: false });
+
+      return {
+        ok: true,
+        kind: entryStat.isDirectory() ? ("directory" as const) : ("file" as const),
+      };
+    }),
+
+  renamePath: publicProcedure
+    .input(
+      z.object({
+        workspaceId: z.string(),
+        fromPath: z.string().min(1),
+        toPath: z.string().min(1),
+      }),
+    )
+    .mutation(async ({ input }) => {
+      const workspace = resolveWorkspace(input.workspaceId);
+      if (!workspace) {
+        throw new Error("Workspace not found");
+      }
+
+      const root = workspace.worktree.path;
+      const fromTarget = resolve(join(root, input.fromPath));
+      const toTarget = resolve(join(root, input.toPath));
+
+      if (!fromTarget.startsWith(root) || fromTarget === root) {
+        throw new Error("Invalid source path");
+      }
+      if (!toTarget.startsWith(root) || toTarget === root) {
+        throw new Error("Invalid destination path");
+      }
+      if (fromTarget === toTarget) {
+        throw new Error("Source and destination are the same");
+      }
+
+      // Block touching .git on either side — corrupting it would break
+      // the entire worktree.
+      const fromRel = fromTarget.slice(root.length + 1);
+      const toRel = toTarget.slice(root.length + 1);
+      if (
+        fromRel === ".git" ||
+        fromRel.startsWith(".git/") ||
+        toRel === ".git" ||
+        toRel.startsWith(".git/")
+      ) {
+        throw new Error("Refusing to rename .git internals");
+      }
+
+      let entryStat: Awaited<ReturnType<typeof stat>>;
+      try {
+        entryStat = await stat(fromTarget);
+      } catch {
+        throw new Error("Source path does not exist");
+      }
+
+      if (existsSync(toTarget)) {
+        throw new Error("A file or directory already exists at the destination");
+      }
+
+      const toParent = dirname(toTarget);
+      if (!existsSync(toParent)) {
+        throw new Error("Destination parent directory does not exist");
+      }
+      const toParentStat = await stat(toParent);
+      if (!toParentStat.isDirectory()) {
+        throw new Error("Destination parent is not a directory");
+      }
+
+      await rename(fromTarget, toTarget);
+
+      return {
+        ok: true,
+        kind: entryStat.isDirectory() ? ("directory" as const) : ("file" as const),
+      };
+    }),
+
+  copyPath: publicProcedure
+    .input(
+      z.object({
+        workspaceId: z.string(),
+        fromPath: z.string().min(1),
+        toPath: z.string().min(1),
+      }),
+    )
+    .mutation(async ({ input }) => {
+      const workspace = resolveWorkspace(input.workspaceId);
+      if (!workspace) {
+        throw new Error("Workspace not found");
+      }
+
+      const root = workspace.worktree.path;
+      const fromTarget = resolve(join(root, input.fromPath));
+      const toTarget = resolve(join(root, input.toPath));
+
+      if (!fromTarget.startsWith(root) || fromTarget === root) {
+        throw new Error("Invalid source path");
+      }
+      if (!toTarget.startsWith(root) || toTarget === root) {
+        throw new Error("Invalid destination path");
+      }
+      if (fromTarget === toTarget) {
+        throw new Error("Source and destination are the same");
+      }
+
+      // Block touching .git on either side — corrupting it would break
+      // the entire worktree.
+      const fromRel = fromTarget.slice(root.length + 1);
+      const toRel = toTarget.slice(root.length + 1);
+      if (
+        fromRel === ".git" ||
+        fromRel.startsWith(".git/") ||
+        toRel === ".git" ||
+        toRel.startsWith(".git/")
+      ) {
+        throw new Error("Refusing to copy .git internals");
+      }
+
+      let entryStat: Awaited<ReturnType<typeof stat>>;
+      try {
+        entryStat = await stat(fromTarget);
+      } catch {
+        throw new Error("Source path does not exist");
+      }
+
+      // Block copying a directory into itself or any descendant — would
+      // either fail mid-copy or produce an infinite tree.
+      if (entryStat.isDirectory() && toTarget.startsWith(fromTarget + sep)) {
+        throw new Error("Cannot copy a directory into itself");
+      }
+
+      if (existsSync(toTarget)) {
+        throw new Error("A file or directory already exists at the destination");
+      }
+
+      const toParent = dirname(toTarget);
+      if (!existsSync(toParent)) {
+        throw new Error("Destination parent directory does not exist");
+      }
+      const toParentStat = await stat(toParent);
+      if (!toParentStat.isDirectory()) {
+        throw new Error("Destination parent is not a directory");
+      }
+
+      // `cp` with `recursive: true` handles both files and directories.
+      // `errorOnExist: true` guards against the race between our
+      // existsSync check above and the write.
+      await cp(fromTarget, toTarget, {
+        recursive: true,
+        errorOnExist: true,
+        force: false,
+      });
+
+      return {
+        ok: true,
+        kind: entryStat.isDirectory() ? ("directory" as const) : ("file" as const),
+      };
     }),
 
   searchFiles: publicProcedure

--- a/apps/web/tests/trpc.test.ts
+++ b/apps/web/tests/trpc.test.ts
@@ -638,6 +638,664 @@ describe("tRPC — workspace operations", () => {
     expect(res.status).toBe(500);
   });
 
+  // -- workspace.createFile --
+
+  it("workspace.createFile creates an empty file at the root", async () => {
+    const res = await trpcMutate(server.url, "workspace.createFile", {
+      workspaceId: "repo-main",
+      path: "NOTES.md",
+    });
+    expect(res.status).toBe(200);
+    const data = await trpcData<{ ok: boolean }>(res);
+    expect(data.ok).toBe(true);
+
+    // Verify the new file appears in listFiles and is empty
+    const listRes = await trpcQuery(server.url, "workspace.listFiles", {
+      workspaceId: "repo-main",
+      path: "",
+    });
+    const listData = await trpcData<{ entries: Array<{ name: string; type: string }> }>(listRes);
+    const entry = listData.entries.find((e) => e.name === "NOTES.md");
+    expect(entry).toBeDefined();
+    expect(entry!.type).toBe("file");
+
+    const getRes = await trpcQuery(server.url, "workspace.getFile", {
+      workspaceId: "repo-main",
+      path: "NOTES.md",
+    });
+    const getData = await trpcData<{ content: string }>(getRes);
+    expect(getData.content).toBe("");
+  });
+
+  it("workspace.createFile creates a file inside a subdirectory with content", async () => {
+    const res = await trpcMutate(server.url, "workspace.createFile", {
+      workspaceId: "repo-main",
+      path: "src/util.ts",
+      content: "export const x = 1;\n",
+    });
+    expect(res.status).toBe(200);
+
+    const getRes = await trpcQuery(server.url, "workspace.getFile", {
+      workspaceId: "repo-main",
+      path: "src/util.ts",
+    });
+    const getData = await trpcData<{ content: string; language?: string }>(getRes);
+    expect(getData.content).toBe("export const x = 1;\n");
+    expect(getData.language).toBe("typescript");
+  });
+
+  it("workspace.createFile rejects an existing path", async () => {
+    const res = await trpcMutate(server.url, "workspace.createFile", {
+      workspaceId: "repo-main",
+      path: "README.md",
+    });
+    expect(res.status).toBe(500);
+    const body = (await res.json()) as { error: { message: string } };
+    expect(body.error.message).toMatch(/already exists/);
+  });
+
+  it("workspace.createFile rejects path traversal attempts", async () => {
+    const res = await trpcMutate(server.url, "workspace.createFile", {
+      workspaceId: "repo-main",
+      path: "../escape.txt",
+    });
+    expect(res.status).toBe(500);
+  });
+
+  it("workspace.createFile rejects when the parent directory does not exist", async () => {
+    const res = await trpcMutate(server.url, "workspace.createFile", {
+      workspaceId: "repo-main",
+      path: "no-such-dir/file.txt",
+    });
+    expect(res.status).toBe(500);
+    const body = (await res.json()) as { error: { message: string } };
+    expect(body.error.message).toMatch(/Parent directory/);
+  });
+
+  it("workspace.createFile rejects empty path input", async () => {
+    const res = await trpcMutate(server.url, "workspace.createFile", {
+      workspaceId: "repo-main",
+      path: "",
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("workspace.createFile rejects unknown workspace", async () => {
+    const res = await trpcMutate(server.url, "workspace.createFile", {
+      workspaceId: "nonexistent-main",
+      path: "x.txt",
+    });
+    expect(res.status).toBe(500);
+  });
+
+  // -- workspace.createDirectory --
+
+  it("workspace.createDirectory creates a directory at the root", async () => {
+    const res = await trpcMutate(server.url, "workspace.createDirectory", {
+      workspaceId: "repo-main",
+      path: "docs",
+    });
+    expect(res.status).toBe(200);
+
+    const listRes = await trpcQuery(server.url, "workspace.listFiles", {
+      workspaceId: "repo-main",
+      path: "",
+    });
+    const listData = await trpcData<{ entries: Array<{ name: string; type: string }> }>(listRes);
+    const entry = listData.entries.find((e) => e.name === "docs");
+    expect(entry).toBeDefined();
+    expect(entry!.type).toBe("directory");
+  });
+
+  it("workspace.createDirectory creates a nested directory under an existing one", async () => {
+    const res = await trpcMutate(server.url, "workspace.createDirectory", {
+      workspaceId: "repo-main",
+      path: "docs/api",
+    });
+    expect(res.status).toBe(200);
+
+    const listRes = await trpcQuery(server.url, "workspace.listFiles", {
+      workspaceId: "repo-main",
+      path: "docs",
+    });
+    const listData = await trpcData<{ entries: Array<{ name: string; type: string }> }>(listRes);
+    const entry = listData.entries.find((e) => e.name === "api");
+    expect(entry).toBeDefined();
+    expect(entry!.type).toBe("directory");
+  });
+
+  it("workspace.createDirectory rejects an existing path", async () => {
+    const res = await trpcMutate(server.url, "workspace.createDirectory", {
+      workspaceId: "repo-main",
+      path: "src",
+    });
+    expect(res.status).toBe(500);
+    const body = (await res.json()) as { error: { message: string } };
+    expect(body.error.message).toMatch(/already exists/);
+  });
+
+  it("workspace.createDirectory rejects path traversal attempts", async () => {
+    const res = await trpcMutate(server.url, "workspace.createDirectory", {
+      workspaceId: "repo-main",
+      path: "../escape-dir",
+    });
+    expect(res.status).toBe(500);
+  });
+
+  it("workspace.createDirectory rejects when the parent directory does not exist", async () => {
+    const res = await trpcMutate(server.url, "workspace.createDirectory", {
+      workspaceId: "repo-main",
+      path: "no-such-parent/child",
+    });
+    expect(res.status).toBe(500);
+    const body = (await res.json()) as { error: { message: string } };
+    expect(body.error.message).toMatch(/Parent directory/);
+  });
+
+  it("workspace.createDirectory rejects empty path input", async () => {
+    const res = await trpcMutate(server.url, "workspace.createDirectory", {
+      workspaceId: "repo-main",
+      path: "",
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("workspace.createDirectory rejects unknown workspace", async () => {
+    const res = await trpcMutate(server.url, "workspace.createDirectory", {
+      workspaceId: "nonexistent-main",
+      path: "newdir",
+    });
+    expect(res.status).toBe(500);
+  });
+
+  // -- workspace.deletePath --
+
+  it("workspace.deletePath deletes a file", async () => {
+    // NOTES.md was created earlier in the createFile tests.
+    const res = await trpcMutate(server.url, "workspace.deletePath", {
+      workspaceId: "repo-main",
+      path: "NOTES.md",
+    });
+    expect(res.status).toBe(200);
+    const data = await trpcData<{ ok: boolean; kind: string }>(res);
+    expect(data.ok).toBe(true);
+    expect(data.kind).toBe("file");
+
+    // Verify it's gone from the listing.
+    const listRes = await trpcQuery(server.url, "workspace.listFiles", {
+      workspaceId: "repo-main",
+      path: "",
+    });
+    const listData = await trpcData<{ entries: Array<{ name: string }> }>(listRes);
+    expect(listData.entries.find((e) => e.name === "NOTES.md")).toBeUndefined();
+  });
+
+  it("workspace.deletePath deletes a nested file", async () => {
+    const res = await trpcMutate(server.url, "workspace.deletePath", {
+      workspaceId: "repo-main",
+      path: "src/util.ts",
+    });
+    expect(res.status).toBe(200);
+    const data = await trpcData<{ kind: string }>(res);
+    expect(data.kind).toBe("file");
+
+    const listRes = await trpcQuery(server.url, "workspace.listFiles", {
+      workspaceId: "repo-main",
+      path: "src",
+    });
+    const listData = await trpcData<{ entries: Array<{ name: string }> }>(listRes);
+    expect(listData.entries.find((e) => e.name === "util.ts")).toBeUndefined();
+  });
+
+  it("workspace.deletePath deletes an empty directory", async () => {
+    const res = await trpcMutate(server.url, "workspace.deletePath", {
+      workspaceId: "repo-main",
+      path: "docs/api",
+    });
+    expect(res.status).toBe(200);
+    const data = await trpcData<{ kind: string }>(res);
+    expect(data.kind).toBe("directory");
+
+    const listRes = await trpcQuery(server.url, "workspace.listFiles", {
+      workspaceId: "repo-main",
+      path: "docs",
+    });
+    const listData = await trpcData<{ entries: Array<{ name: string }> }>(listRes);
+    expect(listData.entries.find((e) => e.name === "api")).toBeUndefined();
+  });
+
+  it("workspace.deletePath deletes a directory recursively", async () => {
+    // Re-populate `docs` with a nested file so we can verify recursive removal.
+    await trpcMutate(server.url, "workspace.createFile", {
+      workspaceId: "repo-main",
+      path: "docs/inner.txt",
+      content: "hi",
+    });
+
+    const res = await trpcMutate(server.url, "workspace.deletePath", {
+      workspaceId: "repo-main",
+      path: "docs",
+    });
+    expect(res.status).toBe(200);
+    const data = await trpcData<{ kind: string }>(res);
+    expect(data.kind).toBe("directory");
+
+    const listRes = await trpcQuery(server.url, "workspace.listFiles", {
+      workspaceId: "repo-main",
+      path: "",
+    });
+    const listData = await trpcData<{ entries: Array<{ name: string }> }>(listRes);
+    expect(listData.entries.find((e) => e.name === "docs")).toBeUndefined();
+  });
+
+  it("workspace.deletePath rejects a missing path", async () => {
+    const res = await trpcMutate(server.url, "workspace.deletePath", {
+      workspaceId: "repo-main",
+      path: "no-such-thing.txt",
+    });
+    expect(res.status).toBe(500);
+    const body = (await res.json()) as { error: { message: string } };
+    expect(body.error.message).toMatch(/does not exist/);
+  });
+
+  it("workspace.deletePath rejects path traversal attempts", async () => {
+    const res = await trpcMutate(server.url, "workspace.deletePath", {
+      workspaceId: "repo-main",
+      path: "../README.md",
+    });
+    expect(res.status).toBe(500);
+  });
+
+  it("workspace.deletePath refuses to delete .git internals", async () => {
+    const res = await trpcMutate(server.url, "workspace.deletePath", {
+      workspaceId: "repo-main",
+      path: ".git",
+    });
+    expect(res.status).toBe(500);
+    const body = (await res.json()) as { error: { message: string } };
+    expect(body.error.message).toMatch(/\.git/);
+  });
+
+  it("workspace.deletePath rejects empty path input", async () => {
+    const res = await trpcMutate(server.url, "workspace.deletePath", {
+      workspaceId: "repo-main",
+      path: "",
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("workspace.deletePath rejects unknown workspace", async () => {
+    const res = await trpcMutate(server.url, "workspace.deletePath", {
+      workspaceId: "nonexistent-main",
+      path: "README.md",
+    });
+    expect(res.status).toBe(500);
+  });
+
+  // -- workspace.renamePath --
+
+  it("workspace.renamePath renames a file at the root", async () => {
+    // Set up: create a file we can rename.
+    await trpcMutate(server.url, "workspace.createFile", {
+      workspaceId: "repo-main",
+      path: "rename-me.txt",
+      content: "rename my contents\n",
+    });
+
+    const res = await trpcMutate(server.url, "workspace.renamePath", {
+      workspaceId: "repo-main",
+      fromPath: "rename-me.txt",
+      toPath: "renamed.txt",
+    });
+    expect(res.status).toBe(200);
+    const data = await trpcData<{ ok: boolean; kind: string }>(res);
+    expect(data.ok).toBe(true);
+    expect(data.kind).toBe("file");
+
+    // Old path is gone, new path exists with the same content.
+    const listRes = await trpcQuery(server.url, "workspace.listFiles", {
+      workspaceId: "repo-main",
+      path: "",
+    });
+    const listData = await trpcData<{ entries: Array<{ name: string }> }>(listRes);
+    expect(listData.entries.find((e) => e.name === "rename-me.txt")).toBeUndefined();
+    expect(listData.entries.find((e) => e.name === "renamed.txt")).toBeDefined();
+
+    const getRes = await trpcQuery(server.url, "workspace.getFile", {
+      workspaceId: "repo-main",
+      path: "renamed.txt",
+    });
+    const getData = await trpcData<{ content: string }>(getRes);
+    expect(getData.content).toBe("rename my contents\n");
+
+    // Cleanup so later tests don't see the renamed entry.
+    await trpcMutate(server.url, "workspace.deletePath", {
+      workspaceId: "repo-main",
+      path: "renamed.txt",
+    });
+  });
+
+  it("workspace.renamePath renames a directory along with its descendants", async () => {
+    await trpcMutate(server.url, "workspace.createDirectory", {
+      workspaceId: "repo-main",
+      path: "rename-dir",
+    });
+    await trpcMutate(server.url, "workspace.createFile", {
+      workspaceId: "repo-main",
+      path: "rename-dir/inner.txt",
+      content: "inside\n",
+    });
+
+    const res = await trpcMutate(server.url, "workspace.renamePath", {
+      workspaceId: "repo-main",
+      fromPath: "rename-dir",
+      toPath: "renamed-dir",
+    });
+    expect(res.status).toBe(200);
+    const data = await trpcData<{ kind: string }>(res);
+    expect(data.kind).toBe("directory");
+
+    // Descendant file should now be under the new path.
+    const innerRes = await trpcQuery(server.url, "workspace.getFile", {
+      workspaceId: "repo-main",
+      path: "renamed-dir/inner.txt",
+    });
+    const innerData = await trpcData<{ content: string }>(innerRes);
+    expect(innerData.content).toBe("inside\n");
+
+    // Cleanup.
+    await trpcMutate(server.url, "workspace.deletePath", {
+      workspaceId: "repo-main",
+      path: "renamed-dir",
+    });
+  });
+
+  it("workspace.renamePath rejects identical source and destination", async () => {
+    const res = await trpcMutate(server.url, "workspace.renamePath", {
+      workspaceId: "repo-main",
+      fromPath: "README.md",
+      toPath: "README.md",
+    });
+    expect(res.status).toBe(500);
+    const body = (await res.json()) as { error: { message: string } };
+    expect(body.error.message).toMatch(/same/);
+  });
+
+  it("workspace.renamePath rejects when destination already exists", async () => {
+    const res = await trpcMutate(server.url, "workspace.renamePath", {
+      workspaceId: "repo-main",
+      fromPath: "README.md",
+      toPath: "src",
+    });
+    expect(res.status).toBe(500);
+    const body = (await res.json()) as { error: { message: string } };
+    expect(body.error.message).toMatch(/already exists/);
+  });
+
+  it("workspace.renamePath rejects missing source", async () => {
+    const res = await trpcMutate(server.url, "workspace.renamePath", {
+      workspaceId: "repo-main",
+      fromPath: "no-such-file.txt",
+      toPath: "elsewhere.txt",
+    });
+    expect(res.status).toBe(500);
+    const body = (await res.json()) as { error: { message: string } };
+    expect(body.error.message).toMatch(/does not exist/);
+  });
+
+  it("workspace.renamePath rejects when destination parent is missing", async () => {
+    const res = await trpcMutate(server.url, "workspace.renamePath", {
+      workspaceId: "repo-main",
+      fromPath: "README.md",
+      toPath: "no-such-dir/README.md",
+    });
+    expect(res.status).toBe(500);
+    const body = (await res.json()) as { error: { message: string } };
+    expect(body.error.message).toMatch(/Destination parent/);
+  });
+
+  it("workspace.renamePath rejects path traversal on the source", async () => {
+    const res = await trpcMutate(server.url, "workspace.renamePath", {
+      workspaceId: "repo-main",
+      fromPath: "../README.md",
+      toPath: "elsewhere.txt",
+    });
+    expect(res.status).toBe(500);
+  });
+
+  it("workspace.renamePath rejects path traversal on the destination", async () => {
+    const res = await trpcMutate(server.url, "workspace.renamePath", {
+      workspaceId: "repo-main",
+      fromPath: "README.md",
+      toPath: "../escape.txt",
+    });
+    expect(res.status).toBe(500);
+  });
+
+  it("workspace.renamePath refuses to rename .git internals", async () => {
+    const res = await trpcMutate(server.url, "workspace.renamePath", {
+      workspaceId: "repo-main",
+      fromPath: ".git",
+      toPath: "git-backup",
+    });
+    expect(res.status).toBe(500);
+    const body = (await res.json()) as { error: { message: string } };
+    expect(body.error.message).toMatch(/\.git/);
+  });
+
+  it("workspace.renamePath rejects empty source path", async () => {
+    const res = await trpcMutate(server.url, "workspace.renamePath", {
+      workspaceId: "repo-main",
+      fromPath: "",
+      toPath: "x.txt",
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("workspace.renamePath rejects empty destination path", async () => {
+    const res = await trpcMutate(server.url, "workspace.renamePath", {
+      workspaceId: "repo-main",
+      fromPath: "README.md",
+      toPath: "",
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("workspace.renamePath rejects unknown workspace", async () => {
+    const res = await trpcMutate(server.url, "workspace.renamePath", {
+      workspaceId: "nonexistent-main",
+      fromPath: "README.md",
+      toPath: "x.md",
+    });
+    expect(res.status).toBe(500);
+  });
+
+  // -- workspace.copyPath --
+
+  it("workspace.copyPath copies a file and leaves the original intact", async () => {
+    const res = await trpcMutate(server.url, "workspace.copyPath", {
+      workspaceId: "repo-main",
+      fromPath: "README.md",
+      toPath: "README-copy.md",
+    });
+    expect(res.status).toBe(200);
+    const data = await trpcData<{ ok: boolean; kind: string }>(res);
+    expect(data.ok).toBe(true);
+    expect(data.kind).toBe("file");
+
+    // Source still exists.
+    const srcRes = await trpcQuery(server.url, "workspace.getFile", {
+      workspaceId: "repo-main",
+      path: "README.md",
+    });
+    expect(srcRes.status).toBe(200);
+
+    // Copy has the same content.
+    const dstRes = await trpcQuery(server.url, "workspace.getFile", {
+      workspaceId: "repo-main",
+      path: "README-copy.md",
+    });
+    const dstData = await trpcData<{ content: string }>(dstRes);
+    expect(dstData.content).toBe("# My Project\n");
+
+    // Cleanup.
+    await trpcMutate(server.url, "workspace.deletePath", {
+      workspaceId: "repo-main",
+      path: "README-copy.md",
+    });
+  });
+
+  it("workspace.copyPath copies a directory recursively", async () => {
+    await trpcMutate(server.url, "workspace.createDirectory", {
+      workspaceId: "repo-main",
+      path: "to-copy",
+    });
+    await trpcMutate(server.url, "workspace.createFile", {
+      workspaceId: "repo-main",
+      path: "to-copy/inside.txt",
+      content: "nested\n",
+    });
+
+    const res = await trpcMutate(server.url, "workspace.copyPath", {
+      workspaceId: "repo-main",
+      fromPath: "to-copy",
+      toPath: "copied",
+    });
+    expect(res.status).toBe(200);
+    const data = await trpcData<{ kind: string }>(res);
+    expect(data.kind).toBe("directory");
+
+    // Verify the nested file landed at the new path with its content.
+    const innerRes = await trpcQuery(server.url, "workspace.getFile", {
+      workspaceId: "repo-main",
+      path: "copied/inside.txt",
+    });
+    const innerData = await trpcData<{ content: string }>(innerRes);
+    expect(innerData.content).toBe("nested\n");
+
+    // Cleanup both source and copy.
+    await trpcMutate(server.url, "workspace.deletePath", {
+      workspaceId: "repo-main",
+      path: "to-copy",
+    });
+    await trpcMutate(server.url, "workspace.deletePath", {
+      workspaceId: "repo-main",
+      path: "copied",
+    });
+  });
+
+  it("workspace.copyPath rejects copying onto an existing destination", async () => {
+    const res = await trpcMutate(server.url, "workspace.copyPath", {
+      workspaceId: "repo-main",
+      fromPath: "README.md",
+      toPath: "src",
+    });
+    expect(res.status).toBe(500);
+    const body = (await res.json()) as { error: { message: string } };
+    expect(body.error.message).toMatch(/already exists/);
+  });
+
+  it("workspace.copyPath rejects copying a directory into its descendant", async () => {
+    await trpcMutate(server.url, "workspace.createDirectory", {
+      workspaceId: "repo-main",
+      path: "outer",
+    });
+    await trpcMutate(server.url, "workspace.createDirectory", {
+      workspaceId: "repo-main",
+      path: "outer/inner",
+    });
+
+    const res = await trpcMutate(server.url, "workspace.copyPath", {
+      workspaceId: "repo-main",
+      fromPath: "outer",
+      toPath: "outer/inner/copy",
+    });
+    expect(res.status).toBe(500);
+    const body = (await res.json()) as { error: { message: string } };
+    expect(body.error.message).toMatch(/into itself/);
+
+    await trpcMutate(server.url, "workspace.deletePath", {
+      workspaceId: "repo-main",
+      path: "outer",
+    });
+  });
+
+  it("workspace.copyPath rejects missing source", async () => {
+    const res = await trpcMutate(server.url, "workspace.copyPath", {
+      workspaceId: "repo-main",
+      fromPath: "no-such-file.txt",
+      toPath: "anywhere.txt",
+    });
+    expect(res.status).toBe(500);
+    const body = (await res.json()) as { error: { message: string } };
+    expect(body.error.message).toMatch(/does not exist/);
+  });
+
+  it("workspace.copyPath rejects path traversal on the source", async () => {
+    const res = await trpcMutate(server.url, "workspace.copyPath", {
+      workspaceId: "repo-main",
+      fromPath: "../README.md",
+      toPath: "elsewhere.txt",
+    });
+    expect(res.status).toBe(500);
+  });
+
+  it("workspace.copyPath rejects path traversal on the destination", async () => {
+    const res = await trpcMutate(server.url, "workspace.copyPath", {
+      workspaceId: "repo-main",
+      fromPath: "README.md",
+      toPath: "../escape.txt",
+    });
+    expect(res.status).toBe(500);
+  });
+
+  it("workspace.copyPath refuses to copy .git internals", async () => {
+    const res = await trpcMutate(server.url, "workspace.copyPath", {
+      workspaceId: "repo-main",
+      fromPath: ".git",
+      toPath: "git-backup",
+    });
+    expect(res.status).toBe(500);
+    const body = (await res.json()) as { error: { message: string } };
+    expect(body.error.message).toMatch(/\.git/);
+  });
+
+  it("workspace.copyPath rejects identical source and destination", async () => {
+    const res = await trpcMutate(server.url, "workspace.copyPath", {
+      workspaceId: "repo-main",
+      fromPath: "README.md",
+      toPath: "README.md",
+    });
+    expect(res.status).toBe(500);
+    const body = (await res.json()) as { error: { message: string } };
+    expect(body.error.message).toMatch(/same/);
+  });
+
+  it("workspace.copyPath rejects empty paths", async () => {
+    const emptyFrom = await trpcMutate(server.url, "workspace.copyPath", {
+      workspaceId: "repo-main",
+      fromPath: "",
+      toPath: "x.txt",
+    });
+    expect(emptyFrom.status).toBe(400);
+
+    const emptyTo = await trpcMutate(server.url, "workspace.copyPath", {
+      workspaceId: "repo-main",
+      fromPath: "README.md",
+      toPath: "",
+    });
+    expect(emptyTo.status).toBe(400);
+  });
+
+  it("workspace.copyPath rejects unknown workspace", async () => {
+    const res = await trpcMutate(server.url, "workspace.copyPath", {
+      workspaceId: "nonexistent-main",
+      fromPath: "README.md",
+      toPath: "x.md",
+    });
+    expect(res.status).toBe(500);
+  });
+
   // -- workspace.getDiff --
 
   it("workspace.getDiff returns empty diff on clean branch", async () => {

--- a/packages/dashboard-core/src/adapter.ts
+++ b/packages/dashboard-core/src/adapter.ts
@@ -94,6 +94,50 @@ export interface DashboardAdapter {
   getWorkspaceFile?(workspaceId: string, path: string): Promise<FileContentResult>;
   saveWorkspaceFile?(workspaceId: string, path: string, content: string): Promise<void>;
 
+  /**
+   * Create a new file at the given workspace-relative path. The file's
+   * parent directory must already exist. Throws if the path already
+   * exists. `content` defaults to an empty string.
+   */
+  createWorkspaceFile?(workspaceId: string, path: string, content?: string): Promise<void>;
+
+  /**
+   * Create a new directory at the given workspace-relative path. The
+   * directory's parent must already exist. Throws if the path already
+   * exists.
+   */
+  createWorkspaceDirectory?(workspaceId: string, path: string): Promise<void>;
+
+  /**
+   * Delete a file or directory at the given workspace-relative path.
+   * Directories are removed recursively. Throws if the path doesn't
+   * exist or refers to a protected location (e.g. `.git`).
+   */
+  deleteWorkspacePath?(workspaceId: string, path: string): Promise<{ kind: "file" | "directory" }>;
+
+  /**
+   * Rename or move a file/directory inside the workspace. `fromPath`
+   * and `toPath` are both workspace-relative. The destination must not
+   * already exist and its parent directory must exist.
+   */
+  renameWorkspacePath?(
+    workspaceId: string,
+    fromPath: string,
+    toPath: string,
+  ): Promise<{ kind: "file" | "directory" }>;
+
+  /**
+   * Recursively copy a file/directory inside the workspace. `fromPath`
+   * and `toPath` are both workspace-relative. The destination must not
+   * already exist and its parent directory must. Directories may not be
+   * copied into themselves.
+   */
+  copyWorkspacePath?(
+    workspaceId: string,
+    fromPath: string,
+    toPath: string,
+  ): Promise<{ kind: "file" | "directory" }>;
+
   /** Revert a single file to its original state, discarding all changes. */
   revertFile?(
     workspaceId: string,

--- a/packages/dashboard-core/src/adapters/web.ts
+++ b/packages/dashboard-core/src/adapters/web.ts
@@ -283,6 +283,47 @@ export class WebDashboardAdapter implements DashboardAdapter {
     await this.trpc.workspace.saveFile.mutate({ workspaceId, path, content });
   }
 
+  async createWorkspaceFile(workspaceId: string, path: string, content = ""): Promise<void> {
+    await this.trpc.workspace.createFile.mutate({ workspaceId, path, content });
+  }
+
+  async createWorkspaceDirectory(workspaceId: string, path: string): Promise<void> {
+    await this.trpc.workspace.createDirectory.mutate({ workspaceId, path });
+  }
+
+  async deleteWorkspacePath(
+    workspaceId: string,
+    path: string,
+  ): Promise<{ kind: "file" | "directory" }> {
+    return (await this.trpc.workspace.deletePath.mutate({ workspaceId, path })) as {
+      kind: "file" | "directory";
+    };
+  }
+
+  async renameWorkspacePath(
+    workspaceId: string,
+    fromPath: string,
+    toPath: string,
+  ): Promise<{ kind: "file" | "directory" }> {
+    return (await this.trpc.workspace.renamePath.mutate({
+      workspaceId,
+      fromPath,
+      toPath,
+    })) as { kind: "file" | "directory" };
+  }
+
+  async copyWorkspacePath(
+    workspaceId: string,
+    fromPath: string,
+    toPath: string,
+  ): Promise<{ kind: "file" | "directory" }> {
+    return (await this.trpc.workspace.copyPath.mutate({
+      workspaceId,
+      fromPath,
+      toPath,
+    })) as { kind: "file" | "directory" };
+  }
+
   async revertFile(
     workspaceId: string,
     filePath: string,

--- a/packages/dashboard-core/src/components/ChangesFileTree.tsx
+++ b/packages/dashboard-core/src/components/ChangesFileTree.tsx
@@ -1,5 +1,26 @@
-import { ChevronDown, ChevronRight, Folder, FolderOpen } from "lucide-react";
-import { useEffect, useMemo, useRef, useState } from "react";
+import {
+  Button,
+  ContextMenu,
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuTrigger,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@band-app/ui";
+import {
+  AlertTriangle,
+  ChevronDown,
+  ChevronRight,
+  Folder,
+  FolderOpen,
+  RotateCcw,
+} from "lucide-react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useDeferredMenuAction } from "../hooks/use-deferred-menu-action";
 import { buildFileTree, type FileTreeNode } from "../lib/build-file-tree";
 import { getFileIcon } from "../lib/file-icon";
 import type { FileStatus } from "../types";
@@ -9,6 +30,13 @@ interface ChangesFileTreeProps {
   fileStatuses: Record<string, FileStatus>;
   onSelectFile: (filePath: string) => void;
   activeFile?: string | null;
+  /**
+   * Revert every path in the list — used by the right-click "Reset
+   * changes" action. For a folder right-click the tree collects all
+   * descendant file paths and passes them all at once. Pass `undefined`
+   * (or leave the prop unset) to hide the menu item entirely.
+   */
+  onRevertPaths?: (paths: string[]) => void | Promise<void>;
 }
 
 interface ChangesTreeNodeProps {
@@ -17,7 +45,20 @@ interface ChangesTreeNodeProps {
   expandedPaths: Set<string>;
   onToggle: (path: string) => void;
   onSelectFile: (filePath: string) => void;
+  onRequestReset: (node: FileTreeNode) => void;
+  canReset: boolean;
   activeFile?: string | null;
+}
+
+/**
+ * Collect every leaf (file) path inside this subtree. For a leaf node
+ * the result is just the node's own path; for a directory it's a flat
+ * list of all descendants. Used to expand a folder right-click into the
+ * full set of files to revert.
+ */
+function collectLeafPaths(node: FileTreeNode): string[] {
+  if (!node.children) return [node.path];
+  return node.children.flatMap(collectLeafPaths);
 }
 
 function ChangesTreeNode({
@@ -26,12 +67,20 @@ function ChangesTreeNode({
   expandedPaths,
   onToggle,
   onSelectFile,
+  onRequestReset,
+  canReset,
   activeFile,
 }: ChangesTreeNodeProps) {
   const isDir = node.children !== undefined;
   const isExpanded = isDir && expandedPaths.has(node.path);
   const isActive = !isDir && activeFile === node.path;
   const btnRef = useRef<HTMLButtonElement>(null);
+
+  // Defer the context-menu action until the menu finishes closing — see
+  // useDeferredMenuAction for the full reasoning. Without this the
+  // confirmation dialog would mount while Radix's FocusScope is still
+  // alive and lose focus management.
+  const menu = useDeferredMenuAction();
 
   // Auto-scroll the active file into view within the sidebar
   useEffect(() => {
@@ -48,54 +97,77 @@ function ChangesTreeNode({
     }
   };
 
+  const button = (
+    <button
+      ref={isActive ? btnRef : undefined}
+      type="button"
+      // data-band-active marks this button so the workspace-level
+      // ⇧⌘G "focus Changes" handler can target it from outside the
+      // file tree.
+      data-band-active={isActive ? "true" : undefined}
+      onClick={handleClick}
+      // Suppress the iOS text-selection / callout that fires on
+      // long-press alongside the Radix contextmenu event.
+      className={`flex h-[28px] w-full select-none items-center gap-1 pr-3 text-left text-[13px] hover:bg-accent/50 [-webkit-touch-callout:none] ${
+        isActive
+          ? "bg-blue-500/30 text-foreground outline outline-1 -outline-offset-1 outline-blue-400/60 hover:bg-blue-500/30 dark:bg-blue-500/40 dark:outline-blue-400/70 dark:hover:bg-blue-500/40"
+          : ""
+      }`}
+      style={{ paddingLeft: `${depth * 12 + 4}px` }}
+    >
+      {/* Chevron / spacer */}
+      {isDir ? (
+        isExpanded ? (
+          <ChevronDown className="size-3.5 shrink-0 text-muted-foreground/70" />
+        ) : (
+          <ChevronRight className="size-3.5 shrink-0 text-muted-foreground/70" />
+        )
+      ) : (
+        <span className="size-3.5 shrink-0" />
+      )}
+
+      {/* Icon */}
+      {isDir ? (
+        isExpanded ? (
+          <FolderOpen className="size-4 shrink-0 text-blue-600 dark:text-blue-400" />
+        ) : (
+          <Folder className="size-4 shrink-0 text-blue-600 dark:text-blue-400" />
+        )
+      ) : (
+        (() => {
+          // Use the last segment of the node name for icon detection
+          const fileName = node.name.includes("/") ? node.name.split("/").pop()! : node.name;
+          const FileIcon = getFileIcon(fileName);
+          return <FileIcon className="size-4 shrink-0 text-muted-foreground" />;
+        })()
+      )}
+
+      {/* Name */}
+      <span className="min-w-0 flex-1 truncate">{node.name}</span>
+
+      {/* Status badge for files */}
+      {!isDir && node.status && <FileStatusBadge status={node.status} />}
+    </button>
+  );
+
   return (
     <>
-      <button
-        ref={isActive ? btnRef : undefined}
-        type="button"
-        // data-band-active marks this button so the workspace-level
-        // ⇧⌘G "focus Changes" handler can target it from outside the
-        // file tree.
-        data-band-active={isActive ? "true" : undefined}
-        onClick={handleClick}
-        className={`flex h-[26px] w-full items-center gap-1 pr-3 text-left text-xs ${
-          isActive ? "bg-accent text-accent-foreground" : "hover:bg-accent/50"
-        }`}
-        style={{ paddingLeft: `${depth * 12 + 4}px` }}
-      >
-        {/* Chevron / spacer */}
-        {isDir ? (
-          isExpanded ? (
-            <ChevronDown className="size-3.5 shrink-0 text-muted-foreground/70" />
-          ) : (
-            <ChevronRight className="size-3.5 shrink-0 text-muted-foreground/70" />
-          )
-        ) : (
-          <span className="size-3.5 shrink-0" />
-        )}
-
-        {/* Icon */}
-        {isDir ? (
-          isExpanded ? (
-            <FolderOpen className="size-4 shrink-0 text-blue-600 dark:text-blue-400" />
-          ) : (
-            <Folder className="size-4 shrink-0 text-blue-600 dark:text-blue-400" />
-          )
-        ) : (
-          (() => {
-            // Use the last segment of the node name for icon detection
-            const fileName = node.name.includes("/") ? node.name.split("/").pop()! : node.name;
-            const FileIcon = getFileIcon(fileName);
-            return <FileIcon className="size-4 shrink-0 text-muted-foreground" />;
-          })()
-        )}
-
-        {/* Name */}
-        <span className="min-w-0 flex-1 truncate">{node.name}</span>
-
-        {/* Status badge for files */}
-        {!isDir && node.status && <FileStatusBadge status={node.status} />}
-      </button>
+      {canReset ? (
+        <ContextMenu>
+          <ContextMenuTrigger asChild>{button}</ContextMenuTrigger>
+          <ContextMenuContent onCloseAutoFocus={menu.flush}>
+            <ContextMenuItem
+              variant="destructive"
+              onSelect={() => menu.queue(() => onRequestReset(node))}
+            >
+              <RotateCcw className="size-4" />
+              Reset changes
+            </ContextMenuItem>
+          </ContextMenuContent>
+        </ContextMenu>
+      ) : (
+        button
+      )}
 
       {/* Children — rendered when directory is expanded */}
       {isExpanded &&
@@ -107,6 +179,8 @@ function ChangesTreeNode({
             expandedPaths={expandedPaths}
             onToggle={onToggle}
             onSelectFile={onSelectFile}
+            onRequestReset={onRequestReset}
+            canReset={canReset}
             activeFile={activeFile}
           />
         ))}
@@ -128,7 +202,12 @@ function collectDirPaths(nodes: FileTreeNode[]): string[] {
   return paths;
 }
 
-export function ChangesFileTree({ fileStatuses, onSelectFile, activeFile }: ChangesFileTreeProps) {
+export function ChangesFileTree({
+  fileStatuses,
+  onSelectFile,
+  activeFile,
+  onRevertPaths,
+}: ChangesFileTreeProps) {
   const tree = useMemo(() => buildFileTree(fileStatuses), [fileStatuses]);
 
   // All directories expanded by default (changed-file sets are typically small)
@@ -153,9 +232,59 @@ export function ChangesFileTree({ fileStatuses, onSelectFile, activeFile }: Chan
     });
   };
 
+  // ---------- Reset-changes flow ----------
+  const [pendingReset, setPendingReset] = useState<{
+    /** Display label — file name for a leaf, folder path for a directory. */
+    label: string;
+    /** Whether the user right-clicked a folder (affects dialog copy). */
+    isFolder: boolean;
+    /** Every leaf path under the right-clicked node. */
+    paths: string[];
+    /** Status for single-file resets — drives the precise warning text. */
+    status?: FileStatus;
+  } | null>(null);
+  const [resetSubmitting, setResetSubmitting] = useState(false);
+
+  const handleRequestReset = useCallback((node: FileTreeNode) => {
+    const paths = collectLeafPaths(node);
+    if (paths.length === 0) return;
+    if (node.children) {
+      setPendingReset({
+        label: node.path,
+        isFolder: true,
+        paths,
+      });
+    } else {
+      setPendingReset({
+        label: node.path,
+        isFolder: false,
+        paths: [node.path],
+        status: node.status,
+      });
+    }
+  }, []);
+
+  const cancelReset = useCallback(() => {
+    if (resetSubmitting) return;
+    setPendingReset(null);
+  }, [resetSubmitting]);
+
+  const confirmReset = useCallback(async () => {
+    if (!pendingReset || !onRevertPaths) return;
+    setResetSubmitting(true);
+    try {
+      await onRevertPaths(pendingReset.paths);
+      setPendingReset(null);
+    } finally {
+      setResetSubmitting(false);
+    }
+  }, [pendingReset, onRevertPaths]);
+
+  const canReset = Boolean(onRevertPaths);
+
   if (tree.length === 0) {
     return (
-      <div className="flex h-16 items-center justify-center text-xs text-muted-foreground">
+      <div className="flex h-16 items-center justify-center text-[13px] text-muted-foreground">
         No files
       </div>
     );
@@ -171,9 +300,76 @@ export function ChangesFileTree({ fileStatuses, onSelectFile, activeFile }: Chan
           expandedPaths={expandedPaths}
           onToggle={handleToggle}
           onSelectFile={onSelectFile}
+          onRequestReset={handleRequestReset}
+          canReset={canReset}
           activeFile={activeFile}
         />
       ))}
+
+      <Dialog
+        open={pendingReset !== null}
+        onOpenChange={(open) => {
+          if (!open) cancelReset();
+        }}
+      >
+        <DialogContent className="sm:max-w-[425px]" onClick={(e) => e.stopPropagation()}>
+          <DialogHeader>
+            <DialogTitle>Reset changes</DialogTitle>
+            <DialogDescription>
+              {pendingReset?.isFolder ? (
+                <>
+                  Reset changes for all {pendingReset.paths.length} file
+                  {pendingReset.paths.length === 1 ? "" : "s"} inside{" "}
+                  <strong className="break-all">{pendingReset.label}</strong>?
+                </>
+              ) : (
+                <>
+                  Reset changes to <strong className="break-all">{pendingReset?.label}</strong>?
+                </>
+              )}
+            </DialogDescription>
+          </DialogHeader>
+          <div className="flex flex-col gap-2 text-sm">
+            <div className="flex items-start gap-2 rounded-md border border-yellow-500/30 bg-yellow-500/10 p-3">
+              <AlertTriangle className="mt-0.5 size-4 shrink-0 text-yellow-500" />
+              <span>
+                {pendingReset?.isFolder
+                  ? "Every change inside this folder will be discarded. Added files are deleted, deleted files are restored, modifications are reverted. This action cannot be undone."
+                  : resetDescriptionForFile(pendingReset?.status)}
+              </span>
+            </div>
+          </div>
+          <DialogFooter>
+            <Button variant="ghost" onClick={cancelReset} disabled={resetSubmitting}>
+              Cancel
+            </Button>
+            <Button
+              variant="destructive"
+              onClick={() => void confirmReset()}
+              disabled={resetSubmitting}
+            >
+              {resetSubmitting ? "Resetting…" : "Reset"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </>
   );
+}
+
+function resetDescriptionForFile(status: FileStatus | undefined): string {
+  switch (status) {
+    case "A":
+      return "This file was added and will be deleted. This action cannot be undone.";
+    case "U":
+      return "This file is untracked and will be deleted. This action cannot be undone.";
+    case "D":
+      return "This file was deleted and will be restored. This action cannot be undone.";
+    case "M":
+      return "All changes to this file will be discarded. This action cannot be undone.";
+    case "R":
+      return "This file was renamed and will be restored to its original path. This action cannot be undone.";
+    default:
+      return "All changes to this file will be discarded. This action cannot be undone.";
+  }
 }

--- a/packages/dashboard-core/src/components/DiffView.tsx
+++ b/packages/dashboard-core/src/components/DiffView.tsx
@@ -1345,6 +1345,48 @@ export function DiffView({
     [adapter, workspaceId, diffMode, compareBranch],
   );
 
+  /**
+   * Reset every path in the list. Used by ChangesFileTree's right-click
+   * "Reset changes" — for a folder right-click the caller collects every
+   * leaf file path under that folder and passes them all here so they're
+   * reverted together. We revert in parallel and only refresh the
+   * summary once at the end so the UI doesn't flicker through N partial
+   * states.
+   */
+  const handleRevertPaths = useCallback(
+    async (paths: string[]) => {
+      const revertFile = adapter.revertFile;
+      if (!revertFile || paths.length === 0) return;
+
+      const results = await Promise.allSettled(
+        paths.map((p) =>
+          revertFile.call(adapter, workspaceId, p, diffMode, compareBranch ?? undefined),
+        ),
+      );
+
+      // Drop reverted entries from local cache.
+      setDiffCache((prev) => {
+        const next = new Map(prev);
+        for (const p of paths) next.delete(p);
+        return next;
+      });
+      for (const p of paths) expandedFilesRef.current.delete(p);
+
+      // Refresh the summary so file rows reflect their new (or absent) state.
+      fetchSummaryRef.current?.(true);
+
+      // Surface any partial failures so the user knows something didn't
+      // get reset. Individual failures don't roll back the rest — git's
+      // own atomicity is per-file anyway.
+      for (const r of results) {
+        if (r.status === "rejected") {
+          console.error("Failed to revert path:", r.reason);
+        }
+      }
+    },
+    [adapter, workspaceId, diffMode, compareBranch],
+  );
+
   // -------------------------------------------------------------------------
   // Fetch diff summary
   // -------------------------------------------------------------------------
@@ -1670,11 +1712,12 @@ export function DiffView({
           <div className="flex h-9 shrink-0 items-center border-b border-border px-3">
             <span className="text-xs font-medium text-muted-foreground">Files</span>
           </div>
-          <div className="min-h-0 flex-1 overflow-y-auto py-1">
+          <div className="min-h-0 flex-1 overflow-y-auto py-1 pl-px">
             <ChangesFileTree
               fileStatuses={fileStatuses}
               onSelectFile={handleScrollToFile}
               activeFile={activeFile}
+              onRevertPaths={adapter.revertFile ? handleRevertPaths : undefined}
             />
           </div>
         </div>

--- a/packages/dashboard-core/src/components/FileBrowser.tsx
+++ b/packages/dashboard-core/src/components/FileBrowser.tsx
@@ -1,6 +1,34 @@
-import { ChevronDown, ChevronRight, Folder, FolderOpen } from "lucide-react";
-import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  Button,
+  ContextMenu,
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuSeparator,
+  ContextMenuTrigger,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@band-app/ui";
+import {
+  AlertTriangle,
+  ChevronDown,
+  ChevronRight,
+  ClipboardPaste,
+  Copy as CopyIcon,
+  File as FileIconLucide,
+  Folder,
+  FolderOpen,
+  FolderPlus,
+  Pencil,
+  Scissors,
+  Trash2,
+} from "lucide-react";
+import { forwardRef, useCallback, useEffect, useImperativeHandle, useRef, useState } from "react";
 import { useAdapter } from "../context";
+import { useDeferredMenuAction } from "../hooks/use-deferred-menu-action";
 import { getFileIcon } from "../lib/file-icon";
 import type { FileEntry } from "../types";
 
@@ -21,6 +49,30 @@ interface FileBrowserProps {
   compact?: boolean;
   /** Currently selected file path for highlighting and auto-expand */
   selectedFile?: string;
+  /**
+   * Called after a path is renamed via the file browser context menu.
+   * `oldPath` and `newPath` are workspace-relative. For directory
+   * renames the caller should also rewrite any descendant tabs whose
+   * paths sit inside `oldPath + "/"`.
+   */
+  onPathRenamed?: (oldPath: string, newPath: string, kind: "file" | "directory") => void;
+  /**
+   * Called after a path is deleted via the file browser context menu.
+   * For directories, the caller should also drop any descendant tabs.
+   */
+  onPathDeleted?: (path: string, kind: "file" | "directory") => void;
+}
+
+/**
+ * Imperative handle exposed via `ref` so external toolbars (e.g. the file
+ * tree toolbar in CodeBrowserView) can trigger an inline "new file" or
+ * "new folder" input at the workspace root.
+ */
+export interface FileBrowserHandle {
+  /** Begin creating a new file at the given parent (defaults to root). */
+  startNewFile(parentPath?: string): void;
+  /** Begin creating a new folder at the given parent (defaults to root). */
+  startNewFolder(parentPath?: string): void;
 }
 
 // ---------------------------------------------------------------------------
@@ -49,6 +101,167 @@ function getCachedContents(wsId: string): Map<string, FileEntry[]> {
 }
 
 // ---------------------------------------------------------------------------
+// Inline name input — shown when the user is creating a new file/folder or
+// renaming an existing one.
+// ---------------------------------------------------------------------------
+interface EntryNameInputProps {
+  kind: "file" | "directory";
+  depth: number;
+  compact?: boolean;
+  /** Pre-filled value (used by the rename flow). Defaults to "". */
+  initialValue?: string;
+  /** Existing sibling names so we can flag duplicates client-side. */
+  siblings: Set<string>;
+  /** Placeholder when the input is empty. */
+  placeholder?: string;
+  onSubmit: (name: string) => Promise<void> | void;
+  onCancel: () => void;
+}
+
+function EntryNameInput({
+  kind,
+  depth,
+  compact,
+  initialValue = "",
+  siblings,
+  placeholder,
+  onSubmit,
+  onCancel,
+}: EntryNameInputProps) {
+  const [value, setValue] = useState(initialValue);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  // Auto-focus the input on mount. When there's an initial value (rename
+  // flow), pre-select the basename portion so typing replaces it without
+  // clobbering the extension.
+  //
+  // Callers that mount this input from a Radix menu defer the action to
+  // `onCloseAutoFocus` (see `useDeferredMenuAction`), so by the time we
+  // run there's no FocusScope competing for focus and a single
+  // `el.focus()` call sticks on the first try.
+  useEffect(() => {
+    const el = inputRef.current;
+    if (!el) return;
+    el.focus();
+    if (initialValue) {
+      const dotIdx = initialValue.lastIndexOf(".");
+      // Select basename only for files, everything for directories and
+      // dotfiles like ".env".
+      const end = dotIdx > 0 ? dotIdx : initialValue.length;
+      try {
+        el.setSelectionRange(0, end);
+      } catch {
+        // Some browsers throw on certain input states — silently ignore.
+      }
+    }
+  }, [initialValue]);
+
+  const indent = compact ? 12 : 16;
+  const basePad = compact ? 4 : 8;
+  const height = compact ? 28 : 32;
+
+  const validate = (name: string): string | null => {
+    const trimmed = name.trim();
+    if (!trimmed) return "Name is required";
+    if (trimmed === "." || trimmed === "..") return "Invalid name";
+    if (trimmed.includes("/") || trimmed.includes("\\")) {
+      return "Name cannot contain slashes";
+    }
+    if (siblings.has(trimmed)) return "A file or folder with this name already exists";
+    return null;
+  };
+
+  const handleSubmit = async () => {
+    const trimmed = value.trim();
+    // Unchanged name in rename mode → treat as cancel.
+    if (trimmed === initialValue) {
+      onCancel();
+      return;
+    }
+    const validationError = validate(trimmed);
+    if (validationError) {
+      setError(validationError);
+      return;
+    }
+    setSubmitting(true);
+    setError(null);
+    try {
+      await onSubmit(trimmed);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      setError(message);
+      setSubmitting(false);
+    }
+  };
+
+  const Icon = kind === "directory" ? Folder : FileIconLucide;
+
+  return (
+    <div className="flex w-full flex-col" style={{ paddingLeft: `${depth * indent + basePad}px` }}>
+      <div
+        className={`flex items-center ${
+          compact ? "h-[28px] gap-1 pr-3 text-[13px]" : "h-[32px] gap-1.5 pr-4 text-[15px]"
+        }`}
+        style={{ height }}
+      >
+        <span className="size-3.5 shrink-0" />
+        <Icon
+          className={
+            kind === "directory"
+              ? "size-4 shrink-0 text-blue-600 dark:text-blue-400"
+              : "size-4 shrink-0 text-muted-foreground"
+          }
+        />
+        <input
+          ref={inputRef}
+          type="text"
+          value={value}
+          onChange={(e) => {
+            setValue(e.target.value);
+            if (error) setError(null);
+          }}
+          disabled={submitting}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") {
+              e.preventDefault();
+              void handleSubmit();
+            } else if (e.key === "Escape") {
+              e.preventDefault();
+              onCancel();
+            }
+          }}
+          onBlur={() => {
+            // Cancel on blur unless we're submitting (in which case the
+            // input is already disabled and we don't want to fight the
+            // submit flow).
+            if (!submitting) {
+              if (value.trim()) {
+                void handleSubmit();
+              } else {
+                onCancel();
+              }
+            }
+          }}
+          placeholder={placeholder ?? (kind === "directory" ? "Folder name" : "File name")}
+          className="min-w-0 flex-1 rounded-sm border border-border bg-background px-1 py-0 text-foreground outline-none ring-1 ring-ring/40 focus:ring-2 focus:ring-ring disabled:opacity-60"
+          aria-label={kind === "directory" ? "Folder name" : "File name"}
+        />
+      </div>
+      {error && (
+        <div
+          className="pointer-events-none text-xs text-destructive"
+          style={{ paddingLeft: `${18 + 6}px`, paddingBottom: 4 }}
+        >
+          {error}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
 // TreeNode — renders a single file or directory row + children recursively
 // ---------------------------------------------------------------------------
 interface TreeNodeProps {
@@ -61,9 +274,41 @@ interface TreeNodeProps {
   onToggle: (dirPath: string) => void;
   onOpenFile: (filePath: string) => void;
   onOpenFilePinned?: (filePath: string) => void;
+  /**
+   * Mark a row as the current tree selection. Set on left-click, on the
+   * file open path, and when a row's context menu opens — so right-click
+   * also drives selection.
+   */
+  onSelectRow: (path: string, kind: "file" | "directory") => void;
+  onRequestNewEntry: (parentPath: string, kind: "file" | "directory") => void;
+  onRequestDelete: (path: string, kind: "file" | "directory") => void;
+  onRequestRename: (path: string) => void;
+  onCut: (path: string, kind: "file" | "directory") => void;
+  onCopy: (path: string, kind: "file" | "directory") => void;
+  onPaste: (destFolder: string) => void | Promise<void>;
+  canDelete: boolean;
+  canRename: boolean;
+  canCut: boolean;
+  canCopy: boolean;
+  canPaste: boolean;
   compact?: boolean;
-  selectedFile?: string;
+  /** Single source of truth for the currently-highlighted tree row. */
+  treeSelection: { path: string; kind: "file" | "directory" } | null;
+  /**
+   * App-internal clipboard. Drives the "cut" dim-on-row visual: a row
+   * (or a descendant of a cut folder) renders at reduced opacity until
+   * the cut is pasted, cleared, or another entry is cut/copied.
+   */
+  clipboard: { path: string; kind: "file" | "directory"; op: "copy" | "cut" } | null;
   selectedRef?: React.RefObject<HTMLButtonElement | null>;
+  /** Render an inline new-entry input as the first child of this directory. */
+  newEntry: { parentPath: string; kind: "file" | "directory" } | null;
+  onNewEntrySubmit: (name: string) => Promise<void>;
+  onNewEntryCancel: () => void;
+  /** When set to this row's path, render an inline rename input. */
+  renamingPath: string | null;
+  onRenameSubmit: (newName: string) => Promise<void>;
+  onRenameCancel: () => void;
 }
 
 function TreeNode({
@@ -76,24 +321,57 @@ function TreeNode({
   onToggle,
   onOpenFile,
   onOpenFilePinned,
+  onSelectRow,
+  onRequestNewEntry,
+  onRequestDelete,
+  onRequestRename,
+  onCut,
+  onCopy,
+  onPaste,
+  canDelete,
+  canRename,
+  canCut,
+  canCopy,
+  canPaste,
   compact,
-  selectedFile,
+  treeSelection,
+  clipboard,
   selectedRef,
+  newEntry,
+  onNewEntrySubmit,
+  onNewEntryCancel,
+  renamingPath,
+  onRenameSubmit,
+  onRenameCancel,
 }: TreeNodeProps) {
   const entryPath = parentPath ? `${parentPath}/${entry.name}` : entry.name;
   const isDir = entry.type === "directory";
   const isExpanded = isDir && expandedPaths.has(entryPath);
-  const isSelected = !isDir && selectedFile === entryPath;
+  // One unified tree selection — kind must match so a folder doesn't
+  // accidentally light up a file row with the same path or vice versa.
+  const isSelected =
+    treeSelection?.path === entryPath && (treeSelection.kind === "directory") === isDir;
+  // "Cut" visual: dim this row when it's the cut source or a descendant
+  // of a cut folder, so the user can see what's about to move.
+  const isCut =
+    clipboard?.op === "cut" &&
+    (clipboard.path === entryPath || entryPath.startsWith(`${clipboard.path}/`));
   const isLoading = isDir && loadingPaths.has(entryPath);
   const children = isDir ? dirContents.get(entryPath) : undefined;
+
+  // Defer every menu action until after the menu's close transition
+  // finishes — see `useDeferredMenuAction` for the why.
+  const menu = useDeferredMenuAction();
 
   const indent = compact ? 12 : 16;
   const basePad = compact ? 4 : 8;
 
   const handleClick = () => {
     if (isDir) {
+      onSelectRow(entryPath, "directory");
       onToggle(entryPath);
     } else {
+      onSelectRow(entryPath, "file");
       onOpenFile(entryPath);
     }
   };
@@ -104,78 +382,208 @@ function TreeNode({
     }
   };
 
+  const button = (
+    <button
+      ref={isSelected ? selectedRef : undefined}
+      type="button"
+      // data-band-active marks this button so the workspace-level
+      // ⇧⌘E "focus Files" handler can target it from outside the
+      // FileBrowser without depending on the brittle Tailwind class
+      // pair below.
+      data-band-active={isSelected ? "true" : undefined}
+      onClick={handleClick}
+      onDoubleClick={handleDoubleClick}
+      // Stop the events Radix uses to detect a context-menu open from
+      // bubbling to the outer FileBrowser-root ContextMenuTrigger:
+      //   * `contextmenu` — fires on mouse right-click. Catches desktop.
+      //   * `pointerdown` — what Radix arms its long-press timer on for
+      //     touch. Without this, BOTH the inner per-row trigger AND the
+      //     outer root trigger see the same pointerdown, each start
+      //     their own 700ms timer, and 700ms later both menus open
+      //     (the "two menus on long-press" issue).
+      // We compose with Radix's own handlers on the same element via
+      // asChild → Slot prop merging, so the inner Trigger's logic still
+      // runs (it sees the pointerdown / right-click and opens this row's
+      // menu); only propagation to the parent is killed.
+      onContextMenu={(e) => e.stopPropagation()}
+      onPointerDown={(e) => e.stopPropagation()}
+      className={`flex w-full items-center text-left select-none hover:bg-accent/50 [-webkit-touch-callout:none] ${
+        compact ? "h-[28px] gap-1 pr-3 text-[13px]" : "h-[32px] gap-1.5 pr-4 text-[15px]"
+      } ${
+        isSelected
+          ? "bg-blue-500/30 text-foreground outline outline-1 -outline-offset-1 outline-blue-400/60 hover:bg-blue-500/30 dark:bg-blue-500/40 dark:outline-blue-400/70 dark:hover:bg-blue-500/40"
+          : ""
+      } ${isCut ? "opacity-50" : ""}`}
+      style={{ paddingLeft: `${depth * indent + basePad}px` }}
+    >
+      {/* Chevron / spacer */}
+      {isDir ? (
+        isExpanded ? (
+          <ChevronDown className="size-3.5 shrink-0 text-muted-foreground/70" />
+        ) : (
+          <ChevronRight className="size-3.5 shrink-0 text-muted-foreground/70" />
+        )
+      ) : (
+        <span className="size-3.5 shrink-0" />
+      )}
+
+      {/* Icon */}
+      {isDir ? (
+        isExpanded ? (
+          <FolderOpen className="size-4 shrink-0 text-blue-600 dark:text-blue-400" />
+        ) : (
+          <Folder className="size-4 shrink-0 text-blue-600 dark:text-blue-400" />
+        )
+      ) : (
+        (() => {
+          const FileIcon = getFileIcon(entry.name);
+          return <FileIcon className="size-4 shrink-0 text-muted-foreground" />;
+        })()
+      )}
+
+      {/* Name */}
+      <span className="min-w-0 flex-1 truncate">{entry.name}</span>
+    </button>
+  );
+
+  const isRenaming = renamingPath === entryPath;
+
+  // Sibling names used to validate the rename input — exclude the
+  // current name so submitting the same name is treated as a cancel.
+  const renameSiblings = (() => {
+    const set = new Set<string>();
+    const cached = dirContents.get(parentPath);
+    if (cached) {
+      for (const e of cached) {
+        if (e.name !== entry.name) set.add(e.name);
+      }
+    }
+    return set;
+  })();
+
+  // Every row exposes a right-click context menu. Directories get the
+  // "New File" / "New Folder" actions scoped inside themselves; both
+  // files and directories get "Rename" and a destructive "Delete" item.
+  const row = isRenaming ? (
+    // EntryNameInput computes its own `paddingLeft = depth * indent + basePad`
+    // — passing the row's actual depth keeps the input row perfectly aligned
+    // with sibling row buttons (which use the same formula). Wrapping it in
+    // a padding div with `depth={0}` would double-apply `basePad`, shifting
+    // the input ~4px to the right and giving it visibly less horizontal
+    // room than the rest of the tree.
+    <EntryNameInput
+      key={`rename-${entryPath}`}
+      kind={isDir ? "directory" : "file"}
+      depth={depth}
+      compact={compact}
+      initialValue={entry.name}
+      siblings={renameSiblings}
+      placeholder={isDir ? "Folder name" : "File name"}
+      onSubmit={onRenameSubmit}
+      onCancel={onRenameCancel}
+    />
+  ) : (
+    <ContextMenu
+      // Right-clicking a row should select it before the menu opens, so
+      // the user can see which row they're acting on (matters most for
+      // folders, where "New File" creates inside the selected dir).
+      onOpenChange={(open) => {
+        if (open) onSelectRow(entryPath, isDir ? "directory" : "file");
+      }}
+    >
+      <ContextMenuTrigger asChild>{button}</ContextMenuTrigger>
+      {/* Each item queues its action; `menu.flush` runs it once the
+          menu finishes closing (and stops Radix from restoring focus
+          to the trigger). See `useDeferredMenuAction` for the why. */}
+      <ContextMenuContent onCloseAutoFocus={menu.flush}>
+        {isDir && (
+          <>
+            <ContextMenuItem
+              onSelect={() => menu.queue(() => onRequestNewEntry(entryPath, "file"))}
+            >
+              <FileIconLucide className="size-4" />
+              New File
+            </ContextMenuItem>
+            <ContextMenuItem
+              onSelect={() => menu.queue(() => onRequestNewEntry(entryPath, "directory"))}
+            >
+              <FolderPlus className="size-4" />
+              New Folder
+            </ContextMenuItem>
+            <ContextMenuSeparator />
+          </>
+        )}
+        {canCut && (
+          <ContextMenuItem
+            onSelect={() => menu.queue(() => onCut(entryPath, isDir ? "directory" : "file"))}
+          >
+            <Scissors className="size-4" />
+            Cut
+          </ContextMenuItem>
+        )}
+        {canCopy && (
+          <ContextMenuItem
+            onSelect={() => menu.queue(() => onCopy(entryPath, isDir ? "directory" : "file"))}
+          >
+            <CopyIcon className="size-4" />
+            Copy
+          </ContextMenuItem>
+        )}
+        {/* Paste only appears on folder rows — pasting onto a file is
+            ambiguous (do you mean its parent dir?). Users who want to
+            paste alongside a file can right-click the parent folder or
+            the empty tree area instead. */}
+        {isDir && canPaste && (
+          <ContextMenuItem onSelect={() => menu.queue(() => void onPaste(entryPath))}>
+            <ClipboardPaste className="size-4" />
+            Paste
+          </ContextMenuItem>
+        )}
+        {(canCut || canCopy || (isDir && canPaste)) && (canRename || canDelete) && (
+          <ContextMenuSeparator />
+        )}
+        {canRename && (
+          <ContextMenuItem onSelect={() => menu.queue(() => onRequestRename(entryPath))}>
+            <Pencil className="size-4" />
+            Rename
+          </ContextMenuItem>
+        )}
+        {canDelete && (
+          <ContextMenuItem
+            variant="destructive"
+            onSelect={() =>
+              menu.queue(() => onRequestDelete(entryPath, isDir ? "directory" : "file"))
+            }
+          >
+            <Trash2 className="size-4" />
+            Delete
+          </ContextMenuItem>
+        )}
+      </ContextMenuContent>
+    </ContextMenu>
+  );
+
+  const showInlineInput = newEntry?.parentPath === entryPath;
+
   return (
     <>
-      <button
-        ref={isSelected ? selectedRef : undefined}
-        type="button"
-        // data-band-active marks this button so the workspace-level
-        // ⇧⌘E "focus Files" handler can target it from outside the
-        // FileBrowser without depending on the brittle Tailwind class
-        // pair below.
-        data-band-active={isSelected ? "true" : undefined}
-        onClick={handleClick}
-        onDoubleClick={handleDoubleClick}
-        className={`flex w-full items-center text-left hover:bg-accent/50 ${
-          compact ? "h-[26px] gap-1 pr-3 text-xs" : "h-[30px] gap-1.5 pr-4 text-sm"
-        } ${isSelected ? "bg-accent text-accent-foreground" : ""}`}
-        style={{ paddingLeft: `${depth * indent + basePad}px` }}
-      >
-        {/* Chevron / spacer */}
-        {isDir ? (
-          isExpanded ? (
-            <ChevronDown className="size-3.5 shrink-0 text-muted-foreground/70" />
-          ) : (
-            <ChevronRight className="size-3.5 shrink-0 text-muted-foreground/70" />
-          )
-        ) : (
-          <span className="size-3.5 shrink-0" />
-        )}
+      {row}
 
-        {/* Icon */}
-        {isDir ? (
-          isExpanded ? (
-            <FolderOpen className="size-4 shrink-0 text-blue-600 dark:text-blue-400" />
-          ) : (
-            <Folder className="size-4 shrink-0 text-blue-600 dark:text-blue-400" />
-          )
-        ) : (
-          (() => {
-            const FileIcon = getFileIcon(entry.name);
-            return <FileIcon className="size-4 shrink-0 text-muted-foreground" />;
-          })()
-        )}
-
-        {/* Name */}
-        <span className="min-w-0 flex-1 truncate">{entry.name}</span>
-      </button>
-
-      {/* Children — rendered when directory is expanded */}
-      {isExpanded && (
-        <>
-          {isLoading && !children?.length && (
-            <div
-              className="flex items-center text-xs text-muted-foreground/70"
-              style={{
-                paddingLeft: `${(depth + 1) * indent + basePad + 18}px`,
-                height: compact ? 26 : 30,
-              }}
-            >
-              Loading…
-            </div>
-          )}
-          {!isLoading && children && children.length === 0 && (
-            <div
-              className="flex items-center text-xs italic text-muted-foreground/50"
-              style={{
-                paddingLeft: `${(depth + 1) * indent + basePad + 18}px`,
-                height: compact ? 26 : 30,
-              }}
-            >
-              Empty
-            </div>
-          )}
-          {children?.map((child) => (
+      {/* Children — rendered when directory is expanded.
+          Children come from the backend already sorted (folders first,
+          then files). When the user is creating a new entry inline we
+          slot the input where the eventual entry will land so the cursor
+          appears in its final sort position:
+            - new folder  → above all folder children (top of the list)
+            - new file    → between folder children and file children
+                            (top of the file section) */}
+      {isExpanded &&
+        (() => {
+          const splitIdx = children?.findIndex((c) => c.type === "file") ?? -1;
+          const folderChildren =
+            splitIdx === -1 ? (children ?? []) : (children ?? []).slice(0, splitIdx);
+          const fileChildren = splitIdx === -1 ? [] : (children ?? []).slice(splitIdx);
+          const renderChild = (child: FileEntry) => (
             <TreeNode
               key={child.name}
               entry={child}
@@ -187,13 +595,76 @@ function TreeNode({
               onToggle={onToggle}
               onOpenFile={onOpenFile}
               onOpenFilePinned={onOpenFilePinned}
+              onSelectRow={onSelectRow}
+              onRequestNewEntry={onRequestNewEntry}
+              onRequestDelete={onRequestDelete}
+              onRequestRename={onRequestRename}
+              onCut={onCut}
+              onCopy={onCopy}
+              onPaste={onPaste}
+              canDelete={canDelete}
+              canRename={canRename}
+              canCut={canCut}
+              canCopy={canCopy}
+              canPaste={canPaste}
               compact={compact}
-              selectedFile={selectedFile}
+              treeSelection={treeSelection}
+              clipboard={clipboard}
               selectedRef={selectedRef}
+              newEntry={newEntry}
+              onNewEntrySubmit={onNewEntrySubmit}
+              onNewEntryCancel={onNewEntryCancel}
+              renamingPath={renamingPath}
+              onRenameSubmit={onRenameSubmit}
+              onRenameCancel={onRenameCancel}
             />
-          ))}
-        </>
-      )}
+          );
+          const newEntryInput = showInlineInput ? (
+            <EntryNameInput
+              key={`new-${newEntry.kind}-${entryPath}`}
+              kind={newEntry.kind}
+              depth={depth + 1}
+              compact={compact}
+              siblings={new Set((children ?? []).map((c) => c.name))}
+              onSubmit={onNewEntrySubmit}
+              onCancel={onNewEntryCancel}
+            />
+          ) : null;
+          return (
+            <>
+              {showInlineInput && newEntry.kind === "directory" && newEntryInput}
+              {isLoading && !children?.length && (
+                <div
+                  className={`flex items-center text-muted-foreground/70 ${
+                    compact ? "text-[13px]" : "text-[15px]"
+                  }`}
+                  style={{
+                    paddingLeft: `${(depth + 1) * indent + basePad + 18}px`,
+                    height: compact ? 28 : 32,
+                  }}
+                >
+                  Loading…
+                </div>
+              )}
+              {!isLoading && !showInlineInput && children && children.length === 0 && (
+                <div
+                  className={`flex items-center italic text-muted-foreground/50 ${
+                    compact ? "text-[13px]" : "text-[15px]"
+                  }`}
+                  style={{
+                    paddingLeft: `${(depth + 1) * indent + basePad + 18}px`,
+                    height: compact ? 28 : 32,
+                  }}
+                >
+                  Empty
+                </div>
+              )}
+              {folderChildren.map(renderChild)}
+              {showInlineInput && newEntry.kind === "file" && newEntryInput}
+              {fileChildren.map(renderChild)}
+            </>
+          );
+        })()}
     </>
   );
 }
@@ -201,13 +672,18 @@ function TreeNode({
 // ---------------------------------------------------------------------------
 // FileBrowser — tree root, manages state & data fetching
 // ---------------------------------------------------------------------------
-export function FileBrowser({
-  workspaceId,
-  onOpenFile,
-  onOpenFilePinned,
-  compact,
-  selectedFile,
-}: FileBrowserProps) {
+export const FileBrowser = forwardRef<FileBrowserHandle, FileBrowserProps>(function FileBrowser(
+  {
+    workspaceId,
+    onOpenFile,
+    onOpenFilePinned,
+    compact,
+    selectedFile,
+    onPathRenamed,
+    onPathDeleted,
+  },
+  handleRef,
+) {
   const adapter = useAdapter();
 
   // React state mirroring the module-level caches so changes trigger renders
@@ -218,6 +694,49 @@ export function FileBrowser({
     () => new Map(getCachedContents(workspaceId)),
   );
   const [loadingPaths, setLoadingPaths] = useState<Set<string>>(new Set());
+
+  // Inline new-entry input state. Only one new entry is shown at a time,
+  // and it's tracked by its parent directory + kind.
+  const [newEntry, setNewEntry] = useState<{
+    parentPath: string;
+    kind: "file" | "directory";
+  } | null>(null);
+
+  // Deletion confirmation state. When non-null, the dialog is shown.
+  const [pendingDelete, setPendingDelete] = useState<{
+    path: string;
+    kind: "file" | "directory";
+  } | null>(null);
+  const [deleteError, setDeleteError] = useState<string | null>(null);
+  const [deleteSubmitting, setDeleteSubmitting] = useState(false);
+
+  // Inline rename state. When set to a path, that row renders the
+  // rename input in place of the usual file/folder button.
+  const [renamingPath, setRenamingPath] = useState<string | null>(null);
+
+  // App-internal clipboard for Cut / Copy / Paste. Persisted only in
+  // memory (not the OS clipboard) so it can hold paths to entries we
+  // own; the OS clipboard is reserved for actual text the user expects
+  // to land in their system buffer.
+  const [clipboard, setClipboard] = useState<{
+    path: string;
+    kind: "file" | "directory";
+    op: "copy" | "cut";
+  } | null>(null);
+
+  // The currently-highlighted tree row. Tracks files AND folders in a
+  // single source of truth so:
+  //  * Only one row ever shows the selection highlight at a time.
+  //  * Right-click (which doesn't open a file in the editor) can still
+  //    mark a row as selected.
+  //  * Right-click on the empty tree area can clear the highlight so
+  //    the user understands new entries will land at the root.
+  // The parent-owned `selectedFile` prop seeds this on mount and on
+  // change, so opening a file via QuickOpen / tabs still highlights it.
+  const [treeSelection, setTreeSelection] = useState<{
+    path: string;
+    kind: "file" | "directory";
+  } | null>(() => (selectedFile ? { path: selectedFile, kind: "file" } : null));
 
   // Ref for scrolling the selected file into view
   const selectedRef = useRef<HTMLButtonElement>(null);
@@ -230,16 +749,43 @@ export function FileBrowser({
       setExpandedPaths(new Set(getCachedExpanded(workspaceId)));
       setDirContents(new Map(getCachedContents(workspaceId)));
       setLoadingPaths(new Set());
+      setNewEntry(null);
+      // The selectedFile-sync effect below will re-seed treeSelection
+      // when the parent passes a new open file for the next workspace.
+      setTreeSelection(null);
+      setPendingDelete(null);
+      setDeleteError(null);
+      setDeleteSubmitting(false);
+      setRenamingPath(null);
+      setClipboard(null);
     }
   }, [workspaceId]);
 
+  // Mirror the parent-owned `selectedFile` into the tree selection
+  // whenever it changes (e.g. user opened a file from QuickOpen or the
+  // tabs strip). Don't fight an active folder selection when the parent
+  // re-renders with the same selectedFile — only react to actual changes.
+  useEffect(() => {
+    if (selectedFile) {
+      setTreeSelection({ path: selectedFile, kind: "file" });
+    }
+  }, [selectedFile]);
+
+  const handleSelectRow = useCallback((path: string, kind: "file" | "directory") => {
+    setTreeSelection({ path, kind });
+  }, []);
+
+  const clearTreeSelection = useCallback(() => {
+    setTreeSelection(null);
+  }, []);
+
   // ------- Fetch helpers -------
   const fetchDir = useCallback(
-    async (dirPath: string): Promise<void> => {
+    async (dirPath: string, opts?: { force?: boolean }): Promise<void> => {
       if (!adapter.listWorkspaceFiles) return;
 
       const cache = getCachedContents(workspaceId);
-      if (cache.has(dirPath)) {
+      if (!opts?.force && cache.has(dirPath)) {
         // Already fetched — make sure React state includes it
         setDirContents((prev) => (prev.has(dirPath) ? prev : new Map(cache)));
         return;
@@ -339,6 +885,406 @@ export function FileBrowser({
     [workspaceId, fetchDir],
   );
 
+  // ------- New file / folder flow -------
+  const ensureDirExpanded = useCallback(
+    async (dirPath: string) => {
+      // Make sure the directory is expanded and its contents are loaded
+      // before we show the inline input inside it.
+      const cached = getCachedExpanded(workspaceId);
+      if (!cached.has(dirPath)) {
+        cached.add(dirPath);
+        expandedStateCache.set(workspaceId, new Set(cached));
+        setExpandedPaths(new Set(cached));
+      }
+      await fetchDir(dirPath);
+    },
+    [workspaceId, fetchDir],
+  );
+
+  const requestNewEntry = useCallback(
+    (parentPath: string, kind: "file" | "directory") => {
+      void ensureDirExpanded(parentPath);
+      setNewEntry({ parentPath, kind });
+    },
+    [ensureDirExpanded],
+  );
+
+  const cancelNewEntry = useCallback(() => {
+    setNewEntry(null);
+  }, []);
+
+  const submitNewEntry = useCallback(
+    async (name: string) => {
+      if (!newEntry) return;
+      const fullPath = newEntry.parentPath ? `${newEntry.parentPath}/${name}` : name;
+
+      if (newEntry.kind === "file") {
+        if (!adapter.createWorkspaceFile) {
+          throw new Error("Creating files is not supported");
+        }
+        await adapter.createWorkspaceFile(workspaceId, fullPath);
+      } else {
+        if (!adapter.createWorkspaceDirectory) {
+          throw new Error("Creating folders is not supported");
+        }
+        await adapter.createWorkspaceDirectory(workspaceId, fullPath);
+      }
+
+      // Refresh the parent directory so the new entry shows up. Force
+      // a refetch to bypass the cache.
+      await fetchDir(newEntry.parentPath, { force: true });
+
+      // Close the input
+      setNewEntry(null);
+
+      // If we created a file, open it for editing. For folders, expand
+      // them and mark them as the active selection so subsequent
+      // "New File" actions land inside the newly-created folder.
+      if (newEntry.kind === "file") {
+        setTreeSelection({ path: fullPath, kind: "file" });
+        onOpenFile(fullPath);
+      } else {
+        const cached = getCachedExpanded(workspaceId);
+        if (!cached.has(fullPath)) {
+          cached.add(fullPath);
+          expandedStateCache.set(workspaceId, new Set(cached));
+          setExpandedPaths(new Set(cached));
+        }
+        setTreeSelection({ path: fullPath, kind: "directory" });
+      }
+    },
+    [adapter, newEntry, fetchDir, onOpenFile, workspaceId],
+  );
+
+  // ------- Delete flow -------
+  const canDelete = Boolean(adapter.deleteWorkspacePath);
+
+  const requestDelete = useCallback((path: string, kind: "file" | "directory") => {
+    setDeleteError(null);
+    setPendingDelete({ path, kind });
+  }, []);
+
+  const cancelDelete = useCallback(() => {
+    if (deleteSubmitting) return;
+    setPendingDelete(null);
+    setDeleteError(null);
+  }, [deleteSubmitting]);
+
+  const confirmDelete = useCallback(async () => {
+    if (!pendingDelete || !adapter.deleteWorkspacePath) return;
+    setDeleteSubmitting(true);
+    setDeleteError(null);
+    try {
+      await adapter.deleteWorkspacePath(workspaceId, pendingDelete.path);
+
+      // Drop cached contents for the deleted path (if it was a directory)
+      // and any descendants, so they aren't resurrected when the user
+      // re-expands a parent.
+      const cache = getCachedContents(workspaceId);
+      const prefix = `${pendingDelete.path}/`;
+      cache.delete(pendingDelete.path);
+      for (const key of Array.from(cache.keys())) {
+        if (key.startsWith(prefix)) cache.delete(key);
+      }
+
+      // Collapse and drop the expanded-state for any descendants
+      const cachedExpanded = getCachedExpanded(workspaceId);
+      cachedExpanded.delete(pendingDelete.path);
+      for (const key of Array.from(cachedExpanded)) {
+        if (key.startsWith(prefix)) cachedExpanded.delete(key);
+      }
+      expandedStateCache.set(workspaceId, new Set(cachedExpanded));
+      setExpandedPaths(new Set(cachedExpanded));
+
+      // If the deleted entry (or one of its descendants) was the
+      // currently-selected tree row, clear it so the toolbar doesn't try
+      // to create new entries inside a missing directory.
+      setTreeSelection((prev) => {
+        if (prev == null) return prev;
+        if (prev.path === pendingDelete.path || prev.path.startsWith(prefix)) {
+          return null;
+        }
+        return prev;
+      });
+
+      // Cancel any in-flight inline new-entry input whose parent was
+      // inside the deleted tree.
+      setNewEntry((prev) => {
+        if (!prev) return prev;
+        if (prev.parentPath === pendingDelete.path || prev.parentPath.startsWith(prefix)) {
+          return null;
+        }
+        return prev;
+      });
+
+      // Refresh the parent so the row disappears from the tree.
+      const idx = pendingDelete.path.lastIndexOf("/");
+      const parent = idx === -1 ? "" : pendingDelete.path.slice(0, idx);
+      await fetchDir(parent, { force: true });
+
+      // Notify the host (CodeBrowserView) so it can drop matching tabs.
+      onPathDeleted?.(pendingDelete.path, pendingDelete.kind);
+
+      setPendingDelete(null);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      setDeleteError(message);
+    } finally {
+      setDeleteSubmitting(false);
+    }
+  }, [adapter, pendingDelete, fetchDir, workspaceId, onPathDeleted]);
+
+  // ------- Rename flow -------
+  const canRename = Boolean(adapter.renameWorkspacePath);
+
+  const requestRename = useCallback((path: string) => {
+    setRenamingPath(path);
+  }, []);
+
+  const cancelRename = useCallback(() => {
+    setRenamingPath(null);
+  }, []);
+
+  const submitRename = useCallback(
+    async (newName: string) => {
+      if (renamingPath == null || !adapter.renameWorkspacePath) return;
+      const oldPath = renamingPath;
+      const slashIdx = oldPath.lastIndexOf("/");
+      const parent = slashIdx === -1 ? "" : oldPath.slice(0, slashIdx);
+      const newPath = parent ? `${parent}/${newName}` : newName;
+
+      const result = await adapter.renameWorkspacePath(workspaceId, oldPath, newPath);
+
+      // Rewrite path-keyed caches: anything sitting in the renamed
+      // subtree needs to be moved to its new prefix.
+      const cache = getCachedContents(workspaceId);
+      const oldPrefix = `${oldPath}/`;
+      const newKeys = new Map<string, FileEntry[]>();
+      for (const [key, value] of cache.entries()) {
+        if (key === oldPath) {
+          newKeys.set(newPath, value);
+        } else if (key.startsWith(oldPrefix)) {
+          newKeys.set(newPath + key.slice(oldPath.length), value);
+        } else {
+          newKeys.set(key, value);
+        }
+      }
+      cache.clear();
+      for (const [k, v] of newKeys) cache.set(k, v);
+
+      const cachedExpanded = getCachedExpanded(workspaceId);
+      const newExpanded = new Set<string>();
+      for (const key of cachedExpanded) {
+        if (key === oldPath) {
+          newExpanded.add(newPath);
+        } else if (key.startsWith(oldPrefix)) {
+          newExpanded.add(newPath + key.slice(oldPath.length));
+        } else {
+          newExpanded.add(key);
+        }
+      }
+      expandedStateCache.set(workspaceId, newExpanded);
+      setExpandedPaths(new Set(newExpanded));
+
+      // Update tree selection if it was inside the renamed subtree.
+      setTreeSelection((prev) => {
+        if (prev == null) return prev;
+        if (prev.path === oldPath) return { ...prev, path: newPath };
+        if (prev.path.startsWith(oldPrefix)) {
+          return { ...prev, path: newPath + prev.path.slice(oldPath.length) };
+        }
+        return prev;
+      });
+
+      // Drop any pending new-entry input rooted in the renamed subtree
+      // (its parentPath is now stale).
+      setNewEntry((prev) => {
+        if (!prev) return prev;
+        if (prev.parentPath === oldPath || prev.parentPath.startsWith(oldPrefix)) {
+          return null;
+        }
+        return prev;
+      });
+
+      // Refresh the parent directory listing so the row reflects the new name.
+      await fetchDir(parent, { force: true });
+
+      setRenamingPath(null);
+
+      // Tell the host to update open tabs / editor state for the rename.
+      onPathRenamed?.(oldPath, newPath, result.kind);
+    },
+    [adapter, renamingPath, fetchDir, onPathRenamed, workspaceId],
+  );
+
+  // Derive the implicit target for "New File" / "New Folder" actions
+  // initiated from the parent toolbar (i.e. callers that don't pass an
+  // explicit parent). Priority: selected folder → selected file's parent
+  // directory → workspace root. The right-click-on-empty-area flow
+  // clears `treeSelection`, which intentionally falls through to root.
+  const resolveDefaultTarget = useCallback((): string => {
+    if (treeSelection?.kind === "directory") return treeSelection.path;
+    if (treeSelection?.kind === "file") {
+      const idx = treeSelection.path.lastIndexOf("/");
+      return idx === -1 ? "" : treeSelection.path.slice(0, idx);
+    }
+    return "";
+  }, [treeSelection]);
+
+  // ------- Cut / Copy / Paste -------
+  const canCutCopy = Boolean(adapter.renameWorkspacePath);
+  const canCopyOp = Boolean(adapter.copyWorkspacePath);
+  const canPaste = Boolean(
+    clipboard &&
+      ((clipboard.op === "copy" && adapter.copyWorkspacePath) ||
+        (clipboard.op === "cut" && adapter.renameWorkspacePath)),
+  );
+
+  const cutPath = useCallback((path: string, kind: "file" | "directory") => {
+    setClipboard({ path, kind, op: "cut" });
+  }, []);
+
+  const copyPath = useCallback((path: string, kind: "file" | "directory") => {
+    setClipboard({ path, kind, op: "copy" });
+  }, []);
+
+  // Build a "copy"-suffixed name unique within the destination folder.
+  // Mirrors Finder/Explorer behaviour: `foo.txt` → `foo copy.txt`,
+  // then `foo copy 2.txt`, `foo copy 3.txt`, ...
+  const uniqueCopyName = useCallback(
+    (baseName: string, destFolder: string, kind: "file" | "directory"): string => {
+      const siblings = new Set(
+        (getCachedContents(workspaceId).get(destFolder) ?? []).map((e) => e.name),
+      );
+      if (!siblings.has(baseName)) return baseName;
+
+      // Split extension only for files; preserve dotfile / dir names whole.
+      const dotIdx = kind === "file" ? baseName.lastIndexOf(".") : -1;
+      const stem = dotIdx > 0 ? baseName.slice(0, dotIdx) : baseName;
+      const ext = dotIdx > 0 ? baseName.slice(dotIdx) : "";
+
+      let n = 1;
+      while (true) {
+        const candidate = n === 1 ? `${stem} copy${ext}` : `${stem} copy ${n}${ext}`;
+        if (!siblings.has(candidate)) return candidate;
+        n += 1;
+      }
+    },
+    [workspaceId],
+  );
+
+  /**
+   * Paste the current clipboard entry into `destFolder` (workspace
+   * root if empty string). For copy operations, the entry's name is
+   * auto-suffixed with "copy" if it would collide. For cut operations,
+   * we surface a collision as an error (matching rename semantics).
+   */
+  const pasteInto = useCallback(
+    async (destFolder: string): Promise<void> => {
+      if (!clipboard) return;
+      const sourcePath = clipboard.path;
+      const sourceParent = (() => {
+        const idx = sourcePath.lastIndexOf("/");
+        return idx === -1 ? "" : sourcePath.slice(0, idx);
+      })();
+      const baseName = sourcePath.slice(sourceParent.length === 0 ? 0 : sourceParent.length + 1);
+
+      // Refuse to paste a directory into itself or any descendant of
+      // itself — the backend rejects this too, but failing fast keeps
+      // the cached filesystem state consistent.
+      if (clipboard.kind === "directory") {
+        if (destFolder === sourcePath || destFolder.startsWith(`${sourcePath}/`)) {
+          return;
+        }
+      }
+
+      if (clipboard.op === "copy") {
+        if (!adapter.copyWorkspacePath) return;
+        const newName = uniqueCopyName(baseName, destFolder, clipboard.kind);
+        const destPath = destFolder ? `${destFolder}/${newName}` : newName;
+        await adapter.copyWorkspacePath(workspaceId, sourcePath, destPath);
+        await fetchDir(destFolder, { force: true });
+        setTreeSelection({ path: destPath, kind: clipboard.kind });
+      } else {
+        // cut → move. If the destination is the same as the source's
+        // current parent the move is a no-op; bail out to avoid an
+        // "already exists" error from the backend.
+        if (destFolder === sourceParent) return;
+        if (!adapter.renameWorkspacePath) return;
+        const destPath = destFolder ? `${destFolder}/${baseName}` : baseName;
+        const result = await adapter.renameWorkspacePath(workspaceId, sourcePath, destPath);
+
+        // Patch the path-keyed caches: anything in the moved subtree
+        // needs its key rewritten to the new prefix.
+        const cache = getCachedContents(workspaceId);
+        const oldPrefix = `${sourcePath}/`;
+        const remapped = new Map<string, FileEntry[]>();
+        for (const [key, value] of cache.entries()) {
+          if (key === sourcePath) {
+            remapped.set(destPath, value);
+          } else if (key.startsWith(oldPrefix)) {
+            remapped.set(destPath + key.slice(sourcePath.length), value);
+          } else {
+            remapped.set(key, value);
+          }
+        }
+        cache.clear();
+        for (const [k, v] of remapped) cache.set(k, v);
+
+        const cachedExpanded = getCachedExpanded(workspaceId);
+        const remappedExpanded = new Set<string>();
+        for (const key of cachedExpanded) {
+          if (key === sourcePath) {
+            remappedExpanded.add(destPath);
+          } else if (key.startsWith(oldPrefix)) {
+            remappedExpanded.add(destPath + key.slice(sourcePath.length));
+          } else {
+            remappedExpanded.add(key);
+          }
+        }
+        expandedStateCache.set(workspaceId, remappedExpanded);
+        setExpandedPaths(new Set(remappedExpanded));
+
+        // Both source-parent and destination need a re-fetch so the
+        // row appears in its new home and vanishes from its old one.
+        await Promise.all([
+          fetchDir(sourceParent, { force: true }),
+          fetchDir(destFolder, { force: true }),
+        ]);
+
+        // Notify the host so it can keep open tabs / editor state
+        // pointed at the moved path — identical to a rename.
+        onPathRenamed?.(sourcePath, destPath, result.kind);
+
+        setTreeSelection({ path: destPath, kind: clipboard.kind });
+        // Cut is one-shot. Clear the clipboard so a subsequent ⌘V
+        // doesn't try to re-move an already-moved entry.
+        setClipboard(null);
+      }
+    },
+    [adapter, clipboard, fetchDir, onPathRenamed, uniqueCopyName, workspaceId],
+  );
+
+  // ------- Imperative handle for parent toolbars -------
+  useImperativeHandle(
+    handleRef,
+    () => ({
+      startNewFile(parentPath) {
+        requestNewEntry(parentPath ?? resolveDefaultTarget(), "file");
+      },
+      startNewFolder(parentPath) {
+        requestNewEntry(parentPath ?? resolveDefaultTarget(), "directory");
+      },
+    }),
+    [requestNewEntry, resolveDefaultTarget],
+  );
+
+  // Defer the root-area context menu's items the same way the per-row
+  // menu does — the menu's FocusScope would otherwise eat the inline
+  // new-entry input's focus on mount. Declared up here (before the
+  // early return below) so the hook call order is stable.
+  const rootMenu = useDeferredMenuAction();
+
   // ------- Render -------
   if (!adapter.listWorkspaceFiles) {
     return (
@@ -350,38 +1296,240 @@ export function FileBrowser({
 
   const rootEntries = dirContents.get("") ?? [];
   const rootLoading = loadingPaths.has("");
+  const rootSiblings = new Set(rootEntries.map((e) => e.name));
+  const showRootInput = newEntry?.parentPath === "";
 
+  // Keyboard shortcuts. We attach to the outer div so they only fire
+  // when focus is somewhere inside the file tree — the editor's own
+  // ⌘C / ⌘X / ⌘V handlers stay in charge when the user is typing.
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
+    // Bail when focus is in an inline input (rename / new-entry).
+    // Otherwise Backspace would try to delete the row instead of a
+    // character, and ⌘C would copy the row's path instead of the text
+    // the user has selected inside the input.
+    const target = e.target as HTMLElement | null;
+    if (
+      target &&
+      (target.tagName === "INPUT" || target.tagName === "TEXTAREA" || target.isContentEditable)
+    ) {
+      return;
+    }
+
+    // Delete / Backspace (no modifiers) → delete the selected row.
+    // Matches VS Code's Explorer behaviour: both keys trigger the same
+    // action, since macOS keyboards label Backspace as "Delete" and
+    // many users reach for that key first.
+    if (
+      (e.key === "Delete" || e.key === "Backspace") &&
+      !e.metaKey &&
+      !e.ctrlKey &&
+      !e.shiftKey &&
+      !e.altKey
+    ) {
+      if (!treeSelection || !canDelete) return;
+      e.preventDefault();
+      requestDelete(treeSelection.path, treeSelection.kind);
+      return;
+    }
+
+    if (!(e.metaKey || e.ctrlKey) || e.shiftKey || e.altKey) return;
+    const key = e.key.toLowerCase();
+
+    if (key === "c") {
+      if (!treeSelection || !canCutCopy) return;
+      e.preventDefault();
+      copyPath(treeSelection.path, treeSelection.kind);
+      return;
+    }
+    if (key === "x") {
+      if (!treeSelection || !canCutCopy) return;
+      e.preventDefault();
+      cutPath(treeSelection.path, treeSelection.kind);
+      return;
+    }
+    if (key === "v") {
+      if (!canPaste) return;
+      e.preventDefault();
+      // Paste into the folder under the cursor (selected folder), the
+      // parent of the selected file, or the workspace root — same
+      // priority order resolveDefaultTarget uses for "New File…".
+      void pasteInto(resolveDefaultTarget());
+    }
+  };
+
+  // The empty area below the tree captures right-clicks targeting the
+  // root, so users can quickly create at the top level even when the
+  // tree itself is dense or fully scrolled.
   return (
-    <div className="flex h-full flex-col overflow-hidden">
-      <div className="min-h-0 flex-1 overflow-y-auto py-1">
-        {rootLoading && rootEntries.length === 0 && (
-          <div className="flex h-32 items-center justify-center text-sm text-muted-foreground">
-            Loading…
+    <div className="flex h-full flex-col overflow-hidden" onKeyDown={handleKeyDown}>
+      <ContextMenu
+        // Right-clicking the empty tree area clears any active row
+        // selection so the user can see that the new entry will land at
+        // the workspace root. Radix's nested ContextMenu triggers stop
+        // propagation, so right-clicks on individual row buttons fire
+        // the per-row menu only and never reach this outer onOpenChange.
+        onOpenChange={(open) => {
+          if (open) clearTreeSelection();
+        }}
+      >
+        <ContextMenuTrigger asChild>
+          <div className="min-h-0 flex-1 overflow-y-auto py-1 pl-px">
+            {(() => {
+              // rootEntries is pre-sorted folders-first; slot the new
+              // entry input at its natural landing position so the user
+              // sees the cursor where the new row will actually appear:
+              //   - new folder  → at the top (before any folder rows)
+              //   - new file    → between the folder section and the
+              //                   file section (top of the file rows)
+              const rootSplitIdx = rootEntries.findIndex((e) => e.type === "file");
+              const rootFolders =
+                rootSplitIdx === -1 ? rootEntries : rootEntries.slice(0, rootSplitIdx);
+              const rootFiles = rootSplitIdx === -1 ? [] : rootEntries.slice(rootSplitIdx);
+              const renderRow = (entry: FileEntry) => (
+                <TreeNode
+                  key={entry.name}
+                  entry={entry}
+                  parentPath=""
+                  depth={0}
+                  expandedPaths={expandedPaths}
+                  dirContents={dirContents}
+                  loadingPaths={loadingPaths}
+                  onToggle={toggleExpand}
+                  onOpenFile={onOpenFile}
+                  onOpenFilePinned={onOpenFilePinned}
+                  onSelectRow={handleSelectRow}
+                  onRequestNewEntry={requestNewEntry}
+                  onRequestDelete={requestDelete}
+                  onRequestRename={requestRename}
+                  onCut={cutPath}
+                  onCopy={copyPath}
+                  onPaste={pasteInto}
+                  canDelete={canDelete}
+                  canRename={canRename}
+                  canCut={canCutCopy}
+                  canCopy={canCopyOp}
+                  canPaste={canPaste}
+                  compact={compact}
+                  treeSelection={treeSelection}
+                  clipboard={clipboard}
+                  selectedRef={selectedRef}
+                  newEntry={newEntry}
+                  onNewEntrySubmit={submitNewEntry}
+                  onNewEntryCancel={cancelNewEntry}
+                  renamingPath={renamingPath}
+                  onRenameSubmit={submitRename}
+                  onRenameCancel={cancelRename}
+                />
+              );
+              const rootInput = showRootInput ? (
+                <EntryNameInput
+                  key={`new-${newEntry.kind}-root`}
+                  kind={newEntry.kind}
+                  depth={0}
+                  compact={compact}
+                  siblings={rootSiblings}
+                  onSubmit={submitNewEntry}
+                  onCancel={cancelNewEntry}
+                />
+              ) : null;
+              return (
+                <>
+                  {showRootInput && newEntry.kind === "directory" && rootInput}
+                  {rootLoading && rootEntries.length === 0 && !showRootInput && (
+                    <div className="flex h-32 items-center justify-center text-sm text-muted-foreground">
+                      Loading…
+                    </div>
+                  )}
+                  {!rootLoading && rootEntries.length === 0 && !showRootInput && (
+                    <div className="flex h-32 items-center justify-center text-sm text-muted-foreground">
+                      Empty directory
+                    </div>
+                  )}
+                  {rootFolders.map(renderRow)}
+                  {showRootInput && newEntry.kind === "file" && rootInput}
+                  {rootFiles.map(renderRow)}
+                </>
+              );
+            })()}
+            {/* Filler so the right-click area extends to the bottom of the panel */}
+            <div className="min-h-[40px] flex-1" />
           </div>
-        )}
-        {!rootLoading && rootEntries.length === 0 && (
-          <div className="flex h-32 items-center justify-center text-sm text-muted-foreground">
-            Empty directory
+        </ContextMenuTrigger>
+        {/* Each item queues its action; `rootMenu.flush` runs it once
+            the menu has finished closing — see `useDeferredMenuAction`. */}
+        <ContextMenuContent onCloseAutoFocus={rootMenu.flush}>
+          <ContextMenuItem onSelect={() => rootMenu.queue(() => requestNewEntry("", "file"))}>
+            <FileIconLucide className="size-4" />
+            New File
+          </ContextMenuItem>
+          <ContextMenuItem onSelect={() => rootMenu.queue(() => requestNewEntry("", "directory"))}>
+            <FolderPlus className="size-4" />
+            New Folder
+          </ContextMenuItem>
+          {canPaste && (
+            <>
+              <ContextMenuSeparator />
+              <ContextMenuItem onSelect={() => rootMenu.queue(() => void pasteInto(""))}>
+                <ClipboardPaste className="size-4" />
+                Paste
+              </ContextMenuItem>
+            </>
+          )}
+        </ContextMenuContent>
+      </ContextMenu>
+
+      <Dialog
+        open={pendingDelete !== null}
+        onOpenChange={(open) => {
+          if (!open) cancelDelete();
+        }}
+      >
+        <DialogContent className="sm:max-w-[425px]" onClick={(e) => e.stopPropagation()}>
+          <DialogHeader>
+            <DialogTitle>
+              Delete {pendingDelete?.kind === "directory" ? "folder" : "file"}
+            </DialogTitle>
+            <DialogDescription>
+              Are you sure you want to delete <strong>{pendingDelete?.path}</strong>?
+            </DialogDescription>
+          </DialogHeader>
+          <div className="flex flex-col gap-2 text-sm">
+            {pendingDelete?.kind === "directory" && (
+              <div className="flex items-start gap-2 rounded-md border border-yellow-500/30 bg-yellow-500/10 p-3">
+                <AlertTriangle className="size-4 shrink-0 text-yellow-500 mt-0.5" />
+                <span>
+                  The folder and all of its contents will be deleted from disk. This cannot be
+                  undone.
+                </span>
+              </div>
+            )}
+            {pendingDelete?.kind === "file" && (
+              <div className="flex items-start gap-2 rounded-md border border-yellow-500/30 bg-yellow-500/10 p-3">
+                <AlertTriangle className="size-4 shrink-0 text-yellow-500 mt-0.5" />
+                <span>The file will be deleted from disk. This cannot be undone.</span>
+              </div>
+            )}
+            {deleteError && (
+              <div className="flex items-start gap-2 rounded-md border border-destructive/30 bg-destructive/10 p-3 text-destructive">
+                <AlertTriangle className="size-4 shrink-0 mt-0.5" />
+                <span>{deleteError}</span>
+              </div>
+            )}
           </div>
-        )}
-        {rootEntries.map((entry) => (
-          <TreeNode
-            key={entry.name}
-            entry={entry}
-            parentPath=""
-            depth={0}
-            expandedPaths={expandedPaths}
-            dirContents={dirContents}
-            loadingPaths={loadingPaths}
-            onToggle={toggleExpand}
-            onOpenFile={onOpenFile}
-            onOpenFilePinned={onOpenFilePinned}
-            compact={compact}
-            selectedFile={selectedFile}
-            selectedRef={selectedRef}
-          />
-        ))}
-      </div>
+          <DialogFooter>
+            <Button variant="ghost" onClick={cancelDelete} disabled={deleteSubmitting}>
+              Cancel
+            </Button>
+            <Button
+              variant="destructive"
+              onClick={() => void confirmDelete()}
+              disabled={deleteSubmitting}
+            >
+              {deleteSubmitting ? "Deleting…" : "Delete"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </div>
   );
-}
+});

--- a/packages/dashboard-core/src/components/FileViewer.tsx
+++ b/packages/dashboard-core/src/components/FileViewer.tsx
@@ -427,13 +427,15 @@ export function FileViewer({
           <PdfPreview src={fileUrl} filename={getFilename(filePath)} />
         )}
 
-        {/* Markdown preview (rendered) — uses displayContent so edits show live */}
+        {/* Markdown preview (rendered) — uses displayContent so edits show live.
+             Note: check `!== undefined` not truthiness so an empty file
+             (content === "") still renders the preview pane. */}
         {!loading &&
           !error &&
           previewType === "markdown" &&
           renderMarkdown &&
           viewMode === "preview" &&
-          displayContent && (
+          displayContent !== undefined && (
             <div className="h-full overflow-auto">
               <div className="mx-auto max-w-3xl px-8 py-6 text-sm">
                 {renderMarkdown(displayContent)}
@@ -441,16 +443,18 @@ export function FileViewer({
             </div>
           )}
 
-        {/* Source view: editable editor or read-only viewer */}
+        {/* Source view: editable editor or read-only viewer.
+             Same undefined-check as the markdown branch — empty files
+             are still valid and must surface the editor. */}
         {!loading &&
           !error &&
-          data?.content &&
+          data?.content !== undefined &&
           (previewType === "code" ||
             (previewType === "markdown" && (!renderMarkdown || viewMode === "source"))) &&
           (canEdit ? (
             <CodeMirrorEditor
-              content={displayContent!}
-              originalContent={data?.content}
+              content={displayContent ?? ""}
+              originalContent={data.content}
               language={lang}
               className="h-full"
               filePath={filePath}

--- a/packages/dashboard-core/src/hooks/use-deferred-menu-action.ts
+++ b/packages/dashboard-core/src/hooks/use-deferred-menu-action.ts
@@ -1,0 +1,45 @@
+import { useCallback, useRef } from "react";
+
+/**
+ * Defer a menu item's action until the menu has fully closed.
+ *
+ * Radix's `ContextMenuContent` / `DropdownMenuContent` keep a
+ * `FocusScope` mounted for the ~150 ms close transition that runs
+ * AFTER `onSelect` fires. Any input that mounts inside the
+ * synchronously-dispatched action ends up fighting that FocusScope
+ * for focus and gets cancelled by its own `onBlur`.
+ *
+ * The fix: in `onSelect`, just *record* what should happen. In the
+ * content's `onCloseAutoFocus` (which fires once the menu is fully
+ * gone), flush the recorded callback. By the time the callback runs
+ * there's no FocusScope competing — the input mounts in a quiet DOM
+ * and gets focus on the first try.
+ *
+ * Usage:
+ *
+ *     const menu = useDeferredMenuAction();
+ *     // ...
+ *     <ContextMenuContent onCloseAutoFocus={menu.flush}>
+ *       <ContextMenuItem onSelect={() => menu.queue(() => doThing())}>
+ *         Do thing
+ *       </ContextMenuItem>
+ *     </ContextMenuContent>
+ */
+export function useDeferredMenuAction() {
+  const pendingRef = useRef<(() => void) | null>(null);
+
+  const queue = useCallback((fn: () => void) => {
+    pendingRef.current = fn;
+  }, []);
+
+  const flush = useCallback((e: { preventDefault: () => void }) => {
+    // Also stops Radix from restoring focus to the trigger — our queued
+    // action will mount its own UI which takes focus instead.
+    e.preventDefault();
+    const fn = pendingRef.current;
+    pendingRef.current = null;
+    fn?.();
+  }, []);
+
+  return { queue, flush };
+}

--- a/packages/dashboard-core/src/index.ts
+++ b/packages/dashboard-core/src/index.ts
@@ -13,7 +13,7 @@ export { CommandPaletteDialog } from "./components/CommandPaletteDialog";
 export { CommitDialog } from "./components/CommitDialog";
 export { DashboardShell } from "./components/DashboardShell";
 export { type DiffStats, DiffView } from "./components/DiffView";
-export { FileBrowser } from "./components/FileBrowser";
+export { FileBrowser, type FileBrowserHandle } from "./components/FileBrowser";
 export { FileViewer } from "./components/FileViewer";
 export { GitStatusIndicator } from "./components/GitStatusIndicator";
 export { ImagePreview } from "./components/ImagePreview";


### PR DESCRIPTION
## Summary

Adds the full mutation surface to the workspace file tree — create, rename, delete, cut, copy, paste — plus a "Reset Changes" action in the Changes tree and a batch of UX work to make the file browser feel like a proper IDE explorer on both desktop and iOS.

### File tree mutations

- **Create file / Create folder** — inline rename-style input that mounts in the row's eventual sort position (new folder at the top, new file between folders and files).
- **Rename** — inline input pre-selects the basename so the extension survives.
- **Delete** — confirmation dialog with status-aware copy (added → "will be deleted", deleted → "will be restored", etc.); recursive on directories.
- **Cut / Copy / Paste** — in-memory clipboard, dimmed rows for cut, Finder-style \`filename copy.txt\` collision suffix on copy, recursive folder copy.
- Each action wired through new tRPC mutations (\`workspace.createFile\`, \`createDirectory\`, \`deletePath\`, \`renamePath\`, \`copyPath\`) and matching \`DashboardAdapter\` methods. All validate path traversal and refuse to touch \`.git\` internals; \`renamePath\` and \`copyPath\` refuse to move a directory into itself.

### Trigger surfaces

- **Right-click context menu** on every row (file and folder), plus the empty tree area.
- **Keyboard shortcuts** — ⌘C / ⌘X / ⌘V for cut/copy/paste, Delete / Backspace for delete, scoped to focus inside the tree so the editor's own shortcuts aren't affected.
- **Toolbar buttons** (\`FilePlus\`, \`FolderPlus\`) that drive the imperative \`FileBrowserHandle\` for new entries; collapses to a kebab dropdown below 200 px width.

### Tab + editor follow-through

\`useFileTabs\` and \`useTabState\` gain \`renameFile\` and \`removePath\` methods that handle both exact-match and \`path + "/"\` prefix-match, so renaming a folder cascades to every descendant tab. \`CodeBrowserView\` consumes \`onPathRenamed\` / \`onPathDeleted\` and migrates the active editor's serialized state (undo history, cursor, scroll) to the new path so open files survive renames seamlessly.

### Changes tree: Reset Changes

Right-click on any row in the Changes file tree → Reset changes. On a folder, it walks the existing \`FileTreeNode\` to collect every leaf path and reverts them all in parallel via \`Promise.allSettled\`, refreshing the diff summary once at the end (no flicker through N intermediate states). Confirmation dialog adapts copy for file-vs-folder, with the same status-aware messages as \`RevertFileDialog\`.

### UX polish

- Unified blue-tint selection + lighter-blue inset outline across both file trees; \`pl-px\` on the scroll container so the outline survives edge-pixel rounding.
- Right-click selects the target row before the menu opens; right-click on empty space clears selection so it's visible that "New File" will land at root.
- Folder selection takes visual priority over the open file's row — only one row is highlighted at a time.
- \`useDeferredMenuAction\` helper (extracted to its own hooks file) that queues a menu item's callback and runs it on \`onCloseAutoFocus\` — sidesteps Radix's \`FocusScope\` eating the inline input's focus during the menu's close transition.
- iOS Safari touch fixes: \`stopPropagation\` on row pointerdown so nested ContextMenus don't both open on long-press; \`select-none\` + \`[-webkit-touch-callout:none]\` to suppress the native callout / text selection.
- Mobile file-tree toolbar mounted above the FileBrowser when no file is open, so create / quick-open / search are reachable on touch.
- Quick Open / Search in Files dispatched via window events (\`band:open-quick-open\`, \`band:open-search-files\`) so the buttons work consistently from both mobile and desktop layouts.
- \`FileViewer\` no longer short-circuits on empty content — newly-created empty files now mount the editor.

## Test plan

- [x] \`npx biome check\` clean across all touched files.
- [x] \`apps/web/tests/trpc.test.ts\` — 110 tests passing, including **23 new** covering create / delete / rename / copy edge cases (.git internals, path traversal, empty paths, recursive folder ops, existing-destination collisions).
- [ ] Manual: right-click a file → Cut → right-click a folder → Paste → file moves, tab follows.
- [ ] Manual: rename an open file → tab title updates, editor state preserved.
- [ ] Manual: delete an open file → tab closes; delete a folder containing the open file → tab closes.
- [ ] Manual: Reset Changes on a folder → confirmation shows N file count → all reset together.
- [ ] Manual on iOS Simulator: toolbar New File / New Folder / Quick Open / Search in Files all open via tap; long-press on a row opens just the per-row context menu (not both).

🤖 Generated with [Claude Code](https://claude.com/claude-code)