### PR TITLE
Reveal selected workspace in tree after Ctrl+R switch

### DIFF
--- a/packages/dashboard-core/src/components/ProjectList.tsx
+++ b/packages/dashboard-core/src/components/ProjectList.tsx
@@ -440,6 +440,42 @@ export function ProjectList({ labelFilter }: ProjectListProps) {
     }
   }, [activeWorkspaceId, allWorkspaceIds]);
 
+  // Reveal the active workspace in the tree by auto-expanding the project
+  // and label group it belongs to. This runs when activeWorkspaceId changes
+  // — typically from the Ctrl+R workspace switcher (WorkspacePickerDialog),
+  // but also for any other external activation (URL nav, notifications,
+  // etc.). It deliberately depends only on activeWorkspaceId (plus the
+  // structural inputs needed to locate the workspace) so a user who
+  // manually re-collapses a project doesn't get fought by this effect on
+  // every render.
+  //
+  // We also clear keyboardNavRef so the focusedIndex effect above can
+  // re-run and move the highlight ring to the freshly-revealed workspace.
+  // Without that reset, arrow-key navigation followed by a Ctrl+R switch
+  // would leave the highlight stuck on the old position.
+  //
+  // If the active workspace falls outside the current label filter we
+  // don't bother expanding anything — it won't be rendered regardless.
+  useEffect(() => {
+    if (!activeWorkspaceId) return;
+    for (const group of groups) {
+      for (const project of group.projects) {
+        const containsActive = project.worktrees.some(
+          (wt) => toWorkspaceId(project.name, wt.branch) === activeWorkspaceId,
+        );
+        if (!containsActive) continue;
+        if (labelFilter && group.labelId !== labelFilter) return;
+        const headerVisible = labels.length > 0 && !labelFilter;
+        if (headerVisible) {
+          labelCollapse.expand(group.labelId ?? UNLABELED_KEY);
+        }
+        projectCollapse.expand(project.name);
+        keyboardNavRef.current = false;
+        return;
+      }
+    }
+  }, [activeWorkspaceId, groups, labelFilter, labels.length, labelCollapse, projectCollapse]);
+
   // Focus the container so keyboard navigation works immediately.
   // Depends on hasProjects because the container div only renders when
   // projects.length > 0 (see the early return below). On first mount with no

--- a/packages/dashboard-core/src/hooks/use-collapse-state.ts
+++ b/packages/dashboard-core/src/hooks/use-collapse-state.ts
@@ -47,6 +47,8 @@ function write(key: string, set: Set<string>): void {
 export interface CollapseState {
   isCollapsed: (id: string) => boolean;
   toggle: (id: string) => void;
+  /** Idempotently mark an id as expanded (remove from collapsed set). */
+  expand: (id: string) => void;
   /** Replace the entire collapsed set in one shot (used for collapse-all). */
   setAll: (ids: Iterable<string>) => void;
 }
@@ -90,6 +92,23 @@ export function useCollapseState(storageKey: string): CollapseState {
     [storageKey],
   );
 
+  // Used by callers that need to reveal an item nested under collapsed
+  // ancestors (e.g. the workspace switcher revealing the selected workspace
+  // in the project tree). Idempotent — a no-op if the id isn't currently
+  // in the collapsed set, so it won't fight a user who manually expanded.
+  const expand = useCallback(
+    (id: string) => {
+      setCollapsed((prev) => {
+        if (!prev.has(id)) return prev;
+        const next = new Set(prev);
+        next.delete(id);
+        write(storageKey, next);
+        return next;
+      });
+    },
+    [storageKey],
+  );
+
   const setAll = useCallback(
     (ids: Iterable<string>) => {
       const next = new Set(ids);
@@ -101,5 +120,8 @@ export function useCollapseState(storageKey: string): CollapseState {
 
   // Memoised so consumers can use the returned object as a useMemo/useEffect
   // dependency without triggering work on every render.
-  return useMemo(() => ({ isCollapsed, toggle, setAll }), [isCollapsed, toggle, setAll]);
+  return useMemo(
+    () => ({ isCollapsed, toggle, expand, setAll }),
+    [isCollapsed, toggle, expand, setAll],
+  );
 }


### PR DESCRIPTION
## Summary

- When a workspace is activated (Ctrl+R picker, URL nav, or any other path that sets `activeWorkspaceId`), auto-expand the project and label group containing it so the user can see where the workspace lives in the tree.
- Adds an idempotent `expand(id)` method to `useCollapseState` — no-op if already expanded, so it won't fight a user who manually re-collapsed something.
- New effect in `ProjectList` locates the containing project + label group and expands both; skips work when the workspace falls outside the current label filter, and only touches the label group when its header is actually visible.
- Clears `keyboardNavRef` so the existing focusedIndex effect can move the highlight ring, and `WorkspaceCard`'s existing `scrollIntoView` brings the card into the viewport.

## Test plan

- [ ] Collapse a project containing a non-active workspace, then Ctrl+R switch to a workspace in that project — project expands, card highlights, card scrolls into view.
- [ ] Same as above but with a collapsed label group — label group expands too.
- [ ] After arrow-key navigation in the tree, Ctrl+R switch — highlight ring moves to the new workspace (not stuck on the old keyboard position).
- [ ] Manually collapse the active workspace's project after switching — it stays collapsed (the effect doesn't fight the user on re-renders).
- [ ] With a label filter active, Ctrl+R switch to a workspace whose label doesn't match — no expand work happens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)