### PR TITLE
feat(web): untitled editor tabs with save-as flow (#434)

### DIFF
--- a/apps/desktop/src/main/ipc/macos-shell.ts
+++ b/apps/desktop/src/main/ipc/macos-shell.ts
@@ -79,10 +79,12 @@ export async function pickFile(parent: BrowserWindow | null): Promise<string | n
  *
  * Backs the editor's "Save untitled tab" flow: an untitled buffer lives
  * entirely in the renderer until the user picks a destination — this
- * bridge surfaces the native save dialog and persists the buffer to the
- * chosen location atomically (one IPC round-trip = one user-visible Save
- * operation). The renderer then transitions the tab from "untitled" to
- * file-backed using the returned path.
+ * bridge surfaces the native save dialog and persists the buffer in a
+ * single IPC round-trip (one user-visible Save operation). The renderer
+ * then transitions the tab from "untitled" to file-backed using the
+ * returned path. The write itself goes through `writeSavedFile`, which
+ * uses a write-to-temp + rename pattern to avoid mid-write truncation —
+ * see that function for the atomicity contract.
  *
  * Anchored to `parent` so the dialog is sheet-style on macOS and modal-
  * relative on other platforms. `defaultPath` and `defaultName` seed the
@@ -108,8 +110,10 @@ export async function pickSaveFile(
 
   // `dialog.showSaveDialog` with `showOverwriteConfirmation` already
   // handled the overwrite prompt, so we trust the path and persist
-  // the bytes. Errors propagate up through the IPC chain.
-  writeSavedFile(result.filePath, args.content);
+  // the bytes. Errors propagate up through the IPC chain. `await` is
+  // load-bearing — `writeSavedFile` is async to keep the Electron main
+  // process event loop responsive during the disk write.
+  await writeSavedFile(result.filePath, args.content);
   return result.filePath;
 }
 

--- a/apps/desktop/src/main/ipc/macos-shell.ts
+++ b/apps/desktop/src/main/ipc/macos-shell.ts
@@ -73,6 +73,21 @@ export async function pickFile(parent: BrowserWindow | null): Promise<string | n
 // ---------------------------------------------------------------------------
 
 /**
+ * Defensive ceiling on the buffer the renderer can hand off in a
+ * single save call. The Electron model is trusted (the renderer is
+ * Band's own code), so this isn't a security boundary — it's a UX
+ * safety net for accidental pastes (multi-MB log files, an image
+ * dropped in as base64, a minified bundle) that would otherwise
+ * sit in IPC shared memory, the main-process heap, and the temp
+ * file concurrently while the disk write stalls the event loop.
+ *
+ * 100 MB matches the rough ceiling above which the OS save dialog
+ * itself becomes the bottleneck rather than the IPC. The renderer
+ * receives the rejection cleanly through the existing error path.
+ */
+const SAVE_CONTENT_MAX_BYTES = 100 * 1024 * 1024;
+
+/**
  * Open the system "Save As" picker and write the supplied `content` to the
  * chosen path. Returns the absolute path of the saved file, or `null` when
  * the user cancels.
@@ -91,21 +106,6 @@ export async function pickFile(parent: BrowserWindow | null): Promise<string | n
  * dialog's starting location and filename (e.g. "Untitled-1.txt") so the
  * user only has to type when overriding.
  */
-/**
- * Defensive ceiling on the buffer the renderer can hand off in a
- * single save call. The Electron model is trusted (the renderer is
- * Band's own code), so this isn't a security boundary — it's a UX
- * safety net for accidental pastes (multi-MB log files, an image
- * dropped in as base64, a minified bundle) that would otherwise
- * sit in IPC shared memory, the main-process heap, and the temp
- * file concurrently while the disk write stalls the event loop.
- *
- * 100 MB matches the rough ceiling above which the OS save dialog
- * itself becomes the bottleneck rather than the IPC. The renderer
- * receives the rejection cleanly through the existing error path.
- */
-const SAVE_CONTENT_MAX_BYTES = 100 * 1024 * 1024;
-
 export async function pickSaveFile(
   parent: BrowserWindow | null,
   args: { content: string; defaultName?: string; defaultPath?: string },

--- a/apps/desktop/src/main/ipc/macos-shell.ts
+++ b/apps/desktop/src/main/ipc/macos-shell.ts
@@ -91,10 +91,35 @@ export async function pickFile(parent: BrowserWindow | null): Promise<string | n
  * dialog's starting location and filename (e.g. "Untitled-1.txt") so the
  * user only has to type when overriding.
  */
+/**
+ * Defensive ceiling on the buffer the renderer can hand off in a
+ * single save call. The Electron model is trusted (the renderer is
+ * Band's own code), so this isn't a security boundary — it's a UX
+ * safety net for accidental pastes (multi-MB log files, an image
+ * dropped in as base64, a minified bundle) that would otherwise
+ * sit in IPC shared memory, the main-process heap, and the temp
+ * file concurrently while the disk write stalls the event loop.
+ *
+ * 100 MB matches the rough ceiling above which the OS save dialog
+ * itself becomes the bottleneck rather than the IPC. The renderer
+ * receives the rejection cleanly through the existing error path.
+ */
+const SAVE_CONTENT_MAX_BYTES = 100 * 1024 * 1024;
+
 export async function pickSaveFile(
   parent: BrowserWindow | null,
   args: { content: string; defaultName?: string; defaultPath?: string },
 ): Promise<string | null> {
+  // Defensive size check — see `SAVE_CONTENT_MAX_BYTES`. Using
+  // `Buffer.byteLength` (not `string.length`) so the cap reflects
+  // the on-disk UTF-8 byte count, not the JS string code-unit count.
+  if (Buffer.byteLength(args.content, "utf8") > SAVE_CONTENT_MAX_BYTES) {
+    throw new Error(
+      `File is too large to save via this flow (over ${SAVE_CONTENT_MAX_BYTES / (1024 * 1024)} MB). ` +
+        "Split the content into smaller files or save through a terminal.",
+    );
+  }
+
   const seed = resolveSaveDialogSeed(args);
   const opts = {
     title: "Save As",

--- a/apps/desktop/src/main/ipc/macos-shell.ts
+++ b/apps/desktop/src/main/ipc/macos-shell.ts
@@ -3,6 +3,7 @@
  *
  *   - `pickFolder` — system folder picker (cross-platform via Electron's `dialog`).
  *   - `pickFile` — system file picker for opening external files (cross-platform).
+ *   - `pickSaveFile` — system "Save As" picker for writing a new file to disk.
  *   - `revealInFinder` — open the path in the platform's file manager.
  *   - `checkAppExists` — look in /Applications and friends, fall back to `which`.
  *   - `openWithApp` — `open -a <app> <path>` (macOS only).
@@ -17,6 +18,7 @@ import { join } from "node:path";
 import { type BrowserWindow, dialog, shell } from "electron";
 
 import { type CliPathOptions, resolveCliBinary } from "../services/cli-paths.js";
+import { resolveSaveDialogSeed, writeSavedFile } from "./save-helpers.js";
 
 const NOT_SUPPORTED = "Not supported on this platform";
 
@@ -64,6 +66,51 @@ export async function pickFile(parent: BrowserWindow | null): Promise<string | n
     : await dialog.showOpenDialog(opts);
   if (result.canceled || result.filePaths.length === 0) return null;
   return result.filePaths[0] ?? null;
+}
+
+// ---------------------------------------------------------------------------
+// pickSaveFile
+// ---------------------------------------------------------------------------
+
+/**
+ * Open the system "Save As" picker and write the supplied `content` to the
+ * chosen path. Returns the absolute path of the saved file, or `null` when
+ * the user cancels.
+ *
+ * Backs the editor's "Save untitled tab" flow: an untitled buffer lives
+ * entirely in the renderer until the user picks a destination — this
+ * bridge surfaces the native save dialog and persists the buffer to the
+ * chosen location atomically (one IPC round-trip = one user-visible Save
+ * operation). The renderer then transitions the tab from "untitled" to
+ * file-backed using the returned path.
+ *
+ * Anchored to `parent` so the dialog is sheet-style on macOS and modal-
+ * relative on other platforms. `defaultPath` and `defaultName` seed the
+ * dialog's starting location and filename (e.g. "Untitled-1.txt") so the
+ * user only has to type when overriding.
+ */
+export async function pickSaveFile(
+  parent: BrowserWindow | null,
+  args: { content: string; defaultName?: string; defaultPath?: string },
+): Promise<string | null> {
+  const seed = resolveSaveDialogSeed(args);
+  const opts = {
+    title: "Save As",
+    defaultPath: seed,
+    properties: ["createDirectory", "showOverwriteConfirmation"] as Array<
+      "createDirectory" | "showOverwriteConfirmation"
+    >,
+  };
+  const result = parent
+    ? await dialog.showSaveDialog(parent, opts)
+    : await dialog.showSaveDialog(opts);
+  if (result.canceled || !result.filePath) return null;
+
+  // `dialog.showSaveDialog` with `showOverwriteConfirmation` already
+  // handled the overwrite prompt, so we trust the path and persist
+  // the bytes. Errors propagate up through the IPC chain.
+  writeSavedFile(result.filePath, args.content);
+  return result.filePath;
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/desktop/src/main/ipc/register.ts
+++ b/apps/desktop/src/main/ipc/register.ts
@@ -23,6 +23,7 @@ import type {
   InstallCliArgs,
   OpenExternalArgs,
   OpenWithAppArgs,
+  PickSaveFileArgs,
   RevealInFinderArgs,
 } from "../../shared/types.js";
 import type { CliPathOptions } from "../services/cli-paths.js";
@@ -35,6 +36,7 @@ import {
   openWithApp,
   pickFile,
   pickFolder,
+  pickSaveFile,
   revealInFinder,
 } from "./macos-shell.js";
 import { getAppTitle } from "./window-title.js";
@@ -95,6 +97,7 @@ export function registerIpc(opts: RegisterOptions): () => void {
   // objects — Electron's IPC has no FFI-level case conversion.
   handle(Channels.pickFolder, () => pickFolder(opts.mainWindow));
   handle(Channels.pickFile, () => pickFile(opts.mainWindow));
+  handle(Channels.pickSaveFile, (args: PickSaveFileArgs) => pickSaveFile(opts.mainWindow, args));
   handle(Channels.revealInFinder, (args: RevealInFinderArgs) => revealInFinder(args.path));
   handle(Channels.checkAppExists, (args: CheckAppExistsArgs) => checkAppExists(args.appName));
   handle(Channels.openWithApp, (args: OpenWithAppArgs) => openWithApp(args.path, args.appName));

--- a/apps/desktop/src/main/ipc/save-helpers.ts
+++ b/apps/desktop/src/main/ipc/save-helpers.ts
@@ -9,8 +9,9 @@
  * default-seed computation are isolated here.
  */
 
-import { writeFileSync } from "node:fs";
-import { join } from "node:path";
+import { randomBytes } from "node:crypto";
+import { rename, unlink, writeFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
 
 /**
  * Compute the default seed path for the OS save dialog from caller-
@@ -37,15 +38,48 @@ export function resolveSaveDialogSeed(args: {
 }
 
 /**
- * Persist `content` to `filePath` using a UTF-8 write. The IPC handler
- * invokes this once Electron's save dialog returns a path; the
- * separation lets the integration tests exercise the on-disk path
- * directly without driving the native dialog.
+ * Persist `content` to `filePath` using an atomic write-to-temp +
+ * rename pattern. Three guarantees that follow from the layout:
  *
- * Throws on filesystem errors (permission denied, parent missing) so
- * the error surfaces through the IPC invoke chain rather than silently
- * succeeding and losing the user's work.
+ *   1. **Async.** The IPC handler runs on the Electron main process —
+ *      a synchronous `writeFileSync` would freeze the event loop and
+ *      every renderer IPC call until the write completes (visible as
+ *      app stalls on slow disks or large buffers). `fs/promises`
+ *      yields between syscalls.
+ *
+ *   2. **Atomic at the filesystem level.** `writeFile` truncates the
+ *      destination before streaming bytes, so a crash / SIGKILL /
+ *      power loss mid-write would zero the file. We write to a sibling
+ *      `.band-save-<rand>.tmp` first, then `rename(2)` — which is
+ *      atomic on POSIX and best-effort on Windows (NTFS implements it
+ *      via MoveFileEx with `REPLACE_EXISTING`). Either the user sees
+ *      the previous contents or the new contents, never a truncated
+ *      file.
+ *
+ *   3. **Errors propagate.** Filesystem failures (permission denied,
+ *      parent missing, disk full mid-rename) throw so the IPC chain
+ *      surfaces them to the renderer; we still try to remove the temp
+ *      file on the error path so a failed save doesn't litter the
+ *      worktree.
  */
-export function writeSavedFile(filePath: string, content: string): void {
-  writeFileSync(filePath, content, "utf8");
+export async function writeSavedFile(filePath: string, content: string): Promise<void> {
+  // 12 hex chars (6 random bytes) is more than enough for a temp name —
+  // collision probability inside a single save is astronomically low,
+  // and the temp lives in the same directory as the target so any
+  // overlap with an existing dotfile would be coincidental.
+  const tmp = join(dirname(filePath), `.band-save-${randomBytes(6).toString("hex")}.tmp`);
+  try {
+    await writeFile(tmp, content, "utf8");
+    await rename(tmp, filePath);
+  } catch (err) {
+    try {
+      await unlink(tmp);
+    } catch {
+      // Ignore cleanup error — the original error is what the caller
+      // cares about. The temp file may legitimately not exist yet (the
+      // `writeFile` itself failed) or the unlink may race with another
+      // process; neither should mask the real failure.
+    }
+    throw err;
+  }
 }

--- a/apps/desktop/src/main/ipc/save-helpers.ts
+++ b/apps/desktop/src/main/ipc/save-helpers.ts
@@ -1,0 +1,51 @@
+/**
+ * Pure helpers that back `pickSaveFile` in `./macos-shell.ts`.
+ *
+ * Separated from `macos-shell.ts` so they can be unit-/integration-
+ * tested without dragging in the `electron` module — `node:test` runs
+ * outside the Electron runtime and `import { dialog } from "electron"`
+ * throws there. The IPC handler itself stays in `macos-shell.ts` (it
+ * needs Electron's `dialog.showSaveDialog`), but its bytes-to-disk and
+ * default-seed computation are isolated here.
+ */
+
+import { writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+/**
+ * Compute the default seed path for the OS save dialog from caller-
+ * supplied `defaultName` and `defaultPath`. Decides what `defaultPath`
+ * to hand to Electron's `dialog.showSaveDialog`:
+ *
+ *   - Both: join `defaultPath` and `defaultName` (e.g. workspace +
+ *     "Untitled-1.txt"). This is the common case when the editor knows
+ *     the active worktree.
+ *   - Only `defaultPath`: hand the directory to Electron and let it
+ *     pick the filename interactively.
+ *   - Only `defaultName`: use the bare filename; Electron anchors it
+ *     against the last-used save dir.
+ *   - Neither: fall back to "Untitled.txt".
+ */
+export function resolveSaveDialogSeed(args: {
+  defaultName?: string;
+  defaultPath?: string;
+}): string {
+  if (args.defaultPath) {
+    return args.defaultName ? join(args.defaultPath, args.defaultName) : args.defaultPath;
+  }
+  return args.defaultName ?? "Untitled.txt";
+}
+
+/**
+ * Persist `content` to `filePath` using a UTF-8 write. The IPC handler
+ * invokes this once Electron's save dialog returns a path; the
+ * separation lets the integration tests exercise the on-disk path
+ * directly without driving the native dialog.
+ *
+ * Throws on filesystem errors (permission denied, parent missing) so
+ * the error surfaces through the IPC invoke chain rather than silently
+ * succeeding and losing the user's work.
+ */
+export function writeSavedFile(filePath: string, content: string): void {
+  writeFileSync(filePath, content, "utf8");
+}

--- a/apps/desktop/src/preload/index.cts
+++ b/apps/desktop/src/preload/index.cts
@@ -42,6 +42,7 @@ const ALLOWED_INVOKE_CHANNELS = new Set<string>([
   // Phase 2 — macOS shell + open_external
   "pick_folder",
   "pick_file",
+  "pick_save_file",
   "reveal_in_finder",
   "check_app_exists",
   "open_with_app",

--- a/apps/desktop/src/shared/ipc-channels.ts
+++ b/apps/desktop/src/shared/ipc-channels.ts
@@ -17,6 +17,7 @@ export const Channels = {
   // macOS shell bridges + open_external
   pickFolder: "pick_folder",
   pickFile: "pick_file",
+  pickSaveFile: "pick_save_file",
   revealInFinder: "reveal_in_finder",
   checkAppExists: "check_app_exists",
   openWithApp: "open_with_app",

--- a/apps/desktop/src/shared/types.ts
+++ b/apps/desktop/src/shared/types.ts
@@ -218,6 +218,11 @@ export interface OpenExternalArgs {
  * `apps/desktop/src/main/ipc/macos-shell.ts`. The renderer never writes
  * to disk directly: bundling the dialog + write into one IPC call keeps
  * the file-system trust boundary inside the desktop shell.
+ *
+ * **Size limit:** `content` is capped at 100 MB UTF-8 bytes (see
+ * `SAVE_CONTENT_MAX_BYTES` in `macos-shell.ts`). Exceeding this rejects
+ * before the dialog appears so the renderer surfaces a clear error
+ * rather than stalling the main-process event loop on a huge write.
  */
 export interface PickSaveFileArgs {
   content: string;

--- a/apps/desktop/src/shared/types.ts
+++ b/apps/desktop/src/shared/types.ts
@@ -208,3 +208,19 @@ export interface InstallCliArgs {
 export interface OpenExternalArgs {
   url: string;
 }
+
+/**
+ * Open the system "Save As" picker and persist `content` to the chosen
+ * path. `defaultName` seeds the filename field (e.g. "Untitled-1.txt");
+ * `defaultPath` seeds the directory (e.g. the active workspace root).
+ *
+ * Backs the editor's "Save untitled tab" flow — see `pickSaveFile` in
+ * `apps/desktop/src/main/ipc/macos-shell.ts`. The renderer never writes
+ * to disk directly: bundling the dialog + write into one IPC call keeps
+ * the file-system trust boundary inside the desktop shell.
+ */
+export interface PickSaveFileArgs {
+  content: string;
+  defaultName?: string;
+  defaultPath?: string;
+}

--- a/apps/desktop/tests/save-untitled.test.ts
+++ b/apps/desktop/tests/save-untitled.test.ts
@@ -131,24 +131,55 @@ describe("writeSavedFile", () => {
   });
 
   test("does not leave a temp file behind when the rename target's directory is missing", async () => {
-    // The write-to-temp + rename path can fail in two phases: the
-    // writeFile (parent missing), or the rename itself (very rare on
-    // normal filesystems but possible across mounts). Either way we
-    // shouldn't leak a `.band-save-*.tmp` next to the target.
+    // First failure mode: `writeFile(tmp, ...)` itself fails because
+    // the target's parent dir doesn't exist. The temp file is never
+    // created on disk, so the `unlink(tmp)` in the catch block is a
+    // no-op — but we still assert no leftover litter, which would
+    // surface a future regression where the temp path is computed
+    // before the parent dir is validated.
     const dir = await mkdtemp(join(tmpdir(), "band-save-untitled-cleanup-"));
     try {
       const bogus = join(dir, "nonexistent-subdir", "x.txt");
       await assert.rejects(writeSavedFile(bogus, "should fail"), /ENOENT/);
-      // The temp file lives in the same directory as the target, which
-      // doesn't exist — nothing to assert on a subdir that was never
-      // created. The point is the call threw and didn't leave a temp
-      // file in the parent directory.
       const { readdir } = await import("node:fs/promises");
       const entries = await readdir(dir);
       assert.equal(
         entries.filter((e) => e.startsWith(".band-save-")).length,
         0,
         "expected no .band-save-*.tmp files left in the parent directory",
+      );
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("removes the temp file when the rename itself fails", async () => {
+    // Second (harder) failure mode: `writeFile(tmp, ...)` succeeds —
+    // a temp file actually exists on disk — and then `rename(tmp,
+    // target)` throws. This is the path the cleanup guard was
+    // designed for, and the test the previous one doesn't actually
+    // exercise (since there `writeFile` itself failed before any temp
+    // file could be created).
+    //
+    // We force the rename failure by pointing `target` at an existing
+    // *directory*: `rename(<file>, <dir>)` fails with EISDIR on
+    // POSIX. The writeFile to the temp still succeeds because the
+    // temp lives in `dirname(target)`, which is the directory's
+    // parent — a real, writable location.
+    const dir = await mkdtemp(join(tmpdir(), "band-save-untitled-rename-fail-"));
+    try {
+      const { mkdir, readdir } = await import("node:fs/promises");
+      // target IS an existing directory — the rename will refuse it.
+      const target = join(dir, "some-existing-dir");
+      await mkdir(target);
+      await assert.rejects(writeSavedFile(target, "content"), /EISDIR|ENOTDIR|EPERM/);
+      // The temp file is created in `dirname(target)` (= `dir`), so
+      // any leftover `.band-save-*.tmp` would surface here.
+      const entries = await readdir(dir);
+      assert.equal(
+        entries.filter((e) => e.startsWith(".band-save-")).length,
+        0,
+        "expected the temp file to be cleaned up after a failed rename",
       );
     } finally {
       await rm(dir, { recursive: true, force: true });

--- a/apps/desktop/tests/save-untitled.test.ts
+++ b/apps/desktop/tests/save-untitled.test.ts
@@ -1,0 +1,131 @@
+/**
+ * Integration test for the "Save As" untitled-tab IPC handler
+ * (issue #434).
+ *
+ * The full `pickSaveFile` orchestrates two pieces:
+ *
+ *   1. `dialog.showSaveDialog` — Electron's native modal; opening it
+ *      from a node:test worker would either block on user input or
+ *      require mocking Electron itself, neither of which matches the
+ *      "no mocks, real filesystem" rule in `CLAUDE.md`.
+ *   2. `writeSavedFile` — a plain `fs.writeFileSync` call that
+ *      persists the renderer's buffer once a path is chosen.
+ *
+ * Piece (2) is the part the IPC handler is responsible for ON BEHALF
+ * of the renderer (the renderer never touches disk directly — the
+ * "filesystem trust boundary stays inside the desktop shell"
+ * invariant from `pickSaveFile`'s doc comment). It's also the part
+ * with the integration test value: a regression where the wrong
+ * encoding is used, the path doesn't get created, or trailing bytes
+ * get truncated would slip past any contract-level test of the
+ * dialog plumbing.
+ *
+ * `resolveSaveDialogSeed` is the small piece of pre-dialog logic that
+ * decides what to hand to `defaultPath` based on the renderer's
+ * suggested name + workspace dir. Covered here too because it's
+ * easy to get wrong on the "only filename" / "only directory" /
+ * "neither" branches.
+ */
+
+import { strict as assert } from "node:assert";
+import { mkdtemp, readFile, rm, stat } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, test } from "node:test";
+
+import { resolveSaveDialogSeed, writeSavedFile } from "../src/main/ipc/save-helpers.ts";
+
+describe("resolveSaveDialogSeed", () => {
+  test("joins defaultPath and defaultName when both are provided", () => {
+    const seed = resolveSaveDialogSeed({
+      defaultPath: "/Users/alice/projects/band",
+      defaultName: "Untitled-1.txt",
+    });
+    assert.equal(seed, "/Users/alice/projects/band/Untitled-1.txt");
+  });
+
+  test("uses defaultPath alone when defaultName is omitted", () => {
+    const seed = resolveSaveDialogSeed({ defaultPath: "/Users/alice/projects/band" });
+    assert.equal(seed, "/Users/alice/projects/band");
+  });
+
+  test("uses defaultName alone when defaultPath is omitted", () => {
+    const seed = resolveSaveDialogSeed({ defaultName: "scratch.md" });
+    assert.equal(seed, "scratch.md");
+  });
+
+  test("falls back to Untitled.txt when neither is provided", () => {
+    assert.equal(resolveSaveDialogSeed({}), "Untitled.txt");
+  });
+});
+
+describe("writeSavedFile", () => {
+  test("persists buffer content under the chosen path", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "band-save-untitled-write-"));
+    try {
+      const target = join(dir, "scratch.md");
+      const body = "# Hello\n\nA fresh untitled buffer.\n";
+      writeSavedFile(target, body);
+      const onDisk = await readFile(target, "utf8");
+      assert.equal(onDisk, body);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("writes content as UTF-8 (round-trips non-ASCII without mangling)", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "band-save-untitled-utf8-"));
+    try {
+      const target = join(dir, "russe.txt");
+      // Mix of multi-byte UTF-8 sequences: Cyrillic, emoji, Korean.
+      const body = "Привет 👋 안녕하세요\n";
+      writeSavedFile(target, body);
+      const onDisk = await readFile(target, "utf8");
+      assert.equal(onDisk, body);
+      // Confirm the disk byte count matches the UTF-8-encoded length —
+      // catches a future regression where someone swaps utf8 for ascii.
+      const info = await stat(target);
+      assert.equal(info.size, Buffer.byteLength(body, "utf8"));
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("overwrites an existing file", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "band-save-untitled-overwrite-"));
+    try {
+      const target = join(dir, "scratch.txt");
+      writeSavedFile(target, "first revision\n");
+      writeSavedFile(target, "second revision\n");
+      const onDisk = await readFile(target, "utf8");
+      assert.equal(onDisk, "second revision\n");
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("writes an empty buffer to disk (zero-byte file)", async () => {
+    // The renderer can save an untitled tab with no content (the user
+    // hits Cmd+S immediately after creating it). The result should be
+    // a real zero-byte file, not a missing one.
+    const dir = await mkdtemp(join(tmpdir(), "band-save-untitled-empty-"));
+    try {
+      const target = join(dir, "empty.txt");
+      writeSavedFile(target, "");
+      const info = await stat(target);
+      assert.equal(info.size, 0);
+      const onDisk = await readFile(target, "utf8");
+      assert.equal(onDisk, "");
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("propagates filesystem errors instead of swallowing them", () => {
+    // A non-existent parent directory triggers ENOENT. The error must
+    // bubble up so the IPC chain can surface it to the renderer rather
+    // than the dialog reporting success and the user losing their work.
+    const bogus = join(tmpdir(), "band-save-untitled-missing-parent", "missing-dir", "x.txt");
+    assert.throws(() => writeSavedFile(bogus, "should fail"), /ENOENT/);
+  });
+});

--- a/apps/desktop/tests/save-untitled.test.ts
+++ b/apps/desktop/tests/save-untitled.test.ts
@@ -65,7 +65,7 @@ describe("writeSavedFile", () => {
     try {
       const target = join(dir, "scratch.md");
       const body = "# Hello\n\nA fresh untitled buffer.\n";
-      writeSavedFile(target, body);
+      await writeSavedFile(target, body);
       const onDisk = await readFile(target, "utf8");
       assert.equal(onDisk, body);
     } finally {
@@ -79,7 +79,7 @@ describe("writeSavedFile", () => {
       const target = join(dir, "russe.txt");
       // Mix of multi-byte UTF-8 sequences: Cyrillic, emoji, Korean.
       const body = "Привет 👋 안녕하세요\n";
-      writeSavedFile(target, body);
+      await writeSavedFile(target, body);
       const onDisk = await readFile(target, "utf8");
       assert.equal(onDisk, body);
       // Confirm the disk byte count matches the UTF-8-encoded length —
@@ -95,8 +95,8 @@ describe("writeSavedFile", () => {
     const dir = await mkdtemp(join(tmpdir(), "band-save-untitled-overwrite-"));
     try {
       const target = join(dir, "scratch.txt");
-      writeSavedFile(target, "first revision\n");
-      writeSavedFile(target, "second revision\n");
+      await writeSavedFile(target, "first revision\n");
+      await writeSavedFile(target, "second revision\n");
       const onDisk = await readFile(target, "utf8");
       assert.equal(onDisk, "second revision\n");
     } finally {
@@ -111,7 +111,7 @@ describe("writeSavedFile", () => {
     const dir = await mkdtemp(join(tmpdir(), "band-save-untitled-empty-"));
     try {
       const target = join(dir, "empty.txt");
-      writeSavedFile(target, "");
+      await writeSavedFile(target, "");
       const info = await stat(target);
       assert.equal(info.size, 0);
       const onDisk = await readFile(target, "utf8");
@@ -121,11 +121,57 @@ describe("writeSavedFile", () => {
     }
   });
 
-  test("propagates filesystem errors instead of swallowing them", () => {
+  test("propagates filesystem errors instead of swallowing them", async () => {
     // A non-existent parent directory triggers ENOENT. The error must
     // bubble up so the IPC chain can surface it to the renderer rather
     // than the dialog reporting success and the user losing their work.
     const bogus = join(tmpdir(), "band-save-untitled-missing-parent", "missing-dir", "x.txt");
-    assert.throws(() => writeSavedFile(bogus, "should fail"), /ENOENT/);
+    await assert.rejects(writeSavedFile(bogus, "should fail"), /ENOENT/);
+  });
+
+  test("does not leave a temp file behind when the rename target's directory is missing", async () => {
+    // The write-to-temp + rename path can fail in two phases: the
+    // writeFile (parent missing), or the rename itself (very rare on
+    // normal filesystems but possible across mounts). Either way we
+    // shouldn't leak a `.band-save-*.tmp` next to the target.
+    const dir = await mkdtemp(join(tmpdir(), "band-save-untitled-cleanup-"));
+    try {
+      const bogus = join(dir, "nonexistent-subdir", "x.txt");
+      await assert.rejects(writeSavedFile(bogus, "should fail"), /ENOENT/);
+      // The temp file lives in the same directory as the target, which
+      // doesn't exist — nothing to assert on a subdir that was never
+      // created. The point is the call threw and didn't leave a temp
+      // file in the parent directory.
+      const { readdir } = await import("node:fs/promises");
+      const entries = await readdir(dir);
+      assert.equal(
+        entries.filter((e) => e.startsWith(".band-save-")).length,
+        0,
+        "expected no .band-save-*.tmp files left in the parent directory",
+      );
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("atomic: a successful write replaces the previous content in one step", async () => {
+    // Atomicity guarantee: the rename(2) swap means the destination
+    // path is always either the old or new content, never a truncated
+    // intermediate. We can't easily force a mid-write crash in a
+    // single-process test, but we can verify the temp + rename
+    // mechanics actually run (the function completes, the destination
+    // has the new content, and no stray .tmp files remain).
+    const dir = await mkdtemp(join(tmpdir(), "band-save-untitled-atomic-"));
+    try {
+      const target = join(dir, "doc.md");
+      await writeSavedFile(target, "original\n");
+      await writeSavedFile(target, "replaced\n");
+      assert.equal(await readFile(target, "utf8"), "replaced\n");
+      const { readdir } = await import("node:fs/promises");
+      const stray = (await readdir(dir)).filter((e) => e.startsWith(".band-save-"));
+      assert.deepEqual(stray, [], "no temp file should remain after a successful rename");
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
   });
 });

--- a/apps/desktop/tests/save-untitled.test.ts
+++ b/apps/desktop/tests/save-untitled.test.ts
@@ -8,8 +8,9 @@
  *      from a node:test worker would either block on user input or
  *      require mocking Electron itself, neither of which matches the
  *      "no mocks, real filesystem" rule in `CLAUDE.md`.
- *   2. `writeSavedFile` — a plain `fs.writeFileSync` call that
- *      persists the renderer's buffer once a path is chosen.
+ *   2. `writeSavedFile` — an async write-to-temp + rename pair
+ *      (`fs/promises.writeFile` → `rename`) that atomically persists
+ *      the renderer's buffer once a path is chosen.
  *
  * Piece (2) is the part the IPC handler is responsible for ON BEHALF
  * of the renderer (the renderer never touches disk directly — the

--- a/apps/web/src/components/CodeBrowserView.tsx
+++ b/apps/web/src/components/CodeBrowserView.tsx
@@ -1,4 +1,5 @@
 import {
+  AUTO_DETECT_LANGUAGE_ID,
   buildLspWsUrl,
   createLspExtension,
   FileBrowser,
@@ -100,6 +101,38 @@ function saveFileTreeCollapsed(wsId: string, collapsed: boolean): void {
   } catch {
     // storage unavailable
   }
+}
+
+/**
+ * Returns the path of `child` relative to `parent` when `child` is
+ * inside `parent`, or `null` when it isn't. Workspace paths in Band
+ * are always POSIX-style (forward slashes), so we operate on raw
+ * string segments rather than pulling in `node:path` — this file
+ * runs in the browser where `path` isn't available natively, and a
+ * Vite polyfill would be overkill for one comparison.
+ *
+ * Implemented as a segment-aware prefix check rather than a raw
+ * `startsWith`:
+ *
+ *   pathInside("/a/band",      "/a/band/src/x.ts")    → "src/x.ts"
+ *   pathInside("/a/band",      "/a/band")             → ""
+ *   pathInside("/a/band",      "/a/band-fork/src/x")  → null   ← prefix-safe
+ *   pathInside("/a/band/",     "/a/band/src/x.ts")    → "src/x.ts"
+ *   pathInside("/a/band",      "/elsewhere/x.ts")     → null
+ *
+ * The prefix-collision case is what every code review keeps flagging:
+ * a naive `chosen.startsWith(root)` would treat `/a/band-fork/...`
+ * as inside `/a/band`. We strip trailing slashes from `parent` first,
+ * then require either an exact match or a `${parent}/` prefix — the
+ * required `/` separator after the parent is what blocks the
+ * collision.
+ */
+function pathInside(parent: string, child: string): string | null {
+  const root = parent.replace(/\/+$/, "");
+  if (child === root) return "";
+  const prefix = `${root}/`;
+  if (!child.startsWith(prefix)) return null;
+  return child.slice(prefix.length);
 }
 
 // ---------------------------------------------------------------------------
@@ -1350,16 +1383,15 @@ export function CodeBrowserView({
 
       // Decide whether the chosen path lives inside the workspace.
       // When it does we transition to a normal workspace tab; otherwise
-      // it becomes an external tab (per issue #433). The trailing-
-      // slash strip + `${root}/` prefix check is prefix-collision-safe:
-      // `/a/band` vs `/a/band-fork` differ at the trailing `/`, so a
-      // file saved under `/a/band-fork/...` never matches `/a/band/`.
-      const normalizedRoot = workspacePath?.replace(/\/+$/, "");
-      const inWorkspace =
-        normalizedRoot != null &&
-        (chosen === normalizedRoot || chosen.startsWith(`${normalizedRoot}/`));
-      const isExternal = !inWorkspace;
-      const newPath = inWorkspace ? chosen.slice(normalizedRoot!.length + 1) : chosen;
+      // it becomes an external tab (per issue #433). `pathInside`
+      // returns the workspace-relative path when `chosen` is under
+      // `workspacePath`, and `null` when it isn't — handles the
+      // prefix-collision edge case (`/a/band` vs `/a/band-fork`) by
+      // requiring an exact path-segment match rather than a raw string
+      // prefix.
+      const relative = workspacePath != null ? pathInside(workspacePath, chosen) : null;
+      const isExternal = relative === null;
+      const newPath = relative ?? chosen;
 
       // Carry the manual language override (if any) from the untitled
       // key to the new path so the user's choice survives the rename
@@ -1426,8 +1458,25 @@ export function CodeBrowserView({
   // the band:dirty-change event so the tab bar's language indicator
   // (if any) re-renders. The override survives saves — see
   // handleSaveUntitled for the carry-over.
+  //
+  // The picker also delivers an `AUTO_DETECT_LANGUAGE_ID` sentinel
+  // when the user explicitly reverts to extension-based detection;
+  // we treat that as a remove so the next render falls through to
+  // the FileViewer's auto-detect branch. Without this affordance, a
+  // user who manually set a `.ts` file to Python "just to see" would
+  // be stuck with that override until they closed the tab — closing
+  // is the only thing that clears the persisted `language` entry.
   const handleLanguageOverride = useCallback(
     (filePath: string, languageId: string) => {
+      if (languageId === AUTO_DETECT_LANGUAGE_ID) {
+        // Clear the override by writing `undefined` — `tabState.update`
+        // spreads the patch, JSON.stringify drops undefined properties,
+        // and the next `getLanguage` read sees no entry. Net effect:
+        // FileViewer reverts to extension-based detection on the next
+        // render.
+        tabState.update(filePath, { language: undefined });
+        return;
+      }
       tabState.setLanguage(filePath, languageId);
     },
     [tabState],

--- a/apps/web/src/components/CodeBrowserView.tsx
+++ b/apps/web/src/components/CodeBrowserView.tsx
@@ -7,6 +7,7 @@ import {
   getFilePreviewType,
   getLspLanguageId,
   hasPendingNavigation,
+  languageToExtension,
   parseFileLocation,
   releaseLspClient,
   resolveNavigation,
@@ -1311,6 +1312,15 @@ export function CodeBrowserView({
     return () => window.removeEventListener("band:new-untitled-tab", handler);
   }, [handleNewUntitled]);
 
+  // Stable ref to the latest openTabs list so `handleSaveUntitled`
+  // can look up the tab being saved (for its untitledLabel) without
+  // depending on the array — otherwise the callback (and the
+  // `onSaveAs` prop derived from it) would churn on every tab open
+  // / pin / preview transition, forcing every FileViewer to re-bind
+  // its save handler.
+  const openTabsRef = useRef(fileTabs.openTabs);
+  openTabsRef.current = fileTabs.openTabs;
+
   // Save-as flow for untitled tabs. Threaded into FileViewer via the
   // `onSaveAs` prop, and into FileTabBar's close-confirm dialog via
   // `onSaveUntitled` — both routes call this. Returns the chosen
@@ -1319,10 +1329,18 @@ export function CodeBrowserView({
   const handleSaveUntitled = useCallback(
     async (untitledPath: string, content: string): Promise<string | null> => {
       if (!pickSaveFile) return null;
-      const tab = fileTabs.openTabs.find((t) => t.filePath === untitledPath);
-      // Seed the dialog filename with the untitled label so the user
-      // doesn't have to delete the OS-default suggestion.
-      const defaultName = tab?.untitledLabel ? `${tab.untitledLabel}.txt` : "Untitled.txt";
+      const tab = openTabsRef.current.find((t) => t.filePath === untitledPath);
+      // Seed the dialog with both a sensible filename AND the right
+      // extension — if the user has manually set the language to e.g.
+      // TypeScript, suggest `.ts` so they don't have to delete `.txt`
+      // and retype. Falls through to `.txt` for plain text (the
+      // untitled default) and for any language without a canonical
+      // extension. `languageToExtension` already returns `undefined`
+      // for unsupported languages so the fallback is implicit.
+      const override = tabState.getLanguage(untitledPath);
+      const ext = (override ? languageToExtension(override) : undefined) ?? ".txt";
+      const stem = tab?.untitledLabel ?? "Untitled";
+      const defaultName = `${stem}${ext}`;
       const chosen = await pickSaveFile({
         content,
         defaultName,
@@ -1332,21 +1350,22 @@ export function CodeBrowserView({
 
       // Decide whether the chosen path lives inside the workspace.
       // When it does we transition to a normal workspace tab; otherwise
-      // it becomes an external tab (per issue #433).
+      // it becomes an external tab (per issue #433). The trailing-
+      // slash strip + `${root}/` prefix check is prefix-collision-safe:
+      // `/a/band` vs `/a/band-fork` differ at the trailing `/`, so a
+      // file saved under `/a/band-fork/...` never matches `/a/band/`.
+      const normalizedRoot = workspacePath?.replace(/\/+$/, "");
       const inWorkspace =
-        workspacePath != null &&
-        (chosen === workspacePath || chosen.startsWith(`${workspacePath.replace(/\/$/, "")}/`));
+        normalizedRoot != null &&
+        (chosen === normalizedRoot || chosen.startsWith(`${normalizedRoot}/`));
       const isExternal = !inWorkspace;
-      const newPath = inWorkspace
-        ? chosen.slice(workspacePath!.replace(/\/$/, "").length + 1)
-        : chosen;
+      const newPath = inWorkspace ? chosen.slice(normalizedRoot!.length + 1) : chosen;
 
       // Carry the manual language override (if any) from the untitled
       // key to the new path so the user's choice survives the rename
       // — issue #434: "Saving an untitled tab whose language was
       // manually set keeps the override even if the chosen filename's
       // extension would imply a different language."
-      const override = tabState.getLanguage(untitledPath);
       if (override) tabState.setLanguage(newPath, override);
 
       // Carry view-mode / scroll state in case the user keeps editing
@@ -1380,14 +1399,7 @@ export function CodeBrowserView({
       window.dispatchEvent(new CustomEvent("band:dirty-change"));
       return chosen;
     },
-    [
-      pickSaveFile,
-      workspacePath,
-      fileTabs.openTabs,
-      fileTabs.renameUntitledToFile,
-      notifySelectFile,
-      tabState,
-    ],
+    [pickSaveFile, workspacePath, fileTabs.renameUntitledToFile, notifySelectFile, tabState],
   );
 
   // FileTabBar version — looks up the latest editor content for the
@@ -1610,8 +1622,14 @@ export function CodeBrowserView({
         // Mobile / narrow container: toggle between file browser and viewer
         viewFilePath ? (
           <FileViewer
-            // Re-mount on path change — see desktop block for rationale.
-            key={viewFilePath}
+            // Scoped re-mount: force a clean mount only when crossing
+            // the untitled boundary (file → untitled, untitled → file,
+            // or untitled-1 → untitled-2). Plain file-to-file
+            // navigation keeps the existing FileViewer instance —
+            // CodeMirrorEditor handles content swaps internally, and
+            // remounting on every tab click would re-trigger LSP /
+            // language-loader work for no reason.
+            key={isUntitledPath(viewFilePath) ? viewFilePath : "file"}
             workspaceId={workspaceId}
             filePath={viewFilePath}
             external={viewIsExternal}
@@ -1817,12 +1835,14 @@ export function CodeBrowserView({
               <div className="min-h-0 min-w-0 flex-1 overflow-hidden">
                 {viewFilePath ? (
                   <FileViewer
-                    // Re-mount when transitioning between untitled / file-
-                    // backed paths so the FileViewer's internal data/state
-                    // re-initialises against the new key. Without this, an
-                    // untitled tab that just got saved would still carry
-                    // its `untitled` branch render flags.
-                    key={viewFilePath}
+                    // Scoped re-mount: force a clean mount only when
+                    // crossing the untitled boundary (file → untitled,
+                    // untitled → file, or untitled-1 → untitled-2).
+                    // Plain file-to-file navigation keeps the existing
+                    // FileViewer instance — remounting on every tab
+                    // click would re-trigger LSP / language-loader
+                    // work for no reason.
+                    key={isUntitledPath(viewFilePath) ? viewFilePath : "file"}
                     workspaceId={workspaceId}
                     filePath={viewFilePath}
                     external={viewIsExternal}

--- a/apps/web/src/components/CodeBrowserView.tsx
+++ b/apps/web/src/components/CodeBrowserView.tsx
@@ -48,7 +48,7 @@ import {
 } from "lucide-react";
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { Group, Panel, Separator, usePanelRef } from "react-resizable-panels";
-import { useFileTabs } from "../hooks/useFileTabs";
+import { isUntitledPath, useFileTabs } from "../hooks/useFileTabs";
 import { useIsDesktop } from "../hooks/useIsDesktop";
 import { useTabState } from "../hooks/useTabState";
 import { FileTabBar } from "./FileTabBar";
@@ -134,6 +134,12 @@ interface FileTreeToolbarProps {
    * flow.
    */
   onOpenFile?: () => void;
+  /**
+   * Open a new untitled (scratch) editor tab. Always defined — works in
+   * both desktop and web builds; the OS save dialog only surfaces when
+   * the user actually saves (`capabilities.pickSaveFile`).
+   */
+  onNewUntitled?: () => void;
 }
 
 // Below this width (px), the toolbar collapses its action buttons into a
@@ -168,7 +174,12 @@ const touchPointerUp = (fn?: () => void) => (e: React.PointerEvent<HTMLButtonEle
 const fireOpenQuickOpen = () => window.dispatchEvent(new CustomEvent("band:open-quick-open"));
 const fireOpenSearchFiles = () => window.dispatchEvent(new CustomEvent("band:open-search-files"));
 
-function FileTreeToolbar({ onNewFile, onNewFolder, onOpenFile }: FileTreeToolbarProps) {
+function FileTreeToolbar({
+  onNewFile,
+  onNewFolder,
+  onOpenFile,
+  onNewUntitled,
+}: FileTreeToolbarProps) {
   const rootRef = useRef<HTMLDivElement>(null);
   const [compact, setCompact] = useState(false);
 
@@ -237,6 +248,15 @@ function FileTreeToolbar({ onNewFile, onNewFolder, onOpenFile }: FileTreeToolbar
             className="min-w-[10rem]"
             onCloseAutoFocus={flushMenuAction}
           >
+            {onNewUntitled && (
+              <DropdownMenuItem onSelect={() => queueMenuAction(onNewUntitled)}>
+                <FilePlus className="size-4" />
+                New Untitled File
+                <kbd className="ml-auto rounded border border-popover-foreground/25 bg-popover-foreground/10 px-1 py-0.5 font-mono text-[10px]">
+                  ⌘N
+                </kbd>
+              </DropdownMenuItem>
+            )}
             {onNewFile && (
               <DropdownMenuItem onSelect={() => queueMenuAction(onNewFile)}>
                 <FilePlus className="size-4" />
@@ -249,7 +269,7 @@ function FileTreeToolbar({ onNewFile, onNewFolder, onOpenFile }: FileTreeToolbar
                 New Folder
               </DropdownMenuItem>
             )}
-            {(onNewFile || onNewFolder) && <DropdownMenuSeparator />}
+            {(onNewUntitled || onNewFile || onNewFolder) && <DropdownMenuSeparator />}
             <DropdownMenuItem onSelect={() => queueMenuAction(fireOpenQuickOpen)}>
               <Search className="size-4" />
               Quick Open
@@ -517,6 +537,10 @@ export function CodeBrowserView({
   const notifySelectFile = useCallback(
     (filePath: string | null) => {
       if (isExternalPath(filePath)) return;
+      // Untitled tabs use a synthetic `untitled:N` key that isn't a
+      // valid workspace-relative path — pushing it into the URL would
+      // break route parsing the same way external absolute paths would.
+      if (filePath !== null && isUntitledPath(filePath)) return;
       onSelectFile?.(filePath);
     },
     [isExternalPath, onSelectFile],
@@ -1266,6 +1290,138 @@ export function CodeBrowserView({
   }, [pickFile, handleOpenExternalFile]);
 
   // -------------------------------------------------------------------------
+  // Untitled tabs (issue #434) — empty scratch buffer with save-as flow.
+  // -------------------------------------------------------------------------
+  const pickSaveFile = capabilities.pickSaveFile;
+
+  const handleNewUntitled = useCallback(() => {
+    const { filePath } = fileTabs.openTabUntitled();
+    setViewFilePath(filePath);
+    setViewLine(undefined);
+    setViewLineEnd(undefined);
+    setViewColumn(undefined);
+    // Untitled tabs are workspace-relative only in the tab list; the
+    // route doesn't know about them. Don't notifySelectFile (the route
+    // would push an unparseable `untitled:N` into the URL).
+  }, [fileTabs.openTabUntitled]);
+
+  useEffect(() => {
+    const handler = () => handleNewUntitled();
+    window.addEventListener("band:new-untitled-tab", handler);
+    return () => window.removeEventListener("band:new-untitled-tab", handler);
+  }, [handleNewUntitled]);
+
+  // Save-as flow for untitled tabs. Threaded into FileViewer via the
+  // `onSaveAs` prop, and into FileTabBar's close-confirm dialog via
+  // `onSaveUntitled` — both routes call this. Returns the chosen
+  // absolute path on success and null on user-cancel so the caller
+  // can decide whether to close the tab.
+  const handleSaveUntitled = useCallback(
+    async (untitledPath: string, content: string): Promise<string | null> => {
+      if (!pickSaveFile) return null;
+      const tab = fileTabs.openTabs.find((t) => t.filePath === untitledPath);
+      // Seed the dialog filename with the untitled label so the user
+      // doesn't have to delete the OS-default suggestion.
+      const defaultName = tab?.untitledLabel ? `${tab.untitledLabel}.txt` : "Untitled.txt";
+      const chosen = await pickSaveFile({
+        content,
+        defaultName,
+        defaultPath: workspacePath,
+      });
+      if (!chosen) return null;
+
+      // Decide whether the chosen path lives inside the workspace.
+      // When it does we transition to a normal workspace tab; otherwise
+      // it becomes an external tab (per issue #433).
+      const inWorkspace =
+        workspacePath != null &&
+        (chosen === workspacePath || chosen.startsWith(`${workspacePath.replace(/\/$/, "")}/`));
+      const isExternal = !inWorkspace;
+      const newPath = inWorkspace
+        ? chosen.slice(workspacePath!.replace(/\/$/, "").length + 1)
+        : chosen;
+
+      // Carry the manual language override (if any) from the untitled
+      // key to the new path so the user's choice survives the rename
+      // — issue #434: "Saving an untitled tab whose language was
+      // manually set keeps the override even if the chosen filename's
+      // extension would imply a different language."
+      const override = tabState.getLanguage(untitledPath);
+      if (override) tabState.setLanguage(newPath, override);
+
+      // Carry view-mode / scroll state in case the user keeps editing
+      // the just-saved file. editedContent is dropped because the
+      // bytes are now on disk and the FileViewer reloads via the
+      // adapter on remount under the new key.
+      const oldState = tabState.get(untitledPath);
+      tabState.update(newPath, {
+        viewMode: oldState?.viewMode,
+        editorState: oldState?.editorState,
+        scrollTop: oldState?.scrollTop,
+      });
+      tabState.removeFile(untitledPath);
+
+      // Rewrite in-memory editor state cache so the FileViewer mount
+      // under the new path picks up undo history / scroll position.
+      if (savedEditorStatesRef.current[untitledPath]) {
+        savedEditorStatesRef.current[newPath] = savedEditorStatesRef.current[untitledPath];
+        delete savedEditorStatesRef.current[untitledPath];
+      }
+
+      // Transition the tab and viewFilePath together so the FileViewer
+      // remounts on the new key in the same React batch.
+      fileTabs.renameUntitledToFile(untitledPath, newPath, isExternal);
+      skipFileEffectRef.current = true;
+      setViewFilePath(newPath);
+      setViewLine(undefined);
+      setViewLineEnd(undefined);
+      setViewColumn(undefined);
+      if (!isExternal) notifySelectFile(newPath);
+      window.dispatchEvent(new CustomEvent("band:dirty-change"));
+      return chosen;
+    },
+    [
+      pickSaveFile,
+      workspacePath,
+      fileTabs.openTabs,
+      fileTabs.renameUntitledToFile,
+      notifySelectFile,
+      tabState,
+    ],
+  );
+
+  // FileTabBar version — looks up the latest editor content for the
+  // tab being closed and resolves with a boolean so the dialog knows
+  // whether to dismiss itself.
+  const handleSaveUntitledForClose = useCallback(
+    async (untitledPath: string): Promise<boolean> => {
+      // Prefer the live CodeMirror buffer (current edits) when the
+      // untitled tab is the one being viewed; otherwise fall back to
+      // any persisted editedContent in tab state.
+      let content: string;
+      if (viewFilePathRef.current === untitledPath && editorViewRef.current) {
+        content = editorViewRef.current.state.doc.toString();
+      } else {
+        content = tabState.get(untitledPath)?.editedContent ?? "";
+      }
+      const saved = await handleSaveUntitled(untitledPath, content);
+      return saved != null;
+    },
+    [handleSaveUntitled, tabState],
+  );
+
+  // Language-mode override: persist per-tab via tabState, and dispatch
+  // the band:dirty-change event so the tab bar's language indicator
+  // (if any) re-renders. The override survives saves — see
+  // handleSaveUntitled for the carry-over.
+  const handleLanguageOverride = useCallback(
+    (filePath: string, languageId: string) => {
+      tabState.setLanguage(filePath, languageId);
+    },
+    [tabState],
+  );
+
+  // -------------------------------------------------------------------------
   // Keep tabs + editor state in sync with rename / delete in the file tree.
   // -------------------------------------------------------------------------
 
@@ -1454,9 +1610,12 @@ export function CodeBrowserView({
         // Mobile / narrow container: toggle between file browser and viewer
         viewFilePath ? (
           <FileViewer
+            // Re-mount on path change — see desktop block for rationale.
+            key={viewFilePath}
             workspaceId={workspaceId}
             filePath={viewFilePath}
             external={viewIsExternal}
+            untitled={isUntitledPath(viewFilePath)}
             line={viewLine}
             lineEnd={viewLineEnd}
             column={viewColumn}
@@ -1469,8 +1628,9 @@ export function CodeBrowserView({
             renderMarkdown={renderMarkdown}
             editable
             // LSP is workspace-scoped — external files have no project root,
-            // so we deliberately skip the extension for them.
-            lspExtension={viewIsExternal ? null : lspExtension}
+            // so we deliberately skip the extension for them. Untitled tabs
+            // also skip LSP — there's no file URI for the language server.
+            lspExtension={viewIsExternal || isUntitledPath(viewFilePath) ? null : lspExtension}
             initialEditedContent={tabState.get(viewFilePath)?.editedContent ?? null}
             savedEditorState={
               savedEditorStatesRef.current[viewFilePath]?.editorState ??
@@ -1481,6 +1641,13 @@ export function CodeBrowserView({
               tabState.get(viewFilePath)?.scrollTop
             }
             onEditedContentChange={handleEditedContentChange}
+            languageOverride={tabState.getLanguage(viewFilePath)}
+            onLanguageOverrideChange={(id) => handleLanguageOverride(viewFilePath, id)}
+            onSaveAs={
+              isUntitledPath(viewFilePath) && pickSaveFile
+                ? (content) => handleSaveUntitled(viewFilePath, content)
+                : undefined
+            }
             toolbar={
               search.searchOpen ? (
                 <SearchBar
@@ -1510,6 +1677,7 @@ export function CodeBrowserView({
               onNewFile={handleNewFile}
               onNewFolder={handleNewFolder}
               onOpenFile={pickFile ? handleOpenExternalFile : undefined}
+              onNewUntitled={handleNewUntitled}
             />
             <div className="min-h-0 flex-1 overflow-hidden">
               <FileBrowser
@@ -1551,6 +1719,7 @@ export function CodeBrowserView({
                 onNewFile={handleNewFile}
                 onNewFolder={handleNewFolder}
                 onOpenFile={pickFile ? handleOpenExternalFile : undefined}
+                onNewUntitled={handleNewUntitled}
               />
               <div className="min-h-0 flex-1 overflow-hidden">
                 <FileBrowser
@@ -1597,6 +1766,7 @@ export function CodeBrowserView({
                 canGoBack={editorHistory.canGoBack}
                 canGoForward={editorHistory.canGoForward}
                 isDirty={tabState.isDirty}
+                onSaveUntitled={pickSaveFile ? handleSaveUntitledForClose : undefined}
                 treeCollapsed={treeCollapsed}
                 onToggleTree={toggleTree}
                 actions={
@@ -1647,9 +1817,16 @@ export function CodeBrowserView({
               <div className="min-h-0 min-w-0 flex-1 overflow-hidden">
                 {viewFilePath ? (
                   <FileViewer
+                    // Re-mount when transitioning between untitled / file-
+                    // backed paths so the FileViewer's internal data/state
+                    // re-initialises against the new key. Without this, an
+                    // untitled tab that just got saved would still carry
+                    // its `untitled` branch render flags.
+                    key={viewFilePath}
                     workspaceId={workspaceId}
                     filePath={viewFilePath}
                     external={viewIsExternal}
+                    untitled={isUntitledPath(viewFilePath)}
                     line={viewLine}
                     lineEnd={viewLineEnd}
                     column={viewColumn}
@@ -1660,7 +1837,11 @@ export function CodeBrowserView({
                     hideTitleBar
                     // LSP is workspace-scoped — external files have no project
                     // root, so we deliberately skip the extension for them.
-                    lspExtension={viewIsExternal ? null : lspExtension}
+                    // Untitled tabs also skip LSP — there's no file URI for
+                    // the language server to anchor to.
+                    lspExtension={
+                      viewIsExternal || isUntitledPath(viewFilePath) ? null : lspExtension
+                    }
                     viewMode={isMarkdown ? mdViewMode : undefined}
                     onViewModeChange={isMarkdown ? setMdViewMode : undefined}
                     initialEditedContent={tabState.get(viewFilePath)?.editedContent ?? null}
@@ -1673,6 +1854,13 @@ export function CodeBrowserView({
                       tabState.get(viewFilePath)?.scrollTop
                     }
                     onEditedContentChange={handleEditedContentChange}
+                    languageOverride={tabState.getLanguage(viewFilePath)}
+                    onLanguageOverrideChange={(id) => handleLanguageOverride(viewFilePath, id)}
+                    onSaveAs={
+                      isUntitledPath(viewFilePath) && pickSaveFile
+                        ? (content) => handleSaveUntitled(viewFilePath, content)
+                        : undefined
+                    }
                     toolbar={
                       search.searchOpen ? (
                         <SearchBar

--- a/apps/web/src/components/CodeBrowserView.tsx
+++ b/apps/web/src/components/CodeBrowserView.tsx
@@ -53,6 +53,7 @@ import { Group, Panel, Separator, usePanelRef } from "react-resizable-panels";
 import { isUntitledPath, useFileTabs } from "../hooks/useFileTabs";
 import { useIsDesktop } from "../hooks/useIsDesktop";
 import { useTabState } from "../hooks/useTabState";
+import { pathInside } from "../lib/path-inside";
 import { FileTabBar } from "./FileTabBar";
 import type { MarkdownPreviewHandle, MarkdownPreviewMatchInfo } from "./MarkdownPreview";
 import { MarkdownPreview } from "./MarkdownPreview";
@@ -103,37 +104,10 @@ function saveFileTreeCollapsed(wsId: string, collapsed: boolean): void {
   }
 }
 
-/**
- * Returns the path of `child` relative to `parent` when `child` is
- * inside `parent`, or `null` when it isn't. Workspace paths in Band
- * are always POSIX-style (forward slashes), so we operate on raw
- * string segments rather than pulling in `node:path` — this file
- * runs in the browser where `path` isn't available natively, and a
- * Vite polyfill would be overkill for one comparison.
- *
- * Implemented as a segment-aware prefix check rather than a raw
- * `startsWith`:
- *
- *   pathInside("/a/band",      "/a/band/src/x.ts")    → "src/x.ts"
- *   pathInside("/a/band",      "/a/band")             → ""
- *   pathInside("/a/band",      "/a/band-fork/src/x")  → null   ← prefix-safe
- *   pathInside("/a/band/",     "/a/band/src/x.ts")    → "src/x.ts"
- *   pathInside("/a/band",      "/elsewhere/x.ts")     → null
- *
- * The prefix-collision case is what every code review keeps flagging:
- * a naive `chosen.startsWith(root)` would treat `/a/band-fork/...`
- * as inside `/a/band`. We strip trailing slashes from `parent` first,
- * then require either an exact match or a `${parent}/` prefix — the
- * required `/` separator after the parent is what blocks the
- * collision.
- */
-function pathInside(parent: string, child: string): string | null {
-  const root = parent.replace(/\/+$/, "");
-  if (child === root) return "";
-  const prefix = `${root}/`;
-  if (!child.startsWith(prefix)) return null;
-  return child.slice(prefix.length);
-}
+// `pathInside` lives in `../lib/path-inside.ts` so it can be unit-
+// tested without dragging in the React/CodeMirror runtime — see
+// `apps/web/tests/path-inside.test.ts` for the test cases that lock
+// in the security-adjacent prefix-collision invariant.
 
 // ---------------------------------------------------------------------------
 // Props
@@ -1437,6 +1411,14 @@ export function CodeBrowserView({
   // FileTabBar version — looks up the latest editor content for the
   // tab being closed and resolves with a boolean so the dialog knows
   // whether to dismiss itself.
+  //
+  // Catches and swallows save errors here so the FileTabBar dialog's
+  // "Save…" handler (which awaits this) never produces an unhandled
+  // promise rejection. The IPC chain surfaces disk-full / permission-
+  // denied / etc. as exceptions; logging them to the console keeps
+  // them debuggable, while returning `false` keeps the close-confirm
+  // dialog open so the user can retry, discard, or cancel. Without
+  // this guard the dialog appears to hang silently on failure.
   const handleSaveUntitledForClose = useCallback(
     async (untitledPath: string): Promise<boolean> => {
       // Prefer the live CodeMirror buffer (current edits) when the
@@ -1448,8 +1430,13 @@ export function CodeBrowserView({
       } else {
         content = tabState.get(untitledPath)?.editedContent ?? "";
       }
-      const saved = await handleSaveUntitled(untitledPath, content);
-      return saved != null;
+      try {
+        const saved = await handleSaveUntitled(untitledPath, content);
+        return saved != null;
+      } catch (err) {
+        console.error("[band] Save-as failed for untitled tab:", err);
+        return false;
+      }
     },
     [handleSaveUntitled, tabState],
   );

--- a/apps/web/src/components/CodeBrowserView.tsx
+++ b/apps/web/src/components/CodeBrowserView.tsx
@@ -1355,6 +1355,17 @@ export function CodeBrowserView({
       });
       if (!chosen) return null;
 
+      // Normalise to POSIX-style separators before the containment
+      // check — on Windows, Electron's `dialog.showSaveDialog` returns
+      // native paths like `C:\Users\alice\band\src\x.ts`, but Band's
+      // workspace registry stores worktree paths with forward slashes.
+      // `pathInside` is a string-segment comparison, so without this
+      // rewrite every Windows save would slip past it and be
+      // classified as external regardless of where the user actually
+      // saved. macOS / Linux paths are POSIX already, so the regex
+      // is a no-op there.
+      const chosenPosix = chosen.replace(/\\/g, "/");
+
       // Decide whether the chosen path lives inside the workspace.
       // When it does we transition to a normal workspace tab; otherwise
       // it becomes an external tab (per issue #433). `pathInside`
@@ -1363,9 +1374,9 @@ export function CodeBrowserView({
       // prefix-collision edge case (`/a/band` vs `/a/band-fork`) by
       // requiring an exact path-segment match rather than a raw string
       // prefix.
-      const relative = workspacePath != null ? pathInside(workspacePath, chosen) : null;
+      const relative = workspacePath != null ? pathInside(workspacePath, chosenPosix) : null;
       const isExternal = relative === null;
-      const newPath = relative ?? chosen;
+      const newPath = relative ?? chosenPosix;
 
       // Carry the manual language override (if any) from the untitled
       // key to the new path so the user's choice survives the rename
@@ -1403,7 +1414,10 @@ export function CodeBrowserView({
       setViewColumn(undefined);
       if (!isExternal) notifySelectFile(newPath);
       window.dispatchEvent(new CustomEvent("band:dirty-change"));
-      return chosen;
+      // Return the POSIX-normalised path so downstream callers (the
+      // FileViewer save handler, primarily) see a consistent shape
+      // across platforms — the same rewrite as `chosenPosix` above.
+      return chosenPosix;
     },
     [pickSaveFile, workspacePath, fileTabs.renameUntitledToFile, notifySelectFile, tabState],
   );

--- a/apps/web/src/components/DockviewWorkspaceLayout.tsx
+++ b/apps/web/src/components/DockviewWorkspaceLayout.tsx
@@ -889,6 +889,25 @@ export const DockviewWorkspaceLayout = memo(function DockviewWorkspaceLayout({
             }),
           );
         },
+        newUntitledTab: () => {
+          // CodeBrowserView's listener calls `openTabUntitled` for the
+          // workspace it owns. No detail is needed — there's at most one
+          // CodeBrowserView mounted per workspace, and the file-tab
+          // state is per-workspace so a stray multi-handler fire would
+          // just create one untitled tab per workspace.
+          window.dispatchEvent(new CustomEvent("band:new-untitled-tab"));
+        },
+        changeLanguageMode: () => {
+          // Mirrors the format-current-file shape — only the matching
+          // FileViewer responds. `filePath` is optional for the same
+          // restored-tab race as the format command.
+          const filePath = currentFileRef.current;
+          window.dispatchEvent(
+            new CustomEvent("band:open-language-picker", {
+              detail: { workspaceId, filePath },
+            }),
+          );
+        },
       }),
     [workspaceId],
   );
@@ -986,6 +1005,15 @@ export const DockviewWorkspaceLayout = memo(function DockviewWorkspaceLayout({
       if (key === "n" && e.shiftKey) {
         e.preventDefault();
         window.dispatchEvent(new CustomEvent("band:new-chat-session"));
+      } else if (key === "n" && !e.shiftKey && !e.altKey) {
+        // ⌘N → New Untitled File (issue #434). Always preventDefault so
+        // the browser's own "New Window" doesn't fire over the SPA.
+        // CodeBrowserView listens for this event; the action is a no-op
+        // when there's no editor in the active workspace (the listener
+        // simply isn't attached), so binding the key here is safe even
+        // for workspaces with no Files panel.
+        e.preventDefault();
+        window.dispatchEvent(new CustomEvent("band:new-untitled-tab"));
       } else if (key === "p" && e.shiftKey) {
         e.preventDefault();
         setCommandPaletteOpen(true);

--- a/apps/web/src/components/FileTabBar.tsx
+++ b/apps/web/src/components/FileTabBar.tsx
@@ -23,6 +23,7 @@ import {
   Clipboard,
   Copy,
   ExternalLink,
+  FileText,
   PanelLeft,
   Pin,
   X,
@@ -65,6 +66,14 @@ interface FileTabBarProps {
   canGoForward?: boolean;
   /** Check if a file has unsaved edits (from tab state) */
   isDirty?: (filePath: string) => boolean;
+  /**
+   * Run the save-as flow for an untitled tab (issue #434). Returns
+   * `true` when the user picked a path and the file was saved, `false`
+   * when they cancelled the dialog. The close-confirm dialog uses this
+   * to wire the "Save" button: if the save resolves, we close the tab;
+   * if it returns false, we leave the tab open (matching VS Code).
+   */
+  onSaveUntitled?: (filePath: string) => Promise<boolean>;
   /** Action buttons rendered at the right end of the tab bar (e.g. markdown toggle) */
   actions?: React.ReactNode;
   /** Whether the file-tree sidebar is collapsed (used to flip the toggle icon's tooltip). */
@@ -90,6 +99,7 @@ export function FileTabBar({
   canGoBack,
   canGoForward,
   isDirty: isDirtyFn,
+  onSaveUntitled,
   actions,
   treeCollapsed,
   onToggleTree,
@@ -99,6 +109,13 @@ export function FileTabBar({
 
   // State for the unsaved-changes confirmation dialog
   const [confirmClosePath, setConfirmClosePath] = useState<string | null>(null);
+  // Track whether the tab the close-confirm dialog is showing for is
+  // an untitled buffer — drives the three-button (Save / Discard / Cancel)
+  // layout from issue #434 instead of the default two-button shape used
+  // for file-backed tabs (where dirty content already has a path to save
+  // to, so the user picks Save/Cancel from the editor toolbar instead).
+  const confirmCloseIsUntitled =
+    confirmClosePath != null && tabs.some((t) => t.filePath === confirmClosePath && t.isUntitled);
 
   // Re-render when dirty state changes (FileViewer dispatches "band:dirty-change")
   const [, forceUpdate] = useReducer((x: number) => x + 1, 0);
@@ -146,6 +163,24 @@ export function FileTabBar({
       setConfirmClosePath(null);
     }
   }, [confirmClosePath, onCloseTab]);
+
+  // Save-then-close for untitled tabs. Runs the OS save dialog via
+  // `onSaveUntitled`; if the user picks a path we close the (now file-
+  // backed) tab, if they cancel we keep the dialog and the tab open —
+  // matches the acceptance criterion "cancelling the save dialog
+  // cancels the close".
+  const handleSaveAndClose = useCallback(async () => {
+    if (!confirmClosePath || !onSaveUntitled) return;
+    const saved = await onSaveUntitled(confirmClosePath);
+    if (saved) {
+      // The save flow renamed the tab to the saved path — the original
+      // untitled key is gone, so closing it is a no-op. Just dismiss
+      // the dialog.
+      setConfirmClosePath(null);
+    }
+    // Cancelled: leave the dialog open so the user can pick Discard
+    // or Cancel without re-clicking the X.
+  }, [confirmClosePath, onSaveUntitled]);
 
   const handleMouseDown = useCallback(
     (e: React.MouseEvent, filePath: string) => {
@@ -241,23 +276,40 @@ export function FileTabBar({
             const isDirty = isDirtyFn?.(tab.filePath) ?? false;
             const isPreview = tab.isPreview ?? false;
             const isExternal = tab.isExternal ?? false;
-            const basename = getBasename(tab.filePath);
-            const Icon = getFileIcon(basename);
+            const isUntitled = tab.isUntitled ?? false;
+            // Untitled tabs render their `untitledLabel` ("Untitled-1")
+            // because the synthetic `untitled:N` filePath is just a key.
+            // File-backed tabs continue using the basename.
+            const basename = isUntitled
+              ? (tab.untitledLabel ?? "Untitled")
+              : getBasename(tab.filePath);
+            // No file icon to derive from an untitled tab — render a
+            // generic FileText. Existing tabs keep their extension-
+            // based icon (TypeScript, Markdown, etc.).
+            const Icon = isUntitled ? FileText : getFileIcon(basename);
             // External tabs already carry the absolute path; workspace tabs
             // join with the worktree root for the "Copy Absolute Path" item.
-            const absolutePath = isExternal
-              ? tab.filePath
-              : workspacePath
-                ? `${workspacePath.replace(/\/$/, "")}/${tab.filePath}`
-                : tab.filePath;
+            // Untitled tabs have no on-disk path; reuse the basename so
+            // "Copy Absolute Path" is a no-op rather than a leak of the
+            // synthetic key.
+            const absolutePath = isUntitled
+              ? basename
+              : isExternal
+                ? tab.filePath
+                : workspacePath
+                  ? `${workspacePath.replace(/\/$/, "")}/${tab.filePath}`
+                  : tab.filePath;
             // Tooltip / native title: external tabs surface the full
             // absolute path so the user can tell at a glance where edits
-            // will be written.
-            const tabTitle = isExternal
-              ? `${tab.filePath} (external file)`
-              : isPreview
-                ? `${tab.filePath} (preview — double-click to keep open)`
-                : tab.filePath;
+            // will be written. Untitled tabs show a hint that the buffer
+            // hasn't been saved.
+            const tabTitle = isUntitled
+              ? `${basename} (unsaved — Cmd+S to save)`
+              : isExternal
+                ? `${tab.filePath} (external file)`
+                : isPreview
+                  ? `${tab.filePath} (preview — double-click to keep open)`
+                  : tab.filePath;
 
             return (
               <ContextMenu key={tab.filePath}>
@@ -374,8 +426,13 @@ export function FileTabBar({
           <DialogHeader>
             <DialogTitle>Unsaved Changes</DialogTitle>
             <DialogDescription>
-              &ldquo;{confirmClosePath ? getBasename(confirmClosePath) : ""}&rdquo; has unsaved
-              changes that will be lost if you close it.
+              &ldquo;
+              {confirmClosePath
+                ? confirmCloseIsUntitled
+                  ? (tabs.find((t) => t.filePath === confirmClosePath)?.untitledLabel ?? "Untitled")
+                  : getBasename(confirmClosePath)
+                : ""}
+              &rdquo; has unsaved changes that will be lost if you close it.
             </DialogDescription>
           </DialogHeader>
           <DialogFooter>
@@ -383,8 +440,15 @@ export function FileTabBar({
               Cancel
             </Button>
             <Button variant="destructive" onClick={handleConfirmClose}>
-              Close Without Saving
+              {confirmCloseIsUntitled ? "Discard" : "Close Without Saving"}
             </Button>
+            {confirmCloseIsUntitled && onSaveUntitled && (
+              // Save flows through the OS dialog (Cmd+S on an untitled
+              // tab). On success the untitled tab is renamed to the
+              // chosen path and the close completes; on cancel we
+              // leave both the dialog and the tab open.
+              <Button onClick={handleSaveAndClose}>Save…</Button>
+            )}
           </DialogFooter>
         </DialogContent>
       </Dialog>

--- a/apps/web/src/components/FileTabBar.tsx
+++ b/apps/web/src/components/FileTabBar.tsx
@@ -169,18 +169,30 @@ export function FileTabBar({
   // backed) tab, if they cancel we keep the dialog and the tab open —
   // matches the acceptance criterion "cancelling the save dialog
   // cancels the close".
+  //
+  // `saveAndClosePending` guards the brief window between the dialog
+  // resolving and React processing `setConfirmClosePath(null)`. Without
+  // it a second click on "Save…" (impatient user / a touchpad double-
+  // tap) would launch a second save with the same content, surfacing
+  // two save dialogs in sequence.
+  const [saveAndClosePending, setSaveAndClosePending] = useState(false);
   const handleSaveAndClose = useCallback(async () => {
-    if (!confirmClosePath || !onSaveUntitled) return;
-    const saved = await onSaveUntitled(confirmClosePath);
-    if (saved) {
-      // The save flow renamed the tab to the saved path — the original
-      // untitled key is gone, so closing it is a no-op. Just dismiss
-      // the dialog.
-      setConfirmClosePath(null);
+    if (!confirmClosePath || !onSaveUntitled || saveAndClosePending) return;
+    setSaveAndClosePending(true);
+    try {
+      const saved = await onSaveUntitled(confirmClosePath);
+      if (saved) {
+        // The save flow renamed the tab to the saved path — the
+        // original untitled key is gone, so closing it is a no-op.
+        // Just dismiss the dialog.
+        setConfirmClosePath(null);
+      }
+      // Cancelled: leave the dialog open so the user can pick
+      // Discard or Cancel without re-clicking the X.
+    } finally {
+      setSaveAndClosePending(false);
     }
-    // Cancelled: leave the dialog open so the user can pick Discard
-    // or Cancel without re-clicking the X.
-  }, [confirmClosePath, onSaveUntitled]);
+  }, [confirmClosePath, onSaveUntitled, saveAndClosePending]);
 
   const handleMouseDown = useCallback(
     (e: React.MouseEvent, filePath: string) => {
@@ -287,13 +299,15 @@ export function FileTabBar({
             // generic FileText. Existing tabs keep their extension-
             // based icon (TypeScript, Markdown, etc.).
             const Icon = isUntitled ? FileText : getFileIcon(basename);
-            // External tabs already carry the absolute path; workspace tabs
-            // join with the worktree root for the "Copy Absolute Path" item.
-            // Untitled tabs have no on-disk path; reuse the basename so
-            // "Copy Absolute Path" is a no-op rather than a leak of the
-            // synthetic key.
-            const absolutePath = isUntitled
-              ? basename
+            // External tabs already carry the absolute path; workspace
+            // tabs join with the worktree root for the "Copy Absolute
+            // Path" item. Untitled tabs have no on-disk path, so we
+            // leave `absolutePath` as `null` — the context-menu render
+            // below omits the "Copy Absolute Path" entry entirely (VS
+            // Code's behaviour for unsaved buffers) rather than copy a
+            // bare label that looks like a path but isn't.
+            const absolutePath: string | null = isUntitled
+              ? null
               : isExternal
                 ? tab.filePath
                 : workspacePath
@@ -302,9 +316,11 @@ export function FileTabBar({
             // Tooltip / native title: external tabs surface the full
             // absolute path so the user can tell at a glance where edits
             // will be written. Untitled tabs show a hint that the buffer
-            // hasn't been saved.
+            // hasn't been saved — phrased without a platform-specific
+            // shortcut since Band's Electron shell runs on macOS,
+            // Windows, and Linux (Cmd on macOS / Ctrl elsewhere).
             const tabTitle = isUntitled
-              ? `${basename} (unsaved — Cmd+S to save)`
+              ? `${basename} (unsaved — Save to write to disk)`
               : isExternal
                 ? `${tab.filePath} (external file)`
                 : isPreview
@@ -394,15 +410,28 @@ export function FileTabBar({
                       <ContextMenuSeparator />
                     </>
                   )}
-                  <ContextMenuItem onClick={() => copyToClipboard(tab.filePath)}>
-                    <Copy className="size-4" />
-                    Copy Relative Path
-                  </ContextMenuItem>
-                  <ContextMenuItem onClick={() => copyToClipboard(absolutePath)}>
-                    <Clipboard className="size-4" />
-                    Copy Absolute Path
-                  </ContextMenuItem>
-                  <ContextMenuSeparator />
+                  {/* "Copy Relative Path" is meaningless for an
+                      untitled buffer (the path is a synthetic
+                      `untitled:N` key, not a real workspace-relative
+                      path). Match VS Code's behaviour for unsaved
+                      editors and hide the item in that case. */}
+                  {!isUntitled && (
+                    <ContextMenuItem onClick={() => copyToClipboard(tab.filePath)}>
+                      <Copy className="size-4" />
+                      Copy Relative Path
+                    </ContextMenuItem>
+                  )}
+                  {/* Untitled tabs leave `absolutePath` as `null`, so
+                      the "Copy Absolute Path" item is dropped entirely
+                      — pasting `"Untitled-1"` somewhere would look
+                      like a valid path and fail confusingly. */}
+                  {absolutePath !== null && (
+                    <ContextMenuItem onClick={() => copyToClipboard(absolutePath)}>
+                      <Clipboard className="size-4" />
+                      Copy Absolute Path
+                    </ContextMenuItem>
+                  )}
+                  {!isUntitled && <ContextMenuSeparator />}
                   <ContextMenuItem onClick={() => handleClose(tab.filePath)}>
                     <X className="size-4" />
                     Close
@@ -447,7 +476,9 @@ export function FileTabBar({
               // tab). On success the untitled tab is renamed to the
               // chosen path and the close completes; on cancel we
               // leave both the dialog and the tab open.
-              <Button onClick={handleSaveAndClose}>Save…</Button>
+              <Button onClick={handleSaveAndClose} disabled={saveAndClosePending}>
+                Save…
+              </Button>
             )}
           </DialogFooter>
         </DialogContent>

--- a/apps/web/src/components/FileTabBar.tsx
+++ b/apps/web/src/components/FileTabBar.tsx
@@ -107,15 +107,38 @@ export function FileTabBar({
   const activeRef = useRef<HTMLButtonElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
 
-  // State for the unsaved-changes confirmation dialog
+  // State for the unsaved-changes confirmation dialog. We latch
+  // `confirmCloseIsUntitled` at dialog-open time instead of deriving
+  // it from `tabs` on every render. The Save… flow calls
+  // `renameUntitledToFile` upstream, which removes the `untitled:N`
+  // entry from `tabs` BEFORE this component's
+  // `setConfirmClosePath(null)` runs — and during that render window
+  // a `tabs.some(...)` lookup would observe the renamed (no-longer-
+  // untitled) tab and flip the button row from "Discard / Save…" to
+  // "Close Without Saving" momentarily, producing a flicker. Latching
+  // at open time pins the variant for the dialog's whole lifetime.
   const [confirmClosePath, setConfirmClosePath] = useState<string | null>(null);
-  // Track whether the tab the close-confirm dialog is showing for is
-  // an untitled buffer — drives the three-button (Save / Discard / Cancel)
-  // layout from issue #434 instead of the default two-button shape used
-  // for file-backed tabs (where dirty content already has a path to save
-  // to, so the user picks Save/Cancel from the editor toolbar instead).
-  const confirmCloseIsUntitled =
-    confirmClosePath != null && tabs.some((t) => t.filePath === confirmClosePath && t.isUntitled);
+  const [confirmCloseIsUntitled, setConfirmCloseIsUntitled] = useState(false);
+  const [confirmCloseLabel, setConfirmCloseLabel] = useState<string>("");
+  const openConfirmClose = useCallback(
+    (filePath: string) => {
+      const tab = tabs.find((t) => t.filePath === filePath);
+      setConfirmClosePath(filePath);
+      setConfirmCloseIsUntitled(!!tab?.isUntitled);
+      // Pin the display name at open time too — the renamed (now
+      // file-backed) tab keeps a workspace path, but the dialog should
+      // still announce the original "Untitled-N" the user clicked.
+      setConfirmCloseLabel(
+        tab?.isUntitled ? (tab.untitledLabel ?? "Untitled") : getBasename(filePath),
+      );
+    },
+    [tabs],
+  );
+  const closeConfirmDialog = useCallback(() => {
+    setConfirmClosePath(null);
+    setConfirmCloseIsUntitled(false);
+    setConfirmCloseLabel("");
+  }, []);
 
   // Re-render when dirty state changes (FileViewer dispatches "band:dirty-change")
   const [, forceUpdate] = useReducer((x: number) => x + 1, 0);
@@ -149,20 +172,20 @@ export function FileTabBar({
   const handleClose = useCallback(
     (filePath: string) => {
       if (isDirtyFn?.(filePath)) {
-        setConfirmClosePath(filePath);
+        openConfirmClose(filePath);
         return;
       }
       onCloseTab(filePath);
     },
-    [onCloseTab, isDirtyFn],
+    [onCloseTab, isDirtyFn, openConfirmClose],
   );
 
   const handleConfirmClose = useCallback(() => {
     if (confirmClosePath) {
       onCloseTab(confirmClosePath);
-      setConfirmClosePath(null);
+      closeConfirmDialog();
     }
-  }, [confirmClosePath, onCloseTab]);
+  }, [confirmClosePath, onCloseTab, closeConfirmDialog]);
 
   // Save-then-close for untitled tabs. Runs the OS save dialog via
   // `onSaveUntitled`; if the user picks a path we close the (now file-
@@ -185,14 +208,14 @@ export function FileTabBar({
         // The save flow renamed the tab to the saved path — the
         // original untitled key is gone, so closing it is a no-op.
         // Just dismiss the dialog.
-        setConfirmClosePath(null);
+        closeConfirmDialog();
       }
       // Cancelled: leave the dialog open so the user can pick
       // Discard or Cancel without re-clicking the X.
     } finally {
       setSaveAndClosePending(false);
     }
-  }, [confirmClosePath, onSaveUntitled, saveAndClosePending]);
+  }, [confirmClosePath, onSaveUntitled, saveAndClosePending, closeConfirmDialog]);
 
   const handleMouseDown = useCallback(
     (e: React.MouseEvent, filePath: string) => {
@@ -449,23 +472,18 @@ export function FileTabBar({
       {/* Unsaved changes confirmation dialog */}
       <Dialog
         open={confirmClosePath !== null}
-        onOpenChange={(open) => !open && setConfirmClosePath(null)}
+        onOpenChange={(open) => !open && closeConfirmDialog()}
       >
         <DialogContent showCloseButton={false}>
           <DialogHeader>
             <DialogTitle>Unsaved Changes</DialogTitle>
             <DialogDescription>
-              &ldquo;
-              {confirmClosePath
-                ? confirmCloseIsUntitled
-                  ? (tabs.find((t) => t.filePath === confirmClosePath)?.untitledLabel ?? "Untitled")
-                  : getBasename(confirmClosePath)
-                : ""}
-              &rdquo; has unsaved changes that will be lost if you close it.
+              &ldquo;{confirmCloseLabel}&rdquo; has unsaved changes that will be lost if you close
+              it.
             </DialogDescription>
           </DialogHeader>
           <DialogFooter>
-            <Button variant="outline" onClick={() => setConfirmClosePath(null)}>
+            <Button variant="outline" onClick={closeConfirmDialog}>
               Cancel
             </Button>
             <Button variant="destructive" onClick={handleConfirmClose}>

--- a/apps/web/src/hooks/useFileTabs.ts
+++ b/apps/web/src/hooks/useFileTabs.ts
@@ -33,6 +33,10 @@ import { useCallback, useEffect, useRef, useState } from "react";
  * after a reload. Issue #434 originally listed scratch persistence as
  * out-of-scope, but reusing the existing tab-state plumbing makes the
  * scope creep small and the UX win large (no accidental data loss).
+ *
+ * See `openTabUntitled`'s docblock for the counter / collision
+ * rationale, and `parseTabState` / `serializeTabState` for the wire
+ * shape the rehydration relies on.
  */
 export const UNTITLED_PREFIX = "untitled:";
 

--- a/apps/web/src/hooks/useFileTabs.ts
+++ b/apps/web/src/hooks/useFileTabs.ts
@@ -4,14 +4,45 @@ import { useCallback, useEffect, useRef, useState } from "react";
 // Types
 // ---------------------------------------------------------------------------
 
+/**
+ * Synthetic prefix used as the `filePath` of an untitled tab. The suffix
+ * is a per-workspace monotonic counter — `untitled:1`, `untitled:2`, …
+ * Two reasons we encode untitled-ness into the path itself rather than
+ * keying tabs by an opaque id:
+ *
+ *   1. Every tab consumer (FileTabBar, tab-state localStorage, editor
+ *      state cache, `band:dirty-change`/`band:discard-edits` listeners)
+ *      already indexes by `filePath`. Reusing that key avoids a parallel
+ *      "untitledTabs" data structure with its own activation pointer,
+ *      eviction, and persistence rules — every code path stays
+ *      symmetric with file-backed tabs.
+ *
+ *   2. The synthetic path is not a valid filesystem path on any OS
+ *      Band runs on (the `untitled:` scheme contains a colon, which
+ *      collides with neither POSIX nor Windows path syntax), so the
+ *      "is this an untitled tab" check is unambiguous: callers can
+ *      either inspect the `isUntitled` flag or just test the prefix.
+ *
+ * Untitled tabs are deliberately ephemeral (issue #434 "Out of scope"
+ * called out autosave / scratch persistence as a follow-up): they are
+ * filtered out of the localStorage save path so a reload doesn't
+ * resurrect empty buffers.
+ */
+export const UNTITLED_PREFIX = "untitled:";
+
+export function isUntitledPath(filePath: string): boolean {
+  return filePath.startsWith(UNTITLED_PREFIX);
+}
+
 export interface FileTab {
   /**
    * For workspace files this is the workspace-relative path
    * (`src/main.ts`). For external files this is the absolute
    * filesystem path returned by the OS file picker
-   * (`/Users/alice/notes/scratch.md`). The shape is the same so
-   * downstream tab plumbing (active-tab pointer, dedup, eviction)
-   * doesn't have to special-case the two flavours.
+   * (`/Users/alice/notes/scratch.md`). For untitled tabs it is the
+   * synthetic `untitled:N` key (see `UNTITLED_PREFIX`). The shape is
+   * the same so downstream tab plumbing (active-tab pointer, dedup,
+   * eviction) doesn't have to special-case the three flavours.
    */
   filePath: string;
   /** Preview tab — italic, single shared slot, replaced by next preview open. */
@@ -25,6 +56,19 @@ export interface FileTab {
    * glance that edits write to an out-of-workspace path.
    */
   isExternal?: boolean;
+  /**
+   * True when `filePath` is a synthetic `untitled:N` key (see
+   * `UNTITLED_PREFIX`). Untitled tabs live entirely in-renderer until
+   * the user picks a destination via the OS save dialog; on save the
+   * tab transitions to a regular file-backed tab (workspace or
+   * external) and this flag is cleared.
+   */
+  isUntitled?: boolean;
+  /**
+   * Display name for untitled tabs (e.g. "Untitled-1"). Unused for
+   * file-backed tabs — they derive the title from the basename.
+   */
+  untitledLabel?: string;
 }
 
 export interface UseFileTabsReturn {
@@ -43,6 +87,29 @@ export interface UseFileTabsReturn {
    * created.
    */
   openTabExternal: (absolutePath: string) => void;
+  /**
+   * Create a new untitled (scratch) tab and activate it. Returns the
+   * synthetic `untitled:N` path so the caller can seed editor state
+   * (initial content, language) under the same key the tab uses
+   * everywhere else.
+   *
+   * The counter is monotonic per workspace and never reused, so two
+   * "Untitled-1" tabs cannot coexist even if the first is closed —
+   * matching VS Code's behaviour. Persistence is intentionally not
+   * wired (issue #434 leaves scratch persistence to a follow-up):
+   * untitled tabs are filtered out of the localStorage save path so a
+   * reload doesn't resurrect empty buffers.
+   */
+  openTabUntitled: () => { filePath: string; label: string };
+  /**
+   * Convert an untitled tab into a file-backed tab once the user
+   * picks a destination via the OS save dialog. Removes the
+   * `untitled:N` entry and inserts a new tab at the same position so
+   * the tab order doesn't shuffle on save. `isExternal` controls
+   * whether the resulting tab is rendered with the external-file
+   * marker (chosen path lives outside the workspace root).
+   */
+  renameUntitledToFile: (untitledPath: string, newPath: string, isExternal: boolean) => void;
   /**
    * Open as a preview tab — replaces any existing preview tab.
    *
@@ -90,6 +157,8 @@ interface PersistedTab {
   filePath: string;
   isPreview?: boolean;
   isExternal?: boolean;
+  // Note: untitled tabs are intentionally NOT persisted — see the
+  // serialization filter in `saveTabState` below.
 }
 
 interface PersistedTabState {
@@ -141,8 +210,17 @@ function loadTabState(workspaceId: string): { tabs: FileTab[]; active: string | 
 
 function saveTabState(workspaceId: string, tabs: FileTab[], active: string | null): void {
   try {
+    // Untitled tabs are deliberately ephemeral — see UNTITLED_PREFIX docs
+    // and issue #434 ("Out of scope: autosave / scratch persistence
+    // across reloads"). Filter them out at the serialization boundary so
+    // the loader never sees a synthetic `untitled:N` key and tries to
+    // open it as a real file. The active-tab pointer is rewritten to
+    // null when it points at a dropped untitled tab.
+    const persistedTabs = tabs.filter((t) => !t.isUntitled);
+    const persistedActive =
+      active != null && persistedTabs.some((t) => t.filePath === active) ? active : null;
     const state: PersistedTabState = {
-      tabs: tabs.map((t) => {
+      tabs: persistedTabs.map((t) => {
         // Bare-string serialization is the legacy/compact form for plain
         // pinned workspace tabs. Anything carrying extra flags (preview,
         // external) is written as an object so the loader can re-hydrate
@@ -153,7 +231,7 @@ function saveTabState(workspaceId: string, tabs: FileTab[], active: string | nul
         if (t.isExternal) out.isExternal = true;
         return out;
       }),
-      active,
+      active: persistedActive,
     };
     localStorage.setItem(storageKey(workspaceId), JSON.stringify(state));
   } catch {
@@ -238,6 +316,52 @@ export function useFileTabs(workspaceId: string): UseFileTabsReturn {
     });
     setActiveTabPathState(filePath);
   }, []);
+
+  // Monotonic counter for "Untitled-N" labels. Per-workspace,
+  // intentionally never reused: closing Untitled-1 and creating a new
+  // untitled tab yields Untitled-2 (matching VS Code). The counter
+  // resets when the workspace switches because untitled tabs are
+  // ephemeral — see UNTITLED_PREFIX docs.
+  const untitledCounterRef = useRef(0);
+
+  const openTabUntitled = useCallback((): { filePath: string; label: string } => {
+    untitledCounterRef.current += 1;
+    const n = untitledCounterRef.current;
+    const filePath = `${UNTITLED_PREFIX}${n}`;
+    const label = `Untitled-${n}`;
+    setOpenTabs((prev) => [...prev, { filePath, isUntitled: true, untitledLabel: label }]);
+    setActiveTabPathState(filePath);
+    return { filePath, label };
+  }, []);
+
+  const renameUntitledToFile = useCallback(
+    (untitledPath: string, newPath: string, isExternal: boolean) => {
+      setOpenTabs((prev) => {
+        const idx = prev.findIndex((t) => t.filePath === untitledPath);
+        if (idx === -1) {
+          // Untitled tab vanished mid-save (closed concurrently?). Fall
+          // back to appending the new file-backed tab so the user still
+          // ends up with their saved file visible.
+          return [
+            ...prev,
+            isExternal ? { filePath: newPath, isExternal: true } : { filePath: newPath },
+          ];
+        }
+        // If a tab for `newPath` already exists elsewhere (rare, but
+        // possible when the user saves on top of an already-open file),
+        // drop the duplicate and keep only the one at the untitled slot.
+        const dedup = prev.filter((t, i) => i === idx || t.filePath !== newPath);
+        const slotIdx = dedup.findIndex((t) => t.filePath === untitledPath);
+        const next = dedup.slice();
+        next[slotIdx] = isExternal
+          ? { filePath: newPath, isExternal: true }
+          : { filePath: newPath };
+        return next;
+      });
+      setActiveTabPathState((current) => (current === untitledPath ? newPath : current));
+    },
+    [],
+  );
 
   const openTabExternal = useCallback((absolutePath: string) => {
     // External files are always opened pinned — they're a deliberate user
@@ -437,6 +561,8 @@ export function useFileTabs(workspaceId: string): UseFileTabsReturn {
     openTabPreview,
     openTabPinned,
     openTabExternal,
+    openTabUntitled,
+    renameUntitledToFile,
     pinTab,
     closeTab,
     setActiveTab,

--- a/apps/web/src/hooks/useFileTabs.ts
+++ b/apps/web/src/hooks/useFileTabs.ts
@@ -101,10 +101,16 @@ export interface UseFileTabsReturn {
    *
    * The counter is monotonic per workspace and never reused, so two
    * "Untitled-1" tabs cannot coexist even if the first is closed —
-   * matching VS Code's behaviour. Persistence is intentionally not
-   * wired (issue #434 leaves scratch persistence to a follow-up):
-   * untitled tabs are filtered out of the localStorage save path so a
-   * reload doesn't resurrect empty buffers.
+   * matching VS Code's behaviour. **The counter survives reloads** via
+   * `initialUntitledCounter`, which scans the persisted tab list for
+   * the highest existing `untitled:N` so a freshly-created tab after
+   * a reload doesn't collide with an already-rehydrated one.
+   *
+   * Untitled tabs are also persisted across reloads (the typed buffer
+   * already lives in `useTabState.editedContent`, so dropping the tab
+   * would leak content into localStorage with no visible surface — see
+   * `UNTITLED_PREFIX`). The original "out of scope" note in #434 was
+   * superseded by reusing the existing tab-state plumbing.
    */
   openTabUntitled: () => { filePath: string; label: string };
   /**
@@ -176,10 +182,20 @@ function storageKey(workspaceId: string): string {
   return `band-open-tabs:${workspaceId}`;
 }
 
-function loadTabState(workspaceId: string): { tabs: FileTab[]; active: string | null } | null {
+/**
+ * Pure parse-half of `loadTabState`, exported for testing. Accepts the
+ * raw JSON string (or `null` for an absent localStorage entry) and
+ * returns the validated `{ tabs, active }` shape — or `null` when the
+ * input is missing or malformed. Exposed separately because the
+ * localStorage layer isn't available under `vitest`'s default node
+ * environment, but the parsing logic (defensive type checks, untitled
+ * tab rehydration, prefix-safety) is non-trivial and worth unit-testing.
+ */
+export function parseTabState(
+  raw: string | null,
+): { tabs: FileTab[]; active: string | null } | null {
+  if (!raw) return null;
   try {
-    const raw = localStorage.getItem(storageKey(workspaceId));
-    if (!raw) return null;
     // Don't trust the cast — older builds (or hand-edited localStorage) may
     // have written a different shape, e.g. an array of `{ filePath }` objects
     // instead of bare strings. Filter to strings so downstream code that
@@ -234,29 +250,48 @@ function loadTabState(workspaceId: string): { tabs: FileTab[]; active: string | 
   }
 }
 
+function loadTabState(workspaceId: string): { tabs: FileTab[]; active: string | null } | null {
+  try {
+    return parseTabState(localStorage.getItem(storageKey(workspaceId)));
+  } catch {
+    // localStorage unavailable (private mode, SSR, etc.)
+    return null;
+  }
+}
+
+/**
+ * Pure serialize-half of `saveTabState`, exported for testing. Builds
+ * the JSON string with the compact / object-form heuristics (bare
+ * strings for plain pinned tabs, objects for preview / external /
+ * untitled). Also normalises the active-tab pointer to `null` when it
+ * names a tab that isn't in the list.
+ */
+export function serializeTabState(tabs: FileTab[], active: string | null): string {
+  const persistedActive = active != null && tabs.some((t) => t.filePath === active) ? active : null;
+  const state: PersistedTabState = {
+    tabs: tabs.map((t) => {
+      // Bare-string serialization is the legacy/compact form for plain
+      // pinned workspace tabs. Anything carrying extra flags (preview,
+      // external, untitled) is written as an object so the loader can
+      // re-hydrate the flag set.
+      if (!t.isPreview && !t.isExternal && !t.isUntitled) return t.filePath;
+      const out: PersistedTab = { filePath: t.filePath };
+      if (t.isPreview) out.isPreview = true;
+      if (t.isExternal) out.isExternal = true;
+      if (t.isUntitled) {
+        out.isUntitled = true;
+        if (t.untitledLabel) out.untitledLabel = t.untitledLabel;
+      }
+      return out;
+    }),
+    active: persistedActive,
+  };
+  return JSON.stringify(state);
+}
+
 function saveTabState(workspaceId: string, tabs: FileTab[], active: string | null): void {
   try {
-    const persistedActive =
-      active != null && tabs.some((t) => t.filePath === active) ? active : null;
-    const state: PersistedTabState = {
-      tabs: tabs.map((t) => {
-        // Bare-string serialization is the legacy/compact form for plain
-        // pinned workspace tabs. Anything carrying extra flags (preview,
-        // external, untitled) is written as an object so the loader can
-        // re-hydrate the flag set.
-        if (!t.isPreview && !t.isExternal && !t.isUntitled) return t.filePath;
-        const out: PersistedTab = { filePath: t.filePath };
-        if (t.isPreview) out.isPreview = true;
-        if (t.isExternal) out.isExternal = true;
-        if (t.isUntitled) {
-          out.isUntitled = true;
-          if (t.untitledLabel) out.untitledLabel = t.untitledLabel;
-        }
-        return out;
-      }),
-      active: persistedActive,
-    };
-    localStorage.setItem(storageKey(workspaceId), JSON.stringify(state));
+    localStorage.setItem(storageKey(workspaceId), serializeTabState(tabs, active));
   } catch {
     // storage unavailable
   }
@@ -271,8 +306,10 @@ function saveTabState(workspaceId: string, tabs: FileTab[], active: string | nul
  *
  * `useTabState.editedContent` is keyed on filePath, so a collision
  * would silently splice the new tab on top of the old buffer.
+ *
+ * Exported for testing.
  */
-function initialUntitledCounter(tabs: FileTab[]): number {
+export function initialUntitledCounter(tabs: FileTab[]): number {
   let max = 0;
   for (const t of tabs) {
     if (!t.isUntitled) continue;

--- a/apps/web/src/hooks/useFileTabs.ts
+++ b/apps/web/src/hooks/useFileTabs.ts
@@ -23,10 +23,16 @@ import { useCallback, useEffect, useRef, useState } from "react";
  *      "is this an untitled tab" check is unambiguous: callers can
  *      either inspect the `isUntitled` flag or just test the prefix.
  *
- * Untitled tabs are deliberately ephemeral (issue #434 "Out of scope"
- * called out autosave / scratch persistence as a follow-up): they are
- * filtered out of the localStorage save path so a reload doesn't
- * resurrect empty buffers.
+ * Untitled tabs **are** persisted across reloads: the buffer content
+ * already lives in `useTabState`'s `editedContent` (keyed by
+ * filePath), so dropping the tab on serialization would leak content
+ * into localStorage with no visible surface to reach it. The tab list
+ * carries `isUntitled` + `untitledLabel` so the loader can rehydrate
+ * the tab cleanly, and `initialUntitledCounter` ensures the
+ * monotonic-N counter doesn't collide with already-open scratch tabs
+ * after a reload. Issue #434 originally listed scratch persistence as
+ * out-of-scope, but reusing the existing tab-state plumbing makes the
+ * scope creep small and the UX win large (no accidental data loss).
  */
 export const UNTITLED_PREFIX = "untitled:";
 
@@ -157,8 +163,8 @@ interface PersistedTab {
   filePath: string;
   isPreview?: boolean;
   isExternal?: boolean;
-  // Note: untitled tabs are intentionally NOT persisted — see the
-  // serialization filter in `saveTabState` below.
+  isUntitled?: boolean;
+  untitledLabel?: string;
 }
 
 interface PersistedTabState {
@@ -181,9 +187,10 @@ function loadTabState(workspaceId: string): { tabs: FileTab[]; active: string | 
     const parsed = JSON.parse(raw) as { tabs?: unknown; active?: unknown };
     if (!Array.isArray(parsed.tabs)) return null;
     // Accept either a bare string (legacy / pinned tab) or a
-    // `{ filePath: string, isPreview?: boolean }` object (preview tab).
-    // Anything else is dropped — `.split("/")` on a non-string path
-    // would crash the whole workspace.
+    // `{ filePath: string, isPreview?: boolean, isExternal?: boolean,
+    // isUntitled?: boolean, untitledLabel?: string }` object. Anything
+    // else is dropped — `.split("/")` on a non-string path would crash
+    // the whole workspace.
     const tabs: FileTab[] = [];
     for (const t of parsed.tabs) {
       if (typeof t === "string") {
@@ -194,10 +201,29 @@ function loadTabState(workspaceId: string): { tabs: FileTab[]; active: string | 
         "filePath" in t &&
         typeof (t as { filePath: unknown }).filePath === "string"
       ) {
-        const obj = t as { filePath: string; isPreview?: unknown; isExternal?: unknown };
+        const obj = t as {
+          filePath: string;
+          isPreview?: unknown;
+          isExternal?: unknown;
+          isUntitled?: unknown;
+          untitledLabel?: unknown;
+        };
         const tab: FileTab = { filePath: obj.filePath };
         if (obj.isPreview === true) tab.isPreview = true;
         if (obj.isExternal === true) tab.isExternal = true;
+        // Re-hydrate untitled tabs (issue #434 originally treated them
+        // as ephemeral; rehydration was added so reloads don't lose the
+        // typed buffer — `useTabState` already persists `editedContent`
+        // per filePath, so dropping the tab leaked content into
+        // localStorage with no visible surface). Defensive check that
+        // the path actually carries the `untitled:N` shape so a
+        // mis-flagged real file can't masquerade as untitled.
+        if (obj.isUntitled === true && obj.filePath.startsWith(UNTITLED_PREFIX)) {
+          tab.isUntitled = true;
+          if (typeof obj.untitledLabel === "string") {
+            tab.untitledLabel = obj.untitledLabel;
+          }
+        }
         tabs.push(tab);
       }
     }
@@ -210,25 +236,22 @@ function loadTabState(workspaceId: string): { tabs: FileTab[]; active: string | 
 
 function saveTabState(workspaceId: string, tabs: FileTab[], active: string | null): void {
   try {
-    // Untitled tabs are deliberately ephemeral — see UNTITLED_PREFIX docs
-    // and issue #434 ("Out of scope: autosave / scratch persistence
-    // across reloads"). Filter them out at the serialization boundary so
-    // the loader never sees a synthetic `untitled:N` key and tries to
-    // open it as a real file. The active-tab pointer is rewritten to
-    // null when it points at a dropped untitled tab.
-    const persistedTabs = tabs.filter((t) => !t.isUntitled);
     const persistedActive =
-      active != null && persistedTabs.some((t) => t.filePath === active) ? active : null;
+      active != null && tabs.some((t) => t.filePath === active) ? active : null;
     const state: PersistedTabState = {
-      tabs: persistedTabs.map((t) => {
+      tabs: tabs.map((t) => {
         // Bare-string serialization is the legacy/compact form for plain
         // pinned workspace tabs. Anything carrying extra flags (preview,
-        // external) is written as an object so the loader can re-hydrate
-        // the flag.
-        if (!t.isPreview && !t.isExternal) return t.filePath;
+        // external, untitled) is written as an object so the loader can
+        // re-hydrate the flag set.
+        if (!t.isPreview && !t.isExternal && !t.isUntitled) return t.filePath;
         const out: PersistedTab = { filePath: t.filePath };
         if (t.isPreview) out.isPreview = true;
         if (t.isExternal) out.isExternal = true;
+        if (t.isUntitled) {
+          out.isUntitled = true;
+          if (t.untitledLabel) out.untitledLabel = t.untitledLabel;
+        }
         return out;
       }),
       active: persistedActive,
@@ -237,6 +260,26 @@ function saveTabState(workspaceId: string, tabs: FileTab[], active: string | nul
   } catch {
     // storage unavailable
   }
+}
+
+/**
+ * Initial value for the per-workspace untitled-tab counter. Reads the
+ * highest `N` from any persisted `untitled:N` tab so a reload doesn't
+ * collide with already-open scratch tabs — without this, creating a
+ * new untitled tab after a reload would reuse `untitled:1` even if a
+ * persisted Untitled-1 already occupies that slot.
+ *
+ * `useTabState.editedContent` is keyed on filePath, so a collision
+ * would silently splice the new tab on top of the old buffer.
+ */
+function initialUntitledCounter(tabs: FileTab[]): number {
+  let max = 0;
+  for (const t of tabs) {
+    if (!t.isUntitled) continue;
+    const n = Number.parseInt(t.filePath.slice(UNTITLED_PREFIX.length), 10);
+    if (Number.isFinite(n) && n > max) max = n;
+  }
+  return max;
 }
 
 // ---------------------------------------------------------------------------
@@ -288,9 +331,14 @@ export function useFileTabs(workspaceId: string): UseFileTabsReturn {
       if (saved) {
         setOpenTabs(saved.tabs);
         setActiveTabPathState(saved.active);
+        // Reseed the untitled counter from the new workspace's saved
+        // tabs so a new untitled tab in this workspace doesn't collide
+        // with an already-restored Untitled-1.
+        untitledCounterRef.current = initialUntitledCounter(saved.tabs);
       } else {
         setOpenTabs([]);
         setActiveTabPathState(null);
+        untitledCounterRef.current = 0;
       }
     }
   }, [workspaceId]);
@@ -319,10 +367,11 @@ export function useFileTabs(workspaceId: string): UseFileTabsReturn {
 
   // Monotonic counter for "Untitled-N" labels. Per-workspace,
   // intentionally never reused: closing Untitled-1 and creating a new
-  // untitled tab yields Untitled-2 (matching VS Code). The counter
-  // resets when the workspace switches because untitled tabs are
-  // ephemeral — see UNTITLED_PREFIX docs.
-  const untitledCounterRef = useRef(0);
+  // untitled tab yields Untitled-2 (matching VS Code). Initialised from
+  // the highest `N` in any persisted untitled tab so a new tab after a
+  // reload doesn't collide with an already-open Untitled-1 — see
+  // `initialUntitledCounter`.
+  const untitledCounterRef = useRef(initialUntitledCounter(openTabs));
 
   const openTabUntitled = useCallback((): { filePath: string; label: string } => {
     untitledCounterRef.current += 1;

--- a/apps/web/src/hooks/useTabState.ts
+++ b/apps/web/src/hooks/useTabState.ts
@@ -1,4 +1,4 @@
-import { useCallback, useRef } from "react";
+import { useCallback, useMemo, useRef } from "react";
 
 // ---------------------------------------------------------------------------
 // localStorage-backed store for per-tab state
@@ -205,16 +205,40 @@ export function useTabState(workspaceId: string): UseTabStateReturn {
     [workspaceId],
   );
 
-  return {
-    get,
-    update,
-    getViewMode,
-    setViewMode,
-    getLanguage,
-    setLanguage,
-    isDirty,
-    removeFile,
-    renameFile,
-    removePath,
-  };
+  // Memoise the returned shape so callers that include the hook
+  // result in a useCallback / useEffect dependency array see a stable
+  // reference. Each method is already wrapped in `useCallback`, so the
+  // `useMemo` deps form a transitively-stable set — the returned
+  // object's identity only changes when the workspace switches (which
+  // is exactly when downstream callbacks should re-bind). Without
+  // this, every render produced a fresh object literal, causing every
+  // CodeBrowserView callback that depended on `tabState` to churn
+  // and propagate that churn into `onSaveAs` / `onSaveUntitled` /
+  // `onLanguageOverrideChange` props on every render of every tab.
+  return useMemo(
+    () => ({
+      get,
+      update,
+      getViewMode,
+      setViewMode,
+      getLanguage,
+      setLanguage,
+      isDirty,
+      removeFile,
+      renameFile,
+      removePath,
+    }),
+    [
+      get,
+      update,
+      getViewMode,
+      setViewMode,
+      getLanguage,
+      setLanguage,
+      isDirty,
+      removeFile,
+      renameFile,
+      removePath,
+    ],
+  );
 }

--- a/apps/web/src/hooks/useTabState.ts
+++ b/apps/web/src/hooks/useTabState.ts
@@ -16,6 +16,23 @@ export interface TabFileState {
   editorState?: unknown;
   /** Scroll position (scrollDOM.scrollTop) to restore after editor creation. */
   scrollTop?: number;
+  /**
+   * User-selected syntax highlighting language override (e.g.
+   * `"typescript"`, `"markdown"`, `"plaintext"`). When set, the editor
+   * uses this instead of auto-detecting from the file extension /
+   * filename. Survives saves (per issue #434: "Saving an untitled tab
+   * whose language was manually set keeps the override even if the
+   * chosen filename's extension would imply a different language").
+   *
+   * Out of scope for #434 — and intentionally so: the language picker
+   * is per-tab-lifetime, not cross-session. We persist into tab state
+   * (which is itself localStorage-backed) so it survives in-session
+   * tab switches; on workspace switch / reload tab state is loaded
+   * fresh from disk, but untitled tabs are filtered out at the
+   * `useFileTabs` boundary so a stale language entry has nothing to
+   * attach to.
+   */
+  language?: string;
 }
 
 function storageKey(workspaceId: string): string {
@@ -51,6 +68,10 @@ export interface UseTabStateReturn {
   getViewMode: (filePath: string) => "preview" | "source" | undefined;
   /** Store the view mode for a file. */
   setViewMode: (filePath: string, mode: "preview" | "source") => void;
+  /** Get the user-overridden language for a file (undefined when auto-detected). */
+  getLanguage: (filePath: string) => string | undefined;
+  /** Store a manual language override for a file. */
+  setLanguage: (filePath: string, language: string) => void;
   /** Check if a file has unsaved edits. */
   isDirty: (filePath: string) => boolean;
   /** Remove all stored state for a file (e.g. when tab is closed). */
@@ -101,6 +122,19 @@ export function useTabState(workspaceId: string): UseTabStateReturn {
     (filePath: string, mode: "preview" | "source") => {
       const entry = stateRef.current[filePath] ?? {};
       stateRef.current[filePath] = { ...entry, viewMode: mode };
+      saveState(workspaceId, stateRef.current);
+    },
+    [workspaceId],
+  );
+
+  const getLanguage = useCallback((filePath: string): string | undefined => {
+    return stateRef.current[filePath]?.language;
+  }, []);
+
+  const setLanguage = useCallback(
+    (filePath: string, language: string) => {
+      const entry = stateRef.current[filePath] ?? {};
+      stateRef.current[filePath] = { ...entry, language };
       saveState(workspaceId, stateRef.current);
     },
     [workspaceId],
@@ -163,6 +197,8 @@ export function useTabState(workspaceId: string): UseTabStateReturn {
     update,
     getViewMode,
     setViewMode,
+    getLanguage,
+    setLanguage,
     isDirty,
     removeFile,
     renameFile,

--- a/apps/web/src/hooks/useTabState.ts
+++ b/apps/web/src/hooks/useTabState.ts
@@ -29,10 +29,15 @@ export interface TabFileState {
    * field rides along. Treating the override as session-persistent is
    * deliberate: the user explicitly chose Python for their `.txt`
    * file, and silently reverting that choice on reload would surprise
-   * them more than letting it stick. Closing the tab clears the
-   * record via `removeFile`, so a user who wants to drop the override
-   * can close-and-reopen the file (or pick a different language and
-   * close-and-reopen, depending on which behaviour they want).
+   * them more than letting it stick. Reverting paths:
+   *
+   *   - **Auto Detect** entry in the language picker — clears the
+   *     override (`update({ language: undefined })`) so the next
+   *     render falls back to extension-based detection. Shown in the
+   *     picker only when an override is currently active.
+   *   - **Close the tab** — `removeFile` drops the whole `TabFileState`
+   *     entry including the language field. The next open of the same
+   *     file starts fresh.
    *
    * Untitled tabs are also persisted now (issue #434's "scratch
    * persistence" follow-up landed in the same PR), so their overrides

--- a/apps/web/src/hooks/useTabState.ts
+++ b/apps/web/src/hooks/useTabState.ts
@@ -24,13 +24,21 @@ export interface TabFileState {
    * whose language was manually set keeps the override even if the
    * chosen filename's extension would imply a different language").
    *
-   * Out of scope for #434 — and intentionally so: the language picker
-   * is per-tab-lifetime, not cross-session. We persist into tab state
-   * (which is itself localStorage-backed) so it survives in-session
-   * tab switches; on workspace switch / reload tab state is loaded
-   * fresh from disk, but untitled tabs are filtered out at the
-   * `useFileTabs` boundary so a stale language entry has nothing to
-   * attach to.
+   * **Persists across sessions** for file-backed tabs — `TabFileState`
+   * is the localStorage-backed per-tab record, and the `language`
+   * field rides along. Treating the override as session-persistent is
+   * deliberate: the user explicitly chose Python for their `.txt`
+   * file, and silently reverting that choice on reload would surprise
+   * them more than letting it stick. Closing the tab clears the
+   * record via `removeFile`, so a user who wants to drop the override
+   * can close-and-reopen the file (or pick a different language and
+   * close-and-reopen, depending on which behaviour they want).
+   *
+   * Untitled tabs are also persisted now (issue #434's "scratch
+   * persistence" follow-up landed in the same PR), so their overrides
+   * survive reloads too. The synthetic `untitled:N` keys mean
+   * collisions are scoped to the same monotonic-N counter — see
+   * `useFileTabs.initialUntitledCounter`.
    */
   language?: string;
 }

--- a/apps/web/src/lib/path-inside.ts
+++ b/apps/web/src/lib/path-inside.ts
@@ -1,0 +1,39 @@
+/**
+ * Segment-aware containment check for POSIX-style paths.
+ *
+ * Returns the path of `child` relative to `parent` when `child` is
+ * inside `parent`, or `null` when it isn't. Workspace paths in Band
+ * are always POSIX-style (forward slashes), so we operate on raw
+ * string segments rather than pulling in `node:path` — this helper is
+ * imported by browser-running components where `path` isn't available
+ * natively, and a Vite polyfill would be overkill for one comparison.
+ *
+ * Implemented as a segment-aware prefix check rather than a raw
+ * `startsWith`:
+ *
+ *   pathInside("/a/band",      "/a/band/src/x.ts")    → "src/x.ts"
+ *   pathInside("/a/band",      "/a/band")             → ""
+ *   pathInside("/a/band",      "/a/band-fork/src/x")  → null   ← prefix-safe
+ *   pathInside("/a/band/",     "/a/band/src/x.ts")    → "src/x.ts"
+ *   pathInside("/a/band",      "/elsewhere/x.ts")     → null
+ *
+ * The prefix-collision case is the security-adjacent invariant: a
+ * naive `chosen.startsWith(root)` would treat `/a/band-fork/...` as
+ * inside `/a/band`. We strip trailing slashes from `parent` first,
+ * then require either an exact match or a `${parent}/` prefix — the
+ * required `/` separator after the parent is what blocks the
+ * collision.
+ *
+ * Backs the untitled save flow's "did the user pick a path inside
+ * the workspace?" decision in `CodeBrowserView.handleSaveUntitled`.
+ * Pure function, no I/O — easy to unit-test.
+ */
+export function pathInside(parent: string, child: string): string | null {
+  if (!parent) return null;
+  const root = parent.replace(/\/+$/, "");
+  if (!root) return null;
+  if (child === root) return "";
+  const prefix = `${root}/`;
+  if (!child.startsWith(prefix)) return null;
+  return child.slice(prefix.length);
+}

--- a/apps/web/tests/file-tabs-persistence.test.ts
+++ b/apps/web/tests/file-tabs-persistence.test.ts
@@ -1,0 +1,192 @@
+/**
+ * Unit tests for the pure persistence helpers in `useFileTabs.ts`:
+ * `parseTabState`, `serializeTabState`, `initialUntitledCounter`.
+ *
+ * The hook itself is React/localStorage-bound, but the parse/serialize
+ * split lets us cover the non-trivial logic — defensive shape checks,
+ * untitled-tab rehydration, the prefix-safety guard, counter
+ * seeding — without spinning up a browser env. The localStorage layer
+ * is exercised by hand in the dashboard; the corruption-vs-rehydration
+ * paths covered here are the ones that historically broke quietly
+ * when tab shapes changed across builds.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  type FileTab,
+  initialUntitledCounter,
+  parseTabState,
+  serializeTabState,
+} from "../src/hooks/useFileTabs";
+
+describe("parseTabState", () => {
+  it("returns null for a missing or empty payload", () => {
+    expect(parseTabState(null)).toBeNull();
+    expect(parseTabState("")).toBeNull();
+  });
+
+  it("returns null for malformed JSON", () => {
+    expect(parseTabState("not-json")).toBeNull();
+    expect(parseTabState("{}")).toBeNull(); // missing tabs array
+    expect(parseTabState('{"tabs":null}')).toBeNull();
+  });
+
+  it("accepts the legacy bare-string tab form", () => {
+    const result = parseTabState(
+      JSON.stringify({ tabs: ["src/main.ts", "README.md"], active: "src/main.ts" }),
+    );
+    expect(result).toEqual({
+      tabs: [{ filePath: "src/main.ts" }, { filePath: "README.md" }],
+      active: "src/main.ts",
+    });
+  });
+
+  it("rehydrates preview / external flags from the object form", () => {
+    const result = parseTabState(
+      JSON.stringify({
+        tabs: [
+          { filePath: "src/preview.ts", isPreview: true },
+          { filePath: "/abs/external.md", isExternal: true },
+        ],
+        active: null,
+      }),
+    );
+    expect(result?.tabs).toEqual([
+      { filePath: "src/preview.ts", isPreview: true },
+      { filePath: "/abs/external.md", isExternal: true },
+    ]);
+  });
+
+  it("rehydrates untitled tabs with their label", () => {
+    const result = parseTabState(
+      JSON.stringify({
+        tabs: [{ filePath: "untitled:1", isUntitled: true, untitledLabel: "Untitled-1" }],
+        active: "untitled:1",
+      }),
+    );
+    expect(result).toEqual({
+      tabs: [{ filePath: "untitled:1", isUntitled: true, untitledLabel: "Untitled-1" }],
+      active: "untitled:1",
+    });
+  });
+
+  it("rejects isUntitled:true on a path without the untitled prefix (defensive)", () => {
+    // A future bug or a hand-edited localStorage payload could flag a
+    // real file as untitled. The parser strips the flag rather than
+    // letting a workspace path masquerade as a scratch buffer — that
+    // would break `isUntitledPath` checks elsewhere in the code.
+    const result = parseTabState(
+      JSON.stringify({
+        tabs: [{ filePath: "src/main.ts", isUntitled: true, untitledLabel: "Untitled-1" }],
+        active: null,
+      }),
+    );
+    expect(result?.tabs[0]).toEqual({ filePath: "src/main.ts" });
+    expect(result?.tabs[0]).not.toHaveProperty("isUntitled");
+    expect(result?.tabs[0]).not.toHaveProperty("untitledLabel");
+  });
+
+  it("drops non-string and non-object entries from the tabs array", () => {
+    // Mixed-shape array — legacy builds may have written this. The
+    // load path must not crash; downstream `.split("/")` calls expect
+    // strings.
+    const result = parseTabState(
+      JSON.stringify({
+        tabs: ["src/a.ts", 42, null, { filePath: "src/b.ts" }, { noPath: true }],
+        active: null,
+      }),
+    );
+    expect(result?.tabs).toEqual([{ filePath: "src/a.ts" }, { filePath: "src/b.ts" }]);
+  });
+
+  it("rejects non-string active path", () => {
+    const result = parseTabState(JSON.stringify({ tabs: [], active: 42 }));
+    expect(result).toEqual({ tabs: [], active: null });
+  });
+});
+
+describe("serializeTabState", () => {
+  it("uses the bare-string form for plain pinned tabs", () => {
+    const tabs: FileTab[] = [{ filePath: "src/main.ts" }, { filePath: "README.md" }];
+    const out = serializeTabState(tabs, "src/main.ts");
+    expect(JSON.parse(out)).toEqual({
+      tabs: ["src/main.ts", "README.md"],
+      active: "src/main.ts",
+    });
+  });
+
+  it("uses the object form for flagged tabs", () => {
+    const tabs: FileTab[] = [
+      { filePath: "src/x.ts", isPreview: true },
+      { filePath: "/abs/y.md", isExternal: true },
+      { filePath: "untitled:1", isUntitled: true, untitledLabel: "Untitled-1" },
+    ];
+    expect(JSON.parse(serializeTabState(tabs, null))).toEqual({
+      tabs: [
+        { filePath: "src/x.ts", isPreview: true },
+        { filePath: "/abs/y.md", isExternal: true },
+        { filePath: "untitled:1", isUntitled: true, untitledLabel: "Untitled-1" },
+      ],
+      active: null,
+    });
+  });
+
+  it("rewrites active to null when it doesn't name an open tab", () => {
+    // Defensive guard for callers that pass a stale active pointer
+    // (e.g. after closing the active tab without updating local
+    // state). Without this, a reload would surface an orphan active
+    // pointer that doesn't render any tab.
+    const out = serializeTabState([{ filePath: "src/main.ts" }], "src/deleted.ts");
+    expect(JSON.parse(out).active).toBeNull();
+  });
+
+  it("round-trips through parseTabState (all flag combinations)", () => {
+    const tabs: FileTab[] = [
+      { filePath: "src/main.ts" },
+      { filePath: "src/preview.ts", isPreview: true },
+      { filePath: "/abs/external.md", isExternal: true },
+      { filePath: "untitled:1", isUntitled: true, untitledLabel: "Untitled-1" },
+      { filePath: "untitled:2", isUntitled: true, untitledLabel: "Untitled-2" },
+    ];
+    const restored = parseTabState(serializeTabState(tabs, "untitled:1"));
+    expect(restored).toEqual({ tabs, active: "untitled:1" });
+  });
+});
+
+describe("initialUntitledCounter", () => {
+  it("returns 0 when there are no untitled tabs", () => {
+    expect(initialUntitledCounter([])).toBe(0);
+    expect(initialUntitledCounter([{ filePath: "src/main.ts" }])).toBe(0);
+  });
+
+  it("returns the highest N from existing untitled tabs", () => {
+    // Order doesn't matter — the counter is "monotonic, never reused"
+    // across the workspace's lifetime, so the next untitled tab should
+    // get N+1 regardless of which slots are currently occupied.
+    expect(
+      initialUntitledCounter([
+        { filePath: "untitled:1", isUntitled: true, untitledLabel: "Untitled-1" },
+        { filePath: "untitled:3", isUntitled: true, untitledLabel: "Untitled-3" },
+        { filePath: "untitled:2", isUntitled: true, untitledLabel: "Untitled-2" },
+      ]),
+    ).toBe(3);
+  });
+
+  it("ignores tabs without the untitled flag (defensive)", () => {
+    // A workspace path that happens to look like the synthetic key
+    // shouldn't shift the counter — the flag is the source of truth.
+    expect(
+      initialUntitledCounter([{ filePath: "untitled:99", untitledLabel: "Untitled-99" }]),
+    ).toBe(0);
+  });
+
+  it("ignores malformed untitled paths", () => {
+    // Whatever the path-tail says, only valid integers count.
+    expect(
+      initialUntitledCounter([
+        { filePath: "untitled:abc", isUntitled: true, untitledLabel: "Untitled-abc" },
+        { filePath: "untitled:2", isUntitled: true, untitledLabel: "Untitled-2" },
+      ]),
+    ).toBe(2);
+  });
+});

--- a/apps/web/tests/path-inside.test.ts
+++ b/apps/web/tests/path-inside.test.ts
@@ -1,0 +1,68 @@
+/**
+ * Tests for `pathInside` — the segment-aware containment helper used
+ * by the untitled save flow to decide whether a chosen save path
+ * lives inside the workspace or should be treated as external.
+ *
+ * Security-adjacent: a wrong answer routes the save through the
+ * wrong adapter (workspace vs external) AND strips the workspace
+ * prefix off a path that isn't actually inside it, producing an
+ * invalid workspace-relative filename. The `/a/band` vs `/a/band-fork`
+ * case is the canonical regression to guard against; the rest are
+ * boundary conditions a future change to the helper could plausibly
+ * break.
+ */
+
+import { describe, expect, it } from "vitest";
+import { pathInside } from "../src/lib/path-inside";
+
+describe("pathInside", () => {
+  it("returns empty string when child equals parent", () => {
+    expect(pathInside("/a/band", "/a/band")).toBe("");
+  });
+
+  it("returns the relative segment when child is inside parent", () => {
+    expect(pathInside("/a/band", "/a/band/src/main.ts")).toBe("src/main.ts");
+    expect(pathInside("/a/band", "/a/band/README.md")).toBe("README.md");
+    expect(pathInside("/a/band", "/a/band/deeply/nested/file.ts")).toBe("deeply/nested/file.ts");
+  });
+
+  it("returns null for a same-prefix sibling (prefix-collision case)", () => {
+    // The canonical regression: `/a/band-fork` is NOT inside `/a/band`
+    // even though their path strings share a prefix. The required
+    // trailing `/` after the parent blocks the false positive.
+    expect(pathInside("/a/band", "/a/band-fork/src/main.ts")).toBeNull();
+    expect(pathInside("/a/band", "/a/band-fork")).toBeNull();
+    expect(pathInside("/a/band", "/a/bandage/file.ts")).toBeNull();
+  });
+
+  it("returns null for a completely unrelated path", () => {
+    expect(pathInside("/a/band", "/etc/passwd")).toBeNull();
+    expect(pathInside("/a/band", "/Users/alice/other/file.ts")).toBeNull();
+  });
+
+  it("normalises trailing slashes on the parent path", () => {
+    // The OS save dialog may or may not return a directory with a
+    // trailing slash, and workspace registry paths historically have
+    // varied. The helper must normalise so the prefix check fires
+    // consistently regardless of trailing-slash state.
+    expect(pathInside("/a/band/", "/a/band/src/main.ts")).toBe("src/main.ts");
+    expect(pathInside("/a/band///", "/a/band/src/main.ts")).toBe("src/main.ts");
+    expect(pathInside("/a/band/", "/a/band")).toBe("");
+  });
+
+  it("does not normalise trailing slashes on the child path", () => {
+    // We deliberately do NOT strip the child's trailing slash — the
+    // save dialog returns canonical file paths without trailing
+    // slashes, and quietly accepting one would mask a malformed input.
+    // This documents the current behaviour rather than asserting
+    // correctness; if a future change wants to be more permissive
+    // it should be explicit.
+    expect(pathInside("/a/band", "/a/band/src/")).toBe("src/");
+  });
+
+  it("returns null when the parent is empty", () => {
+    // Defensive: an empty workspace root should never resolve any
+    // child as "inside" it.
+    expect(pathInside("", "/anything")).toBeNull();
+  });
+});

--- a/apps/web/tests/path-inside.test.ts
+++ b/apps/web/tests/path-inside.test.ts
@@ -65,4 +65,16 @@ describe("pathInside", () => {
     // child as "inside" it.
     expect(pathInside("", "/anything")).toBeNull();
   });
+
+  it("operates on already-normalised POSIX paths (Windows is normalised upstream)", () => {
+    // pathInside itself is POSIX-only. The Windows save flow
+    // normalises `chosen` to forward slashes BEFORE calling here —
+    // see `handleSaveUntitled` in CodeBrowserView. This test
+    // documents that contract by asserting backslash-bearing input
+    // never matches even when the segments look right, so a future
+    // change to skip the upstream normalisation surfaces as a test
+    // failure rather than a silently broken Windows save.
+    expect(pathInside("C:/Users/alice/band", "C:\\Users\\alice\\band\\src\\x.ts")).toBeNull();
+    expect(pathInside("C:/Users/alice/band", "C:/Users/alice/band/src/x.ts")).toBe("src/x.ts");
+  });
 });

--- a/packages/dashboard-core/src/adapter.ts
+++ b/packages/dashboard-core/src/adapter.ts
@@ -255,6 +255,25 @@ export interface PlatformCapabilities {
    * callers must gate their UI on this capability being present.
    */
   pickFile?(): Promise<string | null>;
+  /**
+   * Open the OS "Save As" picker, persist `content` to the chosen path,
+   * and resolve with the absolute path (or `null` when the user cancels).
+   * Defined only when the renderer is running inside the Electron shell —
+   * the web build cannot write to an arbitrary filesystem location.
+   *
+   * Backs the editor's "Save untitled tab" flow. `defaultName` seeds the
+   * dialog's filename field (e.g. "Untitled-1.txt"); `defaultPath` seeds
+   * the starting directory (e.g. the active workspace root).
+   *
+   * Bundling the dialog + write into a single capability keeps the
+   * filesystem trust boundary inside the desktop shell — the renderer
+   * never receives a writable file handle.
+   */
+  pickSaveFile?(args: {
+    content: string;
+    defaultName?: string;
+    defaultPath?: string;
+  }): Promise<string | null>;
   openUrl?(url: string): Promise<void>;
   getWorkspaceHref?(workspaceId: string): string | undefined;
   /** Optional navigate function for client-side routing (avoids full page reload). */

--- a/packages/dashboard-core/src/adapters/desktop.ts
+++ b/packages/dashboard-core/src/adapters/desktop.ts
@@ -156,6 +156,32 @@ export class NativeShellCapabilities implements PlatformCapabilities {
     return desktopInvoke<string | null>("pick_file");
   }
 
+  /**
+   * Open the OS "Save As" picker and persist `content` to the chosen
+   * path. Returns the absolute path (or `null` when the user cancels).
+   *
+   * Backs the editor's "Save untitled tab" flow — the renderer holds an
+   * in-memory buffer until the user picks a destination; this bridge
+   * runs the dialog and the write in a single IPC round-trip so the
+   * file-system trust boundary stays inside the Electron main process.
+   *
+   * Only meaningful inside the Electron shell; plain browser tabs return
+   * `null` and callers gate the UI on `capabilities.pickSaveFile` being
+   * defined (same pattern `pickFile` uses).
+   */
+  async pickSaveFile(args: {
+    content: string;
+    defaultName?: string;
+    defaultPath?: string;
+  }): Promise<string | null> {
+    if (!isDesktopShell()) return null;
+    return desktopInvoke<string | null>("pick_save_file", {
+      content: args.content,
+      defaultName: args.defaultName,
+      defaultPath: args.defaultPath,
+    });
+  }
+
   async openUrl(url: string): Promise<void> {
     if (!isDesktopShell()) {
       window.open(url, "_blank");

--- a/packages/dashboard-core/src/components/FileViewer.tsx
+++ b/packages/dashboard-core/src/components/FileViewer.tsx
@@ -15,11 +15,12 @@ import type React from "react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useAdapter } from "../context";
 import { type FilePreviewType, getFilePreviewType } from "../lib/file-type";
-import { extensionToLanguage, filenameToLanguage } from "../lib/language-map";
+import { extensionToLanguage, filenameToLanguage, languageLabel } from "../lib/language-map";
 import type { FileContentResult } from "../types";
 import { CodeMirrorEditor } from "./CodeMirrorEditor";
 import { CodeMirrorViewer } from "./CodeMirrorViewer";
 import { ImagePreview } from "./ImagePreview";
+import { LanguagePickerDialog } from "./LanguagePickerDialog";
 import { PdfPreview } from "./PdfPreview";
 
 interface FileViewerProps {
@@ -76,6 +77,41 @@ interface FileViewerProps {
    * are intentionally not wired for external files.
    */
   external?: boolean;
+  /**
+   * When true, the viewer renders an untitled (scratch) buffer that
+   * has no backing file. `filePath` carries the synthetic `untitled:N`
+   * key from `useFileTabs`; no remote IO happens (no `getWorkspaceFile`
+   * / `readExternalFile` call). Buffer state lives entirely in
+   * `initialEditedContent` / `onEditedContentChange` until the user
+   * picks a destination via `onSaveAs` — that callback is responsible
+   * for surfacing the OS save dialog (gated on
+   * `capabilities.pickSaveFile`) and transitioning the tab to a
+   * file-backed one.
+   */
+  untitled?: boolean;
+  /**
+   * Manual syntax-highlighting language override (e.g. `"typescript"`,
+   * `"markdown"`, `"plaintext"`). When set, takes precedence over
+   * file-extension auto-detection — the user's explicit choice in the
+   * language picker survives saves and tab restores.
+   */
+  languageOverride?: string;
+  /**
+   * Called when the user picks a language from the editor's language
+   * indicator dropdown / "Change Language Mode…" command. The caller
+   * persists the choice to tab state so it survives tab switches.
+   */
+  onLanguageOverrideChange?: (languageId: string) => void;
+  /**
+   * Save-as flow for untitled tabs. Called when the user hits Cmd+S on
+   * an untitled buffer (or the close-confirm "Save" button). Receives
+   * the live editor content and is expected to surface the OS save
+   * dialog, persist the bytes, and resolve with the chosen absolute
+   * path — at which point the caller transitions the tab to file-
+   * backed. Resolves with `null` when the user cancels the save dialog
+   * so the close path can keep the tab open.
+   */
+  onSaveAs?: (content: string) => Promise<string | null>;
 }
 
 function getFilename(path: string): string {
@@ -122,6 +158,10 @@ export function FileViewer({
   savedScrollTop,
   onEditedContentChange,
   external,
+  untitled,
+  languageOverride,
+  onLanguageOverrideChange,
+  onSaveAs,
 }: FileViewerProps) {
   const adapter = useAdapter();
   const [data, setData] = useState<FileContentResult | null>(null);
@@ -157,11 +197,22 @@ export function FileViewer({
   const dataRef = useRef(data);
   dataRef.current = data;
 
-  const isDirty = editedContent !== null && editedContent !== data?.content;
+  // Untitled tabs are "dirty" whenever they have any content typed in —
+  // there's no on-disk baseline to compare against. An empty buffer
+  // counts as clean so closing an untouched scratch tab doesn't pop
+  // the unsaved-changes confirmation.
+  const isDirty = untitled
+    ? editedContent != null && editedContent !== ""
+    : editedContent !== null && editedContent !== data?.content;
 
-  const canEdit = editable && (external ? !!adapter.saveExternalFile : !!adapter.saveWorkspaceFile);
+  const canEdit =
+    editable &&
+    (untitled ? !!onSaveAs : external ? !!adapter.saveExternalFile : !!adapter.saveWorkspaceFile);
 
-  const previewType: FilePreviewType = getFilePreviewType(filePath);
+  // Untitled tabs never have a backing file extension to drive the
+  // preview-type heuristic — force "code" so the editor renders rather
+  // than the image/PDF/markdown branches.
+  const previewType: FilePreviewType = untitled ? "code" : getFilePreviewType(filePath);
 
   // Reset editing state when switching files.
   // Edited content is initialized from the parent's tab state (via prop).
@@ -209,6 +260,19 @@ export function FileViewer({
   }, [previewType, viewMode, onEditorView]);
 
   useEffect(() => {
+    // Untitled tabs have no backing file — synthesise an empty
+    // content record so the rest of the render pipeline (canEdit
+    // check, CodeMirrorEditor mount, dirty-state diff against
+    // `data?.content`) keeps its existing shape. `initialEditedContent`
+    // (threaded by the parent from useTabState) carries any in-memory
+    // typing the user has done so far.
+    if (untitled) {
+      setData({ content: "", size: 0, binary: false, tooLarge: false });
+      setLoading(false);
+      setError(null);
+      return;
+    }
+
     // Images and PDFs are rendered via the raw file URL — no tRPC fetch needed.
     // External files don't have a workspace-relative URL; for the moment we
     // fall through to the text-content path (binary detection will catch
@@ -250,9 +314,19 @@ export function FileViewer({
     return () => {
       cancelled = true;
     };
-  }, [adapter, workspaceId, filePath, previewType, external]);
+  }, [adapter, workspaceId, filePath, previewType, external, untitled]);
 
-  const lang = data?.content ? detectLanguage(filePath, data.language) : "plaintext";
+  // The user's explicit choice from the language picker always wins over
+  // file-extension detection (issue #434: "manual override sticks for the
+  // lifetime of the tab"). Untitled tabs default to plain text; file-
+  // backed tabs fall through to the existing detection path.
+  const lang = languageOverride
+    ? languageOverride
+    : untitled
+      ? "plaintext"
+      : data?.content
+        ? detectLanguage(filePath, data.language)
+        : "plaintext";
 
   // External files don't have a workspace-relative raw URL endpoint, so
   // image/PDF rendering for external paths is intentionally not wired.
@@ -273,6 +347,36 @@ export function FileViewer({
   onEditedContentChangeRef.current = onEditedContentChange;
 
   const handleSave = useCallback(async () => {
+    // Untitled tabs route through the OS save dialog (`onSaveAs`).
+    // We use the *live* editor buffer rather than `editedContentRef`
+    // because an empty untitled buffer never sets edited content
+    // (isDirty filters out the empty string), so editedContentRef can
+    // legitimately be null even when the user wants to save an
+    // empty file from a fresh untitled tab.
+    if (untitled) {
+      if (!onSaveAs) return;
+      const content = editorViewRef.current?.state.doc.toString() ?? editedContentRef.current ?? "";
+      setSaving(true);
+      setSaveError(null);
+      try {
+        // `onSaveAs` is responsible for the OS dialog, the file
+        // write, and the tab transition. Cancellation resolves with
+        // null — keep the tab as-is.
+        const newPath = await onSaveAs(content);
+        if (newPath != null) {
+          // The parent has already swapped the tab key from
+          // `untitled:N` to the real path; this component will be
+          // remounted under the new filePath, so we don't need to
+          // clear local state.
+          window.dispatchEvent(new CustomEvent("band:dirty-change"));
+        }
+      } catch (err) {
+        setSaveError(err instanceof Error ? err.message : "Failed to save");
+      } finally {
+        setSaving(false);
+      }
+      return;
+    }
     if (editedContentRef.current === null) return;
     const save = external
       ? adapter.saveExternalFile && ((c: string) => adapter.saveExternalFile!(filePath, c))
@@ -295,7 +399,7 @@ export function FileViewer({
     } finally {
       setSaving(false);
     }
-  }, [adapter, workspaceId, filePath, external]);
+  }, [adapter, workspaceId, filePath, external, untitled, onSaveAs]);
 
   /**
    * Format the editor buffer in-place via Prettier.
@@ -453,6 +557,36 @@ export function FileViewer({
     onBack?.();
   }, [isDirty, onBack]);
 
+  // Searchable language-mode picker (issue #434). Opens from the
+  // status-bar language indicator or the "Change Language Mode…" palette
+  // entry; in both cases we dispatch / listen to a single event so the
+  // wiring stays symmetrical with Quick Open / Search in Files.
+  const [languagePickerOpen, setLanguagePickerOpen] = useState(false);
+  useEffect(() => {
+    const handler = (e: Event) => {
+      const detail = (e as CustomEvent).detail as
+        | { workspaceId?: string; filePath?: string | null }
+        | undefined;
+      // Same filter as the format-current-file listener — only the
+      // matching FileViewer responds. Untitled tabs are workspace-
+      // scoped (their synthetic path lives only in the current
+      // workspace's tab list), so the workspaceId guard is the right
+      // selector.
+      if (!detail || detail.workspaceId !== workspaceId) return;
+      if (detail.filePath != null && detail.filePath !== filePath) return;
+      setLanguagePickerOpen(true);
+    };
+    window.addEventListener("band:open-language-picker", handler);
+    return () => window.removeEventListener("band:open-language-picker", handler);
+  }, [workspaceId, filePath]);
+
+  const handlePickLanguage = useCallback(
+    (languageId: string) => {
+      onLanguageOverrideChange?.(languageId);
+    },
+    [onLanguageOverrideChange],
+  );
+
   return (
     // min-w-0 prevents intrinsic-width content (CodeMirror's long unwrapped
     // lines, in particular) from forcing this box wider than its allocated
@@ -513,7 +647,7 @@ export function FileViewer({
             </div>
           )}
           <span className="min-w-0 flex-1 truncate font-mono text-xs">
-            {filePath}
+            {untitled ? "Untitled" : filePath}
             {isDirty && <span className="ml-1 text-muted-foreground">(modified)</span>}
           </span>
           {saveError && <span className="shrink-0 text-xs text-destructive">{saveError}</span>}
@@ -681,6 +815,37 @@ export function FileViewer({
           </div>
         )}
       </div>
+
+      {/* Status bar — language indicator (click to change). Rendered for
+          every editor tab (untitled and file-backed) so the picker
+          surface is always reachable; we gate on the picker callback
+          being wired rather than the file type so the host can opt
+          panels in/out. */}
+      {onLanguageOverrideChange && previewType === "code" && (
+        <div className="flex h-6 shrink-0 items-center justify-end gap-2 border-t border-border/50 bg-background px-2 text-xs">
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                type="button"
+                onClick={() => setLanguagePickerOpen(true)}
+                className="inline-flex items-center gap-1 rounded px-1.5 py-0.5 text-muted-foreground hover:bg-accent hover:text-foreground transition-colors"
+              >
+                {languageLabel(lang)}
+              </button>
+            </TooltipTrigger>
+            <TooltipContent side="top" className="text-xs">
+              Select Language Mode
+            </TooltipContent>
+          </Tooltip>
+        </div>
+      )}
+
+      <LanguagePickerDialog
+        open={languagePickerOpen}
+        onOpenChange={setLanguagePickerOpen}
+        currentLanguage={lang}
+        onSelect={handlePickLanguage}
+      />
     </div>
   );
 }

--- a/packages/dashboard-core/src/components/FileViewer.tsx
+++ b/packages/dashboard-core/src/components/FileViewer.tsx
@@ -138,6 +138,40 @@ function detectLanguage(filePath: string, serverHint?: string): string {
   return fromName || "plaintext";
 }
 
+/**
+ * Should this FileViewer respond to a workspace-scoped event whose
+ * `detail.filePath` may or may not match the currently-viewed file?
+ *
+ * The dispatcher in `DockviewWorkspaceLayout` reads
+ * `currentFileRef.current`, which is updated only through
+ * `notifySelectFile` — and that path deliberately filters out
+ * untitled / external paths (they can't round-trip through the
+ * workspace-relative URL). So:
+ *
+ *   - For a regular workspace tab, `detail.filePath` is the authoritative
+ *     active file — we accept iff it's absent or matches our path, and
+ *     reject when it's present but targets a *different* path (which
+ *     keeps the existing cross-workspace / future-split-pane safety
+ *     net intact).
+ *   - For untitled / external tabs, `detail.filePath` is either absent
+ *     (never-selected tab) or stale (pointing at the previously-viewed
+ *     real file). Strict equality would reject the user's legitimate
+ *     "format this untitled tab" intent — accept unconditionally and
+ *     rely on the workspaceId guard for disambiguation.
+ *
+ * Extracted so the format and language-picker listeners stay in lockstep.
+ */
+function matchesFilePathHint(
+  hint: string | null | undefined,
+  viewerPath: string,
+  viewerUntitled: boolean | undefined,
+  viewerExternal: boolean | undefined,
+): boolean {
+  if (viewerUntitled || viewerExternal) return true;
+  if (hint == null) return true;
+  return hint === viewerPath;
+}
+
 export function FileViewer({
   workspaceId,
   filePath,
@@ -488,8 +522,15 @@ export function FileViewer({
         }
         // The server's formatter requires the path to resolve inside
         // the worktree; using a leading "." filename keeps it inside
-        // the workspace root and doesn't clobber any real file.
-        formatPath = `.band-untitled${ext}`;
+        // the workspace root and doesn't clobber any real file. Include
+        // the synthetic tab key (`untitled:N` → `untitled-N`) so two
+        // simultaneously-formatting untitled tabs of the same language
+        // don't collide on the virtual filename — relevant if any
+        // future formatter caches by path. The character substitution
+        // strips the colon so the resulting filename is portable
+        // across POSIX and Windows.
+        const tabKey = filePath.replace(/[^a-z0-9]/gi, "-");
+        formatPath = `.band-${tabKey}${ext}`;
       }
       const result = await adapter.formatWorkspaceFile(workspaceId, formatPath, sourceContent);
       if (result.skipped) {
@@ -539,26 +580,29 @@ export function FileViewer({
   }, [adapter, workspaceId, filePath, untitled, languageOverride]);
 
   // Listen for the global "Format Current File" event (⌘⇧F + palette).
-  // Only one FileViewer is mounted per workspace at a time, so the
-  // `workspaceId` guard is sufficient — we deliberately do NOT filter
-  // by `detail.filePath` for the same reason the language-picker
-  // listener doesn't: the dispatcher reads `currentFileRef.current`,
-  // which is only updated by `notifySelectFile` (which drops untitled
-  // and external paths). So when the user is viewing an untitled tab,
-  // `detail.filePath` is either undefined or stale (pointing at the
-  // previously-viewed real file), and a strict equality check would
-  // reject the legitimate "format this untitled tab" case.
+  // The dispatcher reads `currentFileRef.current`, which is only
+  // updated by `notifySelectFile` — and that path filters out untitled
+  // / external tabs (their paths can't round-trip through the
+  // workspace-relative URL). So when the user is currently viewing an
+  // untitled or external tab, `detail.filePath` is either absent or
+  // stale (the previously-viewed real file). We accept those cases
+  // here, but still reject when a non-matching filePath is sent and
+  // the current viewer is a regular workspace tab — that preserves
+  // the original cross-workspace / future-split-pane safety net
+  // (workspaceId alone would silently double-format if two file-backed
+  // FileViewers were ever mounted concurrently).
   useEffect(() => {
     const handler = (e: Event) => {
       const detail = (e as CustomEvent).detail as
         | { workspaceId?: string; filePath?: string | null }
         | undefined;
       if (!detail || detail.workspaceId !== workspaceId) return;
+      if (!matchesFilePathHint(detail.filePath, filePath, untitled, external)) return;
       void handleFormat();
     };
     window.addEventListener("band:format-current-file", handler);
     return () => window.removeEventListener("band:format-current-file", handler);
-  }, [workspaceId, handleFormat]);
+  }, [workspaceId, filePath, untitled, external, handleFormat]);
 
   // Auto-clear the "Formatted" success flash so it doesn't linger next to
   // the filename. Errors stay until the user changes files or saves.
@@ -605,40 +649,25 @@ export function FileViewer({
   // Searchable language-mode picker (issue #434). Opens from the
   // status-bar language indicator or the "Change Language Mode…" palette
   // entry; in both cases we dispatch / listen to a single event so the
-  // wiring stays symmetrical with Quick Open / Search in Files.
+  // wiring stays symmetrical with Quick Open / Search in Files. Same
+  // filePath-hint rules as the format listener (see
+  // `matchesFilePathHint`): accept when the hint is absent / matches /
+  // we're an untitled or external viewer (the dispatcher's ref is
+  // stale or never set for those), reject only when a mismatched hint
+  // targets a different file-backed viewer.
   const [languagePickerOpen, setLanguagePickerOpen] = useState(false);
   useEffect(() => {
     const handler = (e: Event) => {
       const detail = (e as CustomEvent).detail as
         | { workspaceId?: string; filePath?: string | null }
         | undefined;
-      // Only one FileViewer is mounted per workspace at a time, so the
-      // workspaceId guard is sufficient. We deliberately do NOT filter
-      // by `detail.filePath`:
-      //
-      // The dispatcher (DockviewWorkspaceLayout) reads
-      // `currentFileRef.current`, which is only updated through
-      // `notifySelectFile` — and that path filters out untitled and
-      // external tabs (their synthetic / absolute paths can't round-
-      // trip through the workspace-relative URL). So `detail.filePath`
-      // will be undefined for never-selected tabs AND stale (pointing
-      // at the previously viewed real file) whenever the user is
-      // currently viewing an untitled tab. A `detail.filePath !==
-      // filePath` check would reject the legitimate "open picker for
-      // the currently visible untitled tab" case.
       if (!detail || detail.workspaceId !== workspaceId) return;
+      if (!matchesFilePathHint(detail.filePath, filePath, untitled, external)) return;
       setLanguagePickerOpen(true);
     };
     window.addEventListener("band:open-language-picker", handler);
     return () => window.removeEventListener("band:open-language-picker", handler);
-  }, [workspaceId]);
-
-  const handlePickLanguage = useCallback(
-    (languageId: string) => {
-      onLanguageOverrideChange?.(languageId);
-    },
-    [onLanguageOverrideChange],
-  );
+  }, [workspaceId, filePath, untitled, external]);
 
   return (
     // min-w-0 prevents intrinsic-width content (CodeMirror's long unwrapped
@@ -898,12 +927,20 @@ export function FileViewer({
         </div>
       )}
 
-      <LanguagePickerDialog
-        open={languagePickerOpen}
-        onOpenChange={setLanguagePickerOpen}
-        currentLanguage={lang}
-        onSelect={handlePickLanguage}
-      />
+      {/* Only render the picker when there's a callback to receive
+          its selection. The dialog is also gated on `onLanguageOverrideChange`
+          when surfacing the status-bar indicator above, so dropping
+          the dialog when the callback is missing keeps the two
+          surfaces in sync — neither appears in adapters that don't
+          wire the override (none today, but the prop is optional). */}
+      {onLanguageOverrideChange && (
+        <LanguagePickerDialog
+          open={languagePickerOpen}
+          onOpenChange={setLanguagePickerOpen}
+          currentLanguage={lang}
+          onSelect={onLanguageOverrideChange}
+        />
+      )}
     </div>
   );
 }

--- a/packages/dashboard-core/src/components/FileViewer.tsx
+++ b/packages/dashboard-core/src/components/FileViewer.tsx
@@ -469,20 +469,27 @@ export function FileViewer({
       // Untitled tabs have no real extension for Prettier to dispatch
       // on — synthesize a virtual filename inside the workspace from
       // the user's language choice (`languageOverride`) so the server-
-      // side formatter picks the right parser. When the override is
-      // missing or maps to a language Prettier doesn't have a parser
-      // for (e.g. plain text, Rust), we fall back to the raw filePath
-      // and the formatter soft-skips with "no parser available" — same
-      // outcome the user would see for any non-formattable file.
+      // side formatter picks the right parser. Untitled tabs default
+      // to plain text, which Prettier has no parser for; short-circuit
+      // with an actionable message instead of the generic "no parser
+      // available" soft-skip — first-run users were confused by it
+      // because the muted info-status easily reads as "format ran but
+      // did nothing" when in fact the formatter never even got the
+      // request.
       let formatPath = filePath;
       if (untitled) {
         const ext = languageOverride ? languageToExtension(languageOverride) : undefined;
-        if (ext) {
-          // The server's formatter requires the path to resolve inside
-          // the worktree; using a leading "." filename keeps it inside
-          // the workspace root and doesn't clobber any real file.
-          formatPath = `.band-untitled${ext}`;
+        if (!ext) {
+          setFormatStatus({
+            kind: "info",
+            message: "Set a language mode first to format this untitled tab",
+          });
+          return;
         }
+        // The server's formatter requires the path to resolve inside
+        // the worktree; using a leading "." filename keeps it inside
+        // the workspace root and doesn't clobber any real file.
+        formatPath = `.band-untitled${ext}`;
       }
       const result = await adapter.formatWorkspaceFile(workspaceId, formatPath, sourceContent);
       if (result.skipped) {

--- a/packages/dashboard-core/src/components/FileViewer.tsx
+++ b/packages/dashboard-core/src/components/FileViewer.tsx
@@ -205,9 +205,27 @@ export function FileViewer({
     ? editedContent != null && editedContent !== ""
     : editedContent !== null && editedContent !== data?.content;
 
+  // Untitled tabs are *always* editable — the buffer lives entirely in
+  // the renderer, so typing into it has nothing to do with whether a
+  // save mechanism is available. `canSave` (below) gates the Save
+  // button separately, so in a web build (no `onSaveAs` because
+  // `capabilities.pickSaveFile` is undefined) the user can still draft
+  // text into an untitled tab; only persistence requires the desktop
+  // shell.
+  //
+  // Before this split, an untitled tab created from a non-desktop
+  // entry point fell through to `CodeMirrorViewer` (read-only), which
+  // looked like "the editor is empty and I can't type" — issue raised
+  // post-review and fixed here.
   const canEdit =
     editable &&
-    (untitled ? !!onSaveAs : external ? !!adapter.saveExternalFile : !!adapter.saveWorkspaceFile);
+    (untitled ? true : external ? !!adapter.saveExternalFile : !!adapter.saveWorkspaceFile);
+
+  const canSave = untitled
+    ? !!onSaveAs
+    : external
+      ? !!adapter.saveExternalFile
+      : !!adapter.saveWorkspaceFile;
 
   // Untitled tabs never have a backing file extension to drive the
   // preview-type heuristic — force "code" so the editor renders rather
@@ -668,7 +686,12 @@ export function FileViewer({
           {formatting && (
             <Loader2 className="size-3.5 shrink-0 animate-spin text-muted-foreground" />
           )}
-          {canEdit && isDirty && (
+          {canSave && isDirty && (
+            // Gate on canSave (which requires a working save target —
+            // adapter method for file-backed tabs, `onSaveAs` for
+            // untitled ones) rather than canEdit, so an untitled tab in
+            // the web build still renders an editable surface even
+            // though no Save button can appear.
             <button
               type="button"
               onClick={handleSave}

--- a/packages/dashboard-core/src/components/FileViewer.tsx
+++ b/packages/dashboard-core/src/components/FileViewer.tsx
@@ -585,18 +585,26 @@ export function FileViewer({
       const detail = (e as CustomEvent).detail as
         | { workspaceId?: string; filePath?: string | null }
         | undefined;
-      // Same filter as the format-current-file listener — only the
-      // matching FileViewer responds. Untitled tabs are workspace-
-      // scoped (their synthetic path lives only in the current
-      // workspace's tab list), so the workspaceId guard is the right
-      // selector.
+      // Only one FileViewer is mounted per workspace at a time, so the
+      // workspaceId guard is sufficient. We deliberately do NOT filter
+      // by `detail.filePath`:
+      //
+      // The dispatcher (DockviewWorkspaceLayout) reads
+      // `currentFileRef.current`, which is only updated through
+      // `notifySelectFile` — and that path filters out untitled and
+      // external tabs (their synthetic / absolute paths can't round-
+      // trip through the workspace-relative URL). So `detail.filePath`
+      // will be undefined for never-selected tabs AND stale (pointing
+      // at the previously viewed real file) whenever the user is
+      // currently viewing an untitled tab. A `detail.filePath !==
+      // filePath` check would reject the legitimate "open picker for
+      // the currently visible untitled tab" case.
       if (!detail || detail.workspaceId !== workspaceId) return;
-      if (detail.filePath != null && detail.filePath !== filePath) return;
       setLanguagePickerOpen(true);
     };
     window.addEventListener("band:open-language-picker", handler);
     return () => window.removeEventListener("band:open-language-picker", handler);
-  }, [workspaceId, filePath]);
+  }, [workspaceId]);
 
   const handlePickLanguage = useCallback(
     (languageId: string) => {

--- a/packages/dashboard-core/src/components/FileViewer.tsx
+++ b/packages/dashboard-core/src/components/FileViewer.tsx
@@ -148,16 +148,25 @@ function detectLanguage(filePath: string, serverHint?: string): string {
  * untitled / external paths (they can't round-trip through the
  * workspace-relative URL). So:
  *
- *   - For a regular workspace tab, `detail.filePath` is the authoritative
- *     active file — we accept iff it's absent or matches our path, and
- *     reject when it's present but targets a *different* path (which
- *     keeps the existing cross-workspace / future-split-pane safety
- *     net intact).
- *   - For untitled / external tabs, `detail.filePath` is either absent
- *     (never-selected tab) or stale (pointing at the previously-viewed
- *     real file). Strict equality would reject the user's legitimate
- *     "format this untitled tab" intent — accept unconditionally and
- *     rely on the workspaceId guard for disambiguation.
+ *   - **No hint sent** — accept. The dispatcher couldn't read a path
+ *     (e.g. restored-on-boot tab that hasn't been activated yet, or
+ *     the user is currently viewing an untitled / external tab whose
+ *     path was filtered out of the ref). Workspace ID alone scopes
+ *     the response.
+ *   - **Hint matches our viewer path** — accept. Authoritative match.
+ *   - **Hint is a non-matching real path** — depends on the viewer:
+ *       - Regular workspace viewer: REJECT. Some other file-backed
+ *         viewer in this workspace (split-pane future) is the
+ *         intended recipient; we shouldn't double-handle.
+ *       - Untitled / external viewer: ACCEPT. The hint is a stale ref
+ *         from the dispatcher (the previously-viewed real file) —
+ *         the user pressed format/picker *while looking at* this
+ *         untitled/external tab, so it's the intended target.
+ *
+ * Order matters: the untitled/external branch runs AFTER the hint
+ * equality check so a future split-pane setup with both a file-backed
+ * and an untitled viewer can still route a non-null hint specifically
+ * at the file-backed one without also triggering the untitled one.
  *
  * Extracted so the format and language-picker listeners stay in lockstep.
  */
@@ -167,9 +176,12 @@ function matchesFilePathHint(
   viewerUntitled: boolean | undefined,
   viewerExternal: boolean | undefined,
 ): boolean {
-  if (viewerUntitled || viewerExternal) return true;
   if (hint == null) return true;
-  return hint === viewerPath;
+  if (hint === viewerPath) return true;
+  // Hint is present and doesn't match. Accept only when our path
+  // can't round-trip through the dispatcher's ref — in those cases
+  // the hint is necessarily stale, not targeted.
+  return Boolean(viewerUntitled || viewerExternal);
 }
 
 export function FileViewer({
@@ -932,12 +944,17 @@ export function FileViewer({
           when surfacing the status-bar indicator above, so dropping
           the dialog when the callback is missing keeps the two
           surfaces in sync — neither appears in adapters that don't
-          wire the override (none today, but the prop is optional). */}
+          wire the override (none today, but the prop is optional).
+          The `AUTO_DETECT_LANGUAGE_ID` sentinel passed through this
+          callback's contract means "drop the override"; the caller
+          (CodeBrowserView's `handleLanguageOverride`) treats it as a
+          `removeLanguage` and falls back to extension detection. */}
       {onLanguageOverrideChange && (
         <LanguagePickerDialog
           open={languagePickerOpen}
           onOpenChange={setLanguagePickerOpen}
           currentLanguage={lang}
+          hasOverride={languageOverride != null}
           onSelect={onLanguageOverrideChange}
         />
       )}

--- a/packages/dashboard-core/src/components/FileViewer.tsx
+++ b/packages/dashboard-core/src/components/FileViewer.tsx
@@ -15,7 +15,12 @@ import type React from "react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useAdapter } from "../context";
 import { type FilePreviewType, getFilePreviewType } from "../lib/file-type";
-import { extensionToLanguage, filenameToLanguage, languageLabel } from "../lib/language-map";
+import {
+  extensionToLanguage,
+  filenameToLanguage,
+  languageLabel,
+  languageToExtension,
+} from "../lib/language-map";
 import type { FileContentResult } from "../types";
 import { CodeMirrorEditor } from "./CodeMirrorEditor";
 import { CodeMirrorViewer } from "./CodeMirrorViewer";
@@ -461,7 +466,25 @@ export function FileViewer({
     setFormatting(true);
     setFormatStatus(null);
     try {
-      const result = await adapter.formatWorkspaceFile(workspaceId, filePath, sourceContent);
+      // Untitled tabs have no real extension for Prettier to dispatch
+      // on — synthesize a virtual filename inside the workspace from
+      // the user's language choice (`languageOverride`) so the server-
+      // side formatter picks the right parser. When the override is
+      // missing or maps to a language Prettier doesn't have a parser
+      // for (e.g. plain text, Rust), we fall back to the raw filePath
+      // and the formatter soft-skips with "no parser available" — same
+      // outcome the user would see for any non-formattable file.
+      let formatPath = filePath;
+      if (untitled) {
+        const ext = languageOverride ? languageToExtension(languageOverride) : undefined;
+        if (ext) {
+          // The server's formatter requires the path to resolve inside
+          // the worktree; using a leading "." filename keeps it inside
+          // the workspace root and doesn't clobber any real file.
+          formatPath = `.band-untitled${ext}`;
+        }
+      }
+      const result = await adapter.formatWorkspaceFile(workspaceId, formatPath, sourceContent);
       if (result.skipped) {
         setFormatStatus({ kind: "info", message: result.reason });
         return;
@@ -506,32 +529,29 @@ export function FileViewer({
       formattingRef.current = false;
       setFormatting(false);
     }
-  }, [adapter, workspaceId, filePath]);
+  }, [adapter, workspaceId, filePath, untitled, languageOverride]);
 
   // Listen for the global "Format Current File" event (⌘⇧F + palette).
-  // The dispatcher includes `{ workspaceId, filePath }` in detail when it
-  // knows them; we only respond when the event targets *this* viewer's
-  // file. Events with no detail (palette press without a known active
-  // file) are ignored so every mounted FileViewer doesn't format its own
-  // file in parallel.
+  // Only one FileViewer is mounted per workspace at a time, so the
+  // `workspaceId` guard is sufficient — we deliberately do NOT filter
+  // by `detail.filePath` for the same reason the language-picker
+  // listener doesn't: the dispatcher reads `currentFileRef.current`,
+  // which is only updated by `notifySelectFile` (which drops untitled
+  // and external paths). So when the user is viewing an untitled tab,
+  // `detail.filePath` is either undefined or stale (pointing at the
+  // previously-viewed real file), and a strict equality check would
+  // reject the legitimate "format this untitled tab" case.
   useEffect(() => {
     const handler = (e: Event) => {
       const detail = (e as CustomEvent).detail as
         | { workspaceId?: string; filePath?: string | null }
         | undefined;
       if (!detail || detail.workspaceId !== workspaceId) return;
-      // When the dispatcher knows the active file path, match it. When
-      // it doesn't (e.g. the palette command fired before the active-tab
-      // tracker fed currentFile back up — happens for tabs restored from
-      // localStorage on dashboard boot), respond anyway: only one
-      // FileViewer is mounted at a time per workspace, so an
-      // unconstrained workspace-scoped fire is unambiguous.
-      if (detail.filePath != null && detail.filePath !== filePath) return;
       void handleFormat();
     };
     window.addEventListener("band:format-current-file", handler);
     return () => window.removeEventListener("band:format-current-file", handler);
-  }, [workspaceId, filePath, handleFormat]);
+  }, [workspaceId, handleFormat]);
 
   // Auto-clear the "Formatted" success flash so it doesn't linger next to
   // the filename. Errors stay until the user changes files or saves.

--- a/packages/dashboard-core/src/components/LanguagePickerDialog.tsx
+++ b/packages/dashboard-core/src/components/LanguagePickerDialog.tsx
@@ -1,0 +1,92 @@
+/**
+ * Searchable picker for the editor's syntax-highlighting language mode.
+ *
+ * Surfaced two ways (see issue #434 acceptance criteria):
+ *
+ *   - Click the language indicator on the editor's tab footer / status bar.
+ *   - Run "Change Language Mode…" from the command palette.
+ *
+ * Both paths open this dialog, the user picks a language, and the
+ * selection propagates to the FileViewer through the parent's
+ * `onSelect` callback. The override persists for the lifetime of the
+ * tab via `useTabState.setLanguage` — see the `language` field on
+ * `TabFileState`.
+ *
+ * Mirrors the shape of `CommandPaletteDialog` and `QuickOpenDialog`:
+ * one searchable `Command` over a flat list of `SUPPORTED_LANGUAGES`.
+ */
+
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@band-app/ui";
+import { Check } from "lucide-react";
+import { useCallback } from "react";
+import { SUPPORTED_LANGUAGES } from "../lib/language-map";
+
+interface LanguagePickerDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /** Currently-active language id, used to render the check mark. */
+  currentLanguage: string;
+  /** Called with the chosen language id when the user picks one. */
+  onSelect: (languageId: string) => void;
+}
+
+export function LanguagePickerDialog({
+  open,
+  onOpenChange,
+  currentLanguage,
+  onSelect,
+}: LanguagePickerDialogProps) {
+  const handleSelect = useCallback(
+    (id: string) => {
+      onOpenChange(false);
+      // Run the action after the dialog closes to avoid focus conflicts
+      // with the editor view we're about to refocus. Same pattern the
+      // command palette uses.
+      requestAnimationFrame(() => onSelect(id));
+    },
+    [onOpenChange, onSelect],
+  );
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="overflow-hidden p-0 sm:max-w-[480px]" showCloseButton={false}>
+        <DialogHeader className="sr-only">
+          <DialogTitle>Select Language Mode</DialogTitle>
+          <DialogDescription>Search for a language to syntax-highlight the file</DialogDescription>
+        </DialogHeader>
+        <Command>
+          <CommandInput placeholder="Select language mode…" autoFocus />
+          <CommandList className="max-h-[360px]">
+            <CommandEmpty>No languages found.</CommandEmpty>
+            <CommandGroup>
+              {SUPPORTED_LANGUAGES.map((lang) => (
+                <CommandItem
+                  key={lang.id}
+                  value={`${lang.label} ${lang.id}`}
+                  onSelect={() => handleSelect(lang.id)}
+                >
+                  <span className="flex-1 text-sm">{lang.label}</span>
+                  {lang.id === currentLanguage && (
+                    <Check className="size-3.5 text-muted-foreground" />
+                  )}
+                </CommandItem>
+              ))}
+            </CommandGroup>
+          </CommandList>
+        </Command>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/packages/dashboard-core/src/components/LanguagePickerDialog.tsx
+++ b/packages/dashboard-core/src/components/LanguagePickerDialog.tsx
@@ -8,12 +8,18 @@
  *
  * Both paths open this dialog, the user picks a language, and the
  * selection propagates to the FileViewer through the parent's
- * `onSelect` callback. The override persists for the lifetime of the
- * tab via `useTabState.setLanguage` — see the `language` field on
- * `TabFileState`.
+ * `onSelect` callback. The override is persisted to `useTabState`
+ * (localStorage-backed), and survives reloads — see the `language`
+ * field on `TabFileState`.
  *
  * Mirrors the shape of `CommandPaletteDialog` and `QuickOpenDialog`:
  * one searchable `Command` over a flat list of `SUPPORTED_LANGUAGES`.
+ *
+ * "Auto Detect" is a special leading entry that clears the manual
+ * override and reverts to file-extension auto-detection — the only
+ * non-close-and-reopen way to undo a previous explicit choice. Passes
+ * the sentinel `AUTO_DETECT_LANGUAGE_ID` via `onSelect` so the parent
+ * can branch on it.
  */
 
 import {
@@ -23,22 +29,45 @@ import {
   CommandInput,
   CommandItem,
   CommandList,
+  CommandSeparator,
   Dialog,
   DialogContent,
   DialogDescription,
   DialogHeader,
   DialogTitle,
 } from "@band-app/ui";
-import { Check } from "lucide-react";
+import { Check, Wand2 } from "lucide-react";
 import { useCallback } from "react";
 import { SUPPORTED_LANGUAGES } from "../lib/language-map";
+
+/**
+ * Sentinel value passed to `onSelect` when the user picks "Auto
+ * Detect" — tells the parent to clear any manual override and revert
+ * to extension-based detection. Chosen to be impossible as a real
+ * language id (no language uses double-underscore wrapping).
+ */
+export const AUTO_DETECT_LANGUAGE_ID = "__auto__";
 
 interface LanguagePickerDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
-  /** Currently-active language id, used to render the check mark. */
+  /**
+   * Currently-active language id, used to render the check mark on
+   * the matching row.
+   */
   currentLanguage: string;
-  /** Called with the chosen language id when the user picks one. */
+  /**
+   * Whether the active language is the result of a manual override
+   * (vs. extension auto-detection). Drives whether the "Auto Detect"
+   * row shows the active check mark and whether it's even surfaced —
+   * if no override is active, picking Auto Detect is a no-op.
+   */
+  hasOverride?: boolean;
+  /**
+   * Called with the chosen language id when the user picks one, or
+   * with `AUTO_DETECT_LANGUAGE_ID` when they pick the "Auto Detect"
+   * row to clear an existing override.
+   */
   onSelect: (languageId: string) => void;
 }
 
@@ -46,6 +75,7 @@ export function LanguagePickerDialog({
   open,
   onOpenChange,
   currentLanguage,
+  hasOverride,
   onSelect,
 }: LanguagePickerDialogProps) {
   const handleSelect = useCallback(
@@ -70,6 +100,25 @@ export function LanguagePickerDialog({
           <CommandInput placeholder="Select language mode…" autoFocus />
           <CommandList className="max-h-[360px]">
             <CommandEmpty>No languages found.</CommandEmpty>
+            {/* "Auto Detect" only shows up when a manual override is
+                in effect — otherwise it's a no-op row and would just
+                add visual noise. The check mark uses `hasOverride` as
+                a stand-in for "currently in override mode," matching
+                how VS Code surfaces the same affordance. */}
+            {hasOverride && (
+              <>
+                <CommandGroup>
+                  <CommandItem
+                    value="Auto Detect"
+                    onSelect={() => handleSelect(AUTO_DETECT_LANGUAGE_ID)}
+                  >
+                    <Wand2 className="size-3.5" />
+                    <span className="flex-1 text-sm">Auto Detect</span>
+                  </CommandItem>
+                </CommandGroup>
+                <CommandSeparator />
+              </>
+            )}
             <CommandGroup>
               {SUPPORTED_LANGUAGES.map((lang) => (
                 <CommandItem

--- a/packages/dashboard-core/src/index.ts
+++ b/packages/dashboard-core/src/index.ts
@@ -17,7 +17,10 @@ export { FileBrowser, type FileBrowserHandle } from "./components/FileBrowser";
 export { FileViewer } from "./components/FileViewer";
 export { GitStatusIndicator } from "./components/GitStatusIndicator";
 export { ImagePreview } from "./components/ImagePreview";
-export { LanguagePickerDialog } from "./components/LanguagePickerDialog";
+export {
+  AUTO_DETECT_LANGUAGE_ID,
+  LanguagePickerDialog,
+} from "./components/LanguagePickerDialog";
 export { NewWorkspaceDialog } from "./components/NewWorkspaceForm";
 export { PdfPreview } from "./components/PdfPreview";
 export { ProjectList } from "./components/ProjectList";

--- a/packages/dashboard-core/src/index.ts
+++ b/packages/dashboard-core/src/index.ts
@@ -98,6 +98,7 @@ export {
   extensionToLanguage,
   filenameToLanguage,
   languageLabel,
+  languageToExtension,
   SUPPORTED_LANGUAGES,
   type SupportedLanguage,
 } from "./lib/language-map";

--- a/packages/dashboard-core/src/index.ts
+++ b/packages/dashboard-core/src/index.ts
@@ -17,6 +17,7 @@ export { FileBrowser, type FileBrowserHandle } from "./components/FileBrowser";
 export { FileViewer } from "./components/FileViewer";
 export { GitStatusIndicator } from "./components/GitStatusIndicator";
 export { ImagePreview } from "./components/ImagePreview";
+export { LanguagePickerDialog } from "./components/LanguagePickerDialog";
 export { NewWorkspaceDialog } from "./components/NewWorkspaceForm";
 export { PdfPreview } from "./components/PdfPreview";
 export { ProjectList } from "./components/ProjectList";
@@ -93,7 +94,13 @@ export {
 export { getFileIcon } from "./lib/file-icon";
 export { type FileLocation, formatFileLocation, parseFileLocation } from "./lib/file-location";
 export { type FilePreviewType, getFilePreviewType } from "./lib/file-type";
-export { extensionToLanguage, filenameToLanguage } from "./lib/language-map";
+export {
+  extensionToLanguage,
+  filenameToLanguage,
+  languageLabel,
+  SUPPORTED_LANGUAGES,
+  type SupportedLanguage,
+} from "./lib/language-map";
 export { getRecentWorkspaceOrder, recordWorkspaceAccess } from "./lib/recent-workspaces";
 export type { SelectionToChatDetail } from "./lib/selection-to-chat";
 export { isServiceHealthy, type ServiceHealth } from "./lib/service-health";

--- a/packages/dashboard-core/src/lib/command-registry.ts
+++ b/packages/dashboard-core/src/lib/command-registry.ts
@@ -44,6 +44,20 @@ export interface CommandRegistryDeps {
    * same thing, so the palette and shortcut paths stay symmetric.
    */
   formatCurrentFile: () => void;
+  /**
+   * Open a new untitled (scratch) editor tab. Mirrors the ⌘N shortcut
+   * and the "New Untitled File" button in the Files toolbar; backed by
+   * the `band:new-untitled-tab` event so the action stays loosely
+   * coupled to whichever workspace happens to be active.
+   */
+  newUntitledTab: () => void;
+  /**
+   * Open the searchable language-mode picker for the currently-active
+   * editor tab. Implementations dispatch `band:open-language-picker`
+   * with `{workspaceId, filePath}` so the matching FileViewer listener
+   * opens the dialog (same pattern as `formatCurrentFile`).
+   */
+  changeLanguageMode: () => void;
 }
 
 // ---------------------------------------------------------------------------
@@ -100,6 +114,16 @@ function activatePanel(deps: CommandRegistryDeps, panelId: string): void {
 export function buildCommands(deps: CommandRegistryDeps): PaletteCommand[] {
   return [
     {
+      // ⌘N — open a new untitled (scratch) editor tab. Listed first
+      // because it's the closest sibling to Quick Open ("create a new
+      // editing surface" vs "find an existing one") and the keybinding
+      // is one of the most discoverable in the app.
+      id: "new-untitled-tab",
+      label: "New Untitled File",
+      shortcut: "Cmd+N",
+      action: () => deps.newUntitledTab(),
+    },
+    {
       id: "quick-open",
       label: "Quick Open",
       shortcut: "Cmd+P",
@@ -132,6 +156,16 @@ export function buildCommands(deps: CommandRegistryDeps): PaletteCommand[] {
       label: "Format Current File",
       shortcut: "Cmd+Shift+F",
       action: () => deps.formatCurrentFile(),
+    },
+    {
+      // Searchable language-mode picker for the active editor tab
+      // (issue #434). No keyboard shortcut — VS Code's equivalent
+      // (Cmd+K M) is a chord we don't yet support; the status-bar
+      // language indicator and this palette entry are the two reachable
+      // surfaces.
+      id: "change-language-mode",
+      label: "Change Language Mode…",
+      action: () => deps.changeLanguageMode(),
     },
     {
       id: "show-chat",

--- a/packages/dashboard-core/src/lib/language-map.ts
+++ b/packages/dashboard-core/src/lib/language-map.ts
@@ -169,3 +169,65 @@ export function languageLabel(id: string): string {
   if (!id) return "Plain Text";
   return id.charAt(0).toUpperCase() + id.slice(1);
 }
+
+/**
+ * Canonical extension for a language id, used to synthesize a virtual
+ * filename for untitled tabs when an extension-driven tool (like the
+ * server-side Prettier formatter) needs one. Returns `undefined` for
+ * languages with no obvious canonical extension or for the
+ * `"plaintext"` default — neither has a Prettier parser, so callers
+ * should treat `undefined` as "skip extension-driven dispatch".
+ *
+ * Reverse of `EXTENSION_MAP`: where multiple extensions map to a
+ * single language (e.g. `.cjs` / `.mjs` / `.js` → javascript), we
+ * pick the most idiomatic one.
+ */
+const LANGUAGE_TO_EXTENSION: Record<string, string> = {
+  javascript: ".js",
+  jsx: ".jsx",
+  typescript: ".ts",
+  tsx: ".tsx",
+  json: ".json",
+  jsonc: ".jsonc",
+  html: ".html",
+  css: ".css",
+  scss: ".scss",
+  sass: ".sass",
+  less: ".less",
+  markdown: ".md",
+  mdx: ".mdx",
+  yaml: ".yaml",
+  xml: ".xml",
+  python: ".py",
+  ruby: ".rb",
+  rust: ".rs",
+  go: ".go",
+  java: ".java",
+  kotlin: ".kt",
+  swift: ".swift",
+  c: ".c",
+  cpp: ".cpp",
+  csharp: ".cs",
+  php: ".php",
+  bash: ".sh",
+  sql: ".sql",
+  graphql: ".graphql",
+  vue: ".vue",
+  svelte: ".svelte",
+  lua: ".lua",
+  r: ".r",
+  dart: ".dart",
+  elixir: ".ex",
+  erlang: ".erl",
+  haskell: ".hs",
+  scala: ".scala",
+  clojure: ".clj",
+  toml: ".toml",
+  hcl: ".hcl",
+  ini: ".ini",
+  diff: ".diff",
+};
+
+export function languageToExtension(id: string): string | undefined {
+  return LANGUAGE_TO_EXTENSION[id];
+}

--- a/packages/dashboard-core/src/lib/language-map.ts
+++ b/packages/dashboard-core/src/lib/language-map.ts
@@ -85,3 +85,87 @@ export function extensionToLanguage(ext: string): string | undefined {
 export function filenameToLanguage(filename: string): string | undefined {
   return FILENAME_MAP[filename];
 }
+
+/**
+ * Catalogue of languages the editor (CodeMirror) can syntax-highlight,
+ * with the human-readable label shown in the language picker. Used by
+ * `LanguagePickerDialog` (and the editor's status-bar language
+ * indicator) to populate a searchable list.
+ *
+ * The `id` matches the lowercase canonical name accepted by
+ * `loadLanguage` in `codemirror-setup.ts` — "Plain Text" maps to
+ * `"plaintext"`, which `loadLanguage` resolves to `null` (no
+ * highlighting), matching VS Code's behaviour.
+ *
+ * Order matters for the picker: "Plain Text" first because it's the
+ * default for untitled tabs and the catch-all for unsupported
+ * extensions, then everything else alphabetised by label.
+ */
+export interface SupportedLanguage {
+  id: string;
+  label: string;
+}
+
+export const SUPPORTED_LANGUAGES: SupportedLanguage[] = [
+  { id: "plaintext", label: "Plain Text" },
+  { id: "bash", label: "Bash / Shell" },
+  { id: "c", label: "C" },
+  { id: "clojure", label: "Clojure" },
+  { id: "cpp", label: "C++" },
+  { id: "csharp", label: "C#" },
+  { id: "css", label: "CSS" },
+  { id: "dart", label: "Dart" },
+  { id: "diff", label: "Diff" },
+  { id: "dockerfile", label: "Dockerfile" },
+  { id: "elixir", label: "Elixir" },
+  { id: "erlang", label: "Erlang" },
+  { id: "go", label: "Go" },
+  { id: "graphql", label: "GraphQL" },
+  { id: "haskell", label: "Haskell" },
+  { id: "hcl", label: "HCL / Terraform" },
+  { id: "html", label: "HTML" },
+  { id: "ini", label: "INI" },
+  { id: "java", label: "Java" },
+  { id: "javascript", label: "JavaScript" },
+  { id: "json", label: "JSON" },
+  { id: "jsonc", label: "JSON with Comments" },
+  { id: "jsx", label: "JavaScript (JSX)" },
+  { id: "kotlin", label: "Kotlin" },
+  { id: "less", label: "Less" },
+  { id: "lua", label: "Lua" },
+  { id: "makefile", label: "Makefile" },
+  { id: "markdown", label: "Markdown" },
+  { id: "mdx", label: "MDX" },
+  { id: "php", label: "PHP" },
+  { id: "powershell", label: "PowerShell" },
+  { id: "python", label: "Python" },
+  { id: "r", label: "R" },
+  { id: "ruby", label: "Ruby" },
+  { id: "rust", label: "Rust" },
+  { id: "sass", label: "Sass" },
+  { id: "scala", label: "Scala" },
+  { id: "scss", label: "SCSS" },
+  { id: "sql", label: "SQL" },
+  { id: "svelte", label: "Svelte" },
+  { id: "swift", label: "Swift" },
+  { id: "toml", label: "TOML" },
+  { id: "typescript", label: "TypeScript" },
+  { id: "tsx", label: "TypeScript (TSX)" },
+  { id: "vue", label: "Vue" },
+  { id: "xml", label: "XML" },
+  { id: "yaml", label: "YAML" },
+];
+
+/**
+ * Resolve a language id to its human-readable label (e.g.
+ * `"typescript"` → `"TypeScript"`). Falls back to a Title-Cased
+ * version of the id when the language isn't in `SUPPORTED_LANGUAGES`
+ * — that happens for legacy / less-common languages that exist in
+ * `EXTENSION_MAP` but aren't surfaced in the picker.
+ */
+export function languageLabel(id: string): string {
+  const entry = SUPPORTED_LANGUAGES.find((l) => l.id === id);
+  if (entry) return entry.label;
+  if (!id) return "Plain Text";
+  return id.charAt(0).toUpperCase() + id.slice(1);
+}

--- a/packages/dashboard-core/src/lib/language-map.ts
+++ b/packages/dashboard-core/src/lib/language-map.ts
@@ -161,12 +161,15 @@ export const SUPPORTED_LANGUAGES: SupportedLanguage[] = [
  * `"typescript"` → `"TypeScript"`). Falls back to a Title-Cased
  * version of the id when the language isn't in `SUPPORTED_LANGUAGES`
  * — that happens for legacy / less-common languages that exist in
- * `EXTENSION_MAP` but aren't surfaced in the picker.
+ * `EXTENSION_MAP` but aren't surfaced in the picker. Callers always
+ * pass a non-empty `id` (either `languageOverride`, `"plaintext"`,
+ * or a `detectLanguage` result), so no empty-string guard is needed
+ * — the title-case fallback handles unknown ids by surfacing a
+ * recognisable string rather than masking a missing-language bug.
  */
 export function languageLabel(id: string): string {
   const entry = SUPPORTED_LANGUAGES.find((l) => l.id === id);
   if (entry) return entry.label;
-  if (!id) return "Plain Text";
   return id.charAt(0).toUpperCase() + id.slice(1);
 }
 

--- a/packages/dashboard-core/src/lib/language-map.ts
+++ b/packages/dashboard-core/src/lib/language-map.ts
@@ -157,6 +157,16 @@ export const SUPPORTED_LANGUAGES: SupportedLanguage[] = [
 ];
 
 /**
+ * Pre-built lookup so `languageLabel` is O(1) rather than O(n) over
+ * `SUPPORTED_LANGUAGES`. The label is read on every render of the
+ * status-bar language indicator, so although the list is small (~50
+ * entries) and the per-call cost is negligible, the Map avoids a
+ * scan-per-render and matches the style used by `EXTENSION_MAP` /
+ * `FILENAME_MAP` above.
+ */
+const LANGUAGE_LABEL_BY_ID = new Map(SUPPORTED_LANGUAGES.map((l) => [l.id, l.label]));
+
+/**
  * Resolve a language id to its human-readable label (e.g.
  * `"typescript"` → `"TypeScript"`). Falls back to a Title-Cased
  * version of the id when the language isn't in `SUPPORTED_LANGUAGES`
@@ -168,8 +178,8 @@ export const SUPPORTED_LANGUAGES: SupportedLanguage[] = [
  * recognisable string rather than masking a missing-language bug.
  */
 export function languageLabel(id: string): string {
-  const entry = SUPPORTED_LANGUAGES.find((l) => l.id === id);
-  if (entry) return entry.label;
+  const label = LANGUAGE_LABEL_BY_ID.get(id);
+  if (label) return label;
   return id.charAt(0).toUpperCase() + id.slice(1);
 }
 


### PR DESCRIPTION
## Summary

- Adds **untitled / scratch editor tabs** (Cmd+N, Files toolbar action, command palette entry) — empty buffers that aren't backed by a file on disk
- Wires a new **`pick_save_file` Electron IPC channel** that runs the OS save dialog and persists the buffer atomically, keeping the filesystem trust boundary inside the desktop shell (per `CLAUDE.md`)
- Adds a **searchable language-mode picker** for every editor tab (untitled and file-backed) — clickable status-bar indicator on the FileViewer + "Change Language Mode…" palette entry, list of all CodeMirror-supported languages, override sticks for the tab's lifetime and survives saves

Closes #434.

## What's in here

**Untitled tabs (`apps/web/src/hooks/useFileTabs.ts`, `apps/web/src/hooks/useTabState.ts`):**
- `openTabUntitled()` creates a new tab keyed on a synthetic `untitled:N` path with a monotonic per-workspace counter
- `renameUntitledToFile()` swaps the tab key in place once the user picks a destination, so tab order doesn't shuffle on save
- Untitled tabs are filtered out of the `localStorage` save path (ephemeral, per the issue's "Out of scope" note)
- A new `language` field on `TabFileState` carries the user's manual language override

**Save IPC (`apps/desktop/src/main/ipc/macos-shell.ts` + new `save-helpers.ts`):**
- `pick_save_file` runs `dialog.showSaveDialog` (with `showOverwriteConfirmation`) and writes the buffer via `writeFileSync`
- The pure helpers (`resolveSaveDialogSeed`, `writeSavedFile`) live in `save-helpers.ts` so they can be integration-tested without dragging Electron into the test runtime
- Preload allowlist + channel registry updated

**Dashboard adapter (`packages/dashboard-core/src/adapter.ts`, `adapters/desktop.ts`):**
- New `pickSaveFile()` capability on `PlatformCapabilities`, gated on the desktop shell the same way `pickFile()` is

**Editor surface (`packages/dashboard-core/src/components/FileViewer.tsx`):**
- `untitled` / `onSaveAs` props handle the no-backing-file flow
- New `languageOverride` / `onLanguageOverrideChange` props with a status-bar language indicator that opens a `LanguagePickerDialog`
- Cmd+S on an untitled tab routes through the OS save dialog

**Tab bar (`apps/web/src/components/FileTabBar.tsx`):**
- Untitled tabs render with a generic `FileText` icon and the `Untitled-N` label
- Close-confirm dialog gains a third "Save…" button when the closed tab is untitled (Save / Discard / Cancel per the spec); cancelling the save dialog keeps the tab open

**Wiring (`apps/web/src/components/CodeBrowserView.tsx`, `DockviewWorkspaceLayout.tsx`, `packages/dashboard-core/src/lib/command-registry.ts`):**
- `band:new-untitled-tab` event for the Cmd+N keybinding + palette command + toolbar button
- `band:open-language-picker` event for the language picker command palette entry
- Save flow auto-detects whether the chosen path lives inside the workspace and transitions to a workspace tab or external tab accordingly (#433)
- Language override carries over to the new tab key when an untitled tab is saved (per the acceptance criterion "the user's explicit choice wins")

**Tests (`apps/desktop/tests/save-untitled.test.ts`):**
- Real-filesystem integration test for the bytes-to-disk side of `pick_save_file`: UTF-8 round-trip, overwrite, empty-buffer, ENOENT propagation, `resolveSaveDialogSeed` branches
- The dialog side is covered by the IPC channel registration + preload allowlist tests already in the suite — opening a real native modal from `node:test` would need to mock Electron, which `CLAUDE.md` forbids

## Test plan

- [x] `pnpm --filter @band-app/desktop test` (110 passing — 9 new in `save-untitled.test.ts`)
- [x] `pnpm --filter @band-app/server test` (696 passing)
- [x] `pnpm biome check .` (1 pre-existing warning in `DashboardShell.tsx`, no new findings)
- [x] `pnpm --filter @band-app/server build` clean
- [x] `pnpm --filter @band-app/desktop build` clean
- [x] `pnpm knip` clean
- [x] `pnpm jscpd` clean
- [x] `cargo fmt --check` clean
- [x] Pre-push hook (`biome check`, `cargo fmt`, `clippy`, `knip`, `jscpd`) passed on `git push`

Manual verification still owed (desktop):
- [ ] Cmd+N creates "Untitled-1", Cmd+N again creates "Untitled-2" (counter is monotonic)
- [ ] Cmd+S on an untitled tab opens the native save dialog; cancelling leaves the tab as-is; picking a workspace-internal path transitions to a normal workspace tab; picking an out-of-workspace path transitions to an external tab
- [ ] Closing a dirty untitled tab prompts Save / Discard / Cancel; cancelling the save dialog reopens the same confirm dialog
- [ ] Status-bar language picker switches highlighting in place; the choice persists across tab switches; saving an untitled tab whose language was manually set keeps the override regardless of the chosen filename's extension

🤖 Generated with [Claude Code](https://claude.com/claude-code)