### PR TITLE
fix(test): stabilize pinned-workspaces teardown on macOS CI

### DIFF
--- a/apps/web/tests/trpc.test.ts
+++ b/apps/web/tests/trpc.test.ts
@@ -1607,7 +1607,7 @@ describe("tRPC — pinned workspaces", () => {
       // best-effort — fine if the test crashed before the worktree was created,
       // or if it was already cleaned up
     }
-    rmSync(tmpHome, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 });
+    rmSync(tmpHome, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 });
   });
 
   it("projects.list returns pinned: false by default", async () => {

--- a/apps/web/tests/trpc.test.ts
+++ b/apps/web/tests/trpc.test.ts
@@ -1601,7 +1601,13 @@ describe("tRPC — pinned workspaces", () => {
 
   afterAll(async () => {
     await server.close();
-    rmSync(tmpHome, { recursive: true, force: true });
+    try {
+      git(repoPath, ["worktree", "remove", "--force", featureWorktreePath]);
+    } catch {
+      // best-effort — fine if the test crashed before the worktree was created,
+      // or if it was already cleaned up
+    }
+    rmSync(tmpHome, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 });
   });
 
   it("projects.list returns pinned: false by default", async () => {


### PR DESCRIPTION
## Summary

- Flaky-test fix only — no behavior change. Unblocks the v0.11.0 release.
- Stabilizes the `tRPC — pinned workspaces` suite teardown in `apps/web/tests/trpc.test.ts`, which intermittently failed on macOS CI with `ENOTEMPTY: directory not empty, rmdir '.../pin-repo/.git'`.
- This suite is the only one in `trpc.test.ts` that registers a real worktree via `git worktree add -b feature ...`; git's fsmonitor / lingering file descriptors / `index.lock` hand-offs can still touch files inside `.git/worktrees/feature/` when `rmSync` starts deleting, producing ENOTEMPTY.

## Failure that blocked the release

Release run that failed: https://github.com/band-app/band/actions/runs/25797776854

```
FAIL tests/trpc.test.ts > tRPC — pinned workspaces
Error: ENOTEMPTY: directory not empty, rmdir '/private/var/folders/.../pin-repo/.git'
```

All 522 individual tests passed; only the suite teardown failed. The previous release (run 25783279284) was built from the **same commit** (92079db) and passed — confirming this is a flake, not a regression.

## What changed

Only the `afterAll` for `describe("tRPC — pinned workspaces", …)`:

1. Explicitly `git worktree remove --force` before `rmSync`, wrapped in `try/catch`, so git releases its locks before the directory tree is deleted. Best-effort — the last test in the suite already removes the worktree via the tRPC API, so in the happy path this is a no-op.
2. Pass `maxRetries: 3, retryDelay: 100` to `rmSync` as belt-and-suspenders for any remaining transient `ENOTEMPTY` / `EBUSY` / `EPERM`. Worst-case ≤600 ms of linear backoff (100+200+300 ms); the explicit `git worktree remove --force` is what handles the primary lock source, so a small retry budget is enough. If CI still flakes here, `maxRetries` is the lever to pull.

No other `afterAll` / `beforeAll` / test was touched. No assertions disabled or relaxed. No new dependencies.

## Test plan

- [x] Run the targeted suite 20× locally — all 20 pass, no ENOTEMPTY, no leaked tmp dirs:
  ```sh
  cd apps/web
  for i in {1..20}; do
    NODE_OPTIONS='--no-warnings=ExperimentalWarning' pnpm exec vitest run tests/trpc.test.ts -t 'tRPC — pinned workspaces' || break
  done
  ```
- [x] Full `apps/web` suite (`pnpm test`) — 512/512 pass across 34 files.
- [x] Working tree clean, no stray `band-trpc-test-*` tmp dirs left after the loop.
- [x] CI green on this PR.
- [ ] After merge, re-dispatch the v0.11.0 release workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)