### PR TITLE
Include dist/openapi.json in published @band-app/server tarball (#475)

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -9,6 +9,7 @@
     "dist/client",
     "dist/server",
     "dist/start-server.mjs",
+    "dist/openapi.json",
     "dist/migrations",
     "bin"
   ],

--- a/apps/web/tests/build-output.test.ts
+++ b/apps/web/tests/build-output.test.ts
@@ -1,7 +1,9 @@
-import { execFileSync } from "node:child_process";
-import { existsSync, readdirSync } from "node:fs";
+import { type ChildProcess, execFileSync, spawn } from "node:child_process";
+import { existsSync, mkdirSync, mkdtempSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import { createServer } from "node:net";
+import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { beforeAll, describe, expect, it } from "vitest";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
 
 const packageRoot = join(import.meta.dirname, "..");
 const dist = join(packageRoot, "dist");
@@ -100,49 +102,174 @@ describe("build output", () => {
   });
 });
 
-describe("published npm tarball", () => {
-  // Regression for #475. The bug there was that `dist/openapi.json` was
-  // generated correctly into the build output but was missing from the
-  // `files` array in `package.json`, so npm stripped it from the published
-  // tarball. start-server.mjs then crashed at startup when it tried to read
-  // it (silently — the uncaughtException handler exited 1 before logging to
-  // the terminal). `npm pack --dry-run` exercises npm's real packing logic
-  // (files array + .npmignore + always-excluded paths), which is what we
-  // need to catch this class of bug. Asserting against dist/ contents alone
-  // is not enough — the previous "contains the OpenAPI spec" check above
-  // passed all along while the published package was broken.
-  let packedPaths: string[];
+// End-to-end regression test for #475. The bug there was that
+// `dist/openapi.json` was generated correctly into the build output but was
+// missing from the `files` array in `package.json`, so npm stripped it from
+// the published tarball. The published server then crashed silently on
+// startup when start-server.ts tried to read it (the uncaughtException
+// handler exited 1 before any output reached the terminal).
+//
+// The pre-existing `existsSync(dist/openapi.json)` check above passed all
+// along while the published package was broken — checking dist/ is not
+// enough. This suite goes through the same path `npx @band-app/server`
+// does: pack the package, install the tarball into a fresh project, spawn
+// the bin shim, and verify the server actually boots and serves the spec.
+describe("published @band-app/server runs via the bin shim", () => {
+  let workDir: string;
+  let server: ChildProcess | undefined;
+  let baseUrl: string;
+  let token: string;
+  let exitCode: number | null = null;
+  const serverOutput: string[] = [];
 
-  beforeAll(() => {
-    const output = execFileSync("npm", ["pack", "--dry-run", "--json"], {
+  beforeAll(async () => {
+    // 1. Build an isolated sandbox: a consumer project (where we'll install
+    //    the tarball) and a fresh BAND_HOME (so the server doesn't touch the
+    //    developer's real ~/.band).
+    workDir = mkdtempSync(join(tmpdir(), "band-pack-test-"));
+    const consumerDir = join(workDir, "consumer");
+    const bandHome = join(workDir, "band-home");
+    mkdirSync(consumerDir, { recursive: true });
+    mkdirSync(bandHome, { recursive: true });
+
+    // 2. Pre-seed a known auth token. Otherwise the server generates a random
+    //    one on first boot and we'd have to race-read settings.json.
+    token = `test-token-${Math.random().toString(36).slice(2)}`;
+    writeFileSync(join(bandHome, "settings.json"), JSON.stringify({ tokenSecret: token }), "utf-8");
+
+    // 3. Pack the workspace package the same way `npm publish` would. The
+    //    `pretest` script already ran `pnpm build`, so dist/ is populated.
+    //    Pipe (don't inherit) npm's chatty `notice` output so the test log
+    //    isn't flooded; execFileSync throws with stderr attached if it fails.
+    execFileSync("npm", ["pack", "--pack-destination", workDir, "--loglevel=error"], {
       cwd: packageRoot,
-      encoding: "utf-8",
-      stdio: ["ignore", "pipe", "ignore"],
+      stdio: ["ignore", "pipe", "pipe"],
     });
-    const result = JSON.parse(output) as Array<{ files: Array<{ path: string }> }>;
-    packedPaths = result[0].files.map((f) => f.path);
+    const tgz = readdirSync(workDir).find((f) => f.endsWith(".tgz"));
+    if (!tgz) throw new Error("npm pack did not produce a tarball");
+
+    // 4. Install the tarball into the consumer project — exactly what `npx
+    //    @band-app/server` does internally (npx unpacks the tarball into a
+    //    temp prefix and runs the bin from inside node_modules).
+    writeFileSync(
+      join(consumerDir, "package.json"),
+      JSON.stringify({ name: "consumer", private: true }),
+      "utf-8",
+    );
+    execFileSync(
+      "npm",
+      [
+        "install",
+        "--no-audit",
+        "--no-fund",
+        "--prefer-offline",
+        "--loglevel=error",
+        join(workDir, tgz),
+      ],
+      { cwd: consumerDir, stdio: ["ignore", "pipe", "pipe"] },
+    );
+
+    const binPath = join(consumerDir, "node_modules/@band-app/server/bin/band-server.mjs");
+    expect(existsSync(binPath), `bin shim missing at ${binPath}`).toBe(true);
+
+    // 5. Pick a free ephemeral port (avoid clashing with the developer's
+    //    dev server on 3456) and boot the bin shim.
+    const port = await findFreePort();
+    baseUrl = `http://127.0.0.1:${port}`;
+
+    server = spawn(process.execPath, [binPath], {
+      env: { ...process.env, PORT: String(port), BAND_HOME: bandHome },
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    server.on("exit", (code) => {
+      exitCode = code;
+    });
+
+    // Capture the server's output continuously. We dump it in afterAll only
+    // if a test failed, so a regression like #475 (which silently exited 1)
+    // surfaces with the actual stack instead of an opaque "fetch failed".
+    server.stdout?.on("data", (chunk: Buffer) => serverOutput.push(chunk.toString()));
+    server.stderr?.on("data", (chunk: Buffer) => serverOutput.push(chunk.toString()));
+
+    try {
+      await waitForServer(baseUrl, 30_000);
+    } catch (err) {
+      process.stderr.write(
+        `\n--- @band-app/server output ---\n${serverOutput.join("")}\n--- exit code: ${exitCode} ---\n`,
+      );
+      throw err;
+    }
+  }, 120_000);
+
+  afterAll((ctx) => {
+    if (ctx.tasks.some((t) => t.result?.state === "fail")) {
+      process.stderr.write(
+        `\n--- @band-app/server output ---\n${serverOutput.join("")}\n--- exit code: ${exitCode} ---\n`,
+      );
+    }
+    if (server && server.exitCode === null && !server.killed) {
+      server.kill("SIGTERM");
+    }
+    if (workDir) {
+      rmSync(workDir, { recursive: true, force: true });
+    }
   });
 
-  // Files that start-server.mjs (or the bin shim) reads directly at runtime.
-  // If any of these go missing the published server crashes on startup, so
-  // they each get their own assertion to make the failure mode obvious.
-  it.each([
-    ["bin/band-server.mjs", "bin shim invoked by `npx @band-app/server`"],
-    ["dist/start-server.mjs", "the server bundle the bin shim spawns"],
-    ["dist/openapi.json", "read by start-server.mjs to serve /api/openapi.json (#475)"],
-  ])("publishes %s — %s", (path) => {
-    expect(packedPaths).toContain(path);
+  it("bin shim process is still running", () => {
+    // The #475 regression was a silent process.exit(1) before any output.
+    // start-server.ts now reads dist/openapi.json lazily (issue #472), so
+    // the crash happens on first request rather than at boot — but boot
+    // crashes are still a valid invariant to lock in.
+    expect(exitCode).toBeNull();
   });
 
-  it("publishes at least one migration", () => {
-    // dist/migrations is a directory; we just need *something* under it so
-    // runMigrations() has work to do at boot.
-    const migrations = packedPaths.filter((p) => p.startsWith("dist/migrations/"));
-    expect(migrations.length).toBeGreaterThan(0);
-  });
-
-  it("publishes the client bundle", () => {
-    const clientFiles = packedPaths.filter((p) => p.startsWith("dist/client/"));
-    expect(clientFiles.length).toBeGreaterThan(0);
+  it("serves the OpenAPI spec via /api/openapi.json", async () => {
+    // The actual #475 regression check: this fetch fails ("other side
+    // closed") when start-server.mjs throws ENOENT reading the missing
+    // dist/openapi.json. afterAll dumps the server output so you can see
+    // why.
+    const res = await fetch(`${baseUrl}/api/openapi.json`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    expect(res.status).toBe(200);
+    const spec = (await res.json()) as { openapi?: string; info?: { title?: string } };
+    expect(spec.openapi).toMatch(/^3\./);
+    expect(spec.info?.title).toBeDefined();
   });
 });
+
+function findFreePort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const srv = createServer();
+    srv.unref();
+    srv.once("error", reject);
+    srv.listen(0, "127.0.0.1", () => {
+      const addr = srv.address();
+      if (typeof addr === "object" && addr) {
+        const { port } = addr;
+        srv.close(() => resolve(port));
+      } else {
+        srv.close();
+        reject(new Error("could not allocate free port"));
+      }
+    });
+  });
+}
+
+async function waitForServer(baseUrl: string, deadlineMs: number): Promise<void> {
+  const deadline = Date.now() + deadlineMs;
+  let lastError: unknown;
+  while (Date.now() < deadline) {
+    try {
+      const res = await fetch(`${baseUrl}/api/openapi.json`);
+      // Any HTTP response (200, 401, etc.) means the server is up and
+      // handling requests. We don't check the status here — auth is
+      // verified by the per-test fetch below.
+      if (res.status >= 100 && res.status < 600) return;
+    } catch (err) {
+      lastError = err;
+    }
+    await new Promise((r) => setTimeout(r, 200));
+  }
+  throw new Error(`server did not become ready within ${deadlineMs}ms: ${String(lastError)}`);
+}

--- a/apps/web/tests/build-output.test.ts
+++ b/apps/web/tests/build-output.test.ts
@@ -1,8 +1,10 @@
+import { execFileSync } from "node:child_process";
 import { existsSync, readdirSync } from "node:fs";
 import { join } from "node:path";
-import { describe, expect, it } from "vitest";
+import { beforeAll, describe, expect, it } from "vitest";
 
-const dist = join(import.meta.dirname, "../dist");
+const packageRoot = join(import.meta.dirname, "..");
+const dist = join(packageRoot, "dist");
 
 const skipSdkChecks = process.env.NPM_PUBLISH === "1";
 
@@ -95,5 +97,52 @@ describe("build output", () => {
 
   it.skipIf(skipSdkChecks)("contains Codex SDK package", () => {
     expect(existsSync(join(dist, "node_modules/@openai/codex/package.json"))).toBe(true);
+  });
+});
+
+describe("published npm tarball", () => {
+  // Regression for #475. The bug there was that `dist/openapi.json` was
+  // generated correctly into the build output but was missing from the
+  // `files` array in `package.json`, so npm stripped it from the published
+  // tarball. start-server.mjs then crashed at startup when it tried to read
+  // it (silently — the uncaughtException handler exited 1 before logging to
+  // the terminal). `npm pack --dry-run` exercises npm's real packing logic
+  // (files array + .npmignore + always-excluded paths), which is what we
+  // need to catch this class of bug. Asserting against dist/ contents alone
+  // is not enough — the previous "contains the OpenAPI spec" check above
+  // passed all along while the published package was broken.
+  let packedPaths: string[];
+
+  beforeAll(() => {
+    const output = execFileSync("npm", ["pack", "--dry-run", "--json"], {
+      cwd: packageRoot,
+      encoding: "utf-8",
+      stdio: ["ignore", "pipe", "ignore"],
+    });
+    const result = JSON.parse(output) as Array<{ files: Array<{ path: string }> }>;
+    packedPaths = result[0].files.map((f) => f.path);
+  });
+
+  // Files that start-server.mjs (or the bin shim) reads directly at runtime.
+  // If any of these go missing the published server crashes on startup, so
+  // they each get their own assertion to make the failure mode obvious.
+  it.each([
+    ["bin/band-server.mjs", "bin shim invoked by `npx @band-app/server`"],
+    ["dist/start-server.mjs", "the server bundle the bin shim spawns"],
+    ["dist/openapi.json", "read by start-server.mjs to serve /api/openapi.json (#475)"],
+  ])("publishes %s — %s", (path) => {
+    expect(packedPaths).toContain(path);
+  });
+
+  it("publishes at least one migration", () => {
+    // dist/migrations is a directory; we just need *something* under it so
+    // runMigrations() has work to do at boot.
+    const migrations = packedPaths.filter((p) => p.startsWith("dist/migrations/"));
+    expect(migrations.length).toBeGreaterThan(0);
+  });
+
+  it("publishes the client bundle", () => {
+    const clientFiles = packedPaths.filter((p) => p.startsWith("dist/client/"));
+    expect(clientFiles.length).toBeGreaterThan(0);
   });
 });

--- a/apps/web/tests/build-output.test.ts
+++ b/apps/web/tests/build-output.test.ts
@@ -177,8 +177,17 @@ describe("published @band-app/server runs via the bin shim", () => {
     const port = await findFreePort();
     baseUrl = `http://127.0.0.1:${port}`;
 
+    // Build an explicit env rather than inheriting the test runner's. NODE_OPTIONS
+    // in particular can carry vitest loader flags (--import tsx/esm,
+    // --experimental-vm-modules) that break the server's ESM boot in subtle ways.
+    const serverEnv: NodeJS.ProcessEnv = {
+      PATH: process.env.PATH,
+      HOME: process.env.HOME,
+      PORT: String(port),
+      BAND_HOME: bandHome,
+    };
     server = spawn(process.execPath, [binPath], {
-      env: { ...process.env, PORT: String(port), BAND_HOME: bandHome },
+      env: serverEnv,
       stdio: ["ignore", "pipe", "pipe"],
     });
     server.on("exit", (code) => {
@@ -215,11 +224,11 @@ describe("published @band-app/server runs via the bin shim", () => {
     }
   });
 
-  it("bin shim process is still running", () => {
-    // The #475 regression was a silent process.exit(1) before any output.
-    // start-server.ts now reads dist/openapi.json lazily (issue #472), so
-    // the crash happens on first request rather than at boot — but boot
-    // crashes are still a valid invariant to lock in.
+  it("server boots without crashing", () => {
+    // Generic boot-crash invariant — not specifically a #475 guard. With
+    // lazy openapi.json reading (issue #472), the #475 failure mode now
+    // surfaces on the first /api/openapi.json request rather than at boot,
+    // so the fetch test below is what actually locks in the packaging fix.
     expect(exitCode).toBeNull();
   });
 
@@ -264,8 +273,13 @@ async function waitForServer(baseUrl: string, deadlineMs: number): Promise<void>
       const res = await fetch(`${baseUrl}/api/openapi.json`);
       // Any HTTP response (200, 401, etc.) means the server is up and
       // handling requests. We don't check the status here — auth is
-      // verified by the per-test fetch below.
-      if (res.status >= 100 && res.status < 600) return;
+      // verified by the per-test fetch below. Drain the body so undici
+      // doesn't leak ~150 keep-alive sockets across the polling loop.
+      if (res.status >= 100 && res.status < 600) {
+        await res.body?.cancel();
+        return;
+      }
+      await res.body?.cancel();
     } catch (err) {
       lastError = err;
     }


### PR DESCRIPTION
## Summary

- Adds `dist/openapi.json` to the `files` array in `apps/web/package.json` so it gets included in the published npm tarball.

## Why

`apps/web/start-server.ts` reads `dist/openapi.json` (the spec generated at build time by `@trpc/openapi`) when serving `/api/openapi.json` and `/api/docs`. The build script (`apps/web/scripts/build-server.sh`) generates this file correctly, but the `files` array in `apps/web/package.json` did not include it, so npm stripped it out of the published tarball.

The result: every published version of `@band-app/server` since the `openapi.json` read was added has been broken. Running `npx @band-app/server` silently exited 1 because the `readFileSync` threw `ENOENT`, the uncaughtException handler wrote the error to `~/.band/server.log`, and `process.exit(1)` fired before any output reached the terminal.

Closes #475.

## Test plan

- [x] `cd apps/web && pnpm build && npm pack --dry-run | grep openapi.json` lists `dist/openapi.json` among the packed files.
- [x] End-to-end smoke test from a clean temp dir:
  - `npm pack` into a temp dir
  - `npm install ./band-app-server-*.tgz` in a fresh project
  - `node node_modules/@band-app/server/bin/band-server.mjs` prints `Web server listening on http://0.0.0.0:3456` instead of crashing silently
  - `curl http://127.0.0.1:3456/api/openapi.json` (with auth) returns the 336 KB OpenAPI 3.1.1 spec

## Notes

- Publishing the fix still requires rotating the EOTP / npm automation token blocking the Release workflow — that's tracked separately and intentionally out of scope here.
- Renaming the bin from `band-server` to `server` is also out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)