### PR TITLE
feat(desktop): run bundled web server via Electron's embedded Node

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ Download the latest signed `.dmg` from [GitHub Releases](https://github.com/band
 
 Auto-update is built in (via `electron-updater`): the app checks daily and prompts before installing.
 
+The desktop app is fully self-contained — it ships its own Node.js runtime (Electron's bundled Node 22.x) and runs the web server under that. End users do **not** need to install Node.js separately.
+
 ### Nightly
 
 Bleeding-edge builds from the `main` branch are published to a single rolling [`nightly` release](https://github.com/band-app/band/releases/tag/nightly) every day at 04:00 UTC. Nightly builds:
@@ -68,7 +70,9 @@ packages/
 
 ## Prerequisites
 
-- [Node.js](https://nodejs.org) v22.5+ (we use the built-in `node:sqlite` module)
+The packaged desktop app ships its own Node runtime via Electron, so end users only need macOS. The prerequisites below apply when **building from source**.
+
+- [Node.js](https://nodejs.org) v22.5+ — required to drive `pnpm install`, run the test suite, and build the web bundle (we use the built-in `node:sqlite` module)
 - [pnpm](https://pnpm.io) v10+
 - [Rust](https://rustup.rs) (for the CLI)
 - macOS

--- a/apps/desktop/electron-builder.yml
+++ b/apps/desktop/electron-builder.yml
@@ -11,8 +11,10 @@
 #     Windows + Linux are out of scope for this phase: the runtime in
 #     `apps/desktop/src/main/` and the bundled web server (apps/web,
 #     `"os": ["darwin", "linux"]`) currently assume a Unix-y host (POSIX
-#     shell for `shellPath`, `lsof` for port reclamation, `node` on PATH for
-#     spawning the bundled server). Adding those platforms is its own issue.
+#     shell for `shellPath`, `lsof` for port reclamation). The bundled web
+#     server is spawned via Electron's embedded Node runtime
+#     (`process.execPath` + `ELECTRON_RUN_AS_NODE=1`), so no system `node`
+#     binary needs to be on PATH. Adding Windows/Linux is its own issue.
 #
 # Cross-references:
 #   - Tauri sidecar:        apps/dashboard/src-tauri/tauri.conf.json (`externalBin`).

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -18,7 +18,7 @@
   },
   "devDependencies": {
     "@types/node": "^22.19.13",
-    "electron": "^33.0.0",
+    "electron": "^35.0.0",
     "electron-builder": "^25.0.0",
     "typescript": "^5.7.0"
   },

--- a/apps/desktop/src/main/services/web-server.ts
+++ b/apps/desktop/src/main/services/web-server.ts
@@ -186,7 +186,14 @@ function makeSpawnOptions(webDir: string, port: number, fds: ServerLogFds): Spaw
       // Silence the `node:sqlite` ExperimentalWarning. Node 22.x still
       // emits it; drop this once the bundled Node hits 24.x where the
       // module is marked Stable.
-      NODE_OPTIONS: "--no-warnings=ExperimentalWarning",
+      //
+      // Append (not replace) so we don't clobber any NODE_OPTIONS the
+      // parent already had — e.g. `--max-old-space-size=…` from a dev's
+      // shell profile, or a `--require` loader. Node parses
+      // space-separated flags in this var.
+      NODE_OPTIONS: [process.env.NODE_OPTIONS, "--no-warnings=ExperimentalWarning"]
+        .filter(Boolean)
+        .join(" "),
     },
     stdio: ["ignore", fds.out, fds.err],
     // Detached on Unix puts the spawn into its own process group so

--- a/apps/desktop/src/main/services/web-server.ts
+++ b/apps/desktop/src/main/services/web-server.ts
@@ -20,6 +20,7 @@ import { setTimeout as delay } from "node:timers/promises";
 import { bandHome, dashLog } from "./log.js";
 import { killPort } from "./port.js";
 import { getConfiguredPort, tryGetToken } from "./settings.js";
+import { shellPath } from "./shell-path.js";
 
 const HEALTH_TIMEOUT_MS = 15_000;
 const HEALTH_POLL_INTERVAL_MS = 200;
@@ -164,7 +165,21 @@ function makeSpawnOptions(webDir: string, port: number, fds: ServerLogFds): Spaw
       // Node.js interpreter — no Chromium, no app lifecycle — so we get the
       // bundled Node runtime (22.x for Electron 35+, with `node:sqlite` as
       // a built-in) without requiring users to install Node themselves.
+      //
+      // Note: this var inherits into every grandchild the web server forks.
+      // Harmless for the current stack (Rust CLIs, git, etc. ignore it) but
+      // if we ever shell out to a tool that is itself an Electron app, it
+      // would be misinterpreted as a request to run that binary as raw
+      // Node. Re-evaluate then.
       ELECTRON_RUN_AS_NODE: "1",
+      // Repopulate PATH from the user's login shell. Even though we no
+      // longer need a system `node` on PATH (spawn target is
+      // `process.execPath`), the web server's *own* children — `claude`,
+      // `band`, `git`, etc. living in `/opt/homebrew/bin` or
+      // `~/.cargo/bin` — inherit this env and rely on it to find their
+      // binaries when the app is launched from Finder/Spotlight (macOS
+      // gives GUI launches only a sparse `/usr/bin:/bin:/usr/sbin:/sbin`).
+      PATH: shellPath(),
       PORT: String(port),
       // Silence the `node:sqlite` ExperimentalWarning. Node 22.x still
       // emits it; drop this once the bundled Node hits 24.x where the

--- a/apps/desktop/src/main/services/web-server.ts
+++ b/apps/desktop/src/main/services/web-server.ts
@@ -20,7 +20,6 @@ import { setTimeout as delay } from "node:timers/promises";
 import { bandHome, dashLog } from "./log.js";
 import { killPort } from "./port.js";
 import { getConfiguredPort, tryGetToken } from "./settings.js";
-import { shellPath } from "./shell-path.js";
 
 const HEALTH_TIMEOUT_MS = 15_000;
 const HEALTH_POLL_INTERVAL_MS = 200;
@@ -160,10 +159,16 @@ function makeSpawnOptions(webDir: string, port: number, fds: ServerLogFds): Spaw
     cwd: webDir,
     env: {
       ...process.env,
-      PATH: shellPath(),
+      // The web server is spawned via `process.execPath` (the Electron
+      // binary). `ELECTRON_RUN_AS_NODE=1` tells Electron to act as a plain
+      // Node.js interpreter — no Chromium, no app lifecycle — so we get the
+      // bundled Node runtime (22.x for Electron 35+, with `node:sqlite` as
+      // a built-in) without requiring users to install Node themselves.
+      ELECTRON_RUN_AS_NODE: "1",
       PORT: String(port),
-      // Silence the `node:sqlite` ExperimentalWarning. Drop once Node marks
-      // the module Stable. Matches the Tauri code.
+      // Silence the `node:sqlite` ExperimentalWarning. Node 22.x still
+      // emits it; drop this once the bundled Node hits 24.x where the
+      // module is marked Stable.
       NODE_OPTIONS: "--no-warnings=ExperimentalWarning",
     },
     stdio: ["ignore", fds.out, fds.err],
@@ -174,23 +179,37 @@ function makeSpawnOptions(webDir: string, port: number, fds: ServerLogFds): Spaw
 }
 
 /**
- * Spawn `node dist/start-server.mjs` in `webDir`. Returns the child handle;
- * caller is responsible for tracking it (typically via `ManagedProcess`).
+ * Spawn the bundled web server in `webDir`, using Electron's embedded Node
+ * runtime (`process.execPath` + `ELECTRON_RUN_AS_NODE=1`). Returns the child
+ * handle; caller is responsible for tracking it (typically via
+ * `ManagedProcess`).
+ *
+ * Using the embedded Node — rather than `spawn("node", ...)` — means the app
+ * works even when the user has no system Node installed (or has the wrong
+ * version, or a sparse `PATH` from a Finder/Spotlight launch). It also
+ * guarantees the runtime ships `node:sqlite` as a built-in, which our
+ * `apps/web/src/lib/db/connection.ts` relies on.
  */
 export async function spawnWebServer(opts: SpawnWebServerOptions): Promise<ChildProcess> {
   const startScript = join(opts.webDir, "dist/start-server.mjs");
   const fds = await openServerLog();
-  const child = spawn("node", [startScript], makeSpawnOptions(opts.webDir, opts.port, fds));
+  const child = spawn(
+    process.execPath,
+    [startScript],
+    makeSpawnOptions(opts.webDir, opts.port, fds),
+  );
   if (process.platform !== "win32") {
     // Don't let the parent process wait on the child; we manage its lifetime.
     child.unref();
   }
   child.on("error", (err) => {
-    if ((err as NodeJS.ErrnoException).code === "ENOENT") {
-      dashLog("Node.js is required but not installed. Install it from https://nodejs.org");
-    } else {
-      dashLog(`Failed to start web server: ${err.message}`);
-    }
+    // After moving to the embedded Node runtime, ENOENT on the spawn binary
+    // is effectively impossible (it's bundled with the .app). Most errors
+    // here will be a missing `cwd` or start script — surface that directly
+    // instead of telling the user to install Node.
+    dashLog(
+      `Failed to start web server: ${err.message} (execPath=${process.execPath}, cwd=${opts.webDir}, script=${startScript})`,
+    );
   });
   return child;
 }

--- a/apps/desktop/src/main/services/web-server.ts
+++ b/apps/desktop/src/main/services/web-server.ts
@@ -168,9 +168,11 @@ function makeSpawnOptions(webDir: string, port: number, fds: ServerLogFds): Spaw
       //
       // Note: this var inherits into every grandchild the web server forks.
       // Harmless for the current stack (Rust CLIs, git, etc. ignore it) but
-      // if we ever shell out to a tool that is itself an Electron app, it
-      // would be misinterpreted as a request to run that binary as raw
-      // Node. Re-evaluate then.
+      // *not* harmless for any Electron-based binary in the call chain. The
+      // most concrete example is the VS Code `code` CLI (Electron) — if the
+      // web server ever shells out to it to open a file or run a task, it
+      // would launch as a plain Node interpreter instead of the editor. If
+      // we ever add such a call site, scrub this var from that spawn's env.
       ELECTRON_RUN_AS_NODE: "1",
       // Repopulate PATH from the user's login shell. Even though we no
       // longer need a system `node` on PATH (spawn target is
@@ -218,10 +220,12 @@ export async function spawnWebServer(opts: SpawnWebServerOptions): Promise<Child
     child.unref();
   }
   child.on("error", (err) => {
-    // After moving to the embedded Node runtime, ENOENT on the spawn binary
-    // is effectively impossible (it's bundled with the .app). Most errors
-    // here will be a missing `cwd` or start script — surface that directly
-    // instead of telling the user to install Node.
+    // After moving to the embedded Node runtime, ENOENT on the spawn
+    // *binary* is effectively impossible — `process.execPath` is the
+    // running interpreter, bundled with the .app. ENOENT on the *start
+    // script* can still happen if the web bundle is missing or
+    // corrupted, hence `script=` in the diagnostic below. Either way,
+    // we no longer tell users to install Node.
     dashLog(
       `Failed to start web server: ${err.message} (execPath=${process.execPath}, cwd=${opts.webDir}, script=${startScript})`,
     );

--- a/apps/desktop/tests/web-server.test.ts
+++ b/apps/desktop/tests/web-server.test.ts
@@ -182,14 +182,12 @@ describe("web-server lifecycle", () => {
       //    child will equal process.execPath of the parent, and both will
       //    be absolute paths.
       //
-      // Note: this set of assertions does *not* distinguish
-      // `spawn(process.execPath, …)` from `spawn("node", …)` in a plain-Node
-      // CI environment — the OS resolves the literal "node" to an absolute
-      // path before the child starts, so the captured execPath would be
-      // identical in both cases. What this test does verify is that the env
-      // we set in `makeSpawnOptions` (ELECTRON_RUN_AS_NODE, NODE_OPTIONS) is
-      // actually propagated to the child, which is the contract the
-      // packaged .app relies on.
+      // CI gap: cannot verify the spawn-binary choice without a real
+      // Electron binary in the test process. The OS resolves the literal
+      // "node" to an absolute path before the child starts, so a refactor
+      // back to `spawn("node", …)` would still pass these assertions. The
+      // only real guard is a manual smoke test of the packaged `.app` with
+      // system `node` removed from PATH.
       assert.equal(captured.execPath, process.execPath);
       assert.ok(captured.execPath.startsWith("/"), "execPath must be absolute");
 
@@ -199,8 +197,10 @@ describe("web-server lifecycle", () => {
       assert.equal(captured.electronRunAsNode, "1");
 
       // Keep the experimental warning silencer until Node bundled by Electron
-      // moves to 24.x where node:sqlite is stable.
-      assert.equal(captured.nodeOptions, "--no-warnings=ExperimentalWarning");
+      // moves to 24.x where node:sqlite is stable. We *append* to whatever
+      // NODE_OPTIONS the parent had, so this assertion checks containment
+      // rather than equality.
+      assert.match(captured.nodeOptions ?? "", /--no-warnings=ExperimentalWarning/);
     } finally {
       await managed.kill();
     }

--- a/apps/desktop/tests/web-server.test.ts
+++ b/apps/desktop/tests/web-server.test.ts
@@ -174,16 +174,19 @@ describe("web-server lifecycle", () => {
 
       // We spawned via process.execPath (the running interpreter — Electron's
       // embedded Node in production, the system `node` in this test process).
-      // In either case it must be an *absolute* path that matches the parent
-      // — NOT the bare string "node", which would indicate a regression back
-      // to `spawn("node", ...)`. (In a test env where `process.execPath` IS
-      // /usr/local/bin/node, simply asserting equality with `process.execPath`
-      // isn't enough to detect that regression — `node` from PATH would
-      // resolve to the same absolute path. Asserting absoluteness +
-      // non-literal-"node" closes that gap.)
+      // The child's execPath must match the parent's and must be absolute.
+      //
+      // Caveat: in a plain-Node test environment, asserting these does *not*
+      // catch a regression back to `spawn("node", [startScript])` — the OS
+      // resolves the literal "node" to an absolute path (e.g. /usr/local/bin/node)
+      // before the child starts, so the child's process.execPath ends up
+      // equal to the parent's. The actual regression detector for that case
+      // is the `electronRunAsNode === "1"` assertion below; plain `node`
+      // doesn't propagate that env var unless we explicitly set it, but the
+      // var MUST be present for the same code to work inside the packaged
+      // .app where process.execPath is the Electron binary.
       assert.equal(captured.execPath, process.execPath);
       assert.ok(captured.execPath.startsWith("/"), "execPath must be absolute");
-      assert.notEqual(captured.execPath, "node");
 
       // ELECTRON_RUN_AS_NODE=1 is what makes the Electron binary act as a
       // pure Node interpreter when this code runs inside the packaged .app.

--- a/apps/desktop/tests/web-server.test.ts
+++ b/apps/desktop/tests/web-server.test.ts
@@ -16,7 +16,7 @@
  */
 
 import { strict as assert } from "node:assert";
-import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { after, before, describe, test } from "node:test";
@@ -58,6 +58,15 @@ const token = "test-token-" + Math.random().toString(36).slice(2);
 const dir = join(homedir(), ".band");
 mkdirSync(dir, { recursive: true });
 writeFileSync(join(dir, "settings.json"), JSON.stringify({ tokenSecret: token, webServerPort: port }, null, 2));
+
+// Record the spawn environment + execPath so the integration test can assert
+// the desktop shell actually invoked us via process.execPath +
+// ELECTRON_RUN_AS_NODE=1. Black-box check — no need to mock spawn.
+writeFileSync(join(dir, "spawn-env.json"), JSON.stringify({
+  execPath: process.execPath,
+  electronRunAsNode: process.env.ELECTRON_RUN_AS_NODE ?? null,
+  nodeOptions: process.env.NODE_OPTIONS ?? null,
+}, null, 2));
 
 const server = http.createServer((req, res) => {
   if (req.url?.startsWith("/api/health")) {
@@ -127,6 +136,41 @@ describe("web-server lifecycle", () => {
       assert.equal(res.status, 200);
       const body = await res.json();
       assert.equal(body.app, "band-web-server");
+    } finally {
+      await managed.kill();
+    }
+  });
+
+  test("spawnWebServer uses process.execPath + ELECTRON_RUN_AS_NODE=1", async () => {
+    const port = await findFreePort();
+    const managed = new ManagedProcess();
+
+    try {
+      await ensureWebserverRunning({ webDir, managed, port });
+
+      // The fake server writes the spawn env it sees into ~/.band/spawn-env.json.
+      // That tells us — black-box — what the desktop shell actually invoked.
+      const raw = await readFile(join(sandboxHome, ".band", "spawn-env.json"), "utf8");
+      const captured = JSON.parse(raw) as {
+        execPath: string;
+        electronRunAsNode: string | null;
+        nodeOptions: string | null;
+      };
+
+      // We spawned via process.execPath (the running interpreter — Electron's
+      // embedded Node in production, the system `node` in this test process).
+      // In either case it must match the parent's execPath, NOT a bare "node"
+      // looked up on PATH.
+      assert.equal(captured.execPath, process.execPath);
+
+      // ELECTRON_RUN_AS_NODE=1 is what makes the Electron binary act as a
+      // pure Node interpreter when this code runs inside the packaged .app.
+      // Plain `node` ignores it, but the value must still be propagated.
+      assert.equal(captured.electronRunAsNode, "1");
+
+      // Keep the experimental warning silencer until Node bundled by Electron
+      // moves to 24.x where node:sqlite is stable.
+      assert.equal(captured.nodeOptions, "--no-warnings=ExperimentalWarning");
     } finally {
       await managed.kill();
     }

--- a/apps/desktop/tests/web-server.test.ts
+++ b/apps/desktop/tests/web-server.test.ts
@@ -172,19 +172,24 @@ describe("web-server lifecycle", () => {
         nodeOptions: string | null;
       };
 
-      // We spawned via process.execPath (the running interpreter — Electron's
-      // embedded Node in production, the system `node` in this test process).
-      // The child's execPath must match the parent's and must be absolute.
+      // The test asserts env *shape*, not the spawn-binary target:
       //
-      // Caveat: in a plain-Node test environment, asserting these does *not*
-      // catch a regression back to `spawn("node", [startScript])` — the OS
-      // resolves the literal "node" to an absolute path (e.g. /usr/local/bin/node)
-      // before the child starts, so the child's process.execPath ends up
-      // equal to the parent's. The actual regression detector for that case
-      // is the `electronRunAsNode === "1"` assertion below; plain `node`
-      // doesn't propagate that env var unless we explicitly set it, but the
-      // var MUST be present for the same code to work inside the packaged
-      // .app where process.execPath is the Electron binary.
+      //  - In production the spawn binary is the Electron `.app` executable
+      //    (process.execPath), which behaves as Node thanks to the
+      //    ELECTRON_RUN_AS_NODE=1 env var below.
+      //  - In this test environment the spawn binary is the system `node`
+      //    that's running the test runner. process.execPath of the spawned
+      //    child will equal process.execPath of the parent, and both will
+      //    be absolute paths.
+      //
+      // Note: this set of assertions does *not* distinguish
+      // `spawn(process.execPath, …)` from `spawn("node", …)` in a plain-Node
+      // CI environment — the OS resolves the literal "node" to an absolute
+      // path before the child starts, so the captured execPath would be
+      // identical in both cases. What this test does verify is that the env
+      // we set in `makeSpawnOptions` (ELECTRON_RUN_AS_NODE, NODE_OPTIONS) is
+      // actually propagated to the child, which is the contract the
+      // packaged .app relies on.
       assert.equal(captured.execPath, process.execPath);
       assert.ok(captured.execPath.startsWith("/"), "execPath must be absolute");
 

--- a/apps/desktop/tests/web-server.test.ts
+++ b/apps/desktop/tests/web-server.test.ts
@@ -62,6 +62,11 @@ writeFileSync(join(dir, "settings.json"), JSON.stringify({ tokenSecret: token, w
 // Record the spawn environment + execPath so the integration test can assert
 // the desktop shell actually invoked us via process.execPath +
 // ELECTRON_RUN_AS_NODE=1. Black-box check — no need to mock spawn.
+//
+// Written once at module load (this file is module-scope), so the assertion
+// captures the *first* spawn's env. That's the only invocation we need today
+// (each test allocates a fresh port and a fresh fake server); revisit if a
+// future test ever reuses a running server across cases.
 writeFileSync(join(dir, "spawn-env.json"), JSON.stringify({
   execPath: process.execPath,
   electronRunAsNode: process.env.ELECTRON_RUN_AS_NODE ?? null,
@@ -150,6 +155,9 @@ describe("web-server lifecycle", () => {
 
       // The fake server writes the spawn env it sees into ~/.band/spawn-env.json.
       // That tells us — black-box — what the desktop shell actually invoked.
+      // Note: `sandboxHome` here is the same path the fake server resolves
+      // via `homedir()` — the `before()` hook overrides `process.env.HOME`
+      // to point at `sandboxHome` before spawning anything.
       const raw = await readFile(join(sandboxHome, ".band", "spawn-env.json"), "utf8");
       const captured = JSON.parse(raw) as {
         execPath: string;

--- a/apps/desktop/tests/web-server.test.ts
+++ b/apps/desktop/tests/web-server.test.ts
@@ -46,6 +46,13 @@ async function findFreePort(): Promise<number> {
   });
 }
 
+// `FAKE_SERVER` is a *string* of JavaScript source. The test harness writes
+// it to `webDir/dist/start-server.mjs` and spawns it as a child process via
+// `spawnWebServer` — it is never `import`ed by the test runner itself. So
+// the `writeFileSync` calls inside this template only ever run inside the
+// spawned child, where `HOME` has already been overridden to `sandboxHome`
+// by the `before()` hook. There is no second context that would touch the
+// user's real `~/.band/`.
 const FAKE_SERVER = `import http from "node:http";
 import { mkdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
@@ -167,9 +174,16 @@ describe("web-server lifecycle", () => {
 
       // We spawned via process.execPath (the running interpreter — Electron's
       // embedded Node in production, the system `node` in this test process).
-      // In either case it must match the parent's execPath, NOT a bare "node"
-      // looked up on PATH.
+      // In either case it must be an *absolute* path that matches the parent
+      // — NOT the bare string "node", which would indicate a regression back
+      // to `spawn("node", ...)`. (In a test env where `process.execPath` IS
+      // /usr/local/bin/node, simply asserting equality with `process.execPath`
+      // isn't enough to detect that regression — `node` from PATH would
+      // resolve to the same absolute path. Asserting absoluteness +
+      // non-literal-"node" closes that gap.)
       assert.equal(captured.execPath, process.execPath);
+      assert.ok(captured.execPath.startsWith("/"), "execPath must be absolute");
+      assert.notEqual(captured.execPath, "node");
 
       // ELECTRON_RUN_AS_NODE=1 is what makes the Electron binary act as a
       // pure Node interpreter when this code runs inside the packaged .app.

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -6,8 +6,10 @@ Web server + dashboard frontend for Band. Provides the tRPC API, WebSocket layer
 
 This package runs under [Node.js](https://nodejs.org) v22.5 or newer. The shebang on `bin/band-server.mjs` is `#!/usr/bin/env node`.
 
+> ℹ️ Users running the Band **desktop app** do **not** need to install Node themselves — the desktop shell ships its own bundled Node runtime (via Electron) and spawns the web server under it. The Node 22.5+ requirement only applies to people running this package directly via `band-server` / `node dist/start-server.mjs`, or doing local development against the source tree.
+
 ```bash
-# Run the server
+# Run the server (standalone consumer scenario)
 band-server
 # or:
 node dist/start-server.mjs
@@ -23,7 +25,7 @@ We were briefly on `bun:sqlite` (PR #353) to dodge the same ABI problem, but Bun
 
 ## Install
 
-Node v22.5+ must be on `PATH` first.
+For the standalone scenario (running `band-server` outside the desktop app), Node v22.5+ must be on `PATH`. Desktop app users can skip this section — the .app brings its own Node.
 
 ```bash
 # 1. Install Node.js 22.5+ (https://nodejs.org)

--- a/apps/website/src/pages/docs/architecture.astro
+++ b/apps/website/src/pages/docs/architecture.astro
@@ -12,8 +12,8 @@ import DocsLayout from "../../layouts/DocsLayout.astro";
   <h2>System Overview</h2>
 
   <ul>
-    <li><strong>Desktop App (Electron)</strong> — Hosts the dashboard webview, auto-starts the web server, and provides macOS-only shell helpers (folder picker, reveal in Finder, install the CLI with admin privileges).</li>
-    <li><strong>Web Server (Node.js)</strong> — Data management, state, API, and background processes.</li>
+    <li><strong>Desktop App (Electron)</strong> — Hosts the dashboard webview, auto-starts the web server, and provides macOS-only shell helpers (folder picker, reveal in Finder, install the CLI with admin privileges). The desktop app spawns the web server using Electron's embedded Node runtime (<code>ELECTRON_RUN_AS_NODE=1</code>), so end users do not need to install Node themselves.</li>
+    <li><strong>Web Server (Node.js)</strong> — Data management, state, API, and background processes. Runs under whichever Node interpreter the host supplies — Electron's bundled Node 22.x in the packaged desktop app, or a system <code>node</code> binary when run standalone.</li>
     <li><strong>CLI (Rust)</strong> — Command-line interface for scripting and automation.</li>
   </ul>
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -46,8 +46,8 @@ importers:
         specifier: ^22.19.13
         version: 22.19.13
       electron:
-        specifier: ^33.0.0
-        version: 33.4.11
+        specifier: ^35.0.0
+        version: 35.7.5
       electron-builder:
         specifier: ^25.0.0
         version: 25.1.8(electron-builder-squirrel-windows@25.1.8)
@@ -3186,9 +3186,6 @@ packages:
   '@types/nlcst@2.0.3':
     resolution: {integrity: sha512-vSYNSDe6Ix3q+6Z7ri9lyWqgGhJTmzRjZRqyq15N0Z/1/UnVsno9G/N40NBijoYx2seFDIl0+B2mgAb9mezUCA==}
 
-  '@types/node@20.19.39':
-    resolution: {integrity: sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw==}
-
   '@types/node@22.19.13':
     resolution: {integrity: sha512-akNQMv0wW5uyRpD2v2IEyRSZiR+BeGuoB6L310EgGObO44HSMNT8z1xzio28V8qOrgYaopIDNA18YgdXd+qTiw==}
 
@@ -4390,8 +4387,8 @@ packages:
   electron-updater@6.8.3:
     resolution: {integrity: sha512-Z6sgw3jgbikWKXei1ENdqFOxBP0WlXg3TtKfz0rgw2vIZFJUyI4pD7ZN7jrkm7EoMK+tcm/qTnPUdqfZukBlBQ==}
 
-  electron@33.4.11:
-    resolution: {integrity: sha512-xmdAs5QWRkInC7TpXGNvzo/7exojubk+72jn1oJL7keNeIlw7xNglf8TGtJtkR4rWC5FJq0oXiIXPS9BcK2Irg==}
+  electron@35.7.5:
+    resolution: {integrity: sha512-dnL+JvLraKZl7iusXTVTGYs10TKfzUi30uEDTqsmTm0guN9V2tbOjTzyIZbh9n3ygUjgEYyo+igAwMRXIi3IPw==}
     engines: {node: '>= 12.20.55'}
     hasBin: true
 
@@ -10261,10 +10258,6 @@ snapshots:
     dependencies:
       '@types/unist': 3.0.3
 
-  '@types/node@20.19.39':
-    dependencies:
-      undici-types: 6.21.0
-
   '@types/node@22.19.13':
     dependencies:
       undici-types: 6.21.0
@@ -11649,10 +11642,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  electron@33.4.11:
+  electron@35.7.5:
     dependencies:
       '@electron/get': 2.0.3
-      '@types/node': 20.19.39
+      '@types/node': 22.19.13
       extract-zip: 2.0.1
     transitivePeerDependencies:
       - supports-color


### PR DESCRIPTION
## Summary

- Bumps Electron 33 → 35 (ships Node 22.16.0, which has `node:sqlite` as a built-in)
- Switches the web-server spawn from `spawn(\"node\", ...)` to `spawn(process.execPath, ..., env.ELECTRON_RUN_AS_NODE=\"1\")` so the desktop app uses Electron's embedded Node runtime
- Eliminates the misleading `Node.js is required but not installed` message (`~/.band/desktop.log`) and the `ERR_UNKNOWN_BUILTIN_MODULE: node:sqlite` failure on Node < 22.5 (`~/.band/server.log`) — both classes of "missing/wrong system Node" bugs disappear since end users no longer need Node at all

## Changes

- `apps/desktop/package.json` — `electron: ^33.0.0` → `^35.0.0` (installed: 35.7.5)
- `apps/desktop/src/main/services/web-server.ts`:
  - spawn via `process.execPath` + `ELECTRON_RUN_AS_NODE: \"1\"`
  - **Kept** `PATH: shellPath()` in the spawn env — even though the spawn target is now `process.execPath`, the web server forks grandchildren (`claude`, `band`, `git`, etc.) that need a real PATH on Finder/Spotlight launches. (An earlier draft dropped it; restored after review.)
  - rewrite the error handler to log `execPath`/`cwd`/`script` instead of telling users to install Node
  - comments call out the `ELECTRON_RUN_AS_NODE` grandchild-inheritance risk for Electron binaries (specifically the VS Code `code` CLI), and distinguish ENOENT-on-binary (impossible) vs ENOENT-on-script (possible)
- `apps/desktop/tests/web-server.test.ts`: extend the fake server to record the spawn env into `~/.band/spawn-env.json`; add a black-box assertion test for `process.execPath` + `ELECTRON_RUN_AS_NODE=1` + `NODE_OPTIONS`
- `apps/desktop/electron-builder.yml`: refresh the header comment about runtime assumptions
- Docs (`README.md`, `apps/web/README.md`, `apps/website/src/pages/docs/architecture.astro`): clarify desktop users no longer need Node; the 22.5+ floor only applies to source builds and the standalone `@band-app/server` package

## Test plan

- [x] `pnpm --filter @band-app/desktop test` — 95/95 pass, including new \`spawnWebServer uses process.execPath + ELECTRON_RUN_AS_NODE=1\` integration test
- [x] \`pnpm --filter @band-app/desktop build\` — clean tsc
- [x] \`pnpm install\` — Electron 35.7.5 resolved
- [ ] \`pnpm build:desktop\` end-to-end + boot the produced \`.app\` and confirm the web server comes up using the embedded Node (recommended before merge)
- [ ] Manually verify with system \`node\` removed from PATH (recommended before merge)

## Caveats to spot-check before merging

- **Native modules** under \`apps/web\` (e.g. \`node-pty\`) must be ABI-compatible with Electron's Node 22.16.0. Prebuilt \`node-pty\` binaries should be fine but worth confirming on first boot.
- **electron-updater@6.8.3** compatibility with Electron 35 — release notes look OK, but verify the in-app update banner from #399 still works.
- **macOS signing/notarization** — \`scripts/after-pack.mjs\` and \`scripts/after-sign.mjs\` deep-sign nested binaries; confirm the script still finds everything after the Electron bump.
- **\`ELECTRON_RUN_AS_NODE\` grandchild leak** — flagged in code comments. Harmless for the current stack (Rust CLIs, git). Future call sites that shell out to Electron-based tools (VS Code \`code\` CLI, Electron MCP servers, etc.) must scrub this var from their spawn env. Worth tracking as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)