### PR TITLE
feat(web): delete workspace tasks on removal and auto-prune >30d tasks (#416)

### DIFF
--- a/apps/web/src/lib/task-store.ts
+++ b/apps/web/src/lib/task-store.ts
@@ -161,6 +161,12 @@ export function deleteWorkspaceTasks(workspaceId: string): number {
  * a stuck `running` row from a month ago is still pruned instead of living
  * forever.
  *
+ * The query intentionally has no `status` filter: a row that's still
+ * marked `running` 30 days after it was started is by definition stale
+ * (every server boot calls `cleanupStaleTasks` to flip dangling `running`
+ * rows to `failed`, so an in-flight task can survive a server restart
+ * but not 30 days of restarts).
+ *
  * Returns the number of rows deleted.
  */
 export function deleteTasksOlderThan(cutoffMs: number): number {
@@ -195,6 +201,11 @@ export const TASK_RETENTION_MS = 30 * 24 * 60 * 60 * 1000;
 /** How often the background sweep re-runs after the first pass on boot. */
 export const TASK_PRUNE_INTERVAL_MS = 24 * 60 * 60 * 1000;
 
+// `Symbol.for` + `globalThis` rather than a plain module-scope variable so
+// the singleton survives module re-evaluation (HMR in dev, vitest worker
+// module isolation). Without this, a second `startTaskPruneScheduler()`
+// call after a reload would schedule a second timer instead of being a
+// no-op. Same pattern as `cronjob-scheduler.ts`.
 const PRUNE_SCHEDULER_KEY = Symbol.for("band.task-prune-scheduler");
 const pruneG = globalThis as unknown as Record<symbol, unknown>;
 

--- a/apps/web/src/lib/task-store.ts
+++ b/apps/web/src/lib/task-store.ts
@@ -1,5 +1,5 @@
 import { createLogger } from "@band-app/logger";
-import { and, desc, eq } from "drizzle-orm";
+import { and, desc, eq, isNull, lt, or } from "drizzle-orm";
 import { getDb } from "./db/connection";
 import { tasks } from "./db/schema";
 
@@ -133,6 +133,125 @@ export function cleanupStaleTasks(): number {
     log.info({ count }, "cleaned up stale tasks on startup");
   }
   return count;
+}
+
+/**
+ * Delete all tasks belonging to a workspace.
+ *
+ * Called when a workspace is removed (`projects.remove` in `trpc/router.ts`).
+ * Workspaces are not first-class DB rows (they live in `state.json`), so we
+ * can't lean on `ON DELETE CASCADE` — the caller is responsible for invoking
+ * this helper next to the other workspace-scoped cleanups.
+ *
+ * Returns the number of rows deleted.
+ */
+export function deleteWorkspaceTasks(workspaceId: string): number {
+  const db = getDb();
+  const result = db.delete(tasks).where(eq(tasks.workspaceId, workspaceId)).run();
+  return result.changes;
+}
+
+/**
+ * Delete tasks whose effective age timestamp is older than `cutoffMs`.
+ *
+ * "Age" is measured against `completedAt` when present, and falls back to
+ * `startedAt` for tasks that never completed (e.g. orphans from a previous
+ * crash that `cleanupStaleTasks` didn't see because the row predates the
+ * current schema, or rows that were inserted but never updated). This way
+ * a stuck `running` row from a month ago is still pruned instead of living
+ * forever.
+ *
+ * Returns the number of rows deleted.
+ */
+export function deleteTasksOlderThan(cutoffMs: number): number {
+  const db = getDb();
+  const result = db
+    .delete(tasks)
+    .where(
+      or(
+        and(isNull(tasks.completedAt), lt(tasks.startedAt, cutoffMs)),
+        // SAFETY: completedAt may be null, but the AND short-circuits via the
+        // OR above; SQLite returns false for NULL comparisons so this branch
+        // only ever matches rows with a non-null completedAt.
+        lt(tasks.completedAt, cutoffMs),
+      ),
+    )
+    .run();
+  return result.changes;
+}
+
+// ---------------------------------------------------------------------------
+// Periodic prune (issue #416)
+// ---------------------------------------------------------------------------
+
+/** Retention window for completed/abandoned task rows. */
+export const TASK_RETENTION_MS = 30 * 24 * 60 * 60 * 1000;
+
+/** How often the background sweep re-runs after the first pass on boot. */
+export const TASK_PRUNE_INTERVAL_MS = 24 * 60 * 60 * 1000;
+
+const PRUNE_SCHEDULER_KEY = Symbol.for("band.task-prune-scheduler");
+const pruneG = globalThis as unknown as Record<symbol, unknown>;
+
+interface PruneSchedulerState {
+  timer: NodeJS.Timeout | null;
+}
+
+if (!pruneG[PRUNE_SCHEDULER_KEY]) {
+  pruneG[PRUNE_SCHEDULER_KEY] = { timer: null } satisfies PruneSchedulerState;
+}
+
+const pruneState = pruneG[PRUNE_SCHEDULER_KEY] as PruneSchedulerState;
+
+/**
+ * Run a single prune pass with the default 30-day retention window.
+ * Exposed as its own export so tests (and the boot path) can trigger a
+ * deterministic sweep without standing up the interval timer.
+ */
+export function pruneOldTasks(retentionMs: number = TASK_RETENTION_MS): number {
+  const cutoff = Date.now() - retentionMs;
+  const count = deleteTasksOlderThan(cutoff);
+  if (count > 0) {
+    log.info({ count, retentionMs }, "pruned tasks older than retention window");
+  }
+  return count;
+}
+
+/**
+ * Start the background prune sweep.
+ *
+ * Runs one pass immediately, then re-runs every `intervalMs` (default 24h).
+ * Idempotent: a second call is a no-op while the previous timer is still
+ * active. The timer is `unref()`'d so it doesn't keep the event loop alive
+ * during shutdown.
+ */
+export function startTaskPruneScheduler(
+  options: { retentionMs?: number; intervalMs?: number } = {},
+): void {
+  if (pruneState.timer) return;
+
+  const retentionMs = options.retentionMs ?? TASK_RETENTION_MS;
+  const intervalMs = options.intervalMs ?? TASK_PRUNE_INTERVAL_MS;
+
+  pruneOldTasks(retentionMs);
+
+  const timer = setInterval(() => {
+    try {
+      pruneOldTasks(retentionMs);
+    } catch (err) {
+      log.error({ err }, "scheduled task prune failed");
+    }
+  }, intervalMs);
+  timer.unref();
+  pruneState.timer = timer;
+}
+
+/** Stop the background prune sweep. Used on graceful shutdown and in tests. */
+export function stopTaskPruneScheduler(): void {
+  if (pruneState.timer) {
+    clearInterval(pruneState.timer);
+    pruneState.timer = null;
+  }
 }
 
 /**

--- a/apps/web/src/lib/task-store.ts
+++ b/apps/web/src/lib/task-store.ts
@@ -165,14 +165,19 @@ export function deleteWorkspaceTasks(workspaceId: string): number {
  */
 export function deleteTasksOlderThan(cutoffMs: number): number {
   const db = getDb();
+  // NOTE: `startedAt` is `NOT NULL` in the schema, so the first branch covers
+  // every NULL-`completedAt` row that's older than the cutoff. A row with both
+  // columns NULL would match neither branch and live forever, but the insert
+  // path always sets `startedAt`, so that combination is unreachable today.
   const result = db
     .delete(tasks)
     .where(
       or(
         and(isNull(tasks.completedAt), lt(tasks.startedAt, cutoffMs)),
-        // SAFETY: completedAt may be null, but the AND short-circuits via the
-        // OR above; SQLite returns false for NULL comparisons so this branch
-        // only ever matches rows with a non-null completedAt.
+        // NULL-`completedAt` rows are already handled by the first branch.
+        // In SQLite, `NULL < cutoffMs` evaluates to NULL (falsy in a WHERE
+        // predicate), so this branch only matches rows where `completedAt`
+        // is non-null and older than the cutoff.
         lt(tasks.completedAt, cutoffMs),
       ),
     )
@@ -233,7 +238,14 @@ export function startTaskPruneScheduler(
   const retentionMs = options.retentionMs ?? TASK_RETENTION_MS;
   const intervalMs = options.intervalMs ?? TASK_PRUNE_INTERVAL_MS;
 
-  pruneOldTasks(retentionMs);
+  // Log-and-continue: a DB lock or corruption at boot time must not crash
+  // `main()` before the server binds its port. The interval handler below
+  // applies the same policy.
+  try {
+    pruneOldTasks(retentionMs);
+  } catch (err) {
+    log.error({ err }, "initial task prune on boot failed");
+  }
 
   const timer = setInterval(() => {
     try {

--- a/apps/web/src/lib/task-store.ts
+++ b/apps/web/src/lib/task-store.ts
@@ -1,5 +1,5 @@
 import { createLogger } from "@band-app/logger";
-import { and, desc, eq, isNull, lt, or } from "drizzle-orm";
+import { and, desc, eq, isNotNull, isNull, lt, or } from "drizzle-orm";
 import { getDb } from "./db/connection";
 import { tasks } from "./db/schema";
 
@@ -180,11 +180,13 @@ export function deleteTasksOlderThan(cutoffMs: number): number {
     .where(
       or(
         and(isNull(tasks.completedAt), lt(tasks.startedAt, cutoffMs)),
-        // NULL-`completedAt` rows are already handled by the first branch.
-        // In SQLite, `NULL < cutoffMs` evaluates to NULL (falsy in a WHERE
-        // predicate), so this branch only matches rows where `completedAt`
-        // is non-null and older than the cutoff.
-        lt(tasks.completedAt, cutoffMs),
+        // The explicit `isNotNull` guard is technically redundant — SQLite
+        // treats `NULL < cutoffMs` as NULL (falsy) in a WHERE predicate, so
+        // null-`completedAt` rows would be skipped here regardless. We keep
+        // it so the intent is obvious without leaning on SQLite NULL
+        // semantics, and so the query stays correct under a future Drizzle
+        // or backend swap.
+        and(isNotNull(tasks.completedAt), lt(tasks.completedAt, cutoffMs)),
       ),
     )
     .run();

--- a/apps/web/src/trpc/router.ts
+++ b/apps/web/src/trpc/router.ts
@@ -487,10 +487,20 @@ const workspacesRouter = t.router({
             // Delete persisted task history for the workspace (issue #416).
             // Tasks aren't covered by a FK cascade because workspaces aren't a
             // first-class DB row, so the cleanup is explicit here next to the
-            // other workspace-scoped removals.
-            const deletedTasks = deleteWorkspaceTasks(workspaceId);
-            if (deletedTasks > 0) {
-              log.info({ workspaceId, count: deletedTasks }, "deleted workspace tasks on removal");
+            // other workspace-scoped removals. Task cleanup is best-effort —
+            // a DB lock or WAL timeout must not abort the whole removal or
+            // suppress the `emit` below, otherwise the dashboard would keep
+            // showing the just-deleted workspace.
+            try {
+              const deletedTasks = deleteWorkspaceTasks(workspaceId);
+              if (deletedTasks > 0) {
+                log.info(
+                  { workspaceId, count: deletedTasks },
+                  "deleted workspace tasks on removal",
+                );
+              }
+            } catch (err) {
+              log.error({ workspaceId, err }, "failed to delete workspace tasks on removal");
             }
 
             // Notify subscribers (dashboard status stream) that this workspace is gone

--- a/apps/web/src/trpc/router.ts
+++ b/apps/web/src/trpc/router.ts
@@ -117,7 +117,7 @@ import {
   submitTask,
   TaskConflictError,
 } from "../lib/task-runner";
-import { listTasks, loadTask } from "../lib/task-store";
+import { deleteWorkspaceTasks, listTasks, loadTask } from "../lib/task-store";
 import { loadWorkspaceTerminalConfig } from "../lib/terminal-config";
 import {
   deleteTerminalLayout,
@@ -483,6 +483,15 @@ const workspacesRouter = t.router({
             // Clean up workspace-scoped cronjobs
             stopJobsForKey(workspaceId);
             deleteCronjobFile(workspaceId);
+
+            // Delete persisted task history for the workspace (issue #416).
+            // Tasks aren't covered by a FK cascade because workspaces aren't a
+            // first-class DB row, so the cleanup is explicit here next to the
+            // other workspace-scoped removals.
+            const deletedTasks = deleteWorkspaceTasks(workspaceId);
+            if (deletedTasks > 0) {
+              log.info({ workspaceId, count: deletedTasks }, "deleted workspace tasks on removal");
+            }
 
             // Notify subscribers (dashboard status stream) that this workspace is gone
             emit({ kind: "remove", workspaceId });

--- a/apps/web/start-server.ts
+++ b/apps/web/start-server.ts
@@ -22,7 +22,11 @@ import { mimeTypeFromFilename } from "./src/lib/mime-types.ts";
 import { checkPrereqs } from "./src/lib/process-utils.ts";
 import { runFirstTimeSetup } from "./src/lib/setup.ts";
 import { bandHome, getOrCreateToken, loadSettings, resetAgentStatuses } from "./src/lib/state.ts";
-import { cleanupStaleTasks } from "./src/lib/task-store.ts";
+import {
+  cleanupStaleTasks,
+  startTaskPruneScheduler,
+  stopTaskPruneScheduler,
+} from "./src/lib/task-store.ts";
 import { killAllTerminals } from "./src/lib/terminal-manager.ts";
 import { handleTerminalConnection } from "./src/lib/terminal-ws.ts";
 import { startTunnel, stopTunnel } from "./src/lib/tunnel.ts";
@@ -188,6 +192,11 @@ async function main() {
   // Mark any persisted "running" tasks as "failed" — no agent can be running
   // if the server just started.
   cleanupStaleTasks();
+
+  // Kick off the periodic task-history sweep (issue #416). Runs one pass
+  // immediately, then every 24h, deleting rows older than 30 days. The
+  // timer is unref()'d so it doesn't block shutdown.
+  startTaskPruneScheduler();
 
   // Reset any "working" agent statuses — no agent is active on a fresh
   // server start.
@@ -517,6 +526,7 @@ async function main() {
   const shutdown = async () => {
     stopBranchStatusPoller();
     stopCronjobScheduler();
+    stopTaskPruneScheduler();
     killAllTerminals();
     killAllServers();
     await stopTunnel().catch(() => {});

--- a/apps/web/start-server.ts
+++ b/apps/web/start-server.ts
@@ -191,6 +191,13 @@ async function main() {
 
   // Mark any persisted "running" tasks as "failed" — no agent can be running
   // if the server just started.
+  //
+  // ORDER MATTERS: this must run BEFORE `startTaskPruneScheduler` below. The
+  // prune's `completedAt`-branch only matches non-null timestamps; stamping
+  // dangling `running` rows with `completedAt = now` here ensures they're
+  // evaluated against the cutoff via `completedAt` rather than relying on
+  // the fallback to `startedAt`. Swapping these two calls would leave very
+  // old in-flight rows wedged in `running` state for one extra boot cycle.
   cleanupStaleTasks();
 
   // Kick off the periodic task-history sweep (issue #416). Runs one pass

--- a/apps/web/tests/task-cleanup.test.ts
+++ b/apps/web/tests/task-cleanup.test.ts
@@ -19,14 +19,13 @@ import { DatabaseSync } from "node:sqlite";
 import { drizzle } from "drizzle-orm/node-sqlite";
 import { migrate } from "drizzle-orm/node-sqlite/migrator";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { TASK_RETENTION_MS } from "../src/lib/task-store";
 import { seedSettings, seedState } from "./helpers/seed-state";
 import { SERVER_RUNTIME, SERVER_SCRIPT } from "./helpers/server-runtime";
 
 const PROJECT_ROOT = join(import.meta.dirname, "..");
 const DEFAULT_TOKEN = "task-cleanup-test-token";
 const MIGRATIONS_FOLDER = join(import.meta.dirname, "..", "src", "lib", "db", "migrations");
-
-const THIRTY_DAYS_MS = 30 * 24 * 60 * 60 * 1000;
 
 // ---------------------------------------------------------------------------
 // Server lifecycle (mirrors the pattern used in `tasks-crud.test.ts`)
@@ -340,7 +339,7 @@ describe("auto-prune tasks older than 30 days (issue #416)", () => {
 
   it("removes old tasks while keeping recent ones; orphaned rows fall back to startedAt; reruns are idempotent", async () => {
     const now = Date.now();
-    const old = now - THIRTY_DAYS_MS - 60_000; // 30 d + 1 min old
+    const old = now - TASK_RETENTION_MS - 60_000; // 30 d + 1 min old
     const recent = now - 60_000; // 1 min old
 
     // ── Seed the DB before the server boots ──

--- a/apps/web/tests/task-cleanup.test.ts
+++ b/apps/web/tests/task-cleanup.test.ts
@@ -84,8 +84,16 @@ async function startServer(opts: { tmpHome: string }): Promise<ServerHandle> {
           url: `http://127.0.0.1:${port}`,
           home: tmpHome,
           close: () =>
+            // SIGTERM first, but fall back to SIGKILL after 5s so a server
+            // stuck in a DB lock can't hang `afterAll` indefinitely.
             new Promise<void>((r) => {
-              child.on("exit", () => r());
+              const fallback = setTimeout(() => {
+                child.kill("SIGKILL");
+              }, 5_000);
+              child.on("exit", () => {
+                clearTimeout(fallback);
+                r();
+              });
               child.kill("SIGTERM");
             }),
         });

--- a/apps/web/tests/task-cleanup.test.ts
+++ b/apps/web/tests/task-cleanup.test.ts
@@ -1,0 +1,439 @@
+// Integration tests for issue #416 — workspace task cleanup and time-based
+// prune. Both behaviours are exercised end-to-end through the running web
+// server so the production code path is what actually wipes the rows:
+//
+//   1. `workspaces.remove` is invoked over tRPC; we then inspect the SQLite
+//      DB the server wrote to and assert the workspace's task rows are gone.
+//   2. The prune sweep runs synchronously on server boot
+//      (`startTaskPruneScheduler` in start-server.ts). We seed task rows
+//      with timestamps older than the 30-day retention window, start the
+//      server, then read the DB to confirm only the recent rows survived.
+//      A second boot against the same DB asserts the prune is idempotent.
+
+import { execFileSync, spawn } from "node:child_process";
+import { mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from "node:fs";
+import { createServer } from "node:net";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import { drizzle } from "drizzle-orm/node-sqlite";
+import { migrate } from "drizzle-orm/node-sqlite/migrator";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { seedSettings, seedState } from "./helpers/seed-state";
+import { SERVER_RUNTIME, SERVER_SCRIPT } from "./helpers/server-runtime";
+
+const PROJECT_ROOT = join(import.meta.dirname, "..");
+const DEFAULT_TOKEN = "task-cleanup-test-token";
+const MIGRATIONS_FOLDER = join(import.meta.dirname, "..", "src", "lib", "db", "migrations");
+
+const THIRTY_DAYS_MS = 30 * 24 * 60 * 60 * 1000;
+
+// ---------------------------------------------------------------------------
+// Server lifecycle (mirrors the pattern used in `tasks-crud.test.ts`)
+// ---------------------------------------------------------------------------
+
+interface ServerHandle {
+  url: string;
+  home: string;
+  close: () => Promise<void>;
+}
+
+function createTmpHome(prefix: string): string {
+  const tmp = realpathSync(mkdtempSync(join(tmpdir(), prefix)));
+  mkdirSync(join(tmp, ".band"), { recursive: true });
+  return tmp;
+}
+
+function getRandomPort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const srv = createServer();
+    srv.listen(0, "127.0.0.1", () => {
+      const { port } = srv.address() as { port: number };
+      srv.close(() => resolve(port));
+    });
+    srv.on("error", reject);
+  });
+}
+
+async function startServer(opts: { tmpHome: string }): Promise<ServerHandle> {
+  const { tmpHome } = opts;
+  const port = await getRandomPort();
+
+  return new Promise((resolve, reject) => {
+    const child = spawn(SERVER_RUNTIME, [SERVER_SCRIPT], {
+      cwd: PROJECT_ROOT,
+      env: {
+        ...process.env,
+        HOME: tmpHome,
+        PORT: String(port),
+        NODE_ENV: "production",
+      },
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+
+    let stderr = "";
+    let settled = false;
+
+    child.stderr!.on("data", (chunk: Buffer) => {
+      stderr += chunk.toString();
+    });
+
+    child.stdout!.on("data", (chunk: Buffer) => {
+      if (chunk.toString().includes("listening") && !settled) {
+        settled = true;
+        resolve({
+          url: `http://127.0.0.1:${port}`,
+          home: tmpHome,
+          close: () =>
+            new Promise<void>((r) => {
+              child.on("exit", () => r());
+              child.kill("SIGTERM");
+            }),
+        });
+      }
+    });
+
+    child.on("error", (err) => {
+      if (!settled) {
+        settled = true;
+        reject(err);
+      }
+    });
+
+    child.on("exit", (code) => {
+      if (!settled) {
+        settled = true;
+        reject(new Error(`Server exited with code ${code} before listening.\nstderr: ${stderr}`));
+      }
+    });
+
+    setTimeout(() => {
+      if (!settled) {
+        settled = true;
+        child.kill("SIGTERM");
+        reject(new Error(`Server did not start within 15 s.\nstderr: ${stderr}`));
+      }
+    }, 15_000);
+  });
+}
+
+const defaultHeaders = { Cookie: `band_token=${DEFAULT_TOKEN}` };
+
+async function trpcMutate(serverUrl: string, procedure: string, input?: unknown) {
+  return fetch(`${serverUrl}/trpc/${procedure}`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", ...defaultHeaders },
+    body: input !== undefined ? JSON.stringify(input) : "{}",
+  });
+}
+
+// ---------------------------------------------------------------------------
+// DB helpers — same shape as the helpers in `tasks-crud.test.ts`.
+// ---------------------------------------------------------------------------
+
+function openDb(tmpHome: string): DatabaseSync {
+  const dbPath = join(tmpHome, ".band", "band.db");
+  mkdirSync(join(tmpHome, ".band"), { recursive: true });
+  const sqlite = new DatabaseSync(dbPath);
+  sqlite.exec("PRAGMA journal_mode = WAL");
+  migrate(drizzle({ client: sqlite }), { migrationsFolder: MIGRATIONS_FOLDER });
+  return sqlite;
+}
+
+interface SeedTask {
+  id: string;
+  workspaceId: string;
+  project: string;
+  branch: string;
+  prompt: string;
+  status: "running" | "completed" | "failed";
+  startedAt: number;
+  completedAt?: number | null;
+}
+
+function seedTask(sqlite: DatabaseSync, task: SeedTask): void {
+  sqlite
+    .prepare(
+      `INSERT OR REPLACE INTO tasks (id, workspace_id, project, branch, prompt, status, started_at, completed_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+    )
+    .run(
+      task.id,
+      task.workspaceId,
+      task.project,
+      task.branch,
+      task.prompt,
+      task.status,
+      task.startedAt,
+      task.completedAt ?? null,
+    );
+}
+
+function listTaskIds(sqlite: DatabaseSync): string[] {
+  const rows = sqlite.prepare("SELECT id FROM tasks ORDER BY id").all() as Array<{ id: string }>;
+  return rows.map((r) => r.id);
+}
+
+function listWorkspaceTaskIds(sqlite: DatabaseSync, workspaceId: string): string[] {
+  const rows = sqlite
+    .prepare("SELECT id FROM tasks WHERE workspace_id = ? ORDER BY id")
+    .all(workspaceId) as Array<{ id: string }>;
+  return rows.map((r) => r.id);
+}
+
+// ---------------------------------------------------------------------------
+// Git helpers
+// ---------------------------------------------------------------------------
+
+const gitEnv = {
+  ...process.env,
+  GIT_AUTHOR_NAME: "Test",
+  GIT_AUTHOR_EMAIL: "test@test.com",
+  GIT_COMMITTER_NAME: "Test",
+  GIT_COMMITTER_EMAIL: "test@test.com",
+};
+
+function git(cwd: string, args: string[]): string {
+  return execFileSync("git", args, { cwd, env: gitEnv, encoding: "utf-8" });
+}
+
+function createGitRepo(parentDir: string, name: string): string {
+  const repoPath = join(parentDir, name);
+  mkdirSync(repoPath, { recursive: true });
+  git(repoPath, ["init", "-b", "main"]);
+  writeFileSync(join(repoPath, "README.md"), "# Test\n");
+  git(repoPath, ["add", "."]);
+  git(repoPath, ["commit", "-m", "init"]);
+  return repoPath;
+}
+
+// ---------------------------------------------------------------------------
+// 1. workspaces.remove deletes the workspace's task rows
+// ---------------------------------------------------------------------------
+
+describe("workspace task cleanup on removal (issue #416)", () => {
+  let server: ServerHandle;
+  let tmpHome: string;
+
+  beforeAll(async () => {
+    tmpHome = createTmpHome("band-task-cleanup-remove-");
+    const repoPath = createGitRepo(tmpHome, "proj");
+
+    // Real git worktree for the feature branch so `workspaces.remove`'s
+    // background `git worktree remove --force` has something to chew on.
+    git(repoPath, ["branch", "feature"]);
+    git(repoPath, ["worktree", "add", join(tmpHome, "proj-feature"), "feature"]);
+
+    seedState(tmpHome, {
+      projects: [
+        {
+          name: "proj",
+          path: repoPath,
+          defaultBranch: "main",
+          worktrees: [
+            { branch: "main", path: repoPath },
+            { branch: "feature", path: join(tmpHome, "proj-feature") },
+          ],
+        },
+      ],
+    });
+    seedSettings(tmpHome, { tokenSecret: DEFAULT_TOKEN });
+
+    const now = Date.now();
+    const sqlite = openDb(tmpHome);
+    try {
+      seedTask(sqlite, {
+        id: "tsk_main_a",
+        workspaceId: "proj-main",
+        project: "proj",
+        branch: "main",
+        prompt: "main task 1",
+        status: "completed",
+        startedAt: now - 2_000,
+        completedAt: now - 1_000,
+      });
+      seedTask(sqlite, {
+        id: "tsk_main_b",
+        workspaceId: "proj-main",
+        project: "proj",
+        branch: "main",
+        prompt: "main task 2",
+        status: "failed",
+        startedAt: now - 5_000,
+        completedAt: now - 4_000,
+      });
+      seedTask(sqlite, {
+        id: "tsk_feature_a",
+        workspaceId: "proj-feature",
+        project: "proj",
+        branch: "feature",
+        prompt: "feature task 1",
+        status: "completed",
+        startedAt: now - 3_000,
+        completedAt: now - 2_500,
+      });
+    } finally {
+      sqlite.close();
+    }
+
+    server = await startServer({ tmpHome });
+  });
+
+  afterAll(async () => {
+    await server.close();
+    rmSync(tmpHome, { recursive: true, force: true });
+  });
+
+  it("deletes the workspace's tasks and leaves other workspaces untouched", async () => {
+    // Sanity-check the seed survived the server boot — `cleanupStaleTasks`
+    // can flip running rows to failed, but the rows themselves must remain
+    // because none of them are >30d old.
+    {
+      const sqlite = openDb(tmpHome);
+      try {
+        expect(listWorkspaceTaskIds(sqlite, "proj-feature")).toEqual(["tsk_feature_a"]);
+        expect(listWorkspaceTaskIds(sqlite, "proj-main").sort()).toEqual([
+          "tsk_main_a",
+          "tsk_main_b",
+        ]);
+      } finally {
+        sqlite.close();
+      }
+    }
+
+    const res = await trpcMutate(server.url, "workspaces.remove", {
+      project: "proj",
+      branch: "feature",
+    });
+    expect(res.status).toBe(200);
+
+    const sqlite = openDb(tmpHome);
+    try {
+      expect(listWorkspaceTaskIds(sqlite, "proj-feature")).toEqual([]);
+      // Other workspace's tasks remain untouched.
+      expect(listWorkspaceTaskIds(sqlite, "proj-main").sort()).toEqual([
+        "tsk_main_a",
+        "tsk_main_b",
+      ]);
+    } finally {
+      sqlite.close();
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. Auto-prune on boot deletes rows older than 30 days
+// ---------------------------------------------------------------------------
+
+describe("auto-prune tasks older than 30 days (issue #416)", () => {
+  let tmpHome: string;
+
+  beforeAll(() => {
+    tmpHome = createTmpHome("band-task-cleanup-prune-");
+    seedState(tmpHome, { projects: [] });
+    seedSettings(tmpHome, { tokenSecret: DEFAULT_TOKEN });
+  });
+
+  afterAll(() => {
+    rmSync(tmpHome, { recursive: true, force: true });
+  });
+
+  it("removes old tasks while keeping recent ones; orphaned rows fall back to startedAt; reruns are idempotent", async () => {
+    const now = Date.now();
+    const old = now - THIRTY_DAYS_MS - 60_000; // 30 d + 1 min old
+    const recent = now - 60_000; // 1 min old
+
+    // ── Seed the DB before the server boots ──
+    {
+      const sqlite = openDb(tmpHome);
+      try {
+        sqlite.exec("DELETE FROM tasks");
+        // Old completed row — must be deleted.
+        seedTask(sqlite, {
+          id: "tsk_old_completed",
+          workspaceId: "any-main",
+          project: "any",
+          branch: "main",
+          prompt: "old completed",
+          status: "completed",
+          startedAt: old - 5_000,
+          completedAt: old,
+        });
+        // Old failed row — must be deleted.
+        seedTask(sqlite, {
+          id: "tsk_old_failed",
+          workspaceId: "any-main",
+          project: "any",
+          branch: "main",
+          prompt: "old failed",
+          status: "failed",
+          startedAt: old - 10_000,
+          completedAt: old,
+        });
+        // Old orphan (no completedAt) older than 30 d by startedAt — must be deleted.
+        seedTask(sqlite, {
+          id: "tsk_old_orphan",
+          workspaceId: "any-main",
+          project: "any",
+          branch: "main",
+          prompt: "abandoned",
+          status: "failed",
+          startedAt: old,
+          completedAt: null,
+        });
+        // Recent completed row — must survive.
+        seedTask(sqlite, {
+          id: "tsk_recent_completed",
+          workspaceId: "any-main",
+          project: "any",
+          branch: "main",
+          prompt: "recent completed",
+          status: "completed",
+          startedAt: recent - 1_000,
+          completedAt: recent,
+        });
+        // Recent orphan (no completedAt) within window by startedAt — must survive.
+        seedTask(sqlite, {
+          id: "tsk_recent_orphan",
+          workspaceId: "any-main",
+          project: "any",
+          branch: "main",
+          prompt: "recent orphan",
+          status: "running",
+          startedAt: recent,
+          completedAt: null,
+        });
+      } finally {
+        sqlite.close();
+      }
+    }
+
+    // ── First boot: the scheduler runs one prune pass synchronously before
+    //     the server announces it's listening, so by the time `startServer`
+    //     resolves, the prune has already executed. ──
+    const server1 = await startServer({ tmpHome });
+    try {
+      const sqlite = openDb(tmpHome);
+      try {
+        expect(listTaskIds(sqlite).sort()).toEqual(["tsk_recent_completed", "tsk_recent_orphan"]);
+      } finally {
+        sqlite.close();
+      }
+    } finally {
+      await server1.close();
+    }
+
+    // ── Second boot against the same DB: no rows should be deleted (idempotent). ──
+    const server2 = await startServer({ tmpHome });
+    try {
+      const sqlite = openDb(tmpHome);
+      try {
+        expect(listTaskIds(sqlite).sort()).toEqual(["tsk_recent_completed", "tsk_recent_orphan"]);
+      } finally {
+        sqlite.close();
+      }
+    } finally {
+      await server2.close();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Closes #416.

Two related cleanups for the `tasks` table in the web server's SQLite DB:

1. **Workspace removal** now deletes the workspace's task rows via a new
   `deleteWorkspaceTasks(workspaceId)` helper. The call sits in
   `projects.remove` next to the other workspace-scoped cleanups
   (`removeWorkspaceChats`, `removeWorkspaceBrowsers`,
   `killWorkspaceTerminals`, `stopJobsForKey`, etc.) and runs on the
   fast path before the `emit({ kind: "remove", ... })` so subscribers
   re-read a consistent DB.

2. **Periodic time-based prune** removes tasks older than 30 days.
   `deleteTasksOlderThan(cutoffMs)` ages rows by `completedAt`, falling
   back to `startedAt` for never-completed orphans. A new
   `startTaskPruneScheduler` runs one pass synchronously on server boot
   and then re-runs every 24h; the timer is `unref()`'d and stopped from
   the `shutdown()` path.

No migration — purely additive over the existing schema. The 30-day
window and 24h interval are constants in `task-store.ts` so they can be
lifted into config later.

Out of scope (per the issue): on-disk task log files. If those exist
and aren't already cleaned up, that's a follow-up.

## Test plan

- [x] New `apps/web/tests/task-cleanup.test.ts` covers both behaviours
      end-to-end through the running web server:
  - workspace removal over tRPC, then assert the DB rows for that
    workspace are gone while another workspace's rows remain
  - seed old + recent + orphaned (no `completedAt`) task rows, boot the
    server, assert only the recent rows survive
  - second boot against the same DB is a no-op (idempotent)
- [x] `pnpm -w lint` clean (same single pre-existing warning in
      `DashboardShell.tsx` as before)
- [x] `pnpm knip` / `pnpm jscpd` clean (pre-push hook passes)
- [x] `vitest run` passes for `task-cleanup`, `tasks-crud`, `trpc`, and
      `cronjobs` (165 tests, all green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)