### PR TITLE
feat(skills): install shared ~/.agents/skills and symlink per agent

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,4 +49,34 @@ The Band CLI ships **six domain-specific skills**, each generated from its own t
 
 Reference-shaped templates (e.g. `band`, `band-chat`, `band-terminal`, `band-browser`) have a `commands:` frontmatter field listing comma-separated CLI command-name prefixes, plus a `<!-- COMMANDS -->` placeholder in the body; the generator filters the schema by those prefixes and splices the rendered Commands section into the placeholder. Workflow-shaped templates (e.g. `band-start`, `band-loop`) are self-contained recipes — they omit both `commands:` and the placeholder, and the generator emits the template body verbatim. The split improves trigger precision and keeps each generated SKILL.md scoped to one task type (issue #331).
 
-Run `band generate-skills --output-dir apps/cli/skills` to regenerate all six skills, then copy each `<name>/SKILL.md` to `~/.claude/skills/<name>/SKILL.md`.
+### Installed skill layout (shared + symlinks)
+
+Skills are installed once into a canonical, agent-agnostic location and then linked into each detected coding-agent's skills directory:
+
+```
+~/.agents/skills/<name>/SKILL.md          ← canonical content (one copy)
+~/.claude/skills/<name>            → ../../.agents/skills/<name>     (symlink)
+~/.codex/skills/<name>             → ../../.agents/skills/<name>     (symlink)
+~/.gemini/skills/<name>            → ../../.agents/skills/<name>     (symlink)
+~/.config/opencode/skills/<name>   → ../../../.agents/skills/<name>  (symlink)
+```
+
+Editing a `SKILL.md` in `~/.agents/skills/` is reflected in every linked agent without re-running the installer.
+
+**Supported coding agents** (Band creates a symlink for each one whose config dir is present on the host):
+
+| Agent type     | Detected via         | Skills dir                       |
+| -------------- | -------------------- | -------------------------------- |
+| `claude-code`  | `~/.claude/` exists  | `~/.claude/skills/`              |
+| `codex`        | `~/.codex/` exists (`$CODEX_HOME` honored) | `~/.codex/skills/` |
+| `openai-codex` | shares `~/.codex/`   | `~/.codex/skills/` (deduped)     |
+| `gemini-cli`   | `~/.gemini/` exists  | `~/.gemini/skills/`              |
+| `opencode`     | `~/.config/opencode/` exists | `~/.config/opencode/skills/` |
+
+`cursor-cli` is deliberately excluded — Cursor has no documented user-scope skills directory.
+
+The list of supported agents lives in `packages/coding-agent/src/install-skills.ts::SUPPORTED_AGENT_TYPES` (a single place to update when a new agent adds skills support). The sync logic lives in `apps/web/src/lib/cli-skills.ts::installSkills` and runs on every server boot from `runFirstTimeSetup` — idempotent: an existing symlink pointing at the right shared dir is left alone, an existing symlink pointing elsewhere (or a real directory occupying the path) is reported as a conflict rather than overwritten.
+
+### Manual regeneration
+
+Run `band generate-skills --output-dir apps/cli/skills` to regenerate all six skill files in-repo. At runtime the Band web server invokes the same subcommand and writes the result into `~/.agents/skills/` — no manual copy step is needed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,11 +55,13 @@ Skills are installed once into a canonical, agent-agnostic location and then lin
 
 ```
 ~/.agents/skills/<name>/SKILL.md          ← canonical content (one copy)
-~/.claude/skills/<name>            → ../../.agents/skills/<name>     (symlink)
-~/.codex/skills/<name>             → ../../.agents/skills/<name>     (symlink)
-~/.gemini/skills/<name>            → ../../.agents/skills/<name>     (symlink)
-~/.config/opencode/skills/<name>   → ../../../.agents/skills/<name>  (symlink)
+~/.claude/skills/<name>            → ~/.agents/skills/<name>     (symlink)
+~/.codex/skills/<name>             → ~/.agents/skills/<name>     (symlink)
+~/.gemini/skills/<name>            → ~/.agents/skills/<name>     (symlink)
+~/.config/opencode/skills/<name>   → ~/.agents/skills/<name>     (symlink)
 ```
+
+The symlinks are created with **absolute** targets (`symlinkSync(target, link, "dir")` in TS / `std::os::unix::fs::symlink` in Rust, both fed the canonical `~/.agents/skills/<name>` path). That keeps the link valid regardless of where it lives in the agent's directory tree, at the cost of breaking if the home directory ever moves — acceptable since each user only installs into their own `$HOME`.
 
 Editing a `SKILL.md` in `~/.agents/skills/` is reflected in every linked agent without re-running the installer.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,6 +77,12 @@ Editing a `SKILL.md` in `~/.agents/skills/` is reflected in every linked agent w
 
 The list of supported agents lives in `packages/coding-agent/src/install-skills.ts::SUPPORTED_AGENT_TYPES` (a single place to update when a new agent adds skills support). The sync logic lives in `apps/web/src/lib/cli-skills.ts::installSkills` and runs on every server boot from `runFirstTimeSetup` — idempotent: an existing symlink pointing at the right shared dir is left alone, an existing symlink pointing elsewhere (or a real directory occupying the path) is reported as a conflict rather than overwritten.
 
-### Manual regeneration
+### Manual regeneration & install
 
-Run `band generate-skills --output-dir apps/cli/skills` to regenerate all six skill files in-repo. At runtime the Band web server invokes the same subcommand and writes the result into `~/.agents/skills/` — no manual copy step is needed.
+- `band generate-skills --output-dir apps/cli/skills` — regenerate the six in-repo skill templates from the live CLI schema (used in development to keep the source-controlled SKILL.md files current).
+- `band skills install` — render the templates against the current schema and install them into `~/.agents/skills/`, then symlink each detected coding agent's skills directory. Idempotent. Useful for users running the CLI outside the Band dashboard, or for forcing a re-sync without rebooting the web server. The Band web server invokes the same install logic on every boot from `runFirstTimeSetup`, so most users never need to call it directly.
+
+Optional flags on `band skills install`:
+
+- `--home <path>` — override the destination home dir (mostly for tests).
+- `--filter <substr>` — only install skills whose name contains the substring (e.g. `--filter chat`).

--- a/apps/cli/skills/band.md
+++ b/apps/cli/skills/band.md
@@ -4,7 +4,7 @@ version: 0.1.0
 description: Programmatic workspace management for Band. Use when the user wants to create, list, or remove Band workspaces or projects, manage tunnels, manage cronjobs, or check settings via the Band CLI. Triggers include "create workspace", "list projects", "band workspace", "band project", "schedule a job". For sending chat messages to coding agents, see the `band-chat` skill.
 allowed-tools: Bash
 argument-hint: [command] [args...]
-commands: projects, workspaces, cronjobs, tunnel, settings, notify, schema, generate-skills
+commands: projects, workspaces, cronjobs, tunnel, settings, notify, schema, generate-skills, skills
 ---
 
 # Band CLI

--- a/apps/cli/src/main.rs
+++ b/apps/cli/src/main.rs
@@ -75,6 +75,27 @@ enum Commands {
         #[arg(long)]
         filter: Option<String>,
     },
+    /// Manage CLI-shipped skills (`band`, `band-chat`, `band-terminal`,
+    /// `band-browser`, `band-start`, `band-loop`)
+    Skills {
+        #[command(subcommand)]
+        cmd: SkillsCmd,
+    },
+}
+
+#[derive(Subcommand)]
+enum SkillsCmd {
+    /// Install (or refresh) skills into the shared `~/.agents/skills/`
+    /// directory and symlink each detected coding agent's skills/ folder.
+    Install {
+        /// Override the destination home dir (advanced; mostly for tests).
+        /// Defaults to `$HOME`.
+        #[arg(long)]
+        home: Option<String>,
+        /// Filter which skills to install by name (substring match).
+        #[arg(long)]
+        filter: Option<String>,
+    },
 }
 
 #[derive(Subcommand)]
@@ -568,6 +589,11 @@ fn main() {
         Commands::GenerateSkills { output_dir, filter } => {
             skills::generate_skills(&output_dir, filter.as_deref())
         }
+        Commands::Skills { cmd } => match cmd {
+            SkillsCmd::Install { home, filter } => {
+                skills::install_skills(home.as_deref(), filter.as_deref())
+            }
+        },
     };
 
     match result {
@@ -2405,6 +2431,15 @@ pub(crate) fn build_schema(command: Option<&str>) -> Result<serde_json::Value, S
                 {"name": "--output-dir", "type": "string", "required": false, "description": "Output directory for generated skills (default: skills/)"},
                 {"name": "--filter", "type": "string", "required": false, "description": "Filter skills by name (substring match)"},
             ]
+        }),
+        serde_json::json!({
+            "name": "skills install",
+            "description": "Install (or refresh) skills into ~/.agents/skills and symlink each detected coding agent's skills/ folder",
+            "parameters": [
+                {"name": "--home", "type": "string", "required": false, "description": "Override the destination home dir (advanced; mostly for tests). Defaults to $HOME."},
+                {"name": "--filter", "type": "string", "required": false, "description": "Filter which skills to install by name (substring match)"},
+            ],
+            "notes": "Idempotent: leaves a correct existing symlink alone; surfaces a clear conflict (without overwriting) when a different symlink or a real directory occupies the target path. Supported agents: claude-code, codex, openai-codex, gemini-cli, opencode. cursor-cli is excluded (no skills dir)."
         }),
     ];
 

--- a/apps/cli/src/skills.rs
+++ b/apps/cli/src/skills.rs
@@ -1,7 +1,8 @@
 use crate::CommandResult;
+use std::env;
 use std::fmt::Write;
 use std::fs;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 /// Skill templates rendered by `band generate-skills`.
 ///
@@ -29,17 +30,38 @@ const SKILL_TEMPLATES: &[(&str, &str)] = &[
     ("band-loop", include_str!("../skills/band-loop.md")),
 ];
 
-pub fn generate_skills(output_dir: &str, filter: Option<&str>) -> Result<CommandResult, String> {
+/// Supported coding agents that get a per-skill symlink under their
+/// own skills directory. Mirrors `SUPPORTED_AGENT_TYPES` on the TS side
+/// (`packages/coding-agent/src/install-skills.ts`); both lists must stay
+/// in sync. `cursor-cli` is deliberately omitted — it has no documented
+/// user-scope skills directory.
+const SUPPORTED_AGENTS: &[&str] = &[
+    "claude-code",
+    "codex",
+    "openai-codex",
+    "gemini-cli",
+    "opencode",
+];
+
+/// A single rendered skill ready to be written to disk.
+struct RenderedSkill {
+    name: String,
+    description: String,
+    command_count: usize,
+    content: String,
+    prefixes: Vec<String>,
+}
+
+/// Render every (filter-matched) skill template against the live CLI
+/// schema. Used by both `generate-skills` and `skills install` so the
+/// rendering logic is defined once.
+fn render_skills(filter: Option<&str>) -> Result<Vec<RenderedSkill>, String> {
     let schema = crate::build_schema(None)?;
     let commands = schema["commands"]
         .as_array()
         .ok_or("Schema has no commands array")?;
 
-    let output_path = Path::new(output_dir);
-    fs::create_dir_all(output_path)
-        .map_err(|e| format!("Failed to create output directory {output_dir}: {e}"))?;
-
-    let mut generated: Vec<serde_json::Value> = Vec::new();
+    let mut rendered: Vec<RenderedSkill> = Vec::new();
 
     for (default_name, template) in SKILL_TEMPLATES {
         let name = parse_frontmatter_field(template, "name")
@@ -90,18 +112,39 @@ pub fn generate_skills(output_dir: &str, filter: Option<&str>) -> Result<Command
         }
 
         let content = generate_skill_content(template, &matched);
-        let dir_path = output_path.join(&name);
+        rendered.push(RenderedSkill {
+            name,
+            description,
+            command_count: matched.len(),
+            content,
+            prefixes,
+        });
+    }
+
+    Ok(rendered)
+}
+
+pub fn generate_skills(output_dir: &str, filter: Option<&str>) -> Result<CommandResult, String> {
+    let output_path = Path::new(output_dir);
+    fs::create_dir_all(output_path)
+        .map_err(|e| format!("Failed to create output directory {output_dir}: {e}"))?;
+
+    let rendered = render_skills(filter)?;
+
+    let mut generated: Vec<serde_json::Value> = Vec::new();
+    for skill in &rendered {
+        let dir_path = output_path.join(&skill.name);
         fs::create_dir_all(&dir_path)
             .map_err(|e| format!("Failed to create directory {}: {e}", dir_path.display()))?;
-        fs::write(dir_path.join("SKILL.md"), &content)
-            .map_err(|e| format!("Failed to write {name}/SKILL.md: {e}"))?;
+        fs::write(dir_path.join("SKILL.md"), &skill.content)
+            .map_err(|e| format!("Failed to write {}/SKILL.md: {e}", skill.name))?;
 
         generated.push(serde_json::json!({
-            "name": name,
-            "description": description,
-            "commandPrefixes": prefixes,
-            "commandCount": matched.len(),
-            "path": format!("{name}/SKILL.md"),
+            "name": skill.name,
+            "description": skill.description,
+            "commandPrefixes": skill.prefixes,
+            "commandCount": skill.command_count,
+            "path": format!("{}/SKILL.md", skill.name),
         }));
     }
 
@@ -127,6 +170,358 @@ pub fn generate_skills(output_dir: &str, filter: Option<&str>) -> Result<Command
             "skills": generated,
         }),
     })
+}
+
+/// Outcome of attempting to write a single shared SKILL.md.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SharedWriteOutcome {
+    Written,
+    Updated,
+    Unchanged,
+}
+
+/// Outcome of attempting to create a per-agent symlink.
+#[derive(Debug, Clone)]
+enum SymlinkOutcome {
+    Created,
+    Already,
+    Conflict(String),
+}
+
+/// Aggregated result of the shared-write phase.
+#[derive(Default)]
+struct SharedWriteSummary {
+    written: Vec<String>,
+    updated: Vec<String>,
+    unchanged: Vec<String>,
+}
+
+/// Aggregated result of the symlink phase.
+#[derive(Default)]
+struct SymlinkSummary {
+    linked: Vec<String>,
+    already_linked: Vec<String>,
+    conflicts: Vec<serde_json::Value>,
+}
+
+fn write_shared_skills(
+    shared_dir: &Path,
+    rendered: &[RenderedSkill],
+) -> Result<SharedWriteSummary, String> {
+    let mut summary = SharedWriteSummary::default();
+    for skill in rendered {
+        let dest_dir = shared_dir.join(&skill.name);
+        let dest_path = dest_dir.join("SKILL.md");
+        fs::create_dir_all(&dest_dir).map_err(|e| {
+            format!(
+                "Failed to create skill directory {}: {e}",
+                dest_dir.display()
+            )
+        })?;
+
+        let outcome = write_shared_skill(&dest_path, skill.content.as_bytes())?;
+        let path_str = dest_path.to_string_lossy().into_owned();
+        match outcome {
+            SharedWriteOutcome::Written => summary.written.push(path_str),
+            SharedWriteOutcome::Updated => summary.updated.push(path_str),
+            SharedWriteOutcome::Unchanged => summary.unchanged.push(path_str),
+        }
+    }
+    Ok(summary)
+}
+
+fn create_agent_symlinks(
+    shared_dir: &Path,
+    rendered: &[RenderedSkill],
+    targets: &[(&'static str, PathBuf)],
+) -> Result<SymlinkSummary, String> {
+    let mut summary = SymlinkSummary::default();
+    for (agent_type, skills_dir) in targets {
+        fs::create_dir_all(skills_dir).map_err(|e| {
+            format!(
+                "Failed to create {agent_type} skills dir {}: {e}",
+                skills_dir.display()
+            )
+        })?;
+        for skill in rendered {
+            let target = shared_dir.join(&skill.name);
+            let link = skills_dir.join(&skill.name);
+            let outcome = ensure_symlink(&link, &target);
+            let link_str = link.to_string_lossy().into_owned();
+            match outcome {
+                SymlinkOutcome::Created => summary.linked.push(link_str),
+                SymlinkOutcome::Already => summary.already_linked.push(link_str),
+                SymlinkOutcome::Conflict(reason) => {
+                    summary.conflicts.push(serde_json::json!({
+                        "path": link_str,
+                        "agentType": agent_type,
+                        "reason": reason,
+                    }));
+                }
+            }
+        }
+    }
+    Ok(summary)
+}
+
+fn render_install_text(
+    shared_dir: &Path,
+    rendered: &[RenderedSkill],
+    shared: &SharedWriteSummary,
+    targets: &[(&'static str, PathBuf)],
+    symlinks: &SymlinkSummary,
+) -> String {
+    let mut text = String::new();
+    let _ = writeln!(
+        text,
+        "Installed {} skill(s) into {}",
+        rendered.len(),
+        shared_dir.display()
+    );
+    let _ = writeln!(
+        text,
+        "  shared: {} written, {} updated, {} unchanged",
+        shared.written.len(),
+        shared.updated.len(),
+        shared.unchanged.len(),
+    );
+    if targets.is_empty() {
+        let _ = writeln!(
+            text,
+            "  symlinks: no supported coding agents detected on host"
+        );
+    } else {
+        let _ = writeln!(
+            text,
+            "  symlinks: {} created, {} already-linked, {} conflict(s)",
+            symlinks.linked.len(),
+            symlinks.already_linked.len(),
+            symlinks.conflicts.len(),
+        );
+        for (agent_type, dir) in targets {
+            let _ = writeln!(text, "    {agent_type} → {}", dir.display());
+        }
+    }
+    for conflict in &symlinks.conflicts {
+        let _ = writeln!(
+            text,
+            "  conflict: {} ({})",
+            conflict["path"].as_str().unwrap_or(""),
+            conflict["reason"].as_str().unwrap_or(""),
+        );
+    }
+    text
+}
+
+/// Install (or refresh) skills into the canonical shared location
+/// `~/.agents/skills/<name>/SKILL.md` and create a directory-level
+/// symlink at each detected coding agent's `skills/<name>` →
+/// `~/.agents/skills/<name>`.
+///
+/// Idempotent:
+///   - Shared SKILL.md whose bytes already match is left alone.
+///   - Symlink already pointing at the correct shared dir is left alone.
+///   - Symlink pointing elsewhere or a real directory at the path:
+///     reported as a conflict and **not** overwritten.
+///
+/// `home_override` lets tests redirect the destination away from the
+/// real `$HOME`. When `None`, falls back to `$HOME` then `dirs::home_dir`.
+pub fn install_skills(
+    home_override: Option<&str>,
+    filter: Option<&str>,
+) -> Result<CommandResult, String> {
+    let home = resolve_home(home_override)?;
+    let shared_dir = home.join(".agents").join("skills");
+
+    let rendered = render_skills(filter)?;
+
+    fs::create_dir_all(&shared_dir).map_err(|e| {
+        format!(
+            "Failed to create shared skills directory {}: {e}",
+            shared_dir.display()
+        )
+    })?;
+
+    let shared = write_shared_skills(&shared_dir, &rendered)?;
+    let targets = detect_agent_targets(&home);
+    let symlinks = create_agent_symlinks(&shared_dir, &rendered, &targets)?;
+
+    let text = render_install_text(&shared_dir, &rendered, &shared, &targets, &symlinks);
+
+    let agents_json: Vec<serde_json::Value> = targets
+        .iter()
+        .map(|(t, d)| {
+            serde_json::json!({
+                "type": t,
+                "skillsDir": d.to_string_lossy(),
+            })
+        })
+        .collect();
+
+    Ok(CommandResult {
+        text,
+        json: serde_json::json!({
+            "home": home.to_string_lossy(),
+            "sharedDir": shared_dir.to_string_lossy(),
+            "skills": rendered.iter().map(|s| serde_json::json!({
+                "name": s.name,
+                "commandCount": s.command_count,
+            })).collect::<Vec<_>>(),
+            "shared": {
+                "written": shared.written,
+                "updated": shared.updated,
+                "unchanged": shared.unchanged,
+            },
+            "agents": agents_json,
+            "symlinks": {
+                "linked": symlinks.linked,
+                "alreadyLinked": symlinks.already_linked,
+                "conflicts": symlinks.conflicts,
+            },
+        }),
+    })
+}
+
+fn resolve_home(home_override: Option<&str>) -> Result<PathBuf, String> {
+    if let Some(h) = home_override {
+        return Ok(PathBuf::from(h));
+    }
+    if let Ok(h) = env::var("HOME") {
+        if !h.is_empty() {
+            return Ok(PathBuf::from(h));
+        }
+    }
+    dirs::home_dir().ok_or_else(|| "Could not resolve user's home directory".to_string())
+}
+
+/// Write `content` to `dest` only if the existing bytes differ. Distinguishes
+/// fresh-write from drift-overwrite so the caller can report each separately.
+fn write_shared_skill(dest: &Path, content: &[u8]) -> Result<SharedWriteOutcome, String> {
+    match fs::read(dest) {
+        Ok(existing) => {
+            if existing == content {
+                Ok(SharedWriteOutcome::Unchanged)
+            } else {
+                fs::write(dest, content)
+                    .map_err(|e| format!("Failed to write {}: {e}", dest.display()))?;
+                Ok(SharedWriteOutcome::Updated)
+            }
+        }
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+            fs::write(dest, content)
+                .map_err(|e| format!("Failed to write {}: {e}", dest.display()))?;
+            Ok(SharedWriteOutcome::Written)
+        }
+        Err(err) => Err(format!("Failed to read {}: {err}", dest.display())),
+    }
+}
+
+/// Detect which supported coding agents are installed on this host
+/// (filesystem-based: the parent config directory exists). Returns
+/// `(agent_type, skills_dir)` pairs, deduplicated by `skills_dir` so the
+/// codex/openai-codex pair doesn't get linked twice.
+fn detect_agent_targets(home: &Path) -> Vec<(&'static str, PathBuf)> {
+    let mut out: Vec<(&'static str, PathBuf)> = Vec::new();
+    let mut seen: Vec<PathBuf> = Vec::new();
+    for agent in SUPPORTED_AGENTS {
+        let Some(config_dir) = agent_config_dir(agent, home) else {
+            continue;
+        };
+        if !config_dir.is_dir() {
+            continue;
+        }
+        let skills_dir = agent_skills_dir(agent, home);
+        if seen.iter().any(|p| p == &skills_dir) {
+            continue;
+        }
+        seen.push(skills_dir.clone());
+        out.push((agent, skills_dir));
+    }
+    out
+}
+
+fn agent_config_dir(agent: &str, home: &Path) -> Option<PathBuf> {
+    match agent {
+        "claude-code" => Some(home.join(".claude")),
+        "codex" | "openai-codex" => Some(codex_home(home)),
+        "gemini-cli" => Some(home.join(".gemini")),
+        "opencode" => Some(home.join(".config").join("opencode")),
+        _ => None,
+    }
+}
+
+fn agent_skills_dir(agent: &str, home: &Path) -> PathBuf {
+    match agent {
+        "claude-code" => home.join(".claude").join("skills"),
+        "codex" | "openai-codex" => codex_home(home).join("skills"),
+        "gemini-cli" => home.join(".gemini").join("skills"),
+        "opencode" => home.join(".config").join("opencode").join("skills"),
+        _ => home.join(agent).join("skills"),
+    }
+}
+
+fn codex_home(home: &Path) -> PathBuf {
+    if let Ok(val) = env::var("CODEX_HOME") {
+        if !val.is_empty() {
+            return PathBuf::from(val);
+        }
+    }
+    home.join(".codex")
+}
+
+/// Create a directory-level symlink at `link` pointing to `target`,
+/// idempotently. Refuses to overwrite a real directory, a regular file,
+/// or a symlink pointing somewhere else — those become `Conflict`s.
+fn ensure_symlink(link: &Path, target: &Path) -> SymlinkOutcome {
+    match fs::symlink_metadata(link) {
+        Ok(meta) => {
+            if meta.file_type().is_symlink() {
+                match fs::canonicalize(link) {
+                    Ok(resolved_link) => match fs::canonicalize(target) {
+                        Ok(resolved_target) => {
+                            if resolved_link == resolved_target {
+                                SymlinkOutcome::Already
+                            } else {
+                                let existing = fs::read_link(link).map_or_else(
+                                    |_| "<unreadable>".to_string(),
+                                    |p| p.to_string_lossy().into_owned(),
+                                );
+                                SymlinkOutcome::Conflict(format!(
+                                    "symlink points to {existing} (expected {})",
+                                    target.display()
+                                ))
+                            }
+                        }
+                        Err(e) => SymlinkOutcome::Conflict(format!("target unreadable ({e})")),
+                    },
+                    Err(e) => SymlinkOutcome::Conflict(format!("existing symlink is broken ({e})")),
+                }
+            } else if meta.is_dir() {
+                SymlinkOutcome::Conflict("path is a real directory (not a symlink)".to_string())
+            } else {
+                SymlinkOutcome::Conflict(
+                    "path is a regular file (not a directory or symlink)".to_string(),
+                )
+            }
+        }
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+            match create_dir_symlink(target, link) {
+                Ok(()) => SymlinkOutcome::Created,
+                Err(e) => SymlinkOutcome::Conflict(format!("failed to create symlink: {e}")),
+            }
+        }
+        Err(err) => SymlinkOutcome::Conflict(format!("lstat failed: {err}")),
+    }
+}
+
+#[cfg(unix)]
+fn create_dir_symlink(target: &Path, link: &Path) -> std::io::Result<()> {
+    std::os::unix::fs::symlink(target, link)
+}
+
+#[cfg(windows)]
+fn create_dir_symlink(target: &Path, link: &Path) -> std::io::Result<()> {
+    std::os::windows::fs::symlink_dir(target, link)
 }
 
 fn matches_filter(name: &str, filter: Option<&str>) -> bool {

--- a/apps/cli/src/skills.rs
+++ b/apps/cli/src/skills.rs
@@ -636,3 +636,43 @@ fn format_usage_line(cmd: &serde_json::Value) -> String {
 
     parts.join(" ")
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Drift guard: the Rust `SUPPORTED_AGENTS` list and the TS
+    /// `SUPPORTED_AGENT_TYPES` list (`packages/coding-agent/src/install-skills.ts`)
+    /// must be identical. If a new agent type is added to one side and not
+    /// the other, the web server's boot-time install and the CLI's
+    /// `skills install` would silently disagree on which agents get
+    /// linked — a bug class that's nearly invisible in normal use.
+    ///
+    /// Mirrored on the TS side by a matching `node:test` case in
+    /// `packages/coding-agent/tests/install-skills.test.ts`. Touching one
+    /// list without the other now fails *that side's* test suite, which
+    /// CI gates on. Adding a new agent therefore requires:
+    ///   1. Wiring up its adapter + `getInstallSkillsDir` + binary detection.
+    ///   2. Adding the type name to both lists (and both tests).
+    ///   3. Adding it to the supported-agents table in CLAUDE.md.
+    #[test]
+    fn supported_agents_matches_canonical_list() {
+        // Order matters: dispatchers iterate in this order, and tests on
+        // both sides assume the same ordering for stable agent-detection
+        // priority.
+        let expected = [
+            "claude-code",
+            "codex",
+            "openai-codex",
+            "gemini-cli",
+            "opencode",
+        ];
+        assert_eq!(
+            SUPPORTED_AGENTS,
+            &expected[..],
+            "Rust SUPPORTED_AGENTS drifted from the canonical list; update both this slice and \
+             packages/coding-agent/src/install-skills.ts::SUPPORTED_AGENT_TYPES (plus the \
+             matching test on each side) when adding/removing an agent"
+        );
+    }
+}

--- a/apps/cli/src/skills.rs
+++ b/apps/cli/src/skills.rs
@@ -456,7 +456,13 @@ fn agent_skills_dir(agent: &str, home: &Path) -> PathBuf {
         "codex" | "openai-codex" => codex_home(home).join("skills"),
         "gemini-cli" => home.join(".gemini").join("skills"),
         "opencode" => home.join(".config").join("opencode").join("skills"),
-        _ => home.join(agent).join("skills"),
+        // All callers iterate `SUPPORTED_AGENTS`, so any other value
+        // is a programming error. Fail loudly rather than constructing
+        // a plausible-looking `home/<unknown>/skills` path that would
+        // create symlinks in the wrong place if a future caller passes
+        // an unvetted string. The `supported_agents_matches_canonical_list`
+        // unit test below is the primary guard against that drift.
+        _ => unreachable!("agent_skills_dir called with unsupported agent type: {agent}"),
     }
 }
 

--- a/apps/cli/tests/integration.rs
+++ b/apps/cli/tests/integration.rs
@@ -2964,6 +2964,49 @@ fn skills_install_surfaces_conflict_when_wrong_target_symlink_exists() {
     assert!(result["symlinks"]["linked"].as_array().unwrap().len() >= 5);
 }
 
+// Dangling-symlink scenario: the link exists but its target has been
+// removed (e.g. the user manually pruned `~/.agents/skills/`, or `$HOME`
+// moved since the last install). Implementation reports
+// `existing symlink is broken (...)` as a Conflict; lock that in.
+#[cfg(unix)]
+#[test]
+fn skills_install_surfaces_conflict_when_dangling_symlink_exists() {
+    let tmp = skills_sandbox(&[".claude"]);
+    let home = tmp.path();
+
+    let claude_skills = home.join(".claude").join("skills");
+    fs::create_dir_all(&claude_skills).expect("create skills dir");
+    let link = claude_skills.join("band");
+
+    // Plant a symlink at ~/.claude/skills/band whose target never existed.
+    let bogus_target = home.join("never-existed").join("agents-skills-band");
+    std::os::unix::fs::symlink(&bogus_target, &link).expect("plant dangling symlink");
+    // Sanity: lstat sees the symlink, canonicalize/read on it fails.
+    assert!(fs::symlink_metadata(&link).is_ok());
+    assert!(fs::canonicalize(&link).is_err());
+
+    let result = run_install_json(home);
+
+    let conflicts = result["symlinks"]["conflicts"]
+        .as_array()
+        .expect("conflicts");
+    assert!(
+        conflicts.iter().any(|c| c["path"].as_str() == Some(link.to_str().unwrap())
+            && c["reason"].as_str().unwrap_or("").contains("broken")),
+        "expected broken-symlink conflict for {} in {conflicts:?}",
+        link.display()
+    );
+    // The dangling symlink is left in place — no overwrite.
+    let meta = fs::symlink_metadata(&link).expect("metadata");
+    assert!(meta.file_type().is_symlink(), "link should still be a symlink");
+    assert!(
+        fs::canonicalize(&link).is_err(),
+        "link should still be dangling"
+    );
+    // Other skills still get linked correctly.
+    assert!(result["symlinks"]["linked"].as_array().unwrap().len() >= 5);
+}
+
 #[test]
 fn skills_install_surfaces_conflict_when_real_directory_occupies_path() {
     let tmp = skills_sandbox(&[".claude"]);

--- a/apps/cli/tests/integration.rs
+++ b/apps/cli/tests/integration.rs
@@ -2757,16 +2757,37 @@ fn skills_sandbox(agent_dirs: &[&str]) -> tempfile::TempDir {
     tmp
 }
 
-/// Run `band skills install --home <tmp>` and parse its JSON output.
+/// Run `band skills install --home <tmp>` with a clean environment (no
+/// inherited `CODEX_HOME`) and parse its JSON output.
+///
+/// The CLI's `codex_home()` helper reads `$CODEX_HOME` at call time and
+/// uses it instead of `home` when set. If a developer runs the test
+/// suite from a shell that has `CODEX_HOME` exported (real install,
+/// previous test session, accidental export), the subprocess would
+/// pick it up and either:
+///   - link skills into the developer's real `$CODEX_HOME/skills/`, or
+///   - silently skip codex detection (if `$CODEX_HOME` points
+///     somewhere that doesn't exist), making assertions like
+///     `agents.len() == 2` flake on otherwise-correct code.
+///
+/// Stripping `CODEX_HOME` from the child's env at this seam isolates
+/// every `run_install_json` caller without touching the developer's
+/// actual shell. Tests that *want* to exercise the env override
+/// (`skills_install_dedupes_codex_and_openai_codex` etc.) can use
+/// `run_install_json_with_env` below.
 fn run_install_json(home: &Path) -> serde_json::Value {
-    let output = band_offline(&[
-        "--output",
-        "json",
-        "skills",
-        "install",
-        "--home",
-        home.to_str().unwrap(),
-    ]);
+    let output = Command::new(env!("CARGO_BIN_EXE_band"))
+        .env_remove("CODEX_HOME")
+        .args([
+            "--output",
+            "json",
+            "skills",
+            "install",
+            "--home",
+            home.to_str().unwrap(),
+        ])
+        .output()
+        .expect("failed to execute band");
     assert!(output.status.success(), "stderr: {}", stderr(&output));
     serde_json::from_str(&stdout(&output))
         .unwrap_or_else(|e| panic!("invalid JSON: {e}\nstdout: {}", stdout(&output)))

--- a/apps/cli/tests/integration.rs
+++ b/apps/cli/tests/integration.rs
@@ -2878,7 +2878,14 @@ fn skills_install_skips_agents_without_a_config_dir() {
     assert!(!home.join(".claude").exists());
     assert!(!home.join(".codex").exists());
     assert!(!home.join(".config").join("opencode").exists());
-    for name in ["band", "band-chat", "band-terminal", "band-browser"] {
+    for name in [
+        "band",
+        "band-chat",
+        "band-terminal",
+        "band-browser",
+        "band-start",
+        "band-loop",
+    ] {
         let link = home.join(".gemini").join("skills").join(name);
         let meta = fs::symlink_metadata(&link)
             .unwrap_or_else(|e| panic!("expected {} to exist: {e}", link.display()));
@@ -3002,7 +3009,14 @@ fn skills_install_writes_shared_skills_even_when_no_agents_are_detected() {
     assert_eq!(result["agents"].as_array().unwrap().len(), 0);
 
     let shared_dir = home.join(".agents").join("skills");
-    for name in ["band", "band-chat", "band-terminal", "band-browser"] {
+    for name in [
+        "band",
+        "band-chat",
+        "band-terminal",
+        "band-browser",
+        "band-start",
+        "band-loop",
+    ] {
         assert!(
             shared_dir.join(name).join("SKILL.md").is_file(),
             "shared {} should exist",

--- a/apps/cli/tests/integration.rs
+++ b/apps/cli/tests/integration.rs
@@ -2924,6 +2924,12 @@ fn skills_install_dedupes_codex_and_openai_codex() {
     assert_eq!(result["symlinks"]["linked"].as_array().unwrap().len(), 12);
 }
 
+// The conflict path relies on `std::os::unix::fs::symlink` to plant a
+// decoy, so it only exercises a meaningful scenario on unix. Gating the
+// whole test on `#[cfg(unix)]` avoids it silently passing-by-omission on
+// other platforms (which would make a Windows-port regression invisible
+// here).
+#[cfg(unix)]
 #[test]
 fn skills_install_surfaces_conflict_when_wrong_target_symlink_exists() {
     let tmp = skills_sandbox(&[".claude"]);
@@ -2935,7 +2941,6 @@ fn skills_install_surfaces_conflict_when_wrong_target_symlink_exists() {
     let claude_skills = home.join(".claude").join("skills");
     fs::create_dir_all(&claude_skills).expect("create skills dir");
     let link = claude_skills.join("band");
-    #[cfg(unix)]
     std::os::unix::fs::symlink(&decoy, &link).expect("plant decoy symlink");
 
     let result = run_install_json(home);

--- a/apps/cli/tests/integration.rs
+++ b/apps/cli/tests/integration.rs
@@ -2743,3 +2743,316 @@ fn generate_skills_json_output_lists_generated_skills() {
         }
     }
 }
+
+// --- skills install tests ---
+
+/// Set up a fresh sandbox HOME for `skills install` tests. Optionally
+/// pre-creates the listed agent config dirs so detection picks them up.
+fn skills_sandbox(agent_dirs: &[&str]) -> tempfile::TempDir {
+    let tmp = tempfile::tempdir().expect("create tempdir");
+    let home = tmp.path();
+    for rel in agent_dirs {
+        fs::create_dir_all(home.join(rel)).expect("create agent config dir");
+    }
+    tmp
+}
+
+/// Run `band skills install --home <tmp>` and parse its JSON output.
+fn run_install_json(home: &Path) -> serde_json::Value {
+    let output = band_offline(&[
+        "--output",
+        "json",
+        "skills",
+        "install",
+        "--home",
+        home.to_str().unwrap(),
+    ]);
+    assert!(output.status.success(), "stderr: {}", stderr(&output));
+    serde_json::from_str(&stdout(&output))
+        .unwrap_or_else(|e| panic!("invalid JSON: {e}\nstdout: {}", stdout(&output)))
+}
+
+#[test]
+fn skills_install_writes_shared_skills_and_links_into_claude() {
+    let tmp = skills_sandbox(&[".claude"]);
+    let home = tmp.path();
+    let result = run_install_json(home);
+
+    // Shared SKILL.md files all created fresh.
+    let written = result["shared"]["written"]
+        .as_array()
+        .expect("written array");
+    assert_eq!(
+        written.len(),
+        6,
+        "expected 6 shared writes, got {written:?}"
+    );
+
+    let shared_dir = home.join(".agents").join("skills");
+    for name in [
+        "band",
+        "band-chat",
+        "band-terminal",
+        "band-browser",
+        "band-start",
+        "band-loop",
+    ] {
+        let shared = shared_dir.join(name).join("SKILL.md");
+        assert!(
+            shared.is_file(),
+            "shared file missing: {}",
+            shared.display()
+        );
+
+        let link = home.join(".claude").join("skills").join(name);
+        let metadata = fs::symlink_metadata(&link)
+            .unwrap_or_else(|e| panic!("symlink_metadata({}) failed: {e}", link.display()));
+        assert!(
+            metadata.file_type().is_symlink(),
+            "{} is not a symlink",
+            link.display()
+        );
+        // Symlink should resolve to the shared dir for this skill (via realpath).
+        let resolved = fs::canonicalize(&link).expect("canonicalize link");
+        let expected = fs::canonicalize(shared_dir.join(name)).expect("canonicalize shared dir");
+        assert_eq!(
+            resolved,
+            expected,
+            "link {} points elsewhere",
+            link.display()
+        );
+    }
+}
+
+#[test]
+fn skills_install_is_idempotent_on_second_run() {
+    let tmp = skills_sandbox(&[".claude"]);
+    let home = tmp.path();
+
+    let first = run_install_json(home);
+    assert_eq!(first["shared"]["written"].as_array().unwrap().len(), 6);
+    assert_eq!(
+        first["symlinks"]["linked"].as_array().unwrap().len(),
+        6,
+        "expected 6 fresh symlinks on first run"
+    );
+
+    let second = run_install_json(home);
+    assert_eq!(
+        second["shared"]["written"].as_array().unwrap().len(),
+        0,
+        "second run should not write any shared files"
+    );
+    assert_eq!(
+        second["shared"]["unchanged"].as_array().unwrap().len(),
+        6,
+        "second run should report 6 unchanged shared files"
+    );
+    assert_eq!(
+        second["symlinks"]["linked"].as_array().unwrap().len(),
+        0,
+        "second run should not create any new symlinks"
+    );
+    assert_eq!(
+        second["symlinks"]["alreadyLinked"]
+            .as_array()
+            .unwrap()
+            .len(),
+        6,
+        "second run should report 6 already-linked"
+    );
+}
+
+#[test]
+fn skills_install_skips_agents_without_a_config_dir() {
+    // Only .gemini exists; the other supported agents should be skipped.
+    let tmp = skills_sandbox(&[".gemini"]);
+    let home = tmp.path();
+    let result = run_install_json(home);
+
+    let agents = result["agents"].as_array().expect("agents array");
+    assert_eq!(agents.len(), 1, "expected 1 agent detected, got {agents:?}");
+    assert_eq!(agents[0]["type"].as_str(), Some("gemini-cli"));
+
+    // No symlinks anywhere except under .gemini/skills.
+    assert!(!home.join(".claude").exists());
+    assert!(!home.join(".codex").exists());
+    assert!(!home.join(".config").join("opencode").exists());
+    for name in ["band", "band-chat", "band-terminal", "band-browser"] {
+        let link = home.join(".gemini").join("skills").join(name);
+        let meta = fs::symlink_metadata(&link)
+            .unwrap_or_else(|e| panic!("expected {} to exist: {e}", link.display()));
+        assert!(
+            meta.file_type().is_symlink(),
+            "{} not symlink",
+            link.display()
+        );
+    }
+}
+
+#[test]
+fn skills_install_dedupes_codex_and_openai_codex() {
+    // codex and openai-codex share $CODEX_HOME (default ~/.codex). The
+    // command must only link once, not twice.
+    let tmp = skills_sandbox(&[".codex", ".claude"]);
+    let home = tmp.path();
+    let result = run_install_json(home);
+
+    let agents = result["agents"].as_array().expect("agents array");
+    let types: Vec<&str> = agents
+        .iter()
+        .map(|a| a["type"].as_str().unwrap_or(""))
+        .collect();
+    // Exactly 2 distinct skill-dir targets: claude-code + codex (openai-codex deduped away).
+    assert_eq!(
+        agents.len(),
+        2,
+        "expected 2 agents after dedupe, got {types:?}"
+    );
+    assert!(types.contains(&"claude-code"));
+    assert!(types.contains(&"codex"));
+    assert!(!types.contains(&"openai-codex"));
+
+    // 6 skills × 2 agents = 12 symlinks total.
+    assert_eq!(result["symlinks"]["linked"].as_array().unwrap().len(), 12);
+}
+
+#[test]
+fn skills_install_surfaces_conflict_when_wrong_target_symlink_exists() {
+    let tmp = skills_sandbox(&[".claude"]);
+    let home = tmp.path();
+
+    // Plant a symlink at ~/.claude/skills/band that points at a decoy.
+    let decoy = home.join("decoy-band-skill");
+    fs::create_dir_all(&decoy).expect("create decoy");
+    let claude_skills = home.join(".claude").join("skills");
+    fs::create_dir_all(&claude_skills).expect("create skills dir");
+    let link = claude_skills.join("band");
+    #[cfg(unix)]
+    std::os::unix::fs::symlink(&decoy, &link).expect("plant decoy symlink");
+
+    let result = run_install_json(home);
+
+    // Conflict reported, link untouched.
+    let conflicts = result["symlinks"]["conflicts"]
+        .as_array()
+        .expect("conflicts");
+    assert!(
+        conflicts
+            .iter()
+            .any(|c| c["path"].as_str() == Some(link.to_str().unwrap())),
+        "expected conflict for {} in {conflicts:?}",
+        link.display()
+    );
+    let resolved = fs::canonicalize(&link).expect("canonicalize");
+    let expected = fs::canonicalize(&decoy).expect("canonicalize decoy");
+    assert_eq!(resolved, expected, "link should still point at decoy");
+
+    // Other skills still get linked normally.
+    assert!(result["symlinks"]["linked"].as_array().unwrap().len() >= 5);
+}
+
+#[test]
+fn skills_install_surfaces_conflict_when_real_directory_occupies_path() {
+    let tmp = skills_sandbox(&[".claude"]);
+    let home = tmp.path();
+
+    // Plant a real directory with user content at ~/.claude/skills/band.
+    let claude_skills = home.join(".claude").join("skills");
+    let real_dir = claude_skills.join("band");
+    fs::create_dir_all(&real_dir).expect("create real dir");
+    let user_file = real_dir.join("SKILL.md");
+    fs::write(&user_file, "# user-authored band skill\n").expect("write user file");
+
+    let result = run_install_json(home);
+
+    let conflicts = result["symlinks"]["conflicts"]
+        .as_array()
+        .expect("conflicts");
+    assert!(
+        conflicts
+            .iter()
+            .any(|c| c["path"].as_str() == Some(real_dir.to_str().unwrap())
+                && c["reason"]
+                    .as_str()
+                    .unwrap_or("")
+                    .contains("real directory")),
+        "expected real-directory conflict, got {conflicts:?}"
+    );
+    // User content preserved.
+    assert_eq!(
+        fs::read_to_string(&user_file).expect("read user file"),
+        "# user-authored band skill\n"
+    );
+    // Path is still a real directory, not a symlink.
+    let meta = fs::symlink_metadata(&real_dir).expect("metadata");
+    assert!(!meta.file_type().is_symlink());
+}
+
+#[test]
+fn skills_install_writes_shared_skills_even_when_no_agents_are_detected() {
+    // No agent config dirs exist — installing still populates ~/.agents/skills/
+    // because the shared content is useful on its own.
+    let tmp = skills_sandbox(&[]);
+    let home = tmp.path();
+    let result = run_install_json(home);
+
+    assert_eq!(result["shared"]["written"].as_array().unwrap().len(), 6);
+    assert_eq!(result["symlinks"]["linked"].as_array().unwrap().len(), 0);
+    assert_eq!(result["agents"].as_array().unwrap().len(), 0);
+
+    let shared_dir = home.join(".agents").join("skills");
+    for name in ["band", "band-chat", "band-terminal", "band-browser"] {
+        assert!(
+            shared_dir.join(name).join("SKILL.md").is_file(),
+            "shared {} should exist",
+            name
+        );
+    }
+}
+
+#[test]
+fn skills_install_text_output_summarizes_each_stage() {
+    let tmp = skills_sandbox(&[".claude"]);
+    let home = tmp.path();
+    let output = band_offline(&["skills", "install", "--home", home.to_str().unwrap()]);
+    assert!(output.status.success(), "stderr: {}", stderr(&output));
+
+    let stdout = stdout(&output);
+    assert!(stdout.contains("Installed 6 skill(s)"));
+    assert!(stdout.contains("shared: 6 written"));
+    assert!(stdout.contains("symlinks: 6 created"));
+    assert!(stdout.contains("claude-code →"));
+}
+
+#[test]
+fn skills_install_filter_limits_to_matching_skills_only() {
+    let tmp = skills_sandbox(&[".claude"]);
+    let home = tmp.path();
+    let output = band_offline(&[
+        "--output",
+        "json",
+        "skills",
+        "install",
+        "--home",
+        home.to_str().unwrap(),
+        "--filter",
+        "chat",
+    ]);
+    assert!(output.status.success(), "stderr: {}", stderr(&output));
+    let result: serde_json::Value = serde_json::from_str(&stdout(&output)).expect("json");
+
+    let skills = result["skills"].as_array().expect("skills");
+    assert_eq!(skills.len(), 1);
+    assert_eq!(skills[0]["name"].as_str(), Some("band-chat"));
+
+    assert!(home
+        .join(".agents")
+        .join("skills")
+        .join("band-chat")
+        .join("SKILL.md")
+        .is_file());
+    assert!(!home.join(".agents").join("skills").join("band").exists());
+    // Only one symlink (just band-chat) under .claude/skills/.
+    assert_eq!(result["symlinks"]["linked"].as_array().unwrap().len(), 1);
+}

--- a/apps/cli/tests/integration.rs
+++ b/apps/cli/tests/integration.rs
@@ -2991,14 +2991,19 @@ fn skills_install_surfaces_conflict_when_dangling_symlink_exists() {
         .as_array()
         .expect("conflicts");
     assert!(
-        conflicts.iter().any(|c| c["path"].as_str() == Some(link.to_str().unwrap())
-            && c["reason"].as_str().unwrap_or("").contains("broken")),
+        conflicts
+            .iter()
+            .any(|c| c["path"].as_str() == Some(link.to_str().unwrap())
+                && c["reason"].as_str().unwrap_or("").contains("broken")),
         "expected broken-symlink conflict for {} in {conflicts:?}",
         link.display()
     );
     // The dangling symlink is left in place — no overwrite.
     let meta = fs::symlink_metadata(&link).expect("metadata");
-    assert!(meta.file_type().is_symlink(), "link should still be a symlink");
+    assert!(
+        meta.file_type().is_symlink(),
+        "link should still be a symlink"
+    );
     assert!(
         fs::canonicalize(&link).is_err(),
         "link should still be dangling"

--- a/apps/web/src/lib/cli-skills.ts
+++ b/apps/web/src/lib/cli-skills.ts
@@ -1,43 +1,63 @@
 /**
  * Sync the CLI-shipped skills (`band`, `band-chat`, `band-terminal`,
- * `band-browser`, `band-start`, `band-loop`) into the user's global
- * coding-agent skill directory so the skills become discoverable to the agent
- * right after install / auto-update, without the user having to manually `cp`
- * each SKILL.md after every release.
+ * `band-browser`, `band-start`, `band-loop`) into a single canonical,
+ * agent-agnostic skills directory (`~/.agents/skills/<name>/SKILL.md`), then
+ * link each detected coding-agent's skills directory to that shared root so
+ * the skills become discoverable to every agent on the host without
+ * duplicating content.
  *
  * The skills are not shipped as loose files in the packaged Electron build —
  * they're baked into the Rust `band` binary via `include_str!` (see
  * `apps/cli/src/skills.rs::SKILL_TEMPLATES`) and rendered against the live
- * CLI schema by `band generate-skills`. We invoke that subcommand at runtime
- * and copy the produced `<name>/SKILL.md` files into each detected agent's
- * known skills directory.
+ * CLI schema by `band generate-skills`. We invoke that subcommand at runtime,
+ * write the produced `<name>/SKILL.md` files into `~/.agents/skills/`, and
+ * then for each supported coding agent that's installed on this machine
+ * create a directory-level symlink at `<agent>/skills/<name>` pointing back
+ * to the shared `~/.agents/skills/<name>`.
  *
- * Idempotency: the destination is only rewritten when its bytes differ from
- * the freshly generated content. Missing destinations are written, identical
- * destinations are skipped, and content drift (user edits or older shipped
- * versions) results in an overwrite + warning log — matching the
- * "blast-and-replace with a log" policy used by `installHooks` and
- * `installCli` (see hooks.ts / cli.ts).
+ * Idempotency:
+ *   - Shared SKILL.md: only rewritten when its bytes differ from the
+ *     freshly generated content.
+ *   - Per-agent symlink: created on first run; on subsequent runs we verify
+ *     it still points at the correct shared location. If it points
+ *     somewhere else, or is a real directory, we *do not* overwrite — we
+ *     log a conflict and skip, so user customizations aren't silently
+ *     blown away.
+ *
+ * Layout:
+ *
+ *   ~/.agents/skills/band/SKILL.md            ← canonical (written once)
+ *   ~/.agents/skills/band-chat/SKILL.md
+ *   ~/.claude/skills/band       → ../../.agents/skills/band     (symlink)
+ *   ~/.codex/skills/band        → ../../.agents/skills/band     (symlink)
+ *   ~/.gemini/skills/band       → ../../.agents/skills/band     (symlink)
+ *   ~/.config/opencode/skills/band → ../../../.agents/skills/band (symlink)
  */
 
 import { execFile } from "node:child_process";
 import {
-  accessSync,
   existsSync,
-  constants as fsConstants,
+  lstatSync,
   mkdirSync,
   mkdtempSync,
   readFileSync,
+  readlinkSync,
+  realpathSync,
   rmSync,
   statSync,
+  symlinkSync,
   writeFileSync,
 } from "node:fs";
 import { homedir, tmpdir } from "node:os";
-import { dirname, join } from "node:path";
-import { getDefaultAgentBinary, getInstallSkillsDir } from "@band-app/coding-agent";
+import { dirname, join, relative } from "node:path";
+import {
+  getAgentConfigDir,
+  getInstallSkillsDir,
+  getSharedSkillsDir,
+  SUPPORTED_AGENT_TYPES,
+} from "@band-app/coding-agent";
 import { findCliBinary } from "./cli";
 import { whichBinary } from "./process-utils";
-import { loadSettings } from "./state";
 
 /** The six skills `band generate-skills` emits. */
 export const BAND_SKILL_NAMES = [
@@ -60,92 +80,48 @@ export interface SkillTarget {
 }
 
 /**
- * Coding agent identity — just the bits `resolveSkillTargets` needs. Mirrors
- * the relevant fields of `CodingAgentDefinition` from state.ts so callers can
- * pass `loadSettings().codingAgents` directly without re-shaping it.
- */
-export interface SkillAgent {
-  /** Stable type discriminator (e.g. `claude-code`, `codex`, `opencode`). */
-  type: string;
-  /**
-   * Optional explicit path to the agent's executable, mirroring
-   * `CodingAgentDefinition.command`. When set we trust this over the
-   * adapter's default binary name — letting users with custom installs
-   * (Homebrew Cellar, NixOS profiles, npm prefix overrides) keep
-   * skills syncing without us re-implementing every package manager's
-   * resolution rules.
-   */
-  command?: string;
-}
-
-/**
- * Verify a coding agent is *actually installed* on this host. Presence in
- * `settings.codingAgents` only proves the agent was detected at some past
- * setup run — the user may have uninstalled the binary since (e.g. removed
- * `claude` while keeping the entry around). Writing skills to that agent's
- * global directory after the fact would just litter the user's home dir.
+ * Resolve write targets for all supported coding agents that are
+ * detected on this host, deduplicating destinations.
  *
- *   1. If the agent definition carries an explicit `command`, check the
- *      file is executable.
- *   2. Otherwise look up the adapter's default binary name (owned by each
- *      adapter — see `packages/coding-agent/src/install-skills.ts`) and
- *      probe PATH via `whichBinary`.
- *
- * Returns `false` when neither path resolves, so callers can skip the
- * agent. Adapter types without a default binary (e.g. `cursor-cli`) also
- * return `false` — we'd have nothing to install for them anyway.
- */
-export async function isAgentInstalled(agent: SkillAgent): Promise<boolean> {
-  if (agent.command) {
-    try {
-      accessSync(agent.command, fsConstants.X_OK);
-      return true;
-    } catch {
-      return false;
-    }
-  }
-
-  const binaryName = await getDefaultAgentBinary(agent.type);
-  if (!binaryName) return false;
-
-  const found = await whichBinary(binaryName);
-  return found !== null;
-}
-
-/**
- * Resolve write targets for the *enabled* agents in the input list,
- * deduplicating destinations.
- *
- * "Enabled" here means: present in `settings.codingAgents` AND the agent's
- * binary is actually reachable on this host (see `isAgentInstalled`).
- * Stale entries — those whose binary has been uninstalled since detection
- * but whose record lingers in settings.json — are skipped so we don't
- * keep refreshing skills for a coding agent the user no longer uses.
+ * "Detected" is filesystem-based: the agent's parent config directory
+ * (e.g. `~/.claude/`) must already exist. We treat the presence of a
+ * config dir as evidence that the user has used the agent on this host
+ * at least once — at which point linking skills into its skills/
+ * subdirectory is safe and useful. We deliberately do *not* probe
+ * `$PATH` for the binary: the user may have installed the agent via a
+ * method that doesn't put a binary on PATH for the Electron app's
+ * environment (npm prefix overrides, Nix profiles, etc.). The config
+ * dir is a stronger signal of "this agent is set up here".
  *
  * Each agent's skills directory comes from its adapter (see
  * `packages/coding-agent/src/install-skills.ts` and the
  * `get<Agent>InstallSkillsDir` exports next to each adapter's discovery
- * logic) — this layer only orchestrates lookup, install-check, and dedupe.
+ * logic) — this layer only orchestrates detection, lookup, and dedupe.
  *
- * Two configured agents can resolve to the same directory (e.g. two
- * claude-code agents with different IDs but the same `type` both map to
- * `~/.claude/skills/`). We dedupe so the (skill, target) loop doesn't write
- * the same file twice on each boot. Agent types without a documented global
- * skills directory (e.g. `cursor-cli`) are silently skipped.
+ * Two agent types can resolve to the same directory (codex and
+ * openai-codex both map to `$CODEX_HOME/skills/`). We dedupe so the
+ * (skill, target) loop doesn't try to create the same symlink twice on
+ * each boot. Agent types without a documented global skills directory
+ * (e.g. `cursor-cli`) are silently skipped at the
+ * `SUPPORTED_AGENT_TYPES` level.
  */
-export async function resolveSkillTargets(
-  agents: readonly SkillAgent[],
-  home: string = homedir(),
-): Promise<SkillTarget[]> {
+export async function resolveSkillTargets(home: string = homedir()): Promise<SkillTarget[]> {
   const seen = new Set<string>();
   const out: SkillTarget[] = [];
-  for (const agent of agents) {
-    if (!(await isAgentInstalled(agent))) continue;
-    const skillsDir = await getInstallSkillsDir(agent.type, home);
+  for (const type of SUPPORTED_AGENT_TYPES) {
+    const configDir = getAgentConfigDir(type, home);
+    if (!configDir) continue;
+    try {
+      const stat = statSync(configDir);
+      if (!stat.isDirectory()) continue;
+    } catch {
+      continue;
+    }
+    const skillsDir = await getInstallSkillsDir(type, home);
     if (!skillsDir) continue;
     if (seen.has(skillsDir)) continue;
     seen.add(skillsDir);
-    out.push({ agentType: agent.type, skillsDir });
+    out.push({ agentType: type, skillsDir });
   }
   return out;
 }
@@ -202,36 +178,37 @@ async function generateSkills(bandPath: string, outputDir: string): Promise<void
 }
 
 /**
- * Result of `installSkills`. Counts each (skill × target) cell once, so
- * syncing 4 skills into 1 target produces up to 4 entries across the three
- * fields combined.
+ * Result of `installSkills`. Counts are split between the canonical
+ * (shared) write path and the per-agent symlink path so callers can log
+ * each phase independently.
  */
 export interface InstallSkillsResult {
-  /** Destination paths that didn't exist before this run. */
+  /** Canonical SKILL.md paths that didn't exist before this run. */
   written: string[];
-  /** Destination paths that existed but had different content (overwritten). */
+  /** Canonical SKILL.md paths that existed but had different content (overwritten). */
   updated: string[];
-  /** Destination paths whose existing content already matched. */
+  /** Canonical SKILL.md paths whose existing content already matched. */
   unchanged: string[];
-  /** Targets that were skipped because no band binary could be located. */
+  /** Symlink paths that were newly created (one entry per (agent, skill)). */
+  linked: string[];
+  /** Symlink paths that already pointed at the correct shared dir. */
+  alreadyLinked: string[];
+  /**
+   * Per-agent skill paths where an existing file/dir/symlink got in our
+   * way and we declined to overwrite it. Each entry is human-readable —
+   * "path: reason" — so the warning log line is self-contained.
+   */
+  conflicts: string[];
+  /**
+   * Per-agent skill paths that were skipped because no band binary
+   * could be located (so no shared skills exist to link to).
+   */
   skipped: string[];
 }
 
 interface InstallSkillsOptions {
   /** Override $HOME (test-only — production callers should leave unset). */
   home?: string;
-  /**
-   * Override the enabled-agents list (test-only). When omitted (the
-   * production path) we read `loadSettings().codingAgents` ourselves so the
-   * function is a self-contained "sync skills for the user's enabled
-   * agents" — callers can't accidentally pass a stale or unfiltered list.
-   *
-   * We dispatch on each agent's `type`, not `id`, because users can
-   * configure several agents of the same type (e.g. two `claude-code`
-   * agents with different labels) and a custom `id` doesn't change the
-   * on-disk skills directory layout.
-   */
-  agents?: readonly SkillAgent[];
   /**
    * Optional logger for visibility into write/update/skip decisions. Pino-
    * compatible signature so we can pass `createLogger(...)` from setup.ts
@@ -244,53 +221,47 @@ interface InstallSkillsOptions {
 }
 
 /**
- * Sync the CLI-shipped skills into each enabled agent's global skills dir.
- *
- * "Enabled" is sourced from `loadSettings().codingAgents` by default — that
- * array is the canonical "agents the user has turned on", populated by
- * `ensureDefaultCodingAgents` on first run and edited via the dashboard
- * settings UI. Tests can pass `opts.agents` to override.
+ * Sync the CLI-shipped skills into the shared `~/.agents/skills/` root and
+ * create per-agent symlinks for every supported coding agent that's
+ * detected on this host.
  *
  * Steps:
- *   1. Read enabled agents from settings (or from `opts.agents`).
- *   2. Filter to those whose binary is actually reachable on this host
- *      (`isAgentInstalled` — handles stale `command` paths and missing
- *      PATH entries).
- *   3. Resolve a deduplicated list of skills directories from each
- *      remaining agent's adapter.
- *   4. Resolve a band binary — abort cleanly if none is available.
- *   5. Run `band generate-skills` into a temp dir.
- *   6. For each (skill, target), compare against the destination and write
- *      only when content differs.
+ *   1. Resolve a band binary — abort cleanly if none is available.
+ *   2. Run `band generate-skills` into a temp dir.
+ *   3. For each skill, compare against `~/.agents/skills/<name>/SKILL.md`
+ *      and write only when content differs.
+ *   4. Detect which supported agents are installed on this host
+ *      (`detectInstalledAgents` via the filesystem config-dir check).
+ *   5. For each (agent, skill), create a directory-level symlink at
+ *      `<agent-skills-dir>/<name>` → `~/.agents/skills/<name>`. Skip
+ *      idempotently if the symlink already points to the right place.
+ *      Surface a clear conflict log if it points elsewhere or is a real
+ *      directory.
  *
- * No-op (returns an empty-ish result) when no targets resolve — e.g. the
- * user has no agents enabled, or all enabled agents have been uninstalled.
+ * No-op (returns an empty-ish result) when no targets resolve.
  */
 export async function installSkills(opts: InstallSkillsOptions = {}): Promise<InstallSkillsResult> {
   const result: InstallSkillsResult = {
     written: [],
     updated: [],
     unchanged: [],
+    linked: [],
+    alreadyLinked: [],
+    conflicts: [],
     skipped: [],
   };
 
   const home = opts.home ?? homedir();
-  const agents = opts.agents ?? loadSettings().codingAgents ?? [];
-  const targets = await resolveSkillTargets(agents, home);
-
-  if (targets.length === 0) {
-    return result;
-  }
+  const sharedDir = getSharedSkillsDir(home);
+  const targets = await resolveSkillTargets(home);
 
   const bandPath = await findBandBinary();
   if (!bandPath) {
     opts.log?.warn(
       "Skipping CLI skills sync — band binary not found (no symlink, not on PATH, no bundled sidecar)",
     );
-    for (const target of targets) {
-      for (const name of BAND_SKILL_NAMES) {
-        result.skipped.push(join(target.skillsDir, name, SKILL_FILE));
-      }
+    for (const name of BAND_SKILL_NAMES) {
+      result.skipped.push(join(sharedDir, name, SKILL_FILE));
     }
     return result;
   }
@@ -299,53 +270,102 @@ export async function installSkills(opts: InstallSkillsOptions = {}): Promise<In
   try {
     await generateSkills(bandPath, stagingDir);
 
+    // -------------------------------------------------------------
+    // Step 1: write the canonical SKILL.md files into ~/.agents/skills/.
+    // -------------------------------------------------------------
+    for (const name of BAND_SKILL_NAMES) {
+      const sourcePath = join(stagingDir, name, SKILL_FILE);
+      const destPath = join(sharedDir, name, SKILL_FILE);
+
+      if (!existsSync(sourcePath)) {
+        // Generator didn't emit this skill. Could happen if the templates
+        // diverge from BAND_SKILL_NAMES — log and move on rather than
+        // crashing the whole boot path.
+        opts.log?.warn("Generated skill missing from staging dir: %s (skipping)", sourcePath);
+        continue;
+      }
+
+      const sourceContent = readFileSync(sourcePath);
+
+      let existingContent: Buffer | null = null;
+      try {
+        existingContent = readFileSync(destPath);
+      } catch (err) {
+        const code = (err as NodeJS.ErrnoException).code;
+        if (code !== "ENOENT") {
+          opts.log?.warn(
+            "Failed to read existing shared skill at %s: %s — overwriting",
+            destPath,
+            err instanceof Error ? err.message : String(err),
+          );
+        }
+      }
+
+      if (existingContent?.equals(sourceContent)) {
+        result.unchanged.push(destPath);
+        continue;
+      }
+
+      mkdirSync(dirname(destPath), { recursive: true });
+      writeFileSync(destPath, sourceContent);
+
+      if (existingContent) {
+        result.updated.push(destPath);
+        opts.log?.info(
+          "Updated %s skill at %s (content differed — local edits, if any, were overwritten)",
+          name,
+          destPath,
+        );
+      } else {
+        result.written.push(destPath);
+        opts.log?.info("Installed %s skill at %s", name, destPath);
+      }
+    }
+
+    // -------------------------------------------------------------
+    // Step 2: link each agent's per-name skill dir back to the shared one.
+    // -------------------------------------------------------------
+    if (targets.length === 0) {
+      opts.log?.info(
+        "No supported coding agents detected on host — skills installed to %s but no agent symlinks created",
+        sharedDir,
+      );
+      return result;
+    }
+
     for (const target of targets) {
       for (const name of BAND_SKILL_NAMES) {
-        const sourcePath = join(stagingDir, name, SKILL_FILE);
-        const destPath = join(target.skillsDir, name, SKILL_FILE);
+        const shared = join(sharedDir, name);
+        const link = join(target.skillsDir, name);
 
-        if (!existsSync(sourcePath)) {
-          // Generator didn't emit this skill. Could happen if the templates
-          // diverge from BAND_SKILL_NAMES — log and move on rather than
-          // crashing the whole boot path.
-          opts.log?.warn("Generated skill missing from staging dir: %s (skipping)", sourcePath);
+        // Skip if the shared dir for this skill isn't actually there
+        // (could happen if the generator failed to emit it above).
+        if (!existsSync(shared)) {
           continue;
         }
 
-        const sourceContent = readFileSync(sourcePath);
-
-        let existingContent: Buffer | null = null;
-        try {
-          existingContent = readFileSync(destPath);
-        } catch (err) {
-          const code = (err as NodeJS.ErrnoException).code;
-          if (code !== "ENOENT") {
-            opts.log?.warn(
-              "Failed to read existing skill at %s: %s — overwriting",
-              destPath,
-              err instanceof Error ? err.message : String(err),
+        const outcome = ensureSymlink({ link, target: shared, log: opts.log });
+        switch (outcome.kind) {
+          case "created":
+            result.linked.push(link);
+            opts.log?.info(
+              "Linked %s skills/%s → %s",
+              target.agentType,
+              name,
+              relative(target.skillsDir, shared),
             );
-          }
-        }
-
-        if (existingContent?.equals(sourceContent)) {
-          result.unchanged.push(destPath);
-          continue;
-        }
-
-        mkdirSync(dirname(destPath), { recursive: true });
-        writeFileSync(destPath, sourceContent);
-
-        if (existingContent) {
-          result.updated.push(destPath);
-          opts.log?.info(
-            "Updated %s skill at %s (content differed — local edits, if any, were overwritten)",
-            name,
-            destPath,
-          );
-        } else {
-          result.written.push(destPath);
-          opts.log?.info("Installed %s skill at %s", name, destPath);
+            break;
+          case "already":
+            result.alreadyLinked.push(link);
+            break;
+          case "conflict":
+            result.conflicts.push(`${link}: ${outcome.reason}`);
+            opts.log?.warn(
+              "Skill symlink conflict at %s — %s (leaving as-is; remove it manually to re-link)",
+              link,
+              outcome.reason,
+            );
+            break;
         }
       }
     }
@@ -358,4 +378,109 @@ export async function installSkills(opts: InstallSkillsOptions = {}): Promise<In
   }
 
   return result;
+}
+
+interface EnsureSymlinkArgs {
+  link: string;
+  target: string;
+  log?: InstallSkillsOptions["log"];
+}
+
+type EnsureSymlinkOutcome =
+  | { kind: "created" }
+  | { kind: "already" }
+  | { kind: "conflict"; reason: string };
+
+/**
+ * Create a symlink at `link` pointing to `target`, idempotently.
+ *
+ *   - No file at `link`: create the symlink. (`created`)
+ *   - Symlink at `link` already pointing at `target` (after realpath
+ *     normalisation): leave it alone. (`already`)
+ *   - Symlink pointing somewhere else: refuse to overwrite — surface a
+ *     conflict so the user can decide. (`conflict`)
+ *   - Real file or directory: refuse to overwrite — likely user data.
+ *     (`conflict`)
+ *
+ * We never blindly `rm -rf` or `unlink` the existing path: this function
+ * runs on every server boot, and a misconfigured detection step could
+ * otherwise destroy a real `~/.claude/skills/foo/` the user is
+ * intentionally maintaining. "Refuse and log" is the safe default.
+ */
+function ensureSymlink(args: EnsureSymlinkArgs): EnsureSymlinkOutcome {
+  const { link, target } = args;
+
+  // Ensure the parent directory of the link exists. Creating it is
+  // safe: it's always inside an agent-owned dir (e.g. ~/.claude/skills/),
+  // and the agent itself would create it on first use anyway.
+  mkdirSync(dirname(link), { recursive: true });
+
+  let existing: ReturnType<typeof lstatSync> | null = null;
+  try {
+    existing = lstatSync(link);
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code !== "ENOENT") {
+      return {
+        kind: "conflict",
+        reason: `lstat failed: ${err instanceof Error ? err.message : String(err)}`,
+      };
+    }
+  }
+
+  if (existing === null) {
+    symlinkSync(target, link, "dir");
+    return { kind: "created" };
+  }
+
+  if (existing.isSymbolicLink()) {
+    let pointsAt: string;
+    try {
+      pointsAt = realpathSync(link);
+    } catch (err) {
+      return {
+        kind: "conflict",
+        reason: `existing symlink is broken (${err instanceof Error ? err.message : String(err)})`,
+      };
+    }
+    let targetReal: string;
+    try {
+      targetReal = realpathSync(target);
+    } catch (err) {
+      // Shared target unreadable — caller already created it, so this
+      // would be unusual. Treat as a conflict so we don't silently
+      // overwrite a (correct) link.
+      return {
+        kind: "conflict",
+        reason: `target unreadable (${err instanceof Error ? err.message : String(err)})`,
+      };
+    }
+    if (pointsAt === targetReal) {
+      return { kind: "already" };
+    }
+    return {
+      kind: "conflict",
+      reason: `symlink points to ${readlinkSafe(link)} (expected ${target})`,
+    };
+  }
+
+  if (existing.isDirectory()) {
+    return {
+      kind: "conflict",
+      reason: "path is a real directory (not a symlink)",
+    };
+  }
+
+  return {
+    kind: "conflict",
+    reason: "path is a regular file (not a directory or symlink)",
+  };
+}
+
+function readlinkSafe(p: string): string {
+  try {
+    return readlinkSync(p);
+  } catch {
+    return "<unreadable>";
+  }
 }

--- a/apps/web/src/lib/cli-skills.ts
+++ b/apps/web/src/lib/cli-skills.ts
@@ -353,7 +353,12 @@ export async function installSkills(opts: InstallSkillsOptions = {}): Promise<In
 
         // Skip if the shared dir for this skill isn't actually there
         // (could happen if the generator failed to emit it above).
+        // Track each missed (agent, skill) pair in `result.skipped`
+        // so the `setup.ts` info-log counter reflects the gap; a
+        // silent `continue` here would make the booted process look
+        // healthier than it is when the shared-write phase warned.
         if (!existsSync(shared)) {
+          result.skipped.push(link);
           continue;
         }
 

--- a/apps/web/src/lib/cli-skills.ts
+++ b/apps/web/src/lib/cli-skills.ts
@@ -429,8 +429,25 @@ function ensureSymlink(args: EnsureSymlinkArgs): EnsureSymlinkOutcome {
   }
 
   if (existing === null) {
-    symlinkSync(target, link, "dir");
-    return { kind: "created" };
+    try {
+      symlinkSync(target, link, "dir");
+      return { kind: "created" };
+    } catch (err) {
+      // Tight TOCTOU race: between the `lstatSync` above and this
+      // `symlinkSync`, another process (concurrent server boot, a shell
+      // command, `band skills install` invoked manually) could have
+      // created something at `link`. Re-enter the function so the
+      // newly-created entry is classified as `already`/`conflict` via
+      // the lstat path above. Any non-EEXIST error is propagated as a
+      // conflict, matching the lstat-failure branch.
+      if ((err as NodeJS.ErrnoException).code === "EEXIST") {
+        return ensureSymlink(args);
+      }
+      return {
+        kind: "conflict",
+        reason: `failed to create symlink: ${err instanceof Error ? err.message : String(err)}`,
+      };
+    }
   }
 
   if (existing.isSymbolicLink()) {

--- a/apps/web/src/lib/cli-skills.ts
+++ b/apps/web/src/lib/cli-skills.ts
@@ -28,10 +28,16 @@
  *
  *   ~/.agents/skills/band/SKILL.md            ← canonical (written once)
  *   ~/.agents/skills/band-chat/SKILL.md
- *   ~/.claude/skills/band       → ../../.agents/skills/band     (symlink)
- *   ~/.codex/skills/band        → ../../.agents/skills/band     (symlink)
- *   ~/.gemini/skills/band       → ../../.agents/skills/band     (symlink)
- *   ~/.config/opencode/skills/band → ../../../.agents/skills/band (symlink)
+ *   ~/.claude/skills/band       → ~/.agents/skills/band     (symlink, absolute target)
+ *   ~/.codex/skills/band        → ~/.agents/skills/band     (symlink, absolute target)
+ *   ~/.gemini/skills/band       → ~/.agents/skills/band     (symlink, absolute target)
+ *   ~/.config/opencode/skills/band → ~/.agents/skills/band  (symlink, absolute target)
+ *
+ * The link target is an absolute path (`symlinkSync(target, link, "dir")`
+ * where `target` is `join(sharedDir, name)`). Absolute keeps the link
+ * valid regardless of where it lives in the agent's directory tree, at
+ * the cost of breaking if `$HOME` ever moves — acceptable for per-user
+ * installs.
  */
 
 import { execFile } from "node:child_process";
@@ -384,6 +390,15 @@ interface EnsureSymlinkArgs {
   link: string;
   target: string;
   log?: InstallSkillsOptions["log"];
+  /**
+   * Internal flag set by the EEXIST recovery branch to prevent unbounded
+   * recursion if the filesystem is in a pathological state (e.g. `lstat`
+   * consistently reports ENOENT but `symlink` consistently returns
+   * EEXIST). One retry is enough for the realistic TOCTOU race; if the
+   * second attempt still hits EEXIST we surface a conflict rather than
+   * looping forever on the boot path.
+   */
+  _retried?: boolean;
 }
 
 type EnsureSymlinkOutcome =
@@ -441,7 +456,16 @@ function ensureSymlink(args: EnsureSymlinkArgs): EnsureSymlinkOutcome {
       // the lstat path above. Any non-EEXIST error is propagated as a
       // conflict, matching the lstat-failure branch.
       if ((err as NodeJS.ErrnoException).code === "EEXIST") {
-        return ensureSymlink(args);
+        if (args._retried) {
+          // Second EEXIST in a row means the filesystem is reporting
+          // contradictory state (lstat says ENOENT, symlink says EEXIST).
+          // Bail out rather than recurse indefinitely on the boot path.
+          return {
+            kind: "conflict",
+            reason: "EEXIST after retry — filesystem state is inconsistent",
+          };
+        }
+        return ensureSymlink({ ...args, _retried: true });
       }
       return {
         kind: "conflict",

--- a/apps/web/src/lib/cli-skills.ts
+++ b/apps/web/src/lib/cli-skills.ts
@@ -55,7 +55,7 @@ import {
   writeFileSync,
 } from "node:fs";
 import { homedir, tmpdir } from "node:os";
-import { dirname, join, relative } from "node:path";
+import { dirname, join } from "node:path";
 import {
   getAgentConfigDir,
   getInstallSkillsDir,
@@ -354,12 +354,11 @@ export async function installSkills(opts: InstallSkillsOptions = {}): Promise<In
         switch (outcome.kind) {
           case "created":
             result.linked.push(link);
-            opts.log?.info(
-              "Linked %s skills/%s → %s",
-              target.agentType,
-              name,
-              relative(target.skillsDir, shared),
-            );
+            // Log the absolute target — that's what `ensureSymlinkInner`
+            // actually writes to disk (`symlinkSync(target, link, "dir")`
+            // with `target = shared`). Logging a relative path here would
+            // disagree with what `ls -la <link>` shows.
+            opts.log?.info("Linked %s skills/%s → %s", target.agentType, name, shared);
             break;
           case "already":
             result.alreadyLinked.push(link);

--- a/apps/web/src/lib/cli-skills.ts
+++ b/apps/web/src/lib/cli-skills.ts
@@ -390,15 +390,6 @@ interface EnsureSymlinkArgs {
   link: string;
   target: string;
   log?: InstallSkillsOptions["log"];
-  /**
-   * Internal flag set by the EEXIST recovery branch to prevent unbounded
-   * recursion if the filesystem is in a pathological state (e.g. `lstat`
-   * consistently reports ENOENT but `symlink` consistently returns
-   * EEXIST). One retry is enough for the realistic TOCTOU race; if the
-   * second attempt still hits EEXIST we surface a conflict rather than
-   * looping forever on the boot path.
-   */
-  _retried?: boolean;
 }
 
 type EnsureSymlinkOutcome =
@@ -423,6 +414,13 @@ type EnsureSymlinkOutcome =
  * intentionally maintaining. "Refuse and log" is the safe default.
  */
 function ensureSymlink(args: EnsureSymlinkArgs): EnsureSymlinkOutcome {
+  // `_retried` is a private recursion guard set only by this function
+  // when the EEXIST recovery branch re-enters. Kept off the public
+  // `EnsureSymlinkArgs` interface so external callers can't supply it.
+  return ensureSymlinkInner(args, false);
+}
+
+function ensureSymlinkInner(args: EnsureSymlinkArgs, retried: boolean): EnsureSymlinkOutcome {
   const { link, target } = args;
 
   // Ensure the parent directory of the link exists. Creating it is
@@ -456,7 +454,7 @@ function ensureSymlink(args: EnsureSymlinkArgs): EnsureSymlinkOutcome {
       // the lstat path above. Any non-EEXIST error is propagated as a
       // conflict, matching the lstat-failure branch.
       if ((err as NodeJS.ErrnoException).code === "EEXIST") {
-        if (args._retried) {
+        if (retried) {
           // Second EEXIST in a row means the filesystem is reporting
           // contradictory state (lstat says ENOENT, symlink says EEXIST).
           // Bail out rather than recurse indefinitely on the boot path.
@@ -465,7 +463,7 @@ function ensureSymlink(args: EnsureSymlinkArgs): EnsureSymlinkOutcome {
             reason: "EEXIST after retry — filesystem state is inconsistent",
           };
         }
-        return ensureSymlink({ ...args, _retried: true });
+        return ensureSymlinkInner(args, true);
       }
       return {
         kind: "conflict",

--- a/apps/web/src/lib/cli-skills.ts
+++ b/apps/web/src/lib/cli-skills.ts
@@ -290,8 +290,11 @@ export async function installSkills(opts: InstallSkillsOptions = {}): Promise<In
       if (!existsSync(sourcePath)) {
         // Generator didn't emit this skill. Could happen if the templates
         // diverge from BAND_SKILL_NAMES — log and move on rather than
-        // crashing the whole boot path.
+        // crashing the whole boot path. Track the shared destination as
+        // `skipped` so the boot-time `setup.ts` log counter reflects
+        // the gap instead of silently dropping to zero.
         opts.log?.warn("Generated skill missing from staging dir: %s (skipping)", sourcePath);
+        result.skipped.push(destPath);
         continue;
       }
 

--- a/apps/web/src/lib/cli-skills.ts
+++ b/apps/web/src/lib/cli-skills.ts
@@ -206,8 +206,12 @@ export interface InstallSkillsResult {
    */
   conflicts: string[];
   /**
-   * Per-agent skill paths that were skipped because no band binary
-   * could be located (so no shared skills exist to link to).
+   * Shared-directory SKILL.md paths that were skipped because no band
+   * binary could be located on this host (so the install can't run at
+   * all). Always one entry per skill in `BAND_SKILL_NAMES` (i.e. exactly
+   * 6 today) — *not* one entry per (agent × skill) pair, because the
+   * shared layout means there is one canonical path regardless of how
+   * many agents would have been linked.
    */
   skipped: string[];
 }

--- a/apps/web/src/lib/setup.ts
+++ b/apps/web/src/lib/setup.ts
@@ -147,29 +147,35 @@ async function ensureClaudeHooks(): Promise<void> {
 }
 
 /**
- * Sync the bundled CLI skills into each detected agent's global skills dir.
+ * Sync the bundled CLI skills into the shared `~/.agents/skills/` root and
+ * link each detected agent's skills directory back to it.
  *
- * `installSkills` is idempotent: it only writes when the destination is
- * missing or has different content. After an electron-updater install, the
- * app relaunches → bootstrap → web server boot → `runFirstTimeSetup`, so
- * this same step also handles the post-update refresh — no separate update
- * hook is needed. Failures are logged but don't block boot, matching the
- * rest of the setup pipeline.
+ * `installSkills` is idempotent: it only writes a shared SKILL.md when the
+ * destination is missing or has different content, and only creates a
+ * per-agent symlink when one isn't already in place. After an
+ * electron-updater install, the app relaunches → bootstrap → web server
+ * boot → `runFirstTimeSetup`, so this same step also handles the
+ * post-update refresh — no separate update hook is needed. Failures are
+ * logged but don't block boot, matching the rest of the setup pipeline.
  */
 async function ensureSkillsInstalled(): Promise<void> {
   try {
-    // installSkills reads `settings.codingAgents` itself and filters to
-    // agents whose binary is actually reachable, so we don't repeat that
-    // logic here. Keeping the trampoline so the boot pipeline stays
-    // uniform with the other `ensureXxx` steps.
+    // `installSkills` detects supported agents by checking each agent's
+    // parent config dir on the filesystem — no settings lookup needed
+    // here. Keeping the trampoline so the boot pipeline stays uniform
+    // with the other `ensureXxx` steps.
     const result = await installSkills({ log });
     const wrote = result.written.length + result.updated.length;
-    if (wrote > 0) {
+    const linkChange = result.linked.length;
+    if (wrote > 0 || linkChange > 0 || result.conflicts.length > 0) {
       log.info(
-        "Synced CLI skills (%d written, %d updated, %d unchanged, %d skipped)",
+        "Synced CLI skills (shared: %d written, %d updated, %d unchanged; symlinks: %d created, %d already-linked, %d conflicts, %d skipped)",
         result.written.length,
         result.updated.length,
         result.unchanged.length,
+        result.linked.length,
+        result.alreadyLinked.length,
+        result.conflicts.length,
         result.skipped.length,
       );
     }

--- a/apps/web/tests/cli-skills.test.ts
+++ b/apps/web/tests/cli-skills.test.ts
@@ -2,24 +2,31 @@
  * Integration tests for the CLI skills sync that runs as part of
  * `runFirstTimeSetup` (apps/web/src/lib/setup.ts → ensureSkillsInstalled).
  *
- * Black-box: drives the public `runFirstTimeSetup` entry point with a
- * sandboxed $HOME / $BAND_HOME, then asserts on the filesystem state of
- * `~/.claude/skills/<name>/SKILL.md`. No mocks — the test relies on a real
- * `band` binary being reachable through `findBandBinary` (the symlink at
- * /usr/local/bin/band, the desktop sidecar, or a cargo build output). When
- * no binary can be located the suite is skipped rather than failing, so CI
- * nodes without a built CLI don't go red.
+ * Black-box: drives the public `runFirstTimeSetup` / `installSkills`
+ * entry points with a sandboxed $HOME / $BAND_HOME, then asserts on the
+ * filesystem state of:
+ *
+ *   - the canonical `~/.agents/skills/<name>/SKILL.md` files
+ *   - the per-agent symlinks at `<agent>/skills/<name> → ../../.agents/...`
+ *
+ * No mocks — the test relies on a real `band` binary being reachable through
+ * `findBandBinary` (the symlink at /usr/local/bin/band, the desktop sidecar,
+ * or a cargo build output). When no binary can be located the suite is
+ * skipped rather than failing, so CI nodes without a built CLI don't go red.
  */
 
 import { execFileSync } from "node:child_process";
 import {
   existsSync,
+  lstatSync,
   mkdirSync,
   mkdtempSync,
   readFileSync,
+  readlinkSync,
   realpathSync,
   rmSync,
   statSync,
+  symlinkSync,
   writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
@@ -67,12 +74,11 @@ beforeAll(async () => {
       if (!existsSync(path)) {
         // The resolved binary is reachable but doesn't emit one of the
         // expected SKILL.md files — almost always means a stale build is
-        // sitting on the host (e.g. CI restored a cached `apps/cli/target/`
-        // from before #361 split the monolithic skill into four). Treat
-        // this exactly like "no binary found" so the suite skips cleanly
-        // instead of the whole test file failing in the module-level
-        // beforeAll. The next CI run that rebuilds the CLI will populate
-        // expectedSkills correctly and exercise the assertions.
+        // sitting on the host. Treat this exactly like "no binary found"
+        // so the suite skips cleanly instead of the whole test file
+        // failing in the module-level beforeAll. The next CI run that
+        // rebuilds the CLI will populate expectedSkills correctly and
+        // exercise the assertions.
         bandBinary = null;
         return;
       }
@@ -129,20 +135,21 @@ describe.skipIf(!bandBinaryReachable())("CLI skills sync (ensureSkillsInstalled)
     const bandDir = join(home, ".band");
     mkdirSync(bandDir, { recursive: true });
 
-    // Pre-seed settings.json with `claude-code` already in `codingAgents`
-    // so `ensureDefaultCodingAgents` doesn't try to detect via `whichBinary`
-    // (which would depend on the host) and so `ensureSkillsInstalled` has a
-    // target agent to write to. We pin `command: /bin/sh` so the new
-    // "binary actually reachable" check passes regardless of whether the
-    // real `claude` CLI is installed on the test host (CI may not have it).
+    // Pre-create the Claude Code config dir so detection in
+    // `resolveSkillTargets` sees it as installed. We don't need a real
+    // `claude` binary on PATH — the new detection strategy is
+    // filesystem-based.
+    mkdirSync(join(home, ".claude"), { recursive: true });
+
+    // Pre-seed an empty settings.json so `loadSettings` doesn't blow up
+    // when called downstream (e.g. by other ensureXxx steps in
+    // runFirstTimeSetup). The shared/symlink layout doesn't actually
+    // read codingAgents anymore.
     writeFileSync(
       join(bandDir, "settings.json"),
       JSON.stringify(
         {
-          codingAgents: [
-            { id: "claude-code", type: "claude-code", label: "Claude Code", command: "/bin/sh" },
-          ],
-          defaultCodingAgent: "claude-code",
+          codingAgents: [],
           // Pre-set notifications so ensureNotificationDefaults is a no-op.
           notifications: { soundOnNeedsAttention: true },
         },
@@ -167,15 +174,17 @@ describe.skipIf(!bandBinaryReachable())("CLI skills sync (ensureSkillsInstalled)
     if (tmp) rmSync(tmp, { recursive: true, force: true });
   });
 
-  it("writes every CLI skill into ~/.claude/skills/<name>/SKILL.md on first run", async () => {
+  it("writes every CLI skill into the shared ~/.agents/skills/<name>/SKILL.md", async () => {
     expect(bandBinary, "band binary must be resolvable for this suite").not.toBeNull();
     const { runFirstTimeSetup } = await import("../src/lib/setup");
     await runFirstTimeSetup();
 
-    const skillsDir = join(process.env.HOME!, ".claude", "skills");
+    const sharedDir = join(process.env.HOME!, ".agents", "skills");
     for (const name of SKILL_NAMES) {
-      const path = join(skillsDir, name, "SKILL.md");
+      const path = join(sharedDir, name, "SKILL.md");
       expect(existsSync(path), `expected ${path} to exist`).toBe(true);
+      // Shared content is a real file, not a symlink.
+      expect(lstatSync(path).isFile(), `${path} is a real file`).toBe(true);
 
       const actual = readFileSync(path);
       const expected = expectedSkills!.get(name)!;
@@ -185,36 +194,71 @@ describe.skipIf(!bandBinaryReachable())("CLI skills sync (ensureSkillsInstalled)
     }
   });
 
+  it("creates a directory symlink at ~/.claude/skills/<name> → ~/.agents/skills/<name>", async () => {
+    const { runFirstTimeSetup } = await import("../src/lib/setup");
+    await runFirstTimeSetup();
+
+    const home = process.env.HOME!;
+    const sharedDir = join(home, ".agents", "skills");
+    const claudeDir = join(home, ".claude", "skills");
+
+    for (const name of SKILL_NAMES) {
+      const link = join(claudeDir, name);
+      expect(existsSync(link), `expected symlink at ${link}`).toBe(true);
+      const lstat = lstatSync(link);
+      expect(lstat.isSymbolicLink(), `${link} is a symlink`).toBe(true);
+      // After realpath the link should resolve to the shared dir for this skill.
+      expect(realpathSync(link)).toBe(realpathSync(join(sharedDir, name)));
+      // And reading the symlink target should yield a path that resolves to
+      // the shared dir (we don't pin to a specific relative/absolute shape
+      // because either is valid).
+      const target = readlinkSync(link);
+      expect(target.length).toBeGreaterThan(0);
+      // SKILL.md is reachable through the link (proves the symlink works).
+      expect(existsSync(join(link, "SKILL.md"))).toBe(true);
+    }
+  });
+
   it("is a no-op on the second invocation when nothing has changed", async () => {
     const { runFirstTimeSetup } = await import("../src/lib/setup");
     await runFirstTimeSetup();
 
-    const skillsDir = join(process.env.HOME!, ".claude", "skills");
-    const path = join(skillsDir, "band", "SKILL.md");
-    const beforeStat = statSync(path);
+    const sharedDir = join(process.env.HOME!, ".agents", "skills");
+    const sharedFile = join(sharedDir, "band", "SKILL.md");
+    const beforeStat = statSync(sharedFile);
     const beforeMtime = beforeStat.mtimeMs;
-    const beforeContent = readFileSync(path);
+    const beforeContent = readFileSync(sharedFile);
+
+    const link = join(process.env.HOME!, ".claude", "skills", "band");
+    const beforeLinkMtime = lstatSync(link).mtimeMs;
 
     // Avoid an mtime collision on filesystems with second-level resolution.
     await new Promise((r) => setTimeout(r, 1100));
 
     await runFirstTimeSetup();
 
-    const afterStat = statSync(path);
-    expect(readFileSync(path).equals(beforeContent), "content is unchanged").toBe(true);
+    const afterStat = statSync(sharedFile);
+    expect(readFileSync(sharedFile).equals(beforeContent), "shared content is unchanged").toBe(
+      true,
+    );
     expect(
       afterStat.mtimeMs,
-      "mtime is preserved when content hasn't changed (skipped, not rewritten)",
+      "shared mtime is preserved when content hasn't changed (skipped, not rewritten)",
     ).toBe(beforeMtime);
+    expect(lstatSync(link).mtimeMs, "symlink is not re-created on the second pass").toBe(
+      beforeLinkMtime,
+    );
   });
 
-  it("overwrites a destination whose content drifted from the shipped version", async () => {
+  it("overwrites a shared destination whose content drifted from the shipped version", async () => {
     const { runFirstTimeSetup } = await import("../src/lib/setup");
 
-    // Pre-create a tampered SKILL.md before the first sync.
-    const skillsDir = join(process.env.HOME!, ".claude", "skills");
-    const target = join(skillsDir, "band", "SKILL.md");
-    mkdirSync(join(skillsDir, "band"), { recursive: true });
+    // Pre-create a tampered SKILL.md in the *shared* location before the
+    // first sync. The agent-level symlink isn't there yet on this test
+    // run, so we test the shared-write overwrite path in isolation.
+    const sharedDir = join(process.env.HOME!, ".agents", "skills");
+    const target = join(sharedDir, "band", "SKILL.md");
+    mkdirSync(join(sharedDir, "band"), { recursive: true });
     writeFileSync(target, "# stale local copy that should be overwritten\n", "utf-8");
 
     await runFirstTimeSetup();
@@ -222,40 +266,33 @@ describe.skipIf(!bandBinaryReachable())("CLI skills sync (ensureSkillsInstalled)
     const expected = expectedSkills!.get("band")!;
     expect(
       readFileSync(target).equals(expected),
-      "tampered file replaced with shipped version",
+      "tampered shared file replaced with shipped version",
     ).toBe(true);
   });
 
   it("does not write outside the sandboxed HOME", async () => {
-    // Structural guard: if HOME ever stopped pointing at the test tmpdir we
-    // could pollute the developer's real ~/.claude/skills. We can't safely
-    // inspect the user's HOME from inside the test, so we instead pin the
-    // override and verify the destination lands under it.
     const { runFirstTimeSetup } = await import("../src/lib/setup");
     await runFirstTimeSetup();
 
     expect(process.env.HOME!.startsWith(tmp), "HOME points inside the test tmpdir").toBe(true);
-    const path = join(process.env.HOME!, ".claude", "skills", "band", "SKILL.md");
-    expect(existsSync(path)).toBe(true);
+    expect(existsSync(join(process.env.HOME!, ".agents", "skills", "band", "SKILL.md"))).toBe(true);
+    expect(existsSync(join(process.env.HOME!, ".claude", "skills", "band"))).toBe(true);
   });
 
-  it("installs into every enabled agent's global skills dir (claude, codex, opencode, gemini)", async () => {
-    // Re-seed settings with all four agent types enabled. We pin
-    // `command: /bin/sh` so the install-check passes on CI nodes that
-    // don't have the real agent binaries installed. The agent's *type*
-    // is what drives skill-dir resolution, not the binary.
-    const { installSkills } = await import("../src/lib/cli-skills");
-    const result = await installSkills({
-      home: process.env.HOME!,
-      agents: [
-        { type: "claude-code", command: "/bin/sh" },
-        { type: "codex", command: "/bin/sh" },
-        { type: "opencode", command: "/bin/sh" },
-        { type: "gemini-cli", command: "/bin/sh" },
-      ],
-    });
-
+  it("links into every supported agent that has a config dir on the host", async () => {
+    // Pre-create config dirs for all four supported agents so the
+    // filesystem-based detection sees each one as installed. The agent's
+    // *type* is what drives skill-dir resolution; no real binaries needed.
     const home = process.env.HOME!;
+    mkdirSync(join(home, ".claude"), { recursive: true });
+    mkdirSync(join(home, ".codex"), { recursive: true });
+    mkdirSync(join(home, ".gemini"), { recursive: true });
+    mkdirSync(join(home, ".config", "opencode"), { recursive: true });
+
+    const { installSkills } = await import("../src/lib/cli-skills");
+    const result = await installSkills({ home });
+
+    const sharedDir = join(home, ".agents", "skills");
     const expectedDirs = [
       join(home, ".claude", "skills"),
       join(home, ".codex", "skills"),
@@ -264,150 +301,154 @@ describe.skipIf(!bandBinaryReachable())("CLI skills sync (ensureSkillsInstalled)
     ];
     for (const dir of expectedDirs) {
       for (const name of SKILL_NAMES) {
-        const path = join(dir, name, "SKILL.md");
-        expect(existsSync(path), `expected ${path} to exist`).toBe(true);
-        expect(readFileSync(path).equals(expectedSkills!.get(name)!)).toBe(true);
+        const link = join(dir, name);
+        expect(lstatSync(link).isSymbolicLink(), `expected symlink at ${link}`).toBe(true);
+        expect(realpathSync(link)).toBe(realpathSync(join(sharedDir, name)));
       }
     }
 
-    // 4 agents × N skills freshly written files (each test gets a new
-    // tmp HOME via beforeEach, so nothing should already exist).
-    expect(result.written.length).toBe(4 * SKILL_NAMES.length);
-    expect(result.unchanged.length).toBe(0);
-  });
-
-  it("dedupes destinations when multiple agents resolve to the same dir", async () => {
-    const { installSkills } = await import("../src/lib/cli-skills");
-    const result = await installSkills({
-      home: process.env.HOME!,
-      // Two claude-code agents (e.g. user has personal + work setups) both
-      // point at ~/.claude/skills — we should only write once per skill, not
-      // twice.
-      agents: [
-        { type: "claude-code", command: "/bin/sh" },
-        { type: "claude-code", command: "/bin/sh" },
-      ],
-    });
-
+    // Shared skills are written once each.
     expect(result.written.length).toBe(SKILL_NAMES.length);
+    // 4 agents × N skills freshly created symlinks.
+    expect(result.linked.length).toBe(4 * SKILL_NAMES.length);
+    expect(result.alreadyLinked.length).toBe(0);
   });
 
-  it("honours $CODEX_HOME when set so codex skills follow the override", async () => {
+  it("does not create symlinks for agents whose config dir is missing", async () => {
+    // Only ~/.claude exists (created by beforeEach). Codex / OpenCode /
+    // Gemini config dirs don't, so those agents should be skipped.
+    const home = process.env.HOME!;
+    const { installSkills } = await import("../src/lib/cli-skills");
+    const result = await installSkills({ home });
+
+    expect(existsSync(join(home, ".claude", "skills", "band"))).toBe(true);
+    expect(existsSync(join(home, ".codex"))).toBe(false);
+    expect(existsSync(join(home, ".gemini"))).toBe(false);
+    expect(existsSync(join(home, ".config", "opencode"))).toBe(false);
+
+    // Only claude symlinks were created (1 agent × N skills).
+    expect(result.linked.length).toBe(SKILL_NAMES.length);
+  });
+
+  it("dedupes targets when codex and openai-codex share $CODEX_HOME/skills", async () => {
+    // Both codex and openai-codex resolve to the same `~/.codex/skills`
+    // dir. Detection should only link once per skill, not twice.
+    mkdirSync(join(process.env.HOME!, ".codex"), { recursive: true });
+    const { installSkills } = await import("../src/lib/cli-skills");
+    const result = await installSkills({ home: process.env.HOME! });
+
+    // Skills are in: ~/.claude/skills (from beforeEach) + ~/.codex/skills.
+    // 2 agents × N skills = 2N symlinks (not 3N — dedupe drops the
+    // openai-codex duplicate).
+    expect(result.linked.length).toBe(2 * SKILL_NAMES.length);
+  });
+
+  it("honours $CODEX_HOME when set so codex symlinks follow the override", async () => {
     const customCodexHome = join(tmp, "custom-codex");
+    mkdirSync(customCodexHome, { recursive: true });
     const originalCodexHome = process.env.CODEX_HOME;
     process.env.CODEX_HOME = customCodexHome;
     try {
       const { installSkills } = await import("../src/lib/cli-skills");
-      await installSkills({
-        home: process.env.HOME!,
-        agents: [{ type: "codex", command: "/bin/sh" }],
-      });
+      await installSkills({ home: process.env.HOME! });
 
       for (const name of SKILL_NAMES) {
-        const path = join(customCodexHome, "skills", name, "SKILL.md");
-        expect(existsSync(path), `expected ${path} to exist under $CODEX_HOME`).toBe(true);
+        const link = join(customCodexHome, "skills", name);
+        expect(lstatSync(link).isSymbolicLink(), `expected symlink under $CODEX_HOME`).toBe(true);
       }
-      // And nothing should have landed under the default ~/.codex/skills/.
-      expect(existsSync(join(process.env.HOME!, ".codex", "skills", "band", "SKILL.md"))).toBe(
-        false,
-      );
+      // And nothing should have landed under the default ~/.codex/skills/
+      // (we didn't create ~/.codex either, so detection skips it).
+      expect(existsSync(join(process.env.HOME!, ".codex", "skills"))).toBe(false);
     } finally {
       if (originalCodexHome !== undefined) process.env.CODEX_HOME = originalCodexHome;
       else delete process.env.CODEX_HOME;
     }
   });
 
-  it("skips agents whose configured command no longer exists on disk", async () => {
-    // Simulates a stale entry in settings.codingAgents: the user uninstalled
-    // their Codex CLI, but its definition (with a now-broken `command` path)
-    // is still in settings.json. We must not touch ~/.codex/skills/.
+  it("leaves a correct existing symlink untouched (idempotent on re-run)", async () => {
     const { installSkills } = await import("../src/lib/cli-skills");
-    const result = await installSkills({
-      home: process.env.HOME!,
-      agents: [
-        { type: "claude-code", command: "/bin/sh" },
-        { type: "codex", command: "/this/path/does/not/exist/codex" },
-      ],
-    });
+    await installSkills({ home: process.env.HOME! });
 
-    expect(existsSync(join(process.env.HOME!, ".claude", "skills", "band", "SKILL.md"))).toBe(true);
-    expect(existsSync(join(process.env.HOME!, ".codex", "skills", "band", "SKILL.md"))).toBe(false);
-    expect(result.written.length).toBe(SKILL_NAMES.length); // only claude-code wrote
+    const link = join(process.env.HOME!, ".claude", "skills", "band");
+    const beforeTarget = readlinkSync(link);
+
+    const second = await installSkills({ home: process.env.HOME! });
+    expect(readlinkSync(link)).toBe(beforeTarget);
+    // Every symlink is reported as already-linked, none re-created.
+    expect(second.linked.length).toBe(0);
+    expect(second.alreadyLinked.length).toBe(SKILL_NAMES.length);
   });
 
-  it("skips agents with no command override when the default binary isn't on PATH", async () => {
-    // Empty PATH guarantees `whichBinary` can't find anything, mirroring a
-    // host where the user genuinely doesn't have the agent installed.
-    const originalPath = process.env.PATH;
-    process.env.PATH = "";
-    try {
-      const { installSkills } = await import("../src/lib/cli-skills");
-      const result = await installSkills({
-        home: process.env.HOME!,
-        // No `command` set — install-check must fall back to PATH lookup.
-        // With PATH empty, `whichBinary("gemini")` should return null and
-        // we should write zero skills.
-        agents: [{ type: "gemini-cli" }],
-      });
+  it("surfaces a conflict (and does not overwrite) when a wrong-target symlink already exists", async () => {
+    const home = process.env.HOME!;
+    const claudeSkills = join(home, ".claude", "skills");
+    mkdirSync(claudeSkills, { recursive: true });
 
-      expect(result.written).toEqual([]);
-      expect(result.updated).toEqual([]);
-      expect(existsSync(join(process.env.HOME!, ".gemini", "skills", "band", "SKILL.md"))).toBe(
-        false,
-      );
-    } finally {
-      if (originalPath !== undefined) process.env.PATH = originalPath;
-      else delete process.env.PATH;
-    }
+    // Plant a symlink pointing somewhere the user might have set up
+    // deliberately (e.g. a sibling project's checkout).
+    const decoy = join(tmp, "decoy-band-skill");
+    mkdirSync(decoy, { recursive: true });
+    const link = join(claudeSkills, "band");
+    symlinkSync(decoy, link, "dir");
+
+    const { installSkills } = await import("../src/lib/cli-skills");
+    const result = await installSkills({ home });
+
+    // Conflict reported, link untouched, shared dir still populated.
+    expect(result.conflicts.length).toBeGreaterThan(0);
+    expect(result.conflicts.some((c) => c.startsWith(link))).toBe(true);
+    expect(realpathSync(link)).toBe(realpathSync(decoy));
+    expect(existsSync(join(home, ".agents", "skills", "band", "SKILL.md"))).toBe(true);
   });
 
-  it("reads settings.codingAgents itself when no agents arg is passed", async () => {
-    // The default settings.json seeded by beforeEach has a single
-    // claude-code agent with `command: /bin/sh`. Calling installSkills
-    // with no `agents` override should still write the four skills into
-    // ~/.claude/skills/ — proving the lib reads settings on its own.
+  it("surfaces a conflict when a real directory occupies the target path", async () => {
+    const home = process.env.HOME!;
+    const claudeSkills = join(home, ".claude", "skills");
+    mkdirSync(claudeSkills, { recursive: true });
+
+    // Plant a real directory at the link path with user content inside.
+    const realDir = join(claudeSkills, "band");
+    mkdirSync(realDir, { recursive: true });
+    const userFile = join(realDir, "SKILL.md");
+    writeFileSync(userFile, "# user-authored band skill\n", "utf-8");
+
+    const { installSkills } = await import("../src/lib/cli-skills");
+    const result = await installSkills({ home });
+
+    expect(result.conflicts.some((c) => c.startsWith(realDir))).toBe(true);
+    // User content preserved.
+    expect(readFileSync(userFile, "utf-8")).toMatch(/user-authored/);
+    // The directory was NOT replaced by a symlink.
+    expect(lstatSync(realDir).isSymbolicLink()).toBe(false);
+  });
+
+  it("writes shared skills but creates no symlinks when no supported agents are detected", async () => {
+    // Wipe the only config dir beforeEach created so nothing is detected.
+    rmSync(join(process.env.HOME!, ".claude"), { recursive: true, force: true });
+
     const { installSkills } = await import("../src/lib/cli-skills");
     const result = await installSkills({ home: process.env.HOME! });
 
-    const skillsDir = join(process.env.HOME!, ".claude", "skills");
+    // Shared files are still written (they're useful on their own).
     for (const name of SKILL_NAMES) {
-      expect(existsSync(join(skillsDir, name, "SKILL.md")), `${name} written`).toBe(true);
+      expect(existsSync(join(process.env.HOME!, ".agents", "skills", name, "SKILL.md"))).toBe(true);
     }
     expect(result.written.length).toBe(SKILL_NAMES.length);
+    expect(result.linked.length).toBe(0);
+    expect(result.alreadyLinked.length).toBe(0);
+    expect(result.conflicts.length).toBe(0);
   });
 
-  it("writes nothing when settings.codingAgents is empty (no enabled agents)", async () => {
-    // Overwrite settings.json with an empty codingAgents array, then
-    // call installSkills with no override. The lib should treat
-    // "no enabled agents" as "no work" — even though a band binary IS
-    // reachable.
-    const bandDir = process.env.BAND_HOME!;
-    writeFileSync(
-      join(bandDir, "settings.json"),
-      JSON.stringify({ codingAgents: [] }, null, 2),
-      "utf-8",
-    );
-
+  it("skips cursor-cli even though it is a known agent (no documented skills dir)", async () => {
+    // Pre-create a `.cursor` config dir to simulate Cursor being
+    // installed. Because cursor-cli isn't in `SUPPORTED_AGENT_TYPES`,
+    // detection should still skip it.
+    mkdirSync(join(process.env.HOME!, ".cursor"), { recursive: true });
     const { installSkills } = await import("../src/lib/cli-skills");
     const result = await installSkills({ home: process.env.HOME! });
 
-    expect(result.written).toEqual([]);
-    expect(result.updated).toEqual([]);
-    expect(existsSync(join(process.env.HOME!, ".claude", "skills", "band", "SKILL.md"))).toBe(
-      false,
-    );
-  });
-
-  it("returns no targets for agent types without a known skills dir (cursor-cli)", async () => {
-    const { installSkills } = await import("../src/lib/cli-skills");
-    const result = await installSkills({
-      home: process.env.HOME!,
-      agents: [{ type: "cursor-cli", command: "/bin/sh" }],
-    });
-
-    expect(result.written).toEqual([]);
-    expect(result.updated).toEqual([]);
-    expect(result.unchanged).toEqual([]);
-    expect(result.skipped).toEqual([]);
+    expect(existsSync(join(process.env.HOME!, ".cursor", "skills"))).toBe(false);
+    // claude alone gets linked (its config dir exists from beforeEach).
+    expect(result.linked.length).toBe(SKILL_NAMES.length);
   });
 });

--- a/apps/web/tests/cli-skills.test.ts
+++ b/apps/web/tests/cli-skills.test.ts
@@ -401,6 +401,44 @@ describe.skipIf(!bandBinaryReachable())("CLI skills sync (ensureSkillsInstalled)
     expect(existsSync(join(home, ".agents", "skills", "band", "SKILL.md"))).toBe(true);
   });
 
+  it("surfaces a conflict when a dangling symlink exists at the link path", async () => {
+    // The link exists but its target was removed (e.g. ~/.agents/skills/
+    // pruned by hand, $HOME moved). The shared-write phase will recreate
+    // the target dir before linking, but if a user planted a dangling
+    // symlink earlier the existing-symlink branch must classify it as a
+    // conflict (broken target) rather than crash on canonicalize.
+    const home = process.env.HOME!;
+    const claudeSkills = join(home, ".claude", "skills");
+    mkdirSync(claudeSkills, { recursive: true });
+    const link = join(claudeSkills, "band");
+    const bogusTarget = join(home, "never-existed", "agents-skills-band");
+    symlinkSync(bogusTarget, link, "dir");
+
+    // Sanity: the shared dir hasn't been written yet, so the link target
+    // does NOT exist on disk before installSkills runs.
+    expect(existsSync(bogusTarget)).toBe(false);
+
+    // Force the shared dir to be different from the bogus target before
+    // running install — by deleting any pre-existing shared dir we would
+    // simulate "shared dir was pruned between runs". (No-op on first run,
+    // but explicit makes the intent clear.)
+    rmSync(join(home, ".agents", "skills", "band"), { recursive: true, force: true });
+
+    const { installSkills } = await import("../src/lib/cli-skills");
+    const result = await installSkills({ home });
+
+    // realpathSync on a dangling symlink fails, which the implementation
+    // surfaces as "existing symlink is broken" (rather than the
+    // wrong-target message used when both endpoints resolve).
+    expect(
+      result.conflicts.some((c) => c.startsWith(link) && c.includes("existing symlink is broken")),
+      `expected broken-symlink conflict for ${link} in ${result.conflicts.join("\n")}`,
+    ).toBe(true);
+    // The dangling symlink is left in place — no overwrite.
+    expect(lstatSync(link).isSymbolicLink()).toBe(true);
+    expect(readlinkSync(link)).toBe(bogusTarget);
+  });
+
   it("surfaces a conflict when a real directory occupies the target path", async () => {
     const home = process.env.HOME!;
     const claudeSkills = join(home, ".claude", "skills");

--- a/apps/web/tests/cli-skills.test.ts
+++ b/apps/web/tests/cli-skills.test.ts
@@ -350,7 +350,7 @@ describe.skipIf(!bandBinaryReachable())("CLI skills sync (ensureSkillsInstalled)
     process.env.CODEX_HOME = customCodexHome;
     try {
       const { installSkills } = await import("../src/lib/cli-skills");
-      await installSkills({ home: process.env.HOME! });
+      const result = await installSkills({ home: process.env.HOME! });
 
       for (const name of SKILL_NAMES) {
         const link = join(customCodexHome, "skills", name);
@@ -359,6 +359,15 @@ describe.skipIf(!bandBinaryReachable())("CLI skills sync (ensureSkillsInstalled)
       // And nothing should have landed under the default ~/.codex/skills/
       // (we didn't create ~/.codex either, so detection skips it).
       expect(existsSync(join(process.env.HOME!, ".codex", "skills"))).toBe(false);
+
+      // Lock in that claude-code (from beforeEach) AND codex (via the
+      // env override) both got linked — without this count, a future
+      // regression that silently skips claude-code while this test
+      // narrowly checks the codex path would pass.
+      expect(
+        result.linked.length,
+        "claude-code (from beforeEach) + codex (via $CODEX_HOME) = 2 × SKILL_NAMES symlinks",
+      ).toBe(SKILL_NAMES.length * 2);
     } finally {
       if (originalCodexHome !== undefined) process.env.CODEX_HOME = originalCodexHome;
       else delete process.env.CODEX_HOME;

--- a/packages/coding-agent/src/adapters/codex.ts
+++ b/packages/coding-agent/src/adapters/codex.ts
@@ -515,7 +515,11 @@ export const CODEX_DEFAULT_BINARY = "codex";
  * value. See https://developers.openai.com/codex/skills.
  */
 export function getCodexInstallSkillsDir(home: string = homedir()): string {
-  const codexHome = process.env.CODEX_HOME ?? join(home, ".codex");
+  // `||` (not `??`) so empty-string `$CODEX_HOME=` falls back to
+  // `~/.codex` instead of returning `"/skills"`. Module-level
+  // `CODEX_HOME` at the bottom of this file already uses the same
+  // guard; keep both consistent.
+  const codexHome = process.env.CODEX_HOME || join(home, ".codex");
   return join(codexHome, "skills");
 }
 

--- a/packages/coding-agent/src/adapters/openai-codex.ts
+++ b/packages/coding-agent/src/adapters/openai-codex.ts
@@ -211,7 +211,11 @@ export const OPENAI_CODEX_DEFAULT_BINARY = "codex";
  * See https://developers.openai.com/codex/skills.
  */
 export function getOpenAICodexInstallSkillsDir(home: string = homedir()): string {
-  const codexHome = process.env.CODEX_HOME ?? join(home, ".codex");
+  // `||` (not `??`) so empty-string `$CODEX_HOME=` falls back to
+  // `~/.codex` instead of returning `"/skills"`. Matches the module-level
+  // `CODEX_HOME` constant above (which uses `||`) and the Rust
+  // `codex_home()` helper.
+  const codexHome = process.env.CODEX_HOME || join(home, ".codex");
   return join(codexHome, "skills");
 }
 

--- a/packages/coding-agent/src/index.ts
+++ b/packages/coding-agent/src/index.ts
@@ -19,7 +19,14 @@ export type {
   ToolUseEvent,
 } from "./events.js";
 export { createCodingAgent } from "./factory.js";
-export { getDefaultAgentBinary, getInstallSkillsDir } from "./install-skills.js";
+export {
+  getAgentConfigDir,
+  getDefaultAgentBinary,
+  getInstallSkillsDir,
+  getSharedSkillsDir,
+  SUPPORTED_AGENT_TYPES,
+  type SupportedAgentType,
+} from "./install-skills.js";
 export type {
   AgentMode,
   AgentModel,

--- a/packages/coding-agent/src/install-skills.ts
+++ b/packages/coding-agent/src/install-skills.ts
@@ -141,6 +141,12 @@ export type SupportedAgentType = (typeof SUPPORTED_AGENT_TYPES)[number];
  *
  * Returns `null` for unknown types so callers can no-op rather than
  * crash if the supported-agents list ever drifts ahead of the switch.
+ *
+ * Note: for `codex`/`openai-codex`, `$CODEX_HOME` takes precedence over
+ * `home` when set — callers that need full isolation (e.g. test
+ * sandboxes) must also control the `CODEX_HOME` environment variable.
+ * The matching Rust helper (`apps/cli/src/skills.rs::codex_home`) has
+ * the same behaviour.
  */
 export function getAgentConfigDir(type: string, home: string = homedir()): string | null {
   switch (type) {

--- a/packages/coding-agent/src/install-skills.ts
+++ b/packages/coding-agent/src/install-skills.ts
@@ -1,4 +1,5 @@
 import { homedir } from "node:os";
+import { join } from "node:path";
 
 /**
  * Resolve the *highest-priority global* skills directory for a coding-agent
@@ -84,6 +85,76 @@ export async function getDefaultAgentBinary(type: string): Promise<string | null
       const { OPENCODE_DEFAULT_BINARY } = await import("./adapters/opencode.js");
       return OPENCODE_DEFAULT_BINARY;
     }
+    default:
+      return null;
+  }
+}
+
+/**
+ * The canonical, agent-agnostic location for Band's shipped skills. Each
+ * skill is installed *once* as `~/.agents/skills/<name>/SKILL.md`; the
+ * per-agent skill directories (e.g. `~/.claude/skills/<name>`) are then
+ * created as directory-level symlinks pointing back here.
+ *
+ * The shared layout means:
+ *
+ *   1. Skill content lives in one place — editing a SKILL.md updates every
+ *      agent that's been linked, without re-running the installer.
+ *   2. No `mkdir`-then-copy fan-out across N agent directories on every
+ *      boot. Idempotency simplifies to "is the symlink already correct?".
+ *   3. The destination follows the tool-agnostic convention already
+ *      documented by OpenCode and Gemini CLI as their lowest-priority
+ *      shared skills root (see the adapter doc-comments). Other agents
+ *      that adopt the convention later don't need adapter changes — only
+ *      a new entry in `SUPPORTED_AGENT_TYPES`.
+ */
+export function getSharedSkillsDir(home: string = homedir()): string {
+  return join(home, ".agents", "skills");
+}
+
+/**
+ * Agent types Band knows how to link into. Each entry must have an
+ * `install-skills-dir` documented by its adapter (`getInstallSkillsDir`
+ * returns a non-null path) — otherwise there's nowhere to put the
+ * symlink. `cursor-cli` is deliberately omitted because the Cursor CLI
+ * has no documented user-scope skills directory at the time of writing.
+ *
+ * Order is informational only: the linker iterates this list once and
+ * skips any agent that isn't detected on the host.
+ */
+export const SUPPORTED_AGENT_TYPES = [
+  "claude-code",
+  "codex",
+  "openai-codex",
+  "gemini-cli",
+  "opencode",
+] as const;
+
+export type SupportedAgentType = (typeof SUPPORTED_AGENT_TYPES)[number];
+
+/**
+ * Filesystem path of the *parent* config directory the agent owns —
+ * `~/.claude` for Claude Code, `~/.codex` for Codex, etc. Used by the
+ * linker to detect "is this agent installed on this machine?" without
+ * shelling out: if the directory exists, the agent has been configured
+ * here at some point and is a legitimate link target.
+ *
+ * Returns `null` for unknown types so callers can no-op rather than
+ * crash if the supported-agents list ever drifts ahead of the switch.
+ */
+export function getAgentConfigDir(type: string, home: string = homedir()): string | null {
+  switch (type) {
+    case "claude-code":
+      return join(home, ".claude");
+    case "codex":
+    case "openai-codex":
+      // Both adapters share `$CODEX_HOME` (default `~/.codex`). Honor
+      // the env override at call time so test overrides take effect.
+      return process.env.CODEX_HOME ?? join(home, ".codex");
+    case "gemini-cli":
+      return join(home, ".gemini");
+    case "opencode":
+      return join(home, ".config", "opencode");
     default:
       return null;
   }

--- a/packages/coding-agent/src/install-skills.ts
+++ b/packages/coding-agent/src/install-skills.ts
@@ -156,7 +156,11 @@ export function getAgentConfigDir(type: string, home: string = homedir()): strin
     case "openai-codex":
       // Both adapters share `$CODEX_HOME` (default `~/.codex`). Honor
       // the env override at call time so test overrides take effect.
-      return process.env.CODEX_HOME ?? join(home, ".codex");
+      // Use `||` instead of `??` so an empty-string `$CODEX_HOME=` is
+      // treated as unset rather than being returned as `""` (which would
+      // explode at the first `statSync`). Matches the Rust
+      // `codex_home()` helper's `!val.is_empty()` check.
+      return process.env.CODEX_HOME || join(home, ".codex");
     case "gemini-cli":
       return join(home, ".gemini");
     case "opencode":

--- a/packages/coding-agent/tests/install-skills.test.ts
+++ b/packages/coding-agent/tests/install-skills.test.ts
@@ -12,7 +12,13 @@
 import assert from "node:assert/strict";
 import { afterEach, describe, it } from "node:test";
 
-import { getDefaultAgentBinary, getInstallSkillsDir } from "../src/install-skills.ts";
+import {
+  getAgentConfigDir,
+  getDefaultAgentBinary,
+  getInstallSkillsDir,
+  getSharedSkillsDir,
+  SUPPORTED_AGENT_TYPES,
+} from "../src/install-skills.ts";
 
 const HOME = "/tmp/band-test-home";
 
@@ -102,5 +108,74 @@ describe("getDefaultAgentBinary", () => {
 
   it("returns null for an unknown agent type without throwing", async () => {
     assert.equal(await getDefaultAgentBinary("future-agent-9000"), null);
+  });
+});
+
+describe("getSharedSkillsDir", () => {
+  it("returns ~/.agents/skills under the provided home", () => {
+    assert.equal(getSharedSkillsDir(HOME), "/tmp/band-test-home/.agents/skills");
+  });
+});
+
+describe("getAgentConfigDir", () => {
+  let originalCodexHome: string | undefined;
+
+  afterEach(() => {
+    if (originalCodexHome !== undefined) process.env.CODEX_HOME = originalCodexHome;
+    else delete process.env.CODEX_HOME;
+    originalCodexHome = undefined;
+  });
+
+  it("resolves claude-code to ~/.claude", () => {
+    assert.equal(getAgentConfigDir("claude-code", HOME), "/tmp/band-test-home/.claude");
+  });
+
+  it("resolves codex to ~/.codex (default, no env override)", () => {
+    delete process.env.CODEX_HOME;
+    assert.equal(getAgentConfigDir("codex", HOME), "/tmp/band-test-home/.codex");
+  });
+
+  it("resolves openai-codex to ~/.codex (shares config dir with codex)", () => {
+    delete process.env.CODEX_HOME;
+    assert.equal(getAgentConfigDir("openai-codex", HOME), "/tmp/band-test-home/.codex");
+  });
+
+  it("honours $CODEX_HOME for codex/openai-codex", () => {
+    originalCodexHome = process.env.CODEX_HOME;
+    process.env.CODEX_HOME = "/custom/codex";
+    assert.equal(getAgentConfigDir("codex", HOME), "/custom/codex");
+    assert.equal(getAgentConfigDir("openai-codex", HOME), "/custom/codex");
+  });
+
+  it("resolves gemini-cli to ~/.gemini", () => {
+    assert.equal(getAgentConfigDir("gemini-cli", HOME), "/tmp/band-test-home/.gemini");
+  });
+
+  it("resolves opencode to ~/.config/opencode", () => {
+    assert.equal(getAgentConfigDir("opencode", HOME), "/tmp/band-test-home/.config/opencode");
+  });
+
+  it("returns null for cursor-cli (no documented config dir wired up)", () => {
+    assert.equal(getAgentConfigDir("cursor-cli", HOME), null);
+  });
+
+  it("returns null for an unknown type without throwing", () => {
+    assert.equal(getAgentConfigDir("future-agent-9000", HOME), null);
+  });
+});
+
+describe("SUPPORTED_AGENT_TYPES", () => {
+  it("only lists agent types that have a documented install-skills dir", async () => {
+    for (const type of SUPPORTED_AGENT_TYPES) {
+      const dir = await getInstallSkillsDir(type, HOME);
+      assert.ok(
+        dir,
+        `expected SUPPORTED_AGENT_TYPES entry '${type}' to have an install-skills dir`,
+      );
+    }
+  });
+
+  it("excludes cursor-cli (no skills dir today)", () => {
+    assert.ok(!SUPPORTED_AGENT_TYPES.includes("cursor-cli" as never));
   });
 });

--- a/packages/coding-agent/tests/install-skills.test.ts
+++ b/packages/coding-agent/tests/install-skills.test.ts
@@ -165,6 +165,29 @@ describe("getAgentConfigDir", () => {
 });
 
 describe("SUPPORTED_AGENT_TYPES", () => {
+  /**
+   * Drift guard: this list and the Rust `SUPPORTED_AGENTS` in
+   * `apps/cli/src/skills.rs` must stay identical. The web server's
+   * boot-time install and the CLI's `band skills install` both read
+   * their own copy; if a new agent is added to one side and not the
+   * other, the two install paths silently disagree.
+   *
+   * Mirrored on the Rust side by a matching `#[test]` in skills.rs.
+   * Touching one list without the other now fails *that side's* test
+   * suite, which CI gates on. Order matters: the value below is also
+   * the iteration order both dispatchers use for stable agent-detection
+   * priority.
+   */
+  it("matches the canonical list (mirrored in Rust SUPPORTED_AGENTS)", () => {
+    assert.deepEqual(
+      [...SUPPORTED_AGENT_TYPES],
+      ["claude-code", "codex", "openai-codex", "gemini-cli", "opencode"],
+      "TS SUPPORTED_AGENT_TYPES drifted from the canonical list; update both this " +
+        "tuple and apps/cli/src/skills.rs::SUPPORTED_AGENTS (plus the matching test on " +
+        "each side) when adding/removing an agent",
+    );
+  });
+
   it("only lists agent types that have a documented install-skills dir", async () => {
     for (const type of SUPPORTED_AGENT_TYPES) {
       const dir = await getInstallSkillsDir(type, HOME);


### PR DESCRIPTION
## Summary

- Install the CLI-shipped skills (`band`, `band-chat`, `band-terminal`, `band-browser`, `band-start`, `band-loop`) *once* to a canonical agent-agnostic location: `~/.agents/skills/<name>/SKILL.md`. Editing the shared SKILL.md is reflected in every linked agent — no re-install needed.
- For every supported coding agent detected on the host, create a directory-level symlink at `<agent-skills-dir>/<name>` → `~/.agents/skills/<name>`. Supported agents: `claude-code` (`~/.claude/skills/`), `codex` / `openai-codex` (`~/.codex/skills/`, deduped, `$CODEX_HOME` honored), `gemini-cli` (`~/.gemini/skills/`), `opencode` (`~/.config/opencode/skills/`). `cursor-cli` is excluded (no documented user-scope skills dir).
- Detection switched from "binary on PATH" to "config dir exists" — an agent installed via Nix profile / npm prefix override / etc. is still picked up as long as its home dir is present.
- Idempotent: an existing correct symlink is left alone; an existing symlink pointing elsewhere — or a real directory at the target path — is reported as a conflict and **not** overwritten.

## Layout

```
~/.agents/skills/<name>/SKILL.md          ← canonical content (one copy)
~/.claude/skills/<name>            → ../../.agents/skills/<name>     (symlink)
~/.codex/skills/<name>             → ../../.agents/skills/<name>     (symlink)
~/.gemini/skills/<name>            → ../../.agents/skills/<name>     (symlink)
~/.config/opencode/skills/<name>   → ../../../.agents/skills/<name>  (symlink)
```

## Key files

- `packages/coding-agent/src/install-skills.ts` — adds `getSharedSkillsDir`, `SUPPORTED_AGENT_TYPES`, `getAgentConfigDir`.
- `apps/web/src/lib/cli-skills.ts` — rewritten to write the shared `~/.agents/skills/` files, then ensure a per-agent symlink for each detected agent (with conflict detection).
- `apps/web/src/lib/setup.ts` — log line widened to surface symlink-stage counters too.
- `CLAUDE.md` — documents the new layout and the supported-agents table.

## Test plan

- [x] `pnpm --filter @band-app/coding-agent test` — 65/65 pass (covers `getSharedSkillsDir`, `getAgentConfigDir`, `SUPPORTED_AGENT_TYPES`).
- [x] `pnpm --filter @band-app/server test` — 535/535 pass (incl. `tests/cli-skills.test.ts` exercising shared writes, symlink creation, idempotency, drift overwrite, dedupe, `$CODEX_HOME` override, missing-config-dir skip, wrong-target conflict, real-dir conflict, cursor-cli excluded).
- [x] `cargo test --manifest-path apps/cli/Cargo.toml` — 75/75 pass.
- [x] `pnpm lint` and `pnpm format` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)