### PR TITLE
feat(file-browser): refresh tree on external file changes (#384)

### DIFF
--- a/apps/web/src/lib/file-watcher.ts
+++ b/apps/web/src/lib/file-watcher.ts
@@ -1,0 +1,168 @@
+import { type FSWatcher, watch as fsWatch } from "node:fs";
+import { resolveWorkspace } from "./workspace";
+
+// ---------------------------------------------------------------------------
+// Server-side file watcher
+// ---------------------------------------------------------------------------
+//
+// One recursive `fs.watch` per workspace, started on demand when a client
+// subscribes for that workspace's file changes and stopped when the last
+// subscriber disconnects. The watcher emits a coalesced `(workspaceId,
+// parentDir)` event so the client FileBrowser can invalidate its
+// in-memory directory cache.
+//
+// We don't push directory contents through the event — the client already
+// knows how to re-fetch via `listFiles`. The event just says which parent
+// directory to invalidate.
+//
+// Per-workspace lifecycle (not global) so we don't hold OS watch handles
+// open on every worktree the user has ever added — see issue #384.
+//
+// Edge-cases:
+//   * Heavy directories (`.git`, `node_modules`, build output) are
+//     filtered out so the watcher doesn't drown the client in noise.
+//   * Events are coalesced per (workspaceId, parentDir) with a short
+//     debounce — a rapid burst (e.g. `git checkout`) maps to one refresh.
+//   * `fs.watch` may emit `null` filenames or throw if the worktree was
+//     deleted; we swallow both.
+// ---------------------------------------------------------------------------
+
+/**
+ * Directory segments whose contents we never report to the client. Keeping
+ * them out of the event stream avoids flooding the FileBrowser with
+ * meaningless events when, for example, `pnpm install` rewrites
+ * `node_modules`.
+ */
+const IGNORED_SEGMENTS = new Set<string>([
+  ".git",
+  "node_modules",
+  ".next",
+  ".turbo",
+  ".cache",
+  ".parcel-cache",
+  ".vite",
+  "dist",
+  "build",
+  "out",
+  "target",
+  "coverage",
+  ".band",
+  ".DS_Store",
+]);
+
+/**
+ * Window (in milliseconds) over which we coalesce events for the same
+ * (workspaceId, parentDir) pair. Short enough to feel snappy; long enough
+ * to collapse rapid bursts (saves, git operations) into one refresh.
+ */
+const DEBOUNCE_MS = 250;
+
+export type FileChangeListener = (path: string) => void;
+export type Unsubscribe = () => void;
+
+interface WatchEntry {
+  watcher: FSWatcher;
+  listeners: Set<FileChangeListener>;
+  pendingTimers: Map<string, ReturnType<typeof setTimeout>>;
+}
+
+const watchers = new Map<string, WatchEntry>();
+
+function isIgnoredPath(relativePath: string): boolean {
+  if (!relativePath) return false;
+  for (const segment of relativePath.split(/[\\/]+/)) {
+    if (IGNORED_SEGMENTS.has(segment)) return true;
+  }
+  return false;
+}
+
+function parentDirOf(relativePath: string): string {
+  const normalised = relativePath.split(/[\\/]+/).join("/");
+  const idx = normalised.lastIndexOf("/");
+  return idx === -1 ? "" : normalised.slice(0, idx);
+}
+
+function scheduleEmit(workspaceId: string, dirPath: string): void {
+  const entry = watchers.get(workspaceId);
+  if (!entry) return;
+  const existing = entry.pendingTimers.get(dirPath);
+  if (existing) clearTimeout(existing);
+  const timer = setTimeout(() => {
+    entry.pendingTimers.delete(dirPath);
+    // Re-resolve the entry — listeners may have been torn down during the
+    // debounce window.
+    const current = watchers.get(workspaceId);
+    if (!current) return;
+    for (const listener of current.listeners) listener(dirPath);
+  }, DEBOUNCE_MS);
+  entry.pendingTimers.set(dirPath, timer);
+}
+
+function stopWatcher(workspaceId: string): void {
+  const entry = watchers.get(workspaceId);
+  if (!entry) return;
+  try {
+    entry.watcher.close();
+  } catch {
+    // Already closed — nothing to do.
+  }
+  for (const timer of entry.pendingTimers.values()) clearTimeout(timer);
+  entry.pendingTimers.clear();
+  watchers.delete(workspaceId);
+}
+
+/**
+ * Subscribe to external file-system changes inside a workspace. The
+ * watcher is started lazily on the first subscription and torn down when
+ * the last subscriber disconnects. Returns an unsubscribe function.
+ *
+ * If the workspace can't be resolved (e.g. it was just removed) the
+ * subscription is a silent no-op so callers don't need a separate
+ * error-handling path.
+ */
+export function subscribeToFileChanges(
+  workspaceId: string,
+  listener: FileChangeListener,
+): Unsubscribe {
+  let entry = watchers.get(workspaceId);
+
+  if (!entry) {
+    const ws = resolveWorkspace(workspaceId);
+    if (!ws) return () => {};
+    const root = ws.worktree.path;
+
+    let watcher: FSWatcher;
+    try {
+      watcher = fsWatch(root, { recursive: true, persistent: false }, (_event, filename) => {
+        // `filename` may be null on some platforms or under heavy churn —
+        // the change is real but we can't pinpoint where, so skip. Without
+        // `encoding: "buffer"` Node returns a string, but we accept both
+        // for safety.
+        if (filename == null) return;
+        const relative = typeof filename === "string" ? filename : Buffer.from(filename).toString();
+        if (!relative || isIgnoredPath(relative)) return;
+        scheduleEmit(workspaceId, parentDirOf(relative));
+      });
+    } catch {
+      // The worktree may have been deleted between resolveWorkspace and
+      // fs.watch. Treat this subscription as a silent no-op.
+      return () => {};
+    }
+
+    entry = { watcher, listeners: new Set(), pendingTimers: new Map() };
+    // Recursive watches can emit transient errors (e.g. when a watched
+    // subdir is removed). Drop the watcher so the next subscriber retries
+    // with a fresh handle.
+    watcher.on("error", () => stopWatcher(workspaceId));
+    watchers.set(workspaceId, entry);
+  }
+
+  entry.listeners.add(listener);
+
+  return () => {
+    const current = watchers.get(workspaceId);
+    if (!current) return;
+    current.listeners.delete(listener);
+    if (current.listeners.size === 0) stopWatcher(workspaceId);
+  };
+}

--- a/apps/web/src/lib/file-watcher.ts
+++ b/apps/web/src/lib/file-watcher.ts
@@ -57,7 +57,18 @@ const IGNORED_SEGMENTS = new Set<string>([
  */
 const DEBOUNCE_MS = 250;
 
-export type FileChangeListener = (path: string) => void;
+/**
+ * Listener for file-change events.
+ *
+ * - `path` (string): workspace-relative parent directory whose contents
+ *   changed.
+ * - `path === null`: sentinel meaning the underlying watcher hit an
+ *   unrecoverable error (e.g. the worktree directory was deleted) and is
+ *   shutting down. Listeners should stop waiting for more events and let
+ *   their subscription complete; the next subscriber will create a fresh
+ *   watcher.
+ */
+export type FileChangeListener = (path: string | null) => void;
 export type Unsubscribe = () => void;
 
 interface WatchEntry {
@@ -154,10 +165,19 @@ export function subscribeToFileChanges(
     }
 
     entry = { watcher, listeners: new Set(), pendingTimers: new Map() };
-    // Recursive watches can emit transient errors (e.g. when a watched
-    // subdir is removed). Drop the watcher so the next subscriber retries
+    // Recursive watches can emit unrecoverable errors (e.g. when the
+    // watched directory is removed). Wake every current subscriber with
+    // a `null` sentinel so their tRPC generators can finish cleanly
+    // instead of parking forever waiting for an event from a dead
+    // watcher. Drop the entry afterwards so the next subscriber retries
     // with a fresh handle.
-    watcher.on("error", () => stopWatcher(workspaceId));
+    watcher.on("error", () => {
+      const current = watchers.get(workspaceId);
+      if (current) {
+        for (const listener of current.listeners) listener(null);
+      }
+      stopWatcher(workspaceId);
+    });
     watchers.set(workspaceId, entry);
   }
 

--- a/apps/web/src/lib/file-watcher.ts
+++ b/apps/web/src/lib/file-watcher.ts
@@ -27,12 +27,19 @@ import { resolveWorkspace } from "./workspace";
 //     deleted; we swallow both.
 // ---------------------------------------------------------------------------
 
-/**
- * Directory segments whose contents we never report to the client. Keeping
- * them out of the event stream avoids flooding the FileBrowser with
- * meaningless events when, for example, `pnpm install` rewrites
- * `node_modules`.
- */
+// Directory segments whose contents we never report to the client. Keeping
+// them out of the event stream avoids flooding the FileBrowser with
+// meaningless events when, for example, "pnpm install" rewrites
+// node_modules.
+//
+// Trade-off: this match is depth-agnostic, so "target/" anywhere in the
+// tree is silently filtered (intentional — Rust monorepos write to
+// apps/cli/target/, packages/*/target/, etc. on every cargo build). The
+// cost is that a repo that legitimately uses one of these names as a
+// source directory (e.g. a Go project with a nested "build/" source
+// folder) will see no refresh events from it. If a real user hits that,
+// the right fix is a per-project configurable ignore list rather than
+// unilaterally narrowing this set.
 const IGNORED_SEGMENTS = new Set<string>([
   ".git",
   "node_modules",

--- a/apps/web/src/lib/file-watcher.ts
+++ b/apps/web/src/lib/file-watcher.ts
@@ -172,20 +172,19 @@ export function subscribeToFileChanges(
     }
 
     entry = { watcher, listeners: new Set(), pendingTimers: new Map() };
+    watchers.set(workspaceId, entry);
     // Recursive watches can emit unrecoverable errors (e.g. when the
     // watched directory is removed). Wake every current subscriber with
     // a `null` sentinel so their tRPC generators can finish cleanly
     // instead of parking forever waiting for an event from a dead
-    // watcher. Drop the entry afterwards so the next subscriber retries
-    // with a fresh handle.
+    // watcher. Closing over `entry` directly (rather than re-resolving
+    // through the map) keeps the notification flow obvious and survives
+    // any future change to how `watchers` is keyed.
+    const localEntry = entry;
     watcher.on("error", () => {
-      const current = watchers.get(workspaceId);
-      if (current) {
-        for (const listener of current.listeners) listener(null);
-      }
+      for (const listener of localEntry.listeners) listener(null);
       stopWatcher(workspaceId);
     });
-    watchers.set(workspaceId, entry);
   }
 
   entry.listeners.add(listener);

--- a/apps/web/src/lib/file-watcher.ts
+++ b/apps/web/src/lib/file-watcher.ts
@@ -133,6 +133,10 @@ export function subscribeToFileChanges(
 
     let watcher: FSWatcher;
     try {
+      // NOTE: `recursive: true` is only supported on macOS and Windows
+      // for Node ≤ 21; Linux gained it in Node 22.0. Band's web server
+      // already requires Node ≥ 22.5 (`apps/web/package.json#engines`),
+      // so this is safe across all supported platforms.
       watcher = fsWatch(root, { recursive: true, persistent: false }, (_event, filename) => {
         // `filename` may be null on some platforms or under heavy churn —
         // the change is real but we can't pinpoint where, so skip. Without

--- a/apps/web/src/trpc/router.ts
+++ b/apps/web/src/trpc/router.ts
@@ -865,11 +865,17 @@ const workspaceRouter = t.router({
   fileChanges: publicProcedure
     .input(z.object({ workspaceId: z.string() }))
     .subscription(async function* (opts) {
-      // We rely on `opts.signal` being supplied by the tRPC adapter —
-      // both the WebSocket and HTTP transports we use today set it on
-      // every subscription. If a future adapter omits it, this loop
-      // would only exit via `watcherClosed` and a misbehaving client
-      // could park the generator indefinitely.
+      // We rely on the tRPC adapter supplying a cancellation signal — both
+      // the WebSocket and HTTP transports we use today set it on every
+      // subscription. Fail loud if a future adapter omits it rather than
+      // silently parking this generator forever.
+      if (!opts.signal) {
+        throw new Error(
+          "workspace.fileChanges requires a cancellable subscription (opts.signal missing)",
+        );
+      }
+      const signal = opts.signal;
+
       const queue: { path: string }[] = [];
       let resolve: (() => void) | null = null;
       // Set to true if the underlying watcher dies — the generator then
@@ -890,26 +896,26 @@ const workspaceRouter = t.router({
       // `finally` so we don't risk a double-unsubscribe if abort fires
       // before the loop's last cleanup.
       const onAbort = () => resolve?.();
-      opts.signal?.addEventListener("abort", onAbort);
+      signal.addEventListener("abort", onAbort);
 
       try {
-        while (!opts.signal?.aborted && !watcherClosed) {
+        while (!signal.aborted && !watcherClosed) {
           while (queue.length > 0) {
             yield queue.shift()!;
           }
-          if (opts.signal?.aborted || watcherClosed) break;
+          if (signal.aborted || watcherClosed) break;
           await new Promise<void>((r) => {
             resolve = r;
             // Close the race where abort/watcher-close fires between
             // `resolve = null` and entering this executor: in that
             // window the upstream `resolve?.()` was a no-op, so wake
             // immediately ourselves.
-            if (opts.signal?.aborted || watcherClosed) r();
+            if (signal.aborted || watcherClosed) r();
           });
           resolve = null;
         }
       } finally {
-        opts.signal?.removeEventListener("abort", onAbort);
+        signal.removeEventListener("abort", onAbort);
         unsubscribe();
       }
     }),

--- a/apps/web/src/trpc/router.ts
+++ b/apps/web/src/trpc/router.ts
@@ -856,15 +856,28 @@ const workspaceRouter = t.router({
    * Yields one event per coalesced (parentDir) change; `path` is the
    * workspace-relative parent directory ("" for the worktree root). The
    * FileBrowser uses it as a cache invalidation key.
+   *
+   * Auth: enforced at the transport layer (the `band_token` cookie gates
+   * the WebSocket upgrade and HTTP requests in start-server.ts), so no
+   * per-procedure guard is needed — consistent with the rest of
+   * `workspaceRouter`.
    */
   fileChanges: publicProcedure
     .input(z.object({ workspaceId: z.string() }))
     .subscription(async function* (opts) {
       const queue: { path: string }[] = [];
       let resolve: (() => void) | null = null;
+      // Set to true if the underlying watcher dies — the generator then
+      // finishes cleanly so the client sees the stream complete instead
+      // of waiting forever for an event from a dead handle.
+      let watcherClosed = false;
 
       const unsubscribe = subscribeToFileChanges(opts.input.workspaceId, (path) => {
-        queue.push({ path });
+        if (path === null) {
+          watcherClosed = true;
+        } else {
+          queue.push({ path });
+        }
         resolve?.();
       });
 
@@ -876,11 +889,11 @@ const workspaceRouter = t.router({
       });
 
       try {
-        while (!opts.signal?.aborted) {
+        while (!opts.signal?.aborted && !watcherClosed) {
           while (queue.length > 0) {
             yield queue.shift()!;
           }
-          if (opts.signal?.aborted) break;
+          if (opts.signal?.aborted || watcherClosed) break;
           await new Promise<void>((r) => {
             resolve = r;
             // Close the race where abort fires between `resolve = null`

--- a/apps/web/src/trpc/router.ts
+++ b/apps/web/src/trpc/router.ts
@@ -895,10 +895,11 @@ const workspaceRouter = t.router({
           if (opts.signal?.aborted || watcherClosed) break;
           await new Promise<void>((r) => {
             resolve = r;
-            // Close the race where abort fires between `resolve = null`
-            // and entering this executor: in that window the listener's
-            // `resolve?.()` was a no-op, so wake immediately ourselves.
-            if (opts.signal?.aborted) r();
+            // Close the race where abort/watcher-close fires between
+            // `resolve = null` and entering this executor: in that
+            // window the upstream `resolve?.()` was a no-op, so wake
+            // immediately ourselves.
+            if (opts.signal?.aborted || watcherClosed) r();
           });
           resolve = null;
         }

--- a/apps/web/src/trpc/router.ts
+++ b/apps/web/src/trpc/router.ts
@@ -868,8 +868,10 @@ const workspaceRouter = t.router({
         resolve?.();
       });
 
+      // Only unpark the generator here; the watcher tear-down lives in
+      // `finally` so we don't risk a double-unsubscribe if abort fires
+      // before the loop's last cleanup.
       opts.signal?.addEventListener("abort", () => {
-        unsubscribe();
         resolve?.();
       });
 
@@ -878,8 +880,13 @@ const workspaceRouter = t.router({
           while (queue.length > 0) {
             yield queue.shift()!;
           }
+          if (opts.signal?.aborted) break;
           await new Promise<void>((r) => {
             resolve = r;
+            // Close the race where abort fires between `resolve = null`
+            // and entering this executor: in that window the listener's
+            // `resolve?.()` was a no-op, so wake immediately ourselves.
+            if (opts.signal?.aborted) r();
           });
           resolve = null;
         }

--- a/apps/web/src/trpc/router.ts
+++ b/apps/web/src/trpc/router.ts
@@ -865,6 +865,11 @@ const workspaceRouter = t.router({
   fileChanges: publicProcedure
     .input(z.object({ workspaceId: z.string() }))
     .subscription(async function* (opts) {
+      // We rely on `opts.signal` being supplied by the tRPC adapter —
+      // both the WebSocket and HTTP transports we use today set it on
+      // every subscription. If a future adapter omits it, this loop
+      // would only exit via `watcherClosed` and a misbehaving client
+      // could park the generator indefinitely.
       const queue: { path: string }[] = [];
       let resolve: (() => void) | null = null;
       // Set to true if the underlying watcher dies — the generator then

--- a/apps/web/src/trpc/router.ts
+++ b/apps/web/src/trpc/router.ts
@@ -65,6 +65,7 @@ import {
   saveCronjobFile,
 } from "../lib/cronjob-store";
 import type { CronjobDefinition } from "../lib/cronjob-types";
+import { subscribeToFileChanges } from "../lib/file-watcher";
 import { fuzzyScore } from "../lib/fuzzy-score";
 import { execGit, gitCmd, listWorktrees } from "../lib/git";
 import { checkHooks, installHooks } from "../lib/hooks";
@@ -844,6 +845,47 @@ const workspaceRouter = t.router({
       if (!workspace) return { config: null };
       const config = loadWorkspaceTerminalConfig(workspace.worktree.path, workspace.project.path);
       return { config };
+    }),
+
+  /**
+   * Subscribe to external file-system changes inside a single workspace.
+   * The watcher is started on demand for that workspace and torn down when
+   * the last subscriber disconnects, so we don't keep OS watch handles
+   * open on every worktree the user has ever added (see issue #384).
+   *
+   * Yields one event per coalesced (parentDir) change; `path` is the
+   * workspace-relative parent directory ("" for the worktree root). The
+   * FileBrowser uses it as a cache invalidation key.
+   */
+  fileChanges: publicProcedure
+    .input(z.object({ workspaceId: z.string() }))
+    .subscription(async function* (opts) {
+      const queue: { path: string }[] = [];
+      let resolve: (() => void) | null = null;
+
+      const unsubscribe = subscribeToFileChanges(opts.input.workspaceId, (path) => {
+        queue.push({ path });
+        resolve?.();
+      });
+
+      opts.signal?.addEventListener("abort", () => {
+        unsubscribe();
+        resolve?.();
+      });
+
+      try {
+        while (!opts.signal?.aborted) {
+          while (queue.length > 0) {
+            yield queue.shift()!;
+          }
+          await new Promise<void>((r) => {
+            resolve = r;
+          });
+          resolve = null;
+        }
+      } finally {
+        unsubscribe();
+      }
     }),
 
   listBranches: publicProcedure

--- a/apps/web/src/trpc/router.ts
+++ b/apps/web/src/trpc/router.ts
@@ -884,9 +884,8 @@ const workspaceRouter = t.router({
       // Only unpark the generator here; the watcher tear-down lives in
       // `finally` so we don't risk a double-unsubscribe if abort fires
       // before the loop's last cleanup.
-      opts.signal?.addEventListener("abort", () => {
-        resolve?.();
-      });
+      const onAbort = () => resolve?.();
+      opts.signal?.addEventListener("abort", onAbort);
 
       try {
         while (!opts.signal?.aborted && !watcherClosed) {
@@ -904,6 +903,7 @@ const workspaceRouter = t.router({
           resolve = null;
         }
       } finally {
+        opts.signal?.removeEventListener("abort", onAbort);
         unsubscribe();
       }
     }),

--- a/apps/web/tests/file-watcher.test.ts
+++ b/apps/web/tests/file-watcher.test.ts
@@ -178,8 +178,10 @@ interface Subscription {
 /**
  * Subscribe to `workspace.fileChanges` for a single workspace. The
  * resolved `ready` promise waits for the server to confirm the
- * subscription has started AND adds a short grace period so the
- * recursive `fs.watch` is fully primed before the test touches the FS.
+ * subscription has started AND adds a grace period so the recursive
+ * `fs.watch` handle is fully primed before the test touches the FS.
+ * 500 ms is conservative for slow / shared CI runners — at 250 ms the
+ * very first write occasionally races the kernel setting up the watch.
  */
 function subscribeFileChanges(serverUrl: string, workspaceId: string): Subscription {
   const wsUrl = `${serverUrl.replace(/^http/, "ws")}/trpc`;
@@ -225,7 +227,7 @@ function subscribeFileChanges(serverUrl: string, workspaceId: string): Subscript
   });
 
   return {
-    ready: started.then(() => new Promise<void>((r) => setTimeout(r, 250))),
+    ready: started.then(() => new Promise<void>((r) => setTimeout(r, 500))),
     fileChanges,
     waitForFileChange(pathPredicate, timeoutMs = 5_000) {
       const matches = (event: FileChangePayload) =>

--- a/apps/web/tests/file-watcher.test.ts
+++ b/apps/web/tests/file-watcher.test.ts
@@ -1,0 +1,524 @@
+// Integration tests for the FileBrowser cache-invalidation flow:
+//
+//   * `apps/web/src/lib/file-watcher.ts` starts a recursive `fs.watch` on
+//     demand when a client subscribes to a workspace's file changes, and
+//     tears it down when the last subscriber disconnects.
+//   * The tRPC `workspace.fileChanges({ workspaceId })` subscription
+//     forwards coalesced events to the WebSocket client.
+//   * The web adapter's `subscribeFileChanges` is a thin wrapper around it.
+//
+// We exercise the full server pipeline by spawning the production server,
+// subscribing via WebSocket for a specific workspace, mutating files on
+// disk from outside the server's own mutation endpoints (the exact
+// scenario issue #384 describes — terminals, IDEs, drag-drop, agents)
+// and asserting that the right events arrive (and nothing leaks across
+// workspaces).
+
+import { execFileSync, spawn } from "node:child_process";
+import { mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from "node:fs";
+import { mkdir, rename, rm, writeFile } from "node:fs/promises";
+import { createServer } from "node:net";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { WebSocket } from "ws";
+import { seedSettings, seedState } from "./helpers/seed-state";
+import { SERVER_RUNTIME, SERVER_SCRIPT } from "./helpers/server-runtime";
+
+const PROJECT_ROOT = join(import.meta.dirname, "..");
+const DEFAULT_TOKEN = "file-watcher-test-token";
+
+// ---------------------------------------------------------------------------
+// Server helpers
+// ---------------------------------------------------------------------------
+
+interface ServerHandle {
+  url: string;
+  home: string;
+  close: () => Promise<void>;
+}
+
+function createTmpHome(): string {
+  const tmp = realpathSync(mkdtempSync(join(tmpdir(), "band-file-watcher-test-")));
+  mkdirSync(join(tmp, ".band"), { recursive: true });
+  return tmp;
+}
+
+function getRandomPort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const srv = createServer();
+    srv.listen(0, "127.0.0.1", () => {
+      const { port } = srv.address() as { port: number };
+      srv.close(() => resolve(port));
+    });
+    srv.on("error", reject);
+  });
+}
+
+async function startServer(opts: { tmpHome: string }): Promise<ServerHandle> {
+  const home = opts.tmpHome;
+  const port = await getRandomPort();
+  return new Promise((resolve, reject) => {
+    const child = spawn(SERVER_RUNTIME, [SERVER_SCRIPT], {
+      cwd: PROJECT_ROOT,
+      env: {
+        ...process.env,
+        HOME: home,
+        PORT: String(port),
+        NODE_ENV: "production",
+      },
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+
+    let stderr = "";
+    let settled = false;
+
+    child.stderr!.on("data", (chunk: Buffer) => {
+      stderr += chunk.toString();
+    });
+
+    child.stdout!.on("data", (chunk: Buffer) => {
+      if (chunk.toString().includes("listening") && !settled) {
+        settled = true;
+        resolve({
+          url: `http://127.0.0.1:${port}`,
+          home,
+          close: () =>
+            new Promise<void>((r) => {
+              child.on("exit", () => r());
+              child.kill("SIGTERM");
+            }),
+        });
+      }
+    });
+
+    child.on("error", (err) => {
+      if (!settled) {
+        settled = true;
+        reject(err);
+      }
+    });
+
+    child.on("exit", (code) => {
+      if (!settled) {
+        settled = true;
+        reject(new Error(`Server exited with code ${code} before listening.\nstderr: ${stderr}`));
+      }
+    });
+
+    setTimeout(() => {
+      if (!settled) {
+        settled = true;
+        child.kill("SIGTERM");
+        reject(new Error(`Server did not start within 15 s.\nstderr: ${stderr}`));
+      }
+    }, 15_000);
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Git helpers — used to build a realistic worktree
+// ---------------------------------------------------------------------------
+
+const gitEnv = {
+  ...process.env,
+  GIT_AUTHOR_NAME: "Test",
+  GIT_AUTHOR_EMAIL: "test@test.com",
+  GIT_COMMITTER_NAME: "Test",
+  GIT_COMMITTER_EMAIL: "test@test.com",
+};
+
+function git(cwd: string, args: string[]): string {
+  return execFileSync("git", args, { cwd, env: gitEnv, encoding: "utf-8" });
+}
+
+function createGitRepo(parentDir: string, name: string): string {
+  const repoPath = join(parentDir, name);
+  mkdirSync(repoPath, { recursive: true });
+  git(repoPath, ["init", "-b", "main"]);
+  mkdirSync(join(repoPath, "src"), { recursive: true });
+  writeFileSync(join(repoPath, "README.md"), "# test\n");
+  writeFileSync(join(repoPath, "src", "index.ts"), 'console.log("hi");\n');
+  git(repoPath, ["add", "."]);
+  git(repoPath, ["commit", "-m", "initial"]);
+  return repoPath;
+}
+
+// ---------------------------------------------------------------------------
+// WebSocket / tRPC helpers
+// ---------------------------------------------------------------------------
+
+const defaultHeaders = { Cookie: `band_token=${DEFAULT_TOKEN}` };
+
+interface WSMessage {
+  id: number;
+  jsonrpc: string;
+  result?: { type: "started" | "data" | "stopped"; data?: unknown };
+}
+
+interface FileChangePayload {
+  path: string;
+}
+
+function isFileChangePayload(data: unknown): data is FileChangePayload {
+  if (!data || typeof data !== "object") return false;
+  return typeof (data as { path?: unknown }).path === "string";
+}
+
+interface Subscription {
+  ready: Promise<void>;
+  fileChanges: FileChangePayload[];
+  waitForFileChange: (
+    pathPredicate?: (path: string) => boolean,
+    timeoutMs?: number,
+  ) => Promise<FileChangePayload>;
+  close: () => void;
+}
+
+/**
+ * Subscribe to `workspace.fileChanges` for a single workspace. The
+ * resolved `ready` promise waits for the server to confirm the
+ * subscription has started AND adds a short grace period so the
+ * recursive `fs.watch` is fully primed before the test touches the FS.
+ */
+function subscribeFileChanges(serverUrl: string, workspaceId: string): Subscription {
+  const wsUrl = `${serverUrl.replace(/^http/, "ws")}/trpc`;
+  const fileChanges: FileChangePayload[] = [];
+  const listeners: Array<{
+    predicate: (event: FileChangePayload) => boolean;
+    resolve: (event: FileChangePayload) => void;
+  }> = [];
+  let startedResolve: () => void;
+  const started = new Promise<void>((r) => {
+    startedResolve = r;
+  });
+
+  const ws = new WebSocket(wsUrl, { headers: defaultHeaders });
+
+  ws.on("open", () => {
+    ws.send(
+      JSON.stringify({
+        id: 1,
+        jsonrpc: "2.0",
+        method: "subscription",
+        params: { path: "workspace.fileChanges", input: { workspaceId } },
+      }),
+    );
+  });
+
+  ws.on("message", (raw: Buffer) => {
+    const msg = JSON.parse(raw.toString()) as WSMessage;
+    if (msg.result?.type === "started") {
+      startedResolve();
+      return;
+    }
+    if (msg.result?.type === "data" && isFileChangePayload(msg.result.data)) {
+      const payload = msg.result.data;
+      fileChanges.push(payload);
+      for (let i = listeners.length - 1; i >= 0; i--) {
+        if (listeners[i].predicate(payload)) {
+          listeners[i].resolve(payload);
+          listeners.splice(i, 1);
+        }
+      }
+    }
+  });
+
+  return {
+    ready: started.then(() => new Promise<void>((r) => setTimeout(r, 250))),
+    fileChanges,
+    waitForFileChange(pathPredicate, timeoutMs = 5_000) {
+      const matches = (event: FileChangePayload) =>
+        pathPredicate ? pathPredicate(event.path) : true;
+
+      for (const event of fileChanges) {
+        if (matches(event)) return Promise.resolve(event);
+      }
+      return new Promise<FileChangePayload>((resolve, reject) => {
+        const timer = setTimeout(() => {
+          const idx = listeners.findIndex((l) => l.resolve === resolve);
+          if (idx !== -1) listeners.splice(idx, 1);
+          reject(
+            new Error(`Timed out waiting for file-change(${pathPredicate ? "predicate" : "any"})`),
+          );
+        }, timeoutMs);
+        listeners.push({
+          predicate: matches,
+          resolve: (event) => {
+            clearTimeout(timer);
+            resolve(event);
+          },
+        });
+      });
+    },
+    close: () => ws.close(),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("file-watcher — external file change events", () => {
+  let server: ServerHandle;
+  let tmpHome: string;
+  let repoPath: string;
+  let otherRepoPath: string;
+  const workspaceId = "myrepo-main";
+
+  beforeAll(async () => {
+    tmpHome = createTmpHome();
+    repoPath = createGitRepo(tmpHome, "myrepo");
+    otherRepoPath = createGitRepo(tmpHome, "otherrepo");
+    seedState(tmpHome, {
+      projects: [
+        {
+          name: "myrepo",
+          path: repoPath,
+          defaultBranch: "main",
+          worktrees: [{ branch: "main", path: repoPath }],
+        },
+        {
+          name: "otherrepo",
+          path: otherRepoPath,
+          defaultBranch: "main",
+          worktrees: [{ branch: "main", path: otherRepoPath }],
+        },
+      ],
+    });
+    seedSettings(tmpHome, { tokenSecret: DEFAULT_TOKEN });
+    server = await startServer({ tmpHome });
+  });
+
+  afterAll(async () => {
+    await server.close();
+    rmSync(tmpHome, { recursive: true, force: true });
+  });
+
+  it("emits a file-change event when a file is created at the workspace root", async () => {
+    const sub = subscribeFileChanges(server.url, workspaceId);
+    try {
+      await sub.ready;
+      const wait = sub.waitForFileChange((p) => p === "");
+      await writeFile(join(repoPath, "external.txt"), "hello\n");
+      const event = await wait;
+      expect(event.path).toBe("");
+    } finally {
+      sub.close();
+    }
+  });
+
+  it("emits a file-change event when a file is created in a subdirectory", async () => {
+    const sub = subscribeFileChanges(server.url, workspaceId);
+    try {
+      await sub.ready;
+      const wait = sub.waitForFileChange((p) => p === "src");
+      await writeFile(join(repoPath, "src", "added.ts"), "export {};\n");
+      const event = await wait;
+      expect(event.path).toBe("src");
+    } finally {
+      sub.close();
+    }
+  });
+
+  it("emits a file-change event when a file is renamed", async () => {
+    const targetDir = join(repoPath, "src");
+    const before = join(targetDir, "rename-before.ts");
+    const after = join(targetDir, "rename-after.ts");
+    await writeFile(before, "// before\n");
+
+    // Drain the create event before subscribing for the rename event so the
+    // assertion isn't satisfied by stale traffic on the wire.
+    await new Promise((r) => setTimeout(r, 400));
+
+    const sub = subscribeFileChanges(server.url, workspaceId);
+    try {
+      await sub.ready;
+      const wait = sub.waitForFileChange((p) => p === "src");
+      await rename(before, after);
+      const event = await wait;
+      expect(event.path).toBe("src");
+    } finally {
+      sub.close();
+    }
+  });
+
+  it("emits a file-change event when a directory is created and ignores it inside node_modules", async () => {
+    // Create a node_modules directory first — events from inside it must be
+    // suppressed so the FileBrowser isn't drowned in `pnpm install` noise.
+    await mkdir(join(repoPath, "node_modules", "junk"), { recursive: true });
+
+    const sub = subscribeFileChanges(server.url, workspaceId);
+    try {
+      await sub.ready;
+
+      // 1. Visible directory creation triggers an event
+      const wait = sub.waitForFileChange((p) => p === "");
+      await mkdir(join(repoPath, "new-dir"));
+      const event = await wait;
+      expect(event.path).toBe("");
+
+      // 2. node_modules churn does NOT trigger an event within 600ms
+      await writeFile(join(repoPath, "node_modules", "junk", "lib.js"), "module.exports={};\n");
+      await expect(sub.waitForFileChange((p) => p.startsWith("node_modules"), 600)).rejects.toThrow(
+        /Timed out/,
+      );
+    } finally {
+      sub.close();
+    }
+  });
+
+  it("does not start a watcher for an unknown workspace", async () => {
+    // Subscribing for a workspace that doesn't exist returns a silent no-op
+    // — no events ever arrive. This is what protects us from runaway
+    // watchers on misconfigured clients.
+    const sub = subscribeFileChanges(server.url, "definitely-not-a-real-workspace");
+    try {
+      await sub.ready;
+      // Touch a file in the OTHER workspace — should NOT leak to this sub.
+      await writeFile(join(repoPath, "isolation-test.txt"), "x\n");
+      await expect(sub.waitForFileChange(undefined, 600)).rejects.toThrow(/Timed out/);
+    } finally {
+      sub.close();
+    }
+  });
+
+  it("scopes events to the subscribed workspace and ignores changes in other workspaces", async () => {
+    // The point of the per-workspace subscription model: a client viewing
+    // workspace A must not be woken up by file activity in workspace B,
+    // and a watcher for B must not start at all just because A is being
+    // viewed (see issue #384 — watching every worktree doesn't scale).
+    const subA = subscribeFileChanges(server.url, workspaceId);
+    try {
+      await subA.ready;
+
+      // Change a file in workspace B — subA must NOT receive it.
+      await writeFile(join(otherRepoPath, "B-only.txt"), "B\n");
+      await expect(subA.waitForFileChange(undefined, 600)).rejects.toThrow(/Timed out/);
+
+      // Change a file in workspace A — subA must receive it.
+      const wait = subA.waitForFileChange((p) => p === "");
+      await writeFile(join(repoPath, "A-only.txt"), "A\n");
+      const event = await wait;
+      expect(event.path).toBe("");
+    } finally {
+      subA.close();
+    }
+  });
+
+  it("delivers a file-change event to every subscriber of the same workspace", async () => {
+    // Two browser tabs / dockview panels viewing the same workspace should
+    // share one underlying `fs.watch` handle but each receive every event.
+    // If a future change accidentally replaced (instead of accumulated) the
+    // listener set on second subscribe, only one sub would receive events.
+    const subA = subscribeFileChanges(server.url, workspaceId);
+    const subB = subscribeFileChanges(server.url, workspaceId);
+    try {
+      await Promise.all([subA.ready, subB.ready]);
+
+      const waitA = subA.waitForFileChange((p) => p === "src");
+      const waitB = subB.waitForFileChange((p) => p === "src");
+      await writeFile(join(repoPath, "src", "fanout.ts"), "// fanout\n");
+
+      const [eventA, eventB] = await Promise.all([waitA, waitB]);
+      expect(eventA.path).toBe("src");
+      expect(eventB.path).toBe("src");
+    } finally {
+      subA.close();
+      subB.close();
+    }
+  });
+
+  it("keeps the watcher alive for remaining subscribers when one disconnects", async () => {
+    // Refcount sanity: closing subA must not stop the watcher while subB
+    // is still listening. Without proper refcounting, the second tab
+    // would silently stop receiving events as soon as the first tab is
+    // closed.
+    const subA = subscribeFileChanges(server.url, workspaceId);
+    const subB = subscribeFileChanges(server.url, workspaceId);
+    try {
+      await Promise.all([subA.ready, subB.ready]);
+
+      subA.close();
+      // Give the server a beat to process the unsubscribe — the watcher
+      // must survive this teardown because subB is still attached.
+      await new Promise((r) => setTimeout(r, 200));
+
+      const waitB = subB.waitForFileChange((p) => p === "src");
+      await writeFile(join(repoPath, "src", "survives.ts"), "// survives\n");
+      const event = await waitB;
+      expect(event.path).toBe("src");
+    } finally {
+      subB.close();
+    }
+  });
+
+  it("ignores changes inside the .git directory", async () => {
+    // `.git/` is the noisiest source of churn on a real worktree (every
+    // `git` command rewrites refs, HEAD, index, etc.). The FileBrowser
+    // never displays it, so it must not produce events.
+    const sub = subscribeFileChanges(server.url, workspaceId);
+    try {
+      await sub.ready;
+      await writeFile(join(repoPath, ".git", "PROBE"), "probe\n");
+      await expect(
+        sub.waitForFileChange((p) => p === "" || p.startsWith(".git"), 600),
+      ).rejects.toThrow(/Timed out/);
+    } finally {
+      sub.close();
+    }
+  });
+
+  it("emits a file-change event when a file is deleted", async () => {
+    const target = join(repoPath, "src", "to-delete.ts");
+    await writeFile(target, "// delete me\n");
+    // Drain the create event before subscribing so the assertion below is
+    // satisfied by the delete event, not the earlier write.
+    await new Promise((r) => setTimeout(r, 400));
+
+    const sub = subscribeFileChanges(server.url, workspaceId);
+    try {
+      await sub.ready;
+      const wait = sub.waitForFileChange((p) => p === "src");
+      await rm(target);
+      const event = await wait;
+      expect(event.path).toBe("src");
+    } finally {
+      sub.close();
+    }
+  });
+
+  it("coalesces a burst of writes in the same directory into a small number of events", async () => {
+    const burstDir = join(repoPath, "burst");
+    await mkdir(burstDir, { recursive: true });
+    // Allow the watcher to register the directory creation.
+    await new Promise((r) => setTimeout(r, 400));
+
+    const sub = subscribeFileChanges(server.url, workspaceId);
+    try {
+      await sub.ready;
+      const before = sub.fileChanges.length;
+
+      // 20 rapid writes inside `burst/` should fire far fewer events
+      // thanks to the 250ms server-side debounce.
+      const writes: Promise<unknown>[] = [];
+      for (let i = 0; i < 20; i++) {
+        writes.push(writeFile(join(burstDir, `f-${i}.ts`), `// ${i}\n`));
+      }
+      await Promise.all(writes);
+
+      // Wait long enough that any in-flight debounce window has fired.
+      await new Promise((r) => setTimeout(r, 1_000));
+
+      const burstEvents = sub.fileChanges.slice(before).filter((e) => e.path === "burst");
+      // At least one — the coalesced event for the burst — but well under
+      // the 20 events one-per-write would produce. Pick a forgiving cap so
+      // slow CI doesn't fail when the OS splits the burst across debounce
+      // windows.
+      expect(burstEvents.length).toBeGreaterThanOrEqual(1);
+      expect(burstEvents.length).toBeLessThan(10);
+    } finally {
+      sub.close();
+    }
+  });
+});

--- a/packages/dashboard-core/src/adapter.ts
+++ b/packages/dashboard-core/src/adapter.ts
@@ -65,6 +65,12 @@ export interface DashboardAdapter {
    * relative path; "" for the root). The FileBrowser uses this to
    * invalidate / refetch directory listings when files are touched by the
    * agent, a terminal, the IDE, or drag-and-drop.
+   *
+   * Optional, matching the rest of the code-browsing methods on this
+   * interface. Adapters that omit it silently disable FileBrowser
+   * auto-refresh — the tree will only update on internal Band mutations
+   * (create/delete/rename/paste), not on external file-system changes
+   * (see issue #384).
    */
   subscribeFileChanges?(workspaceId: string, handler: (path: string) => void): Unsubscribe;
 

--- a/packages/dashboard-core/src/adapter.ts
+++ b/packages/dashboard-core/src/adapter.ts
@@ -59,6 +59,15 @@ export interface DashboardAdapter {
   /** Subscribe to raw status stream events (shared SSE connection). */
   subscribeStatusEvents(handler: (event: Record<string, unknown>) => void): Unsubscribe;
 
+  /**
+   * Subscribe to external file-system changes inside a workspace. The
+   * server emits one event per affected parent directory (workspace-
+   * relative path; "" for the root). The FileBrowser uses this to
+   * invalidate / refetch directory listings when files are touched by the
+   * agent, a terminal, the IDE, or drag-and-drop.
+   */
+  subscribeFileChanges?(workspaceId: string, handler: (path: string) => void): Unsubscribe;
+
   // Hooks
   checkHooks(): Promise<HooksStatus>;
   installHooks(): Promise<void>;

--- a/packages/dashboard-core/src/adapters/web.ts
+++ b/packages/dashboard-core/src/adapters/web.ts
@@ -208,6 +208,16 @@ export class WebDashboardAdapter implements DashboardAdapter {
     });
   }
 
+  subscribeFileChanges(workspaceId: string, handler: (path: string) => void): Unsubscribe {
+    const sub = this.trpc.workspace.fileChanges.subscribe(
+      { workspaceId },
+      {
+        onData: (data: { path: string }) => handler(data.path),
+      },
+    );
+    return () => sub.unsubscribe();
+  }
+
   async checkHooks(): Promise<HooksStatus> {
     return await this.trpc.hooks.check.query();
   }

--- a/packages/dashboard-core/src/adapters/web.ts
+++ b/packages/dashboard-core/src/adapters/web.ts
@@ -211,21 +211,29 @@ export class WebDashboardAdapter implements DashboardAdapter {
   subscribeFileChanges(workspaceId: string, handler: (path: string) => void): Unsubscribe {
     // The server tears the underlying watcher down (and the subscription
     // completes) when its `fs.watch` hits an unrecoverable error — e.g.
-    // the worktree directory was deleted. We reconnect after a short
-    // delay so the FileBrowser silently re-acquires auto-refresh once
-    // the workspace is back. `active` guards against reconnecting after
-    // the caller has explicitly unsubscribed.
+    // the worktree directory was deleted. We reconnect with exponential
+    // backoff so the FileBrowser silently re-acquires auto-refresh when
+    // the workspace comes back, but doesn't busy-loop if the workspace
+    // is permanently gone (server returns immediately each time). The
+    // `active` flag stops reconnects after the caller unsubscribes; in
+    // the steady state the FileBrowser unmounts when the workspace is
+    // removed, so the loop terminates naturally.
     let active = true;
     let currentSub: { unsubscribe: () => void } | null = null;
     let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+    let attempt = 0;
+    const MAX_BACKOFF_MS = 30_000;
 
     const handleDisconnect = () => {
       currentSub = null;
       if (active && !reconnectTimer) {
+        // 500, 1000, 2000, 4000 … capped at 30 s.
+        const delay = Math.min(2 ** attempt * 500, MAX_BACKOFF_MS);
+        attempt += 1;
         reconnectTimer = setTimeout(() => {
           reconnectTimer = null;
           if (active) connect();
-        }, 2_000);
+        }, delay);
       }
     };
 
@@ -233,7 +241,13 @@ export class WebDashboardAdapter implements DashboardAdapter {
       currentSub = this.trpc.workspace.fileChanges.subscribe(
         { workspaceId },
         {
-          onData: (data: { path: string }) => handler(data.path),
+          onData: (data: { path: string }) => {
+            // A successful data delivery proves the watcher is healthy;
+            // reset the backoff so the next disconnection restarts the
+            // climb from the floor.
+            attempt = 0;
+            handler(data.path);
+          },
           onStopped: handleDisconnect,
           onError: handleDisconnect,
         },

--- a/packages/dashboard-core/src/adapters/web.ts
+++ b/packages/dashboard-core/src/adapters/web.ts
@@ -209,13 +209,54 @@ export class WebDashboardAdapter implements DashboardAdapter {
   }
 
   subscribeFileChanges(workspaceId: string, handler: (path: string) => void): Unsubscribe {
-    const sub = this.trpc.workspace.fileChanges.subscribe(
-      { workspaceId },
-      {
-        onData: (data: { path: string }) => handler(data.path),
-      },
-    );
-    return () => sub.unsubscribe();
+    // The server tears the underlying watcher down (and the subscription
+    // completes) when its `fs.watch` hits an unrecoverable error — e.g.
+    // the worktree directory was deleted. We reconnect after a short
+    // delay so the FileBrowser silently re-acquires auto-refresh once
+    // the workspace is back. `active` guards against reconnecting after
+    // the caller has explicitly unsubscribed.
+    let active = true;
+    let currentSub: { unsubscribe: () => void } | null = null;
+    let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+
+    const connect = () => {
+      currentSub = this.trpc.workspace.fileChanges.subscribe(
+        { workspaceId },
+        {
+          onData: (data: { path: string }) => handler(data.path),
+          onStopped: () => {
+            currentSub = null;
+            if (active && !reconnectTimer) {
+              reconnectTimer = setTimeout(() => {
+                reconnectTimer = null;
+                if (active) connect();
+              }, 2_000);
+            }
+          },
+          onError: () => {
+            currentSub = null;
+            if (active && !reconnectTimer) {
+              reconnectTimer = setTimeout(() => {
+                reconnectTimer = null;
+                if (active) connect();
+              }, 2_000);
+            }
+          },
+        },
+      );
+    };
+
+    connect();
+
+    return () => {
+      active = false;
+      if (reconnectTimer) {
+        clearTimeout(reconnectTimer);
+        reconnectTimer = null;
+      }
+      currentSub?.unsubscribe();
+      currentSub = null;
+    };
   }
 
   async checkHooks(): Promise<HooksStatus> {

--- a/packages/dashboard-core/src/adapters/web.ts
+++ b/packages/dashboard-core/src/adapters/web.ts
@@ -224,6 +224,9 @@ export class WebDashboardAdapter implements DashboardAdapter {
     let attempt = 0;
     const MAX_BACKOFF_MS = 30_000;
 
+    // Some tRPC transports can fire onStopped after onError (or vice
+    // versa) for the same disconnect; the `!reconnectTimer` guard makes
+    // the second call a no-op so we don't schedule the reconnect twice.
     const handleDisconnect = () => {
       currentSub = null;
       if (active && !reconnectTimer) {

--- a/packages/dashboard-core/src/adapters/web.ts
+++ b/packages/dashboard-core/src/adapters/web.ts
@@ -219,29 +219,23 @@ export class WebDashboardAdapter implements DashboardAdapter {
     let currentSub: { unsubscribe: () => void } | null = null;
     let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
 
+    const handleDisconnect = () => {
+      currentSub = null;
+      if (active && !reconnectTimer) {
+        reconnectTimer = setTimeout(() => {
+          reconnectTimer = null;
+          if (active) connect();
+        }, 2_000);
+      }
+    };
+
     const connect = () => {
       currentSub = this.trpc.workspace.fileChanges.subscribe(
         { workspaceId },
         {
           onData: (data: { path: string }) => handler(data.path),
-          onStopped: () => {
-            currentSub = null;
-            if (active && !reconnectTimer) {
-              reconnectTimer = setTimeout(() => {
-                reconnectTimer = null;
-                if (active) connect();
-              }, 2_000);
-            }
-          },
-          onError: () => {
-            currentSub = null;
-            if (active && !reconnectTimer) {
-              reconnectTimer = setTimeout(() => {
-                reconnectTimer = null;
-                if (active) connect();
-              }, 2_000);
-            }
-          },
+          onStopped: handleDisconnect,
+          onError: handleDisconnect,
         },
       );
     };

--- a/packages/dashboard-core/src/components/FileBrowser.tsx
+++ b/packages/dashboard-core/src/components/FileBrowser.tsx
@@ -830,6 +830,9 @@ export const FileBrowser = forwardRef<FileBrowserHandle, FileBrowserProps>(funct
   useEffect(() => {
     if (!adapter.subscribeFileChanges) return;
     const unsubscribe = adapter.subscribeFileChanges(workspaceId, (changedPath) => {
+      // `getCachedContents` is a stable module-level helper (defined at
+      // the top of this file), so it doesn't need to be in the effect's
+      // dependency array.
       const cache = getCachedContents(workspaceId);
       if (!cache.has(changedPath)) return;
       void fetchDir(changedPath, { force: true });

--- a/packages/dashboard-core/src/components/FileBrowser.tsx
+++ b/packages/dashboard-core/src/components/FileBrowser.tsx
@@ -838,6 +838,10 @@ export const FileBrowser = forwardRef<FileBrowserHandle, FileBrowserProps>(funct
       void fetchDir(changedPath, { force: true });
     });
     return unsubscribe;
+    // `fetchDir` is wrapped in `useCallback` above with `[adapter,
+    // workspaceId]`, so it's stable across renders of this component —
+    // the effect only tears the subscription down on workspace switch,
+    // not on every render.
   }, [adapter, workspaceId, fetchDir]);
 
   // ------- Auto-expand to selected file -------

--- a/packages/dashboard-core/src/components/FileBrowser.tsx
+++ b/packages/dashboard-core/src/components/FileBrowser.tsx
@@ -816,6 +816,27 @@ export const FileBrowser = forwardRef<FileBrowserHandle, FileBrowserProps>(funct
     fetchDir("");
   }, [fetchDir]);
 
+  // ------- External file-change invalidation -------
+  //
+  // The server watches each workspace's worktree and emits a `file-change`
+  // event with the parent directory of any touched path. We invalidate
+  // only directories the user has already visited (i.e. live in the cache):
+  //  * If the directory is expanded, a force-refetch updates the tree in
+  //    place.
+  //  * If the directory is collapsed but cached, we still re-fetch so the
+  //    next expand shows the current contents instead of a stale snapshot.
+  //  * Paths the user has never visited stay out of cache and are fetched
+  //    on first expand — no invalidation needed.
+  useEffect(() => {
+    if (!adapter.subscribeFileChanges) return;
+    const unsubscribe = adapter.subscribeFileChanges(workspaceId, (changedPath) => {
+      const cache = getCachedContents(workspaceId);
+      if (!cache.has(changedPath)) return;
+      void fetchDir(changedPath, { force: true });
+    });
+    return unsubscribe;
+  }, [adapter, workspaceId, fetchDir]);
+
   // ------- Auto-expand to selected file -------
   const prevSelectedRef = useRef<string | undefined>(undefined);
 


### PR DESCRIPTION
## Summary

Fixes #384 — the File Explorer tree didn't refresh when the agent, a terminal, the IDE, or drag-and-drop changed files outside Band's own create/delete/rename actions. The directory-listing cache only invalidated on internal mutations, so externally-touched files stayed invisible until a hard page reload.

- **Server**: new `apps/web/src/lib/file-watcher.ts` exposes `subscribeToFileChanges(workspaceId, listener)`. It opens a recursive `fs.watch` on the worktree on the first subscription for that workspace and tears it down when the last listener disconnects. Events are coalesced per `(workspaceId, parentDir)` with a 250 ms debounce, and noisy paths (`.git`, `node_modules`, build output, etc.) are filtered out.
- **Transport**: new `workspace.fileChanges({ workspaceId })` tRPC subscription. The subscription's `AbortSignal` lifecycle drives the watcher refcount, so closing a browser tab or evicting a workspace from the dockview cache automatically cleans up the OS handle.
- **Client**: `WebDashboardAdapter.subscribeFileChanges` calls the new tRPC subscription directly. The FileBrowser subscribes for its `workspaceId` on mount and force-refetches any cached directory listed in an incoming event; uncached paths stay out of cache and load fresh on first expand.
- **Scalability**: watchers are scoped to actively-viewed workspaces, not every worktree in `state.json`. A user with 50 added projects but one tab open holds exactly one watch handle, not 50.

## Test plan

- [x] `pnpm --filter @band-app/server test` — 533/533 pass, including 11 new file-watcher integration tests covering: root + nested file create, rename, delete, directory create, `.git` and `node_modules` filtering, unknown-workspace no-op, cross-workspace isolation, multiple subscribers on the same workspace (both receive events), refcount survival when one of two subs disconnects, and burst coalescing.
- [x] `pnpm --filter @band-app/desktop test` — 101/101 pass.
- [x] `biome check` clean for all changed files.
- [x] `tsc --noEmit` clean (only pre-existing unrelated `bigint` warnings in `state.ts`/`task-store.ts`).
- [ ] Manual smoke: open a workspace, expand a folder, `touch` a file in that folder from an external shell — the new file should appear in the tree within ~250 ms with no user action.

🤖 Generated with [Claude Code](https://claude.com/claude-code)