### PR TITLE
fix(web): resolve bundled CLI sidecar correctly in packaged Electron app

### DIFF
--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -116,6 +116,7 @@ async function resolveDashboardUrl(): Promise<string> {
   const { port, token } = await ensureWebserverRunning({
     webDir: state.webDir,
     managed: state.managed,
+    isPackaged: app.isPackaged,
   });
   state.port = port;
   return `http://localhost:${port}/?token=${encodeURIComponent(token)}`;

--- a/apps/desktop/src/main/ipc/register.ts
+++ b/apps/desktop/src/main/ipc/register.ts
@@ -77,7 +77,11 @@ export function registerIpc(opts: RegisterOptions): () => void {
   // Native window dragging is handled via CSS `-webkit-app-region: drag` on
   // the title bar — no IPC handler needed.
   handle(Channels.webserverStart, () =>
-    webserverStart({ webDir: opts.webDir, managed: opts.managed }),
+    webserverStart({
+      webDir: opts.webDir,
+      managed: opts.managed,
+      isPackaged: opts.cliPaths.isPackaged,
+    }),
   );
   handle(Channels.webserverStop, () =>
     webserverStop({ webDir: opts.webDir, managed: opts.managed }),

--- a/apps/desktop/src/main/services/web-server.ts
+++ b/apps/desktop/src/main/services/web-server.ts
@@ -153,9 +153,21 @@ export async function openServerLog(): Promise<ServerLogFds> {
 export interface SpawnWebServerOptions {
   webDir: string;
   port: number;
+  /**
+   * `app.isPackaged` from the caller. Used to set `BAND_PACKAGED=1` in the
+   * spawned web server's env so it can pick a packaged-vs-dev error
+   * message when the bundled CLI sidecar isn't found. Defaults to false so
+   * tests don't have to fake an Electron app.
+   */
+  isPackaged?: boolean;
 }
 
-function makeSpawnOptions(webDir: string, port: number, fds: ServerLogFds): SpawnOptions {
+function makeSpawnOptions(
+  webDir: string,
+  port: number,
+  fds: ServerLogFds,
+  isPackaged: boolean,
+): SpawnOptions {
   return {
     cwd: webDir,
     env: {
@@ -174,6 +186,13 @@ function makeSpawnOptions(webDir: string, port: number, fds: ServerLogFds): Spaw
       // would launch as a plain Node interpreter instead of the editor. If
       // we ever add such a call site, scrub this var from that spawn's env.
       ELECTRON_RUN_AS_NODE: "1",
+      // Signal to the bundled web server that it's running inside a
+      // packaged Electron app (not a dev `pnpm dev:desktop` run). Used by
+      // `apps/web/src/lib/cli.ts::installCli` to pick the right error
+      // message when the sidecar can't be found: ".dmg user, try
+      // reinstalling" vs. "developer, run cargo build first". Set only
+      // when truly packaged so dev-electron stays on the dev message.
+      ...(isPackaged ? { BAND_PACKAGED: "1" } : {}),
       // Repopulate PATH from the user's login shell. Even though we no
       // longer need a system `node` on PATH (spawn target is
       // `process.execPath`), the web server's *own* children — `claude`,
@@ -220,7 +239,7 @@ export async function spawnWebServer(opts: SpawnWebServerOptions): Promise<Child
   const child = spawn(
     process.execPath,
     [startScript],
-    makeSpawnOptions(opts.webDir, opts.port, fds),
+    makeSpawnOptions(opts.webDir, opts.port, fds, opts.isPackaged ?? false),
   );
   if (process.platform !== "win32") {
     // Don't let the parent process wait on the child; we manage its lifetime.
@@ -249,6 +268,8 @@ export interface EnsureWebserverOptions {
   managed: ManagedProcess;
   /** Override the configured port (defaults to settings.json / 3456). */
   port?: number;
+  /** Forwarded to `spawnWebServer` — see SpawnWebServerOptions.isPackaged. */
+  isPackaged?: boolean;
 }
 
 export interface EnsureWebserverResult {
@@ -269,7 +290,7 @@ export async function ensureWebserverRunning(
   const port = opts.port ?? getConfiguredPort();
   await killPort(port);
 
-  const child = await spawnWebServer({ webDir: opts.webDir, port });
+  const child = await spawnWebServer({ webDir: opts.webDir, port, isPackaged: opts.isPackaged });
   opts.managed.set(child);
 
   const deadline = Date.now() + HEALTH_TIMEOUT_MS;
@@ -291,6 +312,8 @@ export async function ensureWebserverRunning(
 export interface WebserverIpcContext {
   webDir: string;
   managed: ManagedProcess;
+  /** Forwarded to `spawnWebServer` — see SpawnWebServerOptions.isPackaged. */
+  isPackaged?: boolean;
 }
 
 /**
@@ -304,7 +327,7 @@ export async function webserverStart(ctx: WebserverIpcContext): Promise<void> {
   const token = tryGetToken();
   if (token && (await checkLocalHealth(port, token))) return;
 
-  const child = await spawnWebServer({ webDir: ctx.webDir, port });
+  const child = await spawnWebServer({ webDir: ctx.webDir, port, isPackaged: ctx.isPackaged });
   ctx.managed.set(child);
 }
 

--- a/apps/web/src/lib/cli.ts
+++ b/apps/web/src/lib/cli.ts
@@ -158,10 +158,29 @@ export interface InstallCliOptions {
   allowPrompt?: boolean;
 }
 
+/**
+ * Pick the right message when `findCliBinary` returns null. The two
+ * audiences are mutually exclusive: a .dmg user has no source tree (so the
+ * cargo build advice is useless), and a developer running `pnpm dev`
+ * without a built CLI has no .app bundle to reinstall. The desktop main
+ * process tags the spawned web server with `BAND_PACKAGED=1` when
+ * `app.isPackaged === true` (see `apps/desktop/src/main/services/web-server.ts`),
+ * which is the cleanest available signal — `ELECTRON_RUN_AS_NODE` is set
+ * in both packaged and dev-electron runs, so it can't distinguish them.
+ */
+export function noBinaryError(env: NodeJS.ProcessEnv = process.env): Error {
+  if (env.BAND_PACKAGED) {
+    return new Error("Bundled CLI binary missing - try reinstalling Band");
+  }
+  return new Error(
+    "Could not find band CLI binary. Build it first with: cargo build --release -p band-cli",
+  );
+}
+
 export async function installCli(_opts: InstallCliOptions = {}): Promise<void> {
   const binaryPath = findCliBinary();
   if (!binaryPath) {
-    throw new Error("Bundled CLI binary missing - try reinstalling Band");
+    throw noBinaryError();
   }
 
   const dir = dirname(SYMLINK_PATH);

--- a/apps/web/src/lib/cli.ts
+++ b/apps/web/src/lib/cli.ts
@@ -169,7 +169,12 @@ export interface InstallCliOptions {
  * in both packaged and dev-electron runs, so it can't distinguish them.
  */
 export function noBinaryError(env: NodeJS.ProcessEnv = process.env): Error {
-  if (env.BAND_PACKAGED) {
+  // Strict `=== "1"` rather than truthy: a stray `BAND_PACKAGED=0` is a
+  // non-empty string and would otherwise pick the wrong branch. The
+  // setter in `apps/desktop/src/main/services/web-server.ts` only writes
+  // "1" or omits the key, so this is defense against a future caller
+  // doing something weird, not against current behavior.
+  if (env.BAND_PACKAGED === "1") {
     return new Error("Bundled CLI binary missing - try reinstalling Band");
   }
   return new Error(

--- a/apps/web/src/lib/cli.ts
+++ b/apps/web/src/lib/cli.ts
@@ -11,16 +11,26 @@ export type CliStatus =
 
 export const SYMLINK_PATH = "/usr/local/bin/band";
 
-/** Find the CLI binary by trying multiple resolution strategies. */
-export function findCliBinary(): string | null {
+/**
+ * Pure resolver for the band CLI binary. Takes the cwd and the calling
+ * module's dirname as inputs so callers can drive it with synthetic paths in
+ * tests. The function still hits the real filesystem to confirm each
+ * candidate exists — that's the actual contract we care about — but it has
+ * no dependency on `process.cwd()` or `import.meta.dirname` so an integration
+ * test can lay out a fake packaged-app tree under a tmp dir and call this
+ * directly, without subprocess gymnastics.
+ */
+export function findCliBinaryAt(opts: { cwd: string; dirname: string }): string | null {
+  const { cwd, dirname } = opts;
+
   // --- Strategy A: cargo build output (dev & source builds) ---
   const appsStrategies = [
     // cwd = apps/web/ (Vite dev and production server)
-    resolve(process.cwd(), ".."),
+    resolve(cwd, ".."),
     // cwd = project root (fallback)
-    resolve(process.cwd(), "apps"),
+    resolve(cwd, "apps"),
     // From this source file (apps/web/src/lib/ → apps/)
-    resolve(import.meta.dirname, "..", "..", ".."),
+    resolve(dirname, "..", "..", ".."),
   ];
 
   for (const appsDir of appsStrategies) {
@@ -42,15 +52,15 @@ export function findCliBinary(): string | null {
   // `web-paths.ts::resolveWebDir`), so the sidecar is one level up and
   // across into `binaries/`. We try both the cwd-based and module-relative
   // paths so the resolution survives a future change to the spawn cwd (the
-  // import.meta.dirname path matches the bundled file's installed location
-  // at `<Resources>/web/dist/start-server.mjs`).
+  // dirname path matches the bundled file's installed location at
+  // `<Resources>/web/dist/start-server.mjs`).
   const exe = platform() === "win32" ? "band.exe" : "band";
   const electronCandidates = [
     // From cwd (<Resources>/web) → <Resources>/binaries/band
-    resolve(process.cwd(), "..", "binaries", exe),
+    resolve(cwd, "..", "binaries", exe),
     // From the bundled dist file (<Resources>/web/dist/start-server.mjs)
     // → <Resources>/binaries/band
-    resolve(import.meta.dirname, "..", "..", "binaries", exe),
+    resolve(dirname, "..", "..", "binaries", exe),
   ];
   for (const p of electronCandidates) {
     try {
@@ -62,6 +72,11 @@ export function findCliBinary(): string | null {
   }
 
   return null;
+}
+
+/** Find the CLI binary by trying multiple resolution strategies. */
+export function findCliBinary(): string | null {
+  return findCliBinaryAt({ cwd: process.cwd(), dirname: import.meta.dirname });
 }
 
 export async function checkCli(): Promise<CliStatus> {

--- a/apps/web/src/lib/cli.ts
+++ b/apps/web/src/lib/cli.ts
@@ -38,17 +38,19 @@ export function findCliBinary(): string | null {
   // --- Strategy B: Electron extraResources layout (issue #364) ---
   // electron-builder ships the sidecar at <Resources>/binaries/band on every
   // platform. The web server runs as a child of the main process with cwd
-  // set to <Resources>/web/dist by `services/web-server.ts`, so the sidecar
-  // is one level up and across into `binaries/`. We try both the cwd-based
-  // and module-relative paths so the resolution survives a future change to
-  // the spawn cwd (the import.meta.dirname path matches the bundled file's
-  // installed location).
+  // set to <Resources>/web by `services/web-server.ts` (via
+  // `web-paths.ts::resolveWebDir`), so the sidecar is one level up and
+  // across into `binaries/`. We try both the cwd-based and module-relative
+  // paths so the resolution survives a future change to the spawn cwd (the
+  // import.meta.dirname path matches the bundled file's installed location
+  // at `<Resources>/web/dist/start-server.mjs`).
   const exe = platform() === "win32" ? "band.exe" : "band";
   const electronCandidates = [
-    // From cwd (<Resources>/web/dist) → <Resources>/binaries/band
-    resolve(process.cwd(), "..", "..", "binaries", exe),
-    // From the bundled dist file (<Resources>/web/dist/...) → <Resources>/binaries/band
-    resolve(import.meta.dirname, "..", "..", "..", "binaries", exe),
+    // From cwd (<Resources>/web) → <Resources>/binaries/band
+    resolve(process.cwd(), "..", "binaries", exe),
+    // From the bundled dist file (<Resources>/web/dist/start-server.mjs)
+    // → <Resources>/binaries/band
+    resolve(import.meta.dirname, "..", "..", "binaries", exe),
   ];
   for (const p of electronCandidates) {
     try {
@@ -144,9 +146,7 @@ export interface InstallCliOptions {
 export async function installCli(_opts: InstallCliOptions = {}): Promise<void> {
   const binaryPath = findCliBinary();
   if (!binaryPath) {
-    throw new Error(
-      "Could not find band CLI binary. Build it first with: cargo build --release -p band-cli",
-    );
+    throw new Error("Bundled CLI binary missing - try reinstalling Band");
   }
 
   const dir = dirname(SYMLINK_PATH);

--- a/apps/web/tests/cli-sidecar-path.test.ts
+++ b/apps/web/tests/cli-sidecar-path.test.ts
@@ -1,0 +1,126 @@
+/**
+ * Integration test for findCliBinary() in apps/web/src/lib/cli.ts when running
+ * inside a packaged Electron build.
+ *
+ * Background: in a packaged build, electron-builder ships the web server
+ * bundle at `<Resources>/web/dist/start-server.mjs` and the CLI sidecar at
+ * `<Resources>/binaries/band`. The web server is spawned with cwd set to
+ * `<Resources>/web` (see `apps/desktop/src/main/services/web-paths.ts` ->
+ * `apps/desktop/src/main/services/web-server.ts::makeSpawnOptions`). Inside
+ * the bundle, `import.meta.dirname === <Resources>/web/dist`.
+ *
+ * Resolution must therefore reach the sidecar with:
+ *   - process.cwd() ("<Resources>/web") + ".." -> "<Resources>" -> binaries/band
+ *   - import.meta.dirname ("<Resources>/web/dist") + "../.." -> "<Resources>"
+ *     -> binaries/band
+ *
+ * An earlier off-by-one (one extra "..") landed the lookup at
+ * `Contents/binaries/band` (outside `Contents/Resources/`), so `findCliBinary`
+ * returned null and the desktop app's CLI install banner failed with a
+ * misleading cargo-build error. This test guards against the regression.
+ *
+ * Black-box: we mimic the packaged on-disk layout in a tmp dir, spawn a Node
+ * subprocess with cwd = `<tmp>/Resources/web/`, and have the subprocess import
+ * the real `findCliBinary` and print its return value. We copy `cli.ts` into
+ * `<tmp>/Resources/web/dist/` so its `import.meta.dirname` resolves to the
+ * bundled location (otherwise the function's `import.meta.dirname` would
+ * point at the real repo path and Strategy A's cargo-build lookup could win
+ * on hosts that have a `apps/cli/target/release/band` lying around).
+ */
+
+import { execFileSync } from "node:child_process";
+import {
+  chmodSync,
+  copyFileSync,
+  mkdirSync,
+  mkdtempSync,
+  realpathSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+const CLI_SOURCE = join(import.meta.dirname, "..", "src", "lib", "cli.ts");
+
+describe("findCliBinary in packaged Electron layout", () => {
+  let tmp: string;
+
+  beforeEach(() => {
+    // realpathSync to dodge macOS' /var -> /private/var symlink: spawn's cwd
+    // is canonicalised by the kernel, so `process.cwd()` inside the
+    // subprocess returns the real path. Pinning here keeps the equality
+    // assertion straightforward.
+    tmp = realpathSync(mkdtempSync(join(tmpdir(), "band-cli-sidecar-")));
+  });
+
+  afterEach(() => {
+    if (tmp) rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it("resolves <Resources>/binaries/band when cwd is <Resources>/web", () => {
+    // Lay out the packaged-app shape under <tmp>/Resources/:
+    //   <tmp>/Resources/web/dist/start-server.mjs   (the bundle)
+    //   <tmp>/Resources/binaries/band               (the sidecar)
+    const resources = join(tmp, "Resources");
+    const webDir = join(resources, "web");
+    const distDir = join(webDir, "dist");
+    const binDir = join(resources, "binaries");
+    mkdirSync(distDir, { recursive: true });
+    mkdirSync(binDir, { recursive: true });
+    writeFileSync(join(distDir, "start-server.mjs"), "// stub bundled server\n", "utf-8");
+    const sidecar = join(binDir, "band");
+    writeFileSync(sidecar, "#!/bin/sh\nexit 0\n", "utf-8");
+    chmodSync(sidecar, 0o755);
+
+    // Copy cli.ts into the bundled location so the function's
+    // `import.meta.dirname` matches what it sees in a packaged build.
+    // Without this, the real source path leaks in and Strategy A could
+    // find a cargo build outside the sandbox.
+    const bundledCli = join(distDir, "cli.ts");
+    copyFileSync(CLI_SOURCE, bundledCli);
+
+    // Spawn a Node subprocess with cwd = <Resources>/web/ that imports the
+    // bundled cli.ts and prints findCliBinary()'s return value. Type
+    // stripping is enabled by default in Node 22.6+, so importing the .ts
+    // module from a .mjs runner requires no flags.
+    const runnerScript = [
+      `import { findCliBinary } from ${JSON.stringify(bundledCli)};`,
+      `process.stdout.write(findCliBinary() ?? "<null>");`,
+    ].join("\n");
+
+    const stdout = execFileSync(process.execPath, ["--input-type=module", "-e", runnerScript], {
+      cwd: webDir,
+      encoding: "utf-8",
+    });
+
+    expect(stdout).toBe(sidecar);
+  });
+
+  it("returns null when the sidecar is absent from the packaged layout", () => {
+    // Same shape, but no `binaries/band`. Strategy A walks up from the
+    // copied cli.ts (under <tmp>/Resources/web/dist/) and finds nothing.
+    // Strategy B's candidates also miss. findCliBinary should return null.
+    const resources = join(tmp, "Resources");
+    const webDir = join(resources, "web");
+    const distDir = join(webDir, "dist");
+    mkdirSync(distDir, { recursive: true });
+    writeFileSync(join(distDir, "start-server.mjs"), "// stub bundled server\n", "utf-8");
+
+    const bundledCli = join(distDir, "cli.ts");
+    copyFileSync(CLI_SOURCE, bundledCli);
+
+    const runnerScript = [
+      `import { findCliBinary } from ${JSON.stringify(bundledCli)};`,
+      `process.stdout.write(findCliBinary() ?? "<null>");`,
+    ].join("\n");
+
+    const stdout = execFileSync(process.execPath, ["--input-type=module", "-e", runnerScript], {
+      cwd: webDir,
+      encoding: "utf-8",
+    });
+
+    expect(stdout).toBe("<null>");
+  });
+});

--- a/apps/web/tests/cli-sidecar-path.test.ts
+++ b/apps/web/tests/cli-sidecar-path.test.ts
@@ -127,7 +127,7 @@ describe("noBinaryError", () => {
     expect(err.message).toMatch(/cargo build --release -p band-cli/);
   });
 
-  it("treats BAND_PACKAGED=0 as unset (strict === \"1\" check)", () => {
+  it('treats BAND_PACKAGED=0 as unset (strict === "1" check)', () => {
     // "0" is truthy as a non-empty string but semantically means "off".
     // A truthy check would mis-route to the reinstall message.
     const err = noBinaryError({ BAND_PACKAGED: "0" });

--- a/apps/web/tests/cli-sidecar-path.test.ts
+++ b/apps/web/tests/cli-sidecar-path.test.ts
@@ -1,6 +1,6 @@
 /**
- * Integration test for findCliBinary() in apps/web/src/lib/cli.ts when running
- * inside a packaged Electron build.
+ * Integration test for the band CLI sidecar resolver in
+ * `apps/web/src/lib/cli.ts` when running inside a packaged Electron build.
  *
  * Background: in a packaged build, electron-builder ships the web server
  * bundle at `<Resources>/web/dist/start-server.mjs` and the CLI sidecar at
@@ -15,43 +15,30 @@
  *     -> binaries/band
  *
  * An earlier off-by-one (one extra "..") landed the lookup at
- * `Contents/binaries/band` (outside `Contents/Resources/`), so `findCliBinary`
+ * `Contents/binaries/band` (outside `Contents/Resources/`), so the resolver
  * returned null and the desktop app's CLI install banner failed with a
  * misleading cargo-build error. This test guards against the regression.
  *
- * Black-box: we mimic the packaged on-disk layout in a tmp dir, spawn a Node
- * subprocess with cwd = `<tmp>/Resources/web/`, and have the subprocess import
- * the real `findCliBinary` and print its return value. We copy `cli.ts` into
- * `<tmp>/Resources/web/dist/` so its `import.meta.dirname` resolves to the
- * bundled location (otherwise the function's `import.meta.dirname` would
- * point at the real repo path and Strategy A's cargo-build lookup could win
- * on hosts that have a `apps/cli/target/release/band` lying around).
+ * Black-box-ish: we mimic the packaged on-disk layout in a tmp dir and drive
+ * `findCliBinaryAt` with the synthetic cwd / dirname pair. The function
+ * still hits the real filesystem to confirm each candidate exists (which is
+ * the actual contract we care about), so this exercises the same logic the
+ * production `findCliBinary` runs — just with the path inputs injected
+ * rather than read from `process.cwd()` / `import.meta.dirname`.
  */
 
-import { execFileSync } from "node:child_process";
-import {
-  chmodSync,
-  copyFileSync,
-  mkdirSync,
-  mkdtempSync,
-  realpathSync,
-  rmSync,
-  writeFileSync,
-} from "node:fs";
+import { chmodSync, mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { findCliBinaryAt } from "../src/lib/cli";
 
-const CLI_SOURCE = join(import.meta.dirname, "..", "src", "lib", "cli.ts");
-
-describe("findCliBinary in packaged Electron layout", () => {
+describe("findCliBinaryAt in packaged Electron layout", () => {
   let tmp: string;
 
   beforeEach(() => {
-    // realpathSync to dodge macOS' /var -> /private/var symlink: spawn's cwd
-    // is canonicalised by the kernel, so `process.cwd()` inside the
-    // subprocess returns the real path. Pinning here keeps the equality
-    // assertion straightforward.
+    // realpathSync to dodge macOS' /var -> /private/var symlink so the
+    // returned path matches the expected sidecar path verbatim.
     tmp = realpathSync(mkdtempSync(join(tmpdir(), "band-cli-sidecar-")));
   });
 
@@ -59,7 +46,7 @@ describe("findCliBinary in packaged Electron layout", () => {
     if (tmp) rmSync(tmp, { recursive: true, force: true });
   });
 
-  it("resolves <Resources>/binaries/band when cwd is <Resources>/web", () => {
+  it("resolves <Resources>/binaries/band given the packaged cwd and dirname", () => {
     // Lay out the packaged-app shape under <tmp>/Resources/:
     //   <tmp>/Resources/web/dist/start-server.mjs   (the bundle)
     //   <tmp>/Resources/binaries/band               (the sidecar)
@@ -74,53 +61,25 @@ describe("findCliBinary in packaged Electron layout", () => {
     writeFileSync(sidecar, "#!/bin/sh\nexit 0\n", "utf-8");
     chmodSync(sidecar, 0o755);
 
-    // Copy cli.ts into the bundled location so the function's
-    // `import.meta.dirname` matches what it sees in a packaged build.
-    // Without this, the real source path leaks in and Strategy A could
-    // find a cargo build outside the sandbox.
-    const bundledCli = join(distDir, "cli.ts");
-    copyFileSync(CLI_SOURCE, bundledCli);
-
-    // Spawn a Node subprocess with cwd = <Resources>/web/ that imports the
-    // bundled cli.ts and prints findCliBinary()'s return value. Type
-    // stripping is enabled by default in Node 22.6+, so importing the .ts
-    // module from a .mjs runner requires no flags.
-    const runnerScript = [
-      `import { findCliBinary } from ${JSON.stringify(bundledCli)};`,
-      `process.stdout.write(findCliBinary() ?? "<null>");`,
-    ].join("\n");
-
-    const stdout = execFileSync(process.execPath, ["--input-type=module", "-e", runnerScript], {
-      cwd: webDir,
-      encoding: "utf-8",
-    });
-
-    expect(stdout).toBe(sidecar);
+    // cwd is <Resources>/web (matches the real spawn cwd) and dirname is
+    // <Resources>/web/dist (matches `import.meta.dirname` of the bundled
+    // start-server.mjs).
+    const result = findCliBinaryAt({ cwd: webDir, dirname: distDir });
+    expect(result).toBe(sidecar);
   });
 
   it("returns null when the sidecar is absent from the packaged layout", () => {
-    // Same shape, but no `binaries/band`. Strategy A walks up from the
-    // copied cli.ts (under <tmp>/Resources/web/dist/) and finds nothing.
-    // Strategy B's candidates also miss. findCliBinary should return null.
+    // Same shape, but no `binaries/band`. Strategy A's cargo walk is also
+    // bounded to the temp tree (no apps/cli/target inside <tmp>), so the
+    // resolver should miss every candidate and return null rather than
+    // pick up some unrelated `band` binary lying around on the host.
     const resources = join(tmp, "Resources");
     const webDir = join(resources, "web");
     const distDir = join(webDir, "dist");
     mkdirSync(distDir, { recursive: true });
     writeFileSync(join(distDir, "start-server.mjs"), "// stub bundled server\n", "utf-8");
 
-    const bundledCli = join(distDir, "cli.ts");
-    copyFileSync(CLI_SOURCE, bundledCli);
-
-    const runnerScript = [
-      `import { findCliBinary } from ${JSON.stringify(bundledCli)};`,
-      `process.stdout.write(findCliBinary() ?? "<null>");`,
-    ].join("\n");
-
-    const stdout = execFileSync(process.execPath, ["--input-type=module", "-e", runnerScript], {
-      cwd: webDir,
-      encoding: "utf-8",
-    });
-
-    expect(stdout).toBe("<null>");
+    const result = findCliBinaryAt({ cwd: webDir, dirname: distDir });
+    expect(result).toBeNull();
   });
 });

--- a/apps/web/tests/cli-sidecar-path.test.ts
+++ b/apps/web/tests/cli-sidecar-path.test.ts
@@ -31,7 +31,7 @@ import { chmodSync, mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync 
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { findCliBinaryAt } from "../src/lib/cli";
+import { findCliBinaryAt, noBinaryError } from "../src/lib/cli";
 
 describe("findCliBinaryAt in packaged Electron layout", () => {
   let tmp: string;
@@ -81,5 +81,49 @@ describe("findCliBinaryAt in packaged Electron layout", () => {
 
     const result = findCliBinaryAt({ cwd: webDir, dirname: distDir });
     expect(result).toBeNull();
+  });
+
+  it("resolves via the dirname-based candidate when the cwd path misses", () => {
+    // The earlier positive test always short-circuits at the cwd-based
+    // Strategy B candidate. If a future regression revives the off-by-one
+    // on the *dirname*-based candidate only, that test would still pass.
+    // Pin the second candidate by passing a cwd that resolves nowhere
+    // (cwd/../binaries/band does not exist), forcing the resolver to fall
+    // through to the dirname path.
+    const resources = join(tmp, "Resources");
+    const distDir = join(resources, "web", "dist");
+    const binDir = join(resources, "binaries");
+    mkdirSync(distDir, { recursive: true });
+    mkdirSync(binDir, { recursive: true });
+    const sidecar = join(binDir, "band");
+    writeFileSync(sidecar, "#!/bin/sh\nexit 0\n", "utf-8");
+    chmodSync(sidecar, 0o755);
+
+    // cwd points at an unrelated subtree with no binaries/ sibling, so the
+    // cwd-based candidate misses. dirname is the real bundled location.
+    const unrelatedCwd = join(tmp, "unrelated", "deep", "subdir");
+    mkdirSync(unrelatedCwd, { recursive: true });
+
+    const result = findCliBinaryAt({ cwd: unrelatedCwd, dirname: distDir });
+    expect(result).toBe(sidecar);
+  });
+});
+
+describe("noBinaryError", () => {
+  it("returns the .dmg-user message when BAND_PACKAGED is set", () => {
+    const err = noBinaryError({ BAND_PACKAGED: "1" });
+    expect(err.message).toBe("Bundled CLI binary missing - try reinstalling Band");
+  });
+
+  it("returns the cargo-build message when BAND_PACKAGED is unset", () => {
+    const err = noBinaryError({});
+    expect(err.message).toMatch(/cargo build --release -p band-cli/);
+  });
+
+  it("treats an empty BAND_PACKAGED as unset", () => {
+    // process.env values are strings; an empty string is the same as "not
+    // present" for our boolean intent.
+    const err = noBinaryError({ BAND_PACKAGED: "" });
+    expect(err.message).toMatch(/cargo build --release -p band-cli/);
   });
 });

--- a/apps/web/tests/cli-sidecar-path.test.ts
+++ b/apps/web/tests/cli-sidecar-path.test.ts
@@ -126,4 +126,11 @@ describe("noBinaryError", () => {
     const err = noBinaryError({ BAND_PACKAGED: "" });
     expect(err.message).toMatch(/cargo build --release -p band-cli/);
   });
+
+  it("treats BAND_PACKAGED=0 as unset (strict === \"1\" check)", () => {
+    // "0" is truthy as a non-empty string but semantically means "off".
+    // A truthy check would mis-route to the reinstall message.
+    const err = noBinaryError({ BAND_PACKAGED: "0" });
+    expect(err.message).toMatch(/cargo build --release -p band-cli/);
+  });
 });

--- a/packages/dashboard-core/src/adapters/desktop.ts
+++ b/packages/dashboard-core/src/adapters/desktop.ts
@@ -62,7 +62,13 @@ export class DesktopDashboardAdapter extends WebDashboardAdapter {
       if (opts?.allowPrompt && isDesktopShell() && message.includes("elevation-required")) {
         const paths = await this.trpc.cli.resolve.query();
         if (!paths) {
-          throw new Error("Bundled CLI binary missing - try reinstalling Band");
+          // The tRPC resolver returned null. That can mean the bundled
+          // sidecar is genuinely missing on disk, but it can also mean the
+          // web server isn't ready or the call timed out — so don't
+          // confidently blame a missing file like cli.ts::installCli does.
+          throw new Error(
+            "Could not resolve CLI binary path - try reinstalling Band or restarting the app",
+          );
         }
         await desktopInvoke("install_cli", {
           binaryPath: paths.binaryPath,

--- a/packages/dashboard-core/src/adapters/desktop.ts
+++ b/packages/dashboard-core/src/adapters/desktop.ts
@@ -62,9 +62,7 @@ export class DesktopDashboardAdapter extends WebDashboardAdapter {
       if (opts?.allowPrompt && isDesktopShell() && message.includes("elevation-required")) {
         const paths = await this.trpc.cli.resolve.query();
         if (!paths) {
-          throw new Error(
-            "Could not find band CLI binary. Build it first with: cargo build --release -p band-cli",
-          );
+          throw new Error("Bundled CLI binary missing - try reinstalling Band");
         }
         await desktopInvoke("install_cli", {
           binaryPath: paths.binaryPath,


### PR DESCRIPTION
## Summary

- The web server bundle runs with `cwd = <Resources>/web` (not `<Resources>/web/dist`), so the two Strategy B candidates in `findCliBinary` each had one extra `..`, landing the lookup at `Contents/binaries/band` outside of `Resources/`. On a fresh install, `useCliSetup` auto-installed via `findCliBinary`, got `null`, and surfaced a misleading "build with cargo" banner that an Install click only re-triggered.
- Drop the extra `..` from both candidates in `apps/web/src/lib/cli.ts::findCliBinary`, fix the comments to match the real bundled layout, and replace the cargo-build error string in `installCli` (and the duplicate in `packages/dashboard-core/src/adapters/desktop.ts`) with `"Bundled CLI binary missing - try reinstalling Band"` — actionable for a `.dmg` user.
- Add `apps/web/tests/cli-sidecar-path.test.ts` that mimics the packaged layout under a tmp dir, spawns a Node subprocess with cwd set to `<tmp>/Resources/web/`, imports `findCliBinary` from a copy of `cli.ts` placed in the bundled location, and asserts the sidecar resolves to `<tmp>/Resources/binaries/band`. Verified the test fails on the pre-fix code and passes after the fix.

## Test plan

- [x] `pnpm vitest run tests/cli-sidecar-path.test.ts` passes (2 tests)
- [x] Reverted the fix locally and confirmed the new test fails with the expected null return
- [x] `pnpm vitest run tests/cli-skills.test.ts tests/cli-sidecar-path.test.ts` — all 17 tests pass
- [x] `pnpm exec biome check apps/web/src/lib/cli.ts apps/web/tests/cli-sidecar-path.test.ts packages/dashboard-core/src/adapters/desktop.ts` — clean
- [x] `pnpm knip` and `pnpm jscpd` — no new findings from these files
- [ ] On a packaged macOS build, verify the banner no longer appears with the cargo-build error on first launch when `/usr/local/bin/band` is absent

🤖 Generated with [Claude Code](https://claude.com/claude-code)