### PR TITLE
fix(web): keep file tree visible in Changes view when there are no changes

### DIFF
--- a/packages/dashboard-core/src/components/ChangesFileTree.tsx
+++ b/packages/dashboard-core/src/components/ChangesFileTree.tsx
@@ -232,6 +232,12 @@ export function ChangesFileTree({
   // explicitly collapsed stay collapsed — we never overwrite an existing
   // entry — so switching between branches (including one with no changes
   // at all) doesn't reset the expansion state.
+  // `seenDirPathsRef` accumulates every directory path observed during the
+  // workspace session and is intentionally never pruned — that's how user
+  // collapses survive paths that disappear from the tree (e.g. switching
+  // selectors). Memory cost is negligible because changed-file sets are
+  // small; if a future "reset expansion to defaults" action is added it
+  // must clear this ref alongside `expandedPaths`.
   useEffect(() => {
     const currentDirs = collectDirPaths(tree);
     const newDirs = currentDirs.filter((p) => !seenDirPathsRef.current.has(p));

--- a/packages/dashboard-core/src/components/ChangesFileTree.tsx
+++ b/packages/dashboard-core/src/components/ChangesFileTree.tsx
@@ -215,14 +215,17 @@ export function ChangesFileTree({
   // collapses for paths that were already in the tree on a previous render
   // (including paths that temporarily disappeared, e.g. when switching the
   // changes selector between branches with different file sets).
-  const seenDirPathsRef = useRef<Set<string>>(new Set());
+  //
+  // Computed once via `useMemo([])` and shared with `expandedPaths` rather
+  // than via a side effect inside the `useState` lazy initializer —
+  // initializers should be pure, and React 18 Strict Mode calls them
+  // twice in dev to catch exactly that anti-pattern.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: initial-only — `tree` is read once on mount and intentionally not re-tracked; later updates flow through the `useEffect` below.
+  const initialDirs = useMemo(() => new Set(collectDirPaths(tree)), []);
+  const seenDirPathsRef = useRef<Set<string>>(initialDirs);
 
   // All directories expanded by default (changed-file sets are typically small)
-  const [expandedPaths, setExpandedPaths] = useState<Set<string>>(() => {
-    const initial = collectDirPaths(tree);
-    seenDirPathsRef.current = new Set(initial);
-    return new Set(initial);
-  });
+  const [expandedPaths, setExpandedPaths] = useState<Set<string>>(() => new Set(initialDirs));
 
   // When the tree changes, expand any directories we haven't seen before
   // and remember them for future renders. Directories the user has

--- a/packages/dashboard-core/src/components/ChangesFileTree.tsx
+++ b/packages/dashboard-core/src/components/ChangesFileTree.tsx
@@ -216,16 +216,16 @@ export function ChangesFileTree({
   // (including paths that temporarily disappeared, e.g. when switching the
   // changes selector between branches with different file sets).
   //
-  // Computed once via `useMemo([])` and shared with `expandedPaths` rather
-  // than via a side effect inside the `useState` lazy initializer —
-  // initializers should be pure, and React 18 Strict Mode calls them
-  // twice in dev to catch exactly that anti-pattern.
-  // biome-ignore lint/correctness/useExhaustiveDependencies: initial-only — `tree` is read once on mount and intentionally not re-tracked; later updates flow through the `useEffect` below.
-  const initialDirs = useMemo(() => new Set(collectDirPaths(tree)), []);
-  const seenDirPathsRef = useRef<Set<string>>(initialDirs);
-
-  // All directories expanded by default (changed-file sets are typically small)
-  const [expandedPaths, setExpandedPaths] = useState<Set<string>>(() => new Set(initialDirs));
+  // `useRef`'s initial value is only consumed on the first render; later
+  // updates flow through the `useEffect` below. The `expandedPaths`
+  // initialiser copies the set rather than aliasing it so a future
+  // mutation of `seenDirPathsRef.current` can't accidentally bleed into
+  // expansion state.
+  const seenDirPathsRef = useRef<Set<string>>(new Set(collectDirPaths(tree)));
+  // All directories expanded by default (changed-file sets are typically small).
+  const [expandedPaths, setExpandedPaths] = useState<Set<string>>(
+    () => new Set(seenDirPathsRef.current),
+  );
 
   // When the tree changes, expand any directories we haven't seen before
   // and remember them for future renders. Directories the user has

--- a/packages/dashboard-core/src/components/ChangesFileTree.tsx
+++ b/packages/dashboard-core/src/components/ChangesFileTree.tsx
@@ -210,14 +210,35 @@ export function ChangesFileTree({
 }: ChangesFileTreeProps) {
   const tree = useMemo(() => buildFileTree(fileStatuses), [fileStatuses]);
 
+  // Track every directory path we've ever seen. Used so newly-appearing
+  // directories default to expanded, while preserving the user's explicit
+  // collapses for paths that were already in the tree on a previous render
+  // (including paths that temporarily disappeared, e.g. when switching the
+  // changes selector between branches with different file sets).
+  const seenDirPathsRef = useRef<Set<string>>(new Set());
+
   // All directories expanded by default (changed-file sets are typically small)
   const [expandedPaths, setExpandedPaths] = useState<Set<string>>(() => {
-    return new Set(collectDirPaths(tree));
+    const initial = collectDirPaths(tree);
+    seenDirPathsRef.current = new Set(initial);
+    return new Set(initial);
   });
 
-  // Re-expand all when tree changes (new diff summary)
+  // When the tree changes, expand any directories we haven't seen before
+  // and remember them for future renders. Directories the user has
+  // explicitly collapsed stay collapsed — we never overwrite an existing
+  // entry — so switching between branches (including one with no changes
+  // at all) doesn't reset the expansion state.
   useEffect(() => {
-    setExpandedPaths(new Set(collectDirPaths(tree)));
+    const currentDirs = collectDirPaths(tree);
+    const newDirs = currentDirs.filter((p) => !seenDirPathsRef.current.has(p));
+    if (newDirs.length === 0) return;
+    for (const p of newDirs) seenDirPathsRef.current.add(p);
+    setExpandedPaths((prev) => {
+      const next = new Set(prev);
+      for (const p of newDirs) next.add(p);
+      return next;
+    });
   }, [tree]);
 
   const handleToggle = (path: string) => {
@@ -282,13 +303,10 @@ export function ChangesFileTree({
 
   const canReset = Boolean(onRevertPaths);
 
-  if (tree.length === 0) {
-    return (
-      <div className="flex h-16 items-center justify-center text-[13px] text-muted-foreground">
-        No files
-      </div>
-    );
-  }
+  // When there are no changes the tree is empty — render nothing so the
+  // surrounding panel layout stays stable rather than collapsing or
+  // showing a placeholder that competes with the "No changes" message in
+  // the diff area.
 
   return (
     <>

--- a/packages/dashboard-core/src/components/DiffView.tsx
+++ b/packages/dashboard-core/src/components/DiffView.tsx
@@ -1562,21 +1562,10 @@ export function DiffView({
     );
   }
 
-  if (loading) {
-    return (
-      <div className="flex h-full items-center justify-center text-sm text-muted-foreground">
-        Loading changes...
-      </div>
-    );
-  }
-
-  if (error) {
-    return (
-      <div className="flex h-full items-center justify-center text-sm text-destructive">
-        {error}
-      </div>
-    );
-  }
+  // For git projects, loading / error / no-changes / populated states all
+  // share the unified layout below — see the comment above the `hasChanges`
+  // derivation. Don't add separate early returns for loading or error here;
+  // they'd reintroduce the layout shift this PR exists to fix.
 
   // Ghost-style classes shared across every toolbar action button. Variants
   // for the segmented view-mode toggle differ slightly because the active
@@ -1650,62 +1639,15 @@ export function DiffView({
     </>
   );
 
-  if (!summary || summary.stats.filesChanged === 0) {
-    return (
-      <div className="flex h-full flex-col overflow-hidden">
-        <div className="flex h-9 shrink-0 items-center justify-between gap-3 border-b border-border pl-3 pr-3">
-          {renderBranchIndicator(summary?.headBranch)}
-          <div className="flex items-center gap-1">{renderGitSyncButtons()}</div>
-        </div>
-        <div className="flex min-h-0 flex-1 items-center justify-center">
-          <span className="text-sm text-muted-foreground">No changes</span>
-        </div>
-        {gitOpStatus && (
-          <div
-            role={gitOpStatus.state === "error" ? "alert" : "status"}
-            className={`flex shrink-0 items-center gap-2 border-t px-3 py-1.5 text-xs ${
-              gitOpStatus.state === "error"
-                ? "border-destructive/40 bg-destructive/10 text-destructive"
-                : "border-border bg-muted/50 text-muted-foreground"
-            }`}
-          >
-            {gitOpStatus.state === "running" && (
-              <>
-                <Spinner className="size-3.5" />
-                <span>{gitOpStatus.op === "pull" ? "Pulling…" : "Pushing…"}</span>
-              </>
-            )}
-            {gitOpStatus.state === "success" && (
-              <>
-                <Check className="size-3.5 text-green-600 dark:text-green-400" />
-                <span>{gitOpStatus.op === "pull" ? "Pulled" : "Pushed"}</span>
-              </>
-            )}
-            {gitOpStatus.state === "error" && (
-              <>
-                <span className="font-medium">
-                  {gitOpStatus.op === "pull" ? "Pull failed" : "Push failed"}:
-                </span>
-                <span className="min-w-0 flex-1 truncate" title={gitOpStatus.message}>
-                  {gitOpStatus.message}
-                </span>
-                <button
-                  type="button"
-                  onClick={() => setGitOpStatus(null)}
-                  className="shrink-0 rounded px-1 text-destructive hover:bg-destructive/20"
-                  aria-label="Dismiss error"
-                >
-                  ×
-                </button>
-              </>
-            )}
-          </div>
-        )}
-      </div>
-    );
-  }
-
-  const fileStatuses = summary.fileStatuses || {};
+  // The loading / error / "no changes" / populated states all share the
+  // outer layout (file tree + toolbar + status banner) so switching the
+  // changes selector between refs (including a ref with no diff) doesn't
+  // collapse the panel or shift the file-tree column out of the layout.
+  // Loading and error take precedence — when either is true we don't
+  // surface the file list even if `summary` still holds data from a
+  // previous fetch.
+  const hasChanges = Boolean(!loading && !error && summary && summary.stats.filesChanged > 0);
+  const fileStatuses = hasChanges ? (summary?.fileStatuses ?? {}) : {};
   const filenames = flattenFileTreeOrder(buildFileTree(fileStatuses));
   filenamesRef.current = filenames;
 
@@ -1746,189 +1688,203 @@ export function DiffView({
         <div className="flex h-9 shrink-0 items-center justify-between gap-3 border-b border-border pl-2 pr-3">
           <div className="flex min-w-0 items-center gap-1.5">
             {renderSidebarToggle()}
-            {renderBranchIndicator(summary.headBranch)}
+            {renderBranchIndicator(summary?.headBranch)}
           </div>
+          {/* When there are no changes the toolbar collapses to just the
+              pull / push controls (the "just fetch upstream" case). The
+              commit / search / expand / view-mode buttons all operate on
+              a non-empty diff and would be no-ops otherwise. */}
+          {!hasChanges && <div className="flex items-center gap-1">{renderGitSyncButtons()}</div>}
           {/* Inline action icons — collapsed into the kebab menu below 44rem.
               The threshold is wider than the branch-label one (32rem) because
               the right-side cluster now carries up to eight icons (commit,
               pull, push, reload, search, expand, unified, split) — squeezing
               them into a narrower toolbar makes the buttons overlap the
               branch indicator on the left. */}
-          <div className="hidden items-center gap-1 @[44rem]/diff:flex">
-            {canCommit && (
-              <button
-                type="button"
-                onClick={() => setCommitDialogOpen(true)}
-                className={ghostBtnAlwaysClass}
-                title="Commit changes"
-                aria-label="Commit changes"
-                disabled={gitOpBusy}
-              >
-                <GitCommit className="size-3.5" />
-              </button>
-            )}
-            {canPull && (
-              <button
-                type="button"
-                onClick={handleGitPull}
-                className={ghostBtnAlwaysClass}
-                title="Git pull"
-                aria-label="Git pull"
-                disabled={gitOpBusy}
-              >
-                {isPulling ? (
-                  <Spinner className="size-3.5" />
-                ) : (
-                  <ArrowDownToLine className="size-3.5" />
-                )}
-              </button>
-            )}
-            {canPush && (
-              <button
-                type="button"
-                onClick={handleGitPush}
-                className={ghostBtnAlwaysClass}
-                title="Git push"
-                aria-label="Git push"
-                disabled={gitOpBusy}
-              >
-                {isPushing ? (
-                  <Spinner className="size-3.5" />
-                ) : (
-                  <ArrowUpFromLine className="size-3.5" />
-                )}
-              </button>
-            )}
-            <button
-              type="button"
-              onClick={() => fetchSummaryRef.current?.(true)}
-              className={ghostBtnAlwaysClass}
-              title="Reload changes"
-              aria-label="Reload changes"
-            >
-              <RefreshCw className="size-3.5" />
-            </button>
-            <button
-              type="button"
-              onClick={search.handleOpenSearch}
-              className={ghostBtnAlwaysClass}
-              title="Find in changes (⌘F)"
-              aria-label="Find in changes"
-            >
-              <Search className="size-3.5" />
-            </button>
-            <button
-              type="button"
-              onClick={() => setExpandAll(!expandAll)}
-              className={`${ghostBtnAlwaysClass} ${expandAll ? "bg-accent text-foreground" : ""}`}
-              title={expandAll ? "Collapse all files" : "Expand all files"}
-              aria-label={expandAll ? "Collapse all files" : "Expand all files"}
-              aria-pressed={expandAll}
-            >
-              {expandAll ? (
-                <ChevronsDownUp className="size-3.5" />
-              ) : (
-                <ChevronsUpDown className="size-3.5" />
+          {hasChanges && (
+            <div className="hidden items-center gap-1 @[44rem]/diff:flex">
+              {canCommit && (
+                <button
+                  type="button"
+                  onClick={() => setCommitDialogOpen(true)}
+                  className={ghostBtnAlwaysClass}
+                  title="Commit changes"
+                  aria-label="Commit changes"
+                  disabled={gitOpBusy}
+                >
+                  <GitCommit className="size-3.5" />
+                </button>
               )}
-            </button>
-            <div className="hidden items-center @[40rem]/diff:flex">
+              {canPull && (
+                <button
+                  type="button"
+                  onClick={handleGitPull}
+                  className={ghostBtnAlwaysClass}
+                  title="Git pull"
+                  aria-label="Git pull"
+                  disabled={gitOpBusy}
+                >
+                  {isPulling ? (
+                    <Spinner className="size-3.5" />
+                  ) : (
+                    <ArrowDownToLine className="size-3.5" />
+                  )}
+                </button>
+              )}
+              {canPush && (
+                <button
+                  type="button"
+                  onClick={handleGitPush}
+                  className={ghostBtnAlwaysClass}
+                  title="Git push"
+                  aria-label="Git push"
+                  disabled={gitOpBusy}
+                >
+                  {isPushing ? (
+                    <Spinner className="size-3.5" />
+                  ) : (
+                    <ArrowUpFromLine className="size-3.5" />
+                  )}
+                </button>
+              )}
               <button
                 type="button"
-                onClick={() => setViewMode("unified")}
-                className={`${ghostBtnAlwaysClass} ${effectiveViewMode === "unified" ? "bg-accent text-foreground" : ""}`}
-                title="Unified view"
-                aria-label="Unified view"
-                aria-pressed={effectiveViewMode === "unified"}
+                onClick={() => fetchSummaryRef.current?.(true)}
+                className={ghostBtnAlwaysClass}
+                title="Reload changes"
+                aria-label="Reload changes"
               >
-                <Rows2 className="size-3.5" />
+                <RefreshCw className="size-3.5" />
               </button>
               <button
                 type="button"
-                onClick={() => setViewMode("split")}
-                className={`${ghostBtnAlwaysClass} ${effectiveViewMode === "split" ? "bg-accent text-foreground" : ""}`}
-                title="Split view"
-                aria-label="Split view"
-                aria-pressed={effectiveViewMode === "split"}
+                onClick={search.handleOpenSearch}
+                className={ghostBtnAlwaysClass}
+                title="Find in changes (⌘F)"
+                aria-label="Find in changes"
               >
-                <Columns2 className="size-3.5" />
+                <Search className="size-3.5" />
               </button>
+              <button
+                type="button"
+                onClick={() => setExpandAll(!expandAll)}
+                className={`${ghostBtnAlwaysClass} ${expandAll ? "bg-accent text-foreground" : ""}`}
+                title={expandAll ? "Collapse all files" : "Expand all files"}
+                aria-label={expandAll ? "Collapse all files" : "Expand all files"}
+                aria-pressed={expandAll}
+              >
+                {expandAll ? (
+                  <ChevronsDownUp className="size-3.5" />
+                ) : (
+                  <ChevronsUpDown className="size-3.5" />
+                )}
+              </button>
+              <div className="hidden items-center @[40rem]/diff:flex">
+                <button
+                  type="button"
+                  onClick={() => setViewMode("unified")}
+                  className={`${ghostBtnAlwaysClass} ${effectiveViewMode === "unified" ? "bg-accent text-foreground" : ""}`}
+                  title="Unified view"
+                  aria-label="Unified view"
+                  aria-pressed={effectiveViewMode === "unified"}
+                >
+                  <Rows2 className="size-3.5" />
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setViewMode("split")}
+                  className={`${ghostBtnAlwaysClass} ${effectiveViewMode === "split" ? "bg-accent text-foreground" : ""}`}
+                  title="Split view"
+                  aria-label="Split view"
+                  aria-pressed={effectiveViewMode === "split"}
+                >
+                  <Columns2 className="size-3.5" />
+                </button>
+              </div>
             </div>
-          </div>
+          )}
 
           {/* Compact "more actions" kebab menu — visible at narrow widths only.
               Mirrors the 44rem breakpoint above so exactly one of the inline
-              cluster / kebab is visible at any width. */}
-          <div className="flex items-center @[44rem]/diff:hidden">
-            <DropdownMenu>
-              <DropdownMenuTrigger asChild>
-                <button
-                  type="button"
-                  className={ghostBtnAlwaysClass}
-                  title="More actions"
-                  aria-label="More actions"
-                >
-                  <MoreVertical className="size-3.5" />
-                </button>
-              </DropdownMenuTrigger>
-              <DropdownMenuContent align="end">
-                {canCommit && (
-                  <DropdownMenuItem onSelect={() => setCommitDialogOpen(true)} disabled={gitOpBusy}>
-                    <GitCommit className="size-4" />
-                    Commit changes
-                  </DropdownMenuItem>
-                )}
-                {canPull && (
-                  <DropdownMenuItem onSelect={() => handleGitPull()} disabled={gitOpBusy}>
-                    {isPulling ? (
-                      <Spinner className="size-4" />
-                    ) : (
-                      <ArrowDownToLine className="size-4" />
-                    )}
-                    Git pull
-                  </DropdownMenuItem>
-                )}
-                {canPush && (
-                  <DropdownMenuItem onSelect={() => handleGitPush()} disabled={gitOpBusy}>
-                    {isPushing ? (
-                      <Spinner className="size-4" />
-                    ) : (
-                      <ArrowUpFromLine className="size-4" />
-                    )}
-                    Git push
-                  </DropdownMenuItem>
-                )}
-                <DropdownMenuItem onSelect={() => fetchSummaryRef.current?.(true)}>
-                  <RefreshCw className="size-4" />
-                  Reload changes
-                </DropdownMenuItem>
-                <DropdownMenuItem onSelect={search.handleOpenSearch}>
-                  <Search className="size-4" />
-                  Find in changes
-                </DropdownMenuItem>
-                <DropdownMenuItem onSelect={() => setExpandAll(!expandAll)}>
-                  {expandAll ? (
-                    <ChevronsDownUp className="size-4" />
-                  ) : (
-                    <ChevronsUpDown className="size-4" />
+              cluster / kebab is visible at any width. Hidden when there are
+              no changes — the simplified pull / push cluster is shown
+              unconditionally at every width instead. */}
+          {hasChanges && (
+            <div className="flex items-center @[44rem]/diff:hidden">
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                  <button
+                    type="button"
+                    className={ghostBtnAlwaysClass}
+                    title="More actions"
+                    aria-label="More actions"
+                  >
+                    <MoreVertical className="size-3.5" />
+                  </button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align="end">
+                  {canCommit && (
+                    <DropdownMenuItem
+                      onSelect={() => setCommitDialogOpen(true)}
+                      disabled={gitOpBusy}
+                    >
+                      <GitCommit className="size-4" />
+                      Commit changes
+                    </DropdownMenuItem>
                   )}
-                  {expandAll ? "Collapse all files" : "Expand all files"}
-                </DropdownMenuItem>
-                <DropdownMenuSeparator />
-                <DropdownMenuItem onSelect={() => setViewMode("unified")}>
-                  <Rows2 className="size-4" />
-                  Unified view
-                  {effectiveViewMode === "unified" && <Check className="ml-auto size-4" />}
-                </DropdownMenuItem>
-                <DropdownMenuItem onSelect={() => setViewMode("split")}>
-                  <Columns2 className="size-4" />
-                  Split view
-                  {effectiveViewMode === "split" && <Check className="ml-auto size-4" />}
-                </DropdownMenuItem>
-              </DropdownMenuContent>
-            </DropdownMenu>
-          </div>
+                  {canPull && (
+                    <DropdownMenuItem onSelect={() => handleGitPull()} disabled={gitOpBusy}>
+                      {isPulling ? (
+                        <Spinner className="size-4" />
+                      ) : (
+                        <ArrowDownToLine className="size-4" />
+                      )}
+                      Git pull
+                    </DropdownMenuItem>
+                  )}
+                  {canPush && (
+                    <DropdownMenuItem onSelect={() => handleGitPush()} disabled={gitOpBusy}>
+                      {isPushing ? (
+                        <Spinner className="size-4" />
+                      ) : (
+                        <ArrowUpFromLine className="size-4" />
+                      )}
+                      Git push
+                    </DropdownMenuItem>
+                  )}
+                  <DropdownMenuItem onSelect={() => fetchSummaryRef.current?.(true)}>
+                    <RefreshCw className="size-4" />
+                    Reload changes
+                  </DropdownMenuItem>
+                  <DropdownMenuItem onSelect={search.handleOpenSearch}>
+                    <Search className="size-4" />
+                    Find in changes
+                  </DropdownMenuItem>
+                  <DropdownMenuItem onSelect={() => setExpandAll(!expandAll)}>
+                    {expandAll ? (
+                      <ChevronsDownUp className="size-4" />
+                    ) : (
+                      <ChevronsUpDown className="size-4" />
+                    )}
+                    {expandAll ? "Collapse all files" : "Expand all files"}
+                  </DropdownMenuItem>
+                  <DropdownMenuSeparator />
+                  <DropdownMenuItem onSelect={() => setViewMode("unified")}>
+                    <Rows2 className="size-4" />
+                    Unified view
+                    {effectiveViewMode === "unified" && <Check className="ml-auto size-4" />}
+                  </DropdownMenuItem>
+                  <DropdownMenuItem onSelect={() => setViewMode("split")}>
+                    <Columns2 className="size-4" />
+                    Split view
+                    {effectiveViewMode === "split" && <Check className="ml-auto size-4" />}
+                  </DropdownMenuItem>
+                </DropdownMenuContent>
+              </DropdownMenu>
+            </div>
+          )}
         </div>
-        {search.searchOpen && (
+        {hasChanges && search.searchOpen && (
           <SearchBar
             ref={search.searchBarRef}
             query={search.searchQuery}
@@ -1942,51 +1898,60 @@ export function DiffView({
             onClose={search.handleCloseSearch}
           />
         )}
-        <div ref={scrollContainerRef} className="min-h-0 flex-1 overflow-y-auto">
-          <div className="flex flex-col gap-3 p-3">
-            {filenames.map((filename, index) => {
-              const isLast = index === filenames.length - 1;
-              const row = (
-                <LazyFileRow
-                  key={filename}
-                  filename={filename}
-                  status={fileStatuses[filename]}
-                  cacheEntry={diffCache.get(filename)}
-                  viewMode={effectiveViewMode}
-                  expandAll={expandAll}
-                  focusedFile={focusedFile}
-                  isActive={activeFile === filename}
-                  scrollContainerRef={scrollContainerRef}
-                  onToggleFile={handleToggleFile}
-                  onLoadMoreContext={handleLoadMoreContext}
-                  onShowFullFile={handleShowFullFile}
-                  onOpenFile={onOpenFile}
-                  onRevertFile={adapter.revertFile ? handleRevertFile : undefined}
-                  onEditorViews={handleEditorViews}
-                />
-              );
-              if (!isLast) return row;
-              // The last row is wrapped in a fake container that owns the
-              // trailing spacer. The wrapper's min-height keeps the bottom of
-              // the scroll content stable so the last row can always be
-              // scrolled to the top of the viewport. Toggling the row's
-              // accordion only resizes the spacer — the LazyFileRow itself
-              // keeps its natural size, so the bordered card hugs its content.
-              return (
-                <div
-                  key={`${filename}-last-wrapper`}
-                  className="flex flex-col"
-                  style={
-                    scrollContainerHeight > 0 ? { minHeight: scrollContainerHeight } : undefined
-                  }
-                >
-                  {row}
-                  <div aria-hidden className="flex-1" />
-                </div>
-              );
-            })}
+        {!hasChanges && (
+          <div className="flex min-h-0 flex-1 items-center justify-center">
+            <span className={`text-sm ${error ? "text-destructive" : "text-muted-foreground"}`}>
+              {loading ? "Loading changes..." : error ? error : "No changes"}
+            </span>
           </div>
-        </div>
+        )}
+        {hasChanges && (
+          <div ref={scrollContainerRef} className="min-h-0 flex-1 overflow-y-auto">
+            <div className="flex flex-col gap-3 p-3">
+              {filenames.map((filename, index) => {
+                const isLast = index === filenames.length - 1;
+                const row = (
+                  <LazyFileRow
+                    key={filename}
+                    filename={filename}
+                    status={fileStatuses[filename]}
+                    cacheEntry={diffCache.get(filename)}
+                    viewMode={effectiveViewMode}
+                    expandAll={expandAll}
+                    focusedFile={focusedFile}
+                    isActive={activeFile === filename}
+                    scrollContainerRef={scrollContainerRef}
+                    onToggleFile={handleToggleFile}
+                    onLoadMoreContext={handleLoadMoreContext}
+                    onShowFullFile={handleShowFullFile}
+                    onOpenFile={onOpenFile}
+                    onRevertFile={adapter.revertFile ? handleRevertFile : undefined}
+                    onEditorViews={handleEditorViews}
+                  />
+                );
+                if (!isLast) return row;
+                // The last row is wrapped in a fake container that owns the
+                // trailing spacer. The wrapper's min-height keeps the bottom of
+                // the scroll content stable so the last row can always be
+                // scrolled to the top of the viewport. Toggling the row's
+                // accordion only resizes the spacer — the LazyFileRow itself
+                // keeps its natural size, so the bordered card hugs its content.
+                return (
+                  <div
+                    key={`${filename}-last-wrapper`}
+                    className="flex flex-col"
+                    style={
+                      scrollContainerHeight > 0 ? { minHeight: scrollContainerHeight } : undefined
+                    }
+                  >
+                    {row}
+                    <div aria-hidden className="flex-1" />
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+        )}
         {/* Inline status banner for one-shot git operations (pull / push).
             Lives above the bottom status bar so it doesn't shift the diff
             viewport. Errors stay until dismissed; success is auto-cleared. */}
@@ -2031,23 +1996,29 @@ export function DiffView({
             )}
           </div>
         )}
-        {/* Bottom status bar — totals for the current diff */}
-        <div className="flex h-9 shrink-0 items-center border-t border-border px-3 text-sm text-muted-foreground">
-          <span className="font-medium text-foreground">{summary.stats.filesChanged}</span>
-          <span className="ml-1">
-            {summary.stats.filesChanged === 1 ? "file" : "files"} changed
-          </span>
-          {summary.stats.insertions > 0 && (
-            <span className="ml-2 text-green-600 dark:text-green-400">
-              +{summary.stats.insertions}
+        {/* Bottom status bar — totals for the current diff. Hidden when
+            there are no changes; the centered "No changes" message in the
+            content area already conveys the empty state. */}
+        {hasChanges && summary && (
+          <div className="flex h-9 shrink-0 items-center border-t border-border px-3 text-sm text-muted-foreground">
+            <span className="font-medium text-foreground">{summary.stats.filesChanged}</span>
+            <span className="ml-1">
+              {summary.stats.filesChanged === 1 ? "file" : "files"} changed
             </span>
-          )}
-          {summary.stats.deletions > 0 && (
-            <span className="ml-1 text-red-600 dark:text-red-400">-{summary.stats.deletions}</span>
-          )}
-        </div>
+            {summary.stats.insertions > 0 && (
+              <span className="ml-2 text-green-600 dark:text-green-400">
+                +{summary.stats.insertions}
+              </span>
+            )}
+            {summary.stats.deletions > 0 && (
+              <span className="ml-1 text-red-600 dark:text-red-400">
+                -{summary.stats.deletions}
+              </span>
+            )}
+          </div>
+        )}
       </div>
-      {canCommit && (
+      {canCommit && hasChanges && summary && (
         <CommitDialog
           open={commitDialogOpen}
           onOpenChange={setCommitDialogOpen}

--- a/packages/dashboard-core/src/components/DiffView.tsx
+++ b/packages/dashboard-core/src/components/DiffView.tsx
@@ -1639,6 +1639,21 @@ export function DiffView({
     </>
   );
 
+  // Manual "reload changes" button — shared between the populated and empty
+  // toolbars so users watching a busy branch can always force a refresh,
+  // even when the current ref has no diff.
+  const renderReloadButton = () => (
+    <button
+      type="button"
+      onClick={() => fetchSummaryRef.current?.(true)}
+      className={ghostBtnAlwaysClass}
+      title="Reload changes"
+      aria-label="Reload changes"
+    >
+      <RefreshCw className="size-3.5" />
+    </button>
+  );
+
   // The loading / error / "no changes" / populated states all share the
   // outer layout (file tree + toolbar + status banner) so switching the
   // changes selector between refs (including a ref with no diff) doesn't
@@ -1650,6 +1665,11 @@ export function DiffView({
   const fileStatuses = hasChanges ? (summary?.fileStatuses ?? {}) : {};
   const filenames = flattenFileTreeOrder(buildFileTree(fileStatuses));
   filenamesRef.current = filenames;
+  // `hasChanges` already implies `summary !== null`, but TypeScript can't
+  // narrow `summary` through a stored boolean. Pull `stats` out once so the
+  // JSX downstream doesn't need a redundant `&& summary` guard for type
+  // narrowing on every `summary.stats.*` access.
+  const stats = hasChanges ? (summary?.stats ?? null) : null;
 
   return (
     <div ref={rootRef} className="@container/diff flex h-full overflow-hidden">
@@ -1665,7 +1685,13 @@ export function DiffView({
             <span className="text-xs font-medium text-muted-foreground">Files</span>
           </div>
           <div className="min-h-0 flex-1 overflow-y-auto py-1 pl-px">
+            {/* Key on workspaceId so switching workspaces remounts the tree
+                and clears its internal "seen directories" memo. Without
+                this, collapsed-directory state from one workspace would
+                bleed into the next when the parent route reuses this
+                DiffView instance across workspace switches. */}
             <ChangesFileTree
+              key={workspaceId}
               fileStatuses={fileStatuses}
               onSelectFile={handleScrollToFile}
               activeFile={activeFile}
@@ -1690,11 +1716,17 @@ export function DiffView({
             {renderSidebarToggle()}
             {renderBranchIndicator(summary?.headBranch)}
           </div>
-          {/* When there are no changes the toolbar collapses to just the
-              pull / push controls (the "just fetch upstream" case). The
-              commit / search / expand / view-mode buttons all operate on
-              a non-empty diff and would be no-ops otherwise. */}
-          {!hasChanges && <div className="flex items-center gap-1">{renderGitSyncButtons()}</div>}
+          {/* When there are no changes the toolbar collapses to the
+              pull / push + reload controls. The commit / search / expand /
+              view-mode buttons all operate on a non-empty diff and would
+              be no-ops, but reload stays so users watching a busy branch
+              can still force a refresh. */}
+          {!hasChanges && (
+            <div className="flex items-center gap-1">
+              {renderGitSyncButtons()}
+              {renderReloadButton()}
+            </div>
+          )}
           {/* Inline action icons — collapsed into the kebab menu below 44rem.
               The threshold is wider than the branch-label one (32rem) because
               the right-side cluster now carries up to eight icons (commit,
@@ -1747,15 +1779,7 @@ export function DiffView({
                   )}
                 </button>
               )}
-              <button
-                type="button"
-                onClick={() => fetchSummaryRef.current?.(true)}
-                className={ghostBtnAlwaysClass}
-                title="Reload changes"
-                aria-label="Reload changes"
-              >
-                <RefreshCw className="size-3.5" />
-              </button>
+              {renderReloadButton()}
               <button
                 type="button"
                 onClick={search.handleOpenSearch}
@@ -1999,31 +2023,25 @@ export function DiffView({
         {/* Bottom status bar — totals for the current diff. Hidden when
             there are no changes; the centered "No changes" message in the
             content area already conveys the empty state. */}
-        {hasChanges && summary && (
+        {stats && (
           <div className="flex h-9 shrink-0 items-center border-t border-border px-3 text-sm text-muted-foreground">
-            <span className="font-medium text-foreground">{summary.stats.filesChanged}</span>
-            <span className="ml-1">
-              {summary.stats.filesChanged === 1 ? "file" : "files"} changed
-            </span>
-            {summary.stats.insertions > 0 && (
-              <span className="ml-2 text-green-600 dark:text-green-400">
-                +{summary.stats.insertions}
-              </span>
+            <span className="font-medium text-foreground">{stats.filesChanged}</span>
+            <span className="ml-1">{stats.filesChanged === 1 ? "file" : "files"} changed</span>
+            {stats.insertions > 0 && (
+              <span className="ml-2 text-green-600 dark:text-green-400">+{stats.insertions}</span>
             )}
-            {summary.stats.deletions > 0 && (
-              <span className="ml-1 text-red-600 dark:text-red-400">
-                -{summary.stats.deletions}
-              </span>
+            {stats.deletions > 0 && (
+              <span className="ml-1 text-red-600 dark:text-red-400">-{stats.deletions}</span>
             )}
           </div>
         )}
       </div>
-      {canCommit && hasChanges && summary && (
+      {canCommit && stats && (
         <CommitDialog
           open={commitDialogOpen}
           onOpenChange={setCommitDialogOpen}
           workspaceId={workspaceId}
-          filesChanged={summary.stats.filesChanged}
+          filesChanged={stats.filesChanged}
           onCommitted={() => {
             // Force a fresh diff fetch — after a commit the working-tree
             // diff (uncommitted) is empty, but the branch diff updates too.

--- a/packages/dashboard-core/src/components/DiffView.tsx
+++ b/packages/dashboard-core/src/components/DiffView.tsx
@@ -1658,10 +1658,15 @@ export function DiffView({
   // outer layout (file tree + toolbar + status banner) so switching the
   // changes selector between refs (including a ref with no diff) doesn't
   // collapse the panel or shift the file-tree column out of the layout.
-  // Loading and error take precedence — when either is true we don't
-  // surface the file list even if `summary` still holds data from a
-  // previous fetch.
-  const hasChanges = Boolean(!loading && !error && summary && summary.stats.filesChanged > 0);
+  //
+  // `loading` is intentionally NOT part of `hasChanges`: keeping stale
+  // summary data visible during a refetch is preferable to blanking the
+  // file list, and the "Loading changes…" message only needs to appear
+  // when there's genuinely no data yet (initial mount; ref switch — both
+  // paired with `setSummary(null)` in the fetch effect). `!error` does
+  // gate it because a failed fetch supersedes whatever the previous
+  // summary held.
+  const hasChanges = Boolean(!error && summary && summary.stats.filesChanged > 0);
   const fileStatuses = hasChanges ? (summary?.fileStatuses ?? {}) : {};
   const filenames = flattenFileTreeOrder(buildFileTree(fileStatuses));
   filenamesRef.current = filenames;

--- a/packages/dashboard-core/src/components/DiffView.tsx
+++ b/packages/dashboard-core/src/components/DiffView.tsx
@@ -1665,11 +1665,11 @@ export function DiffView({
   const fileStatuses = hasChanges ? (summary?.fileStatuses ?? {}) : {};
   const filenames = flattenFileTreeOrder(buildFileTree(fileStatuses));
   filenamesRef.current = filenames;
-  // `hasChanges` already implies `summary !== null`, but TypeScript can't
-  // narrow `summary` through a stored boolean. Pull `stats` out once so the
-  // JSX downstream doesn't need a redundant `&& summary` guard for type
-  // narrowing on every `summary.stats.*` access.
-  const stats = hasChanges ? (summary?.stats ?? null) : null;
+  // `hasChanges` already implies `summary !== null`. Assert it with `!` so
+  // the JSX downstream doesn't need a redundant `&& summary` guard for
+  // type narrowing on every `summary.stats.*` access. (TypeScript can't
+  // narrow through the stored boolean.)
+  const stats = hasChanges ? summary!.stats : null;
 
   return (
     <div ref={rootRef} className="@container/diff flex h-full overflow-hidden">
@@ -1923,7 +1923,20 @@ export function DiffView({
           />
         )}
         {!hasChanges && (
-          <div className="flex min-h-0 flex-1 items-center justify-center">
+          // role="status" implies aria-live="polite" — spell both out as a
+          // defensive pattern. aria-atomic ensures the whole label is
+          // re-read on each transition (e.g. "Loading changes…" → "No
+          // changes" after a ref switch). `<output>` would be biome's
+          // preferred semantic element but it's specifically for the
+          // result of a form computation; a generic status region is
+          // a better fit here.
+          // biome-ignore lint/a11y/useSemanticElements: see comment above.
+          <div
+            role="status"
+            aria-live="polite"
+            aria-atomic="true"
+            className="flex min-h-0 flex-1 items-center justify-center"
+          >
             <span className={`text-sm ${error ? "text-destructive" : "text-muted-foreground"}`}>
               {loading ? "Loading changes..." : error ? error : "No changes"}
             </span>

--- a/packages/dashboard-core/src/components/DiffView.tsx
+++ b/packages/dashboard-core/src/components/DiffView.tsx
@@ -1942,7 +1942,13 @@ export function DiffView({
             aria-atomic="true"
             className="flex min-h-0 flex-1 items-center justify-center"
           >
-            <span className={`text-sm ${error ? "text-destructive" : "text-muted-foreground"}`}>
+            {/* Style follows the same priority as the displayed text:
+                `loading` wins over `error`, so a fresh fetch over a
+                previously-errored summary reads "Loading changes…" in
+                muted text rather than red. */}
+            <span
+              className={`text-sm ${!loading && error ? "text-destructive" : "text-muted-foreground"}`}
+            >
               {loading ? "Loading changes..." : error ? error : "No changes"}
             </span>
           </div>
@@ -2054,12 +2060,19 @@ export function DiffView({
           </div>
         )}
       </div>
-      {canCommit && stats && (
+      {/* Mounted whenever the platform supports commit, not only when
+          there are changes. Otherwise a background fetch failure or a
+          ref switch would unmount the dialog mid-typing and drop the
+          user's commit-message draft. Visibility is controlled by
+          `commitDialogOpen` — the commit button only fires from the
+          populated toolbar, so the dialog never opens with zero
+          changes during normal use. */}
+      {canCommit && (
         <CommitDialog
           open={commitDialogOpen}
           onOpenChange={setCommitDialogOpen}
           workspaceId={workspaceId}
-          filesChanged={stats.filesChanged}
+          filesChanged={stats?.filesChanged ?? 0}
           onCommitted={() => {
             // Force a fresh diff fetch — after a commit the working-tree
             // diff (uncommitted) is empty, but the branch diff updates too.


### PR DESCRIPTION
Closes #460.

## Summary

When the Changes view had no changes to display (e.g. switching the selector from `Uncommitted` to `main`), the file tree disappeared entirely and only a centered "No changes" message was shown, collapsing the layout.

This unifies the four states the view can be in — loading / error / no changes / populated — into one outer layout, so the file tree column stays in place across ref switches.

- **`DiffView`**: removed the early returns for the loading / error / no-changes states. All four states now share the same outer layout (file tree sidebar + toolbar + content + status bar). "No changes" / "Loading…" / error text render in the diff content area instead of replacing the panel.
- **`ChangesFileTree`**: stopped re-expanding every directory on each tree update. A new `seenDirPathsRef` tracks every directory we've ever observed so newly appearing dirs default to expanded, while user-collapsed dirs stay collapsed across diff refreshes — including across ref switches that temporarily empty the tree.
- **`ChangesFileTree`**: dropped the "No files" placeholder so an empty tree renders nothing, keeping the panel layout stable.

## Test plan

- [ ] Open a workspace with uncommitted changes.
- [ ] Open the Changes view — file tree visible on the left, diff on the right.
- [ ] Switch the changes selector from `Uncommitted` to `main` (or any ref with no diff).
- [ ] Verify: file tree column stays rendered; "No changes" appears in the diff area; layout does not shift.
- [ ] Collapse a directory in the tree, then trigger a refetch (e.g. edit a file to fire the SSE branch-status tick). Verify: the directory stays collapsed.
- [ ] Switch from a ref with no changes back to `Uncommitted`. Verify: previously collapsed directories are still collapsed.