### PR TITLE
fix(web): replace `git grep` with ripgrep for find-in-files (#431)

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -31,6 +31,7 @@
     "postinstall": "chmod +x node_modules/node-pty/prebuilds/*/spawn-helper 2>/dev/null || true"
   },
   "dependencies": {
+    "@vscode/ripgrep": "^1.18.0",
     "@xterm/addon-search": "^0.16.0",
     "@xterm/addon-webgl": "0.20.0-beta.215",
     "node-pty": "^1.1.0",

--- a/apps/web/scripts/build-server.sh
+++ b/apps/web/scripts/build-server.sh
@@ -13,6 +13,7 @@ esbuild start-server.ts \
   --outfile=dist/start-server.mjs \
   --external:./server/server.js \
   --external:node-pty \
+  --external:@vscode/ripgrep \
   --banner:js="import{createRequire as __cr}from'module';import{fileURLToPath as __fu}from'url';import{dirname as __dn}from'path';const require=__cr(import.meta.url);const __filename=__fu(import.meta.url);const __dirname=__dn(__filename);"
 
 # Copy native modules into dist/ for self-contained builds (Electron app).
@@ -55,6 +56,39 @@ if [ "${NPM_PUBLISH:-}" != "1" ]; then
       find "$dir" -maxdepth 1 -type f ! -name '*.pdb' -exec cp {} "$target/" \;
     done
     chmod +x dist/node_modules/node-pty/prebuilds/*/spawn-helper 2>/dev/null || true
+  fi
+
+  # -----------------------------------------------------------------------
+  # Copy @vscode/ripgrep wrapper + platform-specific binary into dist/.
+  # The wrapper (lib/index.js) does:
+  #   createRequire(import.meta.url).resolve(`@vscode/ripgrep-${platform}-${arch}/bin/rg`)
+  # so the platform package must be resolvable as a sibling in node_modules.
+  # We only ship the binary for the host platform to keep the bundle small;
+  # cross-platform builds will need to vendor binaries for each target.
+  # -----------------------------------------------------------------------
+
+  RG_REAL="$(cd node_modules/@vscode/ripgrep && pwd -P)"
+  mkdir -p dist/node_modules/@vscode/ripgrep/lib
+  cp "$RG_REAL/package.json" dist/node_modules/@vscode/ripgrep/
+  cp "$RG_REAL/lib/index.js" dist/node_modules/@vscode/ripgrep/lib/
+  cp "$RG_REAL/lib/index.d.ts" dist/node_modules/@vscode/ripgrep/lib/ 2>/dev/null || true
+
+  RG_PLATFORM="$(node -e 'console.log(process.platform)')"
+  RG_ARCH="$(node -e 'console.log(process.arch)')"
+  RG_PLATFORM_PKG="@vscode/ripgrep-${RG_PLATFORM}-${RG_ARCH}"
+  # Under pnpm's strict layout, the platform-specific package is hoisted
+  # only into `@vscode/ripgrep`'s own sandbox, not into the workspace's
+  # top-level node_modules — so we resolve it from the wrapper's directory.
+  RG_PLATFORM_BIN="$(cd "$RG_REAL" && node -e "console.log(require.resolve('${RG_PLATFORM_PKG}/package.json'))" 2>/dev/null || true)"
+  if [ -n "$RG_PLATFORM_BIN" ]; then
+    RG_PLATFORM_DIR="$(dirname "$RG_PLATFORM_BIN")"
+    RG_BIN="$([ "$RG_PLATFORM" = "win32" ] && echo "rg.exe" || echo "rg")"
+    mkdir -p "dist/node_modules/${RG_PLATFORM_PKG}/bin"
+    cp "$RG_PLATFORM_DIR/package.json" "dist/node_modules/${RG_PLATFORM_PKG}/"
+    cp "$RG_PLATFORM_DIR/bin/$RG_BIN" "dist/node_modules/${RG_PLATFORM_PKG}/bin/"
+    chmod +x "dist/node_modules/${RG_PLATFORM_PKG}/bin/$RG_BIN"
+  else
+    echo "WARNING: ${RG_PLATFORM_PKG} not found; find-in-files will not work in this build" >&2
   fi
 
   # SQLite is provided by Node's built-in `node:sqlite` (Stability 1.2 RC,

--- a/apps/web/src/trpc/router.ts
+++ b/apps/web/src/trpc/router.ts
@@ -1,4 +1,4 @@
-import { execFile, execFileSync } from "node:child_process";
+import { execFile, execFileSync, spawn } from "node:child_process";
 import { randomUUID } from "node:crypto";
 import { existsSync, mkdirSync, unlinkSync } from "node:fs";
 import { cp, mkdir, readdir, readFile, rename, rm, stat, writeFile } from "node:fs/promises";
@@ -7,6 +7,7 @@ import { promisify } from "node:util";
 import { toWorkspaceId } from "@band-app/dashboard-core";
 import { createLogger } from "@band-app/logger";
 import { initTRPC, TRPCError } from "@trpc/server";
+import { rgPath } from "@vscode/ripgrep";
 import type { UIMessage } from "ai";
 import { Cron } from "croner";
 import { z } from "zod";
@@ -1846,42 +1847,121 @@ const workspaceRouter = t.router({
       }
 
       const cwd = workspace.worktree.path;
-      const args = ["grep", "-n", "--no-color", "-I"];
-      if (input.regex) {
-        args.push("-E");
-      } else {
-        args.push("-F");
-      }
-      if (!input.caseSensitive) args.push("-i");
-      if (input.wholeWord) args.push("-w");
-      args.push("--", input.query);
 
-      let output: string;
-      try {
-        output = await execGit(args, cwd);
-      } catch {
-        // git grep exits with status 1 when no matches found
-        return { results: [] };
-      }
+      // ripgrep is preferred over `git grep` here because git grep only sees
+      // files in the index. Band workspaces frequently contain untracked
+      // files (agents create files that aren't yet `git add`-ed) and those
+      // would otherwise be invisible to find-in-files. ripgrep respects
+      // `.gitignore` by default, matching git grep's effective filter for
+      // tracked files while also surfacing untracked-but-not-ignored ones.
+      const args: string[] = [];
+      if (!input.caseSensitive) args.push("--ignore-case");
+      if (input.wholeWord) args.push("--word-regexp");
+      if (!input.regex) args.push("--fixed-strings");
+      args.push("--json");
+      // Pass the cwd as an explicit search path. Without a path argument,
+      // ripgrep reads from stdin when its stdin is not a tty — under
+      // `spawn` (which defaults to a piped stdin) that hangs forever.
+      args.push("--", input.query, "./");
 
-      const lines = output.trim().split("\n").filter(Boolean);
-      const results: Array<{ file: string; line: number; content: string }> = [];
+      return await new Promise<{
+        results: Array<{ file: string; line: number; content: string }>;
+      }>((resolvePromise, rejectPromise) => {
+        const results: Array<{ file: string; line: number; content: string }> = [];
+        // `stdio: ['ignore', 'pipe', 'pipe']` also closes stdin so ripgrep
+        // can't fall back into stdin-reading mode.
+        const child = spawn(rgPath, args, { cwd, stdio: ["ignore", "pipe", "pipe"] });
+        let stdoutBuf = "";
+        let stderrBuf = "";
+        let settled = false;
+        let killed = false;
 
-      for (const raw of lines) {
-        if (results.length >= input.limit) break;
-        const colonIdx1 = raw.indexOf(":");
-        if (colonIdx1 === -1) continue;
-        const colonIdx2 = raw.indexOf(":", colonIdx1 + 1);
-        if (colonIdx2 === -1) continue;
+        const finish = (value: typeof results) => {
+          if (settled) return;
+          settled = true;
+          resolvePromise({ results: value });
+        };
 
-        const file = raw.slice(0, colonIdx1);
-        const line = Number.parseInt(raw.slice(colonIdx1 + 1, colonIdx2), 10);
-        const content = raw.slice(colonIdx2 + 1);
+        const fail = (err: Error) => {
+          if (settled) return;
+          settled = true;
+          rejectPromise(err);
+        };
 
-        results.push({ file, line, content });
-      }
+        child.stdout.setEncoding("utf-8");
+        child.stdout.on("data", (chunk: string) => {
+          if (settled) return;
+          stdoutBuf += chunk;
+          // ripgrep --json emits one JSON object per line.
+          while (true) {
+            const nlIdx = stdoutBuf.indexOf("\n");
+            if (nlIdx === -1) break;
+            const line = stdoutBuf.slice(0, nlIdx);
+            stdoutBuf = stdoutBuf.slice(nlIdx + 1);
+            if (!line) continue;
 
-      return { results };
+            let event: {
+              type?: string;
+              data?: {
+                path?: { text?: string };
+                line_number?: number;
+                lines?: { text?: string };
+              };
+            };
+            try {
+              event = JSON.parse(line);
+            } catch {
+              continue;
+            }
+
+            if (event.type !== "match") continue;
+            const data = event.data;
+            if (!data) continue;
+            const rawFile = data.path?.text;
+            const lineNumber = data.line_number;
+            const rawContent = data.lines?.text;
+            // Non-UTF-8 paths/lines come back as `bytes` (base64) instead of
+            // `text`. Skip those — they're rare in workspaces and the UI
+            // can't render them sensibly.
+            if (!rawFile || typeof lineNumber !== "number" || rawContent === undefined) {
+              continue;
+            }
+            // ripgrep prefixes paths with the search root we passed (`./`).
+            // Strip that to match the workspace-relative paths returned by
+            // `workspace.searchFiles` (`git ls-files`).
+            const file = rawFile.startsWith("./") ? rawFile.slice(2) : rawFile;
+            const content = rawContent.endsWith("\n") ? rawContent.slice(0, -1) : rawContent;
+            results.push({ file, line: lineNumber, content });
+
+            if (results.length >= input.limit) {
+              killed = true;
+              child.kill("SIGTERM");
+              finish(results);
+              return;
+            }
+          }
+        });
+
+        child.stderr.setEncoding("utf-8");
+        child.stderr.on("data", (chunk: string) => {
+          stderrBuf += chunk;
+        });
+
+        child.on("error", (err) => {
+          fail(err);
+        });
+
+        child.on("close", (code) => {
+          if (settled) return;
+          // ripgrep exit codes: 0 = matches found, 1 = no matches, 2 = error.
+          // Both 0 and 1 are valid "no failure" outcomes for our purposes.
+          if (code === 0 || code === 1 || killed) {
+            finish(results);
+          } else {
+            fail(new Error(`ripgrep exited with code ${code}: ${stderrBuf.trim()}`));
+          }
+        });
+      });
     }),
 
   switchAgent: publicProcedure

--- a/apps/web/tests/build-output.test.ts
+++ b/apps/web/tests/build-output.test.ts
@@ -37,6 +37,17 @@ describe("build output", () => {
     expect(readdirSync(prebuildsDir).length).toBeGreaterThan(0);
   });
 
+  it("contains the @vscode/ripgrep wrapper package", () => {
+    expect(existsSync(join(dist, "node_modules/@vscode/ripgrep/package.json"))).toBe(true);
+    expect(existsSync(join(dist, "node_modules/@vscode/ripgrep/lib/index.js"))).toBe(true);
+  });
+
+  it("contains the host-platform ripgrep binary", () => {
+    const platformPkg = `@vscode/ripgrep-${process.platform}-${process.arch}`;
+    const binName = process.platform === "win32" ? "rg.exe" : "rg";
+    expect(existsSync(join(dist, "node_modules", platformPkg, "bin", binName))).toBe(true);
+  });
+
   it("does NOT bundle a SQLite native module", () => {
     // SQLite is provided by Node's built-in `node:sqlite` (RC since 22.13).
     // Nothing for SQLite should ship under dist/node_modules/.

--- a/apps/web/tests/search-content.test.ts
+++ b/apps/web/tests/search-content.test.ts
@@ -1,0 +1,362 @@
+import { execFileSync, spawn } from "node:child_process";
+import { mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from "node:fs";
+import { createServer } from "node:net";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { seedSettings, seedState } from "./helpers/seed-state";
+import { SERVER_RUNTIME, SERVER_SCRIPT } from "./helpers/server-runtime";
+
+const PROJECT_ROOT = join(import.meta.dirname, "..");
+const DEFAULT_TOKEN = "search-content-test-token";
+
+// ---------------------------------------------------------------------------
+// Helpers (duplicated from trpc.test.ts to keep this file independent — the
+// existing helpers there are not exported as a module)
+// ---------------------------------------------------------------------------
+
+interface ServerHandle {
+  url: string;
+  home: string;
+  close: () => Promise<void>;
+}
+
+function createTmpHome(): string {
+  const tmp = realpathSync(mkdtempSync(join(tmpdir(), "band-search-test-")));
+  mkdirSync(join(tmp, ".band"), { recursive: true });
+  return tmp;
+}
+
+function getRandomPort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const srv = createServer();
+    srv.listen(0, "127.0.0.1", () => {
+      const { port } = srv.address() as { port: number };
+      srv.close(() => resolve(port));
+    });
+    srv.on("error", reject);
+  });
+}
+
+async function startServer(opts: { tmpHome: string }): Promise<ServerHandle> {
+  const port = await getRandomPort();
+
+  return new Promise((resolve, reject) => {
+    const child = spawn(SERVER_RUNTIME, [SERVER_SCRIPT], {
+      cwd: PROJECT_ROOT,
+      env: {
+        ...process.env,
+        HOME: opts.tmpHome,
+        PORT: String(port),
+        NODE_ENV: "production",
+      },
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+
+    let stderr = "";
+    let settled = false;
+
+    child.stderr!.on("data", (chunk: Buffer) => {
+      stderr += chunk.toString();
+    });
+
+    child.stdout!.on("data", (chunk: Buffer) => {
+      const text = chunk.toString();
+      if (text.includes("listening") && !settled) {
+        settled = true;
+        resolve({
+          url: `http://127.0.0.1:${port}`,
+          home: opts.tmpHome,
+          close: () =>
+            new Promise<void>((r) => {
+              child.on("exit", () => r());
+              child.kill("SIGTERM");
+            }),
+        });
+      }
+    });
+
+    child.on("error", (err) => {
+      if (!settled) {
+        settled = true;
+        reject(err);
+      }
+    });
+
+    child.on("exit", (code) => {
+      if (!settled) {
+        settled = true;
+        reject(new Error(`Server exited with code ${code} before listening.\nstderr: ${stderr}`));
+      }
+    });
+
+    setTimeout(() => {
+      if (!settled) {
+        settled = true;
+        child.kill("SIGTERM");
+        reject(new Error(`Server did not start within 15s.\nstderr: ${stderr}`));
+      }
+    }, 15_000);
+  });
+}
+
+const defaultHeaders = { Cookie: `band_token=${DEFAULT_TOKEN}` };
+
+async function trpcQuery(serverUrl: string, procedure: string, input?: unknown) {
+  const url =
+    input !== undefined
+      ? `${serverUrl}/trpc/${procedure}?input=${encodeURIComponent(JSON.stringify(input))}`
+      : `${serverUrl}/trpc/${procedure}`;
+  return fetch(url, { headers: defaultHeaders });
+}
+
+async function trpcData<T>(res: Response): Promise<T> {
+  const body = (await res.json()) as { result: { data: T } };
+  return body.result.data;
+}
+
+const gitEnv = {
+  ...process.env,
+  GIT_AUTHOR_NAME: "Test",
+  GIT_AUTHOR_EMAIL: "test@test.com",
+  GIT_COMMITTER_NAME: "Test",
+  GIT_COMMITTER_EMAIL: "test@test.com",
+};
+
+function git(cwd: string, args: string[]): string {
+  return execFileSync("git", args, { cwd, env: gitEnv, encoding: "utf-8" });
+}
+
+type SearchResult = { file: string; line: number; content: string };
+
+// ---------------------------------------------------------------------------
+// workspace.searchContent — verifies the ripgrep-backed find-in-files
+// procedure finds both tracked and untracked files (the original `git grep`
+// implementation silently dropped untracked files; see issue #431).
+// ---------------------------------------------------------------------------
+
+describe("tRPC — workspace.searchContent (ripgrep)", () => {
+  let server: ServerHandle;
+  let tmpHome: string;
+  let repoPath: string;
+
+  beforeAll(async () => {
+    tmpHome = createTmpHome();
+
+    // Real git repo with one tracked file containing the marker.
+    repoPath = join(tmpHome, "repo");
+    mkdirSync(repoPath, { recursive: true });
+    git(repoPath, ["init", "-b", "main"]);
+    writeFileSync(join(repoPath, "tracked.txt"), "tracked-file BAND_RG_MARKER hello\n");
+    git(repoPath, ["add", "tracked.txt"]);
+    git(repoPath, ["commit", "-m", "initial"]);
+
+    // Untracked file (matches what coding agents create before `git add`).
+    writeFileSync(join(repoPath, "untracked.txt"), "untracked-file BAND_RG_MARKER world\n");
+
+    // A real subdirectory with another tracked file to verify subdirectory
+    // discovery still works.
+    mkdirSync(join(repoPath, "src"));
+    writeFileSync(
+      join(repoPath, "src", "deep.txt"),
+      "deep tracked BAND_RG_MARKER nested content\n",
+    );
+    git(repoPath, ["add", "src/deep.txt"]);
+    git(repoPath, ["commit", "-m", "deep file"]);
+
+    // A file matching .gitignore should NOT appear in results.
+    writeFileSync(join(repoPath, ".gitignore"), "ignored.txt\n");
+    writeFileSync(join(repoPath, "ignored.txt"), "ignored BAND_RG_MARKER skip\n");
+
+    seedState(tmpHome, {
+      projects: [
+        {
+          name: "repo",
+          path: repoPath,
+          defaultBranch: "main",
+          worktrees: [{ branch: "main", path: repoPath }],
+        },
+      ],
+    });
+    seedSettings(tmpHome, {
+      tokenSecret: DEFAULT_TOKEN,
+      worktreesDir: join(tmpHome, ".band", "worktrees"),
+    });
+    server = await startServer({ tmpHome });
+  });
+
+  afterAll(async () => {
+    await server.close();
+    rmSync(tmpHome, { recursive: true, force: true });
+  });
+
+  it("returns matches from both tracked and untracked files", async () => {
+    const res = await trpcQuery(server.url, "workspace.searchContent", {
+      workspaceId: "repo-main",
+      query: "BAND_RG_MARKER",
+    });
+    expect(res.status).toBe(200);
+
+    const { results } = await trpcData<{ results: SearchResult[] }>(res);
+    const files = new Set(results.map((r) => r.file));
+
+    expect(files.has("tracked.txt")).toBe(true);
+    expect(files.has("untracked.txt")).toBe(true);
+    expect(files.has("src/deep.txt")).toBe(true);
+
+    // Every result must include the marker in its content and a 1-based line number.
+    for (const r of results) {
+      expect(r.content).toContain("BAND_RG_MARKER");
+      expect(r.line).toBeGreaterThan(0);
+    }
+  });
+
+  it("respects .gitignore and excludes ignored files", async () => {
+    const res = await trpcQuery(server.url, "workspace.searchContent", {
+      workspaceId: "repo-main",
+      query: "BAND_RG_MARKER",
+    });
+    const { results } = await trpcData<{ results: SearchResult[] }>(res);
+    expect(results.some((r) => r.file === "ignored.txt")).toBe(false);
+  });
+
+  it("supports case-sensitive search", async () => {
+    // Lowercase query, case-insensitive (default): matches the uppercase marker.
+    const insensitive = await trpcQuery(server.url, "workspace.searchContent", {
+      workspaceId: "repo-main",
+      query: "band_rg_marker",
+    });
+    const insensitiveData = await trpcData<{ results: SearchResult[] }>(insensitive);
+    expect(insensitiveData.results.length).toBeGreaterThan(0);
+
+    // Same query case-sensitive: no matches.
+    const sensitive = await trpcQuery(server.url, "workspace.searchContent", {
+      workspaceId: "repo-main",
+      query: "band_rg_marker",
+      caseSensitive: true,
+    });
+    const sensitiveData = await trpcData<{ results: SearchResult[] }>(sensitive);
+    expect(sensitiveData.results.length).toBe(0);
+  });
+
+  it("supports whole-word matching", async () => {
+    // The tracked.txt content is "tracked-file BAND_RG_MARKER hello". The
+    // word "hello" matches as a whole word; "ello" should not when wholeWord
+    // is true.
+    const wholeWordMatch = await trpcQuery(server.url, "workspace.searchContent", {
+      workspaceId: "repo-main",
+      query: "hello",
+      wholeWord: true,
+    });
+    const matchData = await trpcData<{ results: SearchResult[] }>(wholeWordMatch);
+    expect(matchData.results.some((r) => r.file === "tracked.txt")).toBe(true);
+
+    const wholeWordMiss = await trpcQuery(server.url, "workspace.searchContent", {
+      workspaceId: "repo-main",
+      query: "ello",
+      wholeWord: true,
+    });
+    const missData = await trpcData<{ results: SearchResult[] }>(wholeWordMiss);
+    expect(missData.results.some((r) => r.file === "tracked.txt")).toBe(false);
+  });
+
+  it("treats fixed-string queries literally (regex disabled)", async () => {
+    // A regex meta-character that would match anything in regex mode. With
+    // fixed strings (the default), it should match literally and find nothing.
+    const literal = await trpcQuery(server.url, "workspace.searchContent", {
+      workspaceId: "repo-main",
+      query: "BAND.*MARKER",
+    });
+    const literalData = await trpcData<{ results: SearchResult[] }>(literal);
+    expect(literalData.results.length).toBe(0);
+
+    // Same query with regex enabled should match all marker lines.
+    const regex = await trpcQuery(server.url, "workspace.searchContent", {
+      workspaceId: "repo-main",
+      query: "BAND.*MARKER",
+      regex: true,
+    });
+    const regexData = await trpcData<{ results: SearchResult[] }>(regex);
+    expect(regexData.results.length).toBeGreaterThan(0);
+  });
+
+  it("respects the limit parameter", async () => {
+    const res = await trpcQuery(server.url, "workspace.searchContent", {
+      workspaceId: "repo-main",
+      query: "BAND_RG_MARKER",
+      limit: 1,
+    });
+    const { results } = await trpcData<{ results: SearchResult[] }>(res);
+    expect(results.length).toBe(1);
+  });
+
+  it("returns an empty result set when there are no matches", async () => {
+    const res = await trpcQuery(server.url, "workspace.searchContent", {
+      workspaceId: "repo-main",
+      query: "this-string-does-not-exist-anywhere-in-the-repo-zzz",
+    });
+    expect(res.status).toBe(200);
+    const { results } = await trpcData<{ results: SearchResult[] }>(res);
+    expect(results).toEqual([]);
+  });
+
+  it("returns an error for an unknown workspace", async () => {
+    const res = await trpcQuery(server.url, "workspace.searchContent", {
+      workspaceId: "nonexistent-main",
+      query: "anything",
+    });
+    expect(res.status).toBe(500);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// workspace.searchContent — non-git workspaces.
+//
+// ripgrep does not require a git repository (unlike `git grep`). Verify the
+// procedure works for plain directories that contain files.
+// ---------------------------------------------------------------------------
+
+describe("tRPC — workspace.searchContent in non-git directories", () => {
+  let server: ServerHandle;
+  let tmpHome: string;
+  let plainDir: string;
+
+  beforeAll(async () => {
+    tmpHome = createTmpHome();
+
+    plainDir = join(tmpHome, "plain");
+    mkdirSync(plainDir, { recursive: true });
+    writeFileSync(join(plainDir, "file.txt"), "plain BAND_PLAIN_MARKER content\n");
+
+    seedState(tmpHome, {
+      projects: [
+        {
+          name: "plain",
+          path: plainDir,
+          defaultBranch: "main",
+          worktrees: [{ branch: "main", path: plainDir }],
+        },
+      ],
+    });
+    seedSettings(tmpHome, {
+      tokenSecret: DEFAULT_TOKEN,
+      worktreesDir: join(tmpHome, ".band", "worktrees"),
+    });
+    server = await startServer({ tmpHome });
+  });
+
+  afterAll(async () => {
+    await server.close();
+    rmSync(tmpHome, { recursive: true, force: true });
+  });
+
+  it("finds files in a workspace that is not a git repository", async () => {
+    const res = await trpcQuery(server.url, "workspace.searchContent", {
+      workspaceId: "plain-main",
+      query: "BAND_PLAIN_MARKER",
+    });
+    expect(res.status).toBe(200);
+    const { results } = await trpcData<{ results: SearchResult[] }>(res);
+    expect(results.some((r) => r.file === "file.txt")).toBe(true);
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -57,6 +57,9 @@ importers:
 
   apps/web:
     dependencies:
+      '@vscode/ripgrep':
+        specifier: ^1.18.0
+        version: 1.18.0
       '@xterm/addon-search':
         specifier: ^0.16.0
         version: 0.16.0
@@ -3280,6 +3283,69 @@ packages:
 
   '@vitest/utils@4.0.18':
     resolution: {integrity: sha512-msMRKLMVLWygpK3u2Hybgi4MNjcYJvwTb0Ru09+fOyCXIgT5raYP041DRRdiJiI3k/2U6SEbAETB3YtBrUkCFA==}
+
+  '@vscode/ripgrep-darwin-arm64@1.18.0':
+    resolution: {integrity: sha512-r3ktHSvbFycQNF6sl7sNDPocpsI7J+mEzh1IaZFkY0spm3k2Z9t8hPAeOK7+p0l6p6/swkQC14XWX01low+94Q==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@vscode/ripgrep-darwin-x64@1.18.0':
+    resolution: {integrity: sha512-25b4gWbL138dGuQU244ebCKKc0q05ULBMoFSz9oAEUHNeqK/lOJViDS7DRvbDazzAzSEdan391Znks/R5mkaTQ==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@vscode/ripgrep-linux-arm64@1.18.0':
+    resolution: {integrity: sha512-lQ/5zTG++U0E3IhVgS4EPTTn/U4okncaRMM5GOFfOYZywS4nuD31GhkHbNYlDk5CuDC68+hYJ0/eQeyCKJDA+g==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@vscode/ripgrep-linux-arm@1.18.0':
+    resolution: {integrity: sha512-GDAvufNDHu8zqLEmXstalQF0Wh6wQvdsBi/Vg3Yi3CK4a8XoFXqqXVEHEZ9xQz3t0NfoSEc9JbvK9DDS6FxyxQ==}
+    cpu: [arm]
+    os: [linux]
+
+  '@vscode/ripgrep-linux-ia32@1.18.0':
+    resolution: {integrity: sha512-YWLkSUtFd4Jh5EepIhA9RJSfv3uMAVMo+2rBIGHPBnvgLrZciIs2cDKei1/p6Wc/aCzUoHyMAg2R6tw4ZCBKGg==}
+    cpu: [ia32]
+    os: [linux]
+
+  '@vscode/ripgrep-linux-ppc64@1.18.0':
+    resolution: {integrity: sha512-quXVY8fwQ8O/lvU1yrSqSl3jlUzysRSb+AfUfCL/tRtphxsKlFvPAejryZ6vg4Bgvn8XL74xb4qMCDmWgYrT5w==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@vscode/ripgrep-linux-riscv64@1.18.0':
+    resolution: {integrity: sha512-f5kBQBrWfQt8Q7OhSORuNDei5dkYagBj3y4jImSUXGMy8B/Ke7SltSRcUtjPv166FAFfHCAmWuZp3+cWnX2/Vw==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@vscode/ripgrep-linux-s390x@1.18.0':
+    resolution: {integrity: sha512-rTOcJFGGcl2c07RUOWUo4U1ndnemKhY6A9hnMB18uk7jSgJc0d/QLBGWMWpumdtoJtpizn/wIv5mXIisJukusQ==}
+    cpu: [s390x]
+    os: [linux]
+
+  '@vscode/ripgrep-linux-x64@1.18.0':
+    resolution: {integrity: sha512-mQ3bVrUpnD2vs7QT0vX90Lt0cnUq467uFtEktIdsJJmW296RoSULRGqWgzG1AKxyBpNDD6l4ZO4qKf6SgyC23Q==}
+    cpu: [x64]
+    os: [linux]
+
+  '@vscode/ripgrep-win32-arm64@1.18.0':
+    resolution: {integrity: sha512-vfTIjq1OHnzUjxZcHVQAMbnggp8dpGf+0QKFOZHwWPqFwXxQC8eCWM+5NUdoJ6yrElCeMzoUTXoK/LdZaniB+Q==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@vscode/ripgrep-win32-ia32@1.18.0':
+    resolution: {integrity: sha512-//rfAE+BOw5AC2EMmepmiE36jUuevtQYNQqqlw1s3m9FlRxjxEut97RkRPHAu9BG4mSojatZx+kXZXNdyI9caQ==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@vscode/ripgrep-win32-x64@1.18.0':
+    resolution: {integrity: sha512-KNPvtElldqILHdnAetujPaowkNbpqJy3ssIGGN6F6Kve9Qi+nNLI2DN01O83JjCEVQbCzl8Ov3QZ9Eov3BR8Dg==}
+    cpu: [x64]
+    os: [win32]
+
+  '@vscode/ripgrep@1.18.0':
+    resolution: {integrity: sha512-ns5lWe44tSfbTMbVUsyB+I1819PVSw4AdpgK0RNkzfWfwy6+3IUNSxwSrfTno1/oWaS/hERNz+XLWVyga2aJBQ==}
 
   '@xmldom/xmldom@0.9.10':
     resolution: {integrity: sha512-A9gOqLdi6cV4ibazAjcQufGj0B1y/vDqYrcuP6d/6x8P27gRS8643Dj9o1dEKtB6O7fwxb2FgBmJS2mX7gpvdw==}
@@ -10378,6 +10444,57 @@ snapshots:
     dependencies:
       '@vitest/pretty-format': 4.0.18
       tinyrainbow: 3.0.3
+
+  '@vscode/ripgrep-darwin-arm64@1.18.0':
+    optional: true
+
+  '@vscode/ripgrep-darwin-x64@1.18.0':
+    optional: true
+
+  '@vscode/ripgrep-linux-arm64@1.18.0':
+    optional: true
+
+  '@vscode/ripgrep-linux-arm@1.18.0':
+    optional: true
+
+  '@vscode/ripgrep-linux-ia32@1.18.0':
+    optional: true
+
+  '@vscode/ripgrep-linux-ppc64@1.18.0':
+    optional: true
+
+  '@vscode/ripgrep-linux-riscv64@1.18.0':
+    optional: true
+
+  '@vscode/ripgrep-linux-s390x@1.18.0':
+    optional: true
+
+  '@vscode/ripgrep-linux-x64@1.18.0':
+    optional: true
+
+  '@vscode/ripgrep-win32-arm64@1.18.0':
+    optional: true
+
+  '@vscode/ripgrep-win32-ia32@1.18.0':
+    optional: true
+
+  '@vscode/ripgrep-win32-x64@1.18.0':
+    optional: true
+
+  '@vscode/ripgrep@1.18.0':
+    optionalDependencies:
+      '@vscode/ripgrep-darwin-arm64': 1.18.0
+      '@vscode/ripgrep-darwin-x64': 1.18.0
+      '@vscode/ripgrep-linux-arm': 1.18.0
+      '@vscode/ripgrep-linux-arm64': 1.18.0
+      '@vscode/ripgrep-linux-ia32': 1.18.0
+      '@vscode/ripgrep-linux-ppc64': 1.18.0
+      '@vscode/ripgrep-linux-riscv64': 1.18.0
+      '@vscode/ripgrep-linux-s390x': 1.18.0
+      '@vscode/ripgrep-linux-x64': 1.18.0
+      '@vscode/ripgrep-win32-arm64': 1.18.0
+      '@vscode/ripgrep-win32-ia32': 1.18.0
+      '@vscode/ripgrep-win32-x64': 1.18.0
 
   '@xmldom/xmldom@0.9.10': {}
 


### PR DESCRIPTION
## Summary

- `git grep` only sees files in the index, so files agents create but haven't `git add`-ed are invisible to the find-in-files dialog — the dominant case in Band workspaces. This switches `workspace.searchContent` to spawn `@vscode/ripgrep` with `--json` streaming and respects the existing limit by killing the child early.
- ripgrep respects `.gitignore` by default (matching `git grep`'s effective filter for tracked files) and works in non-git workspaces.
- Bundles the host-platform ripgrep binary into `dist/node_modules/` and marks `@vscode/ripgrep` external in esbuild so the wrapper can resolve its sibling platform package at runtime.
- The tRPC schema is unchanged so `SearchFilesDialog` doesn't need to change.

Closes #431.

## Test plan

- [x] 9 new integration tests in `apps/web/tests/search-content.test.ts` (vitest + real filesystem, no mocks per CLAUDE.md):
  - tracked + untracked file discovery
  - `.gitignore` is respected
  - case sensitivity, whole-word, regex vs fixed-string, limit, empty results, unknown-workspace error
  - non-git workspace search
- [x] Two new `build-output.test.ts` cases that fail-fast if the build script stops shipping the rg binary.
- [x] Full `apps/web` test suite (659 tests) passes.
- [x] `biome check`, `knip`, `jscpd`, `cargo fmt --check`, `cargo clippy -D warnings` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)