### PR TITLE
fix(file-browser): auto-expand tree when last tab closes (#424)

### DIFF
--- a/apps/web/src/components/CodeBrowserView.tsx
+++ b/apps/web/src/components/CodeBrowserView.tsx
@@ -1243,6 +1243,12 @@ export function CodeBrowserView({
   // stranded: FileTabBar (which owns the tree-toggle button) renders null
   // when there are no tabs, so a collapsed tree leaves no visible UI to
   // open another file. (Issue #424)
+  //
+  // `treeCollapsed` is intentionally in the dep array — beyond the
+  // close-last-tab and mount-with-empty-tabs cases, it also re-expands
+  // the tree if the user drags the separator gripper to collapse it
+  // while no tabs are open. That's the desired behaviour: you can't
+  // strand yourself by collapsing the only remaining navigation UI.
   useEffect(() => {
     if (fileTabs.openTabs.length === 0 && treeCollapsed) {
       treePanelRef.current?.expand();

--- a/apps/web/src/components/CodeBrowserView.tsx
+++ b/apps/web/src/components/CodeBrowserView.tsx
@@ -1239,6 +1239,16 @@ export function CodeBrowserView({
     }
   }, [openFilePath, treeCollapsed, treePanelRef]);
 
+  // Auto-expand tree when the last tab is closed. Otherwise the user is
+  // stranded: FileTabBar (which owns the tree-toggle button) renders null
+  // when there are no tabs, so a collapsed tree leaves no visible UI to
+  // open another file. (Issue #424)
+  useEffect(() => {
+    if (fileTabs.openTabs.length === 0 && treeCollapsed) {
+      treePanelRef.current?.expand();
+    }
+  }, [fileTabs.openTabs.length, treeCollapsed, treePanelRef]);
+
   // -------------------------------------------------------------------------
   // Render — mobile toggle layout or desktop side-by-side layout
   // -------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Fixes #424: when the user hides the file tree and then closes the last open tab, the expand-treeview button disappears with the tab bar, leaving no UI to open another file.
- Force the tree open whenever `openTabs` becomes empty while the tree is collapsed. Also covers the persisted-empty-state-on-mount case.

## Root cause
The tree-toggle button lives inside `FileTabBar`, which early-returns `null` when `tabs.length === 0`. With the tree also collapsed, every visible affordance for opening a file is gone (the separator gripper is `opacity-0` until hover, so it's not discoverable).

## Fix
Add a focused `useEffect` in `CodeBrowserView.tsx` that auto-expands the file-tree panel whenever there are no open tabs and the tree is currently collapsed. This sits next to the existing "auto-expand tree when a file is opened externally" effect.

## Test plan
- [ ] Open a file, hide the tree, close the file → tree expands automatically
- [ ] With everything closed and tree collapsed, reload the workspace → tree expands on mount
- [ ] Open multiple files, close them one by one → tree stays collapsed until the last close
- [ ] Existing `useFileTabs` test suite still green (verified locally: 15/15 pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)