### PR TITLE
security(ci): split cache restore + save, gate save on trusted events

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,11 +56,15 @@ jobs:
 
       # Restore caches always (safe to read from untrusted runs). Saves are
       # split out below and gated on trusted events as defence-in-depth —
-      # see "Save … cache" steps near the end of the job.
+      # see "Save … cache" steps near the end of the job. IMPORTANT: keep
+      # `path` and `key` in lock-step between Restore and Save halves; an
+      # edit to one without the matching change to the other silently
+      # creates dangling cache entries.
       - name: Restore Cargo registry cache
         id: cache-cargo-registry
         uses: actions/cache/restore@v5
         with:
+          # When editing path/key here, mirror in "Save Cargo registry cache".
           path: |
             ~/.cargo/registry
             ~/.cargo/git
@@ -71,6 +75,7 @@ jobs:
         id: cache-cargo-cli
         uses: actions/cache/restore@v5
         with:
+          # When editing path/key here, mirror in "Save CLI target cache".
           path: apps/cli/target
           key: cargo-cli-${{ runner.os }}-${{ hashFiles('apps/cli/Cargo.lock') }}
           restore-keys: cargo-cli-${{ runner.os }}-
@@ -135,6 +140,17 @@ jobs:
       # cargo caches that release.yml and nightly.yml also consume. Skipped
       # entirely on an exact restore-key hit so we don't re-write identical
       # state. See: TanStack npm supply-chain compromise postmortem.
+      #
+      # The two save steps differ in their failure semantics:
+      #
+      #   - Cargo registry cache: `always()` so we save even when later
+      #     steps fail. The registry is just downloaded crate tarballs; there
+      #     is no notion of "partial" content and re-saving is harmless.
+      #
+      #   - CLI target cache: defaults to `success()` (no `always()`). The
+      #     target dir holds incremental compiler artifacts — saving them
+      #     after a failed cargo build/test can produce a cache entry that
+      #     poisons the next run with broken incremental state.
       - name: Save Cargo registry cache
         if: |
           always() &&
@@ -143,6 +159,7 @@ jobs:
            github.event.pull_request.head.repo.full_name == github.repository)
         uses: actions/cache/save@v5
         with:
+          # When editing path/key here, mirror in "Restore Cargo registry cache".
           path: |
             ~/.cargo/registry
             ~/.cargo/git
@@ -150,12 +167,13 @@ jobs:
 
       - name: Save CLI target cache
         if: |
-          always() &&
+          success() &&
           steps.cache-cargo-cli.outputs.cache-hit != 'true' &&
           (github.event_name == 'push' ||
            github.event.pull_request.head.repo.full_name == github.repository)
         uses: actions/cache/save@v5
         with:
+          # When editing path/key here, mirror in "Restore CLI target cache".
           path: apps/cli/target
           key: cargo-cli-${{ runner.os }}-${{ hashFiles('apps/cli/Cargo.lock') }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,16 @@ jobs:
 
     env:
       NODE_OPTIONS: "--max-old-space-size=6144"
+      # Path/key shared between the Restore/Save halves of each cargo cache.
+      # Defined once at job scope to remove the manual lock-step requirement
+      # that the in-line comments used to call out — a future edit to the
+      # key here flows to both halves without risk of drift.
+      CARGO_REGISTRY_PATH: |
+        ~/.cargo/registry
+        ~/.cargo/git
+      CARGO_REGISTRY_KEY: cargo-registry-${{ runner.os }}-${{ hashFiles('**/Cargo.lock') }}
+      CARGO_CLI_TARGET_PATH: apps/cli/target
+      CARGO_CLI_TARGET_KEY: cargo-cli-${{ runner.os }}-${{ hashFiles('apps/cli/Cargo.lock') }}
 
     steps:
       - name: Checkout
@@ -56,28 +66,22 @@ jobs:
 
       # Restore caches always (safe to read from untrusted runs). Saves are
       # split out below and gated on trusted events as defence-in-depth —
-      # see "Save … cache" steps near the end of the job. IMPORTANT: keep
-      # `path` and `key` in lock-step between Restore and Save halves; an
-      # edit to one without the matching change to the other silently
-      # creates dangling cache entries.
+      # see "Save … cache" steps near the end of the job. path/key are
+      # sourced from job-level env vars so the two halves can't drift.
       - name: Restore Cargo registry cache
         id: cache-cargo-registry
         uses: actions/cache/restore@v5
         with:
-          # When editing path/key here, mirror in "Save Cargo registry cache".
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-          key: cargo-registry-${{ runner.os }}-${{ hashFiles('**/Cargo.lock') }}
+          path: ${{ env.CARGO_REGISTRY_PATH }}
+          key: ${{ env.CARGO_REGISTRY_KEY }}
           restore-keys: cargo-registry-${{ runner.os }}-
 
       - name: Restore CLI target cache
         id: cache-cargo-cli
         uses: actions/cache/restore@v5
         with:
-          # When editing path/key here, mirror in "Save CLI target cache".
-          path: apps/cli/target
-          key: cargo-cli-${{ runner.os }}-${{ hashFiles('apps/cli/Cargo.lock') }}
+          path: ${{ env.CARGO_CLI_TARGET_PATH }}
+          key: ${{ env.CARGO_CLI_TARGET_KEY }}
           restore-keys: cargo-cli-${{ runner.os }}-
 
       - name: Setup pnpm
@@ -159,9 +163,13 @@ jobs:
       # `pull_request_target`; the latter would otherwise sneak past a
       # `!= 'pull_request'` short-circuit (`pull_request_target` is a
       # distinct event name) and re-introduce the exact poisoning vector
-      # this PR is meant to block as defence-in-depth. New non-PR triggers
-      # (workflow_dispatch, schedule, repository_dispatch, …) remain
-      # allowed without an explicit allowlist entry.
+      # this PR is meant to block as defence-in-depth. Non-PR triggers
+      # (push, workflow_dispatch, schedule, repository_dispatch,
+      # workflow_call, …) remain allowed without an explicit allowlist
+      # entry. NOTE for workflow_call: if ci.yml is ever exposed as a
+      # reusable workflow, `github.event_name` reflects the CALLER's
+      # event, so a caller running under `pull_request_target` would
+      # propagate that here and (correctly) be blocked.
       - name: Save Cargo registry cache
         if: |
           always() &&
@@ -171,11 +179,8 @@ jobs:
            github.event.pull_request.head.repo.full_name == github.repository)
         uses: actions/cache/save@v5
         with:
-          # When editing path/key here, mirror in "Restore Cargo registry cache".
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-          key: cargo-registry-${{ runner.os }}-${{ hashFiles('**/Cargo.lock') }}
+          path: ${{ env.CARGO_REGISTRY_PATH }}
+          key: ${{ env.CARGO_REGISTRY_KEY }}
 
       - name: Save CLI target cache
         if: |
@@ -186,9 +191,8 @@ jobs:
            github.event.pull_request.head.repo.full_name == github.repository)
         uses: actions/cache/save@v5
         with:
-          # When editing path/key here, mirror in "Restore CLI target cache".
-          path: apps/cli/target
-          key: cargo-cli-${{ runner.os }}-${{ hashFiles('apps/cli/Cargo.lock') }}
+          path: ${{ env.CARGO_CLI_TARGET_PATH }}
+          key: ${{ env.CARGO_CLI_TARGET_KEY }}
 
       - name: Build desktop (TypeScript main + preload)
         run: pnpm --filter @band-app/desktop build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,16 +42,6 @@ jobs:
 
     env:
       NODE_OPTIONS: "--max-old-space-size=6144"
-      # Path/key shared between the Restore/Save halves of each cargo cache.
-      # Defined once at job scope to remove the manual lock-step requirement
-      # that the in-line comments used to call out — a future edit to the
-      # key here flows to both halves without risk of drift.
-      CARGO_REGISTRY_PATH: |
-        ~/.cargo/registry
-        ~/.cargo/git
-      CARGO_REGISTRY_KEY: cargo-registry-${{ runner.os }}-${{ hashFiles('**/Cargo.lock') }}
-      CARGO_CLI_TARGET_PATH: apps/cli/target
-      CARGO_CLI_TARGET_KEY: cargo-cli-${{ runner.os }}-${{ hashFiles('apps/cli/Cargo.lock') }}
 
     steps:
       - name: Checkout
@@ -66,22 +56,30 @@ jobs:
 
       # Restore caches always (safe to read from untrusted runs). Saves are
       # split out below and gated on trusted events as defence-in-depth —
-      # see "Save … cache" steps near the end of the job. path/key are
-      # sourced from job-level env vars so the two halves can't drift.
+      # see "Save … cache" steps near the end of the job. IMPORTANT: keep
+      # `path` and `key` in lock-step between Restore and Save halves; an
+      # edit to one without the matching change to the other silently
+      # creates dangling cache entries. (A previous attempt to hoist these
+      # to job-level `env:` failed because `runner.os` isn't available in
+      # `jobs.<id>.env` context — GitHub couldn't parse the workflow.)
       - name: Restore Cargo registry cache
         id: cache-cargo-registry
         uses: actions/cache/restore@v5
         with:
-          path: ${{ env.CARGO_REGISTRY_PATH }}
-          key: ${{ env.CARGO_REGISTRY_KEY }}
+          # When editing path/key here, mirror in "Save Cargo registry cache".
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+          key: cargo-registry-${{ runner.os }}-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: cargo-registry-${{ runner.os }}-
 
       - name: Restore CLI target cache
         id: cache-cargo-cli
         uses: actions/cache/restore@v5
         with:
-          path: ${{ env.CARGO_CLI_TARGET_PATH }}
-          key: ${{ env.CARGO_CLI_TARGET_KEY }}
+          # When editing path/key here, mirror in "Save CLI target cache".
+          path: apps/cli/target
+          key: cargo-cli-${{ runner.os }}-${{ hashFiles('apps/cli/Cargo.lock') }}
           restore-keys: cargo-cli-${{ runner.os }}-
 
       - name: Setup pnpm
@@ -177,10 +175,17 @@ jobs:
           ((github.event_name != 'pull_request' &&
             github.event_name != 'pull_request_target') ||
            github.event.pull_request.head.repo.full_name == github.repository)
+        # Best-effort: if the registry save fails (cache size limits,
+        # transient service error), don't poison the job — the CLI-target
+        # save's `success()` gate would otherwise skip silently.
+        continue-on-error: true
         uses: actions/cache/save@v5
         with:
-          path: ${{ env.CARGO_REGISTRY_PATH }}
-          key: ${{ env.CARGO_REGISTRY_KEY }}
+          # When editing path/key here, mirror in "Restore Cargo registry cache".
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+          key: cargo-registry-${{ runner.os }}-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Save CLI target cache
         if: |
@@ -191,8 +196,9 @@ jobs:
            github.event.pull_request.head.repo.full_name == github.repository)
         uses: actions/cache/save@v5
         with:
-          path: ${{ env.CARGO_CLI_TARGET_PATH }}
-          key: ${{ env.CARGO_CLI_TARGET_KEY }}
+          # When editing path/key here, mirror in "Restore CLI target cache".
+          path: apps/cli/target
+          key: cargo-cli-${{ runner.os }}-${{ hashFiles('apps/cli/Cargo.lock') }}
 
       - name: Build desktop (TypeScript main + preload)
         run: pnpm --filter @band-app/desktop build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,8 +54,12 @@ jobs:
         with:
           components: rustfmt, clippy
 
-      - name: Cache Cargo registry
-        uses: actions/cache@v5
+      # Restore caches always (safe to read from untrusted runs). Saves are
+      # split out below and gated on trusted events as defence-in-depth —
+      # see "Save … cache" steps near the end of the job.
+      - name: Restore Cargo registry cache
+        id: cache-cargo-registry
+        uses: actions/cache/restore@v5
         with:
           path: |
             ~/.cargo/registry
@@ -63,8 +67,9 @@ jobs:
           key: cargo-registry-${{ runner.os }}-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: cargo-registry-${{ runner.os }}-
 
-      - name: Cache CLI target
-        uses: actions/cache@v5
+      - name: Restore CLI target cache
+        id: cache-cargo-cli
+        uses: actions/cache/restore@v5
         with:
           path: apps/cli/target
           key: cargo-cli-${{ runner.os }}-${{ hashFiles('apps/cli/Cargo.lock') }}
@@ -122,6 +127,37 @@ jobs:
 
       - name: Test (CLI)
         run: cargo test --manifest-path apps/cli/Cargo.toml -- --test-threads=4
+
+      # Cache writes (defence-in-depth). Even though our CI trigger is now
+      # `pull_request` (PR-scoped cache writes can't poison main), gating the
+      # save explicitly on a trusted event ensures a future workflow change
+      # that re-introduces `pull_request_target` cannot pollute the shared
+      # cargo caches that release.yml and nightly.yml also consume. Skipped
+      # entirely on an exact restore-key hit so we don't re-write identical
+      # state. See: TanStack npm supply-chain compromise postmortem.
+      - name: Save Cargo registry cache
+        if: |
+          always() &&
+          steps.cache-cargo-registry.outputs.cache-hit != 'true' &&
+          (github.event_name == 'push' ||
+           github.event.pull_request.head.repo.full_name == github.repository)
+        uses: actions/cache/save@v5
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+          key: cargo-registry-${{ runner.os }}-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Save CLI target cache
+        if: |
+          always() &&
+          steps.cache-cargo-cli.outputs.cache-hit != 'true' &&
+          (github.event_name == 'push' ||
+           github.event.pull_request.head.repo.full_name == github.repository)
+        uses: actions/cache/save@v5
+        with:
+          path: apps/cli/target
+          key: cargo-cli-${{ runner.os }}-${{ hashFiles('apps/cli/Cargo.lock') }}
 
       - name: Build desktop (TypeScript main + preload)
         run: pnpm --filter @band-app/desktop build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -187,9 +187,19 @@ jobs:
             ~/.cargo/git
           key: cargo-registry-${{ runner.os }}-${{ hashFiles('**/Cargo.lock') }}
 
+      # NOTE on placement: save steps land here, after `Test (CLI)` and
+      # before `Build desktop`. That's fine today because no Cargo step
+      # runs after this point — TypeScript/Node desktop build doesn't
+      # touch apps/cli/target. If a future Rust step is added later in
+      # the job, move both save steps to the very end so its output
+      # gets cached.
       - name: Save CLI target cache
+        # No `success()` — GitHub Actions applies it implicitly when no
+        # status function is present in the expression. Mirroring that
+        # default keeps the contrast with the registry-save `always()`
+        # explicit: registry saves even on failure/cancel, CLI target
+        # only on a clean run (so we don't cache broken incremental state).
         if: |
-          success() &&
           steps.cache-cargo-cli.outputs.cache-hit != 'true' &&
           ((github.event_name != 'pull_request' &&
             github.event_name != 'pull_request_target') ||

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,18 +144,26 @@ jobs:
       # The two save steps differ in their failure semantics:
       #
       #   - Cargo registry cache: `always()` so we save even when later
-      #     steps fail. The registry is just downloaded crate tarballs; there
-      #     is no notion of "partial" content and re-saving is harmless.
+      #     steps fail. The registry holds downloaded crate tarballs plus
+      #     an index — a job cancelled mid-download may leave incomplete
+      #     files, but cargo re-validates against the index on the next
+      #     run, so a re-save is safe.
       #
       #   - CLI target cache: defaults to `success()` (no `always()`). The
       #     target dir holds incremental compiler artifacts — saving them
       #     after a failed cargo build/test can produce a cache entry that
       #     poisons the next run with broken incremental state.
+      #
+      # The trust gate is phrased as "not a pull_request, OR a same-repo
+      # PR" rather than enumerating allowed event types. New triggers
+      # (workflow_dispatch, schedule, repository_dispatch, …) are allowed
+      # by default and only forks are blocked, which is the invariant we
+      # actually want.
       - name: Save Cargo registry cache
         if: |
           always() &&
           steps.cache-cargo-registry.outputs.cache-hit != 'true' &&
-          (github.event_name == 'push' ||
+          (github.event_name != 'pull_request' ||
            github.event.pull_request.head.repo.full_name == github.repository)
         uses: actions/cache/save@v5
         with:
@@ -169,7 +177,7 @@ jobs:
         if: |
           success() &&
           steps.cache-cargo-cli.outputs.cache-hit != 'true' &&
-          (github.event_name == 'push' ||
+          (github.event_name != 'pull_request' ||
            github.event.pull_request.head.repo.full_name == github.repository)
         uses: actions/cache/save@v5
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,26 +144,30 @@ jobs:
       # The two save steps differ in their failure semantics:
       #
       #   - Cargo registry cache: `always()` so we save even when later
-      #     steps fail. The registry holds downloaded crate tarballs plus
-      #     an index — a job cancelled mid-download may leave incomplete
-      #     files, but cargo re-validates against the index on the next
-      #     run, so a re-save is safe.
+      #     steps fail or the job is cancelled. The registry holds
+      #     downloaded crate tarballs plus an index — a cancellation
+      #     mid-download may leave incomplete files, but cargo
+      #     re-validates against the index on the next run, so a re-save
+      #     is safe.
       #
       #   - CLI target cache: defaults to `success()` (no `always()`). The
       #     target dir holds incremental compiler artifacts — saving them
       #     after a failed cargo build/test can produce a cache entry that
       #     poisons the next run with broken incremental state.
       #
-      # The trust gate is phrased as "not a pull_request, OR a same-repo
-      # PR" rather than enumerating allowed event types. New triggers
-      # (workflow_dispatch, schedule, repository_dispatch, …) are allowed
-      # by default and only forks are blocked, which is the invariant we
-      # actually want.
+      # The trust gate explicitly excludes BOTH `pull_request` and
+      # `pull_request_target`; the latter would otherwise sneak past a
+      # `!= 'pull_request'` short-circuit (`pull_request_target` is a
+      # distinct event name) and re-introduce the exact poisoning vector
+      # this PR is meant to block as defence-in-depth. New non-PR triggers
+      # (workflow_dispatch, schedule, repository_dispatch, …) remain
+      # allowed without an explicit allowlist entry.
       - name: Save Cargo registry cache
         if: |
           always() &&
           steps.cache-cargo-registry.outputs.cache-hit != 'true' &&
-          (github.event_name != 'pull_request' ||
+          ((github.event_name != 'pull_request' &&
+            github.event_name != 'pull_request_target') ||
            github.event.pull_request.head.repo.full_name == github.repository)
         uses: actions/cache/save@v5
         with:
@@ -177,7 +181,8 @@ jobs:
         if: |
           success() &&
           steps.cache-cargo-cli.outputs.cache-hit != 'true' &&
-          (github.event_name != 'pull_request' ||
+          ((github.event_name != 'pull_request' &&
+            github.event_name != 'pull_request_target') ||
            github.event.pull_request.head.repo.full_name == github.repository)
         uses: actions/cache/save@v5
         with:


### PR DESCRIPTION
## Summary

- Defence-in-depth follow-up to #402 (the \`pull_request_target\` → \`pull_request\` switch). That PR alone closes the cache-poisoning vector — fork PRs now write to PR-scoped cache namespaces instead of \`main\`'s. This PR adds a second layer: even if someone later re-introduces \`pull_request_target\` (or any other untrusted-context trigger), the save step itself refuses to fire from untrusted runs, so the shared cargo caches that \`release.yml\` and \`nightly.yml\` later consume stay clean.
- Replaces combined \`actions/cache@v5\` (which does both restore and save unconditionally) with explicit \`actions/cache/restore@v5\` (always-on, safe to read) + \`actions/cache/save@v5\` (gated).
- Save runs only when \`github.event_name == 'push'\` OR the PR head is from this repo. \`always()\` preserves the prior semantics of saving even if a later step fails. \`cache-hit != 'true'\` skips re-writing identical state on exact restore-key matches.

## Why two PRs

#402 makes Band safe in the common case (untrusted forks can't poison main). This PR adds a guardrail so the safety doesn't silently depend on which trigger we use. Reviewing them independently lets you revert one without losing the other.

## Test plan

- [ ] Push CI run (this push) goes green
- [ ] First run on this branch: \`Restore Cargo registry cache\` reports a cache miss (or fuzzy hit via restore-keys), then \`Save Cargo registry cache\` runs at the end
- [ ] Subsequent run on same branch: \`Restore\` reports exact key hit, \`Save\` step is skipped (cache-hit == true)
- [ ] Confirm via Actions UI that the cargo registry cache for \`runner.os=Linux\` keeps the same key shape: \`cargo-registry-Linux-<hash>\`
- [ ] If a fork PR opens, verify \`Save …\` step shows as skipped (gate condition false)

## Refs

- TanStack postmortem: https://tanstack.com/blog/npm-supply-chain-compromise-postmortem
- Stacks on top of: #402

🤖 Generated with [Claude Code](https://claude.com/claude-code)