### PR TITLE
security(ci): switch from pull_request_target to pull_request

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,15 @@ name: CI
 on:
   push:
     branches: [main]
-  pull_request_target:
+  # Use `pull_request` (NOT `pull_request_target`). The latter runs in the base
+  # repo's context with secret access and shared-cache write privilege, while
+  # checking out the fork's untrusted code — the exact "pwn request" + cache
+  # poisoning chain described in the TanStack npm supply-chain compromise
+  # postmortem (https://tanstack.com/blog/npm-supply-chain-compromise-postmortem).
+  # `pull_request` runs fork PR code in an isolated context with no secrets and
+  # PR-scoped cache writes, so a malicious PR cannot poison main's caches or
+  # exfiltrate NPM_TOKEN / signing creds.
+  pull_request:
     types: [opened, reopened, labeled, synchronize]
     branches: [main]
 
@@ -19,6 +27,9 @@ jobs:
     # Always run on push to main.
     # For same-repo PRs (collaborators): run automatically.
     # For fork PRs: only run when a maintainer adds the 'ci:approved' label.
+    # The label gate is now a cost filter (don't burn CI minutes on every
+    # drive-by fork PR), NOT a security barrier — the trigger above already
+    # isolates fork PRs from secrets and shared cache writes.
     if: >
       github.event_name == 'push' ||
       github.event.pull_request.head.repo.full_name == github.repository ||

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,11 @@ jobs:
     # The label gate is now a cost filter (don't burn CI minutes on every
     # drive-by fork PR), NOT a security barrier — the trigger above already
     # isolates fork PRs from secrets and shared cache writes.
+    # Note: under `pull_request`, fork PRs run the fork's own ci.yml, so this
+    # gate is also unreliable as a cost control — a malicious or zealous fork
+    # can simply remove the `if:` and burn minutes. Stricter cost controls
+    # (e.g. paused-by-default workflows, billing limits) belong at the
+    # GitHub Actions account/org level, not in YAML the fork can edit.
     if: >
       github.event_name == 'push' ||
       github.event.pull_request.head.repo.full_name == github.repository ||


### PR DESCRIPTION
## Summary

- Closes the "pwn request" + cache poisoning vector described in the [TanStack npm supply-chain compromise postmortem](https://tanstack.com/blog/npm-supply-chain-compromise-postmortem). Our \`ci.yml\` had **the exact same pattern**: \`pull_request_target\` running fork code in privileged base-repo context + \`actions/cache@v5\` writes to keys shared with \`main\`. A maintainer-labeled fork PR could poison the cargo registry / CLI target cache, which \`release.yml\` then restores — at which point NPM_TOKEN and Apple signing creds are in env.
- Switching the trigger to \`pull_request\` isolates fork PR code: no repo secrets, cache writes scoped to the PR ref (not main), and the workflow file used is the fork's own copy (so the fork can break its own CI but can't pivot into ours).
- Same-repo PRs and pushes to \`main\` are unaffected — they continue running with full privileges as before.
- Keeping the \`ci:approved\` label gate as a cost filter (don't burn CI minutes on every drive-by fork PR). It's no longer a security boundary; the trigger itself is.

## Why this matters

Once \`pull_request_target\` runs fork code, every defense downstream (\`permissions: contents:read\`, branch protections, required reviewers on \`environment: production\`) can be bypassed by the same techniques TanStack saw: cache poisoning, OIDC token extraction from \`/proc/<pid>/mem\`, env-variable exfil. The fix is to never let untrusted code into the privileged context in the first place.

A follow-up PR (#TBD) will split \`actions/cache@v5\` into restore + save with the save gated on trusted events, as defense-in-depth in case \`pull_request_target\` ever gets reintroduced.

## Test plan

- [ ] Push CI run (this push) goes green
- [ ] Open a same-repo PR against \`main\` → check this exact workflow fires and has secrets access (e.g. \`pnpm install\` succeeds with private packages if any)
- [ ] Confirm a fork PR with the \`ci:approved\` label still runs, just without secret access
- [ ] Verify cache restores still work on \`main\` (push run after merge should pick up cargo cache)

🤖 Generated with [Claude Code](https://claude.com/claude-code)