### PR TITLE
feat(terminal): iOS toolbar + long-press word select + arrow extend

### DIFF
--- a/apps/web/src/components/TerminalPanel.tsx
+++ b/apps/web/src/components/TerminalPanel.tsx
@@ -9,6 +9,7 @@ import type { ISearchOptions, SearchAddon } from "@xterm/addon-search";
 import type { WebglAddon } from "@xterm/addon-webgl";
 import type { ITheme, Terminal } from "@xterm/xterm";
 import { useCallback, useEffect, useRef, useState } from "react";
+import { useVirtualKeyboardToolbar } from "../hooks/useVirtualKeyboardToolbar";
 import { openExternalUrl } from "../lib/open-external-url";
 import {
   type ArrowDirection,
@@ -773,6 +774,14 @@ export function TerminalPanel({
     addon.findNext(searchQuery, toXtermSearchOptions(searchOptions));
   }, [searchQuery, searchOptions]);
 
+  // Reserve space at the bottom of the terminal container equal to the
+  // floating toolbar's height. Without this, the toolbar (which uses
+  // `position: fixed`) renders on top of the bottom rows of the terminal
+  // and hides the prompt while typing. The hook returns 0 on desktop so
+  // the layout is unchanged there. The ResizeObserver in the mount effect
+  // notices the size change and reflows xterm via `fitAddon.fit()`.
+  const { contentBottomInset } = useVirtualKeyboardToolbar();
+
   return (
     <div className="relative flex h-full w-full flex-col">
       {searchOpen && (
@@ -790,7 +799,14 @@ export function TerminalPanel({
         />
       )}
       <div className="relative min-h-0 flex-1">
-        <div ref={containerRef} className="absolute inset-2 overflow-hidden" />
+        <div
+          ref={containerRef}
+          className="absolute inset-x-2 top-2 overflow-hidden"
+          // `bottom = base gap + toolbar reservation`. Inline style instead of
+          // a Tailwind class so the reservation can be 0 on desktop without an
+          // extra conditional class.
+          style={{ bottom: 8 + contentBottomInset }}
+        />
       </div>
       {/* iOS / touch keyboard accessory toolbar. Renders nothing on desktop
           (gated by `useVirtualKeyboardToolbar`). Sits in `position: fixed`

--- a/apps/web/src/components/TerminalPanel.tsx
+++ b/apps/web/src/components/TerminalPanel.tsx
@@ -10,6 +10,7 @@ import type { WebglAddon } from "@xterm/addon-webgl";
 import type { ITheme, Terminal } from "@xterm/xterm";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { openExternalUrl } from "../lib/open-external-url";
+import { TerminalToolbar } from "./TerminalToolbar";
 
 /** xterm.js search addon decoration colors. The addon requires decorations to be
  *  set in order for `onDidChangeResults` to fire (which drives the "N of M"
@@ -144,6 +145,25 @@ export function TerminalPanel({
   const searchBarRef = useRef<SearchBarHandle>(null);
   // Stable ref for the xterm key-event closure (which is captured once at mount).
   const openSearchRef = useRef<() => void>(() => {});
+
+  // ---- iOS keyboard accessory toolbar state ----
+  // `terminalReady` flips once the dynamic-imported xterm.js instance is
+  // attached and addons are loaded. We can't render TerminalToolbar before
+  // then because it dereferences `terminalRef.current` directly (e.g. for
+  // `hasSelection()`). Promoting the ref to state is overkill — a single
+  // boolean is enough to trigger the re-render that paints the toolbar.
+  const [terminalReady, setTerminalReady] = useState(false);
+  // Sticky Ctrl modifier wired up to the toolbar. Ref mirrors state because
+  // the xterm `attachCustomKeyEventHandler` closure is captured once at mount
+  // and cannot read React state directly. `setPendingCtrl` from useState is a
+  // stable identity, so reading it from inside the captured closure is safe.
+  const pendingCtrlRef = useRef(false);
+  const [pendingCtrl, setPendingCtrl] = useState(false);
+  const handleToggleCtrl = useCallback(() => {
+    const next = !pendingCtrlRef.current;
+    pendingCtrlRef.current = next;
+    setPendingCtrl(next);
+  }, []);
 
   useEffect(() => {
     if (!containerRef.current) return;
@@ -290,6 +310,37 @@ export function TerminalPanel({
       // - Alt+Arrow   → word navigation (ESC+b / ESC+f)
       terminal.attachCustomKeyEventHandler((e) => {
         if (e.type === "keydown") {
+          // Pending Ctrl (set by the iOS toolbar's sticky Ctrl button): the
+          // user already tapped "Ctrl" once; transform the next single
+          // printable key into a Ctrl+key control character. Letters a..z map
+          // to 0x01..0x1A, the same byte the desktop renderer would emit for
+          // Ctrl+A..Ctrl+Z. Anything outside that range silently clears the
+          // pending flag (consistent with how a real Ctrl modifier behaves on
+          // a hardware keyboard — Ctrl+5 just sends `5`).
+          if (
+            pendingCtrlRef.current &&
+            e.key.length === 1 &&
+            !e.metaKey &&
+            !e.altKey &&
+            !e.ctrlKey
+          ) {
+            const lower = e.key.toLowerCase();
+            const code = lower.charCodeAt(0);
+            if (code >= 97 && code <= 122) {
+              terminal.input(String.fromCharCode(code - 96));
+              pendingCtrlRef.current = false;
+              // Schedule the state update so React renders the un-armed
+              // button — we're inside a non-React event handler.
+              setPendingCtrl(false);
+              e.preventDefault();
+              return false;
+            }
+            // Non-letter printable: just clear the pending modifier and let
+            // the key go through unmodified. This matches "armed-and-dismiss"
+            // behavior in Termius / Blink.
+            pendingCtrlRef.current = false;
+            setPendingCtrl(false);
+          }
           // Cmd+F (macOS) / Ctrl+F (Linux/Windows) → open the find bar.
           // Call preventDefault so the browser doesn't open native find-in-page
           // alongside our overlay (no-op in Electron, important in the web app).
@@ -320,6 +371,10 @@ export function TerminalPanel({
       terminalRef.current = terminal;
       fitAddonRef.current = fitAddon;
       searchAddonRef.current = searchAddon;
+      // Trigger a re-render so the iOS keyboard accessory toolbar (which
+      // dereferences `terminalRef.current`) can mount. We deliberately wait
+      // until *after* the addons are loaded so `hasSelection()` etc. behave.
+      setTerminalReady(true);
 
       // Mobile touch scrolling. xterm renders `.xterm-screen` (canvas/dom) on top
       // of the scrollable `.xterm-viewport`, so touches on the visible terminal
@@ -511,6 +566,7 @@ export function TerminalPanel({
         searchAddonRef.current = null;
         webglAddonRef.current = null;
         wsRef.current = null;
+        setTerminalReady(false);
       };
     });
 
@@ -611,6 +667,21 @@ export function TerminalPanel({
       <div className="relative min-h-0 flex-1">
         <div ref={containerRef} className="absolute inset-2 overflow-hidden" />
       </div>
+      {/* iOS / touch keyboard accessory toolbar. Renders nothing on desktop
+          (gated by `useVirtualKeyboardToolbar`). Sits in `position: fixed`
+          relative to the visual viewport so it floats just above the soft
+          keyboard when open and pins to the screen bottom otherwise. */}
+      {terminalReady && terminalRef.current && (
+        <TerminalToolbar
+          terminal={terminalRef.current}
+          sendInput={(data) => {
+            const ws = wsRef.current;
+            if (ws?.readyState === WebSocket.OPEN) ws.send(data);
+          }}
+          pendingCtrl={pendingCtrl}
+          onToggleCtrl={handleToggleCtrl}
+        />
+      )}
     </div>
   );
 }

--- a/apps/web/src/components/TerminalPanel.tsx
+++ b/apps/web/src/components/TerminalPanel.tsx
@@ -10,7 +10,22 @@ import type { WebglAddon } from "@xterm/addon-webgl";
 import type { ITheme, Terminal } from "@xterm/xterm";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { openExternalUrl } from "../lib/open-external-url";
+import {
+  type ArrowDirection,
+  applySelection,
+  type Cell,
+  getLineText,
+  moveCell,
+  pointToCell,
+  wordSelectionAt,
+} from "../lib/terminal-selection";
 import { TerminalToolbar } from "./TerminalToolbar";
+
+/** How long a finger must rest on the terminal to trigger word-selection. */
+const LONG_PRESS_MS = 500;
+/** Maximum movement (px) tolerated during the long-press timer before we
+ *  treat the gesture as a scroll instead of a long-press. */
+const LONG_PRESS_SLOP_PX = 10;
 
 /** xterm.js search addon decoration colors. The addon requires decorations to be
  *  set in order for `onDidChangeResults` to fire (which drives the "N of M"
@@ -163,6 +178,34 @@ export function TerminalPanel({
     const next = !pendingCtrlRef.current;
     pendingCtrlRef.current = next;
     setPendingCtrl(next);
+  }, []);
+
+  // Long-press → word-select → arrow-extend state.
+  // `selectionAnchor` is the cell that stays fixed; `selectionHead` is the
+  // moving cell the arrow buttons push around. Both are absolute buffer
+  // coordinates (row includes scrollback offset). null = idle mode.
+  // The refs mirror state for the same reason as pendingCtrl: the touch
+  // handlers installed inside the mount effect capture once. The "enter"
+  // path is inlined into the long-press timer callback in the mount effect
+  // — it has more local context (the live terminal + screen element) than
+  // a top-level callback could see without ref-routing every dependency.
+  const selectionAnchorRef = useRef<Cell | null>(null);
+  const selectionHeadRef = useRef<Cell | null>(null);
+  const [selectionMode, setSelectionMode] = useState(false);
+  const exitSelectionMode = useCallback(() => {
+    selectionAnchorRef.current = null;
+    selectionHeadRef.current = null;
+    setSelectionMode(false);
+    terminalRef.current?.clearSelection();
+  }, []);
+  const handleExtendSelection = useCallback((direction: ArrowDirection) => {
+    const terminal = terminalRef.current;
+    const anchor = selectionAnchorRef.current;
+    const head = selectionHeadRef.current;
+    if (!terminal || !anchor || !head) return;
+    const next = moveCell(head, direction, terminal);
+    selectionHeadRef.current = next;
+    applySelection(terminal, anchor, next);
   }, []);
 
   useEffect(() => {
@@ -412,6 +455,72 @@ export function TerminalPanel({
       containerEl.addEventListener("touchend", onTouchEnd, { passive: true });
       containerEl.addEventListener("touchcancel", onTouchEnd, { passive: true });
 
+      // Long-press → word-select. Sets a timer on touchstart; cancels on any
+      // significant movement (so a scroll drag wins) or early lift. When it
+      // fires we resolve the touch point into a buffer cell, read the line
+      // text, expand to word boundaries, and tell the toolbar to switch into
+      // selection mode. From that point the toolbar's arrows extend the
+      // highlighted range.
+      //
+      // Implementation note: we read the .xterm-screen element fresh each
+      // time. xterm.js destroys and rebuilds it on certain renderer switches,
+      // so caching it at mount could leave us pointing at a detached node.
+      let longPressTimer: number | null = null;
+      let longPressStart: { x: number; y: number } | null = null;
+      const cancelLongPress = () => {
+        if (longPressTimer !== null) {
+          window.clearTimeout(longPressTimer);
+          longPressTimer = null;
+        }
+        longPressStart = null;
+      };
+      const onLongPressStart = (e: TouchEvent) => {
+        cancelLongPress();
+        if (e.touches.length !== 1) return;
+        const t = e.touches[0];
+        longPressStart = { x: t.clientX, y: t.clientY };
+        longPressTimer = window.setTimeout(() => {
+          longPressTimer = null;
+          const start = longPressStart;
+          if (!start) return;
+          const screenEl = containerEl.querySelector(".xterm-screen") as HTMLElement | null;
+          if (!screenEl) return;
+          const cell = pointToCell(start.x, start.y, terminal, screenEl);
+          const lineText = getLineText(terminal, cell.row);
+          const { anchor, head } = wordSelectionAt(cell, lineText);
+          applySelection(terminal, anchor, head);
+          selectionAnchorRef.current = anchor;
+          selectionHeadRef.current = head;
+          setSelectionMode(true);
+          // Suppress the tap-to-focus that would otherwise fire when the
+          // finger lifts (we don't want the iOS keyboard to pop open right
+          // after the user just made a selection).
+          tapStartX = null;
+          tapStartY = null;
+          // Light haptic — feels native, no-op where unsupported (desktop,
+          // most non-iOS browsers). Wrapped in typeof check because the
+          // Vibration API isn't in lib.dom.d.ts on all TS versions.
+          if (typeof navigator.vibrate === "function") {
+            try {
+              navigator.vibrate(15);
+            } catch {
+              // Some browsers throw if vibration is policy-blocked; ignore.
+            }
+          }
+        }, LONG_PRESS_MS);
+      };
+      const onLongPressMove = (e: TouchEvent) => {
+        if (!longPressStart || e.touches.length !== 1) return;
+        const t = e.touches[0];
+        const dx = Math.abs(t.clientX - longPressStart.x);
+        const dy = Math.abs(t.clientY - longPressStart.y);
+        if (dx > LONG_PRESS_SLOP_PX || dy > LONG_PRESS_SLOP_PX) cancelLongPress();
+      };
+      containerEl.addEventListener("touchstart", onLongPressStart, { passive: true });
+      containerEl.addEventListener("touchmove", onLongPressMove, { passive: true });
+      containerEl.addEventListener("touchend", cancelLongPress, { passive: true });
+      containerEl.addEventListener("touchcancel", cancelLongPress, { passive: true });
+
       // Mobile focus-on-tap. Disabling `pointer-events` on the WebGL canvas
       // (see `attachWebGL` above) lets touches reach `.xterm-screen`, but
       // xterm.js's built-in click→focus path doesn't reliably re-engage the
@@ -448,6 +557,17 @@ export function TerminalPanel({
         const dx = Math.abs(e.changedTouches[0].clientX - startX);
         const dy = Math.abs(e.changedTouches[0].clientY - startY);
         if (dx < 10 && dy < 10) {
+          // Tap during selection mode: exit selection. iOS users expect a
+          // tap outside the selection to dismiss the edit menu; ours behaves
+          // the same. The toolbar's own buttons sit in a fixed-position
+          // overlay outside containerEl so their taps don't reach this
+          // handler.
+          if (selectionAnchorRef.current !== null) {
+            selectionAnchorRef.current = null;
+            selectionHeadRef.current = null;
+            setSelectionMode(false);
+            terminal.clearSelection();
+          }
           terminal.focus();
         }
       };
@@ -550,10 +670,15 @@ export function TerminalPanel({
         resizeObserver.disconnect();
         searchResultsDisposable.dispose();
         webglContextLossDisposable?.dispose();
+        cancelLongPress();
         containerEl.removeEventListener("touchstart", onTouchStart);
         containerEl.removeEventListener("touchmove", onTouchMove);
         containerEl.removeEventListener("touchend", onTouchEnd);
         containerEl.removeEventListener("touchcancel", onTouchEnd);
+        containerEl.removeEventListener("touchstart", onLongPressStart);
+        containerEl.removeEventListener("touchmove", onLongPressMove);
+        containerEl.removeEventListener("touchend", cancelLongPress);
+        containerEl.removeEventListener("touchcancel", cancelLongPress);
         containerEl.removeEventListener("touchstart", onTapStart);
         containerEl.removeEventListener("touchend", onTapEnd);
         containerEl.removeEventListener("touchcancel", onTapCancel);
@@ -680,6 +805,9 @@ export function TerminalPanel({
           }}
           pendingCtrl={pendingCtrl}
           onToggleCtrl={handleToggleCtrl}
+          selectionMode={selectionMode}
+          onExtendSelection={handleExtendSelection}
+          onExitSelection={exitSelectionMode}
         />
       )}
     </div>

--- a/apps/web/src/components/TerminalPanel.tsx
+++ b/apps/web/src/components/TerminalPanel.tsx
@@ -208,6 +208,24 @@ export function TerminalPanel({
     selectionHeadRef.current = next;
     applySelection(terminal, anchor, next);
   }, []);
+  // Select All from the idle toolbar: highlight every cell in the buffer
+  // AND enter selection mode, so the user immediately sees the Copy / Done
+  // controls. Without the mode flip, Select All would visually select but
+  // leave the user with no way to copy.
+  const handleSelectAll = useCallback(() => {
+    const terminal = terminalRef.current;
+    if (!terminal) return;
+    const anchor: Cell = { col: 0, row: 0 };
+    const lastRow = Math.max(0, terminal.buffer.active.length - 1);
+    const head: Cell = { col: Math.max(0, terminal.cols - 1), row: lastRow };
+    applySelection(terminal, anchor, head);
+    selectionAnchorRef.current = anchor;
+    selectionHeadRef.current = head;
+    setSelectionMode(true);
+    // Same rationale as the long-press path: drop the iOS keyboard so the
+    // toolbar isn't squeezed against the bottom.
+    terminal.blur();
+  }, []);
 
   useEffect(() => {
     if (!containerRef.current) return;
@@ -832,6 +850,7 @@ export function TerminalPanel({
           selectionMode={selectionMode}
           onExtendSelection={handleExtendSelection}
           onExitSelection={exitSelectionMode}
+          onSelectAll={handleSelectAll}
         />
       )}
     </div>

--- a/apps/web/src/components/TerminalPanel.tsx
+++ b/apps/web/src/components/TerminalPanel.tsx
@@ -498,6 +498,14 @@ export function TerminalPanel({
           // after the user just made a selection).
           tapStartX = null;
           tapStartY = null;
+          // Dismiss the iOS soft keyboard. The user is about to navigate
+          // with the toolbar arrows, not type — the keyboard is just stealing
+          // screen space and squeezing the toolbar against the terminal
+          // bottom. `terminal.blur()` blurs xterm's hidden textarea, which
+          // iOS treats as the signal to slide the keyboard down. We re-open
+          // it later if the user taps inside the terminal (existing
+          // tap-to-focus path) or otherwise re-engages typing.
+          terminal.blur();
           // Light haptic — feels native, no-op where unsupported (desktop,
           // most non-iOS browsers). Wrapped in typeof check because the
           // Vibration API isn't in lib.dom.d.ts on all TS versions.

--- a/apps/web/src/components/TerminalPanel.tsx
+++ b/apps/web/src/components/TerminalPanel.tsx
@@ -713,15 +713,39 @@ export function TerminalPanel({
       // re-measures cell dimensions at the new DPR; same recovery path as
       // `onContextLoss`.
       let lastDpr = window.devicePixelRatio;
-      // Shared DPR-change handler. Disposes the WebGL addon and re-attaches
-      // so its canvas is re-sized at the new device-pixel ratio and the
-      // cell dimensions are re-measured. No-op if already in sync, or if
-      // there's no WebGL addon mounted (DOM renderer auto-handles DPR via
-      // CSS).
+      // Shared DPR-change handler. The WebGL canvas's backing store was
+      // sized for the old DPR; without intervention, the browser stretches
+      // it to fit the new CSS dimensions and the terminal text balloons
+      // by a factor of (newDPR/oldDPR). Two things have to happen:
+      //
+      // 1) xterm's CharSizeService must re-measure. Its cache feeds the
+      //    WebGL addon's `_updateDimensions`. Toggling `fontSize` is the
+      //    public-API way to force a re-measure — the options proxy fires
+      //    `onSpecificOptionChange("fontSize")` when the new value differs,
+      //    and CharSizeService is subscribed to that. Perturb-by-one then
+      //    restore so the integer delta fires the event without leaving
+      //    the terminal at the wrong size.
+      //
+      // 2) The WebGL addon's `_devicePixelRatio` cache must update. It's
+      //    set once at activation and only refreshed via the private
+      //    `handleDevicePixelRatioChange()`. The reliable public-API path
+      //    is to dispose the addon and re-attach — the new instance reads
+      //    the live `coreBrowserService.dpr` (a live getter for
+      //    `window.devicePixelRatio`). We do this AFTER the font toggle so
+      //    the new addon picks up the freshly measured CharSizeService
+      //    values.
+      //
+      // No-op when no addon is mounted (DOM renderer — CSS sizing handles
+      // DPR natively).
       const handleDprChange = () => {
         const currentDpr = window.devicePixelRatio;
         if (currentDpr === lastDpr) return;
         lastDpr = currentDpr;
+        const fs = terminal.options.fontSize;
+        if (typeof fs === "number") {
+          terminal.options.fontSize = fs + 1;
+          terminal.options.fontSize = fs;
+        }
         const addon = webglAddonRef.current;
         if (addon) {
           addon.dispose();

--- a/apps/web/src/components/TerminalPanel.tsx
+++ b/apps/web/src/components/TerminalPanel.tsx
@@ -819,6 +819,14 @@ export function TerminalPanel({
         searchAddonRef.current = null;
         webglAddonRef.current = null;
         wsRef.current = null;
+        // Reset toolbar state so a remount (e.g. terminal reconnect) doesn't
+        // come back up with selection mode armed against a buffer row that
+        // no longer exists, or with Ctrl still pending.
+        selectionAnchorRef.current = null;
+        selectionHeadRef.current = null;
+        pendingCtrlRef.current = false;
+        setSelectionMode(false);
+        setPendingCtrl(false);
         setTerminalReady(false);
       };
     });

--- a/apps/web/src/components/TerminalPanel.tsx
+++ b/apps/web/src/components/TerminalPanel.tsx
@@ -692,10 +692,38 @@ export function TerminalPanel({
         if (anchor && head) applySelection(terminal, anchor, head);
       });
 
-      // Auto-fit on container resize (skip zero-size to avoid killing server PTY)
+      // Auto-fit on container resize (skip zero-size to avoid killing server PTY).
+      // Also handles devicePixelRatio changes (Chrome DevTools mobile-emulation
+      // toggle, dragging the window between a retina and non-retina monitor,
+      // OS zoom changes). On DPR change the WebGL canvas's backing store is
+      // mismatched with its CSS display size — the text balloons to fill the
+      // stretched canvas. Re-attaching the addon resizes the backing store and
+      // re-measures cell dimensions at the new DPR; same recovery path as
+      // `onContextLoss`.
+      let lastDpr = window.devicePixelRatio;
+      // Shared DPR-change handler. Disposes the WebGL addon and re-attaches
+      // so its canvas is re-sized at the new device-pixel ratio and the
+      // cell dimensions are re-measured. No-op if already in sync, or if
+      // there's no WebGL addon mounted (DOM renderer auto-handles DPR via
+      // CSS).
+      const handleDprChange = () => {
+        const currentDpr = window.devicePixelRatio;
+        if (currentDpr === lastDpr) return;
+        lastDpr = currentDpr;
+        const addon = webglAddonRef.current;
+        if (addon) {
+          addon.dispose();
+          webglAddonRef.current = null;
+          attachWebGL();
+        }
+        fitAddon.fit();
+      };
       const resizeObserver = new ResizeObserver((entries) => {
         const entry = entries[0];
         if (!entry || entry.contentRect.width === 0 || entry.contentRect.height === 0) return;
+        // Check DPR before fit so the re-attached addon picks up the right
+        // cell dimensions.
+        handleDprChange();
         fitAddon.fit();
         if (ws.readyState === WebSocket.OPEN && terminal.cols > 0 && terminal.rows > 0) {
           ws.send(
@@ -709,12 +737,30 @@ export function TerminalPanel({
       });
       resizeObserver.observe(containerRef.current!);
 
+      // Belt-and-suspenders: also listen for DPR changes that don't cause a
+      // container size change (rare — e.g. an external display unplug, or
+      // dragging the window between two same-size monitors with different
+      // DPR). `matchMedia('(resolution: Xdppx)')` only fires for the
+      // specific transition out of X, so we re-bind after each change.
+      let dprMql: MediaQueryList | undefined;
+      const bindDprListener = () => {
+        dprMql = window.matchMedia(`(resolution: ${window.devicePixelRatio}dppx)`);
+        dprMql.addEventListener("change", onDprMediaChange);
+      };
+      const onDprMediaChange = () => {
+        handleDprChange();
+        dprMql?.removeEventListener("change", onDprMediaChange);
+        bindDprListener();
+      };
+      bindDprListener();
+
       cleanup = () => {
         themeObserver.disconnect();
         resizeObserver.disconnect();
         searchResultsDisposable.dispose();
         selectionResizeDisposable.dispose();
         webglContextLossDisposable?.dispose();
+        dprMql?.removeEventListener("change", onDprMediaChange);
         cancelLongPress();
         containerEl.removeEventListener("touchstart", onTouchStart);
         containerEl.removeEventListener("touchmove", onTouchMove);

--- a/apps/web/src/components/TerminalPanel.tsx
+++ b/apps/web/src/components/TerminalPanel.tsx
@@ -675,6 +675,23 @@ export function TerminalPanel({
         onTitleChangeRef.current?.(title);
       });
 
+      // Re-apply the active selection after every xterm resize. xterm.js's
+      // selection layer doesn't always re-paint after `fit()` reflows the
+      // viewport — the internal SelectionModel still holds the range (so
+      // `hasSelection()` and `getSelection()` keep returning the right
+      // values, and Copy still works correctly) but the visual highlight
+      // disappears. This bites the long-press path on iOS specifically:
+      // entering selection mode blurs the terminal → keyboard dismisses →
+      // visual viewport grows → ResizeObserver fits xterm → selection goes
+      // invisible. Re-running `terminal.select(...)` from our retained
+      // anchor/head triggers a fresh render. No-op when not in selection
+      // mode (refs are null).
+      const selectionResizeDisposable = terminal.onResize(() => {
+        const anchor = selectionAnchorRef.current;
+        const head = selectionHeadRef.current;
+        if (anchor && head) applySelection(terminal, anchor, head);
+      });
+
       // Auto-fit on container resize (skip zero-size to avoid killing server PTY)
       const resizeObserver = new ResizeObserver((entries) => {
         const entry = entries[0];
@@ -696,6 +713,7 @@ export function TerminalPanel({
         themeObserver.disconnect();
         resizeObserver.disconnect();
         searchResultsDisposable.dispose();
+        selectionResizeDisposable.dispose();
         webglContextLossDisposable?.dispose();
         cancelLongPress();
         containerEl.removeEventListener("touchstart", onTouchStart);

--- a/apps/web/src/components/TerminalPanel.tsx
+++ b/apps/web/src/components/TerminalPanel.tsx
@@ -675,22 +675,34 @@ export function TerminalPanel({
         onTitleChangeRef.current?.(title);
       });
 
-      // Re-apply the active selection after every xterm resize. xterm.js's
-      // selection layer doesn't always re-paint after `fit()` reflows the
-      // viewport — the internal SelectionModel still holds the range (so
-      // `hasSelection()` and `getSelection()` keep returning the right
-      // values, and Copy still works correctly) but the visual highlight
-      // disappears. This bites the long-press path on iOS specifically:
-      // entering selection mode blurs the terminal → keyboard dismisses →
-      // visual viewport grows → ResizeObserver fits xterm → selection goes
-      // invisible. Re-running `terminal.select(...)` from our retained
-      // anchor/head triggers a fresh render. No-op when not in selection
-      // mode (refs are null).
-      const selectionResizeDisposable = terminal.onResize(() => {
-        const anchor = selectionAnchorRef.current;
-        const head = selectionHeadRef.current;
-        if (anchor && head) applySelection(terminal, anchor, head);
-      });
+      // Re-apply the active selection after every xterm resize. xterm's
+      // SelectionService internally subscribes to `bufferService.onResize`
+      // and calls `clearSelection()` whenever `rowsChanged` — that wipes
+      // the SelectionModel entirely. Our `terminal.onResize` listener and
+      // the SelectionService's clear listener are both fired during the
+      // same synchronous resize pass, and the registration order isn't
+      // guaranteed: if the clear runs after us, our re-apply gets undone
+      // before the frame paints. (This is what made the iOS keyboard-
+      // dismiss path lose the highlight even after the earlier fix.)
+      //
+      // Defer the re-apply via requestAnimationFrame so it lands *after*
+      // every synchronous resize handler has run, but still before the
+      // browser paints the frame — exactly when xterm is about to render
+      // the new dimensions. Coalesce repeated resizes (iOS animates the
+      // keyboard slide, so multiple onResize events fire in quick
+      // succession) with a single pending-RAF flag.
+      let selectionRafId: number | null = null;
+      const reapplySelectionOnNextFrame = () => {
+        if (selectionRafId !== null) return;
+        if (!selectionAnchorRef.current || !selectionHeadRef.current) return;
+        selectionRafId = requestAnimationFrame(() => {
+          selectionRafId = null;
+          const anchor = selectionAnchorRef.current;
+          const head = selectionHeadRef.current;
+          if (anchor && head) applySelection(terminal, anchor, head);
+        });
+      };
+      const selectionResizeDisposable = terminal.onResize(reapplySelectionOnNextFrame);
 
       // Auto-fit on container resize (skip zero-size to avoid killing server PTY).
       // Also handles devicePixelRatio changes (Chrome DevTools mobile-emulation
@@ -759,6 +771,7 @@ export function TerminalPanel({
         resizeObserver.disconnect();
         searchResultsDisposable.dispose();
         selectionResizeDisposable.dispose();
+        if (selectionRafId !== null) cancelAnimationFrame(selectionRafId);
         webglContextLossDisposable?.dispose();
         dprMql?.removeEventListener("change", onDprMediaChange);
         cancelLongPress();

--- a/apps/web/src/components/TerminalToolbar.tsx
+++ b/apps/web/src/components/TerminalToolbar.tsx
@@ -11,6 +11,7 @@ import {
 } from "lucide-react";
 import { useCallback, useMemo } from "react";
 import { useVirtualKeyboardToolbar } from "../hooks/useVirtualKeyboardToolbar";
+import { readClipboardText, writeClipboardText } from "../lib/clipboard";
 import type { ArrowDirection } from "../lib/terminal-selection";
 
 /**
@@ -85,14 +86,11 @@ export function TerminalToolbar({
     if (!terminal.hasSelection()) return;
     const text = terminal.getSelection();
     if (!text) return;
-    try {
-      await navigator.clipboard.writeText(text);
-    } catch (err) {
-      // iOS may reject this if the page lost the user-gesture token between
-      // pointerdown and the clipboard promise resolving. Surface to console
-      // only — the alternative is a blocking modal that's much worse UX.
-      console.warn("[TerminalToolbar] clipboard write failed:", err);
-    }
+    // `writeClipboardText` falls back to `document.execCommand('copy')` in
+    // non-secure contexts (the common case for iOS on a dev server reached
+    // over the LAN — `navigator.clipboard` is `undefined` there).
+    const ok = await writeClipboardText(text);
+    if (!ok) console.warn("[TerminalToolbar] clipboard write failed");
   }, [terminal]);
 
   // Copy *and* exit selection mode in one tap. Used by the selection-mode
@@ -103,14 +101,13 @@ export function TerminalToolbar({
   }, [handleCopy, onExitSelection]);
 
   const handlePaste = useCallback(async () => {
-    try {
-      const text = await navigator.clipboard.readText();
-      if (text) sendInput(text);
-    } catch (err) {
-      // iOS 13.4+ prompts for clipboard permission the first time and the
-      // promise rejects on denial. Nothing to do — the user can retry.
-      console.warn("[TerminalToolbar] clipboard read failed:", err);
-    }
+    // `readClipboardText` returns "" if the API is unavailable (non-secure
+    // context) or if iOS denies the permission prompt. There's no legacy
+    // fallback for read — modern browsers blocked `execCommand('paste')`
+    // years ago. If you're hitting this on iOS over HTTP, switch to HTTPS
+    // (e.g. via the tunnel feature) for paste to work.
+    const text = await readClipboardText();
+    if (text) sendInput(text);
   }, [sendInput]);
 
   const handleSelectAll = useCallback(() => {

--- a/apps/web/src/components/TerminalToolbar.tsx
+++ b/apps/web/src/components/TerminalToolbar.tsx
@@ -1,0 +1,254 @@
+import type { Terminal } from "@xterm/xterm";
+import {
+  ArrowDown,
+  ArrowLeft,
+  ArrowRight,
+  ArrowUp,
+  ClipboardCopy,
+  ClipboardPaste,
+  TextCursorInput,
+} from "lucide-react";
+import { useCallback, useMemo } from "react";
+import { useVirtualKeyboardToolbar } from "../hooks/useVirtualKeyboardToolbar";
+
+/**
+ * Floating accessory toolbar rendered above the iOS virtual keyboard inside the
+ * terminal panel. Provides copy/paste/select-all (since iOS Safari's native
+ * long-press menu never reaches the xterm canvas) plus the keys the soft
+ * keyboard hides that terminal users need (Esc, Tab, Ctrl, arrows).
+ *
+ * Design notes:
+ * - We render only on touch-only devices via {@link useVirtualKeyboardToolbar}.
+ *   Desktops never paint this — there's no virtual keyboard to float above.
+ * - All actions are dispatched on `onPointerDown` rather than `onClick`. iOS
+ *   Safari treats a `pointerdown` as part of the user gesture chain that
+ *   enables `navigator.clipboard.readText()`; a separate `click` event fires
+ *   too late and after the gesture has expired in some installable-PWA
+ *   contexts. We also call `preventDefault()` so the tap never blurs the
+ *   terminal's hidden textarea — keeping the soft keyboard up between actions.
+ * - "Ctrl" is sticky: tapping it sets a pending flag that the next regular
+ *   keystroke from the iOS keyboard consumes (mapped to a control character by
+ *   the parent's xterm key handler). The button stays highlighted while
+ *   pending and clears itself once a key is sent. This matches Termius /
+ *   Blink behavior on iOS.
+ */
+export interface TerminalToolbarProps {
+  /** Live xterm.js instance. Required for copy / hasSelection / selectAll. */
+  terminal: Terminal;
+  /** Send raw bytes to the PTY (typically `ws.send(data)`). */
+  sendInput: (data: string) => void;
+  /** Whether Ctrl is armed; the next key tap should be a control char. */
+  pendingCtrl: boolean;
+  /** Toggle the pending-Ctrl state. */
+  onToggleCtrl: () => void;
+}
+
+// ANSI / CSI escape sequences for the keys the iOS soft keyboard omits.
+// These are the same sequences xterm.js itself generates internally for these
+// keys on a desktop browser — sending them as raw input mirrors that path.
+const SEQ_ESC = "\x1b";
+const SEQ_TAB = "\t";
+const SEQ_ARROW_UP = "\x1b[A";
+const SEQ_ARROW_DOWN = "\x1b[B";
+const SEQ_ARROW_RIGHT = "\x1b[C";
+const SEQ_ARROW_LEFT = "\x1b[D";
+
+export function TerminalToolbar({
+  terminal,
+  sendInput,
+  pendingCtrl,
+  onToggleCtrl,
+}: TerminalToolbarProps) {
+  const { enabled, bottomOffset } = useVirtualKeyboardToolbar();
+
+  const handleCopy = useCallback(async () => {
+    if (!terminal.hasSelection()) return;
+    const text = terminal.getSelection();
+    if (!text) return;
+    try {
+      await navigator.clipboard.writeText(text);
+    } catch (err) {
+      // iOS may reject this if the page lost the user-gesture token between
+      // pointerdown and the clipboard promise resolving. Surface to console
+      // only — the alternative is a blocking modal that's much worse UX.
+      console.warn("[TerminalToolbar] clipboard write failed:", err);
+    }
+  }, [terminal]);
+
+  const handlePaste = useCallback(async () => {
+    try {
+      const text = await navigator.clipboard.readText();
+      if (text) sendInput(text);
+    } catch (err) {
+      // iOS 13.4+ prompts for clipboard permission the first time and the
+      // promise rejects on denial. Nothing to do — the user can retry.
+      console.warn("[TerminalToolbar] clipboard read failed:", err);
+    }
+  }, [sendInput]);
+
+  const handleSelectAll = useCallback(() => {
+    terminal.selectAll();
+    // selectAll() does not move focus; re-focus so subsequent toolbar Copy
+    // works without an intermediate tap.
+    terminal.focus();
+  }, [terminal]);
+
+  // Build a list of static key buttons. Memoized so the inline object identity
+  // is stable across re-renders (helps if anyone wraps the toolbar in memo).
+  const keyButtons = useMemo(
+    () => [
+      { label: "Esc", seq: SEQ_ESC, ariaLabel: "Send Escape" },
+      { label: "Tab", seq: SEQ_TAB, ariaLabel: "Send Tab" },
+    ],
+    [],
+  );
+
+  const arrowButtons = useMemo(
+    () => [
+      { Icon: ArrowLeft, seq: SEQ_ARROW_LEFT, ariaLabel: "Arrow Left" },
+      { Icon: ArrowDown, seq: SEQ_ARROW_DOWN, ariaLabel: "Arrow Down" },
+      { Icon: ArrowUp, seq: SEQ_ARROW_UP, ariaLabel: "Arrow Up" },
+      { Icon: ArrowRight, seq: SEQ_ARROW_RIGHT, ariaLabel: "Arrow Right" },
+    ],
+    [],
+  );
+
+  if (!enabled) return null;
+
+  // Common pointerdown wrapper: prevent the default so the tap doesn't blur
+  // the xterm helper textarea (which would dismiss the iOS keyboard).
+  // Returns a handler that calls `fn` after preventing default.
+  const tap =
+    (fn: () => void | Promise<void>) =>
+    (e: React.PointerEvent<HTMLButtonElement>): void => {
+      e.preventDefault();
+      void fn();
+    };
+
+  return (
+    <div
+      data-testid="terminal-toolbar"
+      role="toolbar"
+      aria-label="Terminal accessory keys"
+      // `position: fixed` so the bar tracks the visual viewport regardless of
+      // where the terminal panel sits inside its dockview layout. `left: 0;
+      // right: 0` spans the full width; the inner flex row centers content.
+      style={{ bottom: bottomOffset }}
+      className="fixed inset-x-0 z-50 flex justify-center border-t border-border bg-background/95 shadow-lg backdrop-blur-md"
+    >
+      <div className="flex w-full max-w-3xl items-center gap-1 overflow-x-auto px-2 py-1.5">
+        {/* Selection / clipboard group */}
+        <ToolbarButton
+          ariaLabel="Copy selection"
+          title="Copy"
+          onPointerDown={tap(handleCopy)}
+          disabled={!terminal.hasSelection()}
+        >
+          <ClipboardCopy className="size-4" />
+          <span className="text-xs">Copy</span>
+        </ToolbarButton>
+        <ToolbarButton
+          ariaLabel="Paste from clipboard"
+          title="Paste"
+          onPointerDown={tap(handlePaste)}
+        >
+          <ClipboardPaste className="size-4" />
+          <span className="text-xs">Paste</span>
+        </ToolbarButton>
+        <ToolbarButton
+          ariaLabel="Select all"
+          title="Select all"
+          onPointerDown={tap(handleSelectAll)}
+        >
+          <TextCursorInput className="size-4" />
+          <span className="text-xs">All</span>
+        </ToolbarButton>
+
+        <div className="mx-1 h-6 w-px shrink-0 bg-border" aria-hidden="true" />
+
+        {/* Special keys */}
+        {keyButtons.map(({ label, seq, ariaLabel }) => (
+          <ToolbarButton
+            key={label}
+            ariaLabel={ariaLabel}
+            title={label}
+            onPointerDown={tap(() => sendInput(seq))}
+          >
+            <span className="text-xs font-medium">{label}</span>
+          </ToolbarButton>
+        ))}
+        <ToolbarButton
+          ariaLabel={pendingCtrl ? "Cancel pending Ctrl" : "Arm Ctrl modifier"}
+          title="Ctrl (sticky — taps the next key as Ctrl+key)"
+          onPointerDown={tap(onToggleCtrl)}
+          active={pendingCtrl}
+        >
+          <span className="text-xs font-medium">Ctrl</span>
+        </ToolbarButton>
+
+        <div className="mx-1 h-6 w-px shrink-0 bg-border" aria-hidden="true" />
+
+        {/* Arrow cluster */}
+        {arrowButtons.map(({ Icon, seq, ariaLabel }) => (
+          <ToolbarButton
+            key={ariaLabel}
+            ariaLabel={ariaLabel}
+            title={ariaLabel}
+            onPointerDown={tap(() => sendInput(seq))}
+          >
+            <Icon className="size-4" />
+          </ToolbarButton>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// ToolbarButton — minimal local component to keep the markup readable.
+// Not exported from the package's `<Button>` because we want pointerdown
+// semantics, larger touch targets, and the active-state styling for sticky
+// Ctrl; the shared component is built for click semantics.
+// ---------------------------------------------------------------------------
+
+interface ToolbarButtonProps {
+  ariaLabel: string;
+  title: string;
+  onPointerDown: (e: React.PointerEvent<HTMLButtonElement>) => void;
+  active?: boolean;
+  disabled?: boolean;
+  children: React.ReactNode;
+}
+
+function ToolbarButton({
+  ariaLabel,
+  title,
+  onPointerDown,
+  active,
+  disabled,
+  children,
+}: ToolbarButtonProps) {
+  return (
+    <button
+      type="button"
+      aria-label={ariaLabel}
+      aria-pressed={active ? true : undefined}
+      title={title}
+      onPointerDown={onPointerDown}
+      disabled={disabled}
+      // 44×N min-height matches iOS HIG touch target; gap-1 keeps the button
+      // pill compact so the whole row fits on a 320px-wide iPhone SE without
+      // wrapping (the parent uses `overflow-x-auto` as a final safety net).
+      className={[
+        "inline-flex h-9 min-w-9 shrink-0 items-center justify-center gap-1 rounded-md px-2",
+        "text-foreground transition-colors",
+        active
+          ? "bg-primary text-primary-foreground"
+          : "bg-muted/60 hover:bg-muted active:bg-muted",
+        "disabled:opacity-40",
+      ].join(" ")}
+    >
+      {children}
+    </button>
+  );
+}

--- a/apps/web/src/components/TerminalToolbar.tsx
+++ b/apps/web/src/components/TerminalToolbar.tsx
@@ -18,9 +18,12 @@ import type { ArrowDirection } from "../lib/terminal-selection";
  * Floating accessory toolbar rendered above the iOS virtual keyboard inside the
  * terminal panel. Has two layouts that swap based on `selectionMode`:
  *
- * - **Idle** (`selectionMode === false`): Copy · Paste · Select All · Esc ·
- *   Tab · Ctrl · ← → ↑ ↓ (arrows send ANSI escape sequences to the PTY,
- *   identical to a hardware arrow press).
+ * - **Idle** (`selectionMode === false`): Paste · Select All · Esc · Tab ·
+ *   Ctrl · ← → ↑ ↓ (arrows send ANSI escape sequences to the PTY,
+ *   identical to a hardware arrow press). No Copy in idle mode — there's
+ *   no way to make a selection from idle without entering selection mode
+ *   (long-press, or Select All which delegates to the parent's
+ *   `onSelectAll` callback to flip into selection mode immediately).
  *
  * - **Selecting** (`selectionMode === true`): Copy · Done · ← → ↑ ↓ (arrows
  *   extend the highlighted selection one cell at a time; the parent owns the
@@ -59,6 +62,10 @@ export interface TerminalToolbarProps {
   onExtendSelection: (direction: ArrowDirection) => void;
   /** Called when the user dismisses selection mode (Done, or Copy). */
   onExitSelection: () => void;
+  /** Called when the idle-mode "Select All" button is tapped. The parent
+   *  highlights every cell in the buffer and flips into selection mode, so
+   *  the user can immediately Copy via the selection-mode toolbar. */
+  onSelectAll: () => void;
 }
 
 // ANSI / CSI escape sequences for the keys the iOS soft keyboard omits.
@@ -79,6 +86,7 @@ export function TerminalToolbar({
   selectionMode,
   onExtendSelection,
   onExitSelection,
+  onSelectAll,
 }: TerminalToolbarProps) {
   const { enabled, bottomOffset } = useVirtualKeyboardToolbar();
 
@@ -93,8 +101,9 @@ export function TerminalToolbar({
     if (!ok) console.warn("[TerminalToolbar] clipboard write failed");
   }, [terminal]);
 
-  // Copy *and* exit selection mode in one tap. Used by the selection-mode
-  // Copy button; the idle Copy button just calls handleCopy.
+  // Copy *and* exit selection mode in one tap. The only Copy button lives
+  // in the selection-mode layout; idle mode has no Copy (there's no way to
+  // make a selection without first entering selection mode anyway).
   const handleCopyAndExit = useCallback(async () => {
     await handleCopy();
     onExitSelection();
@@ -109,13 +118,6 @@ export function TerminalToolbar({
     const text = await readClipboardText();
     if (text) sendInput(text);
   }, [sendInput]);
-
-  const handleSelectAll = useCallback(() => {
-    terminal.selectAll();
-    // selectAll() does not move focus; re-focus so subsequent toolbar Copy
-    // works without an intermediate tap.
-    terminal.focus();
-  }, [terminal]);
 
   // Memoized button lists so identities are stable across re-renders.
   const idleKeyButtons = useMemo(
@@ -214,15 +216,12 @@ export function TerminalToolbar({
           </>
         ) : (
           <>
-            <ToolbarButton
-              ariaLabel="Copy selection"
-              title="Copy"
-              onPointerDown={tap(handleCopy)}
-              disabled={!terminal.hasSelection()}
-            >
-              <ClipboardCopy className="size-4" />
-              <span className="text-xs">Copy</span>
-            </ToolbarButton>
+            {/* No idle-mode Copy: there's no way to make a selection without
+             *  entering selection mode (long-press or Select All), so an
+             *  idle Copy button is always either disabled or stale (the
+             *  toolbar doesn't re-render on xterm selection changes). Copy
+             *  lives in the selection-mode layout where it's reachable
+             *  immediately after creating a selection. */}
             <ToolbarButton
               ariaLabel="Paste from clipboard"
               title="Paste"
@@ -234,7 +233,10 @@ export function TerminalToolbar({
             <ToolbarButton
               ariaLabel="Select all"
               title="Select all"
-              onPointerDown={tap(handleSelectAll)}
+              // Delegates to the parent so the highlight is paired with a
+              // mode flip into selection-mode — otherwise the user would
+              // see a selection but have no UI to copy it.
+              onPointerDown={tap(onSelectAll)}
             >
               <TextCursorInput className="size-4" />
               <span className="text-xs">All</span>

--- a/apps/web/src/components/TerminalToolbar.tsx
+++ b/apps/web/src/components/TerminalToolbar.tsx
@@ -78,6 +78,17 @@ const SEQ_ARROW_DOWN = "\x1b[B";
 const SEQ_ARROW_RIGHT = "\x1b[C";
 const SEQ_ARROW_LEFT = "\x1b[D";
 
+// Common pointerdown wrapper: prevent the default so the tap doesn't blur
+// the xterm helper textarea (which would dismiss the iOS keyboard) and
+// returns a handler that invokes `fn`. Module-scoped so each render doesn't
+// rebuild a fresh closure for every button.
+const tap =
+  (fn: () => void | Promise<void>) =>
+  (e: React.PointerEvent<HTMLButtonElement>): void => {
+    e.preventDefault();
+    void fn();
+  };
+
 export function TerminalToolbar({
   terminal,
   sendInput,
@@ -128,12 +139,16 @@ export function TerminalToolbar({
     [],
   );
 
+  // Arrow order matches the PR description and the visual convention on
+  // physical iOS keyboards: horizontal pair first (← →), then vertical
+  // pair (↑ ↓). Earlier the order was ← ↓ ↑ → which contradicted the
+  // documented layout (PR #413 review).
   const idleArrows = useMemo(
     () => [
       { Icon: ArrowLeft, seq: SEQ_ARROW_LEFT, ariaLabel: "Arrow Left" },
-      { Icon: ArrowDown, seq: SEQ_ARROW_DOWN, ariaLabel: "Arrow Down" },
-      { Icon: ArrowUp, seq: SEQ_ARROW_UP, ariaLabel: "Arrow Up" },
       { Icon: ArrowRight, seq: SEQ_ARROW_RIGHT, ariaLabel: "Arrow Right" },
+      { Icon: ArrowUp, seq: SEQ_ARROW_UP, ariaLabel: "Arrow Up" },
+      { Icon: ArrowDown, seq: SEQ_ARROW_DOWN, ariaLabel: "Arrow Down" },
     ],
     [],
   );
@@ -142,24 +157,14 @@ export function TerminalToolbar({
     () =>
       [
         { Icon: ArrowLeft, dir: "left", ariaLabel: "Extend selection left" },
-        { Icon: ArrowDown, dir: "down", ariaLabel: "Extend selection down" },
-        { Icon: ArrowUp, dir: "up", ariaLabel: "Extend selection up" },
         { Icon: ArrowRight, dir: "right", ariaLabel: "Extend selection right" },
+        { Icon: ArrowUp, dir: "up", ariaLabel: "Extend selection up" },
+        { Icon: ArrowDown, dir: "down", ariaLabel: "Extend selection down" },
       ] as const,
     [],
   );
 
   if (!enabled) return null;
-
-  // Common pointerdown wrapper: prevent the default so the tap doesn't blur
-  // the xterm helper textarea (which would dismiss the iOS keyboard).
-  // Returns a handler that calls `fn` after preventing default.
-  const tap =
-    (fn: () => void | Promise<void>) =>
-    (e: React.PointerEvent<HTMLButtonElement>): void => {
-      e.preventDefault();
-      void fn();
-    };
 
   // Wrapper that visually distinguishes selection mode — a primary-tinted
   // strip across the top of the bar makes it immediately obvious that
@@ -320,7 +325,11 @@ function ToolbarButton({
     <button
       type="button"
       aria-label={ariaLabel}
-      aria-pressed={active ? true : undefined}
+      // Toggle buttons (sticky Ctrl) explicitly pass a boolean so screen
+      // readers announce the toggle state — `false` renders as
+      // `aria-pressed="false"` not absent, per WAI-ARIA. Plain buttons
+      // pass `active` undefined to omit the attribute entirely.
+      aria-pressed={active}
       title={title}
       onPointerDown={onPointerDown}
       disabled={disabled}

--- a/apps/web/src/components/TerminalToolbar.tsx
+++ b/apps/web/src/components/TerminalToolbar.tsx
@@ -7,29 +7,40 @@ import {
   ClipboardCopy,
   ClipboardPaste,
   TextCursorInput,
+  X,
 } from "lucide-react";
 import { useCallback, useMemo } from "react";
 import { useVirtualKeyboardToolbar } from "../hooks/useVirtualKeyboardToolbar";
+import type { ArrowDirection } from "../lib/terminal-selection";
 
 /**
  * Floating accessory toolbar rendered above the iOS virtual keyboard inside the
- * terminal panel. Provides copy/paste/select-all (since iOS Safari's native
- * long-press menu never reaches the xterm canvas) plus the keys the soft
- * keyboard hides that terminal users need (Esc, Tab, Ctrl, arrows).
+ * terminal panel. Has two layouts that swap based on `selectionMode`:
  *
- * Design notes:
+ * - **Idle** (`selectionMode === false`): Copy · Paste · Select All · Esc ·
+ *   Tab · Ctrl · ← → ↑ ↓ (arrows send ANSI escape sequences to the PTY,
+ *   identical to a hardware arrow press).
+ *
+ * - **Selecting** (`selectionMode === true`): Copy · Done · ← → ↑ ↓ (arrows
+ *   extend the highlighted selection one cell at a time; the parent owns the
+ *   anchor/head state and updates xterm via `terminal.select()`).
+ *
+ * Selection mode is entered by long-pressing inside the terminal — that flow
+ * lives in TerminalPanel.tsx, which calls back here through the `selectionMode`
+ * prop and the `onExtendSelection` / `onExitSelection` callbacks.
+ *
+ * Design notes that apply to both layouts:
  * - We render only on touch-only devices via {@link useVirtualKeyboardToolbar}.
  *   Desktops never paint this — there's no virtual keyboard to float above.
- * - All actions are dispatched on `onPointerDown` rather than `onClick`. iOS
- *   Safari treats a `pointerdown` as part of the user gesture chain that
- *   enables `navigator.clipboard.readText()`; a separate `click` event fires
- *   too late and after the gesture has expired in some installable-PWA
- *   contexts. We also call `preventDefault()` so the tap never blurs the
- *   terminal's hidden textarea — keeping the soft keyboard up between actions.
- * - "Ctrl" is sticky: tapping it sets a pending flag that the next regular
- *   keystroke from the iOS keyboard consumes (mapped to a control character by
- *   the parent's xterm key handler). The button stays highlighted while
- *   pending and clears itself once a key is sent. This matches Termius /
+ * - All actions fire on `onPointerDown` rather than `onClick`. iOS Safari
+ *   treats `pointerdown` as part of the user-gesture chain that enables
+ *   `navigator.clipboard.readText()`; a separate `click` event fires too late
+ *   in some installable-PWA contexts. We also `preventDefault()` so the tap
+ *   never blurs the terminal's hidden textarea — keeping the soft keyboard
+ *   up between actions.
+ * - "Ctrl" (idle only) is sticky: tapping it sets a pending flag that the
+ *   next regular keystroke from the iOS keyboard consumes (mapped to a
+ *   control character by the parent's xterm key handler). Matches Termius /
  *   Blink behavior on iOS.
  */
 export interface TerminalToolbarProps {
@@ -41,6 +52,12 @@ export interface TerminalToolbarProps {
   pendingCtrl: boolean;
   /** Toggle the pending-Ctrl state. */
   onToggleCtrl: () => void;
+  /** True after a long-press has armed a selection. Swaps the layout. */
+  selectionMode: boolean;
+  /** Called when an arrow is tapped while `selectionMode` is true. */
+  onExtendSelection: (direction: ArrowDirection) => void;
+  /** Called when the user dismisses selection mode (Done, or Copy). */
+  onExitSelection: () => void;
 }
 
 // ANSI / CSI escape sequences for the keys the iOS soft keyboard omits.
@@ -58,6 +75,9 @@ export function TerminalToolbar({
   sendInput,
   pendingCtrl,
   onToggleCtrl,
+  selectionMode,
+  onExtendSelection,
+  onExitSelection,
 }: TerminalToolbarProps) {
   const { enabled, bottomOffset } = useVirtualKeyboardToolbar();
 
@@ -74,6 +94,13 @@ export function TerminalToolbar({
       console.warn("[TerminalToolbar] clipboard write failed:", err);
     }
   }, [terminal]);
+
+  // Copy *and* exit selection mode in one tap. Used by the selection-mode
+  // Copy button; the idle Copy button just calls handleCopy.
+  const handleCopyAndExit = useCallback(async () => {
+    await handleCopy();
+    onExitSelection();
+  }, [handleCopy, onExitSelection]);
 
   const handlePaste = useCallback(async () => {
     try {
@@ -93,9 +120,8 @@ export function TerminalToolbar({
     terminal.focus();
   }, [terminal]);
 
-  // Build a list of static key buttons. Memoized so the inline object identity
-  // is stable across re-renders (helps if anyone wraps the toolbar in memo).
-  const keyButtons = useMemo(
+  // Memoized button lists so identities are stable across re-renders.
+  const idleKeyButtons = useMemo(
     () => [
       { label: "Esc", seq: SEQ_ESC, ariaLabel: "Send Escape" },
       { label: "Tab", seq: SEQ_TAB, ariaLabel: "Send Tab" },
@@ -103,13 +129,24 @@ export function TerminalToolbar({
     [],
   );
 
-  const arrowButtons = useMemo(
+  const idleArrows = useMemo(
     () => [
       { Icon: ArrowLeft, seq: SEQ_ARROW_LEFT, ariaLabel: "Arrow Left" },
       { Icon: ArrowDown, seq: SEQ_ARROW_DOWN, ariaLabel: "Arrow Down" },
       { Icon: ArrowUp, seq: SEQ_ARROW_UP, ariaLabel: "Arrow Up" },
       { Icon: ArrowRight, seq: SEQ_ARROW_RIGHT, ariaLabel: "Arrow Right" },
     ],
+    [],
+  );
+
+  const selectionArrows = useMemo(
+    () =>
+      [
+        { Icon: ArrowLeft, dir: "left", ariaLabel: "Extend selection left" },
+        { Icon: ArrowDown, dir: "down", ariaLabel: "Extend selection down" },
+        { Icon: ArrowUp, dir: "up", ariaLabel: "Extend selection up" },
+        { Icon: ArrowRight, dir: "right", ariaLabel: "Extend selection right" },
+      ] as const,
     [],
   );
 
@@ -125,80 +162,122 @@ export function TerminalToolbar({
       void fn();
     };
 
+  // Wrapper that visually distinguishes selection mode — a primary-tinted
+  // strip across the top of the bar makes it immediately obvious that
+  // arrows mean something different right now.
   return (
     <div
       data-testid="terminal-toolbar"
+      data-mode={selectionMode ? "selection" : "idle"}
       role="toolbar"
-      aria-label="Terminal accessory keys"
-      // `position: fixed` so the bar tracks the visual viewport regardless of
-      // where the terminal panel sits inside its dockview layout. `left: 0;
-      // right: 0` spans the full width; the inner flex row centers content.
+      aria-label={selectionMode ? "Terminal selection controls" : "Terminal accessory keys"}
       style={{ bottom: bottomOffset }}
       className="fixed inset-x-0 z-50 flex justify-center border-t border-border bg-background/95 shadow-lg backdrop-blur-md"
     >
       <div className="flex w-full max-w-3xl items-center gap-1 overflow-x-auto px-2 py-1.5">
-        {/* Selection / clipboard group */}
-        <ToolbarButton
-          ariaLabel="Copy selection"
-          title="Copy"
-          onPointerDown={tap(handleCopy)}
-          disabled={!terminal.hasSelection()}
-        >
-          <ClipboardCopy className="size-4" />
-          <span className="text-xs">Copy</span>
-        </ToolbarButton>
-        <ToolbarButton
-          ariaLabel="Paste from clipboard"
-          title="Paste"
-          onPointerDown={tap(handlePaste)}
-        >
-          <ClipboardPaste className="size-4" />
-          <span className="text-xs">Paste</span>
-        </ToolbarButton>
-        <ToolbarButton
-          ariaLabel="Select all"
-          title="Select all"
-          onPointerDown={tap(handleSelectAll)}
-        >
-          <TextCursorInput className="size-4" />
-          <span className="text-xs">All</span>
-        </ToolbarButton>
+        {selectionMode ? (
+          <>
+            <ToolbarButton
+              ariaLabel="Copy selection and exit"
+              title="Copy"
+              onPointerDown={tap(handleCopyAndExit)}
+              variant="primary"
+            >
+              <ClipboardCopy className="size-4" />
+              <span className="text-xs">Copy</span>
+            </ToolbarButton>
+            <ToolbarButton
+              ariaLabel="Exit selection mode"
+              title="Done"
+              onPointerDown={tap(onExitSelection)}
+            >
+              <X className="size-4" />
+              <span className="text-xs">Done</span>
+            </ToolbarButton>
 
-        <div className="mx-1 h-6 w-px shrink-0 bg-border" aria-hidden="true" />
+            <div className="mx-1 h-6 w-px shrink-0 bg-border" aria-hidden="true" />
 
-        {/* Special keys */}
-        {keyButtons.map(({ label, seq, ariaLabel }) => (
-          <ToolbarButton
-            key={label}
-            ariaLabel={ariaLabel}
-            title={label}
-            onPointerDown={tap(() => sendInput(seq))}
-          >
-            <span className="text-xs font-medium">{label}</span>
-          </ToolbarButton>
-        ))}
-        <ToolbarButton
-          ariaLabel={pendingCtrl ? "Cancel pending Ctrl" : "Arm Ctrl modifier"}
-          title="Ctrl (sticky — taps the next key as Ctrl+key)"
-          onPointerDown={tap(onToggleCtrl)}
-          active={pendingCtrl}
-        >
-          <span className="text-xs font-medium">Ctrl</span>
-        </ToolbarButton>
+            <span
+              className="mr-1 shrink-0 select-none text-xs font-medium uppercase tracking-wide text-muted-foreground"
+              aria-hidden="true"
+            >
+              Extend
+            </span>
 
-        <div className="mx-1 h-6 w-px shrink-0 bg-border" aria-hidden="true" />
+            {selectionArrows.map(({ Icon, dir, ariaLabel }) => (
+              <ToolbarButton
+                key={dir}
+                ariaLabel={ariaLabel}
+                title={ariaLabel}
+                onPointerDown={tap(() => onExtendSelection(dir))}
+              >
+                <Icon className="size-4" />
+              </ToolbarButton>
+            ))}
+          </>
+        ) : (
+          <>
+            <ToolbarButton
+              ariaLabel="Copy selection"
+              title="Copy"
+              onPointerDown={tap(handleCopy)}
+              disabled={!terminal.hasSelection()}
+            >
+              <ClipboardCopy className="size-4" />
+              <span className="text-xs">Copy</span>
+            </ToolbarButton>
+            <ToolbarButton
+              ariaLabel="Paste from clipboard"
+              title="Paste"
+              onPointerDown={tap(handlePaste)}
+            >
+              <ClipboardPaste className="size-4" />
+              <span className="text-xs">Paste</span>
+            </ToolbarButton>
+            <ToolbarButton
+              ariaLabel="Select all"
+              title="Select all"
+              onPointerDown={tap(handleSelectAll)}
+            >
+              <TextCursorInput className="size-4" />
+              <span className="text-xs">All</span>
+            </ToolbarButton>
 
-        {/* Arrow cluster */}
-        {arrowButtons.map(({ Icon, seq, ariaLabel }) => (
-          <ToolbarButton
-            key={ariaLabel}
-            ariaLabel={ariaLabel}
-            title={ariaLabel}
-            onPointerDown={tap(() => sendInput(seq))}
-          >
-            <Icon className="size-4" />
-          </ToolbarButton>
-        ))}
+            <div className="mx-1 h-6 w-px shrink-0 bg-border" aria-hidden="true" />
+
+            {idleKeyButtons.map(({ label, seq, ariaLabel }) => (
+              <ToolbarButton
+                key={label}
+                ariaLabel={ariaLabel}
+                title={label}
+                onPointerDown={tap(() => sendInput(seq))}
+              >
+                <span className="text-xs font-medium">{label}</span>
+              </ToolbarButton>
+            ))}
+            <ToolbarButton
+              ariaLabel={pendingCtrl ? "Cancel pending Ctrl" : "Arm Ctrl modifier"}
+              title="Ctrl (sticky — taps the next key as Ctrl+key)"
+              onPointerDown={tap(onToggleCtrl)}
+              active={pendingCtrl}
+            >
+              <span className="text-xs font-medium">Ctrl</span>
+            </ToolbarButton>
+
+            <div className="mx-1 h-6 w-px shrink-0 bg-border" aria-hidden="true" />
+
+            {idleArrows.map(({ Icon, seq, ariaLabel }) => (
+              <ToolbarButton
+                key={ariaLabel}
+                ariaLabel={ariaLabel}
+                title={ariaLabel}
+                onPointerDown={tap(() => sendInput(seq))}
+              >
+                <Icon className="size-4" />
+              </ToolbarButton>
+            ))}
+          </>
+        )}
       </div>
     </div>
   );
@@ -207,8 +286,9 @@ export function TerminalToolbar({
 // ---------------------------------------------------------------------------
 // ToolbarButton — minimal local component to keep the markup readable.
 // Not exported from the package's `<Button>` because we want pointerdown
-// semantics, larger touch targets, and the active-state styling for sticky
-// Ctrl; the shared component is built for click semantics.
+// semantics, larger touch targets, and the active/primary-state styling for
+// sticky Ctrl + the selection-mode Copy button; the shared component is built
+// for click semantics.
 // ---------------------------------------------------------------------------
 
 interface ToolbarButtonProps {
@@ -216,6 +296,9 @@ interface ToolbarButtonProps {
   title: string;
   onPointerDown: (e: React.PointerEvent<HTMLButtonElement>) => void;
   active?: boolean;
+  /** "primary" tints the button like a CTA — used for the prominent Copy in
+   *  selection mode. "default" is the neutral background used elsewhere. */
+  variant?: "default" | "primary";
   disabled?: boolean;
   children: React.ReactNode;
 }
@@ -225,9 +308,15 @@ function ToolbarButton({
   title,
   onPointerDown,
   active,
+  variant = "default",
   disabled,
   children,
 }: ToolbarButtonProps) {
+  const palette = active
+    ? "bg-primary text-primary-foreground"
+    : variant === "primary"
+      ? "bg-primary text-primary-foreground hover:bg-primary/90"
+      : "bg-muted/60 hover:bg-muted active:bg-muted";
   return (
     <button
       type="button"
@@ -242,9 +331,7 @@ function ToolbarButton({
       className={[
         "inline-flex h-9 min-w-9 shrink-0 items-center justify-center gap-1 rounded-md px-2",
         "text-foreground transition-colors",
-        active
-          ? "bg-primary text-primary-foreground"
-          : "bg-muted/60 hover:bg-muted active:bg-muted",
+        palette,
         "disabled:opacity-40",
       ].join(" ")}
     >

--- a/apps/web/src/hooks/useVirtualKeyboardToolbar.ts
+++ b/apps/web/src/hooks/useVirtualKeyboardToolbar.ts
@@ -1,6 +1,17 @@
 import { useEffect, useState } from "react";
 
 /**
+ * Pixel height the accessory toolbar occupies on screen. Derived from its
+ * Tailwind classes: the row is `py-1.5` (12px total padding) + `h-9` buttons
+ * (36px), plus a 1px `border-t`. Kept in sync with TerminalToolbar.tsx by
+ * convention. Used by consumers (TerminalPanel) to reserve a matching strip
+ * of bottom inset so their content isn't covered by the floating bar.
+ *
+ * If you change the toolbar's vertical sizing, update this constant too.
+ */
+export const TERMINAL_TOOLBAR_HEIGHT_PX = 49;
+
+/**
  * Detects whether to render a "virtual keyboard accessory" toolbar (iOS-style
  * row of helper keys above the soft keyboard) and where to position it.
  *
@@ -14,6 +25,13 @@ import { useEffect, useState } from "react";
  *   API reports a smaller `height` + nonzero `offsetTop`; the difference vs
  *   `window.innerHeight` is the keyboard's pixel height. When the keyboard is
  *   closed, this is 0 and the toolbar pins to the bottom of the screen.
+ * - `contentBottomInset`: how many pixels the *terminal content* should
+ *   reserve at the bottom so it isn't hidden beneath the floating toolbar.
+ *   Equal to the toolbar height when `enabled`, else 0. The toolbar itself
+ *   is `position: fixed`, so without this reservation a panel that reaches
+ *   the bottom of the visual viewport (the common iOS layout — the workspace
+ *   already shrinks to `visualViewport.height`) would render its bottom rows
+ *   underneath the bar, hiding the prompt/cursor while typing.
  *
  * Why VisualViewport and not `env(keyboard-inset-height)`: the CSS env var is
  * iOS 17+ and still flaky in PWAs / WKWebView. The VisualViewport API has
@@ -23,6 +41,7 @@ import { useEffect, useState } from "react";
 export interface VirtualKeyboardToolbarState {
   enabled: boolean;
   bottomOffset: number;
+  contentBottomInset: number;
 }
 
 const TOUCH_QUERY = "(hover: none) and (pointer: coarse)";
@@ -76,5 +95,9 @@ export function useVirtualKeyboardToolbar(): VirtualKeyboardToolbarState {
     };
   }, [enabled]);
 
-  return { enabled, bottomOffset };
+  return {
+    enabled,
+    bottomOffset,
+    contentBottomInset: enabled ? TERMINAL_TOOLBAR_HEIGHT_PX : 0,
+  };
 }

--- a/apps/web/src/hooks/useVirtualKeyboardToolbar.ts
+++ b/apps/web/src/hooks/useVirtualKeyboardToolbar.ts
@@ -1,0 +1,80 @@
+import { useEffect, useState } from "react";
+
+/**
+ * Detects whether to render a "virtual keyboard accessory" toolbar (iOS-style
+ * row of helper keys above the soft keyboard) and where to position it.
+ *
+ * Returns:
+ * - `enabled`: true on touch-only devices (no hover + coarse pointer). This
+ *   covers iPhones/iPads in Safari and other mobile browsers. Desktop browsers
+ *   (including those with touchscreens *plus* a mouse) return false, so the
+ *   toolbar stays out of the way per the acceptance criteria in issue #390.
+ * - `bottomOffset`: how many pixels above the bottom of the layout viewport the
+ *   toolbar should sit. When the virtual keyboard is open, the VisualViewport
+ *   API reports a smaller `height` + nonzero `offsetTop`; the difference vs
+ *   `window.innerHeight` is the keyboard's pixel height. When the keyboard is
+ *   closed, this is 0 and the toolbar pins to the bottom of the screen.
+ *
+ * Why VisualViewport and not `env(keyboard-inset-height)`: the CSS env var is
+ * iOS 17+ and still flaky in PWAs / WKWebView. The VisualViewport API has
+ * shipped in iOS Safari since 13 and is the same primitive `useAppHeight`
+ * elsewhere in this app already relies on.
+ */
+export interface VirtualKeyboardToolbarState {
+  enabled: boolean;
+  bottomOffset: number;
+}
+
+const TOUCH_QUERY = "(hover: none) and (pointer: coarse)";
+
+export function useVirtualKeyboardToolbar(): VirtualKeyboardToolbarState {
+  const [enabled, setEnabled] = useState(() =>
+    typeof window === "undefined" ? false : window.matchMedia(TOUCH_QUERY).matches,
+  );
+  const [bottomOffset, setBottomOffset] = useState(0);
+
+  // Track touch-only device status. Used to gate the toolbar entirely so it
+  // never paints on desktop, where the virtual keyboard never exists.
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const mql = window.matchMedia(TOUCH_QUERY);
+    const handler = (e: MediaQueryListEvent) => setEnabled(e.matches);
+    // Sync the initial value too — covers the SSR/hydration mismatch case.
+    setEnabled(mql.matches);
+    mql.addEventListener("change", handler);
+    return () => mql.removeEventListener("change", handler);
+  }, []);
+
+  // Track the keyboard's pixel height via the VisualViewport API. We listen to
+  // both `resize` (fires when the keyboard slides in/out) and `scroll` (fires
+  // while the user scrolls the page-with-keyboard-open, which shifts
+  // `offsetTop` and can otherwise leave the toolbar floating mid-screen).
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    if (!enabled) {
+      setBottomOffset(0);
+      return;
+    }
+    const vv = window.visualViewport;
+    if (!vv) return;
+    const update = () => {
+      // Keyboard occupies the gap between the bottom of the visual viewport
+      // (`vv.offsetTop + vv.height`) and the bottom of the layout viewport
+      // (`window.innerHeight`). Clamp to non-negative so a stale measurement
+      // during orientation change can't push the toolbar off-screen.
+      const keyboardHeight = Math.max(0, window.innerHeight - (vv.offsetTop + vv.height));
+      setBottomOffset(keyboardHeight);
+    };
+    update();
+    vv.addEventListener("resize", update);
+    vv.addEventListener("scroll", update);
+    window.addEventListener("resize", update);
+    return () => {
+      vv.removeEventListener("resize", update);
+      vv.removeEventListener("scroll", update);
+      window.removeEventListener("resize", update);
+    };
+  }, [enabled]);
+
+  return { enabled, bottomOffset };
+}

--- a/apps/web/src/lib/clipboard.ts
+++ b/apps/web/src/lib/clipboard.ts
@@ -1,0 +1,114 @@
+/**
+ * Clipboard helpers that work in both secure and non-secure contexts.
+ *
+ * `navigator.clipboard` is only exposed by browsers in secure contexts —
+ * HTTPS pages or localhost-on-this-device. On iOS Safari that means hitting
+ * a dev server over your LAN (`http://192.168.x.x:port`) makes
+ * `navigator.clipboard` literally `undefined`, and any access throws
+ * `TypeError: undefined is not an object`. Wrapping the modern API in a
+ * try/catch swallows the error and the user just sees nothing on their
+ * clipboard.
+ *
+ * `document.execCommand('copy')` is deprecated but still implemented across
+ * every browser we care about (including iOS Safari) and does not require a
+ * secure context. We use it as the fallback path.
+ *
+ * `readText` is harder — `execCommand('paste')` is blocked in most modern
+ * browsers for security. If `navigator.clipboard.readText` is unavailable
+ * the function rejects, and the caller should surface that to the user.
+ */
+
+/**
+ * Write `text` to the OS clipboard. Tries `navigator.clipboard.writeText`
+ * first (the only path that works in a sandboxed PWA / iframe) and falls
+ * back to a temporary-textarea + `execCommand('copy')` flow if the modern
+ * API is unavailable or rejects.
+ *
+ * MUST be called inside a user gesture (click / pointerdown / keydown).
+ * Both code paths require it.
+ *
+ * Returns true if the write succeeded; false if both paths failed. The
+ * caller decides whether to surface an error to the user.
+ */
+export async function writeClipboardText(text: string): Promise<boolean> {
+  // Modern path — secure-context only.
+  // Use optional chaining so an undefined `navigator.clipboard` (non-secure
+  // context) does NOT throw on property access.
+  if (typeof navigator !== "undefined" && navigator.clipboard?.writeText) {
+    try {
+      await navigator.clipboard.writeText(text);
+      return true;
+    } catch {
+      // Permission denied or transient error — fall through to the legacy
+      // path. We don't log: the fallback is the answer in most cases.
+    }
+  }
+  return legacyCopy(text);
+}
+
+/**
+ * Legacy fallback: create an invisible textarea, select its contents, run
+ * `document.execCommand('copy')`, and clean up. Works in non-secure
+ * contexts (the common iPhone-on-LAN dev case).
+ *
+ * iOS Safari quirks this dance requires:
+ * - The textarea must be visible (not `display:none`) AND focusable.
+ *   We achieve "invisible but focusable" with `opacity: 0` + `position:
+ *   fixed` (so it doesn't shift the layout).
+ * - `select()` alone isn't enough on iOS — we also need
+ *   `setSelectionRange(0, text.length)`. Without it, the selected range
+ *   is empty and the copy is a no-op.
+ * - The element must be `readonly` so the soft keyboard doesn't pop up
+ *   for the split-second it's focused.
+ */
+function legacyCopy(text: string): boolean {
+  if (typeof document === "undefined") return false;
+  const textarea = document.createElement("textarea");
+  textarea.value = text;
+  textarea.setAttribute("readonly", "");
+  textarea.style.position = "fixed";
+  textarea.style.top = "0";
+  textarea.style.left = "0";
+  textarea.style.width = "1px";
+  textarea.style.height = "1px";
+  textarea.style.padding = "0";
+  textarea.style.border = "0";
+  textarea.style.opacity = "0";
+  textarea.style.pointerEvents = "none";
+  document.body.appendChild(textarea);
+  // Remember the previously focused element so we can restore it. On
+  // iOS this matters: stealing focus from the xterm helper textarea
+  // and not restoring it would dismiss the soft keyboard mid-tap.
+  const previouslyFocused = document.activeElement as HTMLElement | null;
+  try {
+    textarea.focus();
+    textarea.select();
+    textarea.setSelectionRange(0, text.length);
+    return document.execCommand("copy");
+  } catch {
+    return false;
+  } finally {
+    document.body.removeChild(textarea);
+    // Best-effort restore; some elements (xterm's textarea is one) lose
+    // focus state irreversibly when stolen from briefly, which is fine
+    // for our use case (the toolbar's Copy button blurs the terminal
+    // anyway in selection mode).
+    previouslyFocused?.focus?.();
+  }
+}
+
+/**
+ * Read text from the OS clipboard. Only the modern API can do this; there
+ * is no execCommand-based fallback that works in modern browsers. Returns
+ * an empty string if the API is unavailable or the read fails.
+ */
+export async function readClipboardText(): Promise<string> {
+  if (typeof navigator === "undefined" || !navigator.clipboard?.readText) {
+    return "";
+  }
+  try {
+    return await navigator.clipboard.readText();
+  } catch {
+    return "";
+  }
+}

--- a/apps/web/src/lib/terminal-selection.ts
+++ b/apps/web/src/lib/terminal-selection.ts
@@ -61,17 +61,24 @@ export function pointToCell(
 /**
  * Find the start/end columns of the "word" at `col` in the given line text.
  *
- * Returns `[col, col + 1)` if `col` is not on a word character — that's a
- * one-cell range, which we still highlight so the user has visible feedback
- * after a long-press on whitespace or a delimiter (they can then use the
- * arrow keys to grow it).
+ * Returns a one-cell range `[c, c + 1)` if `col` is not on a word character
+ * (or is past the end of the line). Clamped to the line bounds so the
+ * caller always gets a 1-cell selection it can apply — the user can grow
+ * it with the toolbar arrows.
  *
  * `end` is exclusive (one past the last word cell), matching xterm.js's
  * `select(col, row, length)` semantics — `length = end - start`.
  */
 export function findWordBoundaries(line: string, col: number): { start: number; end: number } {
+  // Out-of-bounds (or non-word) → always a 1-cell range. Earlier versions
+  // returned `{ start: clamp(...), end: col + 1 }` which for col past the
+  // line length produced a multi-cell highlight of trailing whitespace
+  // (band-app/band PR #413 review). Clamp start AND derive end as start + 1
+  // so the range stays single-cell regardless of how far past the line the
+  // user tapped.
   if (col < 0 || col >= line.length || !WORD_RE.test(line[col])) {
-    return { start: clamp(col, 0, Math.max(0, line.length)), end: col + 1 };
+    const safeCol = clamp(col, 0, Math.max(0, line.length));
+    return { start: safeCol, end: safeCol + 1 };
   }
   let start = col;
   while (start > 0 && WORD_RE.test(line[start - 1])) start--;

--- a/apps/web/src/lib/terminal-selection.ts
+++ b/apps/web/src/lib/terminal-selection.ts
@@ -1,0 +1,158 @@
+/**
+ * Pure helpers for the iOS long-press → word select → arrow-extend flow in
+ * TerminalPanel.
+ *
+ * Kept in a separate module (no React, no DOM mutation) so each function is
+ * trivially unit-testable through the xterm.js public API. The TerminalPanel
+ * orchestrates the state machine; this file does the math.
+ */
+import type { Terminal } from "@xterm/xterm";
+
+export interface Cell {
+  /** Column in the buffer, 0-based. */
+  col: number;
+  /** Absolute buffer row, 0-based (includes scrollback above viewport). */
+  row: number;
+}
+
+export type ArrowDirection = "left" | "right" | "up" | "down";
+
+/**
+ * What counts as a "word character" for the long-press initial selection.
+ *
+ * Terminal users select tokens, not English words — paths (`/etc/hosts`),
+ * URLs, file extensions (`.tar.gz`), hyphenated flags (`--verbose`),
+ * version numbers (`1.2.3`), and namespaced identifiers (`foo::bar`). The
+ * regex below covers all of those. Whitespace, quotes, and brackets are
+ * deliberately excluded so e.g. long-pressing inside `"foo/bar"` selects
+ * `foo/bar` rather than the surrounding quotes.
+ */
+const WORD_RE = /[A-Za-z0-9_./:\-+@~]/;
+
+/**
+ * Convert a touch / pointer position in client coordinates to a buffer cell.
+ *
+ * Uses `getBoundingClientRect()` on the xterm screen element rather than any
+ * private xterm internal: as long as the renderer paints cells edge-to-edge
+ * (true for both DOM and WebGL renderers), the math is just
+ * `floor((x - left) / cellWidth)`.
+ *
+ * Out-of-bounds touches are clamped to the nearest visible cell so e.g. a
+ * tap on the 1px gutter around the screen still maps to a valid cell.
+ */
+export function pointToCell(
+  clientX: number,
+  clientY: number,
+  terminal: Terminal,
+  screenEl: HTMLElement,
+): Cell {
+  const rect = screenEl.getBoundingClientRect();
+  // Defensive: a zero-size rect during a pending fit/resize would divide by 0.
+  if (rect.width <= 0 || rect.height <= 0 || terminal.cols <= 0 || terminal.rows <= 0) {
+    return { col: 0, row: terminal.buffer.active.viewportY };
+  }
+  const cellW = rect.width / terminal.cols;
+  const cellH = rect.height / terminal.rows;
+  const col = clamp(Math.floor((clientX - rect.left) / cellW), 0, terminal.cols - 1);
+  const viewportRow = clamp(Math.floor((clientY - rect.top) / cellH), 0, terminal.rows - 1);
+  return { col, row: terminal.buffer.active.viewportY + viewportRow };
+}
+
+/**
+ * Find the start/end columns of the "word" at `col` in the given line text.
+ *
+ * Returns `[col, col + 1)` if `col` is not on a word character — that's a
+ * one-cell range, which we still highlight so the user has visible feedback
+ * after a long-press on whitespace or a delimiter (they can then use the
+ * arrow keys to grow it).
+ *
+ * `end` is exclusive (one past the last word cell), matching xterm.js's
+ * `select(col, row, length)` semantics — `length = end - start`.
+ */
+export function findWordBoundaries(line: string, col: number): { start: number; end: number } {
+  if (col < 0 || col >= line.length || !WORD_RE.test(line[col])) {
+    return { start: clamp(col, 0, Math.max(0, line.length)), end: col + 1 };
+  }
+  let start = col;
+  while (start > 0 && WORD_RE.test(line[start - 1])) start--;
+  let end = col + 1;
+  while (end < line.length && WORD_RE.test(line[end])) end++;
+  return { start, end };
+}
+
+/**
+ * Read the line text for an absolute buffer row, or return an empty string
+ * if the row doesn't exist (e.g. the user long-pressed past the end of the
+ * scrollback). `false` for trimRight so trailing spaces remain in their
+ * positions — `findWordBoundaries` relies on column offsets matching cells.
+ */
+export function getLineText(terminal: Terminal, row: number): string {
+  return terminal.buffer.active.getLine(row)?.translateToString(false) ?? "";
+}
+
+/**
+ * Move a single cell one step in `dir`, wrapping at row edges and clamping at
+ * the buffer's first/last valid row. This is the per-tap behavior for the
+ * arrow keys in selection mode: extend by one cell.
+ */
+export function moveCell(cell: Cell, dir: ArrowDirection, terminal: Terminal): Cell {
+  const cols = terminal.cols;
+  // `buffer.length` counts every line in scrollback + viewport, so the last
+  // valid row index is `length - 1`.
+  const lastRow = Math.max(0, terminal.buffer.active.length - 1);
+  switch (dir) {
+    case "left":
+      if (cell.col > 0) return { col: cell.col - 1, row: cell.row };
+      if (cell.row > 0) return { col: cols - 1, row: cell.row - 1 };
+      return cell;
+    case "right":
+      if (cell.col < cols - 1) return { col: cell.col + 1, row: cell.row };
+      if (cell.row < lastRow) return { col: 0, row: cell.row + 1 };
+      return cell;
+    case "up":
+      if (cell.row > 0) return { col: cell.col, row: cell.row - 1 };
+      return cell;
+    case "down":
+      if (cell.row < lastRow) return { col: cell.col, row: cell.row + 1 };
+      return cell;
+  }
+}
+
+/**
+ * Apply a selection from `anchor` to `head` to the terminal, regardless of
+ * which end is earlier. Wraps the two endpoints into xterm.js's
+ * (start, row, length) shape, with length counted as the number of cells
+ * inclusive of both endpoints.
+ */
+export function applySelection(terminal: Terminal, anchor: Cell, head: Cell): void {
+  const cols = terminal.cols;
+  if (cols <= 0) return;
+  const anchorLinear = anchor.row * cols + anchor.col;
+  const headLinear = head.row * cols + head.col;
+  const startLinear = Math.min(anchorLinear, headLinear);
+  const endLinear = Math.max(anchorLinear, headLinear);
+  const length = endLinear - startLinear + 1;
+  const startRow = Math.floor(startLinear / cols);
+  const startCol = startLinear - startRow * cols;
+  terminal.select(startCol, startRow, length);
+}
+
+/**
+ * Convenience: given the cell the user long-pressed and the line text at
+ * that row, compute the (anchor, head) pair to highlight the word.
+ */
+export function wordSelectionAt(cell: Cell, lineText: string): { anchor: Cell; head: Cell } {
+  const { start, end } = findWordBoundaries(lineText, cell.col);
+  return {
+    anchor: { col: start, row: cell.row },
+    // `head` is the last cell of the selection (inclusive). `end` from
+    // findWordBoundaries is exclusive, so subtract one.
+    head: { col: Math.max(start, end - 1), row: cell.row },
+  };
+}
+
+function clamp(n: number, lo: number, hi: number): number {
+  if (n < lo) return lo;
+  if (n > hi) return hi;
+  return n;
+}

--- a/apps/web/tests/clipboard.test.ts
+++ b/apps/web/tests/clipboard.test.ts
@@ -1,0 +1,157 @@
+// @vitest-environment jsdom
+/**
+ * Tests for the clipboard compat helper. The most important case is when
+ * `navigator.clipboard` is missing entirely — the production failure mode
+ * was iPhones loading the dev server over HTTP on a LAN IP, where the
+ * Clipboard API is gated behind secure-context and the property is
+ * `undefined`. The helper has to detect that and fall back to
+ * `document.execCommand('copy')`.
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { readClipboardText, writeClipboardText } from "../src/lib/clipboard";
+
+const realClipboardDescriptor = Object.getOwnPropertyDescriptor(Navigator.prototype, "clipboard");
+
+afterEach(() => {
+  // Restore whatever jsdom installed by default. If the descriptor existed,
+  // re-install it on Navigator.prototype; otherwise wipe the per-instance
+  // override our setters left behind.
+  if (realClipboardDescriptor) {
+    Object.defineProperty(Navigator.prototype, "clipboard", realClipboardDescriptor);
+  } else {
+    // No prototype default existed — drop the per-instance override the
+    // tests installed by re-defining the slot as undefined. (Direct
+    // assignment fails because `clipboard` is non-writable in the WebIDL
+    // bindings jsdom synthesizes.)
+    Object.defineProperty(navigator, "clipboard", { configurable: true, value: undefined });
+  }
+  vi.restoreAllMocks();
+});
+
+function installClipboard(stub: Partial<Clipboard> | undefined) {
+  // Define a per-instance property because the jsdom default is on the
+  // prototype and isn't configurable in some versions.
+  Object.defineProperty(navigator, "clipboard", {
+    configurable: true,
+    value: stub,
+  });
+}
+
+/**
+ * jsdom does not implement `document.execCommand`, so `vi.spyOn` rejects
+ * it. Install our own implementation via Object.defineProperty so the
+ * helper's call path is exercised. Returns a spy on the implementation
+ * for call-tracking.
+ */
+function installExecCommand(impl: (cmd: string) => boolean): ReturnType<typeof vi.fn> {
+  const fn = vi.fn(impl);
+  Object.defineProperty(document, "execCommand", {
+    configurable: true,
+    value: fn,
+  });
+  return fn;
+}
+
+// ---------------------------------------------------------------------------
+// writeClipboardText
+// ---------------------------------------------------------------------------
+
+describe("writeClipboardText – modern API", () => {
+  it("uses navigator.clipboard.writeText when available", async () => {
+    const writeText = vi.fn(() => Promise.resolve());
+    installClipboard({ writeText } as unknown as Clipboard);
+    const result = await writeClipboardText("hello");
+    expect(result).toBe(true);
+    expect(writeText).toHaveBeenCalledWith("hello");
+  });
+
+  it("falls back to execCommand when the modern API rejects", async () => {
+    const writeText = vi.fn(() => Promise.reject(new Error("denied")));
+    installClipboard({ writeText } as unknown as Clipboard);
+    const execSpy = installExecCommand(() => true);
+    const result = await writeClipboardText("hello");
+    expect(result).toBe(true);
+    expect(execSpy).toHaveBeenCalledWith("copy");
+  });
+});
+
+describe("writeClipboardText – non-secure context fallback", () => {
+  it("uses execCommand('copy') when navigator.clipboard is undefined", async () => {
+    installClipboard(undefined);
+    const execSpy = installExecCommand(() => true);
+    const result = await writeClipboardText("hello world");
+    expect(result).toBe(true);
+    expect(execSpy).toHaveBeenCalledWith("copy");
+  });
+
+  it("populates and selects a hidden textarea with the payload", async () => {
+    installClipboard(undefined);
+    let capturedValue: string | undefined;
+    let selectCalled = false;
+    let setRangeArgs: [number, number] | undefined;
+    const origAppend = document.body.appendChild.bind(document.body);
+    vi.spyOn(document.body, "appendChild").mockImplementation((node) => {
+      if (node instanceof HTMLTextAreaElement) {
+        capturedValue = node.value;
+        const origSelect = node.select.bind(node);
+        node.select = () => {
+          selectCalled = true;
+          origSelect();
+        };
+        const origSetRange = node.setSelectionRange.bind(node);
+        node.setSelectionRange = ((start: number, end: number) => {
+          setRangeArgs = [start, end];
+          origSetRange(start, end);
+        }) as typeof node.setSelectionRange;
+      }
+      return origAppend(node);
+    });
+    installExecCommand(() => true);
+    await writeClipboardText("hello world");
+    expect(capturedValue).toBe("hello world");
+    expect(selectCalled).toBe(true);
+    expect(setRangeArgs).toEqual([0, "hello world".length]);
+  });
+
+  it("returns false when execCommand also fails", async () => {
+    installClipboard(undefined);
+    installExecCommand(() => false);
+    const result = await writeClipboardText("hello");
+    expect(result).toBe(false);
+  });
+
+  it("cleans up the temporary textarea even when execCommand throws", async () => {
+    installClipboard(undefined);
+    installExecCommand(() => {
+      throw new Error("boom");
+    });
+    const before = document.body.children.length;
+    const result = await writeClipboardText("hello");
+    expect(result).toBe(false);
+    expect(document.body.children.length).toBe(before);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// readClipboardText
+// ---------------------------------------------------------------------------
+
+describe("readClipboardText", () => {
+  it("uses navigator.clipboard.readText when available", async () => {
+    const readText = vi.fn(() => Promise.resolve("pasted"));
+    installClipboard({ readText } as unknown as Clipboard);
+    expect(await readClipboardText()).toBe("pasted");
+    expect(readText).toHaveBeenCalled();
+  });
+
+  it("returns an empty string when navigator.clipboard is undefined", async () => {
+    installClipboard(undefined);
+    expect(await readClipboardText()).toBe("");
+  });
+
+  it("returns an empty string when the read promise rejects", async () => {
+    const readText = vi.fn(() => Promise.reject(new Error("denied")));
+    installClipboard({ readText } as unknown as Clipboard);
+    expect(await readClipboardText()).toBe("");
+  });
+});

--- a/apps/web/tests/terminal-selection.test.ts
+++ b/apps/web/tests/terminal-selection.test.ts
@@ -1,0 +1,316 @@
+// @vitest-environment jsdom
+/**
+ * Unit tests for the pure helpers backing the long-press → word select →
+ * arrow-extend flow. Each helper is a function over xterm.js's public buffer
+ * API and the DOM rect; we exercise them with hand-built fakes that mirror
+ * the shape xterm exposes at runtime.
+ */
+import type { Terminal } from "@xterm/xterm";
+import { describe, expect, it } from "vitest";
+import {
+  applySelection,
+  type Cell,
+  findWordBoundaries,
+  getLineText,
+  moveCell,
+  pointToCell,
+  wordSelectionAt,
+} from "../src/lib/terminal-selection";
+
+// ---------------------------------------------------------------------------
+// Tiny xterm.js shape — only the fields the helpers actually read. Each test
+// builds one of these inline so it's clear which input drove the assertion.
+// ---------------------------------------------------------------------------
+
+interface FakeBufferLine {
+  text: string;
+}
+
+interface FakeTerminal {
+  cols: number;
+  rows: number;
+  viewportY: number;
+  bufferLength: number;
+  lines: Map<number, FakeBufferLine>;
+  selectCalls: Array<{ col: number; row: number; length: number }>;
+}
+
+function makeTerminal(opts: Partial<FakeTerminal> & { cols?: number } = {}): Terminal {
+  const t: FakeTerminal = {
+    cols: 80,
+    rows: 24,
+    viewportY: 0,
+    bufferLength: 100,
+    lines: new Map(),
+    selectCalls: [],
+    ...opts,
+  };
+  return {
+    cols: t.cols,
+    rows: t.rows,
+    buffer: {
+      active: {
+        viewportY: t.viewportY,
+        length: t.bufferLength,
+        getLine: (y: number) => {
+          const line = t.lines.get(y);
+          if (!line) return undefined;
+          return {
+            translateToString: (_trimRight?: boolean) => line.text,
+          };
+        },
+      },
+    },
+    select: (col: number, row: number, length: number) => {
+      t.selectCalls.push({ col, row, length });
+    },
+    // Expose the underlying fake for assertions.
+    __fake: t,
+    // biome-ignore lint/suspicious/noExplicitAny: minimal fake; we only access fields the helpers use.
+  } as any;
+}
+
+function fakeOf(terminal: Terminal): FakeTerminal {
+  return (terminal as unknown as { __fake: FakeTerminal }).__fake;
+}
+
+// ---------------------------------------------------------------------------
+// findWordBoundaries
+// ---------------------------------------------------------------------------
+
+describe("findWordBoundaries", () => {
+  it("selects an alphanumeric identifier in the middle of a line", () => {
+    //           0         1         2
+    //           0123456789012345678901
+    const line = "  hello world foo bar";
+    expect(findWordBoundaries(line, 3)).toEqual({ start: 2, end: 7 }); // "hello"
+    expect(findWordBoundaries(line, 8)).toEqual({ start: 8, end: 13 }); // "world"
+  });
+
+  it("extends across path separators (typical terminal token)", () => {
+    const line = "cd /usr/local/bin";
+    // long-press on "local"
+    expect(findWordBoundaries(line, 9)).toEqual({ start: 3, end: 17 });
+  });
+
+  it("includes dots, dashes, underscores in the word", () => {
+    const line = "run --verbose foo.tar.gz bar_baz";
+    expect(findWordBoundaries(line, 5)).toEqual({ start: 4, end: 13 }); // "--verbose"
+    expect(findWordBoundaries(line, 16)).toEqual({ start: 14, end: 24 }); // "foo.tar.gz"
+    expect(findWordBoundaries(line, 27)).toEqual({ start: 25, end: 32 }); // "bar_baz"
+  });
+
+  it("returns a 1-cell range when col is on whitespace", () => {
+    const line = "abc def";
+    expect(findWordBoundaries(line, 3)).toEqual({ start: 3, end: 4 });
+  });
+
+  it("handles col past end of line by returning a 1-cell range", () => {
+    const line = "abc";
+    expect(findWordBoundaries(line, 10)).toEqual({ start: 3, end: 11 });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// pointToCell
+// ---------------------------------------------------------------------------
+
+describe("pointToCell", () => {
+  function makeScreenEl(width: number, height: number, left = 0, top = 0): HTMLElement {
+    const el = document.createElement("div");
+    el.getBoundingClientRect = () =>
+      ({
+        left,
+        top,
+        right: left + width,
+        bottom: top + height,
+        width,
+        height,
+        x: left,
+        y: top,
+        toJSON: () => ({}),
+      }) as DOMRect;
+    return el;
+  }
+
+  it("maps a click in the middle of the screen to the middle cell", () => {
+    const terminal = makeTerminal({ cols: 80, rows: 24 });
+    const screen = makeScreenEl(800, 480); // 10px/cell wide, 20px/cell tall
+    const cell = pointToCell(405, 245, terminal, screen);
+    expect(cell).toEqual({ col: 40, row: 12 });
+  });
+
+  it("adds viewportY so the returned row is an absolute buffer row", () => {
+    const terminal = makeTerminal({ cols: 80, rows: 24, viewportY: 200 });
+    const screen = makeScreenEl(800, 480);
+    const cell = pointToCell(5, 5, terminal, screen);
+    expect(cell).toEqual({ col: 0, row: 200 });
+  });
+
+  it("clamps to the last visible cell when the touch is past the right edge", () => {
+    const terminal = makeTerminal({ cols: 80, rows: 24 });
+    const screen = makeScreenEl(800, 480);
+    const cell = pointToCell(10_000, 10_000, terminal, screen);
+    expect(cell).toEqual({ col: 79, row: 23 });
+  });
+
+  it("clamps to (0, viewportY) when the touch is past the left/top edge", () => {
+    const terminal = makeTerminal({ cols: 80, rows: 24, viewportY: 50 });
+    const screen = makeScreenEl(800, 480);
+    const cell = pointToCell(-100, -100, terminal, screen);
+    expect(cell).toEqual({ col: 0, row: 50 });
+  });
+
+  it("falls back to (0, viewportY) when the rect has zero area", () => {
+    const terminal = makeTerminal({ cols: 80, rows: 24, viewportY: 7 });
+    const screen = makeScreenEl(0, 0);
+    expect(pointToCell(100, 100, terminal, screen)).toEqual({ col: 0, row: 7 });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// moveCell
+// ---------------------------------------------------------------------------
+
+describe("moveCell", () => {
+  it("moves left within a row", () => {
+    const terminal = makeTerminal({ cols: 80, bufferLength: 100 });
+    expect(moveCell({ col: 10, row: 5 }, "left", terminal)).toEqual({ col: 9, row: 5 });
+  });
+
+  it("wraps left at col 0 to the previous row's last cell", () => {
+    const terminal = makeTerminal({ cols: 80, bufferLength: 100 });
+    expect(moveCell({ col: 0, row: 5 }, "left", terminal)).toEqual({ col: 79, row: 4 });
+  });
+
+  it("does not move left past (0, 0)", () => {
+    const terminal = makeTerminal({ cols: 80, bufferLength: 100 });
+    expect(moveCell({ col: 0, row: 0 }, "left", terminal)).toEqual({ col: 0, row: 0 });
+  });
+
+  it("wraps right at the last column to the next row's first cell", () => {
+    const terminal = makeTerminal({ cols: 80, bufferLength: 100 });
+    expect(moveCell({ col: 79, row: 5 }, "right", terminal)).toEqual({ col: 0, row: 6 });
+  });
+
+  it("does not move right past the last buffer row", () => {
+    const terminal = makeTerminal({ cols: 80, bufferLength: 100 });
+    expect(moveCell({ col: 79, row: 99 }, "right", terminal)).toEqual({ col: 79, row: 99 });
+  });
+
+  it("moves up and down by full rows, clamped to buffer bounds", () => {
+    const terminal = makeTerminal({ cols: 80, bufferLength: 100 });
+    expect(moveCell({ col: 10, row: 5 }, "up", terminal)).toEqual({ col: 10, row: 4 });
+    expect(moveCell({ col: 10, row: 0 }, "up", terminal)).toEqual({ col: 10, row: 0 });
+    expect(moveCell({ col: 10, row: 5 }, "down", terminal)).toEqual({ col: 10, row: 6 });
+    expect(moveCell({ col: 10, row: 99 }, "down", terminal)).toEqual({ col: 10, row: 99 });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// applySelection
+// ---------------------------------------------------------------------------
+
+describe("applySelection", () => {
+  it("forwards a forward range (anchor before head) to terminal.select", () => {
+    const terminal = makeTerminal({ cols: 80 });
+    applySelection(terminal, { col: 5, row: 2 }, { col: 10, row: 2 });
+    expect(fakeOf(terminal).selectCalls).toEqual([{ col: 5, row: 2, length: 6 }]);
+  });
+
+  it("normalizes a reverse range (head before anchor) to start at the smaller end", () => {
+    const terminal = makeTerminal({ cols: 80 });
+    applySelection(terminal, { col: 10, row: 2 }, { col: 5, row: 2 });
+    expect(fakeOf(terminal).selectCalls).toEqual([{ col: 5, row: 2, length: 6 }]);
+  });
+
+  it("spans multiple rows with the correct cell length", () => {
+    const terminal = makeTerminal({ cols: 80 });
+    // (col 70, row 2) → (col 10, row 4)
+    // length = (4*80 + 10) - (2*80 + 70) + 1 = 330 - 230 + 1 = 101
+    applySelection(terminal, { col: 70, row: 2 }, { col: 10, row: 4 });
+    expect(fakeOf(terminal).selectCalls).toEqual([{ col: 70, row: 2, length: 101 }]);
+  });
+
+  it("is a no-op when cols is zero (defensive)", () => {
+    const terminal = makeTerminal({ cols: 0 });
+    applySelection(terminal, { col: 0, row: 0 }, { col: 0, row: 0 });
+    expect(fakeOf(terminal).selectCalls).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// wordSelectionAt + getLineText (integration through findWordBoundaries)
+// ---------------------------------------------------------------------------
+
+describe("wordSelectionAt", () => {
+  it("returns inclusive (anchor, head) cells around the word", () => {
+    const result = wordSelectionAt({ col: 9, row: 7 }, "cd /usr/local/bin");
+    // word = "/usr/local/bin" → start=3, end=17 (exclusive)
+    expect(result.anchor).toEqual({ col: 3, row: 7 });
+    expect(result.head).toEqual({ col: 16, row: 7 });
+  });
+
+  it("collapses to a 1-cell range when long-pressing on whitespace", () => {
+    const result = wordSelectionAt({ col: 2, row: 7 }, "ab  cd");
+    expect(result.anchor).toEqual({ col: 2, row: 7 });
+    expect(result.head).toEqual({ col: 2, row: 7 });
+  });
+});
+
+describe("getLineText", () => {
+  it("returns the line text from xterm.js's buffer", () => {
+    const lines = new Map<number, FakeBufferLine>([
+      [3, { text: "hello world" }],
+      [4, { text: "foo bar" }],
+    ]);
+    const terminal = makeTerminal({ lines });
+    expect(getLineText(terminal, 3)).toBe("hello world");
+    expect(getLineText(terminal, 4)).toBe("foo bar");
+  });
+
+  it("returns an empty string for a missing row", () => {
+    const terminal = makeTerminal({ lines: new Map() });
+    expect(getLineText(terminal, 99)).toBe("");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// End-to-end: simulate a long-press + a few arrow extensions
+// ---------------------------------------------------------------------------
+
+describe("integration: long-press then extend", () => {
+  it("extends a word selection rightward by one cell per arrow press", () => {
+    const terminal = makeTerminal({ cols: 80, bufferLength: 100 });
+    const lineText = "the quick brown fox";
+    // Long-press on "quick" (col 6).
+    const { anchor, head } = wordSelectionAt({ col: 6, row: 1 }, lineText);
+    expect(anchor).toEqual({ col: 4, row: 1 });
+    expect(head).toEqual({ col: 8, row: 1 });
+    applySelection(terminal, anchor, head);
+
+    // Tap → → →: head moves right three times.
+    let h: Cell = head;
+    for (let i = 0; i < 3; i++) h = moveCell(h, "right", terminal);
+    expect(h).toEqual({ col: 11, row: 1 });
+    applySelection(terminal, anchor, h);
+
+    const calls = fakeOf(terminal).selectCalls;
+    expect(calls).toHaveLength(2);
+    expect(calls[0]).toEqual({ col: 4, row: 1, length: 5 }); // "quick"
+    expect(calls[1]).toEqual({ col: 4, row: 1, length: 8 }); // "quick br"
+  });
+
+  it("flips direction when the head crosses the anchor (shrink-and-grow-other-side)", () => {
+    const terminal = makeTerminal({ cols: 80, bufferLength: 100 });
+    // Initial: anchor (10, 1), head (12, 1) — a 3-cell selection.
+    const anchor: Cell = { col: 10, row: 1 };
+    let head: Cell = { col: 12, row: 1 };
+    // Move left 5 times: head ends at col 7. Selection now extends from col 7
+    // through col 10 (anchor), and the call is normalized to start at col 7.
+    for (let i = 0; i < 5; i++) head = moveCell(head, "left", terminal);
+    expect(head).toEqual({ col: 7, row: 1 });
+    applySelection(terminal, anchor, head);
+    expect(fakeOf(terminal).selectCalls.pop()).toEqual({ col: 7, row: 1, length: 4 });
+  });
+});

--- a/apps/web/tests/terminal-selection.test.ts
+++ b/apps/web/tests/terminal-selection.test.ts
@@ -105,9 +105,13 @@ describe("findWordBoundaries", () => {
     expect(findWordBoundaries(line, 3)).toEqual({ start: 3, end: 4 });
   });
 
-  it("handles col past end of line by returning a 1-cell range", () => {
+  it("handles col past end of line by returning a 1-cell range at the line end", () => {
     const line = "abc";
-    expect(findWordBoundaries(line, 10)).toEqual({ start: 3, end: 11 });
+    expect(findWordBoundaries(line, 10)).toEqual({ start: 3, end: 4 });
+  });
+
+  it("handles col past end of an empty line by returning a 1-cell range at 0", () => {
+    expect(findWordBoundaries("", 5)).toEqual({ start: 0, end: 1 });
   });
 });
 

--- a/apps/web/tests/terminal-toolbar.test.ts
+++ b/apps/web/tests/terminal-toolbar.test.ts
@@ -14,9 +14,8 @@
  * observable effect: bytes sent, clipboard writes, or DOM/state changes.
  */
 import type { Terminal } from "@xterm/xterm";
-import { createElement } from "react";
+import { act, createElement } from "react";
 import { createRoot, type Root } from "react-dom/client";
-import { act } from "react-dom/test-utils";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { TerminalToolbar } from "../src/components/TerminalToolbar";
 import { useVirtualKeyboardToolbar } from "../src/hooks/useVirtualKeyboardToolbar";
@@ -456,11 +455,24 @@ describe("TerminalToolbar – special keys", () => {
     const ctrlBtn = container.querySelector(
       "button[aria-label='Arm Ctrl modifier']",
     ) as HTMLButtonElement;
-    expect(ctrlBtn.getAttribute("aria-pressed")).toBeNull();
+    // WAI-ARIA: toggle buttons must have `aria-pressed="false"` (not absent)
+    // when not pressed so assistive tech announces the toggle semantics on
+    // first encounter.
+    expect(ctrlBtn.getAttribute("aria-pressed")).toBe("false");
     act(() => {
       dispatchPointerDown(ctrlBtn);
     });
     expect(onToggleCtrl).toHaveBeenCalledTimes(1);
+    unmount(root, container);
+  });
+
+  it("non-toggle buttons (e.g. Paste) omit aria-pressed entirely", () => {
+    const term = makeFakeTerminal();
+    const { container, root } = mount({ terminal: term, sendInput: () => {} });
+    const pasteBtn = container.querySelector(
+      "button[aria-label='Paste from clipboard']",
+    ) as HTMLButtonElement;
+    expect(pasteBtn.getAttribute("aria-pressed")).toBeNull();
     unmount(root, container);
   });
 

--- a/apps/web/tests/terminal-toolbar.test.ts
+++ b/apps/web/tests/terminal-toolbar.test.ts
@@ -150,6 +150,7 @@ function mount(props: {
   selectionMode?: boolean;
   onExtendSelection?: (direction: "left" | "right" | "up" | "down") => void;
   onExitSelection?: () => void;
+  onSelectAll?: () => void;
 }): { container: HTMLDivElement; root: Root } {
   const container = document.createElement("div");
   document.body.appendChild(container);
@@ -165,6 +166,7 @@ function mount(props: {
         selectionMode: props.selectionMode ?? false,
         onExtendSelection: props.onExtendSelection ?? (() => {}),
         onExitSelection: props.onExitSelection ?? (() => {}),
+        onSelectAll: props.onSelectAll ?? (() => {}),
       }),
     );
   });
@@ -348,31 +350,12 @@ describe("TerminalToolbar – clipboard actions", () => {
     }
   });
 
-  it("Copy writes the terminal selection to the clipboard", async () => {
+  it("idle toolbar has no Copy button (Copy lives in selection mode)", () => {
     const term = makeFakeTerminal("hello world");
     const { container, root } = mount({ terminal: term, sendInput: () => {} });
-    const copyBtn = container.querySelector(
-      "button[aria-label='Copy selection']",
-    ) as HTMLButtonElement;
-    expect(copyBtn).not.toBeNull();
-    expect(copyBtn.disabled).toBe(false);
-    await act(async () => {
-      dispatchPointerDown(copyBtn);
-      // Microtask flush so the async handler resolves before we assert.
-      await Promise.resolve();
-    });
-    expect(writeText).toHaveBeenCalledTimes(1);
-    expect(writeText).toHaveBeenCalledWith("hello world");
-    unmount(root, container);
-  });
-
-  it("Copy button is disabled when there is no selection", () => {
-    const term = makeFakeTerminal("");
-    const { container, root } = mount({ terminal: term, sendInput: () => {} });
-    const copyBtn = container.querySelector(
-      "button[aria-label='Copy selection']",
-    ) as HTMLButtonElement;
-    expect(copyBtn.disabled).toBe(true);
+    // Aria labels for Copy in either mode.
+    expect(container.querySelector("button[aria-label='Copy selection']")).toBeNull();
+    expect(container.querySelector("button[aria-label='Copy selection and exit']")).toBeNull();
     unmount(root, container);
   });
 
@@ -414,15 +397,23 @@ describe("TerminalToolbar – clipboard actions", () => {
     unmount(root, container);
   });
 
-  it("Select All asks xterm to select everything and re-focuses", () => {
+  it("Select All delegates to onSelectAll (parent flips into selection mode)", () => {
+    const onSelectAll = vi.fn();
     const term = makeFakeTerminal();
-    const { container, root } = mount({ terminal: term, sendInput: () => {} });
+    const { container, root } = mount({
+      terminal: term,
+      sendInput: () => {},
+      onSelectAll,
+    });
     const allBtn = container.querySelector("button[aria-label='Select all']") as HTMLButtonElement;
     act(() => {
       dispatchPointerDown(allBtn);
     });
-    expect(term.selectAllCalls).toBe(1);
-    expect(term.focusCalls).toBe(1);
+    // The toolbar no longer pokes the terminal directly — the parent owns
+    // both the selection-state flip and the actual xterm call. We only
+    // assert that the prop fired.
+    expect(onSelectAll).toHaveBeenCalledTimes(1);
+    expect(term.selectAllCalls).toBe(0);
     unmount(root, container);
   });
 });

--- a/apps/web/tests/terminal-toolbar.test.ts
+++ b/apps/web/tests/terminal-toolbar.test.ts
@@ -255,6 +255,35 @@ describe("useVirtualKeyboardToolbar", () => {
     expect(result.current?.bottomOffset).toBe(0);
     u();
   });
+
+  it("contentBottomInset is positive on touch devices so the terminal can reserve space", () => {
+    setTouchDevice(true);
+    const { result, unmount: u } = renderToolbarHook();
+    // Specific value is documented in the hook; just assert it's the toolbar
+    // height and not, say, equal to bottomOffset (a common bug would be to
+    // conflate the two).
+    expect(result.current?.contentBottomInset).toBeGreaterThan(0);
+    expect(result.current?.contentBottomInset).not.toBe(result.current?.bottomOffset);
+    u();
+  });
+
+  it("contentBottomInset stays at 0 on desktop so the layout is untouched", () => {
+    setTouchDevice(false);
+    const { result, unmount: u } = renderToolbarHook();
+    expect(result.current?.contentBottomInset).toBe(0);
+    u();
+  });
+
+  it("contentBottomInset does NOT grow when the keyboard opens (toolbar is fixed-height)", () => {
+    setTouchDevice(true);
+    const { result, unmount: u } = renderToolbarHook();
+    const before = result.current?.contentBottomInset;
+    act(() => {
+      setKeyboardOpen(300);
+    });
+    expect(result.current?.contentBottomInset).toBe(before);
+    u();
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/apps/web/tests/terminal-toolbar.test.ts
+++ b/apps/web/tests/terminal-toolbar.test.ts
@@ -147,6 +147,9 @@ function mount(props: {
   sendInput: (data: string) => void;
   pendingCtrl?: boolean;
   onToggleCtrl?: () => void;
+  selectionMode?: boolean;
+  onExtendSelection?: (direction: "left" | "right" | "up" | "down") => void;
+  onExitSelection?: () => void;
 }): { container: HTMLDivElement; root: Root } {
   const container = document.createElement("div");
   document.body.appendChild(container);
@@ -159,6 +162,9 @@ function mount(props: {
         sendInput: props.sendInput,
         pendingCtrl: props.pendingCtrl ?? false,
         onToggleCtrl: props.onToggleCtrl ?? (() => {}),
+        selectionMode: props.selectionMode ?? false,
+        onExtendSelection: props.onExtendSelection ?? (() => {}),
+        onExitSelection: props.onExitSelection ?? (() => {}),
       }),
     );
   });
@@ -451,5 +457,136 @@ describe("TerminalToolbar – special keys", () => {
     expect(ctrlBtn).not.toBeNull();
     expect(ctrlBtn.getAttribute("aria-pressed")).toBe("true");
     unmount(root, container);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Selection-mode layout
+// ---------------------------------------------------------------------------
+
+describe("TerminalToolbar – selection mode", () => {
+  beforeEach(() => {
+    setTouchDevice(true);
+  });
+
+  it("renders the selection layout when selectionMode is true", () => {
+    const term = makeFakeTerminal("hello");
+    const { container, root } = mount({
+      terminal: term,
+      sendInput: () => {},
+      selectionMode: true,
+    });
+    const bar = container.querySelector("[data-testid='terminal-toolbar']") as HTMLElement;
+    expect(bar.getAttribute("data-mode")).toBe("selection");
+    // Idle-only controls should not be present.
+    expect(container.querySelector("button[aria-label='Paste from clipboard']")).toBeNull();
+    expect(container.querySelector("button[aria-label='Select all']")).toBeNull();
+    expect(container.querySelector("button[aria-label='Arm Ctrl modifier']")).toBeNull();
+    expect(container.querySelector("button[aria-label='Send Escape']")).toBeNull();
+    expect(container.querySelector("button[aria-label='Send Tab']")).toBeNull();
+    // The four extend buttons + Copy + Done should be present.
+    expect(container.querySelector("button[aria-label='Copy selection and exit']")).not.toBeNull();
+    expect(container.querySelector("button[aria-label='Exit selection mode']")).not.toBeNull();
+    for (const aria of [
+      "Extend selection left",
+      "Extend selection right",
+      "Extend selection up",
+      "Extend selection down",
+    ]) {
+      expect(container.querySelector(`button[aria-label='${aria}']`)).not.toBeNull();
+    }
+    unmount(root, container);
+  });
+
+  it("arrow buttons call onExtendSelection with the matching direction", () => {
+    const onExtendSelection = vi.fn();
+    const term = makeFakeTerminal("text");
+    const { container, root } = mount({
+      terminal: term,
+      sendInput: () => {},
+      selectionMode: true,
+      onExtendSelection,
+    });
+    const tap = (label: string) => {
+      const btn = container.querySelector(`button[aria-label='${label}']`) as HTMLButtonElement;
+      act(() => {
+        dispatchPointerDown(btn);
+      });
+    };
+    tap("Extend selection left");
+    tap("Extend selection right");
+    tap("Extend selection up");
+    tap("Extend selection down");
+    expect(onExtendSelection.mock.calls.map((c) => c[0])).toEqual(["left", "right", "up", "down"]);
+    unmount(root, container);
+  });
+
+  it("Done exits selection mode without copying", () => {
+    const onExitSelection = vi.fn();
+    let writeText: ReturnType<typeof vi.fn> | undefined;
+    const originalClipboard = navigator.clipboard;
+    writeText = vi.fn(() => Promise.resolve());
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { writeText, readText: () => Promise.resolve("") },
+    });
+    try {
+      const term = makeFakeTerminal("text");
+      const { container, root } = mount({
+        terminal: term,
+        sendInput: () => {},
+        selectionMode: true,
+        onExitSelection,
+      });
+      const doneBtn = container.querySelector(
+        "button[aria-label='Exit selection mode']",
+      ) as HTMLButtonElement;
+      act(() => {
+        dispatchPointerDown(doneBtn);
+      });
+      expect(onExitSelection).toHaveBeenCalledTimes(1);
+      expect(writeText).not.toHaveBeenCalled();
+      unmount(root, container);
+    } finally {
+      Object.defineProperty(navigator, "clipboard", {
+        configurable: true,
+        value: originalClipboard,
+      });
+    }
+  });
+
+  it("Copy in selection mode copies the selection AND exits selection mode", async () => {
+    const onExitSelection = vi.fn();
+    const writeText = vi.fn(() => Promise.resolve());
+    const originalClipboard = navigator.clipboard;
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { writeText, readText: () => Promise.resolve("") },
+    });
+    try {
+      const term = makeFakeTerminal("selected text");
+      const { container, root } = mount({
+        terminal: term,
+        sendInput: () => {},
+        selectionMode: true,
+        onExitSelection,
+      });
+      const copyBtn = container.querySelector(
+        "button[aria-label='Copy selection and exit']",
+      ) as HTMLButtonElement;
+      await act(async () => {
+        dispatchPointerDown(copyBtn);
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+      expect(writeText).toHaveBeenCalledWith("selected text");
+      expect(onExitSelection).toHaveBeenCalledTimes(1);
+      unmount(root, container);
+    } finally {
+      Object.defineProperty(navigator, "clipboard", {
+        configurable: true,
+        value: originalClipboard,
+      });
+    }
   });
 });

--- a/apps/web/tests/terminal-toolbar.test.ts
+++ b/apps/web/tests/terminal-toolbar.test.ts
@@ -393,7 +393,7 @@ describe("TerminalToolbar – clipboard actions", () => {
     unmount(root, container);
   });
 
-  it("Paste silently swallows clipboard denial (no exception bubbles)", async () => {
+  it("Paste silently swallows clipboard denial — no input sent, no throw", async () => {
     readText.mockRejectedValueOnce(new Error("denied"));
     const sent: string[] = [];
     const term = makeFakeTerminal();
@@ -401,15 +401,16 @@ describe("TerminalToolbar – clipboard actions", () => {
     const pasteBtn = container.querySelector(
       "button[aria-label='Paste from clipboard']",
     ) as HTMLButtonElement;
-    const errorSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    // The new `readClipboardText` helper swallows denial silently and
+    // returns "" — there's no console.warn anymore. Asserting that nothing
+    // got sent is sufficient: a thrown exception would have failed the act
+    // wrapper.
     await act(async () => {
       dispatchPointerDown(pasteBtn);
       await Promise.resolve();
       await Promise.resolve();
     });
     expect(sent).toEqual([]);
-    expect(errorSpy).toHaveBeenCalled();
-    errorSpy.mockRestore();
     unmount(root, container);
   });
 

--- a/apps/web/tests/terminal-toolbar.test.ts
+++ b/apps/web/tests/terminal-toolbar.test.ts
@@ -1,0 +1,455 @@
+// @vitest-environment jsdom
+/**
+ * Behaviour tests for the iOS terminal accessory toolbar (issue #390).
+ *
+ * These tests exercise the *real* React component + hook through the DOM —
+ * we do not mock TerminalToolbar or useVirtualKeyboardToolbar. The only
+ * dependencies we stub are the browser primitives those modules touch
+ * (matchMedia, visualViewport, navigator.clipboard) and the xterm.js
+ * Terminal instance (whose public surface is well-defined: hasSelection /
+ * getSelection / selectAll / focus).
+ *
+ * Each test mounts the component, simulates a `pointerdown` (the gesture iOS
+ * Safari requires for clipboard access), and asserts the externally
+ * observable effect: bytes sent, clipboard writes, or DOM/state changes.
+ */
+import type { Terminal } from "@xterm/xterm";
+import { createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { act } from "react-dom/test-utils";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { TerminalToolbar } from "../src/components/TerminalToolbar";
+import { useVirtualKeyboardToolbar } from "../src/hooks/useVirtualKeyboardToolbar";
+
+// ---------------------------------------------------------------------------
+// Browser primitive stubs.
+// jsdom omits matchMedia + visualViewport. We install them globally and let
+// each test override the matchMedia result (touch vs desktop) and viewport
+// dimensions (keyboard open vs closed).
+// ---------------------------------------------------------------------------
+
+beforeAll(() => {
+  (globalThis as Record<string, unknown>).IS_REACT_ACT_ENVIRONMENT = true;
+});
+
+let matchMediaResult: { matches: boolean; listeners: Set<(e: MediaQueryListEvent) => void> };
+let vvHeight: number;
+let vvOffsetTop: number;
+let vvListeners: Set<() => void>;
+let originalMatchMedia: typeof window.matchMedia | undefined;
+let originalVisualViewport: VisualViewport | undefined;
+
+beforeEach(() => {
+  matchMediaResult = { matches: true, listeners: new Set() };
+  originalMatchMedia = window.matchMedia;
+  window.matchMedia = ((query: string) => ({
+    matches: matchMediaResult.matches,
+    media: query,
+    onchange: null,
+    addListener: () => {},
+    removeListener: () => {},
+    addEventListener: (_event: string, cb: (e: MediaQueryListEvent) => void) => {
+      matchMediaResult.listeners.add(cb);
+    },
+    removeEventListener: (_event: string, cb: (e: MediaQueryListEvent) => void) => {
+      matchMediaResult.listeners.delete(cb);
+    },
+    dispatchEvent: () => false,
+  })) as typeof window.matchMedia;
+
+  vvHeight = 800;
+  vvOffsetTop = 0;
+  vvListeners = new Set();
+  // window.innerHeight defaults to 768 in jsdom; force a known value.
+  Object.defineProperty(window, "innerHeight", { value: 800, configurable: true });
+  originalVisualViewport = window.visualViewport ?? undefined;
+  Object.defineProperty(window, "visualViewport", {
+    configurable: true,
+    value: {
+      get height() {
+        return vvHeight;
+      },
+      get offsetTop() {
+        return vvOffsetTop;
+      },
+      addEventListener: (_event: string, cb: () => void) => {
+        vvListeners.add(cb);
+      },
+      removeEventListener: (_event: string, cb: () => void) => {
+        vvListeners.delete(cb);
+      },
+    },
+  });
+});
+
+afterEach(() => {
+  if (originalMatchMedia) window.matchMedia = originalMatchMedia;
+  if (originalVisualViewport !== undefined) {
+    Object.defineProperty(window, "visualViewport", {
+      configurable: true,
+      value: originalVisualViewport,
+    });
+  }
+});
+
+afterAll(() => {
+  // Restore jsdom defaults for any cross-file leakage.
+  Reflect.deleteProperty(window, "visualViewport");
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function setKeyboardOpen(keyboardPx: number) {
+  vvHeight = 800 - keyboardPx;
+  for (const cb of vvListeners) cb();
+}
+
+function setTouchDevice(touch: boolean) {
+  matchMediaResult.matches = touch;
+  // matchMedia listeners receive a MediaQueryListEvent — we only read .matches.
+  for (const cb of matchMediaResult.listeners) {
+    cb({ matches: touch } as MediaQueryListEvent);
+  }
+}
+
+interface FakeTerminal {
+  selection: string;
+  selectAllCalls: number;
+  focusCalls: number;
+  hasSelection: () => boolean;
+  getSelection: () => string;
+  selectAll: () => void;
+  focus: () => void;
+}
+
+function makeFakeTerminal(initialSelection = ""): FakeTerminal {
+  const t: FakeTerminal = {
+    selection: initialSelection,
+    selectAllCalls: 0,
+    focusCalls: 0,
+    hasSelection: () => t.selection.length > 0,
+    getSelection: () => t.selection,
+    selectAll: () => {
+      t.selectAllCalls += 1;
+      t.selection = "all-selected";
+    },
+    focus: () => {
+      t.focusCalls += 1;
+    },
+  };
+  return t;
+}
+
+function mount(props: {
+  terminal: FakeTerminal;
+  sendInput: (data: string) => void;
+  pendingCtrl?: boolean;
+  onToggleCtrl?: () => void;
+}): { container: HTMLDivElement; root: Root } {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  let root: Root;
+  act(() => {
+    root = createRoot(container);
+    root.render(
+      createElement(TerminalToolbar, {
+        terminal: props.terminal as unknown as Terminal,
+        sendInput: props.sendInput,
+        pendingCtrl: props.pendingCtrl ?? false,
+        onToggleCtrl: props.onToggleCtrl ?? (() => {}),
+      }),
+    );
+  });
+  return { container, root: root as Root };
+}
+
+function unmount(root: Root, container: HTMLDivElement) {
+  act(() => {
+    root.unmount();
+  });
+  container.remove();
+}
+
+function dispatchPointerDown(el: Element) {
+  // jsdom doesn't ship a PointerEvent constructor; React's synthetic event
+  // bridge accepts a MouseEvent of type "pointerdown" just fine for the
+  // pointerdown listener we attach in the toolbar.
+  const ev = new MouseEvent("pointerdown", { bubbles: true, cancelable: true });
+  el.dispatchEvent(ev);
+}
+
+// ---------------------------------------------------------------------------
+// Hook: useVirtualKeyboardToolbar
+// ---------------------------------------------------------------------------
+
+describe("useVirtualKeyboardToolbar", () => {
+  function renderToolbarHook() {
+    const result: { current: ReturnType<typeof useVirtualKeyboardToolbar> | undefined } = {
+      current: undefined,
+    };
+    function TestComponent() {
+      result.current = useVirtualKeyboardToolbar();
+      return null;
+    }
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    let root: Root;
+    act(() => {
+      root = createRoot(container);
+      root.render(createElement(TestComponent));
+    });
+    return {
+      result,
+      unmount: () => unmount(root as Root, container),
+    };
+  }
+
+  it("returns enabled=true on touch-only devices", () => {
+    setTouchDevice(true);
+    const { result, unmount: u } = renderToolbarHook();
+    expect(result.current?.enabled).toBe(true);
+    u();
+  });
+
+  it("returns enabled=false on desktop (hover-capable pointer)", () => {
+    setTouchDevice(false);
+    const { result, unmount: u } = renderToolbarHook();
+    expect(result.current?.enabled).toBe(false);
+    u();
+  });
+
+  it("bottomOffset is 0 when the virtual keyboard is closed", () => {
+    setTouchDevice(true);
+    const { result, unmount: u } = renderToolbarHook();
+    expect(result.current?.bottomOffset).toBe(0);
+    u();
+  });
+
+  it("bottomOffset tracks the keyboard pixel height when open", () => {
+    setTouchDevice(true);
+    const { result, unmount: u } = renderToolbarHook();
+    act(() => {
+      setKeyboardOpen(300);
+    });
+    expect(result.current?.bottomOffset).toBe(300);
+    u();
+  });
+
+  it("clamps a negative measurement to 0 (defensive against stale geometry)", () => {
+    setTouchDevice(true);
+    const { result, unmount: u } = renderToolbarHook();
+    act(() => {
+      // Visual viewport reports MORE area than window.innerHeight — should not
+      // push the toolbar off-screen.
+      vvHeight = 1000;
+      for (const cb of vvListeners) cb();
+    });
+    expect(result.current?.bottomOffset).toBe(0);
+    u();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Component: TerminalToolbar
+// ---------------------------------------------------------------------------
+
+describe("TerminalToolbar – visibility", () => {
+  it("renders nothing on desktop", () => {
+    setTouchDevice(false);
+    const term = makeFakeTerminal();
+    const { container, root } = mount({ terminal: term, sendInput: () => {} });
+    expect(container.querySelector("[data-testid='terminal-toolbar']")).toBeNull();
+    unmount(root, container);
+  });
+
+  it("renders the toolbar on touch-only devices", () => {
+    setTouchDevice(true);
+    const term = makeFakeTerminal();
+    const { container, root } = mount({ terminal: term, sendInput: () => {} });
+    expect(container.querySelector("[data-testid='terminal-toolbar']")).not.toBeNull();
+    unmount(root, container);
+  });
+
+  it("positions itself bottomOffset pixels above the viewport bottom", () => {
+    setTouchDevice(true);
+    const term = makeFakeTerminal();
+    const { container, root } = mount({ terminal: term, sendInput: () => {} });
+    // Open the keyboard *after* the toolbar is mounted to exercise the
+    // visualViewport resize subscription.
+    act(() => {
+      setKeyboardOpen(280);
+    });
+    const el = container.querySelector("[data-testid='terminal-toolbar']") as HTMLElement;
+    expect(el).not.toBeNull();
+    expect(el.style.bottom).toBe("280px");
+    unmount(root, container);
+  });
+});
+
+describe("TerminalToolbar – clipboard actions", () => {
+  let writeText: ReturnType<typeof vi.fn>;
+  let readText: ReturnType<typeof vi.fn>;
+  let originalClipboard: Clipboard | undefined;
+
+  beforeEach(() => {
+    setTouchDevice(true);
+    writeText = vi.fn(() => Promise.resolve());
+    readText = vi.fn(() => Promise.resolve("pasted-text"));
+    originalClipboard = navigator.clipboard;
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { writeText, readText },
+    });
+  });
+
+  afterEach(() => {
+    if (originalClipboard !== undefined) {
+      Object.defineProperty(navigator, "clipboard", {
+        configurable: true,
+        value: originalClipboard,
+      });
+    }
+  });
+
+  it("Copy writes the terminal selection to the clipboard", async () => {
+    const term = makeFakeTerminal("hello world");
+    const { container, root } = mount({ terminal: term, sendInput: () => {} });
+    const copyBtn = container.querySelector(
+      "button[aria-label='Copy selection']",
+    ) as HTMLButtonElement;
+    expect(copyBtn).not.toBeNull();
+    expect(copyBtn.disabled).toBe(false);
+    await act(async () => {
+      dispatchPointerDown(copyBtn);
+      // Microtask flush so the async handler resolves before we assert.
+      await Promise.resolve();
+    });
+    expect(writeText).toHaveBeenCalledTimes(1);
+    expect(writeText).toHaveBeenCalledWith("hello world");
+    unmount(root, container);
+  });
+
+  it("Copy button is disabled when there is no selection", () => {
+    const term = makeFakeTerminal("");
+    const { container, root } = mount({ terminal: term, sendInput: () => {} });
+    const copyBtn = container.querySelector(
+      "button[aria-label='Copy selection']",
+    ) as HTMLButtonElement;
+    expect(copyBtn.disabled).toBe(true);
+    unmount(root, container);
+  });
+
+  it("Paste reads the clipboard and forwards via sendInput", async () => {
+    const sent: string[] = [];
+    const term = makeFakeTerminal();
+    const { container, root } = mount({ terminal: term, sendInput: (d) => sent.push(d) });
+    const pasteBtn = container.querySelector(
+      "button[aria-label='Paste from clipboard']",
+    ) as HTMLButtonElement;
+    await act(async () => {
+      dispatchPointerDown(pasteBtn);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(readText).toHaveBeenCalledTimes(1);
+    expect(sent).toEqual(["pasted-text"]);
+    unmount(root, container);
+  });
+
+  it("Paste silently swallows clipboard denial (no exception bubbles)", async () => {
+    readText.mockRejectedValueOnce(new Error("denied"));
+    const sent: string[] = [];
+    const term = makeFakeTerminal();
+    const { container, root } = mount({ terminal: term, sendInput: (d) => sent.push(d) });
+    const pasteBtn = container.querySelector(
+      "button[aria-label='Paste from clipboard']",
+    ) as HTMLButtonElement;
+    const errorSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    await act(async () => {
+      dispatchPointerDown(pasteBtn);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(sent).toEqual([]);
+    expect(errorSpy).toHaveBeenCalled();
+    errorSpy.mockRestore();
+    unmount(root, container);
+  });
+
+  it("Select All asks xterm to select everything and re-focuses", () => {
+    const term = makeFakeTerminal();
+    const { container, root } = mount({ terminal: term, sendInput: () => {} });
+    const allBtn = container.querySelector("button[aria-label='Select all']") as HTMLButtonElement;
+    act(() => {
+      dispatchPointerDown(allBtn);
+    });
+    expect(term.selectAllCalls).toBe(1);
+    expect(term.focusCalls).toBe(1);
+    unmount(root, container);
+  });
+});
+
+describe("TerminalToolbar – special keys", () => {
+  beforeEach(() => {
+    setTouchDevice(true);
+  });
+
+  it("Esc, Tab, and arrow keys send the canonical ANSI escape sequences", () => {
+    const sent: string[] = [];
+    const term = makeFakeTerminal();
+    const { container, root } = mount({ terminal: term, sendInput: (d) => sent.push(d) });
+    const tap = (label: string) => {
+      const btn = container.querySelector(`button[aria-label='${label}']`) as HTMLButtonElement;
+      expect(btn).not.toBeNull();
+      act(() => {
+        dispatchPointerDown(btn);
+      });
+    };
+    tap("Send Escape");
+    tap("Send Tab");
+    tap("Arrow Up");
+    tap("Arrow Down");
+    tap("Arrow Left");
+    tap("Arrow Right");
+    expect(sent).toEqual(["\x1b", "\t", "\x1b[A", "\x1b[B", "\x1b[D", "\x1b[C"]);
+    unmount(root, container);
+  });
+
+  it("Ctrl button toggles a pending state via onToggleCtrl", () => {
+    const onToggleCtrl = vi.fn();
+    const term = makeFakeTerminal();
+    const { container, root } = mount({
+      terminal: term,
+      sendInput: () => {},
+      pendingCtrl: false,
+      onToggleCtrl,
+    });
+    const ctrlBtn = container.querySelector(
+      "button[aria-label='Arm Ctrl modifier']",
+    ) as HTMLButtonElement;
+    expect(ctrlBtn.getAttribute("aria-pressed")).toBeNull();
+    act(() => {
+      dispatchPointerDown(ctrlBtn);
+    });
+    expect(onToggleCtrl).toHaveBeenCalledTimes(1);
+    unmount(root, container);
+  });
+
+  it("renders the Ctrl button as pressed when pendingCtrl is true", () => {
+    const term = makeFakeTerminal();
+    const { container, root } = mount({
+      terminal: term,
+      sendInput: () => {},
+      pendingCtrl: true,
+      onToggleCtrl: () => {},
+    });
+    const ctrlBtn = container.querySelector(
+      "button[aria-label='Cancel pending Ctrl']",
+    ) as HTMLButtonElement;
+    expect(ctrlBtn).not.toBeNull();
+    expect(ctrlBtn.getAttribute("aria-pressed")).toBe("true");
+    unmount(root, container);
+  });
+});


### PR DESCRIPTION
## Summary

Two parts:

**1. Floating accessory toolbar (above the iOS virtual keyboard)**

A `position: fixed` toolbar that tracks the visual viewport so it sits just above the soft keyboard when open and pins to the screen bottom when closed. Visibility gated by `(hover: none) and (pointer: coarse)` — never paints on desktop. Idle layout: **Copy · Paste · Select All · Esc · Tab · Ctrl · ← → ↑ ↓** (arrows send ANSI escapes to the PTY).

**2. Long-press → word select → arrow-extend**

Touch-driven selection without the cost of drag-extend with handles:

1. A 500ms long-press inside the terminal resolves the touch point to a buffer cell, expands to word boundaries on that line, and calls `terminal.select(...)`.
2. The toolbar swaps to its selection layout: **Copy · Done · ← → ↑ ↓** (arrows now extend the highlighted range cell-by-cell, with the "head" cell moving and the anchor staying fixed; selection flips direction naturally when the head crosses the anchor).
3. **Copy** writes `terminal.getSelection()` to the clipboard and exits. **Done** exits without copying. **Tap on the terminal** exits and re-focuses, matching iOS's edit-menu dismiss UX.

Sticky **Ctrl** (idle mode only): arms a pending modifier that the next iOS keyboard letter consumes as Ctrl+letter (mapped to control bytes 0x01..0x1A by the existing `attachCustomKeyEventHandler`). Matches Termius / Blink behavior.

Closes #390.

## Why arrow-extend instead of drag-extend

The finger occludes a 7px terminal cell, so drag-extend on a small screen needs a magnifier loupe and selection handles to be usable. Arrow-extend is precise without any of that — and ~80% of real terminal selections are single tokens (a path, a URL, an error code), which long-press alone handles. Drag-extend can be a v2 if anyone asks for multi-screen selections.

## Implementation notes

- **Pure helpers in `apps/web/src/lib/terminal-selection.ts`**: `pointToCell` (rect → buffer cell), `findWordBoundaries` (terminal-friendly token regex covering paths/URLs/version strings), `moveCell` (one-step extend with row-edge wrap and buffer clamping), `applySelection` (anchor/head → xterm `select(col, row, length)`), `wordSelectionAt`, `getLineText`. No React, no DOM mutation — testable through xterm's public buffer API.
- **Long-press detector** lives in TerminalPanel's existing touch-handler block. Cancels on >10px movement so drag-to-scroll still wins; the existing tap-to-focus path is unchanged outside of selection mode.
- **Toolbar actions** fire on `pointerdown` (not `click`) with `preventDefault()` — preserves the iOS user-gesture token for `navigator.clipboard.readText()` and keeps the soft keyboard from being dismissed by a button tap.
- **Sticky Ctrl** mirrors React state through a ref so the captured-at-mount xterm key handler can read it without a stale closure.
- **Hapatic feedback** (`navigator.vibrate(15)`) on long-press where supported; wrapped in a try/catch for policy-blocked contexts.

## Test plan

Automated (vitest jsdom — 46 tests added):

- [x] `terminal-selection.test.ts` (26 tests): `findWordBoundaries` on identifiers/paths/flags/versions, `pointToCell` clamping & viewport offset, `moveCell` wrap/clamp on all four directions, `applySelection` forward/reverse/multi-row normalization, end-to-end long-press + extend simulation including direction-flip.
- [x] `terminal-toolbar.test.ts` (20 tests): hook visibility on touch vs desktop, viewport tracking, clamping; clipboard read/write/denial; sticky Ctrl; selection-mode layout swap; arrow → `onExtendSelection` mapping; Copy-and-exit and Done.
- [x] Full jsdom suite (112 tests) passes; no regressions.
- [x] `biome check .` clean; only pre-existing warning in `DashboardShell.tsx`.
- [x] `pnpm knip` and `pnpm jscpd` clean.

Manual (real device required):

- [ ] iPhone Safari: long-press selects the right word; arrows extend cell-by-cell; Copy/Paste round-trips with system clipboard.
- [ ] iPad Safari: same, including in landscape with the keyboard floating.
- [ ] iOS PWA installed to home screen (clipboard rules are stricter — caveat in original issue).
- [ ] Confirm desktop (macOS Safari + Electron) shows no toolbar and long-press does nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)