### PR TITLE
feat(web): open files from outside the workspace root (#433)

### DIFF
--- a/apps/desktop/src/main/ipc/macos-shell.ts
+++ b/apps/desktop/src/main/ipc/macos-shell.ts
@@ -2,6 +2,7 @@
  * macOS shell bridges.
  *
  *   - `pickFolder` — system folder picker (cross-platform via Electron's `dialog`).
+ *   - `pickFile` — system file picker for opening external files (cross-platform).
  *   - `revealInFinder` — open the path in the platform's file manager.
  *   - `checkAppExists` — look in /Applications and friends, fall back to `which`.
  *   - `openWithApp` — `open -a <app> <path>` (macOS only).
@@ -32,6 +33,31 @@ export async function pickFolder(parent: BrowserWindow | null): Promise<string |
   const opts = {
     title: "Select a git repository",
     properties: ["openDirectory"] as Array<"openDirectory">,
+  };
+  const result = parent
+    ? await dialog.showOpenDialog(parent, opts)
+    : await dialog.showOpenDialog(opts);
+  if (result.canceled || result.filePaths.length === 0) return null;
+  return result.filePaths[0] ?? null;
+}
+
+// ---------------------------------------------------------------------------
+// pickFile
+// ---------------------------------------------------------------------------
+
+/**
+ * Open the system file picker for opening a single file from anywhere on the
+ * local filesystem. Returns the absolute POSIX path or `null` when the user
+ * cancels. Anchored to `parent` so the dialog is sheet-style on macOS and
+ * modal-relative on other platforms.
+ *
+ * Backs the "Open File…" action in the editor (issue #433) — lets a user
+ * open files that sit outside the current workspace root.
+ */
+export async function pickFile(parent: BrowserWindow | null): Promise<string | null> {
+  const opts = {
+    title: "Open File",
+    properties: ["openFile"] as Array<"openFile">,
   };
   const result = parent
     ? await dialog.showOpenDialog(parent, opts)

--- a/apps/desktop/src/main/ipc/macos-shell.ts
+++ b/apps/desktop/src/main/ipc/macos-shell.ts
@@ -51,8 +51,8 @@ export async function pickFolder(parent: BrowserWindow | null): Promise<string |
  * cancels. Anchored to `parent` so the dialog is sheet-style on macOS and
  * modal-relative on other platforms.
  *
- * Backs the "Open File…" action in the editor (issue #433) — lets a user
- * open files that sit outside the current workspace root.
+ * Backs the editor's "Open File…" action — lets a user open files
+ * that sit outside the current workspace root.
  */
 export async function pickFile(parent: BrowserWindow | null): Promise<string | null> {
   const opts = {

--- a/apps/desktop/src/main/ipc/register.ts
+++ b/apps/desktop/src/main/ipc/register.ts
@@ -33,6 +33,7 @@ import {
   installCli,
   openExternal,
   openWithApp,
+  pickFile,
   pickFolder,
   revealInFinder,
 } from "./macos-shell.js";
@@ -93,6 +94,7 @@ export function registerIpc(opts: RegisterOptions): () => void {
   // Args are camelCase because they're forwarded to the handlers as typed
   // objects — Electron's IPC has no FFI-level case conversion.
   handle(Channels.pickFolder, () => pickFolder(opts.mainWindow));
+  handle(Channels.pickFile, () => pickFile(opts.mainWindow));
   handle(Channels.revealInFinder, (args: RevealInFinderArgs) => revealInFinder(args.path));
   handle(Channels.checkAppExists, (args: CheckAppExistsArgs) => checkAppExists(args.appName));
   handle(Channels.openWithApp, (args: OpenWithAppArgs) => openWithApp(args.path, args.appName));

--- a/apps/desktop/src/preload/index.cts
+++ b/apps/desktop/src/preload/index.cts
@@ -41,6 +41,7 @@ const ALLOWED_INVOKE_CHANNELS = new Set<string>([
   "get_window_fullscreen",
   // Phase 2 — macOS shell + open_external
   "pick_folder",
+  "pick_file",
   "reveal_in_finder",
   "check_app_exists",
   "open_with_app",

--- a/apps/desktop/src/shared/ipc-channels.ts
+++ b/apps/desktop/src/shared/ipc-channels.ts
@@ -16,6 +16,7 @@ export const Channels = {
 
   // macOS shell bridges + open_external
   pickFolder: "pick_folder",
+  pickFile: "pick_file",
   revealInFinder: "reveal_in_finder",
   checkAppExists: "check_app_exists",
   openWithApp: "open_with_app",

--- a/apps/web/src/components/CodeBrowserView.tsx
+++ b/apps/web/src/components/CodeBrowserView.tsx
@@ -1162,9 +1162,10 @@ export function CodeBrowserView({
   // so reads/writes hit `host.readFile` / `host.saveFile`.
   // -------------------------------------------------------------------------
   const capabilities = useCapabilities();
+  const pickFile = capabilities.pickFile;
   const handleOpenExternalFile = useCallback(async () => {
-    if (!capabilities.pickFile) return;
-    const absolutePath = await capabilities.pickFile();
+    if (!pickFile) return;
+    const absolutePath = await pickFile();
     if (!absolutePath) return;
     fileTabs.openTabExternal(absolutePath);
     setViewFilePath(absolutePath);
@@ -1175,19 +1176,19 @@ export function CodeBrowserView({
     // the route only carries workspace-relative paths, and pushing an
     // absolute path would corrupt the back/forward stack. External tabs
     // remain reachable via the tab bar and Cmd+W close.
-  }, [capabilities, fileTabs.openTabExternal]);
+  }, [pickFile, fileTabs.openTabExternal]);
 
   // Surface the action via the same command-palette event pattern as
   // Quick Open / Search in Files. Listened to here so the desktop-shell
   // capability check stays local.
   useEffect(() => {
-    if (!capabilities.pickFile) return;
+    if (!pickFile) return;
     const handler = () => {
       void handleOpenExternalFile();
     };
     window.addEventListener("band:open-file-external", handler);
     return () => window.removeEventListener("band:open-file-external", handler);
-  }, [capabilities.pickFile, handleOpenExternalFile]);
+  }, [pickFile, handleOpenExternalFile]);
 
   // -------------------------------------------------------------------------
   // Keep tabs + editor state in sync with rename / delete in the file tree.
@@ -1417,7 +1418,7 @@ export function CodeBrowserView({
             <FileTreeToolbar
               onNewFile={handleNewFile}
               onNewFolder={handleNewFolder}
-              onOpenFile={capabilities.pickFile ? handleOpenExternalFile : undefined}
+              onOpenFile={pickFile ? handleOpenExternalFile : undefined}
             />
             <div className="min-h-0 flex-1 overflow-hidden">
               <FileBrowser
@@ -1458,7 +1459,7 @@ export function CodeBrowserView({
               <FileTreeToolbar
                 onNewFile={handleNewFile}
                 onNewFolder={handleNewFolder}
-                onOpenFile={capabilities.pickFile ? handleOpenExternalFile : undefined}
+                onOpenFile={pickFile ? handleOpenExternalFile : undefined}
               />
               <div className="min-h-0 flex-1 overflow-hidden">
                 <FileBrowser

--- a/apps/web/src/components/CodeBrowserView.tsx
+++ b/apps/web/src/components/CodeBrowserView.tsx
@@ -157,7 +157,7 @@ interface FileTreeToolbarProps {
    * editor tab. Only defined inside the desktop shell (where the
    * native dialog is available — see `capabilities.pickFile`), so the
    * toolbar simply omits the action on the web. Backs the "Open File…"
-   * flow for issue #433.
+   * flow.
    */
   onOpenFile?: () => void;
 }
@@ -505,14 +505,26 @@ export function CodeBrowserView({
   // mobile) OR the container is narrower than 600px (narrow dockview panel).
   const useMobileLayout = !isDesktop || (containerWidth !== null && containerWidth < 600);
 
-  // Whether the currently-viewed file lives outside the workspace root
-  // (opened via "Open File…" — issue #433). Derived from the tab list so
-  // we don't have to thread a second flag everywhere a path does.
-  const viewIsExternal = useMemo(() => {
-    if (!viewFilePath) return false;
-    const tab = fileTabs.openTabs.find((t) => t.filePath === viewFilePath);
-    return tab?.isExternal === true;
-  }, [viewFilePath, fileTabs.openTabs]);
+  // Look up whether a given path is an external (out-of-workspace) tab.
+  // Returns `false` for null / unknown paths so the workspace-relative
+  // path through `onSelectFile` keeps firing for anything that hasn't
+  // explicitly been opened as external.
+  const isExternalPath = useCallback(
+    (filePath: string | null): boolean => {
+      if (filePath === null) return false;
+      const tab = fileTabs.openTabs.find((t) => t.filePath === filePath);
+      return tab?.isExternal === true;
+    },
+    [fileTabs.openTabs],
+  );
+
+  // Whether the currently-viewed file lives outside the workspace root.
+  // Derived from the tab list so we don't have to thread a second flag
+  // everywhere a path does.
+  const viewIsExternal = useMemo(
+    () => isExternalPath(viewFilePath || null),
+    [isExternalPath, viewFilePath],
+  );
 
   // The parent route's onSelectFile pushes the path into the URL
   // (`/workspace/$workspaceId/code/$filePath`). External files use
@@ -520,12 +532,17 @@ export function CodeBrowserView({
   // (`/workspace/foo/code//Users/alice/foo.md`) — so we silently drop
   // those notifications. The tab list (persisted to localStorage) is
   // the source of truth for "what's currently being viewed" instead.
+  //
+  // The guard checks `isExternalPath` against the current tab list so
+  // the invariant ("external tabs don't round-trip through the route")
+  // is explicit, rather than relying on the implicit "external paths
+  // happen to be absolute, workspace-relative paths happen not to be."
   const notifySelectFile = useCallback(
     (filePath: string | null) => {
-      if (filePath?.startsWith("/")) return;
+      if (isExternalPath(filePath)) return;
       onSelectFile?.(filePath);
     },
-    [onSelectFile],
+    [isExternalPath, onSelectFile],
   );
 
   // Markdown view mode (controlled from here, rendered in tab bar actions)
@@ -562,9 +579,9 @@ export function CodeBrowserView({
   const [lspExtension, setLspExtension] = useState<Extension | null>(null);
 
   // Detect the language of the current file and build the LSP WebSocket URL.
-  // External files (issue #433) are outside the workspace's project root, so
-  // the workspace's tsserver wouldn't have any useful context for them —
-  // skip LSP entirely.
+  // External files are outside the workspace's project root, so the
+  // workspace's tsserver wouldn't have any useful context for them — skip
+  // LSP entirely.
   const lspServerLang = useMemo(() => {
     if (!settings.enableLSP) return null;
     if (!viewFilePath) return null;
@@ -1139,10 +1156,10 @@ export function CodeBrowserView({
 
   // -------------------------------------------------------------------------
   // Open File… — desktop-only "open a file from anywhere on the local
-  // filesystem" action (issue #433). The OS file picker lives in the
-  // Electron main process; once we have the path back, the file flows
-  // through the same FileViewer used for workspace files, just with the
-  // `external` flag set so reads/writes hit `host.readFile` / `host.saveFile`.
+  // filesystem" action. The OS file picker lives in the Electron main
+  // process; once we have the path back, the file flows through the same
+  // FileViewer used for workspace files, just with the `external` flag set
+  // so reads/writes hit `host.readFile` / `host.saveFile`.
   // -------------------------------------------------------------------------
   const capabilities = useCapabilities();
   const handleOpenExternalFile = useCallback(async () => {
@@ -1376,7 +1393,7 @@ export function CodeBrowserView({
             renderMarkdown={renderMarkdown}
             editable
             // LSP is workspace-scoped — external files have no project root,
-            // so we deliberately skip the extension for them (issue #433).
+            // so we deliberately skip the extension for them.
             lspExtension={viewIsExternal ? null : lspExtension}
             initialEditedContent={tabState.get(viewFilePath)?.editedContent ?? null}
             savedEditorState={

--- a/apps/web/src/components/CodeBrowserView.tsx
+++ b/apps/web/src/components/CodeBrowserView.tsx
@@ -16,6 +16,7 @@ import {
   toFileUri,
   toLspServerLang,
   toWorkspaceId,
+  useCapabilities,
   useEditorHistory,
   useProjects,
   useSearch,
@@ -39,6 +40,7 @@ import {
   Code,
   Eye,
   File,
+  FileInput,
   FilePlus,
   FolderPlus,
   MoreVertical,
@@ -150,6 +152,14 @@ interface CodeBrowserViewProps {
 interface FileTreeToolbarProps {
   onNewFile?: () => void;
   onNewFolder?: () => void;
+  /**
+   * Trigger the OS file picker and open the chosen file in a new
+   * editor tab. Only defined inside the desktop shell (where the
+   * native dialog is available — see `capabilities.pickFile`), so the
+   * toolbar simply omits the action on the web. Backs the "Open File…"
+   * flow for issue #433.
+   */
+  onOpenFile?: () => void;
 }
 
 // Below this width (px), the toolbar collapses its action buttons into a
@@ -184,7 +194,7 @@ const touchPointerUp = (fn?: () => void) => (e: React.PointerEvent<HTMLButtonEle
 const fireOpenQuickOpen = () => window.dispatchEvent(new CustomEvent("band:open-quick-open"));
 const fireOpenSearchFiles = () => window.dispatchEvent(new CustomEvent("band:open-search-files"));
 
-function FileTreeToolbar({ onNewFile, onNewFolder }: FileTreeToolbarProps) {
+function FileTreeToolbar({ onNewFile, onNewFolder, onOpenFile }: FileTreeToolbarProps) {
   const rootRef = useRef<HTMLDivElement>(null);
   const [compact, setCompact] = useState(false);
 
@@ -280,6 +290,12 @@ function FileTreeToolbar({ onNewFile, onNewFolder }: FileTreeToolbarProps) {
                 ⌘⇧F
               </kbd>
             </DropdownMenuItem>
+            {onOpenFile && (
+              <DropdownMenuItem onSelect={() => queueMenuAction(onOpenFile)}>
+                <FileInput className="size-4" />
+                Open File…
+              </DropdownMenuItem>
+            )}
           </DropdownMenuContent>
         </DropdownMenu>
       ) : (
@@ -316,6 +332,24 @@ function FileTreeToolbar({ onNewFile, onNewFolder }: FileTreeToolbarProps) {
               </TooltipTrigger>
               <TooltipContent side="bottom" className="text-xs">
                 New Folder
+              </TooltipContent>
+            </Tooltip>
+          )}
+
+          {onOpenFile && (
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <button
+                  type="button"
+                  onClick={onOpenFile}
+                  onPointerUp={touchPointerUp(onOpenFile)}
+                  className="inline-flex size-6 items-center justify-center rounded-md text-muted-foreground hover:bg-accent hover:text-foreground transition-colors"
+                >
+                  <FileInput className="size-3.5" />
+                </button>
+              </TooltipTrigger>
+              <TooltipContent side="bottom" className="text-xs">
+                Open File…
               </TooltipContent>
             </Tooltip>
           )}
@@ -471,6 +505,29 @@ export function CodeBrowserView({
   // mobile) OR the container is narrower than 600px (narrow dockview panel).
   const useMobileLayout = !isDesktop || (containerWidth !== null && containerWidth < 600);
 
+  // Whether the currently-viewed file lives outside the workspace root
+  // (opened via "Open File…" — issue #433). Derived from the tab list so
+  // we don't have to thread a second flag everywhere a path does.
+  const viewIsExternal = useMemo(() => {
+    if (!viewFilePath) return false;
+    const tab = fileTabs.openTabs.find((t) => t.filePath === viewFilePath);
+    return tab?.isExternal === true;
+  }, [viewFilePath, fileTabs.openTabs]);
+
+  // The parent route's onSelectFile pushes the path into the URL
+  // (`/workspace/$workspaceId/code/$filePath`). External files use
+  // absolute filesystem paths, which would produce a nonsensical URL
+  // (`/workspace/foo/code//Users/alice/foo.md`) — so we silently drop
+  // those notifications. The tab list (persisted to localStorage) is
+  // the source of truth for "what's currently being viewed" instead.
+  const notifySelectFile = useCallback(
+    (filePath: string | null) => {
+      if (filePath?.startsWith("/")) return;
+      onSelectFile?.(filePath);
+    },
+    [onSelectFile],
+  );
+
   // Markdown view mode (controlled from here, rendered in tab bar actions)
   const [mdViewMode, setMdViewModeState] = useState<"preview" | "source">("preview");
   const isMarkdown = viewFilePath ? getFilePreviewType(viewFilePath) === "markdown" : false;
@@ -504,10 +561,14 @@ export function CodeBrowserView({
   // -------------------------------------------------------------------------
   const [lspExtension, setLspExtension] = useState<Extension | null>(null);
 
-  // Detect the language of the current file and build the LSP WebSocket URL
+  // Detect the language of the current file and build the LSP WebSocket URL.
+  // External files (issue #433) are outside the workspace's project root, so
+  // the workspace's tsserver wouldn't have any useful context for them —
+  // skip LSP entirely.
   const lspServerLang = useMemo(() => {
     if (!settings.enableLSP) return null;
     if (!viewFilePath) return null;
+    if (viewIsExternal) return null;
     const ext = viewFilePath.split(".").pop()?.toLowerCase();
     if (!ext) return null;
     // Map file extension to CodeMirror language name, then to LSP server lang
@@ -523,7 +584,7 @@ export function CodeBrowserView({
     };
     const cmLang = langMap[ext];
     return cmLang ? toLspServerLang(cmLang) : null;
-  }, [viewFilePath, settings.enableLSP]);
+  }, [viewFilePath, viewIsExternal, settings.enableLSP]);
 
   const lspWsUrl = useMemo(
     () => (lspServerLang ? buildLspWsUrl(workspaceId, lspServerLang) : null),
@@ -820,10 +881,10 @@ export function CodeBrowserView({
       setViewLine(undefined);
       setViewLineEnd(undefined);
       setViewColumn(undefined);
-      onSelectFile?.(filePath);
+      notifySelectFile(filePath);
     },
     [
-      onSelectFile,
+      notifySelectFile,
       pushDepartureAndArrival,
       openPreviewWithGuard,
       fileTabs.openTabPinned,
@@ -845,9 +906,9 @@ export function CodeBrowserView({
       setViewLine(undefined);
       setViewLineEnd(undefined);
       setViewColumn(undefined);
-      onSelectFile?.(filePath);
+      notifySelectFile(filePath);
     },
-    [onSelectFile, pushDepartureAndArrival, fileTabs.openTabPinned, viewFilePath],
+    [notifySelectFile, pushDepartureAndArrival, fileTabs.openTabPinned, viewFilePath],
   );
 
   const handleBack = useCallback(() => {
@@ -855,8 +916,8 @@ export function CodeBrowserView({
     setViewLine(undefined);
     setViewLineEnd(undefined);
     setViewColumn(undefined);
-    onSelectFile?.(null);
-  }, [onSelectFile]);
+    notifySelectFile(null);
+  }, [notifySelectFile]);
 
   // -------------------------------------------------------------------------
   // Tab handlers
@@ -889,9 +950,9 @@ export function CodeBrowserView({
       setViewLine(undefined);
       setViewLineEnd(undefined);
       setViewColumn(undefined);
-      onSelectFile?.(filePath);
+      notifySelectFile(filePath);
     },
-    [fileTabs.setActiveTab, onSelectFile, viewFilePath, tabState.update],
+    [fileTabs.setActiveTab, notifySelectFile, viewFilePath, tabState.update],
   );
 
   const handleTabClose = useCallback(
@@ -931,7 +992,7 @@ export function CodeBrowserView({
       setViewLine(undefined);
       setViewLineEnd(undefined);
       setViewColumn(undefined);
-      onSelectFile?.(null);
+      notifySelectFile(null);
     } else if (fileTabs.activeTabPath && fileTabs.activeTabPath !== viewFilePath) {
       // Active tab changed (e.g. after closing) — sync to new active tab
       // Cursor/scroll position is restored from savedEditorStatesRef via props
@@ -940,7 +1001,7 @@ export function CodeBrowserView({
       setViewLine(undefined);
       setViewLineEnd(undefined);
       setViewColumn(undefined);
-      onSelectFile?.(fileTabs.activeTabPath);
+      notifySelectFile(fileTabs.activeTabPath);
     }
   }, [fileTabs.activeTabPath, fileTabs.openTabs.length]);
 
@@ -958,7 +1019,7 @@ export function CodeBrowserView({
       setViewLine(entry.line);
       setViewLineEnd(undefined);
       setViewColumn(entry.column);
-      onSelectFile?.(entry.filePath);
+      notifySelectFile(entry.filePath);
 
       if (sameFile && editorViewRef.current) {
         // Same file: directly scroll + focus the editor view.
@@ -972,7 +1033,7 @@ export function CodeBrowserView({
         focusOnViewReadyRef.current = true;
       }
     },
-    [viewFilePath, onSelectFile, openPreviewWithGuard],
+    [viewFilePath, notifySelectFile, openPreviewWithGuard],
   );
 
   const handleEditorGoBack = useCallback(() => {
@@ -1014,7 +1075,7 @@ export function CodeBrowserView({
         setViewLine(undefined);
         setViewLineEnd(undefined);
         setViewColumn(undefined);
-        onSelectFile?.(detail.filePath);
+        notifySelectFile(detail.filePath);
         // The LSP library will position the cursor once resolveNavigation provides the view
         focusOnViewReadyRef.current = true;
       }
@@ -1022,7 +1083,7 @@ export function CodeBrowserView({
 
     window.addEventListener("band:lsp-navigate", handleLspNavigate);
     return () => window.removeEventListener("band:lsp-navigate", handleLspNavigate);
-  }, [pushDepartureAndArrival, fileTabs.openTabPinned, onSelectFile]);
+  }, [pushDepartureAndArrival, fileTabs.openTabPinned, notifySelectFile]);
 
   // Ctrl+Tab / Ctrl+Shift+Tab to switch between file tabs
   useEffect(() => {
@@ -1075,6 +1136,41 @@ export function CodeBrowserView({
   const handleNewFolder = useCallback(() => {
     fileBrowserRef.current?.startNewFolder();
   }, []);
+
+  // -------------------------------------------------------------------------
+  // Open File… — desktop-only "open a file from anywhere on the local
+  // filesystem" action (issue #433). The OS file picker lives in the
+  // Electron main process; once we have the path back, the file flows
+  // through the same FileViewer used for workspace files, just with the
+  // `external` flag set so reads/writes hit `host.readFile` / `host.saveFile`.
+  // -------------------------------------------------------------------------
+  const capabilities = useCapabilities();
+  const handleOpenExternalFile = useCallback(async () => {
+    if (!capabilities.pickFile) return;
+    const absolutePath = await capabilities.pickFile();
+    if (!absolutePath) return;
+    fileTabs.openTabExternal(absolutePath);
+    setViewFilePath(absolutePath);
+    setViewLine(undefined);
+    setViewLineEnd(undefined);
+    setViewColumn(undefined);
+    // We deliberately do NOT call onSelectFile / push to editor history —
+    // the route only carries workspace-relative paths, and pushing an
+    // absolute path would corrupt the back/forward stack. External tabs
+    // remain reachable via the tab bar and Cmd+W close.
+  }, [capabilities, fileTabs.openTabExternal]);
+
+  // Surface the action via the same command-palette event pattern as
+  // Quick Open / Search in Files. Listened to here so the desktop-shell
+  // capability check stays local.
+  useEffect(() => {
+    if (!capabilities.pickFile) return;
+    const handler = () => {
+      void handleOpenExternalFile();
+    };
+    window.addEventListener("band:open-file-external", handler);
+    return () => window.removeEventListener("band:open-file-external", handler);
+  }, [capabilities.pickFile, handleOpenExternalFile]);
 
   // -------------------------------------------------------------------------
   // Keep tabs + editor state in sync with rename / delete in the file tree.
@@ -1144,12 +1240,12 @@ export function CodeBrowserView({
       if (viewFilePath === oldPath) {
         skipFileEffectRef.current = true;
         setViewFilePath(newPath);
-        onSelectFile?.(newPath);
+        notifySelectFile(newPath);
       } else if (viewFilePath.startsWith(oldPrefix)) {
         const rewritten = newPath + viewFilePath.slice(oldPath.length);
         skipFileEffectRef.current = true;
         setViewFilePath(rewritten);
-        onSelectFile?.(rewritten);
+        notifySelectFile(rewritten);
       }
     },
     [
@@ -1158,7 +1254,7 @@ export function CodeBrowserView({
       tabState.update,
       flushActiveEditorState,
       viewFilePath,
-      onSelectFile,
+      notifySelectFile,
     ],
   );
 
@@ -1182,10 +1278,10 @@ export function CodeBrowserView({
         setViewLine(undefined);
         setViewLineEnd(undefined);
         setViewColumn(undefined);
-        onSelectFile?.(null);
+        notifySelectFile(null);
       }
     },
-    [fileTabs.removePath, tabState.removePath, viewFilePath, onSelectFile],
+    [fileTabs.removePath, tabState.removePath, viewFilePath, notifySelectFile],
   );
 
   // -------------------------------------------------------------------------
@@ -1267,6 +1363,7 @@ export function CodeBrowserView({
           <FileViewer
             workspaceId={workspaceId}
             filePath={viewFilePath}
+            external={viewIsExternal}
             line={viewLine}
             lineEnd={viewLineEnd}
             column={viewColumn}
@@ -1278,7 +1375,9 @@ export function CodeBrowserView({
             onCursorLineChange={handleCursorLineChange}
             renderMarkdown={renderMarkdown}
             editable
-            lspExtension={lspExtension}
+            // LSP is workspace-scoped — external files have no project root,
+            // so we deliberately skip the extension for them (issue #433).
+            lspExtension={viewIsExternal ? null : lspExtension}
             initialEditedContent={tabState.get(viewFilePath)?.editedContent ?? null}
             savedEditorState={
               savedEditorStatesRef.current[viewFilePath]?.editorState ??
@@ -1298,7 +1397,11 @@ export function CodeBrowserView({
           // own narrow-width collapse into a kebab, so this works at any
           // mobile viewport.
           <div className="flex h-full flex-col overflow-hidden">
-            <FileTreeToolbar onNewFile={handleNewFile} onNewFolder={handleNewFolder} />
+            <FileTreeToolbar
+              onNewFile={handleNewFile}
+              onNewFolder={handleNewFolder}
+              onOpenFile={capabilities.pickFile ? handleOpenExternalFile : undefined}
+            />
             <div className="min-h-0 flex-1 overflow-hidden">
               <FileBrowser
                 ref={fileBrowserRef}
@@ -1335,7 +1438,11 @@ export function CodeBrowserView({
             }}
           >
             <div className="flex h-full flex-col overflow-hidden border-r border-border">
-              <FileTreeToolbar onNewFile={handleNewFile} onNewFolder={handleNewFolder} />
+              <FileTreeToolbar
+                onNewFile={handleNewFile}
+                onNewFolder={handleNewFolder}
+                onOpenFile={capabilities.pickFile ? handleOpenExternalFile : undefined}
+              />
               <div className="min-h-0 flex-1 overflow-hidden">
                 <FileBrowser
                   ref={fileBrowserRef}
@@ -1433,6 +1540,7 @@ export function CodeBrowserView({
                   <FileViewer
                     workspaceId={workspaceId}
                     filePath={viewFilePath}
+                    external={viewIsExternal}
                     line={viewLine}
                     lineEnd={viewLineEnd}
                     column={viewColumn}
@@ -1441,7 +1549,9 @@ export function CodeBrowserView({
                     renderMarkdown={renderMarkdown}
                     editable
                     hideTitleBar
-                    lspExtension={lspExtension}
+                    // LSP is workspace-scoped — external files have no project
+                    // root, so we deliberately skip the extension for them.
+                    lspExtension={viewIsExternal ? null : lspExtension}
                     viewMode={isMarkdown ? mdViewMode : undefined}
                     onViewModeChange={isMarkdown ? setMdViewMode : undefined}
                     initialEditedContent={tabState.get(viewFilePath)?.editedContent ?? null}

--- a/apps/web/src/components/FileTabBar.tsx
+++ b/apps/web/src/components/FileTabBar.tsx
@@ -17,7 +17,16 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@band-app/ui";
-import { ChevronLeft, ChevronRight, Clipboard, Copy, PanelLeft, Pin, X } from "lucide-react";
+import {
+  ChevronLeft,
+  ChevronRight,
+  Clipboard,
+  Copy,
+  ExternalLink,
+  PanelLeft,
+  Pin,
+  X,
+} from "lucide-react";
 import type React from "react";
 import { useCallback, useEffect, useReducer, useRef, useState } from "react";
 import type { FileTab } from "../hooks/useFileTabs";
@@ -231,11 +240,24 @@ export function FileTabBar({
             const isActive = tab.filePath === activeTabPath;
             const isDirty = isDirtyFn?.(tab.filePath) ?? false;
             const isPreview = tab.isPreview ?? false;
+            const isExternal = tab.isExternal ?? false;
             const basename = getBasename(tab.filePath);
             const Icon = getFileIcon(basename);
-            const absolutePath = workspacePath
-              ? `${workspacePath.replace(/\/$/, "")}/${tab.filePath}`
-              : tab.filePath;
+            // External tabs already carry the absolute path; workspace tabs
+            // join with the worktree root for the "Copy Absolute Path" item.
+            const absolutePath = isExternal
+              ? tab.filePath
+              : workspacePath
+                ? `${workspacePath.replace(/\/$/, "")}/${tab.filePath}`
+                : tab.filePath;
+            // Tooltip / native title: external tabs surface the full
+            // absolute path so the user can tell at a glance where edits
+            // will be written (issue #433 acceptance criteria).
+            const tabTitle = isExternal
+              ? `${tab.filePath} (external file)`
+              : isPreview
+                ? `${tab.filePath} (preview — double-click to keep open)`
+                : tab.filePath;
 
             return (
               <ContextMenu key={tab.filePath}>
@@ -245,11 +267,7 @@ export function FileTabBar({
                     type="button"
                     role="tab"
                     aria-selected={isActive}
-                    title={
-                      isPreview
-                        ? `${tab.filePath} (preview — double-click to keep open)`
-                        : tab.filePath
-                    }
+                    title={tabTitle}
                     onClick={() => onSelectTab(tab.filePath)}
                     onDoubleClick={() => isPreview && onPinTab?.(tab.filePath)}
                     onMouseDown={(e) => handleMouseDown(e, tab.filePath)}
@@ -268,8 +286,23 @@ export function FileTabBar({
                     {/* File icon */}
                     <Icon className="size-3.5 shrink-0" />
 
-                    {/* File name — italic when in preview mode */}
-                    <span className={cn("min-w-0 flex-1 truncate", isPreview && "italic")}>
+                    {/* External-file badge (issue #433). Sits between the
+                        file icon and the name so the user can tell at a
+                        glance that the tab's filePath is an absolute path
+                        outside the workspace root. */}
+                    {isExternal && (
+                      <ExternalLink className="size-3 shrink-0 text-muted-foreground/70" />
+                    )}
+
+                    {/* File name — italic when in preview mode, muted
+                        when external so the badge is reinforced visually. */}
+                    <span
+                      className={cn(
+                        "min-w-0 flex-1 truncate",
+                        isPreview && "italic",
+                        isExternal && "text-muted-foreground/90",
+                      )}
+                    >
                       {basename}
                     </span>
 

--- a/apps/web/src/components/FileTabBar.tsx
+++ b/apps/web/src/components/FileTabBar.tsx
@@ -252,7 +252,7 @@ export function FileTabBar({
                 : tab.filePath;
             // Tooltip / native title: external tabs surface the full
             // absolute path so the user can tell at a glance where edits
-            // will be written (issue #433 acceptance criteria).
+            // will be written.
             const tabTitle = isExternal
               ? `${tab.filePath} (external file)`
               : isPreview
@@ -286,10 +286,10 @@ export function FileTabBar({
                     {/* File icon */}
                     <Icon className="size-3.5 shrink-0" />
 
-                    {/* External-file badge (issue #433). Sits between the
-                        file icon and the name so the user can tell at a
-                        glance that the tab's filePath is an absolute path
-                        outside the workspace root. */}
+                    {/* External-file badge. Sits between the file icon and
+                        the name so the user can tell at a glance that the
+                        tab's filePath is an absolute path outside the
+                        workspace root. */}
                     {isExternal && (
                       <ExternalLink className="size-3 shrink-0 text-muted-foreground/70" />
                     )}

--- a/apps/web/src/hooks/useFileTabs.ts
+++ b/apps/web/src/hooks/useFileTabs.ts
@@ -5,9 +5,26 @@ import { useCallback, useEffect, useRef, useState } from "react";
 // ---------------------------------------------------------------------------
 
 export interface FileTab {
+  /**
+   * For workspace files this is the workspace-relative path
+   * (`src/main.ts`). For external files (issue #433) this is the
+   * absolute filesystem path returned by the OS file picker
+   * (`/Users/alice/notes/scratch.md`). The shape is the same so
+   * downstream tab plumbing (active-tab pointer, dedup, eviction)
+   * doesn't have to special-case the two flavours.
+   */
   filePath: string;
   /** Preview tab — italic, single shared slot, replaced by next preview open. */
   isPreview?: boolean;
+  /**
+   * True when `filePath` is an absolute path to a file outside the
+   * current workspace root, opened via the "Open File…" action. The
+   * editor uses the host file IO surface (`host.readFile` /
+   * `host.saveFile`) instead of the workspace one, and the tab is
+   * rendered with an "external" marker so the user can tell at a
+   * glance that edits write to an out-of-workspace path.
+   */
+  isExternal?: boolean;
 }
 
 export interface UseFileTabsReturn {
@@ -19,6 +36,13 @@ export interface UseFileTabsReturn {
    * New tabs are created as pinned.
    */
   openTab: (filePath: string) => void;
+  /**
+   * Open a file outside the workspace root as a pinned, external tab.
+   * The path is absolute (returned by the OS file picker). If a tab
+   * for this path already exists it is activated; no second tab is
+   * created.
+   */
+  openTabExternal: (absolutePath: string) => void;
   /**
    * Open as a preview tab — replaces any existing preview tab.
    *
@@ -65,6 +89,7 @@ export interface UseFileTabsReturn {
 interface PersistedTab {
   filePath: string;
   isPreview?: boolean;
+  isExternal?: boolean;
 }
 
 interface PersistedTabState {
@@ -100,12 +125,11 @@ function loadTabState(workspaceId: string): { tabs: FileTab[]; active: string | 
         "filePath" in t &&
         typeof (t as { filePath: unknown }).filePath === "string"
       ) {
-        const obj = t as { filePath: string; isPreview?: unknown };
-        tabs.push(
-          obj.isPreview === true
-            ? { filePath: obj.filePath, isPreview: true }
-            : { filePath: obj.filePath },
-        );
+        const obj = t as { filePath: string; isPreview?: unknown; isExternal?: unknown };
+        const tab: FileTab = { filePath: obj.filePath };
+        if (obj.isPreview === true) tab.isPreview = true;
+        if (obj.isExternal === true) tab.isExternal = true;
+        tabs.push(tab);
       }
     }
     const active = typeof parsed.active === "string" ? parsed.active : null;
@@ -118,7 +142,17 @@ function loadTabState(workspaceId: string): { tabs: FileTab[]; active: string | 
 function saveTabState(workspaceId: string, tabs: FileTab[], active: string | null): void {
   try {
     const state: PersistedTabState = {
-      tabs: tabs.map((t) => (t.isPreview ? { filePath: t.filePath, isPreview: true } : t.filePath)),
+      tabs: tabs.map((t) => {
+        // Bare-string serialization is the legacy/compact form for plain
+        // pinned workspace tabs. Anything carrying extra flags (preview,
+        // external) is written as an object so the loader can re-hydrate
+        // the flag.
+        if (!t.isPreview && !t.isExternal) return t.filePath;
+        const out: PersistedTab = { filePath: t.filePath };
+        if (t.isPreview) out.isPreview = true;
+        if (t.isExternal) out.isExternal = true;
+        return out;
+      }),
       active,
     };
     localStorage.setItem(storageKey(workspaceId), JSON.stringify(state));
@@ -198,10 +232,28 @@ export function useFileTabs(workspaceId: string): UseFileTabsReturn {
       if (idx === -1) return [...prev, { filePath }];
       if (!prev[idx].isPreview) return prev;
       const next = prev.slice();
-      next[idx] = { filePath };
+      // Preserve isExternal when promoting a preview tab to pinned.
+      next[idx] = prev[idx].isExternal ? { filePath, isExternal: true } : { filePath };
       return next;
     });
     setActiveTabPathState(filePath);
+  }, []);
+
+  const openTabExternal = useCallback((absolutePath: string) => {
+    // External files are always opened pinned — they're a deliberate user
+    // intent ("I want to edit this specific file"), so the preview-tab
+    // single-slot model isn't appropriate.
+    setOpenTabs((prev) => {
+      const idx = prev.findIndex((t) => t.filePath === absolutePath);
+      if (idx === -1) return [...prev, { filePath: absolutePath, isExternal: true }];
+      // Already open — make sure it stays marked as external and pinned.
+      const existing = prev[idx];
+      if (existing.isExternal && !existing.isPreview) return prev;
+      const next = prev.slice();
+      next[idx] = { filePath: absolutePath, isExternal: true };
+      return next;
+    });
+    setActiveTabPathState(absolutePath);
   }, []);
 
   const openTabPreview = useCallback(
@@ -384,6 +436,7 @@ export function useFileTabs(workspaceId: string): UseFileTabsReturn {
     openTab,
     openTabPreview,
     openTabPinned,
+    openTabExternal,
     pinTab,
     closeTab,
     setActiveTab,

--- a/apps/web/src/hooks/useFileTabs.ts
+++ b/apps/web/src/hooks/useFileTabs.ts
@@ -7,8 +7,8 @@ import { useCallback, useEffect, useRef, useState } from "react";
 export interface FileTab {
   /**
    * For workspace files this is the workspace-relative path
-   * (`src/main.ts`). For external files (issue #433) this is the
-   * absolute filesystem path returned by the OS file picker
+   * (`src/main.ts`). For external files this is the absolute
+   * filesystem path returned by the OS file picker
    * (`/Users/alice/notes/scratch.md`). The shape is the same so
    * downstream tab plumbing (active-tab pointer, dedup, eviction)
    * doesn't have to special-case the two flavours.

--- a/apps/web/src/trpc/router.ts
+++ b/apps/web/src/trpc/router.ts
@@ -2005,6 +2005,88 @@ const workspaceRouter = t.router({
 });
 
 // ---------------------------------------------------------------------------
+// Host (external file operations — outside any workspace root)
+// ---------------------------------------------------------------------------
+
+/**
+ * Read/write files identified by an absolute filesystem path, with no
+ * workspace-root containment check. Backs the "Open File…" action
+ * (issue #433): users pick a file via the desktop file picker and edit
+ * it in a Band editor tab even though it sits outside the current
+ * workspace.
+ *
+ * Authentication: the band_token cookie/header is enforced at the
+ * transport layer (see start-server.ts), so only the local desktop
+ * user can call these procedures. Because they bypass the
+ * workspace-relative path traversal guard used by `workspace.getFile`
+ * / `workspace.saveFile`, we require the path to be absolute and to
+ * point at a regular file. Reading a directory or symlink target that
+ * isn't a file is rejected.
+ */
+const hostRouter = t.router({
+  readFile: publicProcedure
+    .input(z.object({ absolutePath: z.string().min(1) }))
+    .query(async ({ input }) => {
+      const target = input.absolutePath;
+      if (!target.startsWith("/")) {
+        throw new Error("Absolute path required");
+      }
+
+      const fileStat = await stat(target);
+      if (!fileStat.isFile()) {
+        throw new Error("Not a regular file");
+      }
+      const size = fileStat.size;
+
+      if (size > MAX_FILE_SIZE) {
+        return { tooLarge: true as const, size };
+      }
+
+      const buffer = await readFile(target);
+
+      const sample = buffer.subarray(0, 8192);
+      if (sample.includes(0)) {
+        return { binary: true as const, size };
+      }
+
+      const ext = extname(target).toLowerCase();
+      const language = LANG_MAP[ext];
+
+      return {
+        content: buffer.toString("utf-8"),
+        size,
+        language,
+      };
+    }),
+
+  saveFile: publicProcedure
+    .input(
+      z.object({
+        absolutePath: z.string().min(1),
+        content: z.string(),
+      }),
+    )
+    .mutation(async ({ input }) => {
+      const target = input.absolutePath;
+      if (!target.startsWith("/")) {
+        throw new Error("Absolute path required");
+      }
+
+      const fileStat = await stat(target);
+      if (fileStat.isDirectory()) {
+        throw new Error("Cannot write to a directory");
+      }
+      if (!fileStat.isFile()) {
+        throw new Error("Not a regular file");
+      }
+
+      await writeFile(target, input.content, "utf-8");
+
+      return { ok: true };
+    }),
+});
+
+// ---------------------------------------------------------------------------
 // Tunnel
 // ---------------------------------------------------------------------------
 
@@ -3688,6 +3770,7 @@ export const appRouter = t.router({
   hooks: hooksRouter,
   cli: cliRouter,
   workspace: workspaceRouter,
+  host: hostRouter,
   tunnel: tunnelRouter,
   prereqs: prereqsRouter,
   tasks: tasksRouter,

--- a/apps/web/src/trpc/router.ts
+++ b/apps/web/src/trpc/router.ts
@@ -1,8 +1,8 @@
 import { execFile, execFileSync, spawn } from "node:child_process";
 import { randomUUID } from "node:crypto";
-import { existsSync, mkdirSync, unlinkSync } from "node:fs";
-import { cp, lstat, mkdir, readdir, readFile, rename, rm, stat, writeFile } from "node:fs/promises";
-import { basename, dirname, extname, join, resolve, sep } from "node:path";
+import { existsSync, constants as fsConstants, mkdirSync, unlinkSync } from "node:fs";
+import { cp, mkdir, open, readdir, readFile, rename, rm, stat, writeFile } from "node:fs/promises";
+import { basename, dirname, extname, isAbsolute, join, resolve, sep } from "node:path";
 import { promisify } from "node:util";
 import { toWorkspaceId } from "@band-app/dashboard-core";
 import { createLogger } from "@band-app/logger";
@@ -2028,32 +2028,27 @@ const workspaceRouter = t.router({
  *     (which already gives the token holder read/write across every
  *     registered worktree) and is acceptable for a single-user
  *     personal-tool model.
- *   - Symlinks are rejected with `lstat()`. Without this, a symlink
- *     to `/etc/passwd` (or similar) would satisfy `isFile()` because
- *     `stat()` follows symlinks; we'd happily read/write the target.
+ *   - Symlinks are rejected. `stat()` follows symlinks, so a symlink
+ *     to `/etc/passwd` (or similar) would satisfy `isFile()` and we'd
+ *     happily read/write the target. Open paths with `O_NOFOLLOW` so
+ *     the kernel itself refuses to traverse a symlink, eliminating
+ *     the TOCTOU window between an `lstat()` check and the subsequent
+ *     read/write (an attacker swapping the file for a symlink between
+ *     those two syscalls would otherwise slip through).
  *   - Inputs must be absolute paths to regular files. Directories,
  *     symlinks, sockets, devices, FIFOs are all rejected.
+ *
+ * Cross-platform note: `O_NOFOLLOW` is available on macOS/Linux (the
+ * platforms Band's `package.json` declares); Windows lacks a direct
+ * equivalent and is explicitly out of scope here.
  */
-async function statRegularFileOrThrow(target: string): Promise<{ size: number }> {
-  let lstatResult: Awaited<ReturnType<typeof lstat>>;
-  try {
-    lstatResult = await lstat(target);
-  } catch (err) {
-    const code = (err as NodeJS.ErrnoException).code;
-    if (code === "ENOENT") throw new Error("File not found");
-    if (code === "EACCES" || code === "EPERM") throw new Error("Permission denied");
-    throw err;
-  }
-  if (lstatResult.isSymbolicLink()) {
-    throw new Error("Symbolic links are not allowed");
-  }
-  if (lstatResult.isDirectory()) {
-    throw new Error("Cannot operate on a directory");
-  }
-  if (!lstatResult.isFile()) {
-    throw new Error("Not a regular file");
-  }
-  return { size: lstatResult.size };
+function mapFsError(err: unknown): Error {
+  const code = (err as NodeJS.ErrnoException).code;
+  if (code === "ENOENT") return new Error("File not found");
+  if (code === "ELOOP") return new Error("Symbolic links are not allowed");
+  if (code === "EACCES" || code === "EPERM") return new Error("Permission denied");
+  if (code === "EISDIR") return new Error("Cannot operate on a directory");
+  return err as Error;
 }
 
 const hostRouter = t.router({
@@ -2061,31 +2056,57 @@ const hostRouter = t.router({
     .input(z.object({ absolutePath: z.string().min(1) }))
     .query(async ({ input }) => {
       const target = input.absolutePath;
-      if (!target.startsWith("/")) {
+      if (!isAbsolute(target)) {
         throw new Error("Absolute path required");
       }
 
-      const { size } = await statRegularFileOrThrow(target);
-
-      if (size > MAX_FILE_SIZE) {
-        return { tooLarge: true as const, size };
+      // O_RDONLY | O_NOFOLLOW: refuse to traverse a symlink. The kernel
+      // returns ELOOP if the final path component is a symlink, which
+      // we surface as "Symbolic links are not allowed" via mapFsError.
+      let fh: Awaited<ReturnType<typeof open>>;
+      try {
+        fh = await open(target, fsConstants.O_RDONLY | fsConstants.O_NOFOLLOW);
+      } catch (err) {
+        throw mapFsError(err);
       }
+      try {
+        const stats = await fh.stat();
+        if (stats.isDirectory()) {
+          throw new Error("Cannot operate on a directory");
+        }
+        if (!stats.isFile()) {
+          throw new Error("Not a regular file");
+        }
+        const size = stats.size;
 
-      const buffer = await readFile(target);
+        if (size > MAX_FILE_SIZE) {
+          return { tooLarge: true as const, size };
+        }
 
-      const sample = buffer.subarray(0, 8192);
-      if (sample.includes(0)) {
-        return { binary: true as const, size };
+        // Sample the first 8KB to detect binary content before allocating
+        // a buffer for the full file. For a binary file that's the whole
+        // story; for a text file we then read the rest.
+        const sampleLen = Math.min(8192, size);
+        const sample = Buffer.alloc(sampleLen);
+        if (sampleLen > 0) {
+          await fh.read(sample, 0, sampleLen, 0);
+          if (sample.includes(0)) {
+            return { binary: true as const, size };
+          }
+        }
+
+        const buffer = await fh.readFile();
+        const ext = extname(target).toLowerCase();
+        const language = LANG_MAP[ext];
+
+        return {
+          content: buffer.toString("utf-8"),
+          size,
+          language,
+        };
+      } finally {
+        await fh.close();
       }
-
-      const ext = extname(target).toLowerCase();
-      const language = LANG_MAP[ext];
-
-      return {
-        content: buffer.toString("utf-8"),
-        size,
-        language,
-      };
     }),
 
   saveFile: publicProcedure
@@ -2100,13 +2121,36 @@ const hostRouter = t.router({
     )
     .mutation(async ({ input }) => {
       const target = input.absolutePath;
-      if (!target.startsWith("/")) {
+      if (!isAbsolute(target)) {
         throw new Error("Absolute path required");
       }
 
-      await statRegularFileOrThrow(target);
-
-      await writeFile(target, input.content, "utf-8");
+      // O_WRONLY | O_TRUNC | O_NOFOLLOW: open the existing file
+      // exclusively for writing (no symlink traversal, no follow-up
+      // syscall window for an attacker to swap a symlink in). Crucially
+      // we do NOT pass O_CREAT — saveFile is a write-back of an
+      // existing file, not a create.
+      let fh: Awaited<ReturnType<typeof open>>;
+      try {
+        fh = await open(
+          target,
+          fsConstants.O_WRONLY | fsConstants.O_TRUNC | fsConstants.O_NOFOLLOW,
+        );
+      } catch (err) {
+        throw mapFsError(err);
+      }
+      try {
+        const stats = await fh.stat();
+        if (stats.isDirectory()) {
+          throw new Error("Cannot operate on a directory");
+        }
+        if (!stats.isFile()) {
+          throw new Error("Not a regular file");
+        }
+        await fh.writeFile(input.content, "utf-8");
+      } finally {
+        await fh.close();
+      }
 
       return { ok: true };
     }),

--- a/apps/web/src/trpc/router.ts
+++ b/apps/web/src/trpc/router.ts
@@ -1,7 +1,7 @@
 import { execFile, execFileSync, spawn } from "node:child_process";
 import { randomUUID } from "node:crypto";
 import { existsSync, mkdirSync, unlinkSync } from "node:fs";
-import { cp, mkdir, readdir, readFile, rename, rm, stat, writeFile } from "node:fs/promises";
+import { cp, lstat, mkdir, readdir, readFile, rename, rm, stat, writeFile } from "node:fs/promises";
 import { basename, dirname, extname, join, resolve, sep } from "node:path";
 import { promisify } from "node:util";
 import { toWorkspaceId } from "@band-app/dashboard-core";
@@ -2010,19 +2010,52 @@ const workspaceRouter = t.router({
 
 /**
  * Read/write files identified by an absolute filesystem path, with no
- * workspace-root containment check. Backs the "Open File…" action
- * (issue #433): users pick a file via the desktop file picker and edit
- * it in a Band editor tab even though it sits outside the current
+ * workspace-root containment check. Backs the editor's "Open File…"
+ * action: users pick a file via the desktop file picker and edit it
+ * in a Band editor tab even though it sits outside the current
  * workspace.
  *
- * Authentication: the band_token cookie/header is enforced at the
- * transport layer (see start-server.ts), so only the local desktop
- * user can call these procedures. Because they bypass the
- * workspace-relative path traversal guard used by `workspace.getFile`
- * / `workspace.saveFile`, we require the path to be absolute and to
- * point at a regular file. Reading a directory or symlink target that
- * isn't a file is rejected.
+ * Security model:
+ *   - The `band_token` cookie/header is enforced at the transport
+ *     layer (see start-server.ts), so only the local desktop user
+ *     can call these procedures.
+ *   - These procedures intentionally bypass the workspace-relative
+ *     path traversal guard used by `workspace.getFile` /
+ *     `workspace.saveFile`. The renderer is expected to source paths
+ *     from the OS file picker, but the server cannot prove that — a
+ *     bearer of the token can call `host.saveFile` with any absolute
+ *     path. This matches the existing trust boundary of the dashboard
+ *     (which already gives the token holder read/write across every
+ *     registered worktree) and is acceptable for a single-user
+ *     personal-tool model.
+ *   - Symlinks are rejected with `lstat()`. Without this, a symlink
+ *     to `/etc/passwd` (or similar) would satisfy `isFile()` because
+ *     `stat()` follows symlinks; we'd happily read/write the target.
+ *   - Inputs must be absolute paths to regular files. Directories,
+ *     symlinks, sockets, devices, FIFOs are all rejected.
  */
+async function statRegularFileOrThrow(target: string): Promise<{ size: number }> {
+  let lstatResult: Awaited<ReturnType<typeof lstat>>;
+  try {
+    lstatResult = await lstat(target);
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code === "ENOENT") throw new Error("File not found");
+    if (code === "EACCES" || code === "EPERM") throw new Error("Permission denied");
+    throw err;
+  }
+  if (lstatResult.isSymbolicLink()) {
+    throw new Error("Symbolic links are not allowed");
+  }
+  if (lstatResult.isDirectory()) {
+    throw new Error("Cannot operate on a directory");
+  }
+  if (!lstatResult.isFile()) {
+    throw new Error("Not a regular file");
+  }
+  return { size: lstatResult.size };
+}
+
 const hostRouter = t.router({
   readFile: publicProcedure
     .input(z.object({ absolutePath: z.string().min(1) }))
@@ -2032,11 +2065,7 @@ const hostRouter = t.router({
         throw new Error("Absolute path required");
       }
 
-      const fileStat = await stat(target);
-      if (!fileStat.isFile()) {
-        throw new Error("Not a regular file");
-      }
-      const size = fileStat.size;
+      const { size } = await statRegularFileOrThrow(target);
 
       if (size > MAX_FILE_SIZE) {
         return { tooLarge: true as const, size };
@@ -2063,7 +2092,10 @@ const hostRouter = t.router({
     .input(
       z.object({
         absolutePath: z.string().min(1),
-        content: z.string(),
+        // Match the read-side cap so a misbehaving client can't fill
+        // disk via the save endpoint while the read endpoint refuses
+        // anything that wide.
+        content: z.string().max(MAX_FILE_SIZE),
       }),
     )
     .mutation(async ({ input }) => {
@@ -2072,13 +2104,7 @@ const hostRouter = t.router({
         throw new Error("Absolute path required");
       }
 
-      const fileStat = await stat(target);
-      if (fileStat.isDirectory()) {
-        throw new Error("Cannot write to a directory");
-      }
-      if (!fileStat.isFile()) {
-        throw new Error("Not a regular file");
-      }
+      await statRegularFileOrThrow(target);
 
       await writeFile(target, input.content, "utf-8");
 

--- a/apps/web/tests/host-file.test.ts
+++ b/apps/web/tests/host-file.test.ts
@@ -1,5 +1,5 @@
 // Integration tests for the host file IO procedures (`host.readFile`,
-// `host.saveFile`) that back the "Open File…" action — issue #433.
+// `host.saveFile`) that back the editor's "Open File…" action.
 //
 // We exercise the real server pipeline: spawn the production server in a
 // child process, then call the tRPC procedures over HTTP against an actual
@@ -9,7 +9,15 @@
 // the integration-test suite.
 
 import { spawn } from "node:child_process";
-import { mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSync } from "node:fs";
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  realpathSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
 import { createServer } from "node:net";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -191,7 +199,7 @@ describe("tRPC — host.readFile / host.saveFile (external files)", () => {
     const res = await trpcQuery(server.url, "host.readFile", { absolutePath: outsideDir });
     expect(res.status).toBe(500);
     const body = await res.json();
-    expect(body.error.message).toContain("Not a regular file");
+    expect(body.error.message).toMatch(/directory|regular file/);
   });
 
   it("host.saveFile writes new contents to the on-disk file", async () => {
@@ -231,5 +239,109 @@ describe("tRPC — host.readFile / host.saveFile (external files)", () => {
     expect(res.status).toBe(500);
     const body = await res.json();
     expect(body.error.message).toMatch(/directory|regular file/);
+  });
+
+  it("host.saveFile returns a descriptive error for a non-existent file", async () => {
+    // The endpoint refuses to create files — it's a save, not a create.
+    // We want a clean "File not found" message instead of a raw ENOENT
+    // bubbling up as an opaque 500.
+    const missing = join(outsideDir, "definitely-does-not-exist.txt");
+    const res = await trpcMutate(server.url, "host.saveFile", {
+      absolutePath: missing,
+      content: "anything",
+    });
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error.message).toContain("File not found");
+  });
+
+  it("host.readFile rejects symbolic links", async () => {
+    // The OS picker can return a symlink, but the host endpoints must
+    // not silently follow it — a symlink to /etc/passwd would otherwise
+    // pass the `isFile()` check after stat(). lstat()-based detection
+    // surfaces it cleanly.
+    const target = join(outsideDir, "real.txt");
+    writeFileSync(target, "real content\n", "utf-8");
+    const link = join(outsideDir, "link.txt");
+    symlinkSync(target, link);
+
+    const res = await trpcQuery(server.url, "host.readFile", { absolutePath: link });
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error.message).toContain("Symbolic link");
+  });
+
+  it("host.saveFile rejects symbolic links", async () => {
+    const target = join(outsideDir, "real-save.txt");
+    writeFileSync(target, "real content\n", "utf-8");
+    const link = join(outsideDir, "link-save.txt");
+    symlinkSync(target, link);
+
+    const res = await trpcMutate(server.url, "host.saveFile", {
+      absolutePath: link,
+      content: "should not write through symlink",
+    });
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error.message).toContain("Symbolic link");
+
+    // And the target file must be unchanged.
+    expect(readFileSync(target, "utf-8")).toBe("real content\n");
+  });
+
+  it("host.readFile returns { tooLarge: true } for files larger than MAX_FILE_SIZE", async () => {
+    // MAX_FILE_SIZE is 1MB server-side; write something just past the
+    // threshold so the boundary is exercised without bloating the test.
+    const bigPath = join(outsideDir, "big.bin");
+    const big = Buffer.alloc(1024 * 1024 + 1, 65); // 1MB + 1 byte of "A"
+    writeFileSync(bigPath, big);
+
+    const res = await trpcQuery(server.url, "host.readFile", { absolutePath: bigPath });
+    expect(res.status).toBe(200);
+    const data = await trpcData<{ tooLarge?: true; size: number; content?: string }>(res);
+    expect(data.tooLarge).toBe(true);
+    expect(data.size).toBe(big.length);
+    // No content should be sent.
+    expect(data.content).toBeUndefined();
+  });
+
+  it("host.readFile returns { binary: true } for files containing NUL bytes", async () => {
+    // The detection samples the first 8KB for null bytes — the cheapest
+    // signal that a file is binary. We don't want raw binary content
+    // streamed back into a text editor.
+    const binPath = join(outsideDir, "small.bin");
+    const bin = Buffer.from([0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08]);
+    writeFileSync(binPath, bin);
+
+    const res = await trpcQuery(server.url, "host.readFile", { absolutePath: binPath });
+    expect(res.status).toBe(200);
+    const data = await trpcData<{ binary?: true; size: number; content?: string }>(res);
+    expect(data.binary).toBe(true);
+    expect(data.size).toBe(bin.length);
+    expect(data.content).toBeUndefined();
+  });
+
+  it("host.readFile / host.saveFile reject unauthenticated callers", async () => {
+    // The host procedures bypass the workspace containment guard, so
+    // the transport-layer band_token cookie is the only thing standing
+    // between an unauthenticated caller and arbitrary FS access.
+    // Verify the cookie gate actually fires when omitted.
+    const readRes = await fetch(
+      `${server.url}/trpc/host.readFile?input=${encodeURIComponent(
+        JSON.stringify({ absolutePath: externalPath }),
+      )}`,
+    );
+    expect(readRes.status).not.toBe(200);
+
+    const saveRes = await fetch(`${server.url}/trpc/host.saveFile`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ absolutePath: externalPath, content: "evil" }),
+    });
+    expect(saveRes.status).not.toBe(200);
+
+    // And the file on disk must be untouched (still the previous test's content).
+    const onDisk = readFileSync(externalPath, "utf-8");
+    expect(onDisk).not.toBe("evil");
   });
 });

--- a/apps/web/tests/host-file.test.ts
+++ b/apps/web/tests/host-file.test.ts
@@ -1,0 +1,235 @@
+// Integration tests for the host file IO procedures (`host.readFile`,
+// `host.saveFile`) that back the "Open File…" action — issue #433.
+//
+// We exercise the real server pipeline: spawn the production server in a
+// child process, then call the tRPC procedures over HTTP against an actual
+// file living outside any registered workspace root. The assertions are
+// behavioural (HTTP status, response shape, on-disk content after a save)
+// — no mocks; the only seam is the band_token cookie used by the rest of
+// the integration-test suite.
+
+import { spawn } from "node:child_process";
+import { mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSync } from "node:fs";
+import { createServer } from "node:net";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { seedSettings, seedState } from "./helpers/seed-state";
+import { SERVER_RUNTIME, SERVER_SCRIPT } from "./helpers/server-runtime";
+
+const PROJECT_ROOT = join(import.meta.dirname, "..");
+const DEFAULT_TOKEN = "host-file-test-token";
+
+// ---------------------------------------------------------------------------
+// Server helpers (mirror the patterns in trpc.test.ts so the suite stays
+// homogeneous; deliberately copied rather than imported to keep each test
+// file self-contained — the helper file already collected enough churn).
+// ---------------------------------------------------------------------------
+
+interface ServerHandle {
+  url: string;
+  home: string;
+  close: () => Promise<void>;
+}
+
+function createTmpHome(): string {
+  const tmp = realpathSync(mkdtempSync(join(tmpdir(), "band-host-file-test-")));
+  const bandDir = join(tmp, ".band");
+  mkdirSync(bandDir, { recursive: true });
+  return tmp;
+}
+
+function getRandomPort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const srv = createServer();
+    srv.listen(0, "127.0.0.1", () => {
+      const { port } = srv.address() as { port: number };
+      srv.close(() => resolve(port));
+    });
+    srv.on("error", reject);
+  });
+}
+
+async function startServer(opts: { tmpHome: string }): Promise<ServerHandle> {
+  const home = opts.tmpHome;
+  const port = await getRandomPort();
+  return new Promise((resolve, reject) => {
+    const child = spawn(SERVER_RUNTIME, [SERVER_SCRIPT], {
+      cwd: PROJECT_ROOT,
+      env: {
+        ...process.env,
+        HOME: home,
+        PORT: String(port),
+        NODE_ENV: "production",
+      },
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+
+    let stderr = "";
+    let settled = false;
+
+    child.stderr!.on("data", (chunk: Buffer) => {
+      stderr += chunk.toString();
+    });
+
+    child.stdout!.on("data", (chunk: Buffer) => {
+      const text = chunk.toString();
+      if (text.includes("listening") && !settled) {
+        settled = true;
+        resolve({
+          url: `http://127.0.0.1:${port}`,
+          home,
+          close: () =>
+            new Promise<void>((r) => {
+              child.on("exit", () => r());
+              child.kill("SIGTERM");
+            }),
+        });
+      }
+    });
+
+    child.on("error", (err) => {
+      if (!settled) {
+        settled = true;
+        reject(err);
+      }
+    });
+
+    child.on("exit", (code) => {
+      if (!settled) {
+        settled = true;
+        reject(new Error(`Server exited with code ${code} before listening.\nstderr: ${stderr}`));
+      }
+    });
+
+    setTimeout(() => {
+      if (!settled) {
+        settled = true;
+        child.kill("SIGTERM");
+        reject(new Error(`Server did not start within 15 s.\nstderr: ${stderr}`));
+      }
+    }, 15_000);
+  });
+}
+
+// ---------------------------------------------------------------------------
+// tRPC HTTP helpers
+// ---------------------------------------------------------------------------
+
+const defaultHeaders = { Cookie: `band_token=${DEFAULT_TOKEN}` };
+
+async function trpcQuery(serverUrl: string, procedure: string, input?: unknown) {
+  const url =
+    input !== undefined
+      ? `${serverUrl}/trpc/${procedure}?input=${encodeURIComponent(JSON.stringify(input))}`
+      : `${serverUrl}/trpc/${procedure}`;
+  return fetch(url, { headers: defaultHeaders });
+}
+
+async function trpcMutate(serverUrl: string, procedure: string, input?: unknown) {
+  return fetch(`${serverUrl}/trpc/${procedure}`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", ...defaultHeaders },
+    body: input !== undefined ? JSON.stringify(input) : "{}",
+  });
+}
+
+async function trpcData<T>(res: Response): Promise<T> {
+  const body = (await res.json()) as { result: { data: T } };
+  return body.result.data;
+}
+
+// ---------------------------------------------------------------------------
+// host.readFile / host.saveFile — round-trip
+// ---------------------------------------------------------------------------
+
+describe("tRPC — host.readFile / host.saveFile (external files)", () => {
+  let server: ServerHandle;
+  let tmpHome: string;
+  // The "outside" dir lives next to (not inside) the user's home, to model
+  // a path that no workspace would ever contain — i.e. the real-world
+  // case the "Open File…" action is for.
+  let outsideDir: string;
+  let externalPath: string;
+
+  beforeAll(async () => {
+    tmpHome = createTmpHome();
+    outsideDir = realpathSync(mkdtempSync(join(tmpdir(), "band-host-file-outside-")));
+    externalPath = join(outsideDir, "scratch.md");
+    writeFileSync(externalPath, "# external file\n\noriginal contents\n", "utf-8");
+
+    seedState(tmpHome, { projects: [] });
+    seedSettings(tmpHome, { tokenSecret: DEFAULT_TOKEN });
+    server = await startServer({ tmpHome });
+  });
+
+  afterAll(async () => {
+    await server.close();
+    rmSync(tmpHome, { recursive: true, force: true });
+    rmSync(outsideDir, { recursive: true, force: true });
+  });
+
+  it("host.readFile returns the contents of a file outside any workspace", async () => {
+    const res = await trpcQuery(server.url, "host.readFile", { absolutePath: externalPath });
+    expect(res.status).toBe(200);
+    const data = await trpcData<{ content: string; size: number; language?: string }>(res);
+    expect(data.content).toBe("# external file\n\noriginal contents\n");
+    expect(data.size).toBeGreaterThan(0);
+    // Markdown extension is mapped server-side; doesn't matter what the
+    // exact language hint is, only that the path-based detection runs.
+    expect(data.language).toBe("markdown");
+  });
+
+  it("host.readFile rejects a non-absolute path", async () => {
+    const res = await trpcQuery(server.url, "host.readFile", { absolutePath: "relative/path.txt" });
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error.message).toContain("Absolute path required");
+  });
+
+  it("host.readFile rejects a path that is a directory", async () => {
+    const res = await trpcQuery(server.url, "host.readFile", { absolutePath: outsideDir });
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error.message).toContain("Not a regular file");
+  });
+
+  it("host.saveFile writes new contents to the on-disk file", async () => {
+    const newContent = "# external file\n\nedited via Band\n";
+    const res = await trpcMutate(server.url, "host.saveFile", {
+      absolutePath: externalPath,
+      content: newContent,
+    });
+    expect(res.status).toBe(200);
+
+    // Read the file back from disk to confirm the write actually landed —
+    // never trust the procedure's `{ ok: true }` echo alone.
+    const onDisk = readFileSync(externalPath, "utf-8");
+    expect(onDisk).toBe(newContent);
+
+    // And reading via host.readFile should return the new contents too.
+    const readRes = await trpcQuery(server.url, "host.readFile", { absolutePath: externalPath });
+    const readData = await trpcData<{ content: string }>(readRes);
+    expect(readData.content).toBe(newContent);
+  });
+
+  it("host.saveFile rejects a non-absolute path", async () => {
+    const res = await trpcMutate(server.url, "host.saveFile", {
+      absolutePath: "still/relative.txt",
+      content: "hi",
+    });
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error.message).toContain("Absolute path required");
+  });
+
+  it("host.saveFile rejects writing to a directory", async () => {
+    const res = await trpcMutate(server.url, "host.saveFile", {
+      absolutePath: outsideDir,
+      content: "should not work",
+    });
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error.message).toMatch(/directory|regular file/);
+  });
+});

--- a/apps/web/tests/host-file.test.ts
+++ b/apps/web/tests/host-file.test.ts
@@ -324,21 +324,24 @@ describe("tRPC — host.readFile / host.saveFile (external files)", () => {
   it("host.readFile / host.saveFile reject unauthenticated callers", async () => {
     // The host procedures bypass the workspace containment guard, so
     // the transport-layer band_token cookie is the only thing standing
-    // between an unauthenticated caller and arbitrary FS access.
-    // Verify the cookie gate actually fires when omitted.
+    // between an unauthenticated caller and arbitrary FS access. The
+    // assertion pins the response to 401 (the status auth.test.ts also
+    // verifies for missing/invalid tokens) — a generic "non-200" would
+    // pass even if the auth gate were broken and the server returned a
+    // crash 500.
     const readRes = await fetch(
       `${server.url}/trpc/host.readFile?input=${encodeURIComponent(
         JSON.stringify({ absolutePath: externalPath }),
       )}`,
     );
-    expect(readRes.status).not.toBe(200);
+    expect(readRes.status).toBe(401);
 
     const saveRes = await fetch(`${server.url}/trpc/host.saveFile`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ absolutePath: externalPath, content: "evil" }),
     });
-    expect(saveRes.status).not.toBe(200);
+    expect(saveRes.status).toBe(401);
 
     // And the file on disk must be untouched (still the previous test's content).
     const onDisk = readFileSync(externalPath, "utf-8");

--- a/packages/dashboard-core/src/adapter.ts
+++ b/packages/dashboard-core/src/adapter.ts
@@ -118,6 +118,19 @@ export interface DashboardAdapter {
   saveWorkspaceFile?(workspaceId: string, path: string, content: string): Promise<void>;
 
   /**
+   * Read a file by absolute filesystem path — used by the "Open File…"
+   * action (issue #433) for files that sit outside any registered
+   * workspace root. The server-side procedure bypasses the workspace
+   * containment check; authentication still flows through the same
+   * band_token cookie used by every other tRPC call.
+   */
+  readExternalFile?(absolutePath: string): Promise<FileContentResult>;
+
+  /** Write a file by absolute filesystem path. Mirror of `saveWorkspaceFile`
+   *  for external files. */
+  saveExternalFile?(absolutePath: string, content: string): Promise<void>;
+
+  /**
    * Create a new file at the given workspace-relative path. The file's
    * parent directory must already exist. Throws if the path already
    * exists. `content` defaults to an empty string.
@@ -217,6 +230,15 @@ export interface PlatformCapabilities {
   copyPath?: boolean;
   revealInFinder?(path: string): Promise<void>;
   pickFolder?(): Promise<string | null>;
+  /**
+   * Open the OS file picker and resolve with the chosen absolute file path
+   * (or `null` when the user cancels). Defined only when the renderer is
+   * running inside the Electron desktop shell — plain browser tabs cannot
+   * trigger native file dialogs without a user-initiated `<input type="file">`
+   * click and have no way to obtain the file's absolute path anyway, so
+   * callers must gate their UI on this capability being present.
+   */
+  pickFile?(): Promise<string | null>;
   openUrl?(url: string): Promise<void>;
   getWorkspaceHref?(workspaceId: string): string | undefined;
   /** Optional navigate function for client-side routing (avoids full page reload). */

--- a/packages/dashboard-core/src/adapter.ts
+++ b/packages/dashboard-core/src/adapter.ts
@@ -118,8 +118,8 @@ export interface DashboardAdapter {
   saveWorkspaceFile?(workspaceId: string, path: string, content: string): Promise<void>;
 
   /**
-   * Read a file by absolute filesystem path — used by the "Open File…"
-   * action (issue #433) for files that sit outside any registered
+   * Read a file by absolute filesystem path — used by the editor's
+   * "Open File…" action for files that sit outside any registered
    * workspace root. The server-side procedure bypasses the workspace
    * containment check; authentication still flows through the same
    * band_token cookie used by every other tRPC call.

--- a/packages/dashboard-core/src/adapters/desktop.ts
+++ b/packages/dashboard-core/src/adapters/desktop.ts
@@ -141,8 +141,8 @@ export class NativeShellCapabilities implements PlatformCapabilities {
   }
 
   /**
-   * Open the OS file picker for the "Open File…" action (issue #433).
-   * The native dialog returns the absolute path; the renderer hands that
+   * Open the OS file picker for the editor's "Open File…" action. The
+   * native dialog returns the absolute path; the renderer hands that
    * path to `adapter.readExternalFile` / `adapter.saveExternalFile` for
    * the actual file IO.
    *

--- a/packages/dashboard-core/src/adapters/desktop.ts
+++ b/packages/dashboard-core/src/adapters/desktop.ts
@@ -140,6 +140,22 @@ export class NativeShellCapabilities implements PlatformCapabilities {
     return desktopInvoke<string | null>("pick_folder");
   }
 
+  /**
+   * Open the OS file picker for the "Open File…" action (issue #433).
+   * The native dialog returns the absolute path; the renderer hands that
+   * path to `adapter.readExternalFile` / `adapter.saveExternalFile` for
+   * the actual file IO.
+   *
+   * Only meaningful inside the Electron shell — plain browser tabs can't
+   * surface a native dialog that yields an absolute filesystem path, so
+   * we return `null` and callers gate the UI on `capabilities.pickFile`
+   * being defined (same pattern `pickFolder` uses).
+   */
+  async pickFile(): Promise<string | null> {
+    if (!isDesktopShell()) return null;
+    return desktopInvoke<string | null>("pick_file");
+  }
+
   async openUrl(url: string): Promise<void> {
     if (!isDesktopShell()) {
       window.open(url, "_blank");

--- a/packages/dashboard-core/src/adapters/web.ts
+++ b/packages/dashboard-core/src/adapters/web.ts
@@ -350,6 +350,14 @@ export class WebDashboardAdapter implements DashboardAdapter {
     await this.trpc.workspace.saveFile.mutate({ workspaceId, path, content });
   }
 
+  async readExternalFile(absolutePath: string): Promise<FileContentResult> {
+    return (await this.trpc.host.readFile.query({ absolutePath })) as FileContentResult;
+  }
+
+  async saveExternalFile(absolutePath: string, content: string): Promise<void> {
+    await this.trpc.host.saveFile.mutate({ absolutePath, content });
+  }
+
   async createWorkspaceFile(workspaceId: string, path: string, content = ""): Promise<void> {
     await this.trpc.workspace.createFile.mutate({ workspaceId, path, content });
   }

--- a/packages/dashboard-core/src/adapters/web.ts
+++ b/packages/dashboard-core/src/adapters/web.ts
@@ -351,6 +351,11 @@ export class WebDashboardAdapter implements DashboardAdapter {
   }
 
   async readExternalFile(absolutePath: string): Promise<FileContentResult> {
+    // tRPC infers a discriminated union (`{ tooLarge } | { binary } | { content }`)
+    // for the procedure's return. `FileContentResult` widens those into a single
+    // shape with all variants as optional fields — same pattern `getWorkspaceFile`
+    // uses (and the downstream `FileViewer` consumer already keys off the flags
+    // before reading `.content`).
     return (await this.trpc.host.readFile.query({ absolutePath })) as FileContentResult;
   }
 

--- a/packages/dashboard-core/src/components/FileViewer.tsx
+++ b/packages/dashboard-core/src/components/FileViewer.tsx
@@ -66,6 +66,16 @@ interface FileViewerProps {
   savedScrollTop?: number;
   /** Called when edited content changes (for persistence to tab state) */
   onEditedContentChange?: (content: string | null) => void;
+  /**
+   * When true, `filePath` is treated as an absolute filesystem path
+   * outside the workspace root (the "Open File…" flow — issue #433),
+   * and reads/writes go through the host file IO surface
+   * (`adapter.readExternalFile` / `adapter.saveExternalFile`) instead of
+   * the workspace one. `workspaceId` is still required by the prop
+   * shape but is unused on this path — image/PDF preview URLs and LSP
+   * are intentionally not wired for external files.
+   */
+  external?: boolean;
 }
 
 function getFilename(path: string): string {
@@ -111,6 +121,7 @@ export function FileViewer({
   savedEditorState,
   savedScrollTop,
   onEditedContentChange,
+  external,
 }: FileViewerProps) {
   const adapter = useAdapter();
   const [data, setData] = useState<FileContentResult | null>(null);
@@ -133,7 +144,7 @@ export function FileViewer({
 
   const isDirty = editedContent !== null && editedContent !== data?.content;
 
-  const canEdit = editable && !!adapter.saveWorkspaceFile;
+  const canEdit = editable && (external ? !!adapter.saveExternalFile : !!adapter.saveWorkspaceFile);
 
   const previewType: FilePreviewType = getFilePreviewType(filePath);
 
@@ -182,15 +193,20 @@ export function FileViewer({
   }, [previewType, viewMode, onEditorView]);
 
   useEffect(() => {
-    // Images and PDFs are rendered via the raw file URL — no tRPC fetch needed
-    if (previewType === "image" || previewType === "pdf") {
+    // Images and PDFs are rendered via the raw file URL — no tRPC fetch needed.
+    // External files don't have a workspace-relative URL; for the moment we
+    // fall through to the text-content path (binary detection will catch
+    // genuine images), since opening an arbitrary binary outside the workspace
+    // root is rare and the image preview UI isn't a goal of issue #433.
+    if (!external && (previewType === "image" || previewType === "pdf")) {
       setData(null);
       setLoading(false);
       setError(null);
       return;
     }
 
-    if (!adapter.getWorkspaceFile) {
+    const loader = external ? adapter.readExternalFile : adapter.getWorkspaceFile;
+    if (!loader) {
       setError("File viewing not supported");
       setLoading(false);
       return;
@@ -201,8 +217,10 @@ export function FileViewer({
     setError(null);
     setData(null);
 
-    adapter
-      .getWorkspaceFile(workspaceId, filePath)
+    const promise = external
+      ? adapter.readExternalFile!(filePath)
+      : adapter.getWorkspaceFile!(workspaceId, filePath);
+    promise
       .then((result) => {
         if (!cancelled) setData(result);
       })
@@ -215,13 +233,16 @@ export function FileViewer({
     return () => {
       cancelled = true;
     };
-  }, [adapter, workspaceId, filePath, previewType]);
+  }, [adapter, workspaceId, filePath, previewType, external]);
 
   const lang = data?.content ? detectLanguage(filePath, data.language) : "plaintext";
 
-  const fileUrl = adapter.getWorkspaceFileUrl
-    ? adapter.getWorkspaceFileUrl(workspaceId, filePath)
-    : undefined;
+  // External files don't have a workspace-relative raw URL endpoint.
+  // Image/PDF rendering for external paths isn't a goal of issue #433.
+  const fileUrl =
+    !external && adapter.getWorkspaceFileUrl
+      ? adapter.getWorkspaceFileUrl(workspaceId, filePath)
+      : undefined;
 
   const showMarkdownToggle = previewType === "markdown" && renderMarkdown;
 
@@ -235,11 +256,16 @@ export function FileViewer({
   onEditedContentChangeRef.current = onEditedContentChange;
 
   const handleSave = useCallback(async () => {
-    if (!adapter.saveWorkspaceFile || editedContentRef.current === null) return;
+    if (editedContentRef.current === null) return;
+    const save = external
+      ? adapter.saveExternalFile && ((c: string) => adapter.saveExternalFile!(filePath, c))
+      : adapter.saveWorkspaceFile &&
+        ((c: string) => adapter.saveWorkspaceFile!(workspaceId, filePath, c));
+    if (!save) return;
     setSaving(true);
     setSaveError(null);
     try {
-      await adapter.saveWorkspaceFile(workspaceId, filePath, editedContentRef.current);
+      await save(editedContentRef.current);
       // Update the data state so isDirty resets
       const savedContent = editedContentRef.current;
       setData((prev) => (prev ? { ...prev, content: savedContent } : prev));
@@ -252,7 +278,7 @@ export function FileViewer({
     } finally {
       setSaving(false);
     }
-  }, [adapter, workspaceId, filePath]);
+  }, [adapter, workspaceId, filePath, external]);
 
   const handleContentChange = useCallback((newContent: string) => {
     // When undo brings the content back to the on-disk version, clear

--- a/packages/dashboard-core/src/components/FileViewer.tsx
+++ b/packages/dashboard-core/src/components/FileViewer.tsx
@@ -68,8 +68,8 @@ interface FileViewerProps {
   onEditedContentChange?: (content: string | null) => void;
   /**
    * When true, `filePath` is treated as an absolute filesystem path
-   * outside the workspace root (the "Open File…" flow — issue #433),
-   * and reads/writes go through the host file IO surface
+   * outside the workspace root (the "Open File…" flow), and reads
+   * /writes go through the host file IO surface
    * (`adapter.readExternalFile` / `adapter.saveExternalFile`) instead of
    * the workspace one. `workspaceId` is still required by the prop
    * shape but is unused on this path — image/PDF preview URLs and LSP
@@ -197,7 +197,8 @@ export function FileViewer({
     // External files don't have a workspace-relative URL; for the moment we
     // fall through to the text-content path (binary detection will catch
     // genuine images), since opening an arbitrary binary outside the workspace
-    // root is rare and the image preview UI isn't a goal of issue #433.
+    // root is rare and the image preview UI isn't a goal of the external-file
+    // flow.
     if (!external && (previewType === "image" || previewType === "pdf")) {
       setData(null);
       setLoading(false);
@@ -237,8 +238,8 @@ export function FileViewer({
 
   const lang = data?.content ? detectLanguage(filePath, data.language) : "plaintext";
 
-  // External files don't have a workspace-relative raw URL endpoint.
-  // Image/PDF rendering for external paths isn't a goal of issue #433.
+  // External files don't have a workspace-relative raw URL endpoint, so
+  // image/PDF rendering for external paths is intentionally not wired.
   const fileUrl =
     !external && adapter.getWorkspaceFileUrl
       ? adapter.getWorkspaceFileUrl(workspaceId, filePath)

--- a/packages/dashboard-core/src/components/QuickOpenDialog.tsx
+++ b/packages/dashboard-core/src/components/QuickOpenDialog.tsx
@@ -11,8 +11,9 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@band-app/ui";
+import { FileInput } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { useAdapter } from "../context";
+import { useAdapter, useCapabilities } from "../context";
 import { getFileIcon } from "../lib/file-icon";
 import { formatFileLocation, parseFileLocation } from "../lib/file-location";
 
@@ -49,6 +50,7 @@ export function QuickOpenDialog({
   onQueryChange,
 }: QuickOpenDialogProps) {
   const adapter = useAdapter();
+  const capabilities = useCapabilities();
   const [query, setQuery] = useState("");
   const [files, setFiles] = useState<string[]>([]);
   const [loading, setLoading] = useState(false);
@@ -207,6 +209,19 @@ export function QuickOpenDialog({
     [onOpenFile, onOpenChange, parsedQuery],
   );
 
+  // "Open File…" entry — surfaces the OS file picker so the user can
+  // open a file from anywhere on the local filesystem (issue #433).
+  // Only available when the host shell exposes `pickFile` (i.e. the
+  // Electron desktop app); plain browser tabs hide the action.
+  const canOpenExternal = !!capabilities.pickFile;
+  const handleOpenExternal = useCallback(() => {
+    // Dispatch via the same event pattern Quick Open / Search in Files
+    // use — CodeBrowserView owns the OS-picker invocation and tab plumbing,
+    // so this dialog stays free of workspace-state knowledge.
+    onOpenChange(false);
+    window.dispatchEvent(new CustomEvent("band:open-file-external"));
+  }, [onOpenChange]);
+
   // The list of files to render: recent files when query is empty, search results otherwise
   const displayFiles = showRecent ? recentFiles : files;
   const groupHeading = showRecent ? "Recent files" : undefined;
@@ -264,6 +279,17 @@ export function QuickOpenDialog({
                     );
                   })}
                 </CommandGroup>
+                {canOpenExternal && (
+                  <CommandGroup heading="Actions">
+                    <CommandItem value="__band_open_file_external__" onSelect={handleOpenExternal}>
+                      <FileInput className="size-4 shrink-0 text-muted-foreground" />
+                      <span className="text-sm">Open File…</span>
+                      <span className="ml-auto text-xs text-muted-foreground">
+                        Pick a file outside this workspace
+                      </span>
+                    </CommandItem>
+                  </CommandGroup>
+                )}
               </>
             )}
           </CommandList>

--- a/packages/dashboard-core/src/components/QuickOpenDialog.tsx
+++ b/packages/dashboard-core/src/components/QuickOpenDialog.tsx
@@ -210,9 +210,9 @@ export function QuickOpenDialog({
   );
 
   // "Open File…" entry — surfaces the OS file picker so the user can
-  // open a file from anywhere on the local filesystem (issue #433).
-  // Only available when the host shell exposes `pickFile` (i.e. the
-  // Electron desktop app); plain browser tabs hide the action.
+  // open a file from anywhere on the local filesystem. Only available
+  // when the host shell exposes `pickFile` (i.e. the Electron desktop
+  // app); plain browser tabs hide the action.
   const canOpenExternal = !!capabilities.pickFile;
   const handleOpenExternal = useCallback(() => {
     // Dispatch via the same event pattern Quick Open / Search in Files


### PR DESCRIPTION
## Summary

Closes #433. Adds an "Open File…" action that lets users open files
from anywhere on the local filesystem in a Band editor tab, with full
read/write — useful for editing dotfiles, scratch notes, or anything
outside the active workspace root.

- New Electron IPC bridge `pick_file` calls Electron's
  `dialog.showOpenDialog({ properties: ["openFile"] })` and returns
  the chosen absolute path. The web server stays out of the
  macOS-shell business per CLAUDE.md's split.
- New tRPC procedures `host.readFile` / `host.saveFile` perform the
  actual IO. They bypass the workspace containment guard used by
  `workspace.getFile` / `workspace.saveFile`, but enforce absolute
  paths and regular-file checks. Authentication still flows through
  the existing `band_token` cookie.
- `FileTab` gains an `isExternal` flag (persisted to localStorage).
  External tabs flow through the same `FileViewer`, just with
  `external` set so reads/writes hit `host.*` and LSP is skipped
  (workspace `tsserver` has no useful context for them).
- Tabs are visually marked with a chain-link icon, the absolute path
  is shown in the native title/hover, and Copy Absolute Path returns
  the real path. The action is gated on a new `capabilities.pickFile`
  capability, so plain browser tabs hide both the toolbar button and
  the Quick Open entry.
- External files do not appear in Quick Open / Search in Files / git
  status / agent context, because the server only enumerates workspace
  roots. No additional filtering was needed.

## Test plan

- [x] `pnpm --filter @band-app/server test` — 668 tests pass,
  including 6 new integration tests in `tests/host-file.test.ts`
  covering `host.readFile` / `host.saveFile` against a real file
  outside any workspace (real server, real temp filesystem, no
  mocks).
- [x] `pnpm --filter @band-app/desktop test` — 101 tests pass.
- [x] `pnpm exec biome check .` — no new warnings.
- [x] `pnpm --filter @band-app/server build` — full Vite + esbuild +
  OpenAPI generation succeeds with the new `host` router.
- [x] `pnpm --filter @band-app/desktop build` — main + preload
  TypeScript compiles.
- [x] Manual: not yet exercised end-to-end in a packaged Electron
  app; flow has been verified through types + the host-file
  integration test for the read/write half.

## Out of scope (per the issue)

- Untitled / unsaved editor tabs.
- A "recently opened external files" list across reloads. Open tabs
  themselves persist through the existing `useFileTabs` localStorage
  mechanism, but there is no separate recents UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)