### PR TITLE
fix(web): land terminal clicks under the cursor at any zoom level (#463)

### DIFF
--- a/apps/web/src/components/TerminalPanel.tsx
+++ b/apps/web/src/components/TerminalPanel.tsx
@@ -20,7 +20,7 @@ import {
   pointToCell,
   wordSelectionAt,
 } from "../lib/terminal-selection";
-import { getCurrentZoomLevel, subscribeToZoomChanges } from "../lib/zoom";
+import { getCurrentZoomLevel, subscribeToZoomChanges, ZOOM_CSS_VAR } from "../lib/zoom";
 import { TerminalToolbar } from "./TerminalToolbar";
 
 /** Base xterm font size at zoom = 1.0. The terminal lives in a counter-zoomed
@@ -1035,7 +1035,7 @@ export function TerminalPanel({
           // factor (see handleZoomChange above). See band-app/band#463.
           style={{
             bottom: 8 + contentBottomInset,
-            zoom: "calc(1 / var(--app-zoom, 1))",
+            zoom: `calc(1 / var(${ZOOM_CSS_VAR}, 1))`,
           }}
         />
       </div>

--- a/apps/web/src/components/TerminalPanel.tsx
+++ b/apps/web/src/components/TerminalPanel.tsx
@@ -834,7 +834,17 @@ export function TerminalPanel({
       // dance as the DPR path, then a PTY resize so the shell sees the
       // new col/row count. See band-app/band#463 for the bug this fixes.
       const handleZoomChange = (zoom: number) => {
-        const target = BASE_FONT_SIZE * zoom;
+        // Round to 2-decimal precision. `BASE_FONT_SIZE * zoom` produces
+        // IEEE-754 noise at several real zoom levels — e.g.
+        // `13 * 0.6 = 7.800000000000001`, `13 * 0.9 = 11.700000000000001`.
+        // If xterm ever normalises or rounds the stored `fontSize`, the
+        // `===` no-op guard below would silently miss the equality and
+        // we'd dispose+reattach the WebGL addon on every duplicate event
+        // (e.g. cross-window storage echo). Two decimals matches the
+        // precision we already apply to the zoom level itself in
+        // `applyZoomLevelToDom`, so this never throws away meaningful
+        // granularity.
+        const target = Math.round(BASE_FONT_SIZE * zoom * 100) / 100;
         // Bail out if nothing meaningful changed (avoids a redundant
         // WebGL re-attach on no-op events fired by cross-window sync).
         if (terminal.options.fontSize === target) return;

--- a/apps/web/src/components/TerminalPanel.tsx
+++ b/apps/web/src/components/TerminalPanel.tsx
@@ -730,6 +730,13 @@ export function TerminalPanel({
       // Send a PTY resize over the websocket. Coalesced via a small helper
       // because both the ResizeObserver and the zoom-change handler need to
       // notify the server after fitAddon.fit() settles.
+      //
+      // Synchrony note: callers invoke this immediately after
+      // `fitAddon.fit()`, which xterm executes synchronously (it reads
+      // `CharSizeService` after a layout pass and writes the new
+      // `terminal.cols/rows` before returning). If a future xterm version
+      // defers that work, this assumption would need to move to a
+      // post-fit `onResize` listener instead.
       const sendPtyResize = () => {
         if (ws.readyState !== WebSocket.OPEN) return;
         if (terminal.cols <= 0 || terminal.rows <= 0) return;
@@ -764,9 +771,13 @@ export function TerminalPanel({
       const remeasureAndReattach = (opts: { newFontSize?: number } = {}): void => {
         const { newFontSize } = opts;
         if (newFontSize !== undefined) {
-          // Zoom path: assign the new value directly. xterm's options proxy
-          // skips the change event if the new value equals the old, so we
-          // only assign when it's actually different.
+          // Zoom path: assign the new value directly. xterm's options
+          // proxy skips the change event if the new value equals the old,
+          // so we only assign when it's actually different. This is
+          // defensive — the only current caller (`handleZoomChange`)
+          // already early-returns on equality, so in practice this
+          // branch is always taken. Keep the guard so future callers
+          // can't accidentally trigger a no-op WebGL dispose/reattach.
           if (terminal.options.fontSize !== newFontSize) {
             terminal.options.fontSize = newFontSize;
           }
@@ -789,19 +800,26 @@ export function TerminalPanel({
       // run the re-measure dance. DOM renderer is a no-op (CSS sizing
       // handles DPR natively) — `remeasureAndReattach` already handles
       // that by skipping the addon dispose/reattach when none is mounted.
-      const handleDprChange = () => {
+      // Returns true when it actually re-measured so the ResizeObserver
+      // caller can skip its own follow-up `fitAddon.fit()` (the re-measure
+      // already called fit, and a double-call here is more expensive than
+      // it looks because remeasureAndReattach disposes+reattaches the
+      // WebGL addon).
+      const handleDprChange = (): boolean => {
         const currentDpr = window.devicePixelRatio;
-        if (currentDpr === lastDpr) return;
+        if (currentDpr === lastDpr) return false;
         lastDpr = currentDpr;
         remeasureAndReattach();
+        return true;
       };
       const resizeObserver = new ResizeObserver((entries) => {
         const entry = entries[0];
         if (!entry || entry.contentRect.width === 0 || entry.contentRect.height === 0) return;
         // Check DPR before fit so the re-attached addon picks up the right
-        // cell dimensions.
-        handleDprChange();
-        fitAddon.fit();
+        // cell dimensions. When DPR changed, `handleDprChange` already
+        // ran a full re-measure + fit, so skip the extra fit here.
+        const dprChanged = handleDprChange();
+        if (!dprChanged) fitAddon.fit();
         sendPtyResize();
       });
       resizeObserver.observe(containerRef.current!);

--- a/apps/web/src/components/TerminalPanel.tsx
+++ b/apps/web/src/components/TerminalPanel.tsx
@@ -20,7 +20,17 @@ import {
   pointToCell,
   wordSelectionAt,
 } from "../lib/terminal-selection";
+import { getCurrentZoomLevel, subscribeToZoomChanges } from "../lib/zoom";
 import { TerminalToolbar } from "./TerminalToolbar";
+
+/** Base xterm font size at zoom = 1.0. The terminal lives in a counter-zoomed
+ *  container (`zoom: calc(1 / var(--app-zoom, 1))` — see render below) so its
+ *  internal hit-testing math runs in unzoomed pixels regardless of the app
+ *  zoom level. To keep the terminal text visually scaled with the rest of the
+ *  UI, we drive xterm's own `fontSize` instead, multiplying by the live zoom
+ *  factor whenever it changes. See band-app/band#463 for the motivating bug
+ *  (clicks landing on the wrong cell under CSS `zoom`). */
+const BASE_FONT_SIZE = 13;
 
 /** How long a finger must rest on the terminal to trigger word-selection. */
 const LONG_PRESS_MS = 500;
@@ -263,7 +273,11 @@ export function TerminalPanel({
         // first-party xterm.js addons that depend on these APIs.
         allowProposedApi: true,
         cursorBlink: true,
-        fontSize: 13,
+        // Initial font size scales with the persisted app zoom level so the
+        // terminal opens already matching the user's previously-set zoom — the
+        // subscription below keeps it in sync as zoom changes at runtime. See
+        // BASE_FONT_SIZE above for the rationale (xterm lives in counter-zoom).
+        fontSize: BASE_FONT_SIZE * getCurrentZoomLevel(),
         fontFamily: "'SF Mono', Menlo, Monaco, 'Courier New', monospace",
         // iTerm-style row spacing — only safe with the WebGL renderer.
         // The WebGL addon redraws box-drawing (U+2500-U+257F), block
@@ -707,24 +721,37 @@ export function TerminalPanel({
       // Auto-fit on container resize (skip zero-size to avoid killing server PTY).
       // Also handles devicePixelRatio changes (Chrome DevTools mobile-emulation
       // toggle, dragging the window between a retina and non-retina monitor,
-      // OS zoom changes). On DPR change the WebGL canvas's backing store is
-      // mismatched with its CSS display size — the text balloons to fill the
-      // stretched canvas. Re-attaching the addon resizes the backing store and
-      // re-measures cell dimensions at the new DPR; same recovery path as
-      // `onContextLoss`.
+      // OS zoom changes) and app zoom changes. In all three cases the WebGL
+      // canvas's backing store is mismatched with its CSS display size — the
+      // text balloons or shrinks to fill the stretched canvas. Re-attaching
+      // the addon resizes the backing store and re-measures cell dimensions;
+      // same recovery path as `onContextLoss`.
       let lastDpr = window.devicePixelRatio;
-      // Shared DPR-change handler. The WebGL canvas's backing store was
-      // sized for the old DPR; without intervention, the browser stretches
-      // it to fit the new CSS dimensions and the terminal text balloons
-      // by a factor of (newDPR/oldDPR). Two things have to happen:
+      // Send a PTY resize over the websocket. Coalesced via a small helper
+      // because both the ResizeObserver and the zoom-change handler need to
+      // notify the server after fitAddon.fit() settles.
+      const sendPtyResize = () => {
+        if (ws.readyState !== WebSocket.OPEN) return;
+        if (terminal.cols <= 0 || terminal.rows <= 0) return;
+        ws.send(
+          JSON.stringify({
+            type: "resize",
+            cols: terminal.cols,
+            rows: terminal.rows,
+          }),
+        );
+      };
+      // Shared "force xterm to re-measure cell size & re-attach the WebGL
+      // backing store" routine. Two things have to happen:
       //
       // 1) xterm's CharSizeService must re-measure. Its cache feeds the
-      //    WebGL addon's `_updateDimensions`. Toggling `fontSize` is the
-      //    public-API way to force a re-measure — the options proxy fires
-      //    `onSpecificOptionChange("fontSize")` when the new value differs,
-      //    and CharSizeService is subscribed to that. Perturb-by-one then
-      //    restore so the integer delta fires the event without leaving
-      //    the terminal at the wrong size.
+      //    WebGL addon's `_updateDimensions`. Reassigning `fontSize` to a
+      //    distinct value is the public-API way to force a re-measure —
+      //    the options proxy fires `onSpecificOptionChange("fontSize")`
+      //    when the new value differs, and CharSizeService is subscribed
+      //    to that. For the DPR-change path the font size doesn't change,
+      //    so we perturb-by-one and restore; for the zoom path the new
+      //    font size IS the new value and a single assignment suffices.
       //
       // 2) The WebGL addon's `_devicePixelRatio` cache must update. It's
       //    set once at activation and only refreshed via the private
@@ -734,17 +761,21 @@ export function TerminalPanel({
       //    `window.devicePixelRatio`). We do this AFTER the font toggle so
       //    the new addon picks up the freshly measured CharSizeService
       //    values.
-      //
-      // No-op when no addon is mounted (DOM renderer — CSS sizing handles
-      // DPR natively).
-      const handleDprChange = () => {
-        const currentDpr = window.devicePixelRatio;
-        if (currentDpr === lastDpr) return;
-        lastDpr = currentDpr;
-        const fs = terminal.options.fontSize;
-        if (typeof fs === "number") {
-          terminal.options.fontSize = fs + 1;
-          terminal.options.fontSize = fs;
+      const remeasureAndReattach = (opts: { newFontSize?: number } = {}): void => {
+        const { newFontSize } = opts;
+        if (newFontSize !== undefined) {
+          // Zoom path: assign the new value directly. xterm's options proxy
+          // skips the change event if the new value equals the old, so we
+          // only assign when it's actually different.
+          if (terminal.options.fontSize !== newFontSize) {
+            terminal.options.fontSize = newFontSize;
+          }
+        } else {
+          const fs = terminal.options.fontSize;
+          if (typeof fs === "number") {
+            terminal.options.fontSize = fs + 1;
+            terminal.options.fontSize = fs;
+          }
         }
         const addon = webglAddonRef.current;
         if (addon) {
@@ -754,6 +785,16 @@ export function TerminalPanel({
         }
         fitAddon.fit();
       };
+      // DPR-only path: bail out if DPR didn't actually change; otherwise
+      // run the re-measure dance. DOM renderer is a no-op (CSS sizing
+      // handles DPR natively) — `remeasureAndReattach` already handles
+      // that by skipping the addon dispose/reattach when none is mounted.
+      const handleDprChange = () => {
+        const currentDpr = window.devicePixelRatio;
+        if (currentDpr === lastDpr) return;
+        lastDpr = currentDpr;
+        remeasureAndReattach();
+      };
       const resizeObserver = new ResizeObserver((entries) => {
         const entry = entries[0];
         if (!entry || entry.contentRect.width === 0 || entry.contentRect.height === 0) return;
@@ -761,17 +802,28 @@ export function TerminalPanel({
         // cell dimensions.
         handleDprChange();
         fitAddon.fit();
-        if (ws.readyState === WebSocket.OPEN && terminal.cols > 0 && terminal.rows > 0) {
-          ws.send(
-            JSON.stringify({
-              type: "resize",
-              cols: terminal.cols,
-              rows: terminal.rows,
-            }),
-          );
-        }
+        sendPtyResize();
       });
       resizeObserver.observe(containerRef.current!);
+
+      // App-zoom (Cmd+= / Cmd+-) handler. The terminal container is
+      // counter-zoomed via CSS (`zoom: calc(1 / var(--app-zoom, 1))`, see
+      // the render block) so xterm itself lives in unzoomed pixel space —
+      // that's what makes `pointToCell`, drag-select, double-click word,
+      // triple-click line, and link clicks land under the cursor. To keep
+      // the visible terminal text scaled with the rest of the UI we drive
+      // xterm's own `fontSize` here instead. Same re-measure-and-refit
+      // dance as the DPR path, then a PTY resize so the shell sees the
+      // new col/row count. See band-app/band#463 for the bug this fixes.
+      const handleZoomChange = (zoom: number) => {
+        const target = BASE_FONT_SIZE * zoom;
+        // Bail out if nothing meaningful changed (avoids a redundant
+        // WebGL re-attach on no-op events fired by cross-window sync).
+        if (terminal.options.fontSize === target) return;
+        remeasureAndReattach({ newFontSize: target });
+        sendPtyResize();
+      };
+      const unsubscribeZoom = subscribeToZoomChanges(handleZoomChange);
 
       // Belt-and-suspenders: also listen for DPR changes that don't cause a
       // container size change (rare — e.g. an external display unplug, or
@@ -798,6 +850,7 @@ export function TerminalPanel({
         if (selectionRafId !== null) cancelAnimationFrame(selectionRafId);
         webglContextLossDisposable?.dispose();
         dprMql?.removeEventListener("change", onDprMediaChange);
+        unsubscribeZoom();
         cancelLongPress();
         containerEl.removeEventListener("touchstart", onTouchStart);
         containerEl.removeEventListener("touchmove", onTouchMove);
@@ -940,7 +993,22 @@ export function TerminalPanel({
           // `bottom = base gap + toolbar reservation`. Inline style instead of
           // a Tailwind class so the reservation can be 0 on desktop without an
           // extra conditional class.
-          style={{ bottom: 8 + contentBottomInset }}
+          //
+          // `zoom: calc(1 / var(--app-zoom, 1))` counter-zooms the terminal
+          // out of the document-level CSS `zoom` coordinate space — see
+          // `applyZoomLevel` in lib/zoom.ts for the `--app-zoom` CSS variable.
+          // The `<html>` `zoom` multiplied by the counter-zoom is 1, so xterm
+          // renders into unzoomed pixels. That keeps `getBoundingClientRect`,
+          // pointer `clientX/Y`, xterm's internal `CharSizeService`, and the
+          // WebGL canvas backing store all in the same coordinate system —
+          // which is what makes clicks land on the cell under the cursor at
+          // any zoom level. The visible terminal size still scales with zoom
+          // because we drive `terminal.options.fontSize` from the live zoom
+          // factor (see handleZoomChange above). See band-app/band#463.
+          style={{
+            bottom: 8 + contentBottomInset,
+            zoom: "calc(1 / var(--app-zoom, 1))",
+          }}
         />
       </div>
       {/* iOS / touch keyboard accessory toolbar. Renders nothing on desktop

--- a/apps/web/src/lib/zoom.ts
+++ b/apps/web/src/lib/zoom.ts
@@ -59,6 +59,13 @@ export function saveZoomLevel(level: number): void {
  * level helper exists only for the sync path that must avoid the
  * (currently benign in Chromium, but spec-non-guaranteed) cross-window
  * storage echo.
+ *
+ * Exception behaviour: `dispatchEvent` runs synchronously and propagates
+ * any exception thrown by a subscriber. If a subscriber throws, this
+ * function throws and the return value never reaches the caller — do not
+ * rely on the return value in contexts that need to recover from a
+ * subscriber error. The current call sites (`applyZoomLevel` discards
+ * the void path, `ZoomSync` doesn't use the return) are unaffected.
  */
 export function applyZoomLevelToDom(level: number): number {
   const clamped = Math.min(MAX_ZOOM, Math.max(MIN_ZOOM, level));

--- a/apps/web/src/lib/zoom.ts
+++ b/apps/web/src/lib/zoom.ts
@@ -47,12 +47,20 @@ export function saveZoomLevel(level: number): void {
 }
 
 /**
- * Apply a zoom level to the document root, mirror it onto the
- * {@link ZOOM_CSS_VAR} custom property, dispatch the
- * {@link ZOOM_CHANGE_EVENT} so subscribers (e.g. TerminalPanel) can react, and
- * persist the level to localStorage.
+ * DOM-only zoom application: updates `<html>` `zoom`, mirrors the value onto
+ * the {@link ZOOM_CSS_VAR} CSS variable, and dispatches the
+ * {@link ZOOM_CHANGE_EVENT}. Does NOT persist to localStorage — call this
+ * from contexts where the value is already persisted elsewhere (e.g. the
+ * cross-window `storage` event handler in `ZoomSync`, where the originating
+ * window already wrote the value). Returns the clamped/rounded level it
+ * actually applied so callers can save it without re-clamping.
+ *
+ * Prefer {@link applyZoomLevel} for user-driven zoom changes; this lower-
+ * level helper exists only for the sync path that must avoid the
+ * (currently benign in Chromium, but spec-non-guaranteed) cross-window
+ * storage echo.
  */
-export function applyZoomLevel(level: number): void {
+export function applyZoomLevelToDom(level: number): number {
   const clamped = Math.min(MAX_ZOOM, Math.max(MIN_ZOOM, level));
   const rounded = Math.round(clamped * 100) / 100;
   const root = document.documentElement;
@@ -61,14 +69,31 @@ export function applyZoomLevel(level: number): void {
   // (TerminalPanel's xterm container) can do
   // `zoom: calc(1 / var(--app-zoom, 1))` without touching JS.
   root.style.setProperty(ZOOM_CSS_VAR, String(rounded));
-  saveZoomLevel(rounded);
-  // Fire the change event AFTER the DOM/storage are up to date so subscribers
-  // can read the post-update state synchronously.
+  // Fire the change event AFTER the DOM is up to date so subscribers can
+  // read the post-update state synchronously. We surface dispatch failures
+  // in dev so a regression doesn't silently swallow zoom updates — the
+  // CustomEvent constructor and `dispatchEvent` have full cross-browser
+  // support so this branch should never fire, but if it ever does we want
+  // a console signal rather than a mystery missing update.
   try {
     window.dispatchEvent(new CustomEvent<number>(ZOOM_CHANGE_EVENT, { detail: rounded }));
-  } catch {
-    // CustomEvent is widely supported; this catch only guards exotic test envs.
+  } catch (err) {
+    if (process.env.NODE_ENV !== "production") {
+      console.error("[zoom] failed to dispatch zoom-changed event", err);
+    }
   }
+  return rounded;
+}
+
+/**
+ * Apply a zoom level to the document root, mirror it onto the
+ * {@link ZOOM_CSS_VAR} custom property, dispatch the
+ * {@link ZOOM_CHANGE_EVENT} so subscribers (e.g. TerminalPanel) can react, and
+ * persist the level to localStorage.
+ */
+export function applyZoomLevel(level: number): void {
+  const applied = applyZoomLevelToDom(level);
+  saveZoomLevel(applied);
 }
 
 /**

--- a/apps/web/src/lib/zoom.ts
+++ b/apps/web/src/lib/zoom.ts
@@ -5,6 +5,21 @@ export const MIN_ZOOM = 0.5;
 export const MAX_ZOOM = 2.0;
 export const ZOOM_STEP = 0.1;
 
+/** CSS custom property mirroring the current `<html>` zoom factor. Anything that
+ *  needs to opt out of the document-level CSS `zoom` (notably the xterm.js
+ *  terminal — see TerminalPanel) can counter-scale with
+ *  `zoom: calc(1 / var(--app-zoom, 1))`. The `<html>` `zoom` itself is what
+ *  zooms everything else; the CSS variable just gives consumers a handle. */
+export const ZOOM_CSS_VAR = "--app-zoom";
+
+/** Custom window event fired whenever the app-wide zoom level changes (locally
+ *  via {@link applyZoomLevel} or via the cross-window storage handler in
+ *  `ZoomSync`). Subscribers receive the new level via `event.detail`.
+ *  TerminalPanel uses this to drive xterm's `fontSize` so terminal text scales
+ *  with the rest of the UI even though the terminal container itself is taken
+ *  out of the document-level `zoom` coordinate space. */
+export const ZOOM_CHANGE_EVENT = "band:zoom-changed";
+
 /**
  * Load the persisted zoom level (0.5–2.0).
  * Falls back to DEFAULT_ZOOM if nothing is stored or the value is invalid.
@@ -31,12 +46,63 @@ export function saveZoomLevel(level: number): void {
   } catch {}
 }
 
-/** Apply a zoom level to the document root and persist it. */
+/**
+ * Apply a zoom level to the document root, mirror it onto the
+ * {@link ZOOM_CSS_VAR} custom property, dispatch the
+ * {@link ZOOM_CHANGE_EVENT} so subscribers (e.g. TerminalPanel) can react, and
+ * persist the level to localStorage.
+ */
 export function applyZoomLevel(level: number): void {
   const clamped = Math.min(MAX_ZOOM, Math.max(MIN_ZOOM, level));
   const rounded = Math.round(clamped * 100) / 100;
-  document.documentElement.style.zoom = String(rounded);
+  const root = document.documentElement;
+  root.style.zoom = String(rounded);
+  // Mirror onto a CSS custom property so anything that needs to counter-zoom
+  // (TerminalPanel's xterm container) can do
+  // `zoom: calc(1 / var(--app-zoom, 1))` without touching JS.
+  root.style.setProperty(ZOOM_CSS_VAR, String(rounded));
   saveZoomLevel(rounded);
+  // Fire the change event AFTER the DOM/storage are up to date so subscribers
+  // can read the post-update state synchronously.
+  try {
+    window.dispatchEvent(new CustomEvent<number>(ZOOM_CHANGE_EVENT, { detail: rounded }));
+  } catch {
+    // CustomEvent is widely supported; this catch only guards exotic test envs.
+  }
+}
+
+/**
+ * Read the currently applied zoom factor. Prefers the live CSS variable on
+ * `<html>` (what the DOM is actually rendering with) and falls back to the
+ * persisted value, then the default. Safe to call before any `applyZoomLevel`
+ * has run — returns {@link DEFAULT_ZOOM} in that case.
+ */
+export function getCurrentZoomLevel(): number {
+  if (typeof document !== "undefined") {
+    const css = document.documentElement.style.getPropertyValue(ZOOM_CSS_VAR);
+    if (css) {
+      const parsed = Number.parseFloat(css);
+      if (!Number.isNaN(parsed) && parsed >= MIN_ZOOM && parsed <= MAX_ZOOM) {
+        return parsed;
+      }
+    }
+  }
+  return loadZoomLevel();
+}
+
+/**
+ * Subscribe to {@link ZOOM_CHANGE_EVENT}. The handler is invoked with the new
+ * zoom level whenever {@link applyZoomLevel} runs (locally or via cross-window
+ * sync). Returns an unsubscribe function.
+ */
+export function subscribeToZoomChanges(handler: (level: number) => void): () => void {
+  if (typeof window === "undefined") return () => {};
+  const listener = (e: Event) => {
+    const detail = (e as CustomEvent<number>).detail;
+    if (typeof detail === "number") handler(detail);
+  };
+  window.addEventListener(ZOOM_CHANGE_EVENT, listener);
+  return () => window.removeEventListener(ZOOM_CHANGE_EVENT, listener);
 }
 
 export function zoomIn(): void {

--- a/apps/web/src/lib/zoom.ts
+++ b/apps/web/src/lib/zoom.ts
@@ -70,12 +70,13 @@ export function applyZoomLevelToDom(level: number): number {
   // `zoom: calc(1 / var(--app-zoom, 1))` without touching JS.
   root.style.setProperty(ZOOM_CSS_VAR, String(rounded));
   // Fire the change event AFTER the DOM is up to date so subscribers can
-  // read the post-update state synchronously. `CustomEvent` and
-  // `dispatchEvent` have universal cross-browser support and cannot throw
-  // with a `number` detail, so we deliberately do NOT wrap this in a
-  // try/catch — a silent swallow would only mask a real regression (the
-  // event failing to fire means TerminalPanel would stop reacting to
-  // zoom, and we'd rather see the exception loudly).
+  // read the post-update state synchronously. We deliberately do NOT
+  // wrap this in a try/catch: `dispatchEvent` propagates exceptions
+  // thrown synchronously by listeners, but a silent swallow here would
+  // mask the real failure modes (a buggy subscriber, or the event
+  // mysteriously failing to fire and TerminalPanel no longer reacting to
+  // zoom). We'd rather see those exceptions loudly than debug a missing
+  // zoom update later.
   window.dispatchEvent(new CustomEvent<number>(ZOOM_CHANGE_EVENT, { detail: rounded }));
   return rounded;
 }
@@ -96,6 +97,13 @@ export function applyZoomLevel(level: number): void {
  * `<html>` (what the DOM is actually rendering with) and falls back to the
  * persisted value, then the default. Safe to call before any `applyZoomLevel`
  * has run — returns {@link DEFAULT_ZOOM} in that case.
+ *
+ * NOTE: do NOT detect "has the user changed zoom" via a truthiness check
+ * on `document.documentElement.style.zoom`. The pre-paint `ZOOM_INIT_SCRIPT`
+ * (see `apps/web/src/routes/__root.tsx`) always seeds `<html>` with an
+ * inline `zoom: "1"` even on first boot, so `style.zoom` is always
+ * truthy after first paint. Read the persisted value via
+ * {@link loadZoomLevel} (or this helper) instead.
  */
 export function getCurrentZoomLevel(): number {
   if (typeof document !== "undefined") {

--- a/apps/web/src/lib/zoom.ts
+++ b/apps/web/src/lib/zoom.ts
@@ -70,18 +70,13 @@ export function applyZoomLevelToDom(level: number): number {
   // `zoom: calc(1 / var(--app-zoom, 1))` without touching JS.
   root.style.setProperty(ZOOM_CSS_VAR, String(rounded));
   // Fire the change event AFTER the DOM is up to date so subscribers can
-  // read the post-update state synchronously. We surface dispatch failures
-  // in dev so a regression doesn't silently swallow zoom updates — the
-  // CustomEvent constructor and `dispatchEvent` have full cross-browser
-  // support so this branch should never fire, but if it ever does we want
-  // a console signal rather than a mystery missing update.
-  try {
-    window.dispatchEvent(new CustomEvent<number>(ZOOM_CHANGE_EVENT, { detail: rounded }));
-  } catch (err) {
-    if (process.env.NODE_ENV !== "production") {
-      console.error("[zoom] failed to dispatch zoom-changed event", err);
-    }
-  }
+  // read the post-update state synchronously. `CustomEvent` and
+  // `dispatchEvent` have universal cross-browser support and cannot throw
+  // with a `number` detail, so we deliberately do NOT wrap this in a
+  // try/catch — a silent swallow would only mask a real regression (the
+  // event failing to fire means TerminalPanel would stop reacting to
+  // zoom, and we'd rather see the exception loudly).
+  window.dispatchEvent(new CustomEvent<number>(ZOOM_CHANGE_EVENT, { detail: rounded }));
   return rounded;
 }
 

--- a/apps/web/src/lib/zoom.ts
+++ b/apps/web/src/lib/zoom.ts
@@ -86,10 +86,20 @@ export function applyZoomLevelToDom(level: number): number {
  * {@link ZOOM_CSS_VAR} custom property, dispatch the
  * {@link ZOOM_CHANGE_EVENT} so subscribers (e.g. TerminalPanel) can react, and
  * persist the level to localStorage.
+ *
+ * Ordering: clamp/round once at the top, persist FIRST, then apply to the
+ * DOM (which dispatches the event last). `dispatchEvent` propagates
+ * synchronous exceptions from listeners — if a buggy subscriber throws,
+ * we'd rather leave both localStorage and the live DOM updated than have
+ * the persisted value drift behind the rendered one. The dispatch is the
+ * last step in `applyZoomLevelToDom`, so even a throw there leaves the
+ * caller-visible state consistent.
  */
 export function applyZoomLevel(level: number): void {
-  const applied = applyZoomLevelToDom(level);
-  saveZoomLevel(applied);
+  const clamped = Math.min(MAX_ZOOM, Math.max(MIN_ZOOM, level));
+  const rounded = Math.round(clamped * 100) / 100;
+  saveZoomLevel(rounded);
+  applyZoomLevelToDom(rounded);
 }
 
 /**

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -38,7 +38,14 @@ import { useZoom } from "../hooks/useZoom";
 import { getElectronBridge } from "../lib/desktop-ipc";
 import { isDesktop } from "../lib/is-desktop";
 import { parseWorkspaceFromPath } from "../lib/parse-workspace";
-import { applyZoomLevel, loadZoomLevel, zoomIn, zoomOut, zoomReset } from "../lib/zoom";
+import {
+  applyZoomLevel,
+  applyZoomLevelToDom,
+  loadZoomLevel,
+  zoomIn,
+  zoomOut,
+  zoomReset,
+} from "../lib/zoom";
 import "../styles/globals.css";
 
 const adapter = isDesktop ? new DesktopDashboardAdapter() : new WebDashboardAdapter();
@@ -242,16 +249,19 @@ function ZoomSync() {
 
   // Cross-window zoom sync via the storage event.
   // When another window updates "band:zoom-level" in localStorage,
-  // apply the change immediately to this window's DOM. Use `applyZoomLevel`
-  // (rather than poking `style.zoom` directly) so the `--app-zoom` CSS
-  // variable and the `band:zoom-changed` window event stay in sync — the
-  // TerminalPanel relies on both to update xterm's fontSize.
+  // apply the change immediately to this window's DOM. Use the DOM-only
+  // helper (no localStorage write) since the originating window already
+  // persisted the value — re-saving here would be a redundant write that
+  // relies on Chromium's same-value-write behaviour not echoing a storage
+  // event (the spec doesn't require that). The helper still updates the
+  // `--app-zoom` CSS variable and dispatches the `band:zoom-changed`
+  // window event, which is what TerminalPanel subscribes to.
   useEffect(() => {
     const handleStorage = (e: StorageEvent) => {
       if (e.key !== "band:zoom-level" || !e.newValue) return;
       const level = Number.parseFloat(e.newValue);
       if (!Number.isNaN(level) && level >= 0.5 && level <= 2) {
-        applyZoomLevel(level);
+        applyZoomLevelToDom(level);
       }
     };
 

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -94,7 +94,14 @@ const THEME_INIT_SCRIPT = `(function(){try{var t=localStorage.getItem("band-them
  *  to counter-zoom xterm out of the document-level zoom coordinate space — see
  *  ZOOM_CSS_VAR in zoom.ts. We always set the var (defaulting to 1) so the
  *  counter-zoom `calc(1 / var(--app-zoom, 1))` resolves cleanly even when no
- *  zoom override is persisted. */
+ *  zoom override is persisted.
+ *
+ *  Note: this also means `<html>` always gets an inline `zoom: 1` on first
+ *  boot (the previous script left `zoom` unset in that case). This is
+ *  functionally identical to the browser default, but `getComputedStyle`
+ *  on `<html>` now reports `zoom: "1"` instead of `""` — do not use a
+ *  truthiness check on `style.zoom` to detect "has the user ever changed
+ *  zoom"; read the persisted value via `loadZoomLevel()` instead. */
 const ZOOM_INIT_SCRIPT = `(function(){try{var z=localStorage.getItem("band:zoom-level");var n=1;if(z){var p=parseFloat(z);if(!isNaN(p)&&p>=0.5&&p<=2)n=p;}var d=document.documentElement;d.style.zoom=String(n);d.style.setProperty("--app-zoom",String(n));}catch(e){}})()`;
 
 /** Applies a theme value ("dark", "light", or "system") to the document root. */

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -82,8 +82,13 @@ function NotFound() {
 const THEME_INIT_SCRIPT = `(function(){try{var t=localStorage.getItem("band-theme")||"dark";var d=document.documentElement;if(t==="system"){if(window.matchMedia("(prefers-color-scheme:dark)").matches)d.classList.add("dark");else d.classList.remove("dark")}else if(t==="dark"){d.classList.add("dark")}else{d.classList.remove("dark")}}catch(e){document.documentElement.classList.add("dark")}})()`;
 
 /** Blocking script injected into <head> to apply the zoom level before first paint.
- *  Reads a cached zoom value from localStorage (written by ZoomSync / zoom.ts). */
-const ZOOM_INIT_SCRIPT = `(function(){try{var z=localStorage.getItem("band:zoom-level");if(z){var n=parseFloat(z);if(!isNaN(n)&&n>=0.5&&n<=2)document.documentElement.style.zoom=String(n)}}catch(e){}})()`;
+ *  Reads a cached zoom value from localStorage (written by ZoomSync / zoom.ts).
+ *  Also seeds the `--app-zoom` CSS custom property the TerminalPanel relies on
+ *  to counter-zoom xterm out of the document-level zoom coordinate space — see
+ *  ZOOM_CSS_VAR in zoom.ts. We always set the var (defaulting to 1) so the
+ *  counter-zoom `calc(1 / var(--app-zoom, 1))` resolves cleanly even when no
+ *  zoom override is persisted. */
+const ZOOM_INIT_SCRIPT = `(function(){try{var z=localStorage.getItem("band:zoom-level");var n=1;if(z){var p=parseFloat(z);if(!isNaN(p)&&p>=0.5&&p<=2)n=p;}var d=document.documentElement;d.style.zoom=String(n);d.style.setProperty("--app-zoom",String(n));}catch(e){}})()`;
 
 /** Applies a theme value ("dark", "light", or "system") to the document root. */
 function applyTheme(theme: string) {
@@ -237,13 +242,16 @@ function ZoomSync() {
 
   // Cross-window zoom sync via the storage event.
   // When another window updates "band:zoom-level" in localStorage,
-  // apply the change immediately to this window's DOM.
+  // apply the change immediately to this window's DOM. Use `applyZoomLevel`
+  // (rather than poking `style.zoom` directly) so the `--app-zoom` CSS
+  // variable and the `band:zoom-changed` window event stay in sync — the
+  // TerminalPanel relies on both to update xterm's fontSize.
   useEffect(() => {
     const handleStorage = (e: StorageEvent) => {
       if (e.key !== "band:zoom-level" || !e.newValue) return;
       const level = Number.parseFloat(e.newValue);
       if (!Number.isNaN(level) && level >= 0.5 && level <= 2) {
-        document.documentElement.style.zoom = String(level);
+        applyZoomLevel(level);
       }
     };
 

--- a/apps/web/tests/terminal-selection.test.ts
+++ b/apps/web/tests/terminal-selection.test.ts
@@ -170,6 +170,54 @@ describe("pointToCell", () => {
     const screen = makeScreenEl(0, 0);
     expect(pointToCell(100, 100, terminal, screen)).toEqual({ col: 0, row: 7 });
   });
+
+  // Regression coverage for band-app/band#463. We fix the bug by taking the
+  // xterm container out of the document-level CSS `zoom` coordinate space
+  // (counter-zoom on the container — see TerminalPanel render block). Once
+  // that's in place, both `clientX/Y` and `getBoundingClientRect()` report
+  // values in unzoomed CSS pixels, and `pointToCell`'s math is independent
+  // of the app zoom level: the cell under the cursor is always selected.
+  //
+  // These tests assert that property by feeding `pointToCell` rect+click
+  // pairs that are consistently scaled together — the cell index returned
+  // must not depend on the scale factor.
+  describe("regression: cell mapping is stable under counter-zoom", () => {
+    function clickAtCell(
+      col: number,
+      row: number,
+      cols: number,
+      rows: number,
+      rectWidth: number,
+      rectHeight: number,
+      rectLeft = 0,
+      rectTop = 0,
+    ): { clientX: number; clientY: number } {
+      // Pick the middle of the target cell so off-by-one in either floor()
+      // or the half-pixel rect boundary doesn't slip us into a neighbor.
+      const cellW = rectWidth / cols;
+      const cellH = rectHeight / rows;
+      return {
+        clientX: rectLeft + (col + 0.5) * cellW,
+        clientY: rectTop + (row + 0.5) * cellH,
+      };
+    }
+
+    for (const scale of [0.5, 0.75, 1.0, 1.25, 1.5, 2.0]) {
+      it(`maps a click at scale=${scale} to the expected cell`, () => {
+        const terminal = makeTerminal({ cols: 80, rows: 24 });
+        // At app zoom = `scale`, the terminal container is counter-zoomed
+        // to 1/scale so xterm sees an unzoomed rect. The font is driven
+        // from `BASE_FONT_SIZE * scale` (see TerminalPanel), which gives
+        // the same number of cols/rows as if zoom were 1.0. To simulate
+        // this we keep the rect dimensions IDENTICAL to the unzoomed
+        // case: that's the whole guarantee of the counter-zoom approach.
+        const screen = makeScreenEl(800, 480, 50, 30);
+        // Click on the cell at (col=42, row=10).
+        const { clientX, clientY } = clickAtCell(42, 10, 80, 24, 800, 480, 50, 30);
+        expect(pointToCell(clientX, clientY, terminal, screen)).toEqual({ col: 42, row: 10 });
+      });
+    }
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/apps/web/tests/terminal-selection.test.ts
+++ b/apps/web/tests/terminal-selection.test.ts
@@ -171,17 +171,23 @@ describe("pointToCell", () => {
     expect(pointToCell(100, 100, terminal, screen)).toEqual({ col: 0, row: 7 });
   });
 
-  // Regression coverage for band-app/band#463. We fix the bug by taking the
-  // xterm container out of the document-level CSS `zoom` coordinate space
-  // (counter-zoom on the container — see TerminalPanel render block). Once
-  // that's in place, both `clientX/Y` and `getBoundingClientRect()` report
-  // values in unzoomed CSS pixels, and `pointToCell`'s math is independent
-  // of the app zoom level: the cell under the cursor is always selected.
+  // Regression coverage for band-app/band#463. We fix the bug by taking
+  // the xterm container out of the document-level CSS `zoom` coordinate
+  // space (counter-zoom on the container — see TerminalPanel render
+  // block). Once that's in place both `clientX/Y` and
+  // `getBoundingClientRect()` report values in unzoomed CSS pixels, and
+  // `pointToCell`'s math depends only on the relative position of the
+  // click within the rect.
   //
-  // These tests assert that property by feeding `pointToCell` rect+click
-  // pairs that are consistently scaled together — the cell index returned
-  // must not depend on the scale factor.
-  describe("regression: cell mapping is stable under counter-zoom", () => {
+  // The single assertion below pins that property: the helper computes
+  // the click coordinate from a target cell + rect, so passing those
+  // back into `pointToCell` MUST recover the target cell. The math is
+  // scale-invariant by construction, which is exactly what the
+  // counter-zoom approach guarantees at runtime — there's no useful
+  // additional coverage in re-running the same assertion across
+  // arbitrary scale factors (every parameterized iteration would feed
+  // identical inputs).
+  it("regression #463: maps a click to the target cell under counter-zoom", () => {
     function clickAtCell(
       col: number,
       row: number,
@@ -202,21 +208,10 @@ describe("pointToCell", () => {
       };
     }
 
-    for (const scale of [0.5, 0.75, 1.0, 1.25, 1.5, 2.0]) {
-      it(`maps a click at scale=${scale} to the expected cell`, () => {
-        const terminal = makeTerminal({ cols: 80, rows: 24 });
-        // At app zoom = `scale`, the terminal container is counter-zoomed
-        // to 1/scale so xterm sees an unzoomed rect. The font is driven
-        // from `BASE_FONT_SIZE * scale` (see TerminalPanel), which gives
-        // the same number of cols/rows as if zoom were 1.0. To simulate
-        // this we keep the rect dimensions IDENTICAL to the unzoomed
-        // case: that's the whole guarantee of the counter-zoom approach.
-        const screen = makeScreenEl(800, 480, 50, 30);
-        // Click on the cell at (col=42, row=10).
-        const { clientX, clientY } = clickAtCell(42, 10, 80, 24, 800, 480, 50, 30);
-        expect(pointToCell(clientX, clientY, terminal, screen)).toEqual({ col: 42, row: 10 });
-      });
-    }
+    const terminal = makeTerminal({ cols: 80, rows: 24 });
+    const screen = makeScreenEl(800, 480, 50, 30);
+    const { clientX, clientY } = clickAtCell(42, 10, 80, 24, 800, 480, 50, 30);
+    expect(pointToCell(clientX, clientY, terminal, screen)).toEqual({ col: 42, row: 10 });
   });
 });
 

--- a/apps/web/tests/terminal-selection.test.ts
+++ b/apps/web/tests/terminal-selection.test.ts
@@ -187,7 +187,7 @@ describe("pointToCell", () => {
   // additional coverage in re-running the same assertion across
   // arbitrary scale factors (every parameterized iteration would feed
   // identical inputs).
-  it("regression #463: maps a click to the target cell under counter-zoom", () => {
+  it("regression #463: maps a click coordinate to the expected cell (scale-invariant math underpins the counter-zoom fix)", () => {
     function clickAtCell(
       col: number,
       row: number,

--- a/apps/web/tests/terminal-selection.test.ts
+++ b/apps/web/tests/terminal-selection.test.ts
@@ -171,23 +171,20 @@ describe("pointToCell", () => {
     expect(pointToCell(100, 100, terminal, screen)).toEqual({ col: 0, row: 7 });
   });
 
-  // Regression coverage for band-app/band#463. We fix the bug by taking
-  // the xterm container out of the document-level CSS `zoom` coordinate
-  // space (counter-zoom on the container — see TerminalPanel render
-  // block). Once that's in place both `clientX/Y` and
-  // `getBoundingClientRect()` report values in unzoomed CSS pixels, and
-  // `pointToCell`'s math depends only on the relative position of the
-  // click within the rect.
+  // Smoke test for the math underpinning the #463 counter-zoom fix.
   //
-  // The single assertion below pins that property: the helper computes
-  // the click coordinate from a target cell + rect, so passing those
-  // back into `pointToCell` MUST recover the target cell. The math is
-  // scale-invariant by construction, which is exactly what the
-  // counter-zoom approach guarantees at runtime — there's no useful
-  // additional coverage in re-running the same assertion across
-  // arbitrary scale factors (every parameterized iteration would feed
-  // identical inputs).
-  it("regression #463: maps a click coordinate to the expected cell (scale-invariant math underpins the counter-zoom fix)", () => {
+  // The actual bug — `clientX/Y` and `getBoundingClientRect()` living in
+  // *different* coordinate spaces under CSS `zoom` — can't be observed
+  // in jsdom (no `zoom` impl), so this test is unavoidably a round-trip
+  // identity: `clickAtCell` is defined as the inverse of `pointToCell`,
+  // so feeding the output of one into the other passes by construction.
+  // Keeping it because it exercises the `makeScreenEl` rect setup and
+  // catches gross regressions in the math itself (e.g. swapped axes,
+  // wrong viewportY handling). But this does NOT pin the fix — reverting
+  // the `zoom: calc(1 / var(--app-zoom, 1))` style on the xterm
+  // container would let #463 regress without failing this test. The
+  // real verification lives in the manual test plan on the PR.
+  it("round-trips a click coordinate through pointToCell", () => {
     function clickAtCell(
       col: number,
       row: number,

--- a/apps/web/tests/terminal-selection.test.ts
+++ b/apps/web/tests/terminal-selection.test.ts
@@ -207,6 +207,10 @@ describe("pointToCell", () => {
 
     const terminal = makeTerminal({ cols: 80, rows: 24 });
     const screen = makeScreenEl(800, 480, 50, 30);
+    // The (800, 480, 50, 30) below MUST match makeScreenEl above — the
+    // round-trip only proves anything if both sides use the same rect
+    // geometry. If `makeScreenEl`'s argument order ever changes, this
+    // helper call has to change with it.
     const { clientX, clientY } = clickAtCell(42, 10, 80, 24, 800, 480, 50, 30);
     expect(pointToCell(clientX, clientY, terminal, screen)).toEqual({ col: 42, row: 10 });
   });

--- a/apps/web/tests/zoom.test.ts
+++ b/apps/web/tests/zoom.test.ts
@@ -1,0 +1,151 @@
+// @vitest-environment jsdom
+/**
+ * Tests for the zoom helpers backing the TerminalPanel's response to app-zoom
+ * changes (band-app/band#463). The CSS variable + custom-event plumbing is
+ * what lets the terminal counter-scale itself out of the document-level
+ * `zoom` while still driving `terminal.options.fontSize` from the live zoom
+ * factor.
+ */
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  applyZoomLevel,
+  DEFAULT_ZOOM,
+  getCurrentZoomLevel,
+  MAX_ZOOM,
+  MIN_ZOOM,
+  subscribeToZoomChanges,
+  ZOOM_CHANGE_EVENT,
+  ZOOM_CSS_VAR,
+} from "../src/lib/zoom";
+
+function resetZoomState() {
+  // Clear the persisted value so each test starts from a known baseline. The
+  // CSS var on <html> is cleared too so `getCurrentZoomLevel` falls back
+  // cleanly.
+  try {
+    localStorage.removeItem("band:zoom-level");
+  } catch {}
+  document.documentElement.style.removeProperty(ZOOM_CSS_VAR);
+  document.documentElement.style.removeProperty("zoom");
+}
+
+beforeEach(resetZoomState);
+afterEach(resetZoomState);
+
+describe("applyZoomLevel", () => {
+  it("writes `zoom` and `--app-zoom` to <html>", () => {
+    applyZoomLevel(1.5);
+    expect(document.documentElement.style.zoom).toBe("1.5");
+    expect(document.documentElement.style.getPropertyValue(ZOOM_CSS_VAR)).toBe("1.5");
+  });
+
+  it("persists the rounded value to localStorage", () => {
+    applyZoomLevel(1.234567); // rounded to 1.23
+    expect(localStorage.getItem("band:zoom-level")).toBe("1.23");
+    // CSS var matches the rounded value, not the raw input.
+    expect(document.documentElement.style.getPropertyValue(ZOOM_CSS_VAR)).toBe("1.23");
+  });
+
+  it("clamps to [MIN_ZOOM, MAX_ZOOM]", () => {
+    applyZoomLevel(10);
+    expect(document.documentElement.style.zoom).toBe(String(MAX_ZOOM));
+    applyZoomLevel(0);
+    expect(document.documentElement.style.zoom).toBe(String(MIN_ZOOM));
+  });
+
+  it("dispatches a `band:zoom-changed` window event with the new level", () => {
+    const events: number[] = [];
+    const listener = (e: Event) => {
+      const detail = (e as CustomEvent<number>).detail;
+      events.push(detail);
+    };
+    window.addEventListener(ZOOM_CHANGE_EVENT, listener);
+    try {
+      applyZoomLevel(1.2);
+      applyZoomLevel(0.75);
+    } finally {
+      window.removeEventListener(ZOOM_CHANGE_EVENT, listener);
+    }
+    expect(events).toEqual([1.2, 0.75]);
+  });
+});
+
+describe("getCurrentZoomLevel", () => {
+  it("returns DEFAULT_ZOOM when nothing has been applied and storage is empty", () => {
+    expect(getCurrentZoomLevel()).toBe(DEFAULT_ZOOM);
+  });
+
+  it("prefers the live CSS variable over the persisted value", () => {
+    // Persisted: 1.5; live CSS var: 0.8. The CSS var wins because it reflects
+    // what the DOM is actually rendering with (e.g. another window pushed an
+    // update via the storage event handler — see ZoomSync).
+    localStorage.setItem("band:zoom-level", "1.5");
+    document.documentElement.style.setProperty(ZOOM_CSS_VAR, "0.8");
+    expect(getCurrentZoomLevel()).toBe(0.8);
+  });
+
+  it("falls back to localStorage when the CSS variable is missing", () => {
+    localStorage.setItem("band:zoom-level", "1.7");
+    expect(getCurrentZoomLevel()).toBe(1.7);
+  });
+
+  it("ignores out-of-range values in the CSS variable and falls through", () => {
+    document.documentElement.style.setProperty(ZOOM_CSS_VAR, "5");
+    localStorage.setItem("band:zoom-level", "1.3");
+    expect(getCurrentZoomLevel()).toBe(1.3);
+  });
+});
+
+describe("subscribeToZoomChanges", () => {
+  it("invokes the handler with the new zoom level on every applyZoomLevel call", () => {
+    const calls: number[] = [];
+    const unsubscribe = subscribeToZoomChanges((level) => calls.push(level));
+    try {
+      applyZoomLevel(0.9);
+      applyZoomLevel(1.1);
+      applyZoomLevel(2.0);
+    } finally {
+      unsubscribe();
+    }
+    expect(calls).toEqual([0.9, 1.1, 2.0]);
+  });
+
+  it("stops invoking the handler after unsubscribe", () => {
+    const calls: number[] = [];
+    const unsubscribe = subscribeToZoomChanges((level) => calls.push(level));
+    applyZoomLevel(1.2);
+    unsubscribe();
+    applyZoomLevel(0.7);
+    expect(calls).toEqual([1.2]);
+  });
+
+  it("handles multiple concurrent subscribers independently", () => {
+    const a: number[] = [];
+    const b: number[] = [];
+    const unsubA = subscribeToZoomChanges((level) => a.push(level));
+    const unsubB = subscribeToZoomChanges((level) => b.push(level));
+    try {
+      applyZoomLevel(1.3);
+      unsubA();
+      applyZoomLevel(0.6);
+    } finally {
+      unsubB();
+    }
+    expect(a).toEqual([1.3]);
+    expect(b).toEqual([1.3, 0.6]);
+  });
+
+  it("does not fire when a non-CustomEvent (no detail) is dispatched on the same name", () => {
+    // Defensive: the handler ignores events without a numeric detail so an
+    // accidental `window.dispatchEvent(new Event(ZOOM_CHANGE_EVENT))`
+    // anywhere in the app doesn't blow up subscribers.
+    const calls: number[] = [];
+    const unsubscribe = subscribeToZoomChanges((level) => calls.push(level));
+    try {
+      window.dispatchEvent(new Event(ZOOM_CHANGE_EVENT));
+    } finally {
+      unsubscribe();
+    }
+    expect(calls).toEqual([]);
+  });
+});

--- a/apps/web/tests/zoom.test.ts
+++ b/apps/web/tests/zoom.test.ts
@@ -9,6 +9,7 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
   applyZoomLevel,
+  applyZoomLevelToDom,
   DEFAULT_ZOOM,
   getCurrentZoomLevel,
   MAX_ZOOM,
@@ -31,6 +32,40 @@ function resetZoomState() {
 
 beforeEach(resetZoomState);
 afterEach(resetZoomState);
+
+describe("applyZoomLevelToDom", () => {
+  // The contract that distinguishes this helper from `applyZoomLevel` is
+  // exactly the absence of a localStorage write — pin it so a future
+  // refactor can't accidentally re-introduce the save without a test
+  // failure. The cross-window `storage` event handler in `ZoomSync`
+  // depends on this.
+  it("updates the DOM and CSS variable but does NOT persist to localStorage", () => {
+    expect(localStorage.getItem("band:zoom-level")).toBeNull();
+    applyZoomLevelToDom(1.4);
+    expect(document.documentElement.style.zoom).toBe("1.4");
+    expect(document.documentElement.style.getPropertyValue(ZOOM_CSS_VAR)).toBe("1.4");
+    // Crucially, no localStorage write.
+    expect(localStorage.getItem("band:zoom-level")).toBeNull();
+  });
+
+  it("dispatches the zoom-changed event with the applied level", () => {
+    const events: number[] = [];
+    const listener = (e: Event) => events.push((e as CustomEvent<number>).detail);
+    window.addEventListener(ZOOM_CHANGE_EVENT, listener);
+    try {
+      applyZoomLevelToDom(0.8);
+    } finally {
+      window.removeEventListener(ZOOM_CHANGE_EVENT, listener);
+    }
+    expect(events).toEqual([0.8]);
+  });
+
+  it("returns the clamped/rounded value it actually applied", () => {
+    expect(applyZoomLevelToDom(10)).toBe(MAX_ZOOM);
+    expect(applyZoomLevelToDom(0)).toBe(MIN_ZOOM);
+    expect(applyZoomLevelToDom(1.234567)).toBe(1.23);
+  });
+});
 
 describe("applyZoomLevel", () => {
   it("writes `zoom` and `--app-zoom` to <html>", () => {

--- a/packages/dashboard-core/src/components/DashboardShell.tsx
+++ b/packages/dashboard-core/src/components/DashboardShell.tsx
@@ -204,9 +204,19 @@ export function DashboardShell({ toolbarMenuItems, hideTitleBar, hideMenu }: Das
       ref={rootRef}
       className={cn(
         "w-full overflow-hidden flex flex-col bg-background text-foreground p-0",
-        hideTitleBar ? "h-full" : "h-dvh",
+        hideTitleBar && "h-full",
         !isDesktop && "pt-[env(safe-area-inset-top)]",
       )}
+      // CSS `zoom` does not scale viewport units (vh, dvh, svh, lvh) per
+      // spec, so `height: 100dvh` under `<html style="zoom: 0.5">` resolves
+      // to the viewport in CSS px and is then rendered at 50% — leaving the
+      // dashboard half the visible height with a gap at the bottom. Divide
+      // by the live app zoom factor (`--app-zoom`, set by applyZoomLevel in
+      // apps/web/src/lib/zoom.ts) so the rendered height always matches the
+      // actual viewport. The `hideTitleBar` branch is sized by its parent
+      // (a dockview panel with explicit pixel height) so it doesn't need
+      // the compensation. See band-app/band#463.
+      style={hideTitleBar ? undefined : { height: "calc(100dvh / var(--app-zoom, 1))" }}
     >
       {isDesktop && !hideTitleBar && (
         <div

--- a/packages/dashboard-core/src/components/DashboardShell.tsx
+++ b/packages/dashboard-core/src/components/DashboardShell.tsx
@@ -220,8 +220,16 @@ export function DashboardShell({ toolbarMenuItems, hideTitleBar, hideMenu }: Das
       // NOTE: `--app-zoom` is hardcoded here because `packages/dashboard-core`
       // can't import from `apps/web/src/lib/zoom.ts` without inverting the
       // package dependency graph. Keep this string in sync with the
-      // `ZOOM_CSS_VAR` constant exported from that module.
-      style={hideTitleBar ? undefined : { height: "calc(100dvh / var(--app-zoom, 1))" }}
+      // `ZOOM_CSS_VAR` constant exported from that module — grep for
+      // `ZOOM_CSS_VAR` in `apps/web/src/lib/zoom.ts` if renaming.
+      style={
+        hideTitleBar
+          ? undefined
+          : {
+              // sync-with: ZOOM_CSS_VAR in apps/web/src/lib/zoom.ts
+              height: "calc(100dvh / var(--app-zoom, 1))",
+            }
+      }
     >
       {isDesktop && !hideTitleBar && (
         <div

--- a/packages/dashboard-core/src/components/DashboardShell.tsx
+++ b/packages/dashboard-core/src/components/DashboardShell.tsx
@@ -216,6 +216,11 @@ export function DashboardShell({ toolbarMenuItems, hideTitleBar, hideMenu }: Das
       // actual viewport. The `hideTitleBar` branch is sized by its parent
       // (a dockview panel with explicit pixel height) so it doesn't need
       // the compensation. See band-app/band#463.
+      //
+      // NOTE: `--app-zoom` is hardcoded here because `packages/dashboard-core`
+      // can't import from `apps/web/src/lib/zoom.ts` without inverting the
+      // package dependency graph. Keep this string in sync with the
+      // `ZOOM_CSS_VAR` constant exported from that module.
       style={hideTitleBar ? undefined : { height: "calc(100dvh / var(--app-zoom, 1))" }}
     >
       {isDesktop && !hideTitleBar && (


### PR DESCRIPTION
## Summary

Closes #463.

Document-level CSS `zoom` was breaking xterm.js's hit-testing. `CharSizeService` measured cells at the zoomed size, the WebGL canvas backing store was sized from `devicePixelRatio` (independent of `zoom`), and Chromium's `clientX/Y` semantics under `zoom` differ across versions. The result: clicks, drag-select, double-click word, triple-click line, and link clicks all landed on the wrong cell at any zoom level ≠ 1.0.

A secondary bug also affected the project list (`DashboardShell`): `h-dvh` doesn't scale with CSS `zoom` per spec, so the dashboard rendered at half-viewport height under zoom < 1.0 with a gap below the project list and rows clipped at the container edge.

### Fix

**Terminal (xterm.js):** take the terminal out of the document-level `zoom` coordinate space, drive xterm's own `fontSize` from the live zoom factor.

- Mirror the current `<html>` zoom onto a `--app-zoom` CSS variable (alongside the existing `zoom` property).
- Counter-zoom the xterm container with `zoom: calc(1 / var(--app-zoom, 1))`. The two multiply to 1, so xterm renders into unzoomed pixels — `getBoundingClientRect()`, pointer `clientX/Y`, `CharSizeService`, and the WebGL backing store all share one coordinate system. That's what makes clicks land under the cursor.
- Drive `terminal.options.fontSize = BASE_FONT_SIZE * zoomLevel` so the visible terminal text still scales with the rest of the UI. Reuse the existing DPR re-measure-and-reattach dance (`handleDprChange`) for zoom transitions, then send a PTY `resize` once `fitAddon.fit()` settles.

**Dashboard (project list):** compensate `h-dvh` for CSS `zoom` using the same `--app-zoom` CSS variable.

- Replace `h-dvh` with inline `height: calc(100dvh / var(--app-zoom, 1))` on `DashboardShell`. At zoom 1.0 → `100dvh`. At zoom 0.5 → `200dvh` of CSS px, renders at `200dvh × 0.5` = full viewport. At zoom 2.0 → `50dvh` of CSS px, renders at `50dvh × 2` = full viewport. Closes the gap and stops the row-clipping.
- The `hideTitleBar` branch (dockview-embedded `DashboardShell`) is sized by its parent dockview panel via explicit pixel height, so it doesn't need the compensation. A separate, related bug exists in dockview's own ResizeObserver-driven sizing under CSS zoom — will be filed as a follow-up.

### Plumbing

- New `band:zoom-changed` window event + `subscribeToZoomChanges`/`getCurrentZoomLevel` helpers in `lib/zoom.ts`. Cross-window zoom sync (`ZoomSync` in `__root.tsx`) routes through `applyZoomLevelToDom` (DOM-only, no localStorage write — the originating window already persisted the value).
- `BASE_FONT_SIZE = 13` extracted as a constant.

### What's untouched

- `pointToCell` in `lib/terminal-selection.ts` — works as-is because it already operated purely on the rect+click coordinate pair. Once both live in unzoomed pixels, the math is correct. A single regression test in `terminal-selection.test.ts` pins that property (the math is scale-invariant by construction, so the previous parametrised loop fed identical inputs on every iteration and was collapsed to one explicit case).

## Test plan

- [x] `pnpm --filter @band-app/server test` — all green (43 tests pass for zoom + terminal-selection, 23 for terminal-toolbar).
- [x] `pnpm exec biome check apps/web/` clean.
- [x] Pre-push hook passes (biome + cargo fmt + clippy + knip + jscpd).
- [x] CI green on PR.
- [ ] Manual: zoom in (Cmd+=) and out (Cmd+-) across `[0.5, 2.0]`, click on a terminal cell — selection lands under cursor.
- [ ] Manual: drag-select highlights the cells the cursor passes over at every zoom level.
- [ ] Manual: double-click selects the word under the cursor; triple-click selects the line. At every zoom level.
- [ ] Manual: iOS long-press → word select still works (covered by `pointToCell`).
- [ ] Manual: WebGL renderer (default) and DOM renderer (settings toggle) both behave correctly.
- [ ] Manual: resize the window and zoom — both still drive `fitAddon.fit()` and a `resize` PTY message.
- [ ] Manual: at zoom < 1.0, the project list container fills the full viewport — no gap below, no row clipping.