### PR TITLE
fix(web): render single-dollar inline math in chat and md preview

### DIFF
--- a/apps/web/src/components/CodeBrowserView.tsx
+++ b/apps/web/src/components/CodeBrowserView.tsx
@@ -33,10 +33,6 @@ import {
   TooltipTrigger,
 } from "@band-app/ui";
 import type { Extension } from "@codemirror/state";
-import { cjk } from "@streamdown/cjk";
-import { code } from "@streamdown/code";
-import { math } from "@streamdown/math";
-import { mermaid } from "@streamdown/mermaid";
 import {
   ChevronLeft,
   ChevronRight,
@@ -57,9 +53,7 @@ import { useIsDesktop } from "../hooks/useIsDesktop";
 import { useTabState } from "../hooks/useTabState";
 import { applyFrontmatterTable } from "../lib/frontmatter";
 import { FileTabBar } from "./FileTabBar";
-import { streamdownComponents } from "./streamdown-components";
-
-const streamdownPlugins = { cjk, code, math, mermaid };
+import { streamdownComponents, streamdownPlugins } from "./streamdown-components";
 
 // ---------------------------------------------------------------------------
 // File tree width persistence

--- a/apps/web/src/components/ai-elements/message.tsx
+++ b/apps/web/src/components/ai-elements/message.tsx
@@ -1,8 +1,4 @@
 import { cn } from "@band-app/ui";
-import { cjk } from "@streamdown/cjk";
-import { code } from "@streamdown/code";
-import { math } from "@streamdown/math";
-import { mermaid } from "@streamdown/mermaid";
 import type { UIMessage } from "ai";
 import { Download, Expand, FileIcon } from "lucide-react";
 import type { ComponentProps, HTMLAttributes } from "react";
@@ -10,6 +6,7 @@ import { memo, useCallback, useState } from "react";
 import remarkBreaks from "remark-breaks";
 import { defaultRehypePlugins, defaultRemarkPlugins, Streamdown } from "streamdown";
 
+import { streamdownPlugins } from "../streamdown-components";
 import {
   fileLinkComponents,
   fileLinkRehypePlugins,
@@ -52,8 +49,6 @@ export const MessageContent = ({ children, className, ...props }: MessageContent
 );
 
 export type MessageResponseProps = ComponentProps<typeof Streamdown>;
-
-const streamdownPlugins = { cjk, code, math, mermaid };
 
 export const MessageResponse = memo(
   ({ className, ...props }: MessageResponseProps) => (

--- a/apps/web/src/components/streamdown-components.tsx
+++ b/apps/web/src/components/streamdown-components.tsx
@@ -43,8 +43,10 @@ export const streamdownComponents = { a: ExternalLink };
  * across call sites.
  *
  * `singleDollarTextMath: true` opts into `remark-math`'s `$…$` inline syntax.
- * The closing `$` must be followed by whitespace or punctuation, so prose
- * containing literal dollar amounts like "\$5" still renders correctly.
+ * `remark-math` won't open a math span when the character after `$` is
+ * whitespace, and won't close one when the character before `$` is whitespace,
+ * so prose like `costs $5 and $10` is not parsed as math. Authors who want to
+ * be extra defensive can still escape with `\$`.
  */
 export const streamdownPlugins = {
   cjk,

--- a/apps/web/src/components/streamdown-components.tsx
+++ b/apps/web/src/components/streamdown-components.tsx
@@ -1,3 +1,7 @@
+import { cjk } from "@streamdown/cjk";
+import { code } from "@streamdown/code";
+import { createMathPlugin } from "@streamdown/math";
+import { mermaid } from "@streamdown/mermaid";
 import type { AnchorHTMLAttributes } from "react";
 import { openExternalUrl } from "../lib/open-external-url";
 
@@ -31,3 +35,20 @@ function ExternalLink({
 
 /** Shared Streamdown component overrides. */
 export const streamdownComponents = { a: ExternalLink };
+
+/**
+ * Shared Streamdown plugin set used by both the chat message renderer and the
+ * markdown file preview. Single source of truth so a config change (e.g.
+ * enabling single-dollar inline math) lands in one place instead of drifting
+ * across call sites.
+ *
+ * `singleDollarTextMath: true` opts into `remark-math`'s `$…$` inline syntax.
+ * The closing `$` must be followed by whitespace or punctuation, so prose
+ * containing literal dollar amounts like "\$5" still renders correctly.
+ */
+export const streamdownPlugins = {
+  cjk,
+  code,
+  math: createMathPlugin({ singleDollarTextMath: true }),
+  mermaid,
+};


### PR DESCRIPTION
## Summary

- `@streamdown/math`'s default export hard-codes `singleDollarTextMath: false`, so `$x^2 + y^2 = z^2$` rendered as raw source in both the chat message renderer and the markdown file preview. Block math (`$$…$$`) worked because `remark-math` handles it independently.
- Switch both call sites to `createMathPlugin({ singleDollarTextMath: true })`.
- Hoist the plugin set into `apps/web/src/components/streamdown-components.tsx` so the two surfaces share one configured object instead of two identical inline copies.

Closes #437.

## Test plan

- [ ] Send a chat message containing `$\dfrac{3}{4} + \dfrac{5}{6}$` — renders as KaTeX inline math.
- [ ] Open a `.md` file in the file browser preview containing the same expression — renders identically.
- [ ] Confirm `$$\frac{1}{2}$$` block math still renders (regression check).
- [ ] Send a chat message with **unescaped** dollar amounts: `The bill is $5 and the tip is $10.` — verify the prose stays plain text (no substring renders as KaTeX). `remark-math` won't open a span when the next char is whitespace and won't close one when the previous char is whitespace, so this should be safe.
- [ ] Sanity-check that `\$5` (escaped) also stays inert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)