### PR TITLE
feat(updater): periodic background check + in-app install banner

### DIFF
--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -26,7 +26,12 @@ import { killPort } from "./services/port.js";
 import { getConfiguredPort, getWebBrowserCdpEnabled } from "./services/settings.js";
 import { resolveWebDir } from "./services/web-paths.js";
 import { ensureWebserverRunning, ManagedProcess } from "./services/web-server.js";
-import { scheduleStartupCheck } from "./updater.js";
+import {
+  installPendingUpdate,
+  type PendingUpdate,
+  schedulePeriodicCheck,
+  scheduleStartupCheck,
+} from "./updater.js";
 import { createMainWindow } from "./window.js";
 
 interface AppState {
@@ -35,6 +40,12 @@ interface AppState {
   browserManager: BrowserViewManager | null;
   unregisterIpc: (() => void) | null;
   cancelStartupUpdateCheck: (() => void) | null;
+  cancelPeriodicUpdateCheck: (() => void) | null;
+  /** The most recently observed available update, or null. Owned here so
+   *  the renderer can ask via `updater_status` (catching the race where it
+   *  mounts after the startup check completed) and so the broadcast layer
+   *  can dedupe by version. */
+  pendingUpdate: PendingUpdate;
   activityMonitor: ActivityMonitorHandle | null;
   cleanedUp: boolean;
   port: number;
@@ -48,11 +59,29 @@ const state: AppState = {
   browserManager: null,
   unregisterIpc: null,
   cancelStartupUpdateCheck: null,
+  cancelPeriodicUpdateCheck: null,
+  pendingUpdate: null,
   activityMonitor: null,
   cleanedUp: false,
   port: getConfiguredPort(),
   webDir: "",
 };
+
+/**
+ * Broadcast the current `pendingUpdate` to every renderer (multi-window
+ * safe). Dedupes by version so a stable periodic-no-update tick doesn't
+ * re-render the banner every 2h.
+ */
+function setPendingUpdate(next: PendingUpdate): void {
+  const prevVersion = state.pendingUpdate?.version ?? null;
+  const nextVersion = next?.version ?? null;
+  if (prevVersion === nextVersion) return;
+  state.pendingUpdate = next;
+  for (const win of BrowserWindow.getAllWindows()) {
+    if (win.isDestroyed()) continue;
+    win.webContents.send("updater-status-changed", next);
+  }
+}
 
 function installCrashHandlers(): void {
   process.on("uncaughtException", (err) => {
@@ -96,9 +125,11 @@ async function cleanupOnce(): Promise<void> {
   if (state.cleanedUp) return;
   state.cleanedUp = true;
 
-  // Cancel any pending startup update check so its dialog doesn't pop up
-  // mid-shutdown (the 10s delay can outlive Cmd+Q on a quick quit).
+  // Cancel any pending update checks so the deferred timers don't fire
+  // mid-shutdown. The 10s startup delay can outlive a quick Cmd+Q, and
+  // the 2h periodic interval would otherwise tick during teardown.
   state.cancelStartupUpdateCheck?.();
+  state.cancelPeriodicUpdateCheck?.();
   state.activityMonitor?.stop();
   state.unregisterIpc?.();
   state.browserManager?.destroyAll();
@@ -185,13 +216,26 @@ async function bootstrap(): Promise<void> {
       resourcesPath: process.resourcesPath,
       appPath: app.getAppPath(),
     },
+    // Background app-update banner: the renderer reads `pendingUpdate`
+    // on mount and subscribes to `updater-status-changed`; `installUpdate`
+    // drives electron-updater's download + quitAndInstall.
+    getPendingUpdate: () => state.pendingUpdate,
+    installUpdate: () => installPendingUpdate(),
   });
 
   // Auto-update check 10s after launch (matches the Tauri shell's
   // `tokio::time::sleep(Duration::from_secs(10))` in lib.rs::run). No-op
-  // in unpacked dev runs (`!app.isPackaged`) — see updater.ts.
+  // in unpacked dev runs (`!app.isPackaged`) — see updater.ts. The
+  // result feeds the in-app banner via `setPendingUpdate` instead of an
+  // OS dialog (the menu item "Check for Updates…" keeps the dialog flow).
   state.cancelStartupUpdateCheck = scheduleStartupCheck(app.isPackaged, {
-    parentWindow: state.mainWindow,
+    onResult: setPendingUpdate,
+  });
+
+  // Periodic re-check every 2h while the app is running. Same gating + same
+  // banner pipeline as the startup check.
+  state.cancelPeriodicUpdateCheck = schedulePeriodicCheck(app.isPackaged, {
+    onResult: setPendingUpdate,
   });
 
   // Watch focus + AC/battery state and tell the web server to widen the

--- a/apps/desktop/src/main/ipc/register.ts
+++ b/apps/desktop/src/main/ipc/register.ts
@@ -47,6 +47,14 @@ export interface RegisterOptions {
    * resolve the sidecar binary inside the trust boundary.
    */
   cliPaths: CliPathOptions;
+  /**
+   * Background app-update banner state. The bootstrap owns the
+   * `pendingUpdate` cache and the install closure (which captures the
+   * `electron-updater` deps). Passing them in keeps `register.ts`
+   * decoupled from the updater module.
+   */
+  getPendingUpdate: () => { version: string } | null;
+  installUpdate: () => Promise<void>;
 }
 
 /**
@@ -85,6 +93,15 @@ export function registerIpc(opts: RegisterOptions): () => void {
     installCli(args.binaryPath, args.symlinkPath, opts.cliPaths),
   );
   handle(Channels.openExternal, (args: OpenExternalArgs) => openExternal(args.url));
+
+  // ---- Background app-update banner ----
+  // The renderer calls `updater_status` once on mount to seed initial state
+  // (a missed broadcast race) and subscribes to `updater-status-changed`
+  // for subsequent transitions. `updater_install` kicks off
+  // `installPendingUpdate` — the response never resolves on success because
+  // `electron-updater` quits the process to install.
+  handle(Channels.updaterStatus, () => opts.getPendingUpdate());
+  handle(Channels.updaterInstall, () => opts.installUpdate());
 
   // ---- Browser panels ----
   const bm = { manager: opts.browserManager };

--- a/apps/desktop/src/main/updater.ts
+++ b/apps/desktop/src/main/updater.ts
@@ -38,6 +38,33 @@ import type { BrowserWindow } from "electron";
 import { dashLog } from "./services/log.js";
 
 /**
+ * The "we've seen a newer version" carrier shared between the background
+ * periodic check, the main-process broadcast layer, and the renderer banner.
+ * `null` means no update is currently known to be available.
+ */
+export type PendingUpdate = { version: string } | null;
+
+/**
+ * Module-scoped single-flight guards. The `electron-updater` singleton has
+ * one set of listeners shared across all callers, so a second invocation
+ * while a check or install is in flight would cross-wire listener teardowns.
+ *
+ * The guards return immediately (no-op) when something is already running,
+ * which is the right semantics for both the background loop firing while
+ * an install is downloading and for a double-clicked Install button.
+ *
+ * Visible for tests (`__resetUpdaterGuardsForTests`) so a process-level
+ * mutex doesn't leak state across the test suite's back-to-back cases.
+ */
+let inFlightCheck = false;
+let inFlightInstall = false;
+
+export function __resetUpdaterGuardsForTests(): void {
+  inFlightCheck = false;
+  inFlightInstall = false;
+}
+
+/**
  * Whether the updater is enabled at runtime.
  *
  * Tauri gated this on `option_env!("TAURI_SIGNING_PRIVATE_KEY").is_some()`,
@@ -216,144 +243,266 @@ export async function checkForUpdate(
   const showInfo = deps.showInfo ?? ((t, m) => defaultShowInfo(parent, t, m));
   const showConfirm = deps.showConfirm ?? ((t, m) => defaultShowConfirm(parent, t, m));
 
-  let updater: UpdaterLike;
-  try {
-    updater = deps.updater ?? (await loadDefaultUpdater());
-  } catch (e) {
-    const msg = e instanceof Error ? e.message : String(e);
-    dashLog(`updater: failed to create updater: ${msg}`);
+  // Share the check guard with `checkForUpdateBackground` — both touch the
+  // same `electron-updater` listener bus. If a background tick or another
+  // menu click is already in flight, no-op rather than cross-wiring events.
+  if (inFlightCheck) {
+    dashLog("updater: check already in flight, skipping");
     if (interactive) {
-      await showInfo("Update Error", `Failed to check for updates: ${msg}`);
+      await showInfo("Checking for Updates", "An update check is already in progress.");
     }
     return;
   }
+  inFlightCheck = true;
+  try {
+    let updater: UpdaterLike;
+    try {
+      updater = deps.updater ?? (await loadDefaultUpdater());
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      dashLog(`updater: failed to create updater: ${msg}`);
+      if (interactive) {
+        await showInfo("Update Error", `Failed to check for updates: ${msg}`);
+      }
+      return;
+    }
 
-  // We drive the download + install ourselves so we can show a confirmation
-  // dialog after `update-available` fires (matching Tauri's flow). With
-  // `autoDownload=false`, electron-updater emits `update-available` and
-  // stops; we then call `downloadUpdate()` after the user confirms.
+    const result = await performCheck(updater);
+
+    if (result.kind === "error") {
+      dashLog(`updater: check failed: ${result.error.message}`);
+      if (interactive) {
+        await showInfo("Update Error", "Failed to check for updates. Please try again later.");
+      }
+      return;
+    }
+
+    if (result.kind === "not-available") {
+      dashLog("updater: no update available");
+      if (interactive) {
+        await showInfo("No Updates Available", "You're running the latest version of Band.");
+      }
+      return;
+    }
+
+    const { version } = result;
+    dashLog(`updater: update available — v${version}`);
+
+    const accepted = await showConfirm(
+      "Update Available",
+      `Band v${version} is available. Would you like to download and install it now?`,
+    );
+    if (!accepted) {
+      return;
+    }
+
+    const installed = await performDownload(updater);
+
+    if (!installed.ok) {
+      dashLog(`updater: install failed: ${installed.error.message}`);
+      await showInfo("Update Failed", `Failed to install the update: ${installed.error.message}`);
+      return;
+    }
+
+    dashLog(`updater: installed v${version}, restarting…`);
+    if (deps.restart) {
+      deps.restart();
+    } else {
+      // electron-updater's quitAndInstall handles the relaunch flow. It
+      // closes all windows, fires `before-quit`, then runs the installer.
+      updater.quitAndInstall();
+    }
+  } finally {
+    inFlightCheck = false;
+  }
+}
+
+/**
+ * Shared check-phase helper used by both `checkForUpdate` (menu / dialog path)
+ * and `checkForUpdateBackground` (banner path). Drives a single
+ * `checkForUpdates()` round-trip and bridges the event-based result back to
+ * a linear value. Always tears down its listeners before returning.
+ */
+type CheckOutcome =
+  | { kind: "available"; version: string }
+  | { kind: "not-available" }
+  | { kind: "error"; error: Error };
+
+async function performCheck(updater: UpdaterLike): Promise<CheckOutcome> {
+  // We drive the download + install ourselves so the caller can decide whether
+  // to confirm via dialog (interactive) or via in-app banner (background).
+  // With `autoDownload=false`, electron-updater emits `update-available` and
+  // stops; we then call `downloadUpdate()` later if the caller proceeds.
   updater.autoDownload = false;
   updater.autoInstallOnAppQuit = false;
 
-  // Wire the event listeners against a single CheckForUpdates round-trip,
-  // then tear them all down before returning so a second invocation
-  // doesn't double-fire.
-  type Outcome =
-    | { kind: "available"; version: string }
-    | { kind: "not-available" }
-    | { kind: "error"; error: Error };
+  try {
+    return await new Promise<CheckOutcome>((resolve) => {
+      let settled = false;
+      const settle = (o: CheckOutcome) => {
+        if (settled) return;
+        settled = true;
+        resolve(o);
+      };
 
-  const result = await new Promise<Outcome>((resolve) => {
-    let settled = false;
-    const settle = (o: Outcome) => {
-      if (settled) return;
-      settled = true;
-      resolve(o);
-    };
+      updater.on("update-available", (info) => {
+        settle({ kind: "available", version: info.version });
+      });
+      updater.on("update-not-available", () => {
+        settle({ kind: "not-available" });
+      });
+      updater.on("error", (err) => {
+        settle({ kind: "error", error: err });
+      });
 
-    updater.on("update-available", (info) => {
-      settle({ kind: "available", version: info.version });
-    });
-    updater.on("update-not-available", () => {
-      settle({ kind: "not-available" });
-    });
-    updater.on("error", (err) => {
-      settle({ kind: "error", error: err });
-    });
-
-    Promise.resolve(updater.checkForUpdates()).catch((err) => {
-      settle({
-        kind: "error",
-        error: err instanceof Error ? err : new Error(String(err)),
+      Promise.resolve(updater.checkForUpdates()).catch((err) => {
+        settle({
+          kind: "error",
+          error: err instanceof Error ? err : new Error(String(err)),
+        });
       });
     });
-  });
-
-  // We're going to add fresh listeners for the download phase below; clear
-  // the check-phase ones first so we don't accidentally re-handle them.
-  updater.removeAllListeners("update-available");
-  updater.removeAllListeners("update-not-available");
-  updater.removeAllListeners("error");
-
-  if (result.kind === "error") {
-    dashLog(`updater: check failed: ${result.error.message}`);
-    if (interactive) {
-      await showInfo("Update Error", "Failed to check for updates. Please try again later.");
-    }
-    return;
+  } finally {
+    // Tear the check-phase listeners down so a second invocation doesn't
+    // double-fire, and so the download phase below can re-wire `error`.
+    updater.removeAllListeners("update-available");
+    updater.removeAllListeners("update-not-available");
+    updater.removeAllListeners("error");
   }
+}
 
-  if (result.kind === "not-available") {
-    dashLog("updater: no update available");
-    if (interactive) {
-      await showInfo("No Updates Available", "You're running the latest version of Band.");
-    }
-    return;
-  }
+/** Shared download-phase helper used by `checkForUpdate` and
+ *  `installPendingUpdate`. Drives `downloadUpdate()`, logs progress ticks,
+ *  resolves on `update-downloaded` / `error`. Listener teardown is
+ *  guaranteed via the `finally` block. */
+async function performDownload(
+  updater: UpdaterLike,
+): Promise<{ ok: true } | { ok: false; error: Error }> {
+  try {
+    return await new Promise<{ ok: true } | { ok: false; error: Error }>((resolve) => {
+      let settled = false;
+      const settle = (r: { ok: true } | { ok: false; error: Error }) => {
+        if (settled) return;
+        settled = true;
+        resolve(r);
+      };
 
-  const { version } = result;
-  dashLog(`updater: update available — v${version}`);
+      updater.on("download-progress", (info) => {
+        // electron-updater emits at a sensible interval (~every few hundred
+        // ms) so we just forward to the log.
+        const transferred = Math.round(info.transferred);
+        const total = Math.round(info.total);
+        const pct = info.percent.toFixed(1);
+        dashLog(`updater: progress — ${transferred}/${total} bytes (${pct}%)`);
+      });
+      updater.on("update-downloaded", () => {
+        dashLog("updater: download finished, installing…");
+        settle({ ok: true });
+      });
+      updater.on("error", (err) => {
+        settle({ ok: false, error: err });
+      });
 
-  const accepted = await showConfirm(
-    "Update Available",
-    `Band v${version} is available. Would you like to download and install it now?`,
-  );
-  if (!accepted) {
-    return;
-  }
-
-  dashLog(`updater: downloading v${version}…`);
-
-  const installed = await new Promise<{ ok: true } | { ok: false; error: Error }>((resolve) => {
-    let settled = false;
-    const settle = (r: { ok: true } | { ok: false; error: Error }) => {
-      if (settled) return;
-      settled = true;
-      resolve(r);
-    };
-
-    updater.on("download-progress", (info) => {
-      // The Tauri version logs every chunk; electron-updater emits at a
-      // sensible interval (~every few hundred ms) so we just forward.
-      const transferred = Math.round(info.transferred);
-      const total = Math.round(info.total);
-      const pct = info.percent.toFixed(1);
-      dashLog(`updater: progress — ${transferred}/${total} bytes (${pct}%)`);
-    });
-    updater.on("update-downloaded", () => {
-      dashLog("updater: download finished, installing…");
-      settle({ ok: true });
-    });
-    updater.on("error", (err) => {
-      settle({ ok: false, error: err });
-    });
-
-    Promise.resolve(updater.downloadUpdate()).catch((err) => {
-      settle({
-        ok: false,
-        error: err instanceof Error ? err : new Error(String(err)),
+      Promise.resolve(updater.downloadUpdate()).catch((err) => {
+        settle({
+          ok: false,
+          error: err instanceof Error ? err : new Error(String(err)),
+        });
       });
     });
-  });
+  } finally {
+    updater.removeAllListeners("download-progress");
+    updater.removeAllListeners("update-downloaded");
+    updater.removeAllListeners("error");
+  }
+}
 
-  // Same teardown reasoning as above.
-  updater.removeAllListeners("download-progress");
-  updater.removeAllListeners("update-downloaded");
-  updater.removeAllListeners("error");
+/**
+ * Silent check used by the background path (startup + 2h periodic). Returns
+ * the available `{ version }` or `null`. Never shows a dialog. The renderer
+ * is notified separately via `broadcastUpdaterStatus` in the bootstrap.
+ *
+ * Shares the `inFlightCheck` mutex with `checkForUpdate`, so a menu-click
+ * mid-periodic-tick can't cross-fire listeners on the shared singleton.
+ */
+export async function checkForUpdateBackground(
+  deps: CheckForUpdateDeps = ZERO_DEPS,
+): Promise<PendingUpdate> {
+  if (inFlightCheck) {
+    dashLog("updater: background check skipped (check already in flight)");
+    return null;
+  }
+  inFlightCheck = true;
+  try {
+    let updater: UpdaterLike;
+    try {
+      updater = deps.updater ?? (await loadDefaultUpdater());
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      dashLog(`updater: failed to create updater (background): ${msg}`);
+      return null;
+    }
 
-  if (!installed.ok) {
-    dashLog(`updater: install failed: ${installed.error.message}`);
-    await showInfo("Update Failed", `Failed to install the update: ${installed.error.message}`);
+    const result = await performCheck(updater);
+    if (result.kind === "available") {
+      dashLog(`updater: background check found v${result.version}`);
+      return { version: result.version };
+    }
+    if (result.kind === "error") {
+      dashLog(`updater: background check failed: ${result.error.message}`);
+    } else {
+      dashLog("updater: background check — no update");
+    }
+    return null;
+  } finally {
+    inFlightCheck = false;
+  }
+}
+
+/**
+ * Download + install a pending update without any dialogs. Invoked from the
+ * IPC handler when the user clicks the in-app banner's Install button.
+ *
+ * Single-flight: a second click while a download is in flight is a no-op.
+ * The renderer also disables its button optimistically, but a stray invoke
+ * from another window would otherwise re-enter and cross-wire listeners.
+ *
+ * On success, calls `updater.quitAndInstall()` (or the test `restart`
+ * override), which terminates the process — anything after that point
+ * never runs in production.
+ */
+export async function installPendingUpdate(deps: CheckForUpdateDeps = ZERO_DEPS): Promise<void> {
+  if (inFlightInstall) {
+    dashLog("updater: install already in flight, skipping");
     return;
   }
+  inFlightInstall = true;
+  try {
+    let updater: UpdaterLike;
+    try {
+      updater = deps.updater ?? (await loadDefaultUpdater());
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      dashLog(`updater: failed to create updater (install): ${msg}`);
+      throw e instanceof Error ? e : new Error(msg);
+    }
+    updater.autoDownload = false;
+    updater.autoInstallOnAppQuit = false;
 
-  dashLog(`updater: installed v${version}, restarting…`);
-  if (deps.restart) {
-    deps.restart();
-  } else {
-    // electron-updater's quitAndInstall handles the relaunch flow. It
-    // closes all windows, fires `before-quit`, then runs the installer.
+    const installed = await performDownload(updater);
+    if (!installed.ok) {
+      dashLog(`updater: install failed: ${installed.error.message}`);
+      throw installed.error;
+    }
+
+    dashLog("updater: install complete, restarting…");
+    if (deps.restart) {
+      deps.restart();
+      return;
+    }
     updater.quitAndInstall();
+  } finally {
+    inFlightInstall = false;
   }
 }
 
@@ -364,16 +513,24 @@ export async function checkForUpdate(
  * network.
  *
  * Returns a cancellation function so the caller can abort the pending check
- * during shutdown (avoids a stray dialog popping up after Cmd+Q).
+ * during shutdown (avoids a stray banner state flip after Cmd+Q).
  *
  * `isPackaged` is supplied by the caller (typically `app.isPackaged`) so
  * this module doesn't need to import `electron` eagerly. `delayMs` is
  * overridable for tests; production always uses the 10s default to match
- * Tauri.
+ * the legacy Tauri shell.
+ *
+ * Background mode: this used to call the interactive `checkForUpdate` which
+ * popped OS dialogs to confirm download. The flow is now a silent
+ * `checkForUpdateBackground`; the result is fed to `opts.onResult` so the
+ * bootstrap can broadcast it to the renderer banner.
  */
 export function scheduleStartupCheck(
   isPackaged: boolean,
-  deps: CheckForUpdateDeps & { delayMs?: number } = {},
+  opts: CheckForUpdateDeps & {
+    delayMs?: number;
+    onResult?: (pending: PendingUpdate) => void;
+  } = {},
 ): () => void {
   // Skip in unpacked dev runs — electron-updater refuses to operate
   // without a packaged `app-update.yml` and would log a confusing warning
@@ -383,10 +540,47 @@ export function scheduleStartupCheck(
   }
 
   const handle = setTimeout(() => {
-    void checkForUpdate(false, deps).catch((err) => {
-      dashLog(`updater: startup check threw: ${String(err)}`);
-    });
-  }, deps.delayMs ?? 10_000);
+    void checkForUpdateBackground(opts)
+      .then((pending) => opts.onResult?.(pending))
+      .catch((err) => {
+        dashLog(`updater: startup check threw: ${String(err)}`);
+      });
+  }, opts.delayMs ?? 10_000);
 
   return () => clearTimeout(handle);
+}
+
+/**
+ * Periodic background update check. Fires every `intervalMs` (default 2h)
+ * starting `intervalMs` after the call (it does NOT fire immediately — the
+ * 10s startup check already covered that). Each tick runs
+ * `checkForUpdateBackground` and forwards the result to `opts.onResult`,
+ * which the bootstrap uses to update state + broadcast to the renderer.
+ *
+ * No-op in unpacked dev (mirrors `scheduleStartupCheck`).
+ *
+ * Returns a cancellation function — call it in `cleanupOnce` so the
+ * interval doesn't outlive the process.
+ */
+export function schedulePeriodicCheck(
+  isPackaged: boolean,
+  opts: CheckForUpdateDeps & {
+    intervalMs?: number;
+    onResult?: (pending: PendingUpdate) => void;
+  } = {},
+): () => void {
+  if (!isUpdaterEnabled(isPackaged)) {
+    return () => undefined;
+  }
+
+  const intervalMs = opts.intervalMs ?? 2 * 60 * 60 * 1000;
+  const handle = setInterval(() => {
+    void checkForUpdateBackground(opts)
+      .then((pending) => opts.onResult?.(pending))
+      .catch((err) => {
+        dashLog(`updater: periodic check threw: ${String(err)}`);
+      });
+  }, intervalMs);
+
+  return () => clearInterval(handle);
 }

--- a/apps/desktop/src/preload/index.cts
+++ b/apps/desktop/src/preload/index.cts
@@ -46,6 +46,9 @@ const ALLOWED_INVOKE_CHANNELS = new Set<string>([
   "open_with_app",
   "install_cli",
   "open_external",
+  // Background app-update banner
+  "updater_status",
+  "updater_install",
   // Phase 3 — browser panels
   "browser_create",
   "browser_navigate",
@@ -69,6 +72,7 @@ const ALLOWED_EVENT_NAMES = new Set<string>([
   "browser-title-changed",
   "browser-view-destroyed",
   "window-fullscreen-changed",
+  "updater-status-changed",
 ]);
 
 type Unlisten = () => void;

--- a/apps/desktop/src/shared/ipc-channels.ts
+++ b/apps/desktop/src/shared/ipc-channels.ts
@@ -22,6 +22,10 @@ export const Channels = {
   installCli: "install_cli",
   openExternal: "open_external",
 
+  // Background app-update banner (see updater.ts)
+  updaterStatus: "updater_status",
+  updaterInstall: "updater_install",
+
   // Browser panels
   browserCreate: "browser_create",
   browserNavigate: "browser_navigate",
@@ -53,6 +57,10 @@ export const Events = {
    *  the `browserHost.viewDestroyed` tRPC mutation. */
   browserViewDestroyed: "browser-view-destroyed",
   windowFullscreenChanged: "window-fullscreen-changed",
+  /** Pushed by the main process when the background updater detects (or
+   *  clears) a pending app update. Payload: `PendingUpdate` from
+   *  updater.ts — `null` or `{ version }`. */
+  updaterStatusChanged: "updater-status-changed",
 } as const;
 
 export type EventName = (typeof Events)[keyof typeof Events];

--- a/apps/desktop/tests/updater.test.ts
+++ b/apps/desktop/tests/updater.test.ts
@@ -20,16 +20,28 @@
  */
 
 import { strict as assert } from "node:assert";
-import { describe, test } from "node:test";
+import { beforeEach, describe, test } from "node:test";
 import { setTimeout as delay } from "node:timers/promises";
 
 import {
+  __resetUpdaterGuardsForTests,
   type CheckForUpdateDeps,
   checkForUpdate,
+  checkForUpdateBackground,
+  installPendingUpdate,
+  type PendingUpdate,
   pickAutoUpdater,
+  schedulePeriodicCheck,
   scheduleStartupCheck,
   type UpdaterLike,
 } from "../src/main/updater.ts";
+
+// Module-scoped guards (`inFlightCheck`, `inFlightInstall`) persist across
+// the suite. Reset them before every test so a previous "skip" case doesn't
+// leak into the next.
+beforeEach(() => {
+  __resetUpdaterGuardsForTests();
+});
 
 // ---------------------------------------------------------------------------
 // FakeUpdater: same event surface as electron-updater's AppUpdater singleton
@@ -376,5 +388,250 @@ describe("pickAutoUpdater", () => {
     // `autoUpdater` is undefined because Node didn't hoist the CJS getter.
     const mod = { default: {}, AppUpdater: class {} };
     assert.throws(() => pickAutoUpdater(mod), /did not expose autoUpdater singleton/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// checkForUpdateBackground — silent check used by the 10s startup + 2h
+// periodic banner pipeline. No dialogs. Returns { version } or null.
+// ---------------------------------------------------------------------------
+
+describe("checkForUpdateBackground", () => {
+  test("returns { version } when an update is available", async () => {
+    const updater = new FakeUpdater({ checkOutcome: "available", version: "4.5.6" });
+    const result = await checkForUpdateBackground({ updater });
+    assert.deepEqual(result, { version: "4.5.6" });
+    assert.equal(updater.checkForUpdatesCalls, 1);
+    assert.equal(updater.downloadUpdateCalls, 0); // banner-driven, not auto-download
+  });
+
+  test("returns null when no update is available", async () => {
+    const updater = new FakeUpdater({ checkOutcome: "not-available" });
+    const result = await checkForUpdateBackground({ updater });
+    assert.equal(result, null);
+  });
+
+  test("returns null on error (silent — no dialog escape hatch)", async () => {
+    const updater = new FakeUpdater({ checkOutcome: "error", errorMessage: "503" });
+    const result = await checkForUpdateBackground({ updater });
+    assert.equal(result, null);
+  });
+
+  test("forces autoDownload + autoInstallOnAppQuit off", async () => {
+    const updater = new FakeUpdater({ checkOutcome: "not-available" });
+    updater.autoDownload = true;
+    updater.autoInstallOnAppQuit = true;
+    await checkForUpdateBackground({ updater });
+    assert.equal(updater.autoDownload, false);
+    assert.equal(updater.autoInstallOnAppQuit, false);
+  });
+
+  test("back-to-back calls don't cross-fire listeners", async () => {
+    const updater = new FakeUpdater({ checkOutcome: "available", version: "1.0.0" });
+    const r1 = await checkForUpdateBackground({ updater });
+    const r2 = await checkForUpdateBackground({ updater });
+    assert.deepEqual(r1, { version: "1.0.0" });
+    assert.deepEqual(r2, { version: "1.0.0" });
+    assert.equal(updater.checkForUpdatesCalls, 2);
+  });
+
+  test("skips when a check is already in flight (shared mutex)", async () => {
+    // Hold the first call inside `performCheck` by capturing the
+    // `update-not-available` listener and only invoking it once we want
+    // the first call to complete. Until then `inFlightCheck` is true and
+    // any second call should no-op.
+    let notAvailableListener: (() => void) | null = null;
+    const blockingUpdater: UpdaterLike = {
+      autoDownload: false,
+      autoInstallOnAppQuit: false,
+      on(event: string, listener: (...args: unknown[]) => void): void {
+        if (event === "update-not-available") notAvailableListener = listener as () => void;
+      },
+      removeAllListeners(): void {
+        notAvailableListener = null;
+      },
+      async checkForUpdates() {
+        return null; // resolves but doesn't emit — we drive the event below
+      },
+      async downloadUpdate() {
+        return null;
+      },
+      quitAndInstall() {},
+    };
+
+    const first = checkForUpdateBackground({ updater: blockingUpdater });
+    // Yield so the first call enters performCheck and registers its listener.
+    await delay(5);
+
+    // Second call: should no-op without touching its updater.
+    const tracker = new FakeUpdater({ checkOutcome: "available" });
+    const second = await checkForUpdateBackground({ updater: tracker });
+    assert.equal(second, null);
+    assert.equal(tracker.checkForUpdatesCalls, 0);
+
+    // Unblock the first call.
+    notAvailableListener?.();
+    const firstResult = await first;
+    assert.equal(firstResult, null);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// installPendingUpdate — banner-driven install. No dialogs.
+// ---------------------------------------------------------------------------
+
+describe("installPendingUpdate", () => {
+  test("downloads and restarts on success", async () => {
+    const updater = new FakeUpdater({
+      checkOutcome: "available", // unused — we don't run a check here
+      downloadOutcome: "downloaded",
+    });
+    let restarts = 0;
+    await installPendingUpdate({ updater, restart: () => restarts++ });
+    assert.equal(updater.downloadUpdateCalls, 1);
+    assert.equal(restarts, 1);
+  });
+
+  test("throws when the download fails (renderer flips banner to error)", async () => {
+    const updater = new FakeUpdater({
+      downloadOutcome: "error",
+      downloadErrorMessage: "checksum",
+    });
+    await assert.rejects(installPendingUpdate({ updater, restart: () => undefined }), /checksum/);
+  });
+
+  test("skips when an install is already in flight (mutex)", async () => {
+    // Hold the first install in the download phase by capturing the
+    // `update-downloaded` listener but never invoking it until we say so.
+    let downloadedListener: (() => void) | null = null;
+    let resolveDownload: (() => void) | null = null;
+    const blockingUpdater: UpdaterLike = {
+      autoDownload: false,
+      autoInstallOnAppQuit: false,
+      on(event: string, listener: (...args: unknown[]) => void): void {
+        if (event === "update-downloaded") downloadedListener = listener as () => void;
+      },
+      removeAllListeners(): void {
+        downloadedListener = null;
+      },
+      async checkForUpdates() {
+        return null;
+      },
+      async downloadUpdate() {
+        return new Promise<void>((resolve) => {
+          resolveDownload = resolve;
+        });
+      },
+      quitAndInstall() {},
+    };
+
+    let firstRestarts = 0;
+    const first = installPendingUpdate({
+      updater: blockingUpdater,
+      restart: () => firstRestarts++,
+    });
+    // Yield so the first call sets the guard and registers its listener.
+    await delay(5);
+
+    // Second call: should bail on the mutex without touching its updater.
+    const tracker = new FakeUpdater({ downloadOutcome: "downloaded" });
+    await installPendingUpdate({ updater: tracker, restart: () => undefined });
+    assert.equal(tracker.downloadUpdateCalls, 0);
+
+    // Unblock the first install so the test ends cleanly: emit downloaded,
+    // then resolve `downloadUpdate`'s promise.
+    downloadedListener?.();
+    resolveDownload?.();
+    await first;
+    assert.equal(firstRestarts, 1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// schedulePeriodicCheck — 2h ticker, banner-driven.
+// ---------------------------------------------------------------------------
+
+describe("schedulePeriodicCheck", () => {
+  test("returns no-op when not packaged (dev runs)", async () => {
+    const updater = new FakeUpdater({ checkOutcome: "available" });
+    let results = 0;
+    schedulePeriodicCheck(false, {
+      updater,
+      intervalMs: 10,
+      onResult: () => results++,
+    });
+    await delay(40);
+    assert.equal(updater.checkForUpdatesCalls, 0);
+    assert.equal(results, 0);
+  });
+
+  test("fires onResult on every tick", async () => {
+    const updater = new FakeUpdater({ checkOutcome: "available", version: "2.0.0" });
+    const observed: PendingUpdate[] = [];
+    const cancel = schedulePeriodicCheck(true, {
+      updater,
+      intervalMs: 15,
+      onResult: (p) => observed.push(p),
+    });
+
+    // Wait for a few ticks. setInterval doesn't fire immediately — first tick
+    // lands at ~intervalMs.
+    await delay(55);
+    cancel();
+
+    assert.ok(observed.length >= 2, `expected >=2 ticks, got ${observed.length}`);
+    for (const o of observed) {
+      assert.deepEqual(o, { version: "2.0.0" });
+    }
+  });
+
+  test("cancellation stops further ticks", async () => {
+    const updater = new FakeUpdater({ checkOutcome: "not-available" });
+    let results = 0;
+    const cancel = schedulePeriodicCheck(true, {
+      updater,
+      intervalMs: 10,
+      onResult: () => results++,
+    });
+    // Let one tick fire, then cancel.
+    await delay(25);
+    cancel();
+    const callsAfterCancel = updater.checkForUpdatesCalls;
+    await delay(40);
+    assert.equal(updater.checkForUpdatesCalls, callsAfterCancel);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// scheduleStartupCheck — refactored to use the background flow + onResult.
+// ---------------------------------------------------------------------------
+
+describe("scheduleStartupCheck (background mode)", () => {
+  test("invokes onResult with the available update", async () => {
+    const updater = new FakeUpdater({ checkOutcome: "available", version: "7.7.7" });
+    let observed: PendingUpdate = "sentinel" as unknown as PendingUpdate;
+    scheduleStartupCheck(true, {
+      updater,
+      delayMs: 5,
+      onResult: (p) => {
+        observed = p;
+      },
+    });
+    await delay(40);
+    assert.deepEqual(observed, { version: "7.7.7" });
+  });
+
+  test("invokes onResult with null when no update is available", async () => {
+    const updater = new FakeUpdater({ checkOutcome: "not-available" });
+    let observed: PendingUpdate = "sentinel" as unknown as PendingUpdate;
+    scheduleStartupCheck(true, {
+      updater,
+      delayMs: 5,
+      onResult: (p) => {
+        observed = p;
+      },
+    });
+    await delay(40);
+    assert.equal(observed, null);
   });
 });

--- a/packages/dashboard-core/src/adapter.ts
+++ b/packages/dashboard-core/src/adapter.ts
@@ -66,6 +66,13 @@ export interface DashboardAdapter {
   checkCli(): Promise<CliStatus>;
   installCli(opts?: { allowPrompt?: boolean }): Promise<void>;
 
+  // Background app-update banner (desktop only — the web adapter omits these
+  // and the hook short-circuits to "none" so the banner never appears in a
+  // plain browser tab).
+  getUpdateStatus?(): Promise<{ version: string } | null>;
+  installUpdate?(): Promise<void>;
+  subscribeUpdateStatus?(cb: (pending: { version: string } | null) => void): Unsubscribe;
+
   // Agent status (optional)
   clearNeedsAttention?(workspaceId: string): Promise<void>;
 

--- a/packages/dashboard-core/src/adapters/desktop.ts
+++ b/packages/dashboard-core/src/adapters/desktop.ts
@@ -1,4 +1,4 @@
-import type { PlatformCapabilities } from "../adapter";
+import type { PlatformCapabilities, Unsubscribe } from "../adapter";
 import { WebCapabilities, WebDashboardAdapter } from "./web";
 
 // ---------------------------------------------------------------------------
@@ -16,6 +16,9 @@ function isDesktopShell(): boolean {
 
 interface ElectronBridge {
   invoke(channel: string, args?: unknown): Promise<unknown>;
+  /** Subscribe to a main-process event. Returns an unlisten function. The
+   *  preload exposes this for any name in its event allowlist. */
+  on(event: string, cb: (payload: unknown) => void): () => void;
 }
 
 function electronBridge(): ElectronBridge | null {
@@ -71,6 +74,39 @@ export class DesktopDashboardAdapter extends WebDashboardAdapter {
       }
       throw err;
     }
+  }
+
+  // ---- Background app-update banner (see updater.ts) -----------------------
+  // The web adapter intentionally omits these so a plain browser tab never
+  // sees the banner (the hook short-circuits to "none" when the adapter
+  // method is undefined). Only the desktop shell can drive electron-updater.
+
+  /** Read the current pending update, if any. Used by the hook on mount to
+   *  catch the race where the renderer mounts after the startup check
+   *  already populated main-process state. */
+  async getUpdateStatus(): Promise<{ version: string } | null> {
+    return desktopInvoke<{ version: string } | null>("updater_status");
+  }
+
+  /** Kick off the download + install. On success the OS quits the process,
+   *  so this promise typically never resolves in production. */
+  async installUpdate(): Promise<void> {
+    await desktopInvoke<void>("updater_install");
+  }
+
+  /** Subscribe to `updater-status-changed` events emitted by the main
+   *  process. Returns the unlisten. Throws if called outside the shell —
+   *  callers should gate on `getUpdateStatus` being defined first. */
+  subscribeUpdateStatus(cb: (pending: { version: string } | null) => void): Unsubscribe {
+    const bridge = electronBridge();
+    if (!bridge) {
+      // The hook guards on the method being defined, but if for some reason
+      // this is called outside the shell, fail loud rather than silently.
+      throw new Error("subscribeUpdateStatus called outside the desktop shell");
+    }
+    return bridge.on("updater-status-changed", (payload) =>
+      cb(payload as { version: string } | null),
+    );
   }
 }
 

--- a/packages/dashboard-core/src/components/DashboardShell.tsx
+++ b/packages/dashboard-core/src/components/DashboardShell.tsx
@@ -19,6 +19,7 @@ import {
 } from "@band-app/ui";
 import { Check, ChevronsDownUp, FolderPlus, Menu, Plus, Settings, Tag, X } from "lucide-react";
 import { type ReactNode, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useAppUpdate } from "../hooks/use-app-update";
 import { useCliSetup } from "../hooks/use-cli-setup";
 import {
   LABELS_COLLAPSE_KEY,
@@ -85,6 +86,7 @@ export function DashboardShell({ toolbarMenuItems, hideTitleBar, hideMenu }: Das
   const [labelFilter, setLabelFilter] = useLabelFilter();
   const { state: hooksState, install: installHooks } = useHooksSetup();
   const { state: cliState, install: installCli } = useCliSetup();
+  const { state: updateState, install: installUpdate } = useAppUpdate();
 
   const [appTitle, setAppTitle] = useState("Band");
 
@@ -365,6 +367,35 @@ export function DashboardShell({ toolbarMenuItems, hideTitleBar, hideMenu }: Das
           )}
         </main>
       </ScrollArea>
+
+      {updateState.status === "available" && (
+        <div className="mx-4 mb-2 px-4 py-2 bg-blue-500/10 border border-blue-500/30 rounded-lg text-sm flex items-center justify-between gap-2">
+          <span className="text-blue-700 dark:text-blue-200">
+            {`Band v${updateState.version} is available`}
+          </span>
+          <Button variant="outline" size="sm" className="shrink-0 text-xs" onClick={installUpdate}>
+            Install
+          </Button>
+        </div>
+      )}
+
+      {updateState.status === "installing" && (
+        <div className="mx-4 mb-2 px-4 py-2 bg-blue-500/10 border border-blue-500/30 rounded-lg text-sm flex items-center justify-between gap-2">
+          <span className="text-blue-700 dark:text-blue-200">Installing update…</span>
+          <Button variant="outline" size="sm" className="shrink-0 text-xs" disabled>
+            Install
+          </Button>
+        </div>
+      )}
+
+      {updateState.status === "error" && (
+        <div className="mx-4 mb-2 px-4 py-2 bg-destructive/10 border border-destructive/30 rounded-lg text-sm text-destructive flex items-center justify-between gap-2">
+          <span className="truncate">{`Update failed: ${updateState.message}`}</span>
+          <Button variant="outline" size="sm" className="shrink-0 text-xs" onClick={installUpdate}>
+            Retry
+          </Button>
+        </div>
+      )}
 
       {(cliState.status === "manual" || cliState.status === "conflict") && (
         <div className="mx-4 mb-2 px-4 py-2 bg-blue-500/10 border border-blue-500/30 rounded-lg text-sm flex items-center justify-between gap-2">

--- a/packages/dashboard-core/src/hooks/use-app-update.ts
+++ b/packages/dashboard-core/src/hooks/use-app-update.ts
@@ -1,0 +1,82 @@
+import { useEffect, useState } from "react";
+import { useAdapter } from "../context";
+
+/**
+ * Banner state for the desktop auto-updater. Driven by:
+ *   - Main process (`apps/desktop/src/main/updater.ts`) running a 10s startup
+ *     check + a 2h periodic check.
+ *   - The renderer subscribing to `updater-status-changed` and, on mount,
+ *     polling `updater_status` once to catch the race where the renderer
+ *     mounted after the startup check already completed.
+ *
+ * Outside the desktop shell (plain browser tab, or web adapter that doesn't
+ * implement `getUpdateStatus`), the hook stays permanently at `"none"` so the
+ * banner never appears.
+ */
+export type AppUpdateState =
+  | { status: "none" }
+  | { status: "available"; version: string }
+  | { status: "installing" }
+  | { status: "error"; message: string };
+
+export function useAppUpdate() {
+  const adapter = useAdapter();
+  const [state, setState] = useState<AppUpdateState>({ status: "none" });
+
+  useEffect(() => {
+    // Web adapter doesn't implement these — the banner stays hidden.
+    if (!adapter.getUpdateStatus || !adapter.subscribeUpdateStatus) return;
+
+    let cancelled = false;
+
+    // Seed initial state. If the main-process startup check fired before
+    // this component mounted, the subscription below would miss that
+    // broadcast — the one-shot query catches it.
+    adapter
+      .getUpdateStatus()
+      .then((pending) => {
+        if (cancelled) return;
+        if (pending) {
+          setState({ status: "available", version: pending.version });
+        }
+      })
+      .catch(() => {
+        // Swallow — the hook's job is the banner, not error surfacing.
+        // The main process logs failures via `dashLog`.
+      });
+
+    const unsubscribe = adapter.subscribeUpdateStatus((pending) => {
+      // Don't clobber an in-flight install with a stale broadcast (the
+      // periodic check could fire after the user clicked Install but
+      // before quitAndInstall takes the process down).
+      setState((prev) => {
+        if (prev.status === "installing") return prev;
+        return pending ? { status: "available", version: pending.version } : { status: "none" };
+      });
+    });
+
+    return () => {
+      cancelled = true;
+      unsubscribe();
+    };
+  }, [adapter]);
+
+  const install = async () => {
+    if (!adapter.installUpdate) return;
+    // Optimistic state flip BEFORE awaiting — the OS quits the process on
+    // success, so the awaited promise typically never resolves in
+    // production. The banner needs to swap to the "Installing…" state
+    // before that happens so the user has visible feedback.
+    setState({ status: "installing" });
+    try {
+      await adapter.installUpdate();
+    } catch (err) {
+      setState({
+        status: "error",
+        message: err instanceof Error ? err.message : String(err),
+      });
+    }
+  };
+
+  return { state, install };
+}


### PR DESCRIPTION
## Summary

- Check for app updates every 2h in the background while the app is running, in addition to the existing 10s startup check.
- When an update is found, surface it as a banner at the bottom of the projects list (same style as the band CLI install message) with an **Install** button that drives `electron-updater`'s download + `quitAndInstall` flow — no native OS dialogs.
- The existing "Check for Updates…" menu item still uses dialogs (unchanged).

## Implementation

- **`updater.ts`**: split `checkForUpdate` into reusable `performCheck` / `performDownload` helpers; add `checkForUpdateBackground` (silent), `installPendingUpdate`, and `schedulePeriodicCheck`. Module-scoped in-flight mutexes prevent the periodic loop, menu item, and a double-clicked Install button from cross-wiring listeners on the shared `electron-updater` singleton. `scheduleStartupCheck` now drives the banner via an `onResult` callback instead of OS dialogs.
- **`main/index.ts`**: owns a `pendingUpdate` cache, dedupes by version, and broadcasts `updater-status-changed` to every `BrowserWindow`. The periodic interval is cancelled in `cleanupOnce`.
- **IPC**: new `updater_status` / `updater_install` channels and `updater-status-changed` event, with matching preload allowlist entries.
- **dashboard-core**: added optional `getUpdateStatus` / `installUpdate` / `subscribeUpdateStatus` to `DashboardAdapter` (web adapter omits these, so the banner stays hidden in browser tabs). New `use-app-update` hook seeds via a one-shot status query (catching the mount-after-startup-check race) and subscribes for live updates. Banner is placed above the existing CLI install banner, with three states: available, installing, error.

## Test plan

- [x] All 94 desktop tests pass (13 new cases covering background check, install, periodic schedule, and refactored startup-check `onResult` path)
- [x] Desktop build typechecks clean
- [x] Server build clean
- [x] Repo lint passes
- [x] Repo format passes
- [ ] Manual end-to-end: package the desktop app, temporarily lower `intervalMs` and roll back the local version so GitHub Releases reports a newer one available; confirm the banner appears at the bottom of the projects list and the Install button drives download + relaunch with no OS dialog
- [ ] Verify the "Check for Updates…" menu item still shows the existing dialog flow (unchanged path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)