### PR TITLE
feat(browser): find-in-page, contextual reload/zoom shortcuts, docked devtools

### DIFF
--- a/apps/desktop/src/browser/layout.ts
+++ b/apps/desktop/src/browser/layout.ts
@@ -1,0 +1,68 @@
+/**
+ * Pure layout math for the browser pane's tab bounds, extracted so the
+ * splitting logic can be exercised in isolation (no Electron import).
+ *
+ * `BrowserViewManager` owns the side-effectful `setBounds` calls; this
+ * module just computes "given a tab's outer bounds, what bounds should
+ * the page view and the (optional) docked DevTools sibling each get?".
+ */
+
+export interface Rect {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+export interface SplitOptions {
+  /** Fraction of `bounds.height` the DevTools strip wants by default. */
+  splitRatio: number;
+  /** Minimum height the DevTools strip prefers to keep, when there's room. */
+  devMinHeight: number;
+  /** Minimum height the page view should never collapse below. */
+  pageMinHeight: number;
+}
+
+export interface SplitResult {
+  /** Page view bounds (top portion when DevTools is open). */
+  page: Rect;
+  /** DevTools sibling bounds (bottom portion). Always set; callers
+   *  ignore it when no DevTools sibling exists. */
+  dev: Rect;
+}
+
+/**
+ * Split a tab's outer bounds between the page view (top) and the
+ * docked DevTools sibling (bottom).
+ *
+ * Invariants the test suite covers:
+ *
+ *   - `page.height + dev.height === bounds.height` for any non-negative
+ *     `bounds.height` — the two pieces always sum to the original, no
+ *     overflow even on short windows where the clamps would otherwise
+ *     overlap.
+ *   - `page.height >= min(pageMinHeight, bounds.height)` when the
+ *     window has any room at all.
+ *   - `dev.height >= min(devMinHeight, bounds.height - pageMinHeight)`
+ *     when there's room; otherwise DevTools is sacrificed to keep the
+ *     page view at its minimum.
+ *   - `page` and `dev` together cover exactly `bounds` (no gap, no
+ *     overlap).
+ */
+export function splitTabBounds(bounds: Rect, options: SplitOptions): SplitResult {
+  const { splitRatio, devMinHeight, pageMinHeight } = options;
+  const rawDevHeight = Math.round(bounds.height * splitRatio);
+  const maxDevHeight = Math.max(0, bounds.height - pageMinHeight);
+  const clampedMin = Math.min(devMinHeight, maxDevHeight);
+  const devHeight = Math.min(maxDevHeight, Math.max(clampedMin, rawDevHeight));
+  const pageHeight = Math.max(0, bounds.height - devHeight);
+  return {
+    page: { x: bounds.x, y: bounds.y, width: bounds.width, height: pageHeight },
+    dev: {
+      x: bounds.x,
+      y: bounds.y + pageHeight,
+      width: bounds.width,
+      height: devHeight,
+    },
+  };
+}

--- a/apps/desktop/src/browser/view-manager.ts
+++ b/apps/desktop/src/browser/view-manager.ts
@@ -146,8 +146,13 @@ export class BrowserViewManager {
 
     this.enforceLru();
 
-    this.spawn(args.url, key);
-    this.moveTo(key, this.views.get(key) as WebContentsView, "main");
+    // Capture `spawn`'s return value directly. The previous form
+    // (`spawn(...); this.views.get(key) as WebContentsView`) papered
+    // over the failure mode where `spawn` is unable to insert into the
+    // map — `moveTo` would then be handed `undefined`, and
+    // `addChildView(undefined)` takes down the window.
+    const view = this.spawn(args.url, key);
+    this.moveTo(key, view, "main");
     this.lastBoundsByKey.set(key, args);
     this.applyTabLayout(key, args);
     this.setTabVisibility(key, true);
@@ -394,8 +399,11 @@ export class BrowserViewManager {
       // give the page view the full bounds back.
       try {
         wc.closeDevTools();
-      } catch {
-        // best-effort: closing on an already-detached state may throw
+      } catch (err) {
+        // best-effort: closing on an already-detached state may throw.
+        // Log so a real failure in the field is observable, but don't
+        // re-throw — the sibling view cleanup below still has to run.
+        console.error("toggleDevTools: closeDevTools threw:", err);
       }
       this.removeChildFromParent(key, existing);
       if (!existing.webContents.isDestroyed()) {
@@ -509,6 +517,10 @@ export class BrowserViewManager {
    * tab can be torn down between the menu firing and this lookup.
    */
   findFocused(): WebContentsView | null {
+    // Iterating `this.views.values()` (Map insertion order) is fine
+    // here — keyboard focus is exclusive, so at most one view can
+    // match, and the order doesn't affect the result. Do NOT switch
+    // to `this.order` (LRU order); that's only used for eviction.
     for (const view of this.views.values()) {
       if (view.webContents.isDestroyed()) continue;
       if (view.webContents.isFocused()) return view;

--- a/apps/desktop/src/browser/view-manager.ts
+++ b/apps/desktop/src/browser/view-manager.ts
@@ -39,6 +39,7 @@ import {
   type BrowserZoomArgs,
   browserKey,
 } from "../shared/types.js";
+import { splitTabBounds } from "./layout.js";
 
 const MAX_BROWSER_VIEWS = 10;
 
@@ -58,6 +59,10 @@ const ZOOM_DEFAULT = 1.0;
 // short.
 const DEVTOOLS_SPLIT_RATIO = 0.4;
 const DEVTOOLS_MIN_HEIGHT = 160;
+// Page view never collapses below this on tall enough windows. On
+// windows shorter than `PAGE_MIN_HEIGHT`, the page view shrinks to
+// `bounds.height` (DevTools is sacrificed to keep page visible).
+const PAGE_MIN_HEIGHT = 40;
 
 export interface ViewManagerOptions {
   /** User-visible window that hosts the React UI; renders WebContentsViews
@@ -107,6 +112,14 @@ export class BrowserViewManager {
     string,
     { x: number; y: number; width: number; height: number }
   >();
+  /**
+   * Tracks the latest `setVisible` argument we passed for each tab so
+   * `toggleDevTools` can mirror the page view's current visibility on
+   * the new DevTools sibling. `WebContentsView` has a setter but no
+   * cross-version-stable getter (Electron's `WebContents.isVisible`
+   * isn't on the public typings of this version).
+   */
+  private readonly visibleByKey = new Map<string, boolean>();
 
   constructor(private readonly opts: ViewManagerOptions) {}
 
@@ -127,18 +140,17 @@ export class BrowserViewManager {
       this.moveTo(key, existing, "main");
       this.lastBoundsByKey.set(key, args);
       this.applyTabLayout(key, args);
-      existing.setVisible(true);
-      this.devToolsViews.get(key)?.setVisible(true);
+      this.setTabVisibility(key, true);
       return;
     }
 
     this.enforceLru();
 
-    const view = this.spawn(args.url, key);
-    this.moveTo(key, view, "main");
+    this.spawn(args.url, key);
+    this.moveTo(key, this.views.get(key) as WebContentsView, "main");
     this.lastBoundsByKey.set(key, args);
     this.applyTabLayout(key, args);
-    view.setVisible(true);
+    this.setTabVisibility(key, true);
   }
 
   /**
@@ -178,7 +190,7 @@ export class BrowserViewManager {
       // Belt-and-suspenders against ever leaving a view at
       // setVisible(false): no current code path does, but if a future
       // change introduces one, this keeps `ensure` robust.
-      existing.setVisible(true);
+      this.setTabVisibility(key, true);
       return;
     }
     this.enforceLru();
@@ -238,8 +250,7 @@ export class BrowserViewManager {
     if (!view) return;
     // Migrate back to the main window so the user can see the tab.
     if (this.opts.hiddenWindow) this.moveTo(key, view, "main");
-    view.setVisible(true);
-    this.devToolsViews.get(key)?.setVisible(true);
+    this.setTabVisibility(key, true);
   }
 
   hide(args: BrowserKeyArg): void {
@@ -252,14 +263,12 @@ export class BrowserViewManager {
       // on web. The hidden window is invisible to the user but counts as a
       // visible parent from chromium's POV.
       this.moveTo(key, view, "hidden");
-      view.setVisible(true);
-      this.devToolsViews.get(key)?.setVisible(true);
+      this.setTabVisibility(key, true);
     } else {
       // CDP screencast disabled: original behavior. setVisible(false)
       // parks the compositor, which is exactly what we want for a tab
       // the user isn't currently viewing.
-      view.setVisible(false);
-      this.devToolsViews.get(key)?.setVisible(false);
+      this.setTabVisibility(key, false);
     }
   }
 
@@ -428,9 +437,13 @@ export class BrowserViewManager {
       return;
     }
 
-    // Match page-view visibility (in case the tab is currently parked
-    // in the hidden window) and apply the split.
-    dt.setVisible(true);
+    // Match page-view visibility (the tab may currently be hidden —
+    // e.g. parked while another workspace is active). Showing the
+    // DevTools sibling while its page view is hidden would paint the
+    // panel over the workspace. We track visibility in `visibleByKey`
+    // because `WebContentsView` has a setter but no public getter.
+    const pageVisible = this.visibleByKey.get(key) ?? true;
+    dt.setVisible(pageVisible);
     const last = this.lastBoundsByKey.get(key);
     if (last) this.applyTabLayout(key, last);
   }
@@ -473,6 +486,7 @@ export class BrowserViewManager {
     this.views.delete(key);
     this.parentByKey.delete(key);
     this.lastBoundsByKey.delete(key);
+    this.visibleByKey.delete(key);
     const idx = this.order.indexOf(key);
     if (idx >= 0) this.order.splice(idx, 1);
     // Notify the renderer (which forwards to the web server's
@@ -502,18 +516,21 @@ export class BrowserViewManager {
     return null;
   }
 
-  /** Hide every tracked view. The Rust impl ignores `workspace_id`. */
+  /**
+   * Hide every tracked view. The Rust impl ignores `workspace_id`.
+   *
+   * Docked DevTools siblings must be hidden in lockstep — otherwise an
+   * open DevTools panel stays painted over the workspace when the user
+   * switches away (the page view goes invisible but its sibling
+   * doesn't).
+   */
   hideAll(): void {
-    for (const id of this.order) {
-      this.views.get(id)?.setVisible(false);
-    }
+    for (const id of this.order) this.setTabVisibility(id, false);
   }
 
   /** Show every tracked view. The Rust impl ignores `workspace_id`. */
   showAll(): void {
-    for (const id of this.order) {
-      this.views.get(id)?.setVisible(true);
-    }
+    for (const id of this.order) this.setTabVisibility(id, true);
   }
 
   /**
@@ -589,6 +606,7 @@ export class BrowserViewManager {
       this.parentByKey.set(key, "hidden");
       view.setBounds({ x: 0, y: 0, width: 1280, height: 720 });
       view.setVisible(true);
+      this.visibleByKey.set(key, true);
     } else {
       // CDP screencast disabled — original behavior. create() will
       // immediately call applyBounds + setVisible to position the view
@@ -631,6 +649,19 @@ export class BrowserViewManager {
     this.parentByKey.set(key, target);
   }
 
+  /**
+   * Single funnel for setting a tab's visibility. Mirrors `setVisible`
+   * on the page view AND its docked DevTools sibling (if any), and
+   * caches the state in `visibleByKey` so other code paths (e.g.
+   * `toggleDevTools` opening DevTools on an already-hidden tab) can
+   * read the current visibility without a getter on `WebContentsView`.
+   */
+  private setTabVisibility(key: string, visible: boolean): void {
+    this.views.get(key)?.setVisible(visible);
+    this.devToolsViews.get(key)?.setVisible(visible);
+    this.visibleByKey.set(key, visible);
+  }
+
   /** Resolve the BrowserWindow for a `Parent` enum value. */
   private windowFor(parent: Parent): BrowserWindow {
     return parent === "hidden" && this.opts.hiddenWindow
@@ -662,18 +693,18 @@ export class BrowserViewManager {
       this.applyBounds(view, bounds);
       return;
     }
-    const devHeight = Math.max(
-      DEVTOOLS_MIN_HEIGHT,
-      Math.round(bounds.height * DEVTOOLS_SPLIT_RATIO),
-    );
-    const pageHeight = Math.max(40, bounds.height - devHeight);
-    this.applyBounds(view, { ...bounds, height: pageHeight });
-    this.applyBounds(dt, {
-      x: bounds.x,
-      y: bounds.y + pageHeight,
-      width: bounds.width,
-      height: devHeight,
+    // Delegate the geometry to the pure helper in `./layout.ts` so the
+    // splitting logic can be exercised in tests without an Electron
+    // import. The helper guarantees `page.height + dev.height ===
+    // bounds.height`, even on short windows where the natural clamps
+    // would otherwise overlap.
+    const { page, dev } = splitTabBounds(bounds, {
+      splitRatio: DEVTOOLS_SPLIT_RATIO,
+      devMinHeight: DEVTOOLS_MIN_HEIGHT,
+      pageMinHeight: PAGE_MIN_HEIGHT,
     });
+    this.applyBounds(view, page);
+    this.applyBounds(dt, dev);
   }
 
   private wireEvents(key: string, view: WebContentsView): void {

--- a/apps/desktop/src/browser/view-manager.ts
+++ b/apps/desktop/src/browser/view-manager.ts
@@ -477,9 +477,20 @@ export class BrowserViewManager {
     const view = this.views.get(key);
     if (!view) return;
     // If DevTools is docked for this tab, tear down the sibling view
-    // first so we don't leak a WebContentsView whose page view is gone.
+    // first so we don't leak a WebContentsView whose page view is
+    // gone. Close the DevTools session on the page webContents first
+    // (mirrors `toggleDevTools`'s close path) — the page view is
+    // destroyed seconds later anyway so the call is best-effort, but
+    // keeping the two paths symmetric avoids surprises.
     const dt = this.devToolsViews.get(key);
     if (dt) {
+      if (!view.webContents.isDestroyed()) {
+        try {
+          view.webContents.closeDevTools();
+        } catch (err) {
+          console.error("destroy: closeDevTools threw:", err);
+        }
+      }
       this.removeChildFromParent(key, dt);
       if (!dt.webContents.isDestroyed()) dt.webContents.close();
       this.devToolsViews.delete(key);

--- a/apps/desktop/src/browser/view-manager.ts
+++ b/apps/desktop/src/browser/view-manager.ts
@@ -26,15 +26,38 @@ import {
   type BrowserCreateArgs,
   type BrowserEnsureArgs,
   type BrowserEvalArgs,
+  type BrowserFindInPageArgs,
+  type BrowserFindShortcutPayload,
+  type BrowserFoundInPagePayload,
   type BrowserKeyArg,
   type BrowserNavigateArgs,
+  type BrowserNewTabShortcutPayload,
+  type BrowserStopFindInPageArgs,
   type BrowserTitleChangedPayload,
   type BrowserUrlChangedPayload,
   type BrowserViewDestroyedPayload,
+  type BrowserZoomArgs,
   browserKey,
 } from "../shared/types.js";
 
 const MAX_BROWSER_VIEWS = 10;
+
+// Zoom range + step, intentionally aligned with the dashboard's zoom
+// settings (`apps/web/src/lib/zoom.ts`). Keeping them in sync avoids
+// the dashboard chrome and the tab content drifting to different
+// scale-step sizes when the user holds down Cmd+=.
+const ZOOM_MIN = 0.5;
+const ZOOM_MAX = 2.0;
+const ZOOM_STEP = 0.1;
+const ZOOM_DEFAULT = 1.0;
+
+// DevTools docking: when the DevTools-host sibling view is attached,
+// the tab's bounds are split — the page view gets the top portion and
+// DevTools gets the bottom `DEVTOOLS_SPLIT_RATIO`, clamped to
+// `DEVTOOLS_MIN_HEIGHT` so the panel stays usable when the tab area is
+// short.
+const DEVTOOLS_SPLIT_RATIO = 0.4;
+const DEVTOOLS_MIN_HEIGHT = 160;
 
 export interface ViewManagerOptions {
   /** User-visible window that hosts the React UI; renders WebContentsViews
@@ -66,6 +89,24 @@ export class BrowserViewManager {
   private readonly parentByKey = new Map<string, Parent>();
   /** LRU order, oldest first. */
   private readonly order: string[] = [];
+  /**
+   * Optional DevTools-host sibling view per tab. Created lazily by
+   * `toggleDevTools`. When present, the tab's bounds are split between
+   * the page view (top) and this DevTools view (bottom) — see
+   * `applyTabLayout`. The DevTools view is migrated alongside the page
+   * view on every `moveTo`, and destroyed when the page view goes
+   * away (LRU eviction, explicit destroy, app quit).
+   */
+  private readonly devToolsViews = new Map<string, WebContentsView>();
+  /**
+   * Latest bounds the renderer reported for each tab. Cached so
+   * `toggleDevTools` can re-layout (split / un-split) without
+   * round-tripping through the renderer.
+   */
+  private readonly lastBoundsByKey = new Map<
+    string,
+    { x: number; y: number; width: number; height: number }
+  >();
 
   constructor(private readonly opts: ViewManagerOptions) {}
 
@@ -84,8 +125,10 @@ export class BrowserViewManager {
     if (existing) {
       this.touch(key);
       this.moveTo(key, existing, "main");
-      this.applyBounds(existing, args);
+      this.lastBoundsByKey.set(key, args);
+      this.applyTabLayout(key, args);
       existing.setVisible(true);
+      this.devToolsViews.get(key)?.setVisible(true);
       return;
     }
 
@@ -93,7 +136,8 @@ export class BrowserViewManager {
 
     const view = this.spawn(args.url, key);
     this.moveTo(key, view, "main");
-    this.applyBounds(view, args);
+    this.lastBoundsByKey.set(key, args);
+    this.applyTabLayout(key, args);
     view.setVisible(true);
   }
 
@@ -182,9 +226,10 @@ export class BrowserViewManager {
   }
 
   setBounds(args: BrowserBoundsArgs): void {
-    const view = this.views.get(browserKey(args));
-    if (!view) return;
-    this.applyBounds(view, args);
+    const key = browserKey(args);
+    if (!this.views.get(key)) return;
+    this.lastBoundsByKey.set(key, args);
+    this.applyTabLayout(key, args);
   }
 
   show(args: BrowserKeyArg): void {
@@ -194,6 +239,7 @@ export class BrowserViewManager {
     // Migrate back to the main window so the user can see the tab.
     if (this.opts.hiddenWindow) this.moveTo(key, view, "main");
     view.setVisible(true);
+    this.devToolsViews.get(key)?.setVisible(true);
   }
 
   hide(args: BrowserKeyArg): void {
@@ -207,11 +253,13 @@ export class BrowserViewManager {
       // visible parent from chromium's POV.
       this.moveTo(key, view, "hidden");
       view.setVisible(true);
+      this.devToolsViews.get(key)?.setVisible(true);
     } else {
       // CDP screencast disabled: original behavior. setVisible(false)
       // parks the compositor, which is exactly what we want for a tab
       // the user isn't currently viewing.
       view.setVisible(false);
+      this.devToolsViews.get(key)?.setVisible(false);
     }
   }
 
@@ -244,10 +292,177 @@ export class BrowserViewManager {
     await view.webContents.executeJavaScript(args.js, true);
   }
 
+  /**
+   * Forward the renderer's find-bar query to Chromium's native
+   * `findInPage`. Match highlighting is painted by the WebContentsView
+   * itself; the only thing the renderer needs back is the running match
+   * counter, which arrives via the `browser-found-in-page` event wired
+   * up in `wireEvents`.
+   *
+   * Returns the chromium request id so the renderer can correlate
+   * streamed updates (Chromium may emit several `found-in-page` events
+   * per request as it scans large pages — only the one with
+   * `final_update: true` is authoritative).
+   */
+  findInPage(args: BrowserFindInPageArgs): number | undefined {
+    const view = this.views.get(browserKey(args));
+    if (!view) return undefined;
+    // Empty queries are a UX no-op (no highlight, no counter); Chromium
+    // would reject the call anyway, so short-circuit before bothering
+    // the webContents.
+    if (!args.text) {
+      view.webContents.stopFindInPage("clearSelection");
+      return undefined;
+    }
+    return view.webContents.findInPage(args.text, args.options);
+  }
+
+  /**
+   * End an active findInPage session. The default `clearSelection` action
+   * removes both the highlight and the selection so closing the find bar
+   * leaves the page visually untouched. Safe to call when no search is
+   * active — Chromium silently no-ops.
+   */
+  stopFindInPage(args: BrowserStopFindInPageArgs): void {
+    const view = this.views.get(browserKey(args));
+    if (!view) return;
+    view.webContents.stopFindInPage(args.action ?? "clearSelection");
+  }
+
+  /**
+   * Per-tab zoom. Adjusts `webContents.zoomFactor` on the targeted view
+   * by ±`ZOOM_STEP`, or sets it back to `ZOOM_DEFAULT`. The zoom is
+   * stored on the WebContents (Electron preserves it across reloads on
+   * the same origin, same as Chrome), and is independent of every
+   * other tab and of the dashboard's `document.documentElement.style.zoom`.
+   *
+   * The `direct` overload, taking a view rather than an args bag, lets
+   * the menu handler reuse this logic for the
+   * "WebContentsView has focus" path without re-resolving the key.
+   */
+  zoom(args: BrowserZoomArgs): void {
+    const view = this.views.get(browserKey(args));
+    if (!view) return;
+    this.applyZoomAction(view, args.action);
+  }
+
+  zoomFocused(action: BrowserZoomArgs["action"]): boolean {
+    const view = this.findFocused();
+    if (!view) return false;
+    this.applyZoomAction(view, action);
+    return true;
+  }
+
+  /**
+   * Toggle Chromium DevTools for the matching tab, docked **inside the
+   * tab area** (bottom split) — not as a detached OS window.
+   *
+   * Approach:
+   *
+   *   1. Create a sibling `WebContentsView` parented to the same window
+   *      as the page view. This sibling will host the DevTools UI.
+   *   2. Call `setDevToolsWebContents(devToolsView.webContents)` on the
+   *      page view's webContents so Chromium renders its DevTools panel
+   *      inside the sibling instead of opening its own window.
+   *   3. `openDevTools({ mode: "detach" })` triggers DevTools.
+   *      `detach` here just tells Chromium "don't try to embed in a
+   *      host window" — the *visual* docking is achieved by our
+   *      `applyTabLayout` splitting the bounds between the two views.
+   *
+   * Toggling again destroys the sibling view and restores the page
+   * view to the full bounds.
+   */
+  toggleDevTools(args: BrowserKeyArg): void {
+    const key = browserKey(args);
+    const view = this.views.get(key);
+    if (!view) return;
+    const wc = view.webContents;
+    if (wc.isDestroyed()) return;
+
+    const existing = this.devToolsViews.get(key);
+    if (existing) {
+      // Close the DevTools session, tear down the sibling view, then
+      // give the page view the full bounds back.
+      try {
+        wc.closeDevTools();
+      } catch {
+        // best-effort: closing on an already-detached state may throw
+      }
+      this.removeChildFromParent(key, existing);
+      if (!existing.webContents.isDestroyed()) {
+        existing.webContents.close();
+      }
+      this.devToolsViews.delete(key);
+      const last = this.lastBoundsByKey.get(key);
+      if (last) this.applyTabLayout(key, last);
+      return;
+    }
+
+    // Create the DevTools-host sibling. Same security flags as the
+    // page view — DevTools is just a webpage from Chromium's POV.
+    const dt = new WebContentsView({
+      webPreferences: {
+        contextIsolation: true,
+        sandbox: true,
+        nodeIntegration: false,
+      },
+    });
+    const parent = this.parentByKey.get(key) ?? "main";
+    const parentWin = this.windowFor(parent);
+    parentWin.contentView.addChildView(dt);
+    this.devToolsViews.set(key, dt);
+
+    try {
+      wc.setDevToolsWebContents(dt.webContents);
+      wc.openDevTools({ mode: "detach" });
+    } catch (err) {
+      // If wiring the sibling fails for any reason, fall back to
+      // detached-window DevTools so the user still gets something.
+      this.removeChildFromParent(key, dt);
+      if (!dt.webContents.isDestroyed()) dt.webContents.close();
+      this.devToolsViews.delete(key);
+      console.error("setDevToolsWebContents failed, falling back to detached:", err);
+      try {
+        wc.openDevTools({ mode: "detach" });
+      } catch {}
+      return;
+    }
+
+    // Match page-view visibility (in case the tab is currently parked
+    // in the hidden window) and apply the split.
+    dt.setVisible(true);
+    const last = this.lastBoundsByKey.get(key);
+    if (last) this.applyTabLayout(key, last);
+  }
+
+  private applyZoomAction(view: WebContentsView, action: BrowserZoomArgs["action"]): void {
+    const wc = view.webContents;
+    if (wc.isDestroyed()) return;
+    let next: number;
+    if (action === "reset") {
+      next = ZOOM_DEFAULT;
+    } else {
+      const current = wc.zoomFactor;
+      next = action === "in" ? current + ZOOM_STEP : current - ZOOM_STEP;
+    }
+    // Clamp + round to 0.01 to avoid floating-point drift across many
+    // steps (0.1 * 7 = 0.7000000000000001 etc.).
+    const clamped = Math.min(ZOOM_MAX, Math.max(ZOOM_MIN, next));
+    wc.zoomFactor = Math.round(clamped * 100) / 100;
+  }
+
   destroy(args: BrowserKeyArg): void {
     const key = browserKey(args);
     const view = this.views.get(key);
     if (!view) return;
+    // If DevTools is docked for this tab, tear down the sibling view
+    // first so we don't leak a WebContentsView whose page view is gone.
+    const dt = this.devToolsViews.get(key);
+    if (dt) {
+      this.removeChildFromParent(key, dt);
+      if (!dt.webContents.isDestroyed()) dt.webContents.close();
+      this.devToolsViews.delete(key);
+    }
     const parent = this.parentByKey.get(key) ?? "main";
     const win =
       parent === "hidden" && this.opts.hiddenWindow ? this.opts.hiddenWindow : this.opts.mainWindow;
@@ -257,6 +472,7 @@ export class BrowserViewManager {
     }
     this.views.delete(key);
     this.parentByKey.delete(key);
+    this.lastBoundsByKey.delete(key);
     const idx = this.order.indexOf(key);
     if (idx >= 0) this.order.splice(idx, 1);
     // Notify the renderer (which forwards to the web server's
@@ -269,6 +485,21 @@ export class BrowserViewManager {
       workspace_id: key,
     };
     this.emit(Events.browserViewDestroyed, payload);
+  }
+
+  /**
+   * Return the live `WebContentsView` that currently has keyboard focus,
+   * or `null` if none does. Used by the main-process menu handler to
+   * route Cmd+R to "reload the page the user is in" instead of "reload
+   * the dashboard". `isDestroyed()` is checked defensively because a
+   * tab can be torn down between the menu firing and this lookup.
+   */
+  findFocused(): WebContentsView | null {
+    for (const view of this.views.values()) {
+      if (view.webContents.isDestroyed()) continue;
+      if (view.webContents.isFocused()) return view;
+    }
+    return null;
   }
 
   /** Hide every tracked view. The Rust impl ignores `workspace_id`. */
@@ -388,27 +619,111 @@ export class BrowserViewManager {
     const toWin = target === "main" ? this.opts.mainWindow : this.opts.hiddenWindow;
     fromWin.contentView.removeChildView(view);
     toWin.contentView.addChildView(view);
+    // The docked DevTools sibling has to follow — its `webContents`
+    // hosts the DevTools UI for `view`, and Chromium requires that
+    // sibling to be attached to a compositing window (else the
+    // DevTools panel goes blank).
+    const dt = this.devToolsViews.get(key);
+    if (dt) {
+      fromWin.contentView.removeChildView(dt);
+      toWin.contentView.addChildView(dt);
+    }
     this.parentByKey.set(key, target);
   }
 
+  /** Resolve the BrowserWindow for a `Parent` enum value. */
+  private windowFor(parent: Parent): BrowserWindow {
+    return parent === "hidden" && this.opts.hiddenWindow
+      ? this.opts.hiddenWindow
+      : this.opts.mainWindow;
+  }
+
+  /** Detach a child view from whichever window currently parents the
+   *  matching tab. Used when tearing down the DevTools sibling. */
+  private removeChildFromParent(key: string, child: WebContentsView): void {
+    const parent = this.parentByKey.get(key) ?? "main";
+    this.windowFor(parent).contentView.removeChildView(child);
+  }
+
+  /**
+   * Apply the renderer-reported bounds to the tab. When DevTools is
+   * docked, the bounds are split: page view gets the top portion, the
+   * DevTools sibling gets the bottom `DEVTOOLS_SPLIT_RATIO` (clamped to
+   * a minimum height so the panel stays usable on short windows).
+   */
+  private applyTabLayout(
+    key: string,
+    bounds: { x: number; y: number; width: number; height: number },
+  ): void {
+    const view = this.views.get(key);
+    if (!view) return;
+    const dt = this.devToolsViews.get(key);
+    if (!dt) {
+      this.applyBounds(view, bounds);
+      return;
+    }
+    const devHeight = Math.max(
+      DEVTOOLS_MIN_HEIGHT,
+      Math.round(bounds.height * DEVTOOLS_SPLIT_RATIO),
+    );
+    const pageHeight = Math.max(40, bounds.height - devHeight);
+    this.applyBounds(view, { ...bounds, height: pageHeight });
+    this.applyBounds(dt, {
+      x: bounds.x,
+      y: bounds.y + pageHeight,
+      width: bounds.width,
+      height: devHeight,
+    });
+  }
+
   private wireEvents(key: string, view: WebContentsView): void {
-    const emitUrl = (loading: boolean): void => {
-      // The renderer's two modes (workspace-keyed vs browser-keyed)
-      // destructure different field names. We populate both with the same
-      // value so either filter matches. The opposite key matches because
-      // the renderer compares `event.payload.workspace_id !== workspaceIdRef`
-      // (and similarly for browser_id), and the local ref equals the key
-      // we used at creation time.
+    // The renderer's two modes (workspace-keyed vs browser-keyed)
+    // destructure different field names. We populate both with the same
+    // value so either filter matches. The opposite key matches because
+    // the renderer compares `event.payload.workspace_id !== workspaceIdRef`
+    // (and similarly for browser_id), and the local ref equals the key
+    // we used at creation time.
+    const emitUrl = (url: string, loading: boolean): void => {
       const payload: BrowserUrlChangedPayload = {
-        url: view.webContents.getURL(),
+        url,
         browser_id: key,
         workspace_id: key,
         loading,
       };
       this.emit(Events.browserUrlChanged, payload);
     };
-    view.webContents.on("did-start-loading", () => emitUrl(true));
-    view.webContents.on("did-stop-loading", () => emitUrl(false));
+
+    // ---- URL & loading state ----
+    // `did-start-navigation` carries the *target* URL of a pending
+    // navigation, so we can update the address bar the moment the user
+    // clicks a link (or types and submits one). Using
+    // `did-start-loading` here was wrong: that event fires before the
+    // navigation is committed, and `webContents.getURL()` at that point
+    // still returns the OLD document's URL — so the renderer would
+    // overwrite the user's freshly-typed URL with the previous one and
+    // only "snap back" when `did-stop-loading` arrived.
+    //
+    // Notes:
+    //   - We only react to *main-frame* navigations. Iframe and
+    //     subresource loads must not touch the address bar.
+    //   - Same-document transitions (hash changes, History API
+    //     pushState) don't trigger a network load, so we set
+    //     `loading: false` for them. They still need an emit because
+    //     the URL itself changes and the address bar should reflect it.
+    //   - Redirect chains fire `did-start-navigation` for each hop, so
+    //     the address bar follows the redirect — matches Chrome's UX.
+    view.webContents.on("did-start-navigation", (details) => {
+      if (!details.isMainFrame) return;
+      emitUrl(details.url, !details.isSameDocument);
+    });
+    // `did-stop-loading` is still the right signal for "the load
+    // finished" — flips the loading indicator off and re-emits the
+    // (now-committed) URL, which corrects any drift if the final URL
+    // differs from what `did-start-navigation` reported (e.g. a 3xx
+    // chain that resolved server-side).
+    view.webContents.on("did-stop-loading", () => {
+      emitUrl(view.webContents.getURL(), false);
+    });
     view.webContents.on("page-title-updated", (_e, title) => {
       const payload: BrowserTitleChangedPayload = {
         browser_id: key,
@@ -416,6 +731,74 @@ export class BrowserViewManager {
         title,
       };
       this.emit(Events.browserTitleChanged, payload);
+    });
+
+    // ---- Find in page: stream results back to the renderer ----
+    // Chromium emits at least one `found-in-page` per `findInPage(text)`
+    // call. Large pages emit incremental updates as the scan walks the
+    // DOM — the renderer only trusts `final_update: true`, but rendering
+    // intermediate counts gives the find bar a snappy feel.
+    view.webContents.on("found-in-page", (_e, result) => {
+      const payload: BrowserFoundInPagePayload = {
+        browser_id: key,
+        workspace_id: key,
+        request_id: result.requestId,
+        active_match_ordinal: result.activeMatchOrdinal,
+        matches: result.matches,
+        final_update: result.finalUpdate,
+      };
+      this.emit(Events.browserFoundInPage, payload);
+    });
+
+    // ---- Cmd+F / Ctrl+F intercept while the webview has focus ----
+    // The renderer's DOM-level keydown listener never sees keys typed
+    // while focus is inside the child `WebContentsView` — Chromium
+    // handles them in the embedded page process. Intercept here so the
+    // shortcut still pops the find bar even when the user is focused on
+    // the rendered page (e.g. just clicked a link).
+    //
+    // `event.preventDefault()` swallows the key so Chromium doesn't also
+    // trigger any builtin shortcut (none exists for Cmd+F in
+    // WebContentsView today, but defensive against future Chromium
+    // changes).
+    view.webContents.on("before-input-event", (event, input) => {
+      if (input.type !== "keyDown") return;
+      if (input.shift || input.alt) return;
+      const modifier =
+        process.platform === "darwin" ? input.meta && !input.control : input.control && !input.meta;
+      if (!modifier) return;
+      const pressedKey = input.key.toLowerCase();
+      // Transfer keyboard focus back to the main window's webContents so
+      // the React side (find bar input, new-tab address bar, etc.)
+      // receives subsequent keystrokes instead of the WebContentsView
+      // the user was just typing into. Shared by every shortcut below.
+      const handleShortcut = (eventName: string, payload: BrowserFindShortcutPayload) => {
+        event.preventDefault();
+        if (!this.opts.mainWindow.webContents.isDestroyed()) {
+          this.opts.mainWindow.webContents.focus();
+        }
+        this.emit(eventName, payload);
+      };
+      // Cmd+F / Ctrl+F → open the find bar for this tab.
+      if (pressedKey === "f") {
+        handleShortcut(Events.browserFindShortcut, {
+          browser_id: key,
+          workspace_id: key,
+        } satisfies BrowserFindShortcutPayload);
+        return;
+      }
+      // Cmd+T / Ctrl+T → open a new sibling browser tab in the same
+      // dockview group. The renderer's `DockviewBrowserContainer`
+      // already handles Cmd+T when DOM focus is inside it; we forward
+      // the same intent for the case where Chromium consumed the
+      // keydown inside the WebContentsView.
+      if (pressedKey === "t") {
+        handleShortcut(Events.browserNewTabShortcut, {
+          browser_id: key,
+          workspace_id: key,
+        } satisfies BrowserNewTabShortcutPayload);
+        return;
+      }
     });
   }
 

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -167,7 +167,9 @@ async function bootstrap(): Promise<void> {
 
   // Install the application menu (Edit/View/Settings + accelerators) before
   // creating the window so Cmd+, etc. are bound from the first frame.
-  installAppMenu();
+  // The Reload item resolves `state.browserManager` lazily because the
+  // manager is constructed later, after `createMainWindow`.
+  installAppMenu({ getBrowserManager: () => state.browserManager });
 
   // macOS dock icon. In a packaged build this comes from the .app's .icns
   // (Info.plist resolves CFBundleIconFile); in dev there's no bundle so we

--- a/apps/desktop/src/main/ipc/browser.ts
+++ b/apps/desktop/src/main/ipc/browser.ts
@@ -10,8 +10,11 @@ import type {
   BrowserCreateArgs,
   BrowserEnsureArgs,
   BrowserEvalArgs,
+  BrowserFindInPageArgs,
   BrowserKeyArg,
   BrowserNavigateArgs,
+  BrowserStopFindInPageArgs,
+  BrowserZoomArgs,
 } from "../../shared/types.js";
 
 export interface BrowserIpcContext {
@@ -35,4 +38,11 @@ export const browserHandlers = {
   ensure: (ctx: BrowserIpcContext, args: BrowserEnsureArgs): void => ctx.manager.ensure(args),
   getCdpTarget: (ctx: BrowserIpcContext, args: BrowserKeyArg): Promise<string> =>
     ctx.manager.getCdpTargetId(args),
+  findInPage: (ctx: BrowserIpcContext, args: BrowserFindInPageArgs): number | undefined =>
+    ctx.manager.findInPage(args),
+  stopFindInPage: (ctx: BrowserIpcContext, args: BrowserStopFindInPageArgs): void =>
+    ctx.manager.stopFindInPage(args),
+  zoom: (ctx: BrowserIpcContext, args: BrowserZoomArgs): void => ctx.manager.zoom(args),
+  toggleDevTools: (ctx: BrowserIpcContext, args: BrowserKeyArg): void =>
+    ctx.manager.toggleDevTools(args),
 };

--- a/apps/desktop/src/main/ipc/register.ts
+++ b/apps/desktop/src/main/ipc/register.ts
@@ -14,8 +14,11 @@ import type {
   BrowserCreateArgs,
   BrowserEnsureArgs,
   BrowserEvalArgs,
+  BrowserFindInPageArgs,
   BrowserKeyArg,
   BrowserNavigateArgs,
+  BrowserStopFindInPageArgs,
+  BrowserZoomArgs,
   CheckAppExistsArgs,
   InstallCliArgs,
   OpenExternalArgs,
@@ -125,6 +128,19 @@ export function registerIpc(opts: RegisterOptions): () => void {
   handle(Channels.browserEnsure, (args: BrowserEnsureArgs) => browserHandlers.ensure(bm, args));
   handle(Channels.browserGetCdpTarget, (args: BrowserKeyArg) =>
     browserHandlers.getCdpTarget(bm, args),
+  );
+  // Find in page
+  handle(Channels.browserFindInPage, (args: BrowserFindInPageArgs) =>
+    browserHandlers.findInPage(bm, args),
+  );
+  handle(Channels.browserStopFindInPage, (args: BrowserStopFindInPageArgs) =>
+    browserHandlers.stopFindInPage(bm, args),
+  );
+  // Per-tab zoom
+  handle(Channels.browserZoom, (args: BrowserZoomArgs) => browserHandlers.zoom(bm, args));
+  // Toggle DevTools for a browser tab
+  handle(Channels.browserToggleDevTools, (args: BrowserKeyArg) =>
+    browserHandlers.toggleDevTools(bm, args),
   );
 
   return () => {

--- a/apps/desktop/src/main/menu.ts
+++ b/apps/desktop/src/main/menu.ts
@@ -20,8 +20,18 @@
  */
 
 import { app, BrowserWindow, Menu, type MenuItemConstructorOptions } from "electron";
+import type { BrowserViewManager } from "../browser/view-manager.js";
 import { dashLog } from "./services/log.js";
 import { checkForUpdate, isUpdaterEnabled } from "./updater.js";
+
+/**
+ * Resolved at menu-click time so the menu can be installed before the
+ * `BrowserViewManager` exists (we install the menu in `app.whenReady`,
+ * the manager is constructed after the main window is created).
+ */
+export interface MenuDeps {
+  getBrowserManager: () => BrowserViewManager | null;
+}
 
 /** Run JS in whichever window is focused, falling back to the main window. */
 function evalInFocused(js: string): void {
@@ -33,6 +43,20 @@ function evalInFocused(js: string): void {
   void target.webContents.executeJavaScript(js, true).catch(() => {
     // Renderer hasn't registered the global yet (e.g. mid-reload). Drop.
   });
+}
+
+/**
+ * Cmd+= / Cmd+- / Actual-Size routing — same shape as `reloadFocused`:
+ *
+ *   1. WebContentsView has focus (user is in a rendered web page) →
+ *      adjust that view's `zoomFactor` directly.
+ *   2. Otherwise call `window.__bandZoom(action)`, which decides between
+ *      "zoom the browser pane the user is in" (IPC back to
+ *      `browser_zoom`) and "zoom the dashboard chrome".
+ */
+function zoomFocused(deps: MenuDeps, action: "in" | "out" | "reset"): void {
+  if (deps.getBrowserManager()?.zoomFocused(action)) return;
+  evalInFocused(`if(window.__bandZoom)window.__bandZoom(${JSON.stringify(action)})`);
 }
 
 /**
@@ -76,13 +100,55 @@ async function callRendererGlobal(name: string): Promise<void> {
   }
 }
 
-function reloadFocused(): void {
-  const target = BrowserWindow.getFocusedWindow();
+/**
+ * Cmd+R / Ctrl+R reload, routed by what's actually focused:
+ *
+ *   1. If a browser-pane `WebContentsView` has keyboard focus (the user
+ *      is clicked inside a rendered web page), reload that view — don't
+ *      reload the whole dashboard out from under them.
+ *
+ *   2. Otherwise call the renderer's `__bandReload` global. If keyboard
+ *      focus is in a browser-pane's *React* chrome (address bar, find
+ *      bar, tab handle), the global locates the pane via the
+ *      `data-band-browser-pane-*` attributes and reloads its tab via
+ *      `browser_reload` IPC. If focus is anywhere else, the global
+ *      falls through to `location.reload()` — same effect as the
+ *      previous dumb behaviour.
+ *
+ *   3. If the renderer global isn't registered (preload missing, or
+ *      called before the React tree mounted), reload the focused window
+ *      directly so the menu item still does *something*.
+ */
+async function reloadFocused(deps: MenuDeps): Promise<void> {
+  const focusedView = deps.getBrowserManager()?.findFocused();
+  if (focusedView) {
+    focusedView.webContents.reload();
+    return;
+  }
+
+  const target =
+    BrowserWindow.getFocusedWindow() ??
+    BrowserWindow.getAllWindows().find((w) => !w.isDestroyed()) ??
+    null;
   if (!target) return;
-  target.webContents.reload();
+
+  // `__bandReload` returns true if it consumed the event (either
+  // reloaded a browser pane or chose to reload the app itself). If it's
+  // not registered we get false and fall back to reloading the window.
+  const js = `(() => {
+    if (typeof window.__bandReload === "function") { window.__bandReload(); return true; }
+    return false;
+  })()`;
+  try {
+    const handled = await target.webContents.executeJavaScript(js, true);
+    if (!handled) target.webContents.reload();
+  } catch (err) {
+    dashLog(`menu: __bandReload invocation failed: ${String(err)}`);
+    target.webContents.reload();
+  }
 }
 
-export function buildAppMenu(): Menu {
+export function buildAppMenu(deps: MenuDeps): Menu {
   const isMac = process.platform === "darwin";
 
   const appName = app.name ?? "Band";
@@ -131,25 +197,27 @@ export function buildAppMenu(): Menu {
     {
       label: "Reload",
       accelerator: "CmdOrCtrl+R",
-      click: () => reloadFocused(),
+      click: () => {
+        void reloadFocused(deps);
+      },
     },
     { type: "separator" },
     {
       label: "Zoom In",
       accelerator: "CmdOrCtrl+=",
-      click: () => evalInFocused("if(window.__bandZoom)window.__bandZoom('in')"),
+      click: () => zoomFocused(deps, "in"),
     },
     {
       label: "Zoom Out",
       accelerator: "CmdOrCtrl+-",
-      click: () => evalInFocused("if(window.__bandZoom)window.__bandZoom('out')"),
+      click: () => zoomFocused(deps, "out"),
     },
     // Zoom-reset deliberately has no accelerator: CmdOrCtrl+0 is owned by
     // the dashboard's "All projects" label filter (see DashboardShell).
     // Reset is still reachable here via menu click.
     {
       label: "Actual Size",
-      click: () => evalInFocused("if(window.__bandZoom)window.__bandZoom('reset')"),
+      click: () => zoomFocused(deps, "reset"),
     },
     { type: "separator" },
     {
@@ -189,6 +257,6 @@ export function buildAppMenu(): Menu {
   return Menu.buildFromTemplate(template);
 }
 
-export function installAppMenu(): void {
-  Menu.setApplicationMenu(buildAppMenu());
+export function installAppMenu(deps: MenuDeps): void {
+  Menu.setApplicationMenu(buildAppMenu(deps));
 }

--- a/apps/desktop/src/preload/index.cts
+++ b/apps/desktop/src/preload/index.cts
@@ -65,12 +65,22 @@ const ALLOWED_INVOKE_CHANNELS = new Set<string>([
   // CDP screencast experiment bridge
   "browser_ensure",
   "browser_get_cdp_target",
+  // Find in page (Cmd+F / Ctrl+F overlay)
+  "browser_find_in_page",
+  "browser_stop_find_in_page",
+  // Per-tab zoom (Cmd+= / Cmd+- / Actual Size)
+  "browser_zoom",
+  // Toggle Chromium DevTools for a browser tab
+  "browser_toggle_dev_tools",
 ]);
 
 const ALLOWED_EVENT_NAMES = new Set<string>([
   "browser-url-changed",
   "browser-title-changed",
   "browser-view-destroyed",
+  "browser-found-in-page",
+  "browser-find-shortcut",
+  "browser-new-tab-shortcut",
   "window-fullscreen-changed",
   "updater-status-changed",
 ]);

--- a/apps/desktop/src/shared/ipc-channels.ts
+++ b/apps/desktop/src/shared/ipc-channels.ts
@@ -55,9 +55,10 @@ export const Channels = {
   // dashboard's `document.documentElement.style.zoom` and from other
   // tabs.
   browserZoom: "browser_zoom",
-  // Toggle Chromium DevTools for the matching view. Opens in a
-  // detached window because a `WebContentsView` has no host window of
-  // its own to dock the panel into.
+  // Toggle Chromium DevTools for the matching view. DevTools is docked
+  // inside the tab area (bottom split) via a sibling `WebContentsView`
+  // wired up with `setDevToolsWebContents` — not as a detached OS
+  // window.
   browserToggleDevTools: "browser_toggle_dev_tools",
 } as const;
 

--- a/apps/desktop/src/shared/ipc-channels.ts
+++ b/apps/desktop/src/shared/ipc-channels.ts
@@ -44,6 +44,21 @@ export const Channels = {
   // chromium-side targetId.
   browserEnsure: "browser_ensure",
   browserGetCdpTarget: "browser_get_cdp_target",
+  // Find-in-page (Cmd+F / Ctrl+F overlay on a browser tab). The main
+  // process calls Electron's native `webContents.findInPage` so matches
+  // are highlighted by Chromium itself; results stream back as
+  // `browser-found-in-page` events.
+  browserFindInPage: "browser_find_in_page",
+  browserStopFindInPage: "browser_stop_find_in_page",
+  // Per-tab zoom (Cmd+= / Cmd+- / Actual Size). Adjusts
+  // `webContents.zoomFactor` on the matching view — independent of the
+  // dashboard's `document.documentElement.style.zoom` and from other
+  // tabs.
+  browserZoom: "browser_zoom",
+  // Toggle Chromium DevTools for the matching view. Opens in a
+  // detached window because a `WebContentsView` has no host window of
+  // its own to dock the panel into.
+  browserToggleDevTools: "browser_toggle_dev_tools",
 } as const;
 
 export type ChannelName = (typeof Channels)[keyof typeof Channels];
@@ -56,6 +71,21 @@ export const Events = {
    *  this to invalidate the server's bandTabId → cdpTargetId cache via
    *  the `browserHost.viewDestroyed` tRPC mutation. */
   browserViewDestroyed: "browser-view-destroyed",
+  /** Streamed for every `webContents.findInPage` request (one initial
+   *  result + zero or more updates ending with `final_update: true`).
+   *  Drives the match counter (`3 of 12`) in the renderer find bar. */
+  browserFoundInPage: "browser-found-in-page",
+  /** Pushed when the user presses Cmd+F / Ctrl+F while keyboard focus is
+   *  inside the WebContentsView. The renderer's DOM-level keydown
+   *  listener never sees those events (Chromium consumes them inside the
+   *  child view) so the main process intercepts them via
+   *  `before-input-event` and forwards them back as this event for the
+   *  React find bar to open. */
+  browserFindShortcut: "browser-find-shortcut",
+  /** Pushed when the user presses Cmd+T / Ctrl+T while focus is inside a
+   *  WebContentsView. The renderer's DockviewBrowserContainer reacts by
+   *  opening a new tab in whichever container holds the source pane. */
+  browserNewTabShortcut: "browser-new-tab-shortcut",
   windowFullscreenChanged: "window-fullscreen-changed",
   /** Pushed by the main process when the background updater detects (or
    *  clears) a pending app update. Payload: `PendingUpdate` from

--- a/apps/desktop/src/shared/types.ts
+++ b/apps/desktop/src/shared/types.ts
@@ -63,6 +63,57 @@ export interface BrowserEnsureArgs extends BrowserKeyArg {
   url: string;
 }
 
+/**
+ * Forwarded verbatim to Electron's `webContents.findInPage(text, options)`.
+ *
+ *   - **First search** for a given query: omit `findNext` (or set false).
+ *     Chromium runs the full match scan and emits a `found-in-page` event
+ *     with `matches` set to the total count.
+ *   - **Step to next/previous match**: set `findNext: true` and toggle
+ *     `forward` to control direction. Chromium reuses the cached result
+ *     set instead of rescanning, so the counter stays in sync.
+ *
+ * `matchCase` is the only option Chromium reliably honours today —
+ * `wordStart` / `medialCapitalAsWordStart` are accepted for forward
+ * compatibility but have no visible effect, and `regex` is not supported
+ * at all. Callers should hide UI toggles for unsupported options
+ * (`SearchBar`'s `visibleOptions` prop) rather than silently surface a
+ * no-op control.
+ */
+export interface BrowserFindInPageArgs extends BrowserKeyArg {
+  text: string;
+  options?: {
+    forward?: boolean;
+    findNext?: boolean;
+    matchCase?: boolean;
+    wordStart?: boolean;
+    medialCapitalAsWordStart?: boolean;
+  };
+}
+
+/**
+ * Stop an active `findInPage` session. `action` controls what happens to
+ * the page selection — defaults to `clearSelection` which removes both
+ * the highlight and the selection so closing the find bar leaves the
+ * page visually undisturbed.
+ */
+export interface BrowserStopFindInPageArgs extends BrowserKeyArg {
+  action?: "clearSelection" | "keepSelection" | "activateSelection";
+}
+
+/**
+ * Per-tab zoom adjustment.
+ *
+ *   - `"in"` / `"out"` step the existing `webContents.zoomFactor` by a
+ *     fixed amount (currently 0.1, matching the dashboard's zoom step).
+ *   - `"reset"` sets it back to 1.0 (100%).
+ *
+ * Clamped to [0.5, 2.0] to mirror the dashboard's range.
+ */
+export interface BrowserZoomArgs extends BrowserKeyArg {
+  action: "in" | "out" | "reset";
+}
+
 /** Resolve the LRU key from whichever id the renderer included. */
 export function browserKey(args: BrowserKeyArg): string {
   return args.browserId ?? args.workspaceId ?? "";
@@ -90,6 +141,46 @@ export interface BrowserTitleChangedPayload {
  * bandTabId → cdpTargetId cache.
  */
 export interface BrowserViewDestroyedPayload {
+  browser_id: string;
+  workspace_id: string;
+}
+
+/**
+ * One result tick from a `webContents.findInPage` request. Chromium
+ * emits at least one event per request and may stream incremental
+ * updates as it scans large pages — `final_update` flips to `true` on
+ * the last event for the request, at which point `matches` is the
+ * authoritative total. `active_match_ordinal` is 1-indexed (or 0 when
+ * the query is empty / no match is selected).
+ */
+export interface BrowserFoundInPagePayload {
+  browser_id: string;
+  workspace_id: string;
+  request_id: number;
+  active_match_ordinal: number;
+  matches: number;
+  final_update: boolean;
+}
+
+/**
+ * Emitted when the user presses the find-in-page shortcut (Cmd+F on
+ * macOS, Ctrl+F elsewhere) while keyboard focus is *inside* the
+ * `WebContentsView` — i.e. the React DOM cannot see the keydown. The
+ * renderer reacts the same way it does to its own keydown handler:
+ * opens the find bar for the matching tab.
+ */
+export interface BrowserFindShortcutPayload {
+  browser_id: string;
+  workspace_id: string;
+}
+
+/**
+ * Emitted when the user presses Cmd+T / Ctrl+T while keyboard focus is
+ * inside a `WebContentsView`. Carries the source tab's key so the
+ * renderer can locate the right `DockviewBrowserContainer` and add a
+ * new sibling tab into it.
+ */
+export interface BrowserNewTabShortcutPayload {
   browser_id: string;
   workspace_id: string;
 }

--- a/apps/desktop/tests/browser-layout.test.ts
+++ b/apps/desktop/tests/browser-layout.test.ts
@@ -1,0 +1,71 @@
+/**
+ * Pure-function tests for `splitTabBounds` (the geometry used to dock
+ * Chromium DevTools at the bottom of a browser tab). No Electron deps,
+ * so the test runs under `node:test` like the other desktop tests.
+ *
+ * The invariants enforced here exist because the DevTools dock has to
+ * cope with very short windows — early versions of this code clamped
+ * `devHeight` to a minimum without also capping it, causing
+ * `page.height + dev.height` to exceed the outer bounds.
+ */
+
+import { strict as assert } from "node:assert";
+import { describe, test } from "node:test";
+
+import { splitTabBounds } from "../src/browser/layout.ts";
+
+const OPTIONS = { splitRatio: 0.4, devMinHeight: 160, pageMinHeight: 40 };
+
+describe("splitTabBounds", () => {
+  test("comfortable window: dev = round(height * splitRatio)", () => {
+    const { page, dev } = splitTabBounds({ x: 10, y: 20, width: 800, height: 1000 }, OPTIONS);
+    assert.equal(dev.height, 400);
+    assert.equal(page.height, 600);
+    assert.equal(page.x, 10);
+    assert.equal(page.y, 20);
+    assert.equal(page.width, 800);
+    assert.equal(dev.x, 10);
+    assert.equal(dev.y, 620);
+    assert.equal(dev.width, 800);
+  });
+
+  test("medium window: split honours dev min-height when ratio would go below it", () => {
+    // 350 * 0.4 = 140 < devMinHeight (160) → bumped to 160.
+    const { page, dev } = splitTabBounds({ x: 0, y: 0, width: 600, height: 350 }, OPTIONS);
+    assert.equal(dev.height, 160);
+    assert.equal(page.height, 190);
+  });
+
+  test("short window: page+dev still sum to bounds.height (no overflow)", () => {
+    // 180 < devMinHeight + pageMinHeight = 200; the naive clamp would
+    // overflow.  Dev gets `height - pageMinHeight = 140`, page gets 40.
+    const { page, dev } = splitTabBounds({ x: 0, y: 0, width: 600, height: 180 }, OPTIONS);
+    assert.equal(page.height + dev.height, 180);
+    assert.equal(page.height, 40);
+    assert.equal(dev.height, 140);
+  });
+
+  test("very short window (< pageMinHeight): dev sacrificed, page = bounds.height", () => {
+    const { page, dev } = splitTabBounds({ x: 0, y: 0, width: 600, height: 20 }, OPTIONS);
+    assert.equal(page.height, 20);
+    assert.equal(dev.height, 0);
+    assert.equal(page.height + dev.height, 20);
+  });
+
+  test("zero-height bounds: both pieces collapse to 0", () => {
+    const { page, dev } = splitTabBounds({ x: 0, y: 0, width: 600, height: 0 }, OPTIONS);
+    assert.equal(page.height, 0);
+    assert.equal(dev.height, 0);
+  });
+
+  test("invariant: page and dev are vertically adjacent (dev.y = page.y + page.height)", () => {
+    const samples = [50, 180, 240, 600, 1000, 4000];
+    for (const height of samples) {
+      const { page, dev } = splitTabBounds({ x: 17, y: 23, width: 800, height }, OPTIONS);
+      assert.equal(dev.y, page.y + page.height, `mismatch at height=${height}`);
+      assert.equal(page.height + dev.height, height, `sum mismatch at height=${height}`);
+      assert.equal(page.x, dev.x);
+      assert.equal(page.width, dev.width);
+    }
+  });
+});

--- a/apps/web/src/components/BrowserFindBar.tsx
+++ b/apps/web/src/components/BrowserFindBar.tsx
@@ -1,0 +1,32 @@
+/**
+ * Thin presentational wrapper around the shared `SearchBar` for the
+ * browser pane. Renders as a full-width strip directly below the
+ * address bar — the WebContentsView shrinks naturally because the
+ * strip participates in the flex column.
+ *
+ * The toggles other than match-case are hidden: Chromium's
+ * `webContents.findInPage` only reliably implements `matchCase` —
+ * `wholeWord`/`regex` would be silent no-ops.
+ */
+
+import { SearchBar } from "@band-app/dashboard-core";
+import type { UseBrowserFindInPageReturn } from "../hooks/useBrowserFindInPage";
+
+export function BrowserFindBar({ find }: { find: UseBrowserFindInPageReturn }) {
+  if (!find.isOpen) return null;
+  return (
+    <SearchBar
+      ref={find.searchBarRef}
+      query={find.query}
+      onQueryChange={find.setQuery}
+      options={find.options}
+      onOptionsChange={find.setOptions}
+      placeholder="Find in page"
+      matchInfo={find.matchInfo ?? undefined}
+      onNext={find.findNext}
+      onPrevious={find.findPrevious}
+      onClose={find.close}
+      visibleOptions={["caseSensitive"]}
+    />
+  );
+}

--- a/apps/web/src/components/BrowserPanel.tsx
+++ b/apps/web/src/components/BrowserPanel.tsx
@@ -1,7 +1,7 @@
 import type { IDockviewPanelProps } from "dockview";
 import { ArrowLeft, ArrowRight, RotateCw, Wrench, X } from "lucide-react";
 import { useCallback, useEffect, useRef, useState, useSyncExternalStore } from "react";
-import { useBrowserFindInPage } from "../hooks/useBrowserFindInPage";
+import { useBrowserPaneControls } from "../hooks/useBrowserPaneControls";
 import { invoke as desktopInvoke, listen as desktopListen } from "../lib/desktop-ipc";
 import { isDesktop } from "../lib/is-desktop";
 import { trpc } from "../lib/trpc-client";
@@ -92,13 +92,10 @@ export function BrowserPanelComponent({ params, api }: IDockviewPanelProps<Brows
   workspaceIdRef.current = workspaceId;
   const currentUrlRef = useRef(currentUrl);
   currentUrlRef.current = currentUrl;
-  // `inputUrl` is user-owned while the address-bar input has keyboard
-  // focus: incoming `browser-url-changed` events (e.g. navigation
-  // completing, redirects, in-page hash updates) must not overwrite
-  // the half-typed URL the user is editing. We sync from focus/blur
-  // rather than reading `document.activeElement` so the check stays
-  // synchronous inside the event listener.
-  const addressInputFocusedRef = useRef(false);
+  // `addressInputFocusedRef` is now owned by `useBrowserPaneControls`
+  // — it's destructured back out below and read inside the
+  // `browser-url-changed` listener to skip clobbering an in-progress
+  // address-bar edit.
 
   // ------- restore persisted URL when workspaceId becomes available -------
   // useState initializers run on first mount when workspaceId may still be
@@ -190,7 +187,12 @@ export function BrowserPanelComponent({ params, api }: IDockviewPanelProps<Brows
   }, [created, getBounds, invoke, workspaceId]);
 
   // ------- listen for URL changes from the Rust side -------
+  // Refs (`workspaceIdRef`, `addressInputFocusedRef`) are intentionally
+  // read via `.current` inside the listener — adding `.current` to the
+  // deps would force the listener to re-bind on every focus/blur or
+  // workspace switch.
 
+  // biome-ignore lint/correctness/useExhaustiveDependencies: see above
   useEffect(() => {
     if (!isDesktop) return;
     let unlisten: (() => void) | undefined;
@@ -379,73 +381,24 @@ export function BrowserPanelComponent({ params, api }: IDockviewPanelProps<Brows
     }
   }, [invoke, workspaceId]);
 
-  const handleToggleDevTools = useCallback(async () => {
-    try {
-      await invoke("browser_toggle_dev_tools", { workspaceId });
-    } catch (e) {
-      console.error("browser_toggle_dev_tools failed:", e);
-    }
-  }, [invoke, workspaceId]);
-
-  const handleKeyDown = useCallback(
-    (e: React.KeyboardEvent<HTMLInputElement>) => {
-      if (e.key === "Enter") {
-        e.preventDefault();
-        handleNavigate(inputUrl);
-        return;
-      }
-      // Escape abandons an in-progress edit and snaps the input back
-      // to the canonical URL with the whole value re-selected — same
-      // as Chrome's address bar. Keep focus so the user can type to
-      // replace without re-clicking the bar.
-      if (e.key === "Escape") {
-        e.preventDefault();
-        setInputUrl(currentUrlRef.current);
-        const input = e.currentTarget;
-        // Defer past the React commit so we select against the
-        // restored value (setting `input.value` mid-render would clear
-        // any selection we made here).
-        requestAnimationFrame(() => input.select());
-      }
-    },
-    [inputUrl, handleNavigate],
-  );
-
-  const handleAddressFocus = useCallback((e: React.FocusEvent<HTMLInputElement>) => {
-    addressInputFocusedRef.current = true;
-    e.target.select();
-  }, []);
-
-  const handleAddressBlur = useCallback(() => {
-    addressInputFocusedRef.current = false;
-    // Re-sync to the latest committed URL in case events fired (and
-    // were ignored) while we were focused. Matches Chrome: typed-but-
-    // not-submitted URLs revert on blur.
-    setInputUrl(currentUrlRef.current);
-  }, []);
-
-  // ------- find in page -------
-  const find = useBrowserFindInPage({ key: workspaceId, keyName: "workspaceId" });
-
-  // Pane-scoped Cmd+F / Ctrl+F handler. Covers the case where keyboard
-  // focus is inside the React DOM (address bar, find bar input, the
-  // panel itself). The complementary case — focus inside the
-  // WebContentsView — is handled by the main process via
-  // `before-input-event` and reaches the hook through the
-  // `browser-find-shortcut` event.
-  const handlePaneKeyDown = useCallback(
-    (e: React.KeyboardEvent<HTMLDivElement>) => {
-      if (e.key.toLowerCase() !== "f") return;
-      if (e.shiftKey || e.altKey) return;
-      const isMac = navigator.platform.toLowerCase().includes("mac");
-      const wantsFind = isMac ? e.metaKey && !e.ctrlKey : e.ctrlKey && !e.metaKey;
-      if (!wantsFind) return;
-      e.preventDefault();
-      e.stopPropagation();
-      find.open();
-    },
-    [find],
-  );
+  // ------- pane chrome controls (find bar, DevTools, address-bar UX) -------
+  const {
+    find,
+    addressInputFocusedRef,
+    handleAddressFocus,
+    handleAddressBlur,
+    handleAddressKeyDown,
+    handlePaneKeyDown,
+    handleToggleDevTools,
+    paneDataAttrs,
+  } = useBrowserPaneControls({
+    key: workspaceId,
+    keyName: "workspaceId",
+    currentUrlRef,
+    setInputUrl,
+    inputUrl,
+    onNavigate: handleNavigate,
+  });
 
   // Don't render until workspaceId is injected — during layout sync fromJSON
   // recreates panels with empty params before injectParams runs a tick later.
@@ -465,13 +418,12 @@ export function BrowserPanelComponent({ params, api }: IDockviewPanelProps<Brows
     <div
       className="flex h-full w-full flex-col"
       onKeyDown={handlePaneKeyDown}
-      // Cmd+R routing: the desktop menu's renderer-global handler walks
-      // up from `document.activeElement` looking for these data attrs
-      // to decide whether to reload this tab or fall through to the
-      // app.
-      data-band-browser-pane=""
-      data-band-browser-pane-key={workspaceId}
-      data-band-browser-pane-keyname="workspaceId"
+      // Cmd+R / Cmd+= routing: the desktop menu's renderer-global
+      // handlers walk up from `document.activeElement` looking for
+      // these data attrs to decide whether to act on this tab or fall
+      // through to the app. Sourced from `useBrowserPaneControls` so
+      // both panel variants stay in sync.
+      {...paneDataAttrs}
     >
       {/* Keyframes for the loading bar (injected once, deduped by browser) */}
       <style>{`@keyframes browser-bar-slide {
@@ -520,7 +472,7 @@ export function BrowserPanelComponent({ params, api }: IDockviewPanelProps<Brows
           type="text"
           value={inputUrl}
           onChange={(e) => setInputUrl(e.target.value)}
-          onKeyDown={handleKeyDown}
+          onKeyDown={handleAddressKeyDown}
           onFocus={handleAddressFocus}
           onBlur={handleAddressBlur}
           className="min-w-0 flex-1 rounded border border-transparent bg-muted/50 px-3 py-1.5 text-sm text-foreground outline-none transition-colors focus:border-border"
@@ -584,9 +536,10 @@ export function BrowserPaneComponent({
   browserIdRef.current = browserId;
   const currentUrlRef = useRef(currentUrl);
   currentUrlRef.current = currentUrl;
-  // While the address-bar input has focus, the user owns `inputUrl` —
-  // browser-url-changed events must not overwrite an in-progress edit.
-  const addressInputFocusedRef = useRef(false);
+  // `addressInputFocusedRef` is destructured from
+  // `useBrowserPaneControls` below and read inside the
+  // `browser-url-changed` listener to skip clobbering an in-progress
+  // address-bar edit.
 
   // ------- helpers -------
 
@@ -688,8 +641,14 @@ export function BrowserPaneComponent({
 
   // ------- listen for URL / title changes from the Rust side -------
   // Persist URL to server (debounced) so it survives workspace switches.
+  // Refs (`browserIdRef`, `currentUrlRef`, `addressInputFocusedRef`,
+  // `urlPersistTimer`) are read via `.current` inside the listener —
+  // adding `.current` to the deps would force the listener to re-bind
+  // every URL/focus change. The `api` dep is the only thing that
+  // should re-bind this effect.
   const urlPersistTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
+  // biome-ignore lint/correctness/useExhaustiveDependencies: see above
   useEffect(() => {
     if (!isDesktop) return;
     let unlistenUrl: (() => void) | undefined;
@@ -900,66 +859,24 @@ export function BrowserPaneComponent({
     }
   }, [invoke, browserId]);
 
-  const handleToggleDevTools = useCallback(async () => {
-    try {
-      await invoke("browser_toggle_dev_tools", { browserId });
-    } catch (e) {
-      console.error("browser_toggle_dev_tools failed:", e);
-    }
-  }, [invoke, browserId]);
-
-  const handleKeyDown = useCallback(
-    (e: React.KeyboardEvent<HTMLInputElement>) => {
-      if (e.key === "Enter") {
-        e.preventDefault();
-        handleNavigate(inputUrl);
-        return;
-      }
-      // Escape abandons an in-progress edit and snaps the input back
-      // to the canonical URL with the whole value re-selected — same
-      // as Chrome's address bar. Keep focus so the user can type to
-      // replace without re-clicking the bar.
-      if (e.key === "Escape") {
-        e.preventDefault();
-        setInputUrl(currentUrlRef.current);
-        const input = e.currentTarget;
-        // Defer past the React commit so we select against the
-        // restored value (setting `input.value` mid-render would clear
-        // any selection we made here).
-        requestAnimationFrame(() => input.select());
-      }
-    },
-    [inputUrl, handleNavigate],
-  );
-
-  const handleAddressFocus = useCallback((e: React.FocusEvent<HTMLInputElement>) => {
-    addressInputFocusedRef.current = true;
-    e.target.select();
-  }, []);
-
-  const handleAddressBlur = useCallback(() => {
-    addressInputFocusedRef.current = false;
-    // Re-sync to the latest committed URL in case events fired (and
-    // were ignored) while we were focused.
-    setInputUrl(currentUrlRef.current);
-  }, []);
-
-  // ------- find in page -------
-  const find = useBrowserFindInPage({ key: browserId, keyName: "browserId" });
-
-  const handlePaneKeyDown = useCallback(
-    (e: React.KeyboardEvent<HTMLDivElement>) => {
-      if (e.key.toLowerCase() !== "f") return;
-      if (e.shiftKey || e.altKey) return;
-      const isMac = navigator.platform.toLowerCase().includes("mac");
-      const wantsFind = isMac ? e.metaKey && !e.ctrlKey : e.ctrlKey && !e.metaKey;
-      if (!wantsFind) return;
-      e.preventDefault();
-      e.stopPropagation();
-      find.open();
-    },
-    [find],
-  );
+  // ------- pane chrome controls (find bar, DevTools, address-bar UX) -------
+  const {
+    find,
+    addressInputFocusedRef,
+    handleAddressFocus,
+    handleAddressBlur,
+    handleAddressKeyDown,
+    handlePaneKeyDown,
+    handleToggleDevTools,
+    paneDataAttrs,
+  } = useBrowserPaneControls({
+    key: browserId,
+    keyName: "browserId",
+    currentUrlRef,
+    setInputUrl,
+    inputUrl,
+    onNavigate: handleNavigate,
+  });
 
   if (!browserId) return null;
 
@@ -972,13 +889,7 @@ export function BrowserPaneComponent({
   }
 
   return (
-    <div
-      className="flex h-full w-full flex-col"
-      onKeyDown={handlePaneKeyDown}
-      data-band-browser-pane=""
-      data-band-browser-pane-key={browserId}
-      data-band-browser-pane-keyname="browserId"
-    >
+    <div className="flex h-full w-full flex-col" onKeyDown={handlePaneKeyDown} {...paneDataAttrs}>
       <style>{`@keyframes browser-bar-slide {
   0% { transform: translateX(-100%); }
   50% { transform: translateX(200%); }
@@ -1024,7 +935,7 @@ export function BrowserPaneComponent({
           type="text"
           value={inputUrl}
           onChange={(e) => setInputUrl(e.target.value)}
-          onKeyDown={handleKeyDown}
+          onKeyDown={handleAddressKeyDown}
           onFocus={handleAddressFocus}
           onBlur={handleAddressBlur}
           className="min-w-0 flex-1 rounded border border-transparent bg-muted/50 px-3 py-1.5 text-sm text-foreground outline-none transition-colors focus:border-border"

--- a/apps/web/src/components/BrowserPanel.tsx
+++ b/apps/web/src/components/BrowserPanel.tsx
@@ -1,9 +1,11 @@
 import type { IDockviewPanelProps } from "dockview";
-import { ArrowLeft, ArrowRight, RotateCw, X } from "lucide-react";
+import { ArrowLeft, ArrowRight, RotateCw, Wrench, X } from "lucide-react";
 import { useCallback, useEffect, useRef, useState, useSyncExternalStore } from "react";
+import { useBrowserFindInPage } from "../hooks/useBrowserFindInPage";
 import { invoke as desktopInvoke, listen as desktopListen } from "../lib/desktop-ipc";
 import { isDesktop } from "../lib/is-desktop";
 import { trpc } from "../lib/trpc-client";
+import { BrowserFindBar } from "./BrowserFindBar";
 
 const DEFAULT_URL = "";
 const BLANK_URL = "about:blank";
@@ -90,6 +92,13 @@ export function BrowserPanelComponent({ params, api }: IDockviewPanelProps<Brows
   workspaceIdRef.current = workspaceId;
   const currentUrlRef = useRef(currentUrl);
   currentUrlRef.current = currentUrl;
+  // `inputUrl` is user-owned while the address-bar input has keyboard
+  // focus: incoming `browser-url-changed` events (e.g. navigation
+  // completing, redirects, in-page hash updates) must not overwrite
+  // the half-typed URL the user is editing. We sync from focus/blur
+  // rather than reading `document.activeElement` so the check stays
+  // synchronous inside the event listener.
+  const addressInputFocusedRef = useRef(false);
 
   // ------- restore persisted URL when workspaceId becomes available -------
   // useState initializers run on first mount when workspaceId may still be
@@ -199,7 +208,13 @@ export function BrowserPanelComponent({ params, api }: IDockviewPanelProps<Brows
         // Don't sync about:blank to the address bar or localStorage
         if (url === BLANK_URL) return;
         setCurrentUrl(url);
-        setInputUrl(url);
+        // Preserve in-progress edits: while the user is typing in the
+        // address bar, the canonical URL still updates behind the scenes
+        // but the visible input value is left alone. See the matching
+        // logic in `BrowserPaneComponent` below.
+        if (!addressInputFocusedRef.current) {
+          setInputUrl(url);
+        }
         saveUrl(workspaceIdRef.current, url);
       });
     })();
@@ -364,14 +379,72 @@ export function BrowserPanelComponent({ params, api }: IDockviewPanelProps<Brows
     }
   }, [invoke, workspaceId]);
 
+  const handleToggleDevTools = useCallback(async () => {
+    try {
+      await invoke("browser_toggle_dev_tools", { workspaceId });
+    } catch (e) {
+      console.error("browser_toggle_dev_tools failed:", e);
+    }
+  }, [invoke, workspaceId]);
+
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent<HTMLInputElement>) => {
       if (e.key === "Enter") {
         e.preventDefault();
         handleNavigate(inputUrl);
+        return;
+      }
+      // Escape abandons an in-progress edit and snaps the input back
+      // to the canonical URL with the whole value re-selected — same
+      // as Chrome's address bar. Keep focus so the user can type to
+      // replace without re-clicking the bar.
+      if (e.key === "Escape") {
+        e.preventDefault();
+        setInputUrl(currentUrlRef.current);
+        const input = e.currentTarget;
+        // Defer past the React commit so we select against the
+        // restored value (setting `input.value` mid-render would clear
+        // any selection we made here).
+        requestAnimationFrame(() => input.select());
       }
     },
     [inputUrl, handleNavigate],
+  );
+
+  const handleAddressFocus = useCallback((e: React.FocusEvent<HTMLInputElement>) => {
+    addressInputFocusedRef.current = true;
+    e.target.select();
+  }, []);
+
+  const handleAddressBlur = useCallback(() => {
+    addressInputFocusedRef.current = false;
+    // Re-sync to the latest committed URL in case events fired (and
+    // were ignored) while we were focused. Matches Chrome: typed-but-
+    // not-submitted URLs revert on blur.
+    setInputUrl(currentUrlRef.current);
+  }, []);
+
+  // ------- find in page -------
+  const find = useBrowserFindInPage({ key: workspaceId, keyName: "workspaceId" });
+
+  // Pane-scoped Cmd+F / Ctrl+F handler. Covers the case where keyboard
+  // focus is inside the React DOM (address bar, find bar input, the
+  // panel itself). The complementary case — focus inside the
+  // WebContentsView — is handled by the main process via
+  // `before-input-event` and reaches the hook through the
+  // `browser-find-shortcut` event.
+  const handlePaneKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLDivElement>) => {
+      if (e.key.toLowerCase() !== "f") return;
+      if (e.shiftKey || e.altKey) return;
+      const isMac = navigator.platform.toLowerCase().includes("mac");
+      const wantsFind = isMac ? e.metaKey && !e.ctrlKey : e.ctrlKey && !e.metaKey;
+      if (!wantsFind) return;
+      e.preventDefault();
+      e.stopPropagation();
+      find.open();
+    },
+    [find],
   );
 
   // Don't render until workspaceId is injected — during layout sync fromJSON
@@ -389,7 +462,17 @@ export function BrowserPanelComponent({ params, api }: IDockviewPanelProps<Brows
   }
 
   return (
-    <div className="flex h-full w-full flex-col">
+    <div
+      className="flex h-full w-full flex-col"
+      onKeyDown={handlePaneKeyDown}
+      // Cmd+R routing: the desktop menu's renderer-global handler walks
+      // up from `document.activeElement` looking for these data attrs
+      // to decide whether to reload this tab or fall through to the
+      // app.
+      data-band-browser-pane=""
+      data-band-browser-pane-key={workspaceId}
+      data-band-browser-pane-keyname="workspaceId"
+    >
       {/* Keyframes for the loading bar (injected once, deduped by browser) */}
       <style>{`@keyframes browser-bar-slide {
   0% { transform: translateX(-100%); }
@@ -438,10 +521,19 @@ export function BrowserPanelComponent({ params, api }: IDockviewPanelProps<Brows
           value={inputUrl}
           onChange={(e) => setInputUrl(e.target.value)}
           onKeyDown={handleKeyDown}
-          onFocus={(e) => e.target.select()}
+          onFocus={handleAddressFocus}
+          onBlur={handleAddressBlur}
           className="min-w-0 flex-1 rounded border border-transparent bg-muted/50 px-3 py-1.5 text-sm text-foreground outline-none transition-colors focus:border-border"
           placeholder="Enter URL or search..."
         />
+        <button
+          type="button"
+          onClick={handleToggleDevTools}
+          className="flex items-center justify-center rounded p-1.5 text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+          title="Toggle DevTools"
+        >
+          <Wrench className="size-4" />
+        </button>
         {/* Loading progress bar — indeterminate sliding indicator */}
         {loading && (
           <div className="absolute inset-x-0 bottom-0 h-0.5 overflow-hidden bg-blue-500/10">
@@ -454,6 +546,11 @@ export function BrowserPanelComponent({ params, api }: IDockviewPanelProps<Brows
           </div>
         )}
       </div>
+
+      {/* Find-in-page bar (Cmd+F / Ctrl+F) — slots between the address bar
+       *  and the webview placeholder so it stacks naturally above the
+       *  native WebContentsView. */}
+      <BrowserFindBar find={find} />
 
       {/* Placeholder – the native webview is positioned over this area */}
       <div ref={placeholderRef} className="min-h-0 flex-1" />
@@ -487,6 +584,9 @@ export function BrowserPaneComponent({
   browserIdRef.current = browserId;
   const currentUrlRef = useRef(currentUrl);
   currentUrlRef.current = currentUrl;
+  // While the address-bar input has focus, the user owns `inputUrl` —
+  // browser-url-changed events must not overwrite an in-progress edit.
+  const addressInputFocusedRef = useRef(false);
 
   // ------- helpers -------
 
@@ -606,7 +706,12 @@ export function BrowserPaneComponent({
         setLoading(event.payload.loading);
         if (url === BLANK_URL) return;
         setCurrentUrl(url);
-        setInputUrl(url);
+        // Don't clobber the user's in-progress address-bar edit. If they
+        // started typing mid-navigation, their text stays put until they
+        // submit (Enter), abandon (Escape), or blur the input.
+        if (!addressInputFocusedRef.current) {
+          setInputUrl(url);
+        }
 
         // Persist to server (debounced to avoid hammering on redirect chains)
         if (urlPersistTimer.current) clearTimeout(urlPersistTimer.current);
@@ -636,7 +741,22 @@ export function BrowserPaneComponent({
     return () => {
       unlistenUrl?.();
       unlistenTitle?.();
-      if (urlPersistTimer.current) clearTimeout(urlPersistTimer.current);
+      // Flush a pending URL persist before tearing down. Just clearing
+      // the timer would lose the latest URL — e.g. when the user
+      // navigates and then the workspace gets LRU-evicted before the
+      // debounce window elapses. Fire the mutation with whatever URL
+      // we have on hand; it's `void`-returning so it can safely race
+      // the unmount.
+      if (urlPersistTimer.current) {
+        clearTimeout(urlPersistTimer.current);
+        urlPersistTimer.current = null;
+        const finalUrl = currentUrlRef.current;
+        if (finalUrl && finalUrl !== BLANK_URL) {
+          trpc.browsers.navigate
+            .mutate({ browserId: browserIdRef.current, url: finalUrl })
+            .catch(() => {});
+        }
+      }
     };
   }, [api]);
 
@@ -780,14 +900,65 @@ export function BrowserPaneComponent({
     }
   }, [invoke, browserId]);
 
+  const handleToggleDevTools = useCallback(async () => {
+    try {
+      await invoke("browser_toggle_dev_tools", { browserId });
+    } catch (e) {
+      console.error("browser_toggle_dev_tools failed:", e);
+    }
+  }, [invoke, browserId]);
+
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent<HTMLInputElement>) => {
       if (e.key === "Enter") {
         e.preventDefault();
         handleNavigate(inputUrl);
+        return;
+      }
+      // Escape abandons an in-progress edit and snaps the input back
+      // to the canonical URL with the whole value re-selected — same
+      // as Chrome's address bar. Keep focus so the user can type to
+      // replace without re-clicking the bar.
+      if (e.key === "Escape") {
+        e.preventDefault();
+        setInputUrl(currentUrlRef.current);
+        const input = e.currentTarget;
+        // Defer past the React commit so we select against the
+        // restored value (setting `input.value` mid-render would clear
+        // any selection we made here).
+        requestAnimationFrame(() => input.select());
       }
     },
     [inputUrl, handleNavigate],
+  );
+
+  const handleAddressFocus = useCallback((e: React.FocusEvent<HTMLInputElement>) => {
+    addressInputFocusedRef.current = true;
+    e.target.select();
+  }, []);
+
+  const handleAddressBlur = useCallback(() => {
+    addressInputFocusedRef.current = false;
+    // Re-sync to the latest committed URL in case events fired (and
+    // were ignored) while we were focused.
+    setInputUrl(currentUrlRef.current);
+  }, []);
+
+  // ------- find in page -------
+  const find = useBrowserFindInPage({ key: browserId, keyName: "browserId" });
+
+  const handlePaneKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLDivElement>) => {
+      if (e.key.toLowerCase() !== "f") return;
+      if (e.shiftKey || e.altKey) return;
+      const isMac = navigator.platform.toLowerCase().includes("mac");
+      const wantsFind = isMac ? e.metaKey && !e.ctrlKey : e.ctrlKey && !e.metaKey;
+      if (!wantsFind) return;
+      e.preventDefault();
+      e.stopPropagation();
+      find.open();
+    },
+    [find],
   );
 
   if (!browserId) return null;
@@ -801,7 +972,13 @@ export function BrowserPaneComponent({
   }
 
   return (
-    <div className="flex h-full w-full flex-col">
+    <div
+      className="flex h-full w-full flex-col"
+      onKeyDown={handlePaneKeyDown}
+      data-band-browser-pane=""
+      data-band-browser-pane-key={browserId}
+      data-band-browser-pane-keyname="browserId"
+    >
       <style>{`@keyframes browser-bar-slide {
   0% { transform: translateX(-100%); }
   50% { transform: translateX(200%); }
@@ -848,10 +1025,19 @@ export function BrowserPaneComponent({
           value={inputUrl}
           onChange={(e) => setInputUrl(e.target.value)}
           onKeyDown={handleKeyDown}
-          onFocus={(e) => e.target.select()}
+          onFocus={handleAddressFocus}
+          onBlur={handleAddressBlur}
           className="min-w-0 flex-1 rounded border border-transparent bg-muted/50 px-3 py-1.5 text-sm text-foreground outline-none transition-colors focus:border-border"
           placeholder="Enter URL or search..."
         />
+        <button
+          type="button"
+          onClick={handleToggleDevTools}
+          className="flex items-center justify-center rounded p-1.5 text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+          title="Toggle DevTools"
+        >
+          <Wrench className="size-4" />
+        </button>
         {loading && (
           <div className="absolute inset-x-0 bottom-0 h-0.5 overflow-hidden bg-blue-500/10">
             <div
@@ -863,6 +1049,7 @@ export function BrowserPaneComponent({
           </div>
         )}
       </div>
+      <BrowserFindBar find={find} />
       <div ref={placeholderRef} className="min-h-0 flex-1" />
     </div>
   );

--- a/apps/web/src/components/BrowserPanel.tsx
+++ b/apps/web/src/components/BrowserPanel.tsx
@@ -477,6 +477,11 @@ export function BrowserPanelComponent({ params, api }: IDockviewPanelProps<Brows
           onBlur={handleAddressBlur}
           className="min-w-0 flex-1 rounded border border-transparent bg-muted/50 px-3 py-1.5 text-sm text-foreground outline-none transition-colors focus:border-border"
           placeholder="Enter URL or search..."
+          // Stable hook for `DockviewBrowserContainer` to focus the
+          // address bar via `[data-band-address-input]` — more durable
+          // than `input[type='text']`, which would also match the
+          // find-bar's search input.
+          data-band-address-input=""
         />
         <button
           type="button"
@@ -940,6 +945,11 @@ export function BrowserPaneComponent({
           onBlur={handleAddressBlur}
           className="min-w-0 flex-1 rounded border border-transparent bg-muted/50 px-3 py-1.5 text-sm text-foreground outline-none transition-colors focus:border-border"
           placeholder="Enter URL or search..."
+          // Stable hook for `DockviewBrowserContainer` to focus the
+          // address bar via `[data-band-address-input]` — more durable
+          // than `input[type='text']`, which would also match the
+          // find-bar's search input.
+          data-band-address-input=""
         />
         <button
           type="button"

--- a/apps/web/src/components/DockviewBrowserContainer.tsx
+++ b/apps/web/src/components/DockviewBrowserContainer.tsx
@@ -19,6 +19,7 @@ import React, {
   useRef,
   useState,
 } from "react";
+import { injectInitialUrls } from "../lib/browser-layout";
 import { invoke as desktopInvoke, listen as desktopListen } from "../lib/desktop-ipc";
 import { isDesktop } from "../lib/is-desktop";
 import { trpc } from "../lib/trpc-client";
@@ -145,46 +146,6 @@ function isDockviewLayout(obj: unknown): boolean {
   if (typeof obj !== "object" || obj === null) return false;
   const o = obj as Record<string, unknown>;
   return typeof o.grid === "object" && typeof o.panels === "object";
-}
-
-/**
- * Clone the saved layout and inject `params.initialUrl` for any panel
- * whose browserId appears in `urls`. Returns the layout unchanged when
- * `urls` is null / empty so the original `fromJSON` path is exercised
- * in tests / non-desktop modes.
- *
- * Done as a pre-`fromJSON` mutation rather than a post-restore
- * `api.updateParameters` because BrowserPaneComponent reads
- * `params.initialUrl` only in `useState` initializers — by the time
- * we'd call updateParameters, the panel has already mounted with
- * `initialUrl: undefined` and started the fallback server fetch.
- */
-function injectInitialUrls(layout: unknown, urls: Map<string, string> | null): unknown {
-  if (!urls || urls.size === 0) return layout;
-  if (typeof layout !== "object" || layout === null) return layout;
-  const panels = (layout as Record<string, unknown>).panels;
-  if (typeof panels !== "object" || panels === null) return layout;
-  // Shallow clone the layout + panels map so we don't mutate the cache.
-  const nextPanels: Record<string, unknown> = {};
-  for (const [id, panel] of Object.entries(panels as Record<string, unknown>)) {
-    const url = urls.get(id);
-    if (
-      url &&
-      typeof panel === "object" &&
-      panel !== null &&
-      typeof (panel as Record<string, unknown>).params === "object"
-    ) {
-      const params = (panel as Record<string, unknown>).params as Record<string, unknown>;
-      // Only seed initialUrl when the layout didn't already carry one
-      // (a legacy save might have had it; respect it).
-      if (!params.initialUrl) {
-        nextPanels[id] = { ...panel, params: { ...params, initialUrl: url } };
-        continue;
-      }
-    }
-    nextPanels[id] = panel;
-  }
-  return { ...(layout as Record<string, unknown>), panels: nextPanels };
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/web/src/components/DockviewBrowserContainer.tsx
+++ b/apps/web/src/components/DockviewBrowserContainer.tsx
@@ -527,7 +527,13 @@ export function DockviewBrowserContainer({
         requestAnimationFrame(() => {
           const panel = api.activePanel;
           if (!panel) return;
-          panel.view.content.element.querySelector<HTMLInputElement>("input[type='text']")?.focus();
+          // `data-band-address-input` is set on the address-bar input in
+          // BrowserPanel.tsx — using the data attribute (rather than
+          // `input[type='text']`) avoids accidentally matching the
+          // find-bar input if it's mounted in the same panel.
+          panel.view.content.element
+            .querySelector<HTMLInputElement>("[data-band-address-input]")
+            ?.focus();
         });
         return;
       }
@@ -544,7 +550,7 @@ export function DockviewBrowserContainer({
             const panel = apiRef.current?.activePanel;
             if (!panel) return;
             panel.view.content.element
-              .querySelector<HTMLInputElement>("input[type='text']")
+              .querySelector<HTMLInputElement>("[data-band-address-input]")
               ?.focus();
           });
         });
@@ -609,7 +615,7 @@ export function DockviewBrowserContainer({
             requestAnimationFrame(() => {
               const panel = apiRef.current?.activePanel;
               panel?.view.content.element
-                .querySelector<HTMLInputElement>("input[type='text']")
+                .querySelector<HTMLInputElement>("[data-band-address-input]")
                 ?.focus();
             });
           });
@@ -631,7 +637,7 @@ export function DockviewBrowserContainer({
       if (!root || root.offsetParent === null) return;
       // Prefer the visible address bar (multiple are mounted while
       // the user has multiple browser tabs open inside the panel).
-      const inputs = root.querySelectorAll<HTMLInputElement>('input[placeholder^="Enter URL"]');
+      const inputs = root.querySelectorAll<HTMLInputElement>("[data-band-address-input]");
       for (const input of inputs) {
         if (input.offsetParent !== null) {
           input.focus({ preventScroll: true });

--- a/apps/web/src/components/DockviewBrowserContainer.tsx
+++ b/apps/web/src/components/DockviewBrowserContainer.tsx
@@ -19,7 +19,7 @@ import React, {
   useRef,
   useState,
 } from "react";
-import { invoke as desktopInvoke } from "../lib/desktop-ipc";
+import { invoke as desktopInvoke, listen as desktopListen } from "../lib/desktop-ipc";
 import { isDesktop } from "../lib/is-desktop";
 import { trpc } from "../lib/trpc-client";
 import { BrowserPaneComponent, type BrowserPaneParams, useFavicon } from "./BrowserPanel";
@@ -94,10 +94,16 @@ function persistToServer(workspaceId: string, layout: unknown, opts?: PersistOpt
   // Update React Query cache immediately so next mount is instant.
   // Derive browserIds from the layout's panels map so the cache stays
   // in sync — prevents orphan-pruning on remount after CLI additions.
+  // The `urls` map is owned by the queryFn (it comes from
+  // `trpc.browsers.list`) — preserve whatever the cache already holds,
+  // since URL changes are persisted via `trpc.browsers.navigate` and
+  // don't flow through this code path.
   if (opts?.queryClient) {
+    const prev = opts.queryClient.getQueryData<BrowserLayoutData>(browserLayoutKey(workspaceId));
     opts.queryClient.setQueryData(browserLayoutKey(workspaceId), {
       layout,
       browserIds: panelIdsFromLayout(layout),
+      urls: prev?.urls ?? new Map<string, string>(),
     });
   }
 
@@ -121,6 +127,14 @@ function persistToServer(workspaceId: string, layout: unknown, opts?: PersistOpt
 interface BrowserLayoutData {
   layout: unknown | null;
   browserIds: Set<string>;
+  /**
+   * Latest URL the server has on file for each browser, indexed by
+   * browserId. Injected into the layout's panel params on restore so
+   * BrowserPaneComponent mounts with `initialUrl` already set, instead
+   * of having to round-trip through `trpc.browsers.get` and racing the
+   * create-webview effect.
+   */
+  urls: Map<string, string>;
 }
 
 // ---------------------------------------------------------------------------
@@ -131,6 +145,46 @@ function isDockviewLayout(obj: unknown): boolean {
   if (typeof obj !== "object" || obj === null) return false;
   const o = obj as Record<string, unknown>;
   return typeof o.grid === "object" && typeof o.panels === "object";
+}
+
+/**
+ * Clone the saved layout and inject `params.initialUrl` for any panel
+ * whose browserId appears in `urls`. Returns the layout unchanged when
+ * `urls` is null / empty so the original `fromJSON` path is exercised
+ * in tests / non-desktop modes.
+ *
+ * Done as a pre-`fromJSON` mutation rather than a post-restore
+ * `api.updateParameters` because BrowserPaneComponent reads
+ * `params.initialUrl` only in `useState` initializers — by the time
+ * we'd call updateParameters, the panel has already mounted with
+ * `initialUrl: undefined` and started the fallback server fetch.
+ */
+function injectInitialUrls(layout: unknown, urls: Map<string, string> | null): unknown {
+  if (!urls || urls.size === 0) return layout;
+  if (typeof layout !== "object" || layout === null) return layout;
+  const panels = (layout as Record<string, unknown>).panels;
+  if (typeof panels !== "object" || panels === null) return layout;
+  // Shallow clone the layout + panels map so we don't mutate the cache.
+  const nextPanels: Record<string, unknown> = {};
+  for (const [id, panel] of Object.entries(panels as Record<string, unknown>)) {
+    const url = urls.get(id);
+    if (
+      url &&
+      typeof panel === "object" &&
+      panel !== null &&
+      typeof (panel as Record<string, unknown>).params === "object"
+    ) {
+      const params = (panel as Record<string, unknown>).params as Record<string, unknown>;
+      // Only seed initialUrl when the layout didn't already carry one
+      // (a legacy save might have had it; respect it).
+      if (!params.initialUrl) {
+        nextPanels[id] = { ...panel, params: { ...params, initialUrl: url } };
+        continue;
+      }
+    }
+    nextPanels[id] = panel;
+  }
+  return { ...(layout as Record<string, unknown>), panels: nextPanels };
 }
 
 // ---------------------------------------------------------------------------
@@ -366,11 +420,18 @@ export function DockviewBrowserContainer({
         trpc.browserLayout.get.query({ workspaceId }).catch(() => ({ tree: null })),
         trpc.browsers.list
           .query({ workspaceId })
-          .catch(() => ({ browsers: [] as { id: string }[] })),
+          .catch(() => ({ browsers: [] as { id: string; url?: string }[] })),
       ]);
+      const urls = new Map<string, string>();
+      for (const b of browsers as { id: string; url?: string }[]) {
+        // Skip empty / about:blank — those won't usefully seed
+        // `initialUrl` and would just suppress the fallback fetch.
+        if (b.url && b.url !== "about:blank") urls.set(b.id, b.url);
+      }
       return {
         layout: tree,
         browserIds: new Set(browsers.map((b: { id: string }) => b.id)),
+        urls,
       };
     },
     staleTime: Number.POSITIVE_INFINITY, // never auto-refetch — we manage persistence ourselves
@@ -561,6 +622,42 @@ export function DockviewBrowserContainer({
     return () => window.removeEventListener("keydown", handler, true);
   }, [visible, closeTab, handleSplit, handleAddTab]);
 
+  // Cmd+T / Ctrl+T when the WebContentsView itself has focus.
+  // The keydown listener above only fires when DOM focus is inside this
+  // container; once the user clicks into the rendered web page, focus
+  // moves to a separate webContents and Chromium swallows the key. The
+  // main process intercepts the shortcut there (see
+  // `view-manager.ts::before-input-event`) and forwards
+  // `browser-new-tab-shortcut` carrying the source pane's browserId.
+  // We only react if the pane belongs to *this* container.
+  useEffect(() => {
+    if (!isDesktop) return;
+    let unlisten: (() => void) | undefined;
+    void (async () => {
+      unlisten = await desktopListen<{ browser_id: string; workspace_id: string }>(
+        "browser-new-tab-shortcut",
+        (event) => {
+          const api = apiRef.current;
+          if (!api) return;
+          const sourceId = event.payload.browser_id;
+          // Ignore the event if the source tab isn't one of ours —
+          // multiple workspaces can have a DockviewBrowserContainer
+          // mounted at once.
+          if (!sourceId || !api.getPanel(sourceId)) return;
+          void handleAddTab().then(() => {
+            requestAnimationFrame(() => {
+              const panel = apiRef.current?.activePanel;
+              panel?.view.content.element
+                .querySelector<HTMLInputElement>("input[type='text']")
+                ?.focus();
+            });
+          });
+        },
+      );
+    })();
+    return () => unlisten?.();
+  }, [handleAddTab]);
+
   // Listen for the workspace-level ⇧⌘B "focus Browser" event. Scoped
   // to this container's subtree via containerRef. The native webview
   // can't be focused from React, so we focus the URL input instead —
@@ -627,19 +724,27 @@ export function DockviewBrowserContainer({
   initialLayoutRef.current = initialData?.layout ?? null;
   const initialBrowserIdsRef = useRef<Set<string> | null>(null);
   initialBrowserIdsRef.current = initialData?.browserIds ?? null;
+  const initialUrlsRef = useRef<Map<string, string> | null>(null);
+  initialUrlsRef.current = initialData?.urls ?? null;
 
   const onReady = useCallback(
     (event: DockviewReadyEvent) => {
       apiRef.current = event.api;
       const savedLayout = initialLayoutRef.current;
       const knownBrowserIds = initialBrowserIdsRef.current;
+      const knownUrls = initialUrlsRef.current;
 
       if (savedLayout && isDockviewLayout(savedLayout)) {
         // Restore full dockview layout (preserves groups, splits, sizes)
         isRestoringRef.current = true;
+        // Inject the latest URLs into each panel's `params.initialUrl`
+        // before `fromJSON` so BrowserPaneComponent mounts with the URL
+        // already in hand — avoids the create-webview / server-fetch
+        // race that was leaving address bars empty after eviction.
+        const layoutToRestore = injectInitialUrls(savedLayout, knownUrls);
         try {
           // biome-ignore lint/suspicious/noExplicitAny: dockview fromJSON API requires any
-          event.api.fromJSON(savedLayout as any);
+          event.api.fromJSON(layoutToRestore as any);
         } catch (err) {
           console.error("[DockviewBrowserContainer] fromJSON failed, creating default:", err);
           createDefaultPanel(event.api, workspaceId);

--- a/apps/web/src/hooks/useBrowserFindInPage.ts
+++ b/apps/web/src/hooks/useBrowserFindInPage.ts
@@ -56,6 +56,21 @@ export interface UseBrowserFindInPageReturn {
   searchBarRef: React.RefObject<SearchBarHandle | null>;
 }
 
+/**
+ * `SearchOptions` is shared with other search bars in the app (file
+ * search, diff search, etc.), which need all three toggles. Browser
+ * find-in-page only honours `caseSensitive` — Chromium's
+ * `webContents.findInPage` API does not expose whole-word or regex
+ * mode. `BrowserFindBar` therefore renders only the case-sensitive
+ * toggle (`visibleOptions={["caseSensitive"]}`); `wholeWord` and
+ * `regex` are accepted on the type but silently ignored here.
+ *
+ * If a future caller flips them on (e.g. a test or programmatic
+ * usage), the search will NOT re-fire — `issueFind` only depends on
+ * `options.caseSensitive` — and the result set won't change. This is
+ * intentional: silently dropping the unsupported toggles is more
+ * honest than pretending to honour them.
+ */
 const DEFAULT_OPTIONS: SearchOptions = {
   caseSensitive: false,
   wholeWord: false,
@@ -95,6 +110,14 @@ export function useBrowserFindInPage({
   const searchBarRef = useRef<SearchBarHandle>(null);
   const keyRef = useRef(key);
   keyRef.current = key;
+  /**
+   * The `requestId` returned by the most recent `webContents.findInPage`
+   * call. Chromium can keep emitting `found-in-page` events for a
+   * cancelled request after the next request has already started; the
+   * stale match counter would briefly overwrite the new one. Filtering
+   * the listener by `requestId` discards those late stragglers.
+   */
+  const activeRequestIdRef = useRef<number | null>(null);
 
   // Pull the right id field out of an event payload — both fields carry
   // the same value today, but using the renderer's chosen `keyName` keeps
@@ -125,6 +148,9 @@ export function useBrowserFindInPage({
       if (!isDesktop) return;
       if (!text) {
         setMatchInfo(null);
+        // Forget the in-flight request so any straggling `found-in-page`
+        // events for it are dropped by the listener.
+        activeRequestIdRef.current = null;
         try {
           await desktopInvoke("browser_stop_find_in_page", buildArgs({ action: "clearSelection" }));
         } catch {
@@ -133,7 +159,7 @@ export function useBrowserFindInPage({
         return;
       }
       try {
-        await desktopInvoke(
+        const reqId = await desktopInvoke<number | undefined>(
           "browser_find_in_page",
           buildArgs({
             text,
@@ -146,6 +172,9 @@ export function useBrowserFindInPage({
             },
           }),
         );
+        // Track the new requestId so the `found-in-page` listener can
+        // ignore late events from the previous query.
+        if (typeof reqId === "number") activeRequestIdRef.current = reqId;
       } catch (e) {
         // Network is in-process IPC; only fails on shape mismatch /
         // missing handler. Log but don't propagate.
@@ -159,6 +188,7 @@ export function useBrowserFindInPage({
     setIsOpen(false);
     setQuery("");
     setMatchInfo(null);
+    activeRequestIdRef.current = null;
     if (!isDesktop) return;
     desktopInvoke("browser_stop_find_in_page", buildArgs({ action: "clearSelection" })).catch(
       () => {},
@@ -186,6 +216,16 @@ export function useBrowserFindInPage({
     void (async () => {
       unlisten = await desktopListen<FoundInPagePayload>("browser-found-in-page", (event) => {
         if (payloadKey(event.payload) !== keyRef.current) return;
+        // Drop late events from a cancelled request — Chromium can
+        // emit them after we've already started a new scan, and the
+        // stale `matches` / `activeMatchOrdinal` would briefly flicker
+        // into the visible counter.
+        if (
+          activeRequestIdRef.current !== null &&
+          event.payload.request_id !== activeRequestIdRef.current
+        ) {
+          return;
+        }
         setMatchInfo({
           total: event.payload.matches,
           // Chromium reports `0` while a query is being typed and the

--- a/apps/web/src/hooks/useBrowserFindInPage.ts
+++ b/apps/web/src/hooks/useBrowserFindInPage.ts
@@ -158,6 +158,19 @@ export function useBrowserFindInPage({
         }
         return;
       }
+      // When starting a brand-new scan (not just stepping through the
+      // existing match set), clear the stale counter from the previous
+      // query so the UI doesn't briefly flash the old "3 of 12" while
+      // the new scan is in flight. Stepping (`findNext: true`) reuses
+      // the previous result set so the counter stays accurate.
+      if (!(opts.findNext ?? false)) {
+        setMatchInfo(null);
+        // Also forget the in-flight request id so the listener doesn't
+        // accept any late events from the previous scan during the
+        // race window between this clear and the new invoke
+        // returning.
+        activeRequestIdRef.current = null;
+      }
       try {
         const reqId = await desktopInvoke<number | undefined>(
           "browser_find_in_page",

--- a/apps/web/src/hooks/useBrowserFindInPage.ts
+++ b/apps/web/src/hooks/useBrowserFindInPage.ts
@@ -1,0 +1,260 @@
+/**
+ * Find-in-page state machine for a single browser pane.
+ *
+ * The hook is shared by both browser-pane variants (`BrowserPanelComponent`,
+ * keyed by `workspaceId`, and the multi-tab `BrowserPaneComponent`, keyed by
+ * `browserId`). Pass whichever identifier the pane uses; the hook scopes
+ * its IPC subscriptions accordingly.
+ *
+ * Behaviour:
+ *   - Owns `query`, `options`, `matchInfo`, and `isOpen` state.
+ *   - On query / case-toggle changes, calls `browser_find_in_page` so
+ *     Chromium re-runs its native scan and re-paints the highlights.
+ *   - `findNext` / `findPrevious` reuse the cached match set
+ *     (`{ findNext: true }`) instead of rescanning.
+ *   - Reads back `browser-found-in-page` events to drive the match
+ *     counter ("3 of 12"). Intermediate updates are shown immediately;
+ *     `final_update: true` is just the authoritative total.
+ *   - Reacts to the main-process `browser-find-shortcut` event so the
+ *     shortcut works even when keyboard focus is inside the
+ *     `WebContentsView` (where the renderer's DOM keydown listener never
+ *     fires).
+ *   - Closes itself when the tab navigates to a new URL — matches the
+ *     "the find bar resets when … navigating away" requirement without
+ *     persisting anything.
+ *
+ * No-op outside the Electron desktop shell.
+ */
+
+import type { SearchBarHandle, SearchOptions } from "@band-app/dashboard-core";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { invoke as desktopInvoke, listen as desktopListen } from "../lib/desktop-ipc";
+import { isDesktop } from "../lib/is-desktop";
+
+export type BrowserKeyName = "browserId" | "workspaceId";
+
+export interface UseBrowserFindInPageArgs {
+  /** The opaque LRU key of the underlying WebContentsView. */
+  key: string;
+  /** Whether `key` is a multi-tab `browserId` or a legacy `workspaceId`. */
+  keyName: BrowserKeyName;
+}
+
+export interface UseBrowserFindInPageReturn {
+  isOpen: boolean;
+  open: () => void;
+  close: () => void;
+  query: string;
+  setQuery: (q: string) => void;
+  options: SearchOptions;
+  setOptions: (o: SearchOptions) => void;
+  /** `{ total, current }` (1-indexed), or `null` while there is no result yet. */
+  matchInfo: { total: number; current: number } | null;
+  findNext: () => void;
+  findPrevious: () => void;
+  /** Pass to `<SearchBar ref={...} />` to enable focus/select on open. */
+  searchBarRef: React.RefObject<SearchBarHandle | null>;
+}
+
+const DEFAULT_OPTIONS: SearchOptions = {
+  caseSensitive: false,
+  wholeWord: false,
+  regex: false,
+};
+
+interface FoundInPagePayload {
+  browser_id: string;
+  workspace_id: string;
+  request_id: number;
+  active_match_ordinal: number;
+  matches: number;
+  final_update: boolean;
+}
+
+interface FindShortcutPayload {
+  browser_id: string;
+  workspace_id: string;
+}
+
+interface UrlChangedPayload {
+  browser_id: string;
+  workspace_id: string;
+  url: string;
+  loading: boolean;
+}
+
+export function useBrowserFindInPage({
+  key,
+  keyName,
+}: UseBrowserFindInPageArgs): UseBrowserFindInPageReturn {
+  const [isOpen, setIsOpen] = useState(false);
+  const [query, setQuery] = useState("");
+  const [options, setOptions] = useState<SearchOptions>(DEFAULT_OPTIONS);
+  const [matchInfo, setMatchInfo] = useState<{ total: number; current: number } | null>(null);
+
+  const searchBarRef = useRef<SearchBarHandle>(null);
+  const keyRef = useRef(key);
+  keyRef.current = key;
+
+  // Pull the right id field out of an event payload — both fields carry
+  // the same value today, but using the renderer's chosen `keyName` keeps
+  // the code honest if that ever diverges.
+  const payloadKey = useCallback(
+    (payload: { browser_id: string; workspace_id: string }): string =>
+      keyName === "browserId" ? payload.browser_id : payload.workspace_id,
+    [keyName],
+  );
+
+  const buildArgs = useCallback(
+    (extra: Record<string, unknown> = {}) => ({ [keyName]: keyRef.current, ...extra }),
+    [keyName],
+  );
+
+  const focusInput = useCallback(() => {
+    // Defer so the input is mounted before we try to focus it (the
+    // SearchBar only renders when `isOpen` flips to true).
+    requestAnimationFrame(() => {
+      searchBarRef.current?.focus();
+      searchBarRef.current?.select();
+    });
+  }, []);
+
+  // ---- Issue a findInPage request through the desktop IPC bridge ----
+  const issueFind = useCallback(
+    async (text: string, opts: { findNext?: boolean; forward?: boolean } = {}): Promise<void> => {
+      if (!isDesktop) return;
+      if (!text) {
+        setMatchInfo(null);
+        try {
+          await desktopInvoke("browser_stop_find_in_page", buildArgs({ action: "clearSelection" }));
+        } catch {
+          // best-effort — the view may already be gone
+        }
+        return;
+      }
+      try {
+        await desktopInvoke(
+          "browser_find_in_page",
+          buildArgs({
+            text,
+            options: {
+              matchCase: options.caseSensitive,
+              // First search for a query → omit findNext so Chromium
+              // rescans. Stepping → set findNext: true and toggle forward.
+              findNext: opts.findNext ?? false,
+              forward: opts.forward ?? true,
+            },
+          }),
+        );
+      } catch (e) {
+        // Network is in-process IPC; only fails on shape mismatch /
+        // missing handler. Log but don't propagate.
+        console.error("browser_find_in_page failed:", e);
+      }
+    },
+    [buildArgs, options.caseSensitive],
+  );
+
+  const close = useCallback(() => {
+    setIsOpen(false);
+    setQuery("");
+    setMatchInfo(null);
+    if (!isDesktop) return;
+    desktopInvoke("browser_stop_find_in_page", buildArgs({ action: "clearSelection" })).catch(
+      () => {},
+    );
+  }, [buildArgs]);
+
+  const open = useCallback(() => {
+    setIsOpen(true);
+    focusInput();
+  }, [focusInput]);
+
+  // ---- Re-issue the search whenever the query or case toggle changes ----
+  // Debounce-free: Chromium's findInPage already handles rapid succession
+  // gracefully (it cancels the prior request before starting a new scan),
+  // and the renderer feels snappier without a typing delay.
+  useEffect(() => {
+    if (!isOpen) return;
+    void issueFind(query);
+  }, [query, isOpen, issueFind]);
+
+  // ---- Subscribe to streamed `found-in-page` results ----
+  useEffect(() => {
+    if (!isDesktop) return;
+    let unlisten: (() => void) | undefined;
+    void (async () => {
+      unlisten = await desktopListen<FoundInPagePayload>("browser-found-in-page", (event) => {
+        if (payloadKey(event.payload) !== keyRef.current) return;
+        setMatchInfo({
+          total: event.payload.matches,
+          // Chromium reports `0` while a query is being typed and the
+          // scan is mid-flight; promote to 0 of N so the UI shows
+          // "No results" until a match is selected.
+          current: event.payload.active_match_ordinal,
+        });
+      });
+    })();
+    return () => unlisten?.();
+  }, [payloadKey]);
+
+  // ---- Subscribe to the main-process Cmd+F intercept ----
+  // Fired when the WebContentsView itself has focus and consumed the
+  // keydown before the renderer DOM could see it.
+  useEffect(() => {
+    if (!isDesktop) return;
+    let unlisten: (() => void) | undefined;
+    void (async () => {
+      unlisten = await desktopListen<FindShortcutPayload>("browser-find-shortcut", (event) => {
+        if (payloadKey(event.payload) !== keyRef.current) return;
+        setIsOpen(true);
+        focusInput();
+      });
+    })();
+    return () => unlisten?.();
+  }, [focusInput, payloadKey]);
+
+  // ---- Auto-close on navigation ----
+  // The find bar resets when the underlying page changes; matches from
+  // the old document would be meaningless on the new one anyway.
+  useEffect(() => {
+    if (!isDesktop) return;
+    let unlisten: (() => void) | undefined;
+    void (async () => {
+      unlisten = await desktopListen<UrlChangedPayload>("browser-url-changed", (event) => {
+        if (payloadKey(event.payload) !== keyRef.current) return;
+        // Only react to a fresh load (loading=true) — the trailing
+        // loading=false event would otherwise close the bar
+        // immediately after the user opens it on a finished page.
+        if (event.payload.loading) {
+          close();
+        }
+      });
+    })();
+    return () => unlisten?.();
+  }, [close, payloadKey]);
+
+  const findNext = useCallback(() => {
+    if (!query) return;
+    void issueFind(query, { findNext: true, forward: true });
+  }, [query, issueFind]);
+
+  const findPrevious = useCallback(() => {
+    if (!query) return;
+    void issueFind(query, { findNext: true, forward: false });
+  }, [query, issueFind]);
+
+  return {
+    isOpen,
+    open,
+    close,
+    query,
+    setQuery,
+    options,
+    setOptions,
+    matchInfo,
+    findNext,
+    findPrevious,
+    searchBarRef,
+  };
+}

--- a/apps/web/src/hooks/useBrowserPaneControls.ts
+++ b/apps/web/src/hooks/useBrowserPaneControls.ts
@@ -1,0 +1,161 @@
+/**
+ * Shared controls for the browser pane chrome.
+ *
+ * `BrowserPanelComponent` (legacy workspace-keyed) and
+ * `BrowserPaneComponent` (multi-tab browserId-keyed) need the same
+ * behaviour around the address bar, find bar, DevTools toggle, and
+ * pane-scoped keyboard shortcuts. This hook owns that surface so the
+ * two variants stop drifting:
+ *
+ *   - `find` — the `useBrowserFindInPage` state machine for this tab.
+ *   - `handleAddressFocus` / `handleAddressBlur` — manage the
+ *     focused-input ref so `browser-url-changed` events don't clobber
+ *     an in-progress edit, and snap the input back to `currentUrl` on
+ *     blur.
+ *   - `handleAddressKeyDown` — Enter submits via `onNavigate`; Escape
+ *     restores `currentUrlRef`, re-selects the input, keeps focus.
+ *   - `handlePaneKeyDown` — opens the find bar on Cmd/Ctrl+F when DOM
+ *     focus is somewhere inside the pane chrome.
+ *   - `handleToggleDevTools` — wires the wrench button to the
+ *     `browser_toggle_dev_tools` IPC.
+ *   - `paneDataAttrs` — `data-band-browser-pane-*` attributes that
+ *     `__bandReload` / `__bandZoom` walk up from `document.activeElement`
+ *     to identify which tab to act on.
+ *
+ * No-op outside the Electron desktop shell.
+ */
+
+import { useCallback, useRef } from "react";
+import { invoke as desktopInvoke } from "../lib/desktop-ipc";
+import { isDesktop } from "../lib/is-desktop";
+import {
+  type BrowserKeyName,
+  type UseBrowserFindInPageReturn,
+  useBrowserFindInPage,
+} from "./useBrowserFindInPage";
+
+export interface UseBrowserPaneControlsArgs {
+  /** Opaque LRU key of the underlying WebContentsView. */
+  key: string;
+  /** Whether `key` is a multi-tab `browserId` or a legacy `workspaceId`. */
+  keyName: BrowserKeyName;
+  /** Latest committed URL (for Escape restore). Ref so `setInputUrl`
+   *  reads the current value, not a stale closure. */
+  currentUrlRef: React.RefObject<string>;
+  /** Address-bar input setter. */
+  setInputUrl: (s: string) => void;
+  /** Address-bar input value (passed to `onNavigate` on Enter). */
+  inputUrl: string;
+  /** Called when the user submits the address bar (Enter). */
+  onNavigate: (url: string) => void;
+}
+
+export interface UseBrowserPaneControlsReturn {
+  find: UseBrowserFindInPageReturn;
+  /** Set to `true` while the address-bar input has focus. */
+  addressInputFocusedRef: React.RefObject<boolean>;
+  handleAddressFocus: (e: React.FocusEvent<HTMLInputElement>) => void;
+  handleAddressBlur: () => void;
+  handleAddressKeyDown: (e: React.KeyboardEvent<HTMLInputElement>) => void;
+  handlePaneKeyDown: (e: React.KeyboardEvent<HTMLDivElement>) => void;
+  handleToggleDevTools: () => Promise<void>;
+  /** Spread onto the pane's root `<div>` so the desktop menu's
+   *  contextual Cmd+R / Cmd+= can locate this pane via
+   *  `document.activeElement.closest("[data-band-browser-pane]")`. */
+  paneDataAttrs: {
+    "data-band-browser-pane": "";
+    "data-band-browser-pane-key": string;
+    "data-band-browser-pane-keyname": BrowserKeyName;
+  };
+}
+
+export function useBrowserPaneControls(
+  args: UseBrowserPaneControlsArgs,
+): UseBrowserPaneControlsReturn {
+  const { key, keyName, currentUrlRef, setInputUrl, inputUrl, onNavigate } = args;
+
+  const find = useBrowserFindInPage({ key, keyName });
+  const addressInputFocusedRef = useRef(false);
+
+  const handleAddressFocus = useCallback((e: React.FocusEvent<HTMLInputElement>) => {
+    addressInputFocusedRef.current = true;
+    e.target.select();
+  }, []);
+
+  const handleAddressBlur = useCallback(() => {
+    addressInputFocusedRef.current = false;
+    // Re-sync to the latest committed URL in case events fired (and
+    // were ignored) while we were focused. Matches Chrome: typed-but-
+    // not-submitted URLs revert on blur.
+    setInputUrl(currentUrlRef.current);
+  }, [currentUrlRef, setInputUrl]);
+
+  const handleAddressKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLInputElement>) => {
+      if (e.key === "Enter") {
+        e.preventDefault();
+        onNavigate(inputUrl);
+        return;
+      }
+      // Escape abandons an in-progress edit and snaps the input back
+      // to the canonical URL with the whole value re-selected — same
+      // as Chrome's address bar. Keep focus so the user can type to
+      // replace without re-clicking the bar.
+      if (e.key === "Escape") {
+        e.preventDefault();
+        setInputUrl(currentUrlRef.current);
+        const input = e.currentTarget;
+        // Defer past the React commit so we select against the
+        // restored value (setting `input.value` mid-render would clear
+        // any selection we made here). Guard with `isConnected` because
+        // the component may unmount between Escape and the next frame
+        // (e.g. user closes the workspace immediately after pressing
+        // Escape) — calling `.select()` on a detached element throws.
+        requestAnimationFrame(() => {
+          if (input.isConnected) input.select();
+        });
+      }
+    },
+    [inputUrl, onNavigate, setInputUrl, currentUrlRef],
+  );
+
+  const handlePaneKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLDivElement>) => {
+      if (e.key.toLowerCase() !== "f") return;
+      if (e.shiftKey || e.altKey) return;
+      // `navigator.platform` is deprecated (Chrome 113+ planned-removal);
+      // use the UA string which still reliably contains "Mac" on macOS.
+      const isMac = /mac/i.test(navigator.userAgent);
+      const wantsFind = isMac ? e.metaKey && !e.ctrlKey : e.ctrlKey && !e.metaKey;
+      if (!wantsFind) return;
+      e.preventDefault();
+      e.stopPropagation();
+      find.open();
+    },
+    [find],
+  );
+
+  const handleToggleDevTools = useCallback(async () => {
+    if (!isDesktop) return;
+    try {
+      await desktopInvoke("browser_toggle_dev_tools", { [keyName]: key });
+    } catch (e) {
+      console.error("browser_toggle_dev_tools failed:", e);
+    }
+  }, [key, keyName]);
+
+  return {
+    find,
+    addressInputFocusedRef,
+    handleAddressFocus,
+    handleAddressBlur,
+    handleAddressKeyDown,
+    handlePaneKeyDown,
+    handleToggleDevTools,
+    paneDataAttrs: {
+      "data-band-browser-pane": "",
+      "data-band-browser-pane-key": key,
+      "data-band-browser-pane-keyname": keyName,
+    },
+  };
+}

--- a/apps/web/src/lib/browser-layout.ts
+++ b/apps/web/src/lib/browser-layout.ts
@@ -26,6 +26,7 @@ export function injectInitialUrls(layout: unknown, urls: Map<string, string> | n
   if (typeof layout !== "object" || layout === null) return layout;
   const panels = (layout as Record<string, unknown>).panels;
   if (typeof panels !== "object" || panels === null) return layout;
+  let changed = false;
   const nextPanels: Record<string, unknown> = {};
   for (const [id, panel] of Object.entries(panels as Record<string, unknown>)) {
     const url = urls.get(id);
@@ -41,10 +42,16 @@ export function injectInitialUrls(layout: unknown, urls: Map<string, string> | n
       // one — a legacy save might have had it; respect it.
       if (!params.initialUrl) {
         nextPanels[id] = { ...panel, params: { ...params, initialUrl: url } };
+        changed = true;
         continue;
       }
     }
     nextPanels[id] = panel;
   }
+  // Preserve reference equality when nothing actually changed —
+  // callers (e.g. React Query) may rely on `===` to detect a stale
+  // layout, and re-allocating the wrapper on every workspace reopen
+  // would defeat that.
+  if (!changed) return layout;
   return { ...(layout as Record<string, unknown>), panels: nextPanels };
 }

--- a/apps/web/src/lib/browser-layout.ts
+++ b/apps/web/src/lib/browser-layout.ts
@@ -1,0 +1,50 @@
+/**
+ * Pure helpers for the saved dockview-browser layout JSON. Extracted
+ * out of `DockviewBrowserContainer.tsx` so the URL-injection logic can
+ * be exercised in isolation (no React / dockview / trpc imports).
+ */
+
+/**
+ * Clone the saved dockview layout and inject `params.initialUrl` for
+ * any panel whose browserId appears in `urls`. Returns the layout
+ * unchanged when `urls` is null / empty so the original `fromJSON`
+ * path is exercised in tests / non-desktop modes.
+ *
+ * Done as a pre-`fromJSON` mutation rather than a post-restore
+ * `api.updateParameters` because `BrowserPaneComponent` reads
+ * `params.initialUrl` only in `useState` initializers — by the time
+ * we'd call `updateParameters`, the panel has already mounted with
+ * `initialUrl: undefined` and started the fallback server fetch.
+ *
+ * The clone is shallow per-panel: we don't mutate the source layout
+ * (it lives in the React Query cache and is referentially compared by
+ * other code), and we skip panels whose params already carry an
+ * `initialUrl` so a legacy save that did persist it is respected.
+ */
+export function injectInitialUrls(layout: unknown, urls: Map<string, string> | null): unknown {
+  if (!urls || urls.size === 0) return layout;
+  if (typeof layout !== "object" || layout === null) return layout;
+  const panels = (layout as Record<string, unknown>).panels;
+  if (typeof panels !== "object" || panels === null) return layout;
+  const nextPanels: Record<string, unknown> = {};
+  for (const [id, panel] of Object.entries(panels as Record<string, unknown>)) {
+    const url = urls.get(id);
+    if (
+      url &&
+      typeof panel === "object" &&
+      panel !== null &&
+      typeof (panel as Record<string, unknown>).params === "object" &&
+      (panel as Record<string, unknown>).params !== null
+    ) {
+      const params = (panel as Record<string, unknown>).params as Record<string, unknown>;
+      // Only seed `initialUrl` when the layout didn't already carry
+      // one — a legacy save might have had it; respect it.
+      if (!params.initialUrl) {
+        nextPanels[id] = { ...panel, params: { ...params, initialUrl: url } };
+        continue;
+      }
+    }
+    nextPanels[id] = panel;
+  }
+  return { ...(layout as Record<string, unknown>), panels: nextPanels };
+}

--- a/apps/web/src/lib/desktop-ipc.ts
+++ b/apps/web/src/lib/desktop-ipc.ts
@@ -20,10 +20,23 @@ interface ElectronBridge {
   on(event: string, cb: (payload: unknown) => void): Unlisten;
 }
 
-function electronBridge(): ElectronBridge | null {
+/**
+ * Resolve the Electron preload bridge directly. Most call sites should
+ * prefer `invoke()` / `listen()` above (which throw helpfully when the
+ * bridge is missing); exported only for renderer code that needs to
+ * forward IPC calls *without* throwing on the web/dev path — e.g. the
+ * `__bandReload` / `__bandZoom` menu globals in `routes/__root.tsx`,
+ * which silently fall back to dashboard-level reload/zoom when run
+ * outside the desktop shell.
+ */
+export function getElectronBridge(): ElectronBridge | null {
   if (!isDesktop) return null;
   const bridge = (window as unknown as { __BAND_DESKTOP__?: ElectronBridge }).__BAND_DESKTOP__;
   return bridge ?? null;
+}
+
+function electronBridge(): ElectronBridge | null {
+  return getElectronBridge();
 }
 
 /**

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -35,6 +35,7 @@ import { ToolbarOverflowMenuItems, ToolbarOverflowProvider } from "../components
 import { useIsDesktop } from "../hooks/useIsDesktop";
 import { useNavigationHistory } from "../hooks/useNavigationHistory";
 import { useZoom } from "../hooks/useZoom";
+import { getElectronBridge } from "../lib/desktop-ipc";
 import { isDesktop } from "../lib/is-desktop";
 import { parseWorkspaceFromPath } from "../lib/parse-workspace";
 import { applyZoomLevel, loadZoomLevel, zoomIn, zoomOut, zoomReset } from "../lib/zoom";
@@ -167,15 +168,7 @@ function ReloadSync() {
         const key = paneEl.dataset.bandBrowserPaneKey;
         const keyName = paneEl.dataset.bandBrowserPaneKeyname;
         if (key && (keyName === "browserId" || keyName === "workspaceId")) {
-          const bridge = (
-            window as unknown as {
-              __BAND_DESKTOP__?: { invoke: (channel: string, args?: unknown) => Promise<unknown> };
-            }
-          ).__BAND_DESKTOP__;
-          // Calling the preload bridge directly keeps this independent of
-          // any React-side IPC wrapper module — the route file already
-          // imports adapters but not desktop-ipc, and dragging it in here
-          // just to call one channel feels heavy.
+          const bridge = getElectronBridge();
           if (bridge) {
             void bridge.invoke("browser_reload", { [keyName]: key });
             return;
@@ -225,11 +218,7 @@ function ZoomSync() {
         const key = paneEl.dataset.bandBrowserPaneKey;
         const keyName = paneEl.dataset.bandBrowserPaneKeyname;
         if (key && (keyName === "browserId" || keyName === "workspaceId")) {
-          const bridge = (
-            window as unknown as {
-              __BAND_DESKTOP__?: { invoke: (channel: string, args?: unknown) => Promise<unknown> };
-            }
-          ).__BAND_DESKTOP__;
+          const bridge = getElectronBridge();
           if (bridge) {
             void bridge.invoke("browser_zoom", { [keyName]: key, action });
             return;

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -138,6 +138,68 @@ function ThemeSync() {
   return null;
 }
 
+/**
+ * Exposes `window.__bandReload` for the desktop menu's Cmd+R handler.
+ *
+ * Routes the reload based on what's currently focused in the React DOM:
+ *
+ *   - Focus inside a browser pane (address bar, find bar, tab handle,
+ *     etc., identified by the `data-band-browser-pane` attribute the
+ *     `BrowserPanel` root sets): reload that browser tab via the
+ *     `browser_reload` IPC instead of reloading the whole dashboard.
+ *   - Anywhere else: `location.reload()`, matching the previous
+ *     default-menu behaviour.
+ *
+ * The webview-focused case (user is clicked inside a rendered web page)
+ * is handled in the main process *before* this global is called — see
+ * `menu.ts::reloadFocused`. By the time `__bandReload` runs, focus is
+ * inside the main-window DOM.
+ */
+function ReloadSync() {
+  useEffect(() => {
+    const globalKey = "__bandReload";
+    const win = window as unknown as Record<string, unknown>;
+    const handler = () => {
+      // Walk up from the focused element looking for a browser-pane root.
+      const active = document.activeElement as HTMLElement | null;
+      const paneEl = active?.closest("[data-band-browser-pane]") as HTMLElement | null;
+      if (paneEl) {
+        const key = paneEl.dataset.bandBrowserPaneKey;
+        const keyName = paneEl.dataset.bandBrowserPaneKeyname;
+        if (key && (keyName === "browserId" || keyName === "workspaceId")) {
+          const bridge = (
+            window as unknown as {
+              __BAND_DESKTOP__?: { invoke: (channel: string, args?: unknown) => Promise<unknown> };
+            }
+          ).__BAND_DESKTOP__;
+          // Calling the preload bridge directly keeps this independent of
+          // any React-side IPC wrapper module — the route file already
+          // imports adapters but not desktop-ipc, and dragging it in here
+          // just to call one channel feels heavy.
+          if (bridge) {
+            void bridge.invoke("browser_reload", { [keyName]: key });
+            return;
+          }
+        }
+      }
+      // No browser pane focused — preserve the historical "Cmd+R reloads
+      // the dashboard" behaviour.
+      window.location.reload();
+    };
+    // Same defensive ownership check pattern as `__bandOpenSettings` in
+    // DashboardShell: cleanup only deletes if we still own the slot, so
+    // a stale unmount can't wipe a newer registration.
+    win[globalKey] = handler;
+    return () => {
+      if (win[globalKey] === handler) {
+        delete win[globalKey];
+      }
+    };
+  }, []);
+
+  return null;
+}
+
 /** Syncs the zoom level across windows and exposes a global function
  *  for the Electron menu handler to call via webContents.executeJavaScript(). */
 function ZoomSync() {
@@ -149,7 +211,31 @@ function ZoomSync() {
 
     // Expose a global function the Electron menu event handler can call via
     // webContents.executeJavaScript("if(window.__bandZoom)window.__bandZoom('in')").
+    //
+    // Same routing shape as `__bandReload`: if focus is inside a browser
+    // pane's React chrome (address bar, find bar, etc.), zoom that
+    // tab's WebContentsView via IPC. Otherwise fall through to the
+    // dashboard-wide CSS zoom. The "focus inside the rendered web page"
+    // case is handled in the main process before this function is
+    // called — see `menu.ts::zoomFocused`.
     (window as unknown as Record<string, unknown>).__bandZoom = (action: string) => {
+      const active = document.activeElement as HTMLElement | null;
+      const paneEl = active?.closest("[data-band-browser-pane]") as HTMLElement | null;
+      if (paneEl) {
+        const key = paneEl.dataset.bandBrowserPaneKey;
+        const keyName = paneEl.dataset.bandBrowserPaneKeyname;
+        if (key && (keyName === "browserId" || keyName === "workspaceId")) {
+          const bridge = (
+            window as unknown as {
+              __BAND_DESKTOP__?: { invoke: (channel: string, args?: unknown) => Promise<unknown> };
+            }
+          ).__BAND_DESKTOP__;
+          if (bridge) {
+            void bridge.invoke("browser_zoom", { [keyName]: key, action });
+            return;
+          }
+        }
+      }
       if (action === "in") zoomIn();
       else if (action === "out") zoomOut();
       else zoomReset();
@@ -324,6 +410,7 @@ function RootLayout() {
         <DashboardProvider adapter={adapter} capabilities={capabilities}>
           <ThemeSync />
           <ZoomSync />
+          <ReloadSync />
           <TooltipProvider>
             <AppShell />
           </TooltipProvider>

--- a/apps/web/tests/browser-layout.test.ts
+++ b/apps/web/tests/browser-layout.test.ts
@@ -85,6 +85,21 @@ describe("injectInitialUrls", () => {
     expect(result.panels.b.params.initialUrl).toBeUndefined();
   });
 
+  it("preserves reference equality when no panel matches", () => {
+    // urls has entries, but the keys don't intersect with any panel
+    // id — the function should hand the source layout straight back so
+    // callers using `===` to detect changes aren't fooled.
+    const layout = makeLayout({ a: { id: "a", params: { browserId: "a" } } });
+    expect(injectInitialUrls(layout, new Map([["zzz", "https://x.test"]]))).toBe(layout);
+  });
+
+  it("preserves reference equality when every match already has initialUrl", () => {
+    const layout = makeLayout({
+      a: { id: "a", params: { browserId: "a", initialUrl: "https://kept.test" } },
+    });
+    expect(injectInitialUrls(layout, new Map([["a", "https://incoming.test"]]))).toBe(layout);
+  });
+
   it("skips panels whose params are missing or malformed", () => {
     const layout = makeLayout({
       a: { id: "a" /* no params */ },

--- a/apps/web/tests/browser-layout.test.ts
+++ b/apps/web/tests/browser-layout.test.ts
@@ -1,0 +1,110 @@
+/**
+ * Pure-function tests for `injectInitialUrls`. This is the function that
+ * seeds `params.initialUrl` on the restored dockview layout so reopened
+ * tabs mount with their URL already in hand instead of having to round-
+ * trip through `trpc.browsers.get` and racing the create-webview effect.
+ *
+ * The bugs this guards against:
+ *   - Source layout being mutated (it lives in the React Query cache).
+ *   - Empty / null `urls` map causing an unnecessary copy.
+ *   - Overwriting an existing `initialUrl` that a legacy save carried.
+ *   - Touching panels that aren't in the urls map.
+ */
+
+import { describe, expect, it } from "vitest";
+import { injectInitialUrls } from "../src/lib/browser-layout";
+
+function makeLayout(panels: Record<string, Record<string, unknown>>) {
+  return { grid: {}, panels, activeGroup: null };
+}
+
+describe("injectInitialUrls", () => {
+  it("returns the layout unchanged when urls is null", () => {
+    const layout = makeLayout({ a: { id: "a", params: { browserId: "a" } } });
+    expect(injectInitialUrls(layout, null)).toBe(layout);
+  });
+
+  it("returns the layout unchanged when urls is empty", () => {
+    const layout = makeLayout({ a: { id: "a", params: { browserId: "a" } } });
+    expect(injectInitialUrls(layout, new Map())).toBe(layout);
+  });
+
+  it("returns the input unchanged when it isn't a dockview-shaped object", () => {
+    expect(injectInitialUrls(null, new Map([["a", "u"]]))).toBe(null);
+    const arr: unknown = [1, 2, 3];
+    expect(injectInitialUrls(arr, new Map([["a", "u"]]))).toBe(arr);
+    const malformed = { grid: {} }; // no panels
+    expect(injectInitialUrls(malformed, new Map([["a", "u"]]))).toBe(malformed);
+  });
+
+  it("injects initialUrl into matching panel params", () => {
+    const layout = makeLayout({
+      a: { id: "a", params: { workspaceId: "ws", browserId: "a" } },
+      b: { id: "b", params: { workspaceId: "ws", browserId: "b" } },
+    });
+    const result = injectInitialUrls(
+      layout,
+      new Map([
+        ["a", "https://example.com"],
+        ["b", "https://other.test/path"],
+      ]),
+    ) as { panels: Record<string, { params: Record<string, unknown> }> };
+    expect(result.panels.a.params.initialUrl).toBe("https://example.com");
+    expect(result.panels.b.params.initialUrl).toBe("https://other.test/path");
+    // Existing keys preserved.
+    expect(result.panels.a.params.browserId).toBe("a");
+    expect(result.panels.a.params.workspaceId).toBe("ws");
+  });
+
+  it("doesn't mutate the source layout", () => {
+    const layout = makeLayout({ a: { id: "a", params: { browserId: "a" } } });
+    const copy = JSON.parse(JSON.stringify(layout));
+    injectInitialUrls(layout, new Map([["a", "https://example.com"]]));
+    expect(layout).toEqual(copy);
+  });
+
+  it("respects an existing initialUrl on the saved layout", () => {
+    const layout = makeLayout({
+      a: { id: "a", params: { browserId: "a", initialUrl: "https://kept.test" } },
+    });
+    const result = injectInitialUrls(layout, new Map([["a", "https://incoming.test"]])) as {
+      panels: Record<string, { params: { initialUrl: string } }>;
+    };
+    expect(result.panels.a.params.initialUrl).toBe("https://kept.test");
+  });
+
+  it("skips panels with no matching url", () => {
+    const layout = makeLayout({
+      a: { id: "a", params: { browserId: "a" } },
+      b: { id: "b", params: { browserId: "b" } },
+    });
+    const result = injectInitialUrls(layout, new Map([["a", "https://example.com"]])) as {
+      panels: Record<string, { params: Record<string, unknown> }>;
+    };
+    expect(result.panels.a.params.initialUrl).toBe("https://example.com");
+    expect(result.panels.b.params.initialUrl).toBeUndefined();
+  });
+
+  it("skips panels whose params are missing or malformed", () => {
+    const layout = makeLayout({
+      a: { id: "a" /* no params */ },
+      b: { id: "b", params: "broken" },
+      c: { id: "c", params: null },
+    });
+    const result = injectInitialUrls(
+      layout,
+      new Map([
+        ["a", "u"],
+        ["b", "u"],
+        ["c", "u"],
+      ]),
+    ) as {
+      panels: Record<string, unknown>;
+    };
+    // Each malformed panel is passed through untouched (same identity).
+    const original = layout.panels;
+    expect(result.panels.a).toBe(original.a);
+    expect(result.panels.b).toBe(original.b);
+    expect(result.panels.c).toBe(original.c);
+  });
+});

--- a/packages/dashboard-core/src/components/SearchBar.tsx
+++ b/packages/dashboard-core/src/components/SearchBar.tsx
@@ -7,6 +7,8 @@ export interface SearchOptions {
   regex: boolean;
 }
 
+export type SearchOptionKey = keyof SearchOptions;
+
 export interface SearchBarProps {
   /** Current search query text */
   query: string;
@@ -26,9 +28,19 @@ export interface SearchBarProps {
   onPrevious?: () => void;
   /** Called when user closes the search bar (Escape / X button) — omit to hide close button */
   onClose?: () => void;
+  /**
+   * Subset of toggle buttons to render. Defaults to all three
+   * (`caseSensitive`, `wholeWord`, `regex`). Callers backed by engines that
+   * only support a subset (e.g. Electron's `webContents.findInPage`, which
+   * only honours match-case) can narrow this to avoid showing toggles that
+   * would be no-ops.
+   */
+  visibleOptions?: readonly SearchOptionKey[];
   /** Extra class names for the root container */
   className?: string;
 }
+
+const DEFAULT_VISIBLE_OPTIONS: readonly SearchOptionKey[] = ["caseSensitive", "wholeWord", "regex"];
 
 export interface SearchBarHandle {
   focus: () => void;
@@ -71,10 +83,14 @@ export const SearchBar = forwardRef<SearchBarHandle, SearchBarProps>(function Se
     onNext,
     onPrevious,
     onClose,
+    visibleOptions = DEFAULT_VISIBLE_OPTIONS,
     className,
   },
   ref,
 ) {
+  const showCase = visibleOptions.includes("caseSensitive");
+  const showWholeWord = visibleOptions.includes("wholeWord");
+  const showRegex = visibleOptions.includes("regex");
   const inputRef = useRef<HTMLInputElement>(null);
 
   useImperativeHandle(ref, () => ({
@@ -117,15 +133,21 @@ export const SearchBar = forwardRef<SearchBarHandle, SearchBarProps>(function Se
           }
         }}
       />
-      <ToggleButton active={options.caseSensitive} onClick={toggleCase} title="Match Case">
-        <CaseSensitive className="size-4" />
-      </ToggleButton>
-      <ToggleButton active={options.wholeWord} onClick={toggleWholeWord} title="Match Whole Word">
-        <WholeWord className="size-4" />
-      </ToggleButton>
-      <ToggleButton active={options.regex} onClick={toggleRegex} title="Use Regular Expression">
-        <Regex className="size-4" />
-      </ToggleButton>
+      {showCase && (
+        <ToggleButton active={options.caseSensitive} onClick={toggleCase} title="Match Case">
+          <CaseSensitive className="size-4" />
+        </ToggleButton>
+      )}
+      {showWholeWord && (
+        <ToggleButton active={options.wholeWord} onClick={toggleWholeWord} title="Match Whole Word">
+          <WholeWord className="size-4" />
+        </ToggleButton>
+      )}
+      {showRegex && (
+        <ToggleButton active={options.regex} onClick={toggleRegex} title="Use Regular Expression">
+          <Regex className="size-4" />
+        </ToggleButton>
+      )}
       {matchInfo && query && (
         <span className="shrink-0 text-xs text-muted-foreground tabular-nums">
           {matchInfo.total > 0 ? `${matchInfo.current} of ${matchInfo.total}` : "No results"}

--- a/packages/dashboard-core/src/index.ts
+++ b/packages/dashboard-core/src/index.ts
@@ -21,7 +21,12 @@ export { NewWorkspaceDialog } from "./components/NewWorkspaceForm";
 export { PdfPreview } from "./components/PdfPreview";
 export { ProjectList } from "./components/ProjectList";
 export { QuickOpenDialog } from "./components/QuickOpenDialog";
-export { SearchBar, type SearchBarHandle, type SearchOptions } from "./components/SearchBar";
+export {
+  SearchBar,
+  type SearchBarHandle,
+  type SearchOptionKey,
+  type SearchOptions,
+} from "./components/SearchBar";
 export { SearchFilesDialog } from "./components/SearchFilesDialog";
 export { SettingsPage } from "./components/SettingsPage";
 export { SetupStatusIndicator } from "./components/SetupStatusIndicator";


### PR DESCRIPTION
## Summary

A bundle of browser-pane improvements that share the same intercept / IPC plumbing.

### Find in page (Cmd+F / Ctrl+F)
- Native Chromium `webContents.findInPage` for highlighting + match counting.
- `before-input-event` intercept so the shortcut also works when focus is inside the `WebContentsView`.
- Shared `SearchBar` gets a `visibleOptions` prop; browser bar shows only match-case (the option Chromium reliably honors).
- New `useBrowserFindInPage` hook + `BrowserFindBar` component, wired into both pane variants.

### Contextual desktop shortcuts
- **Cmd+R** reloads the focused tab when one is in use, otherwise the dashboard. Routed via `manager.findFocused()` + a new `window.__bandReload` renderer global, gated on the `data-band-browser-pane` attribute.
- **Cmd+= / Cmd+- / Actual Size** adjust the focused tab's \`webContents.zoomFactor\` first, falling back to the dashboard CSS zoom.
- **Cmd+T** is intercepted from the WebContentsView and forwarded as \`browser-new-tab-shortcut\` so it opens a new tab regardless of focus.

### DevTools docked in the tab
- \`toggleDevTools\` creates a sibling \`WebContentsView\` and points the page's DevTools at it via \`setDevToolsWebContents\`, then splits the tab bounds 60/40 so DevTools sits inside the tab area instead of opening as a detached window.
- \`setBounds\` / \`show\` / \`hide\` / \`destroy\` / \`moveTo\` all coordinate the DevTools sibling (including hidden-window migration).

### Address bar UX
- Wrench-icon DevTools toggle on the right of the address bar.
- \`did-start-navigation\` is the new source of truth for the address-bar URL during loading (fixes the old-URL flash that \`did-start-loading\` produced).
- Input is user-owned while focused: incoming events don't clobber an in-progress edit; Escape restores + re-selects; blur snaps to the canonical URL.

### Workspace-reopen URL loss
- Pending \`trpc.browsers.navigate\` debounces are flushed on \`BrowserPaneComponent\` unmount instead of canceled.
- \`DockviewBrowserContainer\` reads each tab's URL from \`trpc.browsers.list\` and injects it into the layout's \`params.initialUrl\` before \`fromJSON\`, so restored panels mount with the URL already in hand and don't race the create-webview effect.

## Test plan
- [ ] Cmd+F opens the find bar in any focused browser tab (page focus and React chrome focus both work); typing highlights matches; Enter / Shift+Enter step through; match counter updates; Escape closes.
- [ ] Cmd+R reloads the focused tab when a browser pane is focused; reloads the dashboard otherwise.
- [ ] Cmd+= / Cmd+- adjust the focused tab's zoom (independent per tab); fall back to dashboard zoom elsewhere.
- [ ] Cmd+T opens a new tab whether focus is on the address bar, the panel chrome, or inside the rendered web page.
- [ ] Wrench button toggles DevTools; DevTools appears docked at the bottom of the tab (not as a separate window); toggling again restores full-height page.
- [ ] Typing a URL while a page is still loading is not overwritten by the navigation completing.
- [ ] Address-bar Escape restores the URL, re-selects it, keeps focus in the input.
- [ ] Open tabs with URLs, switch workspaces until one is LRU-evicted, switch back: address bars show the correct URL and pages reload automatically.
- [ ] No regressions in single-pane workspaces (legacy \`BrowserPanelComponent\`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)