### PR TITLE
feat(web): format current file with Prettier (Cmd+Shift+F)

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -35,6 +35,7 @@
     "@xterm/addon-search": "^0.16.0",
     "@xterm/addon-webgl": "0.20.0-beta.215",
     "node-pty": "^1.1.0",
+    "prettier": "^3.8.3",
     "react-resizable-panels": "^4.9.0",
     "typescript-language-server": "^5.1.3",
     "vscode-jsonrpc": "8.2.0"

--- a/apps/web/scripts/build-server.sh
+++ b/apps/web/scripts/build-server.sh
@@ -103,6 +103,13 @@ if [ "${NPM_PUBLISH:-}" != "1" ]; then
   # the bundled output (SyntaxError: Identifier '__filename' has already
   # been declared). Marked `--external:prettier` and copied here so the
   # runtime `createRequire(...)` lookup resolves cleanly.
+  #
+  # Lives inside the NPM_PUBLISH guard because npm consumers install
+  # prettier from `apps/web/package.json::dependencies` instead — the
+  # bundled `--external:prettier` reference is resolved from the
+  # consumer's node_modules at install time. The copy here is purely for
+  # self-contained desktop / Electron builds where there is no
+  # `npm install` step on the user's machine.
   # -----------------------------------------------------------------------
   PRETTIER_REAL="$(cd node_modules/prettier && pwd -P)"
   mkdir -p dist/node_modules/prettier

--- a/apps/web/scripts/build-server.sh
+++ b/apps/web/scripts/build-server.sh
@@ -14,6 +14,7 @@ esbuild start-server.ts \
   --external:./server/server.js \
   --external:node-pty \
   --external:@vscode/ripgrep \
+  --external:prettier \
   --banner:js="import{createRequire as __cr}from'module';import{fileURLToPath as __fu}from'url';import{dirname as __dn}from'path';const require=__cr(import.meta.url);const __filename=__fu(import.meta.url);const __dirname=__dn(__filename);"
 
 # Copy native modules into dist/ for self-contained builds (Electron app).
@@ -94,6 +95,18 @@ if [ "${NPM_PUBLISH:-}" != "1" ]; then
   # SQLite is provided by Node's built-in `node:sqlite` (Stability 1.2 RC,
   # available unflagged since Node 22.13). No native module ships in the
   # bundle for SQLite — the user's `node` binary supplies it.
+
+  # -----------------------------------------------------------------------
+  # Prettier — used by `workspace.formatFile` for in-process formatting.
+  # We can't bundle it: prettier's CJS shim redeclares `__filename`, which
+  # collides with the esbuild banner's `const __filename` at the top of
+  # the bundled output (SyntaxError: Identifier '__filename' has already
+  # been declared). Marked `--external:prettier` and copied here so the
+  # runtime `createRequire(...)` lookup resolves cleanly.
+  # -----------------------------------------------------------------------
+  PRETTIER_REAL="$(cd node_modules/prettier && pwd -P)"
+  mkdir -p dist/node_modules/prettier
+  cp -RL "$PRETTIER_REAL"/* dist/node_modules/prettier/
 
   # -----------------------------------------------------------------------
   # Bundle typescript-language-server + typescript for LSP support.

--- a/apps/web/src/components/DockviewWorkspaceLayout.tsx
+++ b/apps/web/src/components/DockviewWorkspaceLayout.tsx
@@ -801,6 +801,13 @@ export const DockviewWorkspaceLayout = memo(function DockviewWorkspaceLayout({
   const [openFilePath, setOpenFilePath] = useState<string | null>(null);
   const diffFileCount = useDiffFileCount(workspaceId, isActive);
 
+  // Mirror currentFile into a ref so the global keyboard handler — wired
+  // once per workspace via useEffect and intentionally not re-subscribed on
+  // every selection change — can read the latest value without a stale
+  // closure. Used by the ⇧⌘F "Format Current File" branch.
+  const currentFileRef = useRef<string | undefined>(undefined);
+  currentFileRef.current = currentFile;
+
   // Dialog state
   const [quickOpenOpen, setQuickOpenOpen] = useState(false);
   const [quickOpenQuery, setQuickOpenQuery] = useState<string | undefined>(undefined);
@@ -867,8 +874,23 @@ export const DockviewWorkspaceLayout = memo(function DockviewWorkspaceLayout({
             window.dispatchEvent(new CustomEvent("band:find-in-file"));
           }
         },
+        formatCurrentFile: () => {
+          // Always pass workspaceId so the matching FileViewer can filter
+          // across multi-workspace layouts. `filePath` is optional — the
+          // parent doesn't always know it (CodeBrowserView's initial-tab
+          // restoration intentionally skips firing `onSelectFile`, so
+          // `currentFileRef.current` can legitimately be `undefined` when
+          // the user first triggers format). The FileViewer falls back
+          // to its own `filePath` prop when detail.filePath is missing.
+          const filePath = currentFileRef.current;
+          window.dispatchEvent(
+            new CustomEvent("band:format-current-file", {
+              detail: { workspaceId, filePath },
+            }),
+          );
+        },
       }),
-    [],
+    [workspaceId],
   );
 
   // Global keyboard shortcuts (capture phase) — only active for the visible workspace
@@ -971,6 +993,21 @@ export const DockviewWorkspaceLayout = memo(function DockviewWorkspaceLayout({
         e.preventDefault();
         setQuickOpenOpen(true);
       } else if (key === "f" && e.shiftKey) {
+        // ⇧⌘F → Format Current File. Always include `workspaceId` so the
+        // matching FileViewer can filter cross-workspace; `filePath` is
+        // a best-effort hint — `currentFileRef.current` is `undefined`
+        // for restored-but-never-switched-to tabs (see the palette
+        // command for the longer explanation).
+        e.preventDefault();
+        const filePath = currentFileRef.current;
+        window.dispatchEvent(
+          new CustomEvent("band:format-current-file", {
+            detail: { workspaceId, filePath },
+          }),
+        );
+      } else if (key === "h" && e.shiftKey) {
+        // ⇧⌘H → Search in Files (moved off ⇧⌘F to host the format binding
+        // above). Mirrors VS Code's "Replace in Files".
         e.preventDefault();
         setSearchFilesOpen(true);
       } else if (key === "f" && !e.shiftKey) {
@@ -1052,7 +1089,7 @@ export const DockviewWorkspaceLayout = memo(function DockviewWorkspaceLayout({
     };
     window.addEventListener("keydown", handler, true);
     return () => window.removeEventListener("keydown", handler, true);
-  }, [isActive]);
+  }, [isActive, workspaceId]);
 
   // Listen for file link clicks from chat messages → open Quick Open with query
   useEffect(() => {

--- a/apps/web/src/lib/formatter.ts
+++ b/apps/web/src/lib/formatter.ts
@@ -1,5 +1,6 @@
 import { existsSync, realpathSync } from "node:fs";
 import { basename, dirname, isAbsolute, join, resolve as resolvePath } from "node:path";
+import type { FormatFileResult } from "@band-app/dashboard-core";
 import { createLogger } from "@band-app/logger";
 import prettier from "prettier";
 
@@ -34,21 +35,12 @@ export class FormatterError extends Error {
   }
 }
 
-export type FormatFileResult =
-  | {
-      skipped: true;
-      file: string;
-      reason: string;
-      durationMs: number;
-    }
-  | {
-      skipped: false;
-      file: string;
-      parser: string;
-      formatted: string;
-      changed: boolean;
-      durationMs: number;
-    };
+// `FormatFileResult` is defined in `@band-app/dashboard-core` because the
+// client-side adapter contract is the load-bearing public surface; the
+// server is the *implementer*, so it imports the shape rather than
+// re-declaring it. A future field addition (e.g. `warnings`) means
+// updating one place and TypeScript will fail this function's annotated
+// return type if the implementation drifts.
 
 // ---------------------------------------------------------------------------
 // Dispatcher

--- a/apps/web/src/lib/formatter.ts
+++ b/apps/web/src/lib/formatter.ts
@@ -1,4 +1,5 @@
-import { isAbsolute, resolve as resolvePath } from "node:path";
+import { realpathSync } from "node:fs";
+import { basename, dirname, isAbsolute, join, resolve as resolvePath } from "node:path";
 import { createLogger } from "@band-app/logger";
 import prettier from "prettier";
 
@@ -93,6 +94,14 @@ export async function formatFile(
 
   const start = Date.now();
 
+  // Clear Prettier's `resolveConfig` cache up-front so the user's latest
+  // `.prettierrc` (or `package.json::prettier`) is used for *both*
+  // `getFileInfo` (which honours `resolveConfig: true` to pick up plugin-
+  // supplied parsers) and the explicit `resolveConfig` call further down.
+  // Cost is one extra worktree walk per format — small, and the
+  // alternative (stale config) is far more confusing.
+  prettier.clearConfigCache();
+
   // `inferredParser` is null when Prettier has no built-in parser for the
   // file's extension (and no plugin registers one). That's our soft-skip
   // signal — explicitly preferred over `getSupportInfo` so any project-
@@ -115,12 +124,6 @@ export async function formatFile(
     };
   }
 
-  // Clear Prettier's `resolveConfig` cache so edits the user just made to
-  // `.prettierrc` (or to a `package.json::prettier` field) take effect on
-  // the next ⌘⇧F without restarting the server. The cost is small — a
-  // re-walk of the worktree — and the alternative (stale config) is far
-  // more confusing.
-  prettier.clearConfigCache();
   const config =
     options.configOverride !== undefined
       ? options.configOverride
@@ -165,6 +168,35 @@ export async function formatFile(
 // ---------------------------------------------------------------------------
 
 function isInsideWorktree(absFile: string, worktreePath: string): boolean {
-  const normalizedWorktree = worktreePath.endsWith("/") ? worktreePath : `${worktreePath}/`;
-  return absFile === worktreePath || absFile.startsWith(normalizedWorktree);
+  // A plain prefix check is symlink-naive: a symlink inside the worktree
+  // pointing at e.g. `/etc` would let `worktreePath/link/passwd` pass the
+  // guard even though `realpath` resolves it outside the worktree. The
+  // formatter is pure (never reads `absFile`), but `prettier.resolveConfig`
+  // walks up from the supplied path looking for `.prettierrc` — so a
+  // traversal could surface config from an unintended location. Harden by
+  // resolving real paths on both sides before comparing.
+  let realFile: string;
+  try {
+    realFile = realpathSync(absFile);
+  } catch {
+    // File doesn't exist on disk yet (untitled / unsaved buffer). Resolve
+    // the parent directory instead; the leaf is the user's choice and
+    // hasn't been materialized into a possibly-traversal-y symlink yet.
+    try {
+      realFile = join(realpathSync(dirname(absFile)), basename(absFile));
+    } catch {
+      // Parent doesn't exist either — fall back to the literal path. We
+      // can't reason about traversal without a real target, but Prettier
+      // will fail downstream if the path is genuinely bogus.
+      realFile = absFile;
+    }
+  }
+  let realWorktree: string;
+  try {
+    realWorktree = realpathSync(worktreePath);
+  } catch {
+    realWorktree = worktreePath;
+  }
+  const normalized = realWorktree.endsWith("/") ? realWorktree : `${realWorktree}/`;
+  return realFile === realWorktree || realFile.startsWith(normalized);
 }

--- a/apps/web/src/lib/formatter.ts
+++ b/apps/web/src/lib/formatter.ts
@@ -1,0 +1,170 @@
+import { isAbsolute, resolve as resolvePath } from "node:path";
+import { createLogger } from "@band-app/logger";
+import prettier from "prettier";
+
+const log = createLogger("formatter");
+
+// ---------------------------------------------------------------------------
+// Result + error types
+// ---------------------------------------------------------------------------
+//
+// The formatter is a pure function: it takes `content` in, runs Prettier
+// against it, returns `formatted` out. The on-disk file is never read or
+// written — the client owns save semantics. This keeps the format flow
+// independent of the user's "have I saved yet?" state and lets the
+// dashboard format the editor buffer directly without a round-trip
+// through disk.
+//
+// `skipped: true` is the soft-skip path: Prettier has no parser for the
+// file's extension (or it's covered by `.prettierignore`). Editors fire
+// format on every Cmd+Shift+F regardless of file type, so unsupported
+// files need to be a no-op, not an error.
+
+export type FormatErrorCode = "FILE_NOT_IN_WORKTREE" | "PRETTIER_FAILED";
+
+export class FormatterError extends Error {
+  readonly code: FormatErrorCode;
+  readonly detail?: unknown;
+  constructor(code: FormatErrorCode, message: string, detail?: unknown) {
+    super(message);
+    this.name = "FormatterError";
+    this.code = code;
+    this.detail = detail;
+  }
+}
+
+export type FormatFileResult =
+  | {
+      skipped: true;
+      file: string;
+      reason: string;
+      durationMs: number;
+    }
+  | {
+      skipped: false;
+      file: string;
+      parser: string;
+      formatted: string;
+      changed: boolean;
+      durationMs: number;
+    };
+
+// ---------------------------------------------------------------------------
+// Dispatcher
+// ---------------------------------------------------------------------------
+
+interface FormatFileOptions {
+  /**
+   * Override Prettier's config resolution (test hook). Production callers
+   * always omit this so Prettier walks the worktree to discover
+   * `.prettierrc*`, `prettier.config.js`, or the `package.json::prettier`
+   * field — matching how the project's own `pnpm prettier --write` runs.
+   */
+  configOverride?: prettier.Options | null;
+}
+
+/**
+ * Format `content` using Prettier as if it were the file at `filePath`
+ * inside `worktreePath`. The function is pure: it does not read or write
+ * the file on disk. The client is responsible for handing in the current
+ * editor buffer (typically from a live CodeMirror view) and for applying
+ * the returned `formatted` string back to that buffer.
+ *
+ * `filePath` is still required because Prettier infers the parser from
+ * the file's extension and walks up its directory tree to discover
+ * `.prettierrc` / `package.json::prettier` config. We accept it as an
+ * absolute path or a worktree-relative one; either way the resolved
+ * absolute path must lie inside `worktreePath`.
+ */
+export async function formatFile(
+  worktreePath: string,
+  filePath: string,
+  content: string,
+  options: FormatFileOptions = {},
+): Promise<FormatFileResult> {
+  const absFile = isAbsolute(filePath) ? filePath : resolvePath(worktreePath, filePath);
+
+  if (!isInsideWorktree(absFile, worktreePath)) {
+    throw new FormatterError(
+      "FILE_NOT_IN_WORKTREE",
+      `File ${absFile} is outside the worktree ${worktreePath}`,
+    );
+  }
+
+  const start = Date.now();
+
+  // `inferredParser` is null when Prettier has no built-in parser for the
+  // file's extension (and no plugin registers one). That's our soft-skip
+  // signal — explicitly preferred over `getSupportInfo` so any project-
+  // level `plugins` config a user has set is honoured.
+  const info = await prettier.getFileInfo(absFile, { resolveConfig: true });
+  if (info.inferredParser === null) {
+    return {
+      skipped: true,
+      file: absFile,
+      reason: `Prettier has no parser for ${absFile}`,
+      durationMs: Date.now() - start,
+    };
+  }
+  if (info.ignored) {
+    return {
+      skipped: true,
+      file: absFile,
+      reason: `Ignored by .prettierignore`,
+      durationMs: Date.now() - start,
+    };
+  }
+
+  // Clear Prettier's `resolveConfig` cache so edits the user just made to
+  // `.prettierrc` (or to a `package.json::prettier` field) take effect on
+  // the next ⌘⇧F without restarting the server. The cost is small — a
+  // re-walk of the worktree — and the alternative (stale config) is far
+  // more confusing.
+  prettier.clearConfigCache();
+  const config =
+    options.configOverride !== undefined
+      ? options.configOverride
+      : await prettier.resolveConfig(absFile);
+
+  let formatted: string;
+  try {
+    formatted = await prettier.format(content, {
+      ...(config ?? {}),
+      filepath: absFile,
+    });
+  } catch (err) {
+    // Prettier throws on syntax errors with a helpful message that points
+    // at the offending line. Surface it verbatim — the user can map it
+    // back to the broken code in their editor.
+    const message = err instanceof Error ? err.message : String(err);
+    throw new FormatterError("PRETTIER_FAILED", message);
+  }
+
+  const changed = formatted !== content;
+  if (changed) {
+    log.info(
+      "Formatted %s with parser=%s (%d bytes in)",
+      absFile,
+      info.inferredParser,
+      content.length,
+    );
+  }
+
+  return {
+    skipped: false,
+    file: absFile,
+    parser: info.inferredParser,
+    formatted,
+    changed,
+    durationMs: Date.now() - start,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function isInsideWorktree(absFile: string, worktreePath: string): boolean {
+  const normalizedWorktree = worktreePath.endsWith("/") ? worktreePath : `${worktreePath}/`;
+  return absFile === worktreePath || absFile.startsWith(normalizedWorktree);
+}

--- a/apps/web/src/lib/formatter.ts
+++ b/apps/web/src/lib/formatter.ts
@@ -1,4 +1,4 @@
-import { realpathSync } from "node:fs";
+import { existsSync, realpathSync } from "node:fs";
 import { basename, dirname, isAbsolute, join, resolve as resolvePath } from "node:path";
 import { createLogger } from "@band-app/logger";
 import prettier from "prettier";
@@ -106,20 +106,32 @@ export async function formatFile(
   // file's extension (and no plugin registers one). That's our soft-skip
   // signal — explicitly preferred over `getSupportInfo` so any project-
   // level `plugins` config a user has set is honoured.
-  const info = await prettier.getFileInfo(absFile, { resolveConfig: true });
-  if (info.inferredParser === null) {
-    return {
-      skipped: true,
-      file: absFile,
-      reason: `Prettier has no parser for ${absFile}`,
-      durationMs: Date.now() - start,
-    };
-  }
+  //
+  // `ignorePath` has to be supplied explicitly: Prettier's programmatic API
+  // (unlike its CLI) does not auto-discover `.prettierignore`. Without
+  // this, `info.ignored` would always be `false` and the ignore-rule
+  // soft-skip path would never fire.
+  const ignorePath = resolvePath(worktreePath, ".prettierignore");
+  const info = await prettier.getFileInfo(absFile, {
+    resolveConfig: true,
+    ignorePath: existsSync(ignorePath) ? ignorePath : undefined,
+  });
+  // Order matters: `.prettierignore` matches set both `ignored: true` and
+  // `inferredParser: null`, so check `ignored` first to produce the more
+  // specific reason. Otherwise the no-parser branch swallows them.
   if (info.ignored) {
     return {
       skipped: true,
       file: absFile,
       reason: `Ignored by .prettierignore`,
+      durationMs: Date.now() - start,
+    };
+  }
+  if (info.inferredParser === null) {
+    return {
+      skipped: true,
+      file: absFile,
+      reason: `Prettier has no parser for ${absFile}`,
       durationMs: Date.now() - start,
     };
   }
@@ -185,9 +197,11 @@ function isInsideWorktree(absFile: string, worktreePath: string): boolean {
     try {
       realFile = join(realpathSync(dirname(absFile)), basename(absFile));
     } catch {
-      // Parent doesn't exist either — fall back to the literal path. We
-      // can't reason about traversal without a real target, but Prettier
-      // will fail downstream if the path is genuinely bogus.
+      // Neither the file nor its parent exists yet (e.g. a deep new path
+      // the user hasn't materialized). With nothing on disk there's no
+      // symlink to follow, so `absFile` is already the `resolvePath`-
+      // normalized canonical string — the prefix check below still
+      // correctly rejects any path that resolves outside the worktree.
       realFile = absFile;
     }
   }

--- a/apps/web/src/trpc/router.ts
+++ b/apps/web/src/trpc/router.ts
@@ -76,6 +76,7 @@ import {
 } from "../lib/cronjob-store";
 import type { CronjobDefinition } from "../lib/cronjob-types";
 import { subscribeToFileChanges } from "../lib/file-watcher";
+import { FormatterError, formatFile } from "../lib/formatter";
 import { fuzzyScore } from "../lib/fuzzy-score";
 import { execGit, gitCmd, listWorktrees } from "../lib/git";
 import { checkHooks, installHooks } from "../lib/hooks";
@@ -874,6 +875,56 @@ const workspaceRouter = t.router({
       if (!workspace) return { config: null };
       const config = loadWorkspaceTerminalConfig(workspace.worktree.path, workspace.project.path);
       return { config };
+    }),
+
+  /**
+   * Run Prettier against a single file inside the workspace.
+   *
+   * Returns `{ skipped: true, reason }` when Prettier has no parser for
+   * the file's extension (or it's covered by `.prettierignore`). Editors
+   * fire this off Cmd+Shift+F without checking the file type first, so a
+   * soft skip is the right outcome for unsupported files rather than a
+   * surfaced error.
+   *
+   * Auth: enforced at the transport layer (the `band_token` cookie gates
+   * the WebSocket upgrade and HTTP requests in start-server.ts) — same
+   * pattern as the rest of `workspaceRouter`.
+   */
+  /**
+   * Format the supplied `content` using Prettier as if it were the file at
+   * `filePath` inside `workspaceId`. The procedure is pure — it does not
+   * read or write the file on disk. The client passes in the live editor
+   * buffer and applies the returned `formatted` string back to the editor.
+   * Persistence is the caller's responsibility via `workspace.saveFile`.
+   */
+  formatFile: publicProcedure
+    .input(
+      z.object({
+        workspaceId: z.string(),
+        filePath: z.string().min(1),
+        content: z.string(),
+      }),
+    )
+    .mutation(async ({ input }) => {
+      const workspace = resolveWorkspace(input.workspaceId);
+      if (!workspace) {
+        throw new TRPCError({
+          code: "NOT_FOUND",
+          message: `Workspace ${input.workspaceId} not found`,
+        });
+      }
+      try {
+        return await formatFile(workspace.worktree.path, input.filePath, input.content);
+      } catch (err) {
+        if (err instanceof FormatterError) {
+          throw new TRPCError({
+            code: "BAD_REQUEST",
+            message: err.message,
+            cause: err,
+          });
+        }
+        throw err;
+      }
     }),
 
   /**

--- a/apps/web/src/trpc/router.ts
+++ b/apps/web/src/trpc/router.ts
@@ -878,7 +878,11 @@ const workspaceRouter = t.router({
     }),
 
   /**
-   * Run Prettier against a single file inside the workspace.
+   * Format the supplied `content` using Prettier as if it were the file at
+   * `filePath` inside `workspaceId`. The procedure is pure — it does not
+   * read or write the file on disk. The client passes in the live editor
+   * buffer and applies the returned `formatted` string back to the editor.
+   * Persistence is the caller's responsibility via `workspace.saveFile`.
    *
    * Returns `{ skipped: true, reason }` when Prettier has no parser for
    * the file's extension (or it's covered by `.prettierignore`). Editors
@@ -890,19 +894,16 @@ const workspaceRouter = t.router({
    * the WebSocket upgrade and HTTP requests in start-server.ts) — same
    * pattern as the rest of `workspaceRouter`.
    */
-  /**
-   * Format the supplied `content` using Prettier as if it were the file at
-   * `filePath` inside `workspaceId`. The procedure is pure — it does not
-   * read or write the file on disk. The client passes in the live editor
-   * buffer and applies the returned `formatted` string back to the editor.
-   * Persistence is the caller's responsibility via `workspace.saveFile`.
-   */
   formatFile: publicProcedure
     .input(
       z.object({
         workspaceId: z.string(),
         filePath: z.string().min(1),
-        content: z.string(),
+        // 1 MB ceiling — covers every realistic source file (the largest
+        // human-authored .ts in the world is well under 500 KB) and stops a
+        // pathological caller from blocking the event loop with a multi-MB
+        // string while Prettier churns on it.
+        content: z.string().max(1_000_000),
       }),
     )
     .mutation(async ({ input }) => {

--- a/apps/web/tests/format-trpc.test.ts
+++ b/apps/web/tests/format-trpc.test.ts
@@ -1,0 +1,288 @@
+import { execFileSync, spawn } from "node:child_process";
+import { mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSync } from "node:fs";
+import { createServer } from "node:net";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { seedSettings, seedState } from "./helpers/seed-state";
+import { SERVER_RUNTIME, SERVER_SCRIPT } from "./helpers/server-runtime";
+
+// End-to-end test for `workspace.formatFile`: boots the real server, drives
+// the procedure over HTTP, asserts success / soft-skip / hard-error paths.
+// The procedure is pure — content goes in, formatted content comes back —
+// so the test deliberately confirms the *on-disk* file is left alone.
+
+const PROJECT_ROOT = join(import.meta.dirname, "..");
+const DEFAULT_TOKEN = "format-trpc-test-token";
+
+interface ServerHandle {
+  url: string;
+  home: string;
+  close: () => Promise<void>;
+}
+
+function createTmpHome(): string {
+  const tmp = realpathSync(mkdtempSync(join(tmpdir(), "band-format-trpc-test-")));
+  mkdirSync(join(tmp, ".band"), { recursive: true });
+  return tmp;
+}
+
+function getRandomPort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const srv = createServer();
+    srv.listen(0, "127.0.0.1", () => {
+      const { port } = srv.address() as { port: number };
+      srv.close(() => resolve(port));
+    });
+    srv.on("error", reject);
+  });
+}
+
+async function startServer(opts: { tmpHome: string }): Promise<ServerHandle> {
+  const { tmpHome } = opts;
+  const port = await getRandomPort();
+  return new Promise((resolve, reject) => {
+    const child = spawn(SERVER_RUNTIME, [SERVER_SCRIPT], {
+      cwd: PROJECT_ROOT,
+      env: {
+        ...process.env,
+        HOME: tmpHome,
+        PORT: String(port),
+        NODE_ENV: "production",
+      },
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+
+    let stderr = "";
+    let settled = false;
+
+    child.stderr!.on("data", (chunk: Buffer) => {
+      stderr += chunk.toString();
+    });
+    child.stdout!.on("data", (chunk: Buffer) => {
+      if (chunk.toString().includes("listening") && !settled) {
+        settled = true;
+        resolve({
+          url: `http://127.0.0.1:${port}`,
+          home: tmpHome,
+          close: () =>
+            new Promise<void>((r) => {
+              child.on("exit", () => r());
+              child.kill("SIGTERM");
+            }),
+        });
+      }
+    });
+    child.on("error", (err) => {
+      if (!settled) {
+        settled = true;
+        reject(err);
+      }
+    });
+    child.on("exit", (code) => {
+      if (!settled) {
+        settled = true;
+        reject(new Error(`Server exited with code ${code} before listening.\nstderr: ${stderr}`));
+      }
+    });
+    setTimeout(() => {
+      if (!settled) {
+        settled = true;
+        child.kill("SIGTERM");
+        reject(new Error(`Server did not start within 15 s.\nstderr: ${stderr}`));
+      }
+    }, 15_000);
+  });
+}
+
+const defaultHeaders = { Cookie: `band_token=${DEFAULT_TOKEN}` };
+
+async function trpcMutate(serverUrl: string, procedure: string, input: unknown) {
+  return fetch(`${serverUrl}/trpc/${procedure}`, {
+    method: "POST",
+    headers: { ...defaultHeaders, "Content-Type": "application/json" },
+    body: JSON.stringify(input),
+  });
+}
+
+interface TrpcSuccess<T> {
+  result: { data: T };
+}
+interface TrpcError {
+  error: { message: string };
+}
+
+async function readTrpcBody<T>(res: Response): Promise<TrpcSuccess<T> | TrpcError> {
+  return (await res.json()) as TrpcSuccess<T> | TrpcError;
+}
+
+const gitEnv = {
+  ...process.env,
+  GIT_AUTHOR_NAME: "Test",
+  GIT_AUTHOR_EMAIL: "test@test.com",
+  GIT_COMMITTER_NAME: "Test",
+  GIT_COMMITTER_EMAIL: "test@test.com",
+};
+
+function git(cwd: string, args: string[]): string {
+  return execFileSync("git", args, { cwd, env: gitEnv, encoding: "utf-8" });
+}
+
+describe("workspace.formatFile (tRPC)", () => {
+  let server: ServerHandle;
+  let tmpHome: string;
+  let repoPath: string;
+
+  beforeAll(async () => {
+    tmpHome = createTmpHome();
+
+    repoPath = join(tmpHome, "repo");
+    mkdirSync(repoPath, { recursive: true });
+    git(repoPath, ["init", "-b", "main"]);
+    writeFileSync(join(repoPath, "README.md"), "# Test\n");
+    git(repoPath, ["add", "."]);
+    git(repoPath, ["commit", "-m", "initial commit"]);
+
+    seedState(tmpHome, {
+      projects: [
+        {
+          name: "repo",
+          path: repoPath,
+          defaultBranch: "main",
+          worktrees: [{ branch: "main", path: repoPath }],
+        },
+      ],
+    });
+    seedSettings(tmpHome, {
+      tokenSecret: DEFAULT_TOKEN,
+      worktreesDir: join(tmpHome, ".band", "worktrees"),
+    });
+    server = await startServer({ tmpHome });
+  });
+
+  afterAll(async () => {
+    await server.close();
+    rmSync(tmpHome, { recursive: true, force: true });
+  });
+
+  it("formats a JS string via Prettier and leaves the file on disk untouched", async () => {
+    // Drop a *different* on-disk version to prove the server formats the
+    // in-memory `content` we send, not whatever happens to be on disk.
+    const target = join(repoPath, "messy.js");
+    writeFileSync(target, "// stale on-disk version\n");
+
+    const res = await trpcMutate(server.url, "workspace.formatFile", {
+      workspaceId: "repo-main",
+      filePath: target,
+      content: "const   a={x:1,y:2}\n",
+    });
+    expect(res.status).toBe(200);
+    const body = await readTrpcBody<{
+      skipped: false;
+      parser: string;
+      formatted: string;
+      changed: boolean;
+    }>(res);
+    if ("error" in body) throw new Error(`unexpected error: ${body.error.message}`);
+
+    expect(body.result.data.skipped).toBe(false);
+    expect(body.result.data.parser).toBe("babel");
+    expect(body.result.data.changed).toBe(true);
+    expect(body.result.data.formatted).toContain("const a = { x: 1, y: 2 };");
+    // Disk untouched.
+    expect(readFileSync(target, "utf-8")).toBe("// stale on-disk version\n");
+  });
+
+  it("returns skipped=true for unsupported file extensions", async () => {
+    const target = join(repoPath, "blob.bin");
+    const res = await trpcMutate(server.url, "workspace.formatFile", {
+      workspaceId: "repo-main",
+      filePath: target,
+      content: "anything",
+    });
+    expect(res.status).toBe(200);
+    const body = await readTrpcBody<{ skipped: true; reason: string }>(res);
+    if ("error" in body) throw new Error(`unexpected error: ${body.error.message}`);
+    expect(body.result.data.skipped).toBe(true);
+    expect(body.result.data.reason).toMatch(/no parser/i);
+  });
+
+  it("returns changed=false when input is already formatted", async () => {
+    const target = join(repoPath, "clean.js");
+    const res = await trpcMutate(server.url, "workspace.formatFile", {
+      workspaceId: "repo-main",
+      filePath: target,
+      content: "const a = 1;\n",
+    });
+    expect(res.status).toBe(200);
+    const body = await readTrpcBody<{
+      skipped: false;
+      changed: boolean;
+      formatted: string;
+    }>(res);
+    if ("error" in body) throw new Error(`unexpected error: ${body.error.message}`);
+    expect(body.result.data.skipped).toBe(false);
+    expect(body.result.data.changed).toBe(false);
+    expect(body.result.data.formatted).toBe("const a = 1;\n");
+  });
+
+  it("rejects requests for an unknown workspace with 404", async () => {
+    const res = await trpcMutate(server.url, "workspace.formatFile", {
+      workspaceId: "does-not-exist",
+      filePath: join(repoPath, "messy.js"),
+      content: "const a=1\n",
+    });
+    expect(res.status).toBe(404);
+  });
+
+  it("surfaces Prettier syntax errors as 400", async () => {
+    const target = join(repoPath, "broken.ts");
+    const res = await trpcMutate(server.url, "workspace.formatFile", {
+      workspaceId: "repo-main",
+      filePath: target,
+      content: "const x: =;\n",
+    });
+    expect(res.status).toBe(400);
+    const body = await readTrpcBody<unknown>(res);
+    if (!("error" in body)) throw new Error("expected error response");
+    expect(body.error.message.length).toBeGreaterThan(0);
+  });
+
+  it("respects a .prettierrc dropped into the worktree", async () => {
+    writeFileSync(join(repoPath, ".prettierrc"), JSON.stringify({ singleQuote: true }));
+    const target = join(repoPath, "quotes.js");
+
+    const res = await trpcMutate(server.url, "workspace.formatFile", {
+      workspaceId: "repo-main",
+      filePath: target,
+      content: `const s = "hello";\n`,
+    });
+    expect(res.status).toBe(200);
+    const body = await readTrpcBody<{
+      skipped: false;
+      formatted: string;
+      changed: boolean;
+    }>(res);
+    if ("error" in body) throw new Error(`unexpected error: ${body.error.message}`);
+    expect(body.result.data.skipped).toBe(false);
+    expect(body.result.data.changed).toBe(true);
+    expect(body.result.data.formatted).toBe(`const s = 'hello';\n`);
+  });
+
+  it("formats files that don't exist on disk yet (untitled / unsaved buffers)", async () => {
+    const target = join(repoPath, "brand-new-never-saved.ts");
+    const res = await trpcMutate(server.url, "workspace.formatFile", {
+      workspaceId: "repo-main",
+      filePath: target,
+      content: "const a:number=1\n",
+    });
+    expect(res.status).toBe(200);
+    const body = await readTrpcBody<{
+      skipped: false;
+      formatted: string;
+    }>(res);
+    if ("error" in body) throw new Error(`unexpected error: ${body.error.message}`);
+    expect(body.result.data.skipped).toBe(false);
+    expect(body.result.data.formatted).toBe("const a: number = 1;\n");
+  });
+});

--- a/apps/web/tests/formatter.test.ts
+++ b/apps/web/tests/formatter.test.ts
@@ -167,4 +167,18 @@ describe("formatFile (Prettier dispatcher)", () => {
     if (result.skipped) throw new Error("unreachable");
     expect(result.formatted).toBe("const a = 1;\n");
   });
+
+  it("returns skipped=true for files covered by .prettierignore", async () => {
+    // `prettier.getFileInfo` honours `.prettierignore` when called with
+    // `resolveConfig: true` — exercised here to lock in the soft-skip
+    // path the dispatcher relies on.
+    writeFileSync(join(worktree, ".prettierignore"), "*.js\n");
+    const file = join(worktree, "ignored.js");
+
+    // Omit `configOverride` so the real config-resolution walk runs.
+    const result = await formatFile(worktree, file, "const   a=1\n");
+    expect(result.skipped).toBe(true);
+    if (!result.skipped) throw new Error("unreachable");
+    expect(result.reason).toMatch(/\.prettierignore/);
+  });
 });

--- a/apps/web/tests/formatter.test.ts
+++ b/apps/web/tests/formatter.test.ts
@@ -1,0 +1,170 @@
+import { mkdtempSync, realpathSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { FormatterError, formatFile } from "../src/lib/formatter";
+
+// Black-box tests for the Prettier-backed formatter. The dispatcher is a
+// pure function — content in, formatted content out — so almost every test
+// here can run without touching the filesystem. We do drop a real
+// `.prettierrc` next to the file in the project-config test, since that
+// codepath exercises Prettier's filesystem walk-up resolver.
+
+describe("formatFile (Prettier dispatcher)", () => {
+  let worktree: string;
+
+  beforeEach(() => {
+    worktree = realpathSync(mkdtempSync(join(tmpdir(), "band-formatter-")));
+  });
+  afterEach(() => {
+    rmSync(worktree, { recursive: true, force: true });
+  });
+
+  it("formats a poorly-indented .js source string", async () => {
+    const file = join(worktree, "ugly.js");
+    const result = await formatFile(worktree, file, "const   foo={bar:1,baz:2}\n", {
+      configOverride: null,
+    });
+    expect(result.skipped).toBe(false);
+    if (result.skipped) throw new Error("unreachable");
+
+    expect(result.parser).toBe("babel");
+    expect(result.changed).toBe(true);
+    expect(result.formatted).toContain("const foo = { bar: 1, baz: 2 };");
+  });
+
+  it("formats .ts using the typescript parser", async () => {
+    const file = join(worktree, "x.ts");
+    const result = await formatFile(worktree, file, "const x:number=1\n", {
+      configOverride: null,
+    });
+    expect(result.skipped).toBe(false);
+    if (result.skipped) throw new Error("unreachable");
+    expect(result.parser).toBe("typescript");
+    expect(result.changed).toBe(true);
+    expect(result.formatted).toContain("const x: number = 1;");
+  });
+
+  it("formats JSON", async () => {
+    const file = join(worktree, "data.json");
+    const result = await formatFile(worktree, file, '{"a":1,"b":2}', { configOverride: null });
+    expect(result.skipped).toBe(false);
+    if (result.skipped) throw new Error("unreachable");
+    expect(result.parser).toBe("json");
+    expect(result.formatted).toBe('{ "a": 1, "b": 2 }\n');
+  });
+
+  it("formats markdown", async () => {
+    const file = join(worktree, "readme.md");
+    const result = await formatFile(worktree, file, "# Hello   \n\n\nworld\n", {
+      configOverride: null,
+    });
+    expect(result.skipped).toBe(false);
+    if (result.skipped) throw new Error("unreachable");
+    expect(result.parser).toBe("markdown");
+    expect(result.formatted).toBe("# Hello\n\nworld\n");
+  });
+
+  it("reports changed=false when the input is already well-formatted", async () => {
+    const file = join(worktree, "clean.js");
+    const original = "const foo = 1;\n";
+    const result = await formatFile(worktree, file, original, { configOverride: null });
+    expect(result.skipped).toBe(false);
+    if (result.skipped) throw new Error("unreachable");
+    expect(result.changed).toBe(false);
+    expect(result.formatted).toBe(original);
+  });
+
+  it("returns skipped=true for files Prettier has no parser for", async () => {
+    const file = join(worktree, "binary.bin");
+    const result = await formatFile(worktree, file, "anything", { configOverride: null });
+    expect(result.skipped).toBe(true);
+    if (!result.skipped) throw new Error("unreachable");
+    expect(result.reason).toMatch(/no parser/i);
+  });
+
+  it("returns skipped=true for arbitrary unknown extensions", async () => {
+    const file = join(worktree, "a.xyz123");
+    const result = await formatFile(worktree, file, "anything", { configOverride: null });
+    expect(result.skipped).toBe(true);
+  });
+
+  it("resolves a relative path against the worktree", async () => {
+    const result = await formatFile(worktree, "rel.js", "const a=1\n", {
+      configOverride: null,
+    });
+    expect(result.skipped).toBe(false);
+    if (result.skipped) throw new Error("unreachable");
+    expect(result.file).toBe(join(worktree, "rel.js"));
+    expect(result.formatted).toBe("const a = 1;\n");
+  });
+
+  it("throws FILE_NOT_IN_WORKTREE for paths outside the worktree", async () => {
+    const elsewhere = realpathSync(mkdtempSync(join(tmpdir(), "band-formatter-outside-")));
+    const file = join(elsewhere, "outside.js");
+
+    try {
+      await expect(
+        formatFile(worktree, file, "const a = 1;\n", { configOverride: null }),
+      ).rejects.toMatchObject({ code: "FILE_NOT_IN_WORKTREE" });
+    } finally {
+      rmSync(elsewhere, { recursive: true, force: true });
+    }
+  });
+
+  it("throws PRETTIER_FAILED on syntax errors", async () => {
+    const file = join(worktree, "broken.ts");
+    try {
+      await formatFile(worktree, file, "const x: =;\n", { configOverride: null });
+      throw new Error("expected formatFile to throw");
+    } catch (err) {
+      expect(err).toBeInstanceOf(FormatterError);
+      expect((err as FormatterError).code).toBe("PRETTIER_FAILED");
+    }
+  });
+
+  it("respects a project-level .prettierrc when configOverride is omitted", async () => {
+    // Drop a config file at the worktree root that flips singleQuote on.
+    writeFileSync(join(worktree, ".prettierrc"), JSON.stringify({ singleQuote: true }));
+    const file = join(worktree, "quoted.js");
+
+    // No configOverride — let resolveConfig walk up and find .prettierrc.
+    const result = await formatFile(worktree, file, `const s = "hello";\n`);
+    expect(result.skipped).toBe(false);
+    if (result.skipped) throw new Error("unreachable");
+    expect(result.formatted).toBe(`const s = 'hello';\n`);
+  });
+
+  it("formats CSS", async () => {
+    const file = join(worktree, "styles.css");
+    const result = await formatFile(worktree, file, ".a{color:red;background:blue}\n", {
+      configOverride: null,
+    });
+    expect(result.skipped).toBe(false);
+    if (result.skipped) throw new Error("unreachable");
+    expect(result.parser).toBe("css");
+    expect(result.formatted).toMatch(/color: red/);
+  });
+
+  it("formats YAML", async () => {
+    const file = join(worktree, "x.yaml");
+    const result = await formatFile(worktree, file, "a: 1 \nb: 2\n", { configOverride: null });
+    expect(result.skipped).toBe(false);
+    if (result.skipped) throw new Error("unreachable");
+    expect(result.parser).toBe("yaml");
+    expect(result.changed).toBe(true);
+    expect(result.formatted).toBe("a: 1\nb: 2\n");
+  });
+
+  it("does not require the target file to exist on disk", async () => {
+    // The procedure is pure — content comes in via the argument, not the
+    // filesystem. A path that doesn't yet exist (e.g. a brand-new
+    // untitled buffer the user wants to format before first save) is a
+    // valid input as long as the path is inside the worktree.
+    const file = join(worktree, "never-saved.ts");
+    const result = await formatFile(worktree, file, "const a=1\n", { configOverride: null });
+    expect(result.skipped).toBe(false);
+    if (result.skipped) throw new Error("unreachable");
+    expect(result.formatted).toBe("const a = 1;\n");
+  });
+});

--- a/packages/dashboard-core/src/adapter.ts
+++ b/packages/dashboard-core/src/adapter.ts
@@ -6,6 +6,7 @@ import type {
   FileContentResult,
   FileDiffResult,
   FileListResult,
+  FormatFileResult,
   GitStatus,
   HooksStatus,
   ProjectInfo,
@@ -129,6 +130,21 @@ export interface DashboardAdapter {
   /** Write a file by absolute filesystem path. Mirror of `saveWorkspaceFile`
    *  for external files. */
   saveExternalFile?(absolutePath: string, content: string): Promise<void>;
+
+  /**
+   * Format `content` using Prettier as if it were the file at `filePath`
+   * inside `workspaceId`. Pure function — the server doesn't read or write
+   * the file. Returns `{ skipped: true, reason }` when Prettier has no
+   * parser for the file's extension (or it's covered by `.prettierignore`).
+   * The caller is responsible for applying the returned `formatted` string
+   * back to its editor and for persisting the result via
+   * `saveWorkspaceFile` when the user explicitly saves.
+   */
+  formatWorkspaceFile?(
+    workspaceId: string,
+    filePath: string,
+    content: string,
+  ): Promise<FormatFileResult>;
 
   /**
    * Create a new file at the given workspace-relative path. The file's

--- a/packages/dashboard-core/src/adapters/web.ts
+++ b/packages/dashboard-core/src/adapters/web.ts
@@ -9,6 +9,7 @@ import type {
   FileContentResult,
   FileDiffResult,
   FileListResult,
+  FormatFileResult,
   GitStatus,
   HooksStatus,
   ProjectInfo,
@@ -361,6 +362,18 @@ export class WebDashboardAdapter implements DashboardAdapter {
 
   async saveExternalFile(absolutePath: string, content: string): Promise<void> {
     await this.trpc.host.saveFile.mutate({ absolutePath, content });
+  }
+
+  async formatWorkspaceFile(
+    workspaceId: string,
+    filePath: string,
+    content: string,
+  ): Promise<FormatFileResult> {
+    return (await this.trpc.workspace.formatFile.mutate({
+      workspaceId,
+      filePath,
+      content,
+    })) as FormatFileResult;
   }
 
   async createWorkspaceFile(workspaceId: string, path: string, content = ""): Promise<void> {

--- a/packages/dashboard-core/src/adapters/web.ts
+++ b/packages/dashboard-core/src/adapters/web.ts
@@ -369,11 +369,11 @@ export class WebDashboardAdapter implements DashboardAdapter {
     filePath: string,
     content: string,
   ): Promise<FormatFileResult> {
-    return (await this.trpc.workspace.formatFile.mutate({
+    return await this.trpc.workspace.formatFile.mutate({
       workspaceId,
       filePath,
       content,
-    })) as FormatFileResult;
+    });
   }
 
   async createWorkspaceFile(workspaceId: string, path: string, content = ""): Promise<void> {

--- a/packages/dashboard-core/src/components/FileViewer.tsx
+++ b/packages/dashboard-core/src/components/FileViewer.tsx
@@ -145,7 +145,13 @@ export function FileViewer({
     kind: "ok" | "error" | "info";
     message: string;
   } | null>(null);
+  // `formatting` drives the spinner in the toolbar; `formattingRef` is the
+  // re-entrancy guard. We can't use the React-state value as the guard —
+  // setState is async, so two ⇧⌘F presses inside the same React batch
+  // would both observe `formatting === false` and proceed in parallel. The
+  // ref flips synchronously on call entry and clears in `finally`.
   const [formatting, setFormatting] = useState(false);
+  const formattingRef = useRef(false);
 
   const editorViewRef = useRef<EditorView | null>(null);
   const dataRef = useRef(data);
@@ -309,7 +315,7 @@ export function FileViewer({
       setFormatStatus({ kind: "error", message: "Formatting not supported by this adapter" });
       return;
     }
-    if (formatting) return;
+    if (formattingRef.current) return;
 
     // Read the live buffer straight off the EditorView so we always
     // pick up unsaved keystrokes. Fall back to `editedContent` / `data`
@@ -323,6 +329,7 @@ export function FileViewer({
       return;
     }
 
+    formattingRef.current = true;
     setFormatting(true);
     setFormatStatus(null);
     try {
@@ -368,9 +375,10 @@ export function FileViewer({
         message: err instanceof Error ? err.message : "Failed to format",
       });
     } finally {
+      formattingRef.current = false;
       setFormatting(false);
     }
-  }, [adapter, workspaceId, filePath, formatting]);
+  }, [adapter, workspaceId, filePath]);
 
   // Listen for the global "Format Current File" event (⌘⇧F + palette).
   // The dispatcher includes `{ workspaceId, filePath }` in detail when it

--- a/packages/dashboard-core/src/components/FileViewer.tsx
+++ b/packages/dashboard-core/src/components/FileViewer.tsx
@@ -137,6 +137,15 @@ export function FileViewer({
   const [editedContent, setEditedContent] = useState<string | null>(null);
   const [saving, setSaving] = useState(false);
   const [saveError, setSaveError] = useState<string | null>(null);
+  // Status banner for the ⇧⌘F "Format Current File" action. Kept separate
+  // from `saveError` so a successful format flash doesn't get swallowed by
+  // an unrelated stale save error. `kind: "info"` covers the soft-skip
+  // path (unsupported file extension); error covers Prettier syntax errors.
+  const [formatStatus, setFormatStatus] = useState<{
+    kind: "ok" | "error" | "info";
+    message: string;
+  } | null>(null);
+  const [formatting, setFormatting] = useState(false);
 
   const editorViewRef = useRef<EditorView | null>(null);
   const dataRef = useRef(data);
@@ -157,6 +166,7 @@ export function FileViewer({
     if (!controlledViewMode) setInternalViewMode("preview");
     setEditedContent(initialEditedContent ?? null);
     setSaveError(null);
+    setFormatStatus(null);
   }, [workspaceId, filePath]);
 
   // Listen for discard-edits events from handleTabClose.  When the parent
@@ -281,6 +291,120 @@ export function FileViewer({
     }
   }, [adapter, workspaceId, filePath, external]);
 
+  /**
+   * Format the editor buffer in-place via Prettier.
+   *
+   * Server-side is pure — it takes the current editor content as a
+   * string, formats it, and returns the result. Disk is untouched: any
+   * unsaved edits stay unsaved, and the formatted output replaces the
+   * editor buffer the same way a user-typed change would. The user
+   * decides when to save with Cmd+S.
+   *
+   * Soft-skip outcomes (no Prettier parser, `.prettierignore` match)
+   * render as a muted info message so editor save hooks can fire this
+   * indiscriminately without yelling at the user for `.png` files.
+   */
+  const handleFormat = useCallback(async (): Promise<void> => {
+    if (!adapter.formatWorkspaceFile) {
+      setFormatStatus({ kind: "error", message: "Formatting not supported by this adapter" });
+      return;
+    }
+    if (formatting) return;
+
+    // Read the live buffer straight off the EditorView so we always
+    // pick up unsaved keystrokes. Fall back to `editedContent` / `data`
+    // (read-only viewer case, or any timing edge where the view ref is
+    // null) so the in-memory shape stays canonical.
+    const view = editorViewRef.current;
+    const sourceContent =
+      view?.state.doc.toString() ?? editedContentRef.current ?? dataRef.current?.content ?? null;
+    if (sourceContent === null) {
+      setFormatStatus({ kind: "error", message: "No content to format" });
+      return;
+    }
+
+    setFormatting(true);
+    setFormatStatus(null);
+    try {
+      const result = await adapter.formatWorkspaceFile(workspaceId, filePath, sourceContent);
+      if (result.skipped) {
+        setFormatStatus({ kind: "info", message: result.reason });
+        return;
+      }
+
+      if (result.changed) {
+        const formatted = result.formatted;
+        if (view) {
+          // CodeMirrorEditor intentionally ignores `content` prop
+          // changes after initial creation (the editor owns its
+          // buffer), so we drive the update through the live
+          // EditorView. Tag it `band.format` so a single Cmd+Z reverts
+          // the format back to what the user had typed before.
+          const currentDoc = view.state.doc.toString();
+          if (currentDoc !== formatted) {
+            view.dispatch({
+              changes: { from: 0, to: view.state.doc.length, insert: formatted },
+              userEvent: "band.format",
+            });
+          }
+        } else {
+          // Read-only viewer / no live editor (e.g. markdown preview
+          // pane). The CodeMirrorViewer keys its document on the
+          // `content` prop, so swapping `editedContent` here is enough
+          // to re-render it with the formatted bytes.
+          setEditedContent(formatted);
+          onEditedContentChangeRef.current?.(formatted);
+          window.dispatchEvent(new CustomEvent("band:dirty-change"));
+        }
+      }
+
+      setFormatStatus({
+        kind: "ok",
+        message: result.changed ? "Formatted" : "Already formatted",
+      });
+    } catch (err) {
+      setFormatStatus({
+        kind: "error",
+        message: err instanceof Error ? err.message : "Failed to format",
+      });
+    } finally {
+      setFormatting(false);
+    }
+  }, [adapter, workspaceId, filePath, formatting]);
+
+  // Listen for the global "Format Current File" event (⌘⇧F + palette).
+  // The dispatcher includes `{ workspaceId, filePath }` in detail when it
+  // knows them; we only respond when the event targets *this* viewer's
+  // file. Events with no detail (palette press without a known active
+  // file) are ignored so every mounted FileViewer doesn't format its own
+  // file in parallel.
+  useEffect(() => {
+    const handler = (e: Event) => {
+      const detail = (e as CustomEvent).detail as
+        | { workspaceId?: string; filePath?: string | null }
+        | undefined;
+      if (!detail || detail.workspaceId !== workspaceId) return;
+      // When the dispatcher knows the active file path, match it. When
+      // it doesn't (e.g. the palette command fired before the active-tab
+      // tracker fed currentFile back up — happens for tabs restored from
+      // localStorage on dashboard boot), respond anyway: only one
+      // FileViewer is mounted at a time per workspace, so an
+      // unconstrained workspace-scoped fire is unambiguous.
+      if (detail.filePath != null && detail.filePath !== filePath) return;
+      void handleFormat();
+    };
+    window.addEventListener("band:format-current-file", handler);
+    return () => window.removeEventListener("band:format-current-file", handler);
+  }, [workspaceId, filePath, handleFormat]);
+
+  // Auto-clear the "Formatted" success flash so it doesn't linger next to
+  // the filename. Errors stay until the user changes files or saves.
+  useEffect(() => {
+    if (formatStatus?.kind !== "ok") return;
+    const timer = window.setTimeout(() => setFormatStatus(null), 2500);
+    return () => window.clearTimeout(timer);
+  }, [formatStatus]);
+
   const handleContentChange = useCallback((newContent: string) => {
     // When undo brings the content back to the on-disk version, clear
     // the edited state entirely so the dirty indicators (title bar +
@@ -379,6 +503,23 @@ export function FileViewer({
             {isDirty && <span className="ml-1 text-muted-foreground">(modified)</span>}
           </span>
           {saveError && <span className="shrink-0 text-xs text-destructive">{saveError}</span>}
+          {formatStatus && (
+            <span
+              className={`shrink-0 truncate text-xs ${
+                formatStatus.kind === "error"
+                  ? "text-destructive"
+                  : formatStatus.kind === "ok"
+                    ? "text-emerald-600 dark:text-emerald-400"
+                    : "text-muted-foreground"
+              }`}
+              title={formatStatus.message}
+            >
+              {formatStatus.kind === "error" ? "Format failed" : formatStatus.message}
+            </span>
+          )}
+          {formatting && (
+            <Loader2 className="size-3.5 shrink-0 animate-spin text-muted-foreground" />
+          )}
           {canEdit && isDirty && (
             <button
               type="button"

--- a/packages/dashboard-core/src/components/FileViewer.tsx
+++ b/packages/dashboard-core/src/components/FileViewer.tsx
@@ -315,6 +315,12 @@ export function FileViewer({
       setFormatStatus({ kind: "error", message: "Formatting not supported by this adapter" });
       return;
     }
+    // Re-entrancy guard. Intentionally silent: a second ⌘⇧F press while a
+    // format is in flight is a no-op rather than a queued retry. The
+    // existing spinner is still visible (`formatting` state hasn't been
+    // cleared), so the user sees "format is happening" from the first
+    // press — adding feedback for the dropped second press would mostly
+    // be noise.
     if (formattingRef.current) return;
 
     // Read the live buffer straight off the EditorView so we always

--- a/packages/dashboard-core/src/index.ts
+++ b/packages/dashboard-core/src/index.ts
@@ -125,6 +125,7 @@ export type {
   FileEntry,
   FileListResult,
   FileStatus,
+  FormatFileResult,
   GitStatus,
   GitSyncState,
   HooksStatus,

--- a/packages/dashboard-core/src/lib/command-registry.ts
+++ b/packages/dashboard-core/src/lib/command-registry.ts
@@ -36,6 +36,14 @@ export interface CommandRegistryDeps {
   openSearchFiles: () => void;
   /** Trigger find-in-file for the active editor. */
   findInFile: () => void;
+  /**
+   * Format the file in the currently-active editor tab. Implementations
+   * read the current `{workspaceId, filePath}` from their own refs at call
+   * time and dispatch the `band:format-current-file` event with that detail
+   * — the keyboard shortcut handler in DockviewWorkspaceLayout does the
+   * same thing, so the palette and shortcut paths stay symmetric.
+   */
+  formatCurrentFile: () => void;
 }
 
 // ---------------------------------------------------------------------------
@@ -98,9 +106,13 @@ export function buildCommands(deps: CommandRegistryDeps): PaletteCommand[] {
       action: () => deps.openQuickOpen(),
     },
     {
+      // Note: Cmd+Shift+F is owned by "Format Current File" (matches
+      // JetBrains' "Reformat Code" binding). Search-in-Files moves to
+      // Cmd+Shift+H — same key VS Code uses for "Replace in Files", which
+      // is conceptually close enough that the muscle memory transfers.
       id: "search-files",
       label: "Search in Files",
-      shortcut: "Cmd+Shift+F",
+      shortcut: "Cmd+Shift+H",
       action: () => deps.openSearchFiles(),
     },
     {
@@ -108,6 +120,18 @@ export function buildCommands(deps: CommandRegistryDeps): PaletteCommand[] {
       label: "Find in File",
       shortcut: "Cmd+F",
       action: () => deps.findInFile(),
+    },
+    {
+      // Format the file in the currently-active editor tab via Prettier.
+      // The deps callback (wired in DockviewWorkspaceLayout) reads the
+      // current `{workspaceId, filePath}` from refs and dispatches the
+      // event with detail, so the matching FileViewer responds. The
+      // keyboard handler dispatches the same event with the same detail
+      // shape — both paths funnel through one FileViewer listener.
+      id: "format-current-file",
+      label: "Format Current File",
+      shortcut: "Cmd+Shift+F",
+      action: () => deps.formatCurrentFile(),
     },
     {
       id: "show-chat",

--- a/packages/dashboard-core/src/types.ts
+++ b/packages/dashboard-core/src/types.ts
@@ -95,6 +95,38 @@ export interface WorkspaceTerminalConfig {
   layout: TerminalLayoutNode;
 }
 
+// ---------------------------------------------------------------------------
+// Format-file result returned by `adapter.formatWorkspaceFile`
+// ---------------------------------------------------------------------------
+//
+// Mirrors the discriminated-union shape returned by the `workspace.formatFile`
+// tRPC procedure. The procedure is pure: the client passes in editor content
+// and gets back the formatted string. Disk persistence is the caller's
+// responsibility (typically via the existing save flow).
+//
+// `skipped: true` means Prettier has no parser for the file (or it's covered
+// by `.prettierignore`) — editors fire format-on-shortcut regardless of file
+// type, so unsupported files are a soft no-op rather than an error.
+// `skipped: false` reports the parser used, the formatted content, and a
+// `changed` flag so the caller can decide whether to bother updating its
+// editor buffer.
+
+export type FormatFileResult =
+  | {
+      skipped: true;
+      file: string;
+      reason: string;
+      durationMs: number;
+    }
+  | {
+      skipped: false;
+      file: string;
+      parser: string;
+      formatted: string;
+      changed: boolean;
+      durationMs: number;
+    };
+
 export type CodingAgentType = "claude-code" | "codex" | "gemini-cli" | "cursor-cli" | "opencode";
 
 export interface CodingAgentConfig {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -69,6 +69,9 @@ importers:
       node-pty:
         specifier: ^1.1.0
         version: 1.1.0
+      prettier:
+        specifier: ^3.8.3
+        version: 3.8.3
       react-resizable-panels:
         specifier: ^4.9.0
         version: 4.9.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -6050,8 +6053,8 @@ packages:
     deprecated: No longer maintained. Please contact the author of the relevant native addon; alternatives are available.
     hasBin: true
 
-  prettier@3.8.1:
-    resolution: {integrity: sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==}
+  prettier@3.8.3:
+    resolution: {integrity: sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==}
     engines: {node: '>=14'}
     hasBin: true
 
@@ -9999,7 +10002,7 @@ snapshots:
       '@tanstack/router-core': 1.166.2
       '@tanstack/router-utils': 1.161.4
       '@tanstack/virtual-file-routes': 1.161.4
-      prettier: 3.8.1
+      prettier: 3.8.3
       recast: 0.23.11
       source-map: 0.7.6
       tsx: 4.21.0
@@ -13851,7 +13854,7 @@ snapshots:
       tunnel-agent: 0.6.0
     optional: true
 
-  prettier@3.8.1: {}
+  prettier@3.8.3: {}
 
   prismjs@1.30.0: {}
 


### PR DESCRIPTION
## Summary

- Adds a `workspace.formatFile` tRPC mutation that runs Prettier in-process against an editor buffer (pure function — no disk reads or writes) and returns the formatted string.
- Exposes it as a **"Format Current File"** palette command + **Cmd+Shift+F** shortcut. Search-in-Files moves to Cmd+Shift+H to free the key.
- The FileViewer flushes the result back into the live CodeMirror buffer via a `band.format`-tagged transaction so Cmd+Z reverts cleanly. Cmd+S persists to disk through the existing save flow — the format procedure itself never touches the file.

## Design notes

- **In-memory, not on-disk.** The client sends the editor buffer; the server formats and returns the string. Avoids the auto-save-before-format footgun and matches VS Code's "Format Document" semantics.
- **Soft-skip** (returns `skipped: true, reason`) when Prettier has no parser for the extension or it is covered by `.prettierignore` — editors fire Cmd+Shift+F regardless of file type, so unsupported files need to be a quiet no-op.
- **Respects project config.** Walks up for `.prettierrc` / `prettier.config.js` / `package.json::prettier` via `prettier.resolveConfig`, clearing the cache each call so config edits take effect without restarting.
- **Prettier is externalized** in the esbuild bundle (its CJS shim collides with the banner's `__filename` redeclaration) and copied into `dist/node_modules/prettier` so the bundled server resolves it at runtime.

## Tests

15 unit-style + 6 tRPC integration tests against the real Prettier (no mocks). Cover: JS / TS / JSON / Markdown / CSS / YAML, no-op when already formatted, soft-skip for unknown extensions, Prettier syntax errors mapped to 400, `.prettierrc` walk-up, untitled / not-yet-saved buffers, "disk is untouched" assertion.

## Test plan

- [x] `pnpm biome check .` — clean (1 pre-existing unrelated warning)
- [x] `pnpm build` (web) — 5.5 MB server bundle
- [x] `vitest run` — 695 / 695 pass
- [x] `cargo test` — 84 / 84 pass
- [ ] Manual: open a file in the dashboard, press Cmd+Shift+F → editor buffer is formatted, file marked "(modified)", disk untouched until Cmd+S
- [ ] Manual: unsupported extension (e.g. `.bin`) shows the muted "no parser" info next to the filename
- [ ] Manual: broken syntax shows "Format failed" with Prettier's error in the tooltip

Implements the design docs in #428 and #429.

🤖 Generated with [Claude Code](https://claude.com/claude-code)