### PR TITLE
fix(web): heal stale workspace_statuses rows so EditorPicker dropdown appears

### DIFF
--- a/apps/web/src/lib/state.ts
+++ b/apps/web/src/lib/state.ts
@@ -345,8 +345,27 @@ export function upsertWorkspaceStatus(
   };
 
   if (existing) {
+    // Self-heal stale rows whose identity fields are empty. Older rows
+    // could be inserted with empty `project`/`branch`/`worktreePath`
+    // when the agent started before the project's worktree was
+    // persisted (or were left behind by a prior version of Band). The
+    // desktop title-bar EditorPicker is gated on a non-empty
+    // `worktreePath` (DesktopTitleBar.tsx), so an empty value hides
+    // the dropdown forever even though the worktree path is
+    // recoverable from the projects/worktrees tables. Only overwrite
+    // fields that are currently empty so we never clobber correct
+    // data when the projects table is momentarily out of sync.
+    const identityPatch: Partial<{ project: string; branch: string; worktreePath: string }> = {};
+    if (!existing.project || !existing.branch || !existing.worktreePath) {
+      const ws = resolveWorkspaceIdentity(workspaceId);
+      if (ws) {
+        if (!existing.project) identityPatch.project = ws.project;
+        if (!existing.branch) identityPatch.branch = ws.branch;
+        if (!existing.worktreePath) identityPatch.worktreePath = ws.worktreePath;
+      }
+    }
     db.update(workspaceStatusesTable)
-      .set({ ...mergedAgent, updatedAt: now })
+      .set({ ...mergedAgent, ...identityPatch, updatedAt: now })
       .where(eq(workspaceStatusesTable.workspaceId, workspaceId))
       .run();
   } else {

--- a/apps/web/src/lib/state.ts
+++ b/apps/web/src/lib/state.ts
@@ -3,7 +3,7 @@ import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from "
 import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 import { toWorkspaceId } from "@band-app/dashboard-core";
-import { eq, or } from "drizzle-orm";
+import { eq, or, sql } from "drizzle-orm";
 import { getDb } from "./db/connection";
 import {
   branchStatuses as branchStatusesTable,
@@ -344,6 +344,14 @@ export function upsertWorkspaceStatus(
     codingAgentId: agent.codingAgentId ?? existing?.codingAgentId ?? null,
   };
 
+  // Final identity to return. Starts from `existing` (UPDATE) or empty
+  // (INSERT); may be overridden by the patch / freshly-resolved values
+  // below so we can build the return value in-memory without a third
+  // round-trip to the DB.
+  let finalProject = existing?.project ?? "";
+  let finalBranch = existing?.branch ?? "";
+  let finalWorktreePath = existing?.worktreePath ?? "";
+
   if (existing) {
     // Self-heal stale rows whose identity fields are empty. Older rows
     // could be inserted with empty `project`/`branch`/`worktreePath`
@@ -359,31 +367,79 @@ export function upsertWorkspaceStatus(
     if (!existing.project || !existing.branch || !existing.worktreePath) {
       const ws = resolveWorkspaceIdentity(workspaceId);
       if (ws) {
-        if (!existing.project) identityPatch.project = ws.project;
-        if (!existing.branch) identityPatch.branch = ws.branch;
-        if (!existing.worktreePath) identityPatch.worktreePath = ws.worktreePath;
+        if (!existing.project) {
+          identityPatch.project = ws.project;
+          finalProject = ws.project;
+        }
+        if (!existing.branch) {
+          identityPatch.branch = ws.branch;
+          finalBranch = ws.branch;
+        }
+        if (!existing.worktreePath) {
+          identityPatch.worktreePath = ws.worktreePath;
+          finalWorktreePath = ws.worktreePath;
+        }
       }
     }
-    db.update(workspaceStatusesTable)
-      .set({ ...mergedAgent, ...identityPatch, updatedAt: now })
-      .where(eq(workspaceStatusesTable.workspaceId, workspaceId))
-      .run();
+
+    // Skip the write when the row is already in the desired state.
+    // The poller calls `upsertWorkspaceStatus(_, { status: "waiting" })`
+    // on every tick for every idle workspace; without this guard each
+    // tick produces a WAL frame just to bump `updatedAt`, which nothing
+    // reads. `agentName`/`agentSummary` are computed from `existing`
+    // and only differ on legacy rows where they were null, so we
+    // include them in the comparison too.
+    const agentChanged =
+      existing.agentName !== mergedAgent.agentName ||
+      existing.agentStatus !== mergedAgent.agentStatus ||
+      existing.agentLastActivity !== mergedAgent.agentLastActivity ||
+      existing.agentSummary !== mergedAgent.agentSummary ||
+      existing.codingAgentId !== mergedAgent.codingAgentId;
+    const identityChanged =
+      identityPatch.project !== undefined ||
+      identityPatch.branch !== undefined ||
+      identityPatch.worktreePath !== undefined;
+
+    if (agentChanged || identityChanged) {
+      db.update(workspaceStatusesTable)
+        .set({ ...mergedAgent, ...identityPatch, updatedAt: now })
+        .where(eq(workspaceStatusesTable.workspaceId, workspaceId))
+        .run();
+    }
   } else {
     // For new rows, resolve workspace identity from the worktrees DB
     const ws = resolveWorkspaceIdentity(workspaceId);
+    finalProject = ws?.project ?? "";
+    finalBranch = ws?.branch ?? "";
+    finalWorktreePath = ws?.worktreePath ?? "";
     db.insert(workspaceStatusesTable)
       .values({
         workspaceId,
-        project: ws?.project ?? "",
-        branch: ws?.branch ?? "",
-        worktreePath: ws?.worktreePath ?? "",
+        project: finalProject,
+        branch: finalBranch,
+        worktreePath: finalWorktreePath,
         ...mergedAgent,
         updatedAt: now,
       })
       .run();
   }
 
-  return getWorkspaceStatus(workspaceId)!;
+  // Build the return value in-memory — avoids a third SELECT after
+  // the write. `agentName` is always set (defaulted to "claude-code"),
+  // so the agent field is always populated after upsert.
+  return {
+    workspaceId,
+    project: finalProject,
+    branch: finalBranch,
+    worktreePath: finalWorktreePath,
+    agent: {
+      name: mergedAgent.agentName,
+      status: mergedAgent.agentStatus,
+      lastActivity: mergedAgent.agentLastActivity,
+      summary: mergedAgent.agentSummary ?? undefined,
+      codingAgentId: mergedAgent.codingAgentId ?? undefined,
+    },
+  };
 }
 
 /**
@@ -409,13 +465,32 @@ export function resetAgentStatuses(): number {
 function resolveWorkspaceIdentity(
   workspaceId: string,
 ): { project: string; branch: string; worktreePath: string } | null {
-  const state = loadState();
-  for (const proj of state.projects) {
-    for (const wt of proj.worktrees) {
-      if (toWorkspaceId(proj.name, wt.branch) === workspaceId) {
-        return { project: proj.name, branch: wt.branch, worktreePath: wt.path };
-      }
-    }
+  // Push the `toWorkspaceId` match down into SQL: scan the worktrees
+  // table directly, filter server-side, and read at most one row. The
+  // previous implementation called `loadState()`, which did
+  // `SELECT * FROM projects` + `SELECT * FROM worktrees` and built the
+  // full ProjectState[] tree just to find a single workspace.
+  //
+  // The match expression mirrors `toWorkspaceId(project, branch)`:
+  //   `${project}-${branch.replaceAll("/", "-")}`
+  // SQLite's `REPLACE(str, "/", "-")` is also a replace-all, so this
+  // is bit-identical to the JS computation.
+  const db = getDb();
+  const row = db
+    .select({
+      project: worktreesTable.projectName,
+      branch: worktreesTable.branch,
+      worktreePath: worktreesTable.path,
+    })
+    .from(worktreesTable)
+    .where(
+      sql`${worktreesTable.projectName} || '-' || REPLACE(${worktreesTable.branch}, '/', '-') = ${workspaceId}`,
+    )
+    .get();
+  // Use the `toWorkspaceId` helper as a runtime sanity check in case
+  // the helper's encoding ever evolves to disagree with the SQL above.
+  if (row && toWorkspaceId(row.project, row.branch) === workspaceId) {
+    return { project: row.project, branch: row.branch, worktreePath: row.worktreePath };
   }
   return null;
 }

--- a/apps/web/src/lib/state.ts
+++ b/apps/web/src/lib/state.ts
@@ -475,6 +475,14 @@ function resolveWorkspaceIdentity(
   //   `${project}-${branch.replaceAll("/", "-")}`
   // SQLite's `REPLACE(str, "/", "-")` is also a replace-all, so this
   // is bit-identical to the JS computation.
+  //
+  // TODO: `toWorkspaceId`'s encoding is not injective — project
+  // `foo-bar` + branch `main` and project `foo` + branch `bar/main`
+  // both serialize to `foo-bar-main`. `.get()` returns whichever row
+  // SQLite finds first, and the sanity check below cannot
+  // disambiguate (both candidates satisfy it). Fixing this requires
+  // changing the workspace-id encoding, which is a cross-cutting
+  // change tracked separately from this PR.
   const db = getDb();
   const row = db
     .select({

--- a/apps/web/tests/helpers/seed-state.ts
+++ b/apps/web/tests/helpers/seed-state.ts
@@ -79,6 +79,12 @@ export interface WorkspaceStatusData {
   agentLastActivity?: string;
   agentSummary?: string;
   codingAgentId?: string;
+  /**
+   * Override `updated_at`. Defaults to `Date.now()`. Tests that assert
+   * on `updated_at` advancement should seed an explicit value (e.g.
+   * `0`) so they can compare against it without timing dependencies.
+   */
+  updatedAt?: number;
 }
 
 export function seedWorkspaceStatuses(tmpHome: string, statuses: WorkspaceStatusData[]): void {
@@ -106,7 +112,7 @@ export function seedWorkspaceStatuses(tmpHome: string, statuses: WorkspaceStatus
           agentLastActivity: s.agentLastActivity ?? "",
           agentSummary: s.agentSummary ?? null,
           codingAgentId: s.codingAgentId ?? null,
-          updatedAt: now,
+          updatedAt: s.updatedAt ?? now,
         })
         .run();
     }

--- a/apps/web/tests/state.test.ts
+++ b/apps/web/tests/state.test.ts
@@ -1,11 +1,27 @@
 import { mkdtempSync, realpathSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { DatabaseSync } from "node:sqlite";
 import { toWorkspaceId } from "@band-app/dashboard-core";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { closeDb } from "../src/lib/db/connection";
 import { getWorkspaceStatus, upsertWorkspaceStatus } from "../src/lib/state";
 import { seedState, seedWorkspaceStatuses } from "./helpers/seed-state";
+
+// Read `updated_at` directly from SQLite — used to assert that the
+// no-op write skip actually prevents writes (rather than the higher-level
+// row staying logically identical).
+function readUpdatedAt(tmpHome: string, workspaceId: string): number | undefined {
+  const sqlite = new DatabaseSync(join(tmpHome, ".band", "band.db"));
+  try {
+    const row = sqlite
+      .prepare("SELECT updated_at FROM workspace_statuses WHERE workspace_id = ?")
+      .get(workspaceId) as { updated_at: number } | undefined;
+    return row?.updated_at;
+  } finally {
+    sqlite.close();
+  }
+}
 
 // ---------------------------------------------------------------------------
 // upsertWorkspaceStatus — heals stale rows with empty identity fields.
@@ -181,5 +197,186 @@ describe("upsertWorkspaceStatus — identity healing", () => {
     expect(result.project).toBe("");
     expect(result.branch).toBe("");
     expect(result.worktreePath).toBe("");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// upsertWorkspaceStatus — no-op write skip.
+//
+// The status poller calls `upsertWorkspaceStatus(_, { status: "waiting" })`
+// on every tick for every idle workspace; without a no-op guard each tick
+// produces a WAL frame just to bump `updatedAt`, which nothing reads.
+// ---------------------------------------------------------------------------
+
+describe("upsertWorkspaceStatus — no-op write skip", () => {
+  let tmp: string;
+  let originalBandHome: string | undefined;
+
+  beforeEach(() => {
+    tmp = realpathSync(mkdtempSync(join(tmpdir(), "band-state-noop-test-")));
+    originalBandHome = process.env.BAND_HOME;
+    process.env.BAND_HOME = join(tmp, ".band");
+  });
+
+  afterEach(() => {
+    closeDb();
+    if (originalBandHome !== undefined) {
+      process.env.BAND_HOME = originalBandHome;
+    } else {
+      delete process.env.BAND_HOME;
+    }
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it("does not bump updated_at when nothing changed", () => {
+    const projectName = "demo";
+    const branch = "main";
+    const wtPath = join(tmp, "worktrees", "demo-main");
+    const workspaceId = toWorkspaceId(projectName, branch);
+
+    seedState(tmp, {
+      projects: [
+        {
+          name: projectName,
+          path: join(tmp, "repos", "demo"),
+          defaultBranch: "main",
+          worktrees: [{ branch, path: wtPath }],
+        },
+      ],
+    });
+
+    // Seed a fully-populated row so no healing or status change is needed.
+    seedWorkspaceStatuses(tmp, [
+      {
+        workspaceId,
+        project: projectName,
+        branch,
+        worktreePath: wtPath,
+        agentStatus: "waiting",
+        agentLastActivity: "",
+      },
+    ]);
+
+    const before = readUpdatedAt(tmp, workspaceId);
+    expect(before).toBeDefined();
+
+    upsertWorkspaceStatus(workspaceId, { status: "waiting" });
+
+    const after = readUpdatedAt(tmp, workspaceId);
+    // updated_at must be byte-identical — no UPDATE was issued.
+    expect(after).toBe(before);
+  });
+
+  it("does bump updated_at when status changes", () => {
+    const projectName = "demo";
+    const branch = "main";
+    const wtPath = join(tmp, "worktrees", "demo-main");
+    const workspaceId = toWorkspaceId(projectName, branch);
+
+    seedState(tmp, {
+      projects: [
+        {
+          name: projectName,
+          path: join(tmp, "repos", "demo"),
+          defaultBranch: "main",
+          worktrees: [{ branch, path: wtPath }],
+        },
+      ],
+    });
+
+    seedWorkspaceStatuses(tmp, [
+      {
+        workspaceId,
+        project: projectName,
+        branch,
+        worktreePath: wtPath,
+        agentStatus: "waiting",
+      },
+    ]);
+
+    const before = readUpdatedAt(tmp, workspaceId)!;
+
+    // Ensure the wall clock has advanced past `before` so a real
+    // write would be observable. Date.now() has millisecond
+    // resolution on every supported platform, but back-to-back
+    // calls can land on the same tick.
+    const start = Date.now();
+    while (Date.now() <= before) {
+      // spin until next ms tick
+      if (Date.now() - start > 100) break;
+    }
+
+    upsertWorkspaceStatus(workspaceId, { status: "working" });
+
+    const after = readUpdatedAt(tmp, workspaceId)!;
+    expect(after).toBeGreaterThan(before);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveWorkspaceIdentity — SQL-side `toWorkspaceId` match.
+//
+// The lookup pushes the `${project}-${branch.replaceAll("/", "-")}`
+// computation into SQL (`project || '-' || REPLACE(branch, '/', '-')`)
+// so it can filter server-side instead of scanning every worktree in
+// JS. Exercise the slash-in-branch case to prove the REPLACE works.
+// ---------------------------------------------------------------------------
+
+describe("upsertWorkspaceStatus — identity lookup with slashes in branch", () => {
+  let tmp: string;
+  let originalBandHome: string | undefined;
+
+  beforeEach(() => {
+    tmp = realpathSync(mkdtempSync(join(tmpdir(), "band-state-slash-test-")));
+    originalBandHome = process.env.BAND_HOME;
+    process.env.BAND_HOME = join(tmp, ".band");
+  });
+
+  afterEach(() => {
+    closeDb();
+    if (originalBandHome !== undefined) {
+      process.env.BAND_HOME = originalBandHome;
+    } else {
+      delete process.env.BAND_HOME;
+    }
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it("resolves a workspaceId whose branch contains slashes", () => {
+    const projectName = "demo";
+    const branch = "feat/nested/thing";
+    const wtPath = join(tmp, "worktrees", "demo-feat-nested-thing");
+    const workspaceId = toWorkspaceId(projectName, branch);
+    // Sanity: helper collapses slashes to dashes.
+    expect(workspaceId).toBe("demo-feat-nested-thing");
+
+    seedState(tmp, {
+      projects: [
+        {
+          name: projectName,
+          path: join(tmp, "repos", "demo"),
+          defaultBranch: "main",
+          worktrees: [{ branch, path: wtPath }],
+        },
+      ],
+    });
+
+    // Stale row with empty identity — forces the heal path through
+    // the new SQL-backed `resolveWorkspaceIdentity`.
+    seedWorkspaceStatuses(tmp, [
+      {
+        workspaceId,
+        project: "",
+        branch: "",
+        worktreePath: "",
+        agentStatus: "waiting",
+      },
+    ]);
+
+    const healed = upsertWorkspaceStatus(workspaceId, { status: "waiting" });
+
+    expect(healed.project).toBe(projectName);
+    expect(healed.branch).toBe(branch);
+    expect(healed.worktreePath).toBe(wtPath);
   });
 });

--- a/apps/web/tests/state.test.ts
+++ b/apps/web/tests/state.test.ts
@@ -284,6 +284,10 @@ describe("upsertWorkspaceStatus — no-op write skip", () => {
       ],
     });
 
+    // Seed `updated_at` far in the past so any real write is
+    // observable without depending on wall-clock progression between
+    // the seed and the upsert (which on a loaded CI host can land on
+    // the same millisecond as `Date.now()` inside upsert).
     seedWorkspaceStatuses(tmp, [
       {
         workspaceId,
@@ -291,25 +295,16 @@ describe("upsertWorkspaceStatus — no-op write skip", () => {
         branch,
         worktreePath: wtPath,
         agentStatus: "waiting",
+        updatedAt: 0,
       },
     ]);
 
-    const before = readUpdatedAt(tmp, workspaceId)!;
-
-    // Ensure the wall clock has advanced past `before` so a real
-    // write would be observable. Date.now() has millisecond
-    // resolution on every supported platform, but back-to-back
-    // calls can land on the same tick.
-    const start = Date.now();
-    while (Date.now() <= before) {
-      // spin until next ms tick
-      if (Date.now() - start > 100) break;
-    }
+    expect(readUpdatedAt(tmp, workspaceId)).toBe(0);
 
     upsertWorkspaceStatus(workspaceId, { status: "working" });
 
     const after = readUpdatedAt(tmp, workspaceId)!;
-    expect(after).toBeGreaterThan(before);
+    expect(after).toBeGreaterThan(0);
   });
 });
 

--- a/apps/web/tests/state.test.ts
+++ b/apps/web/tests/state.test.ts
@@ -1,0 +1,185 @@
+import { mkdtempSync, realpathSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { toWorkspaceId } from "@band-app/dashboard-core";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { closeDb } from "../src/lib/db/connection";
+import { getWorkspaceStatus, upsertWorkspaceStatus } from "../src/lib/state";
+import { seedState, seedWorkspaceStatuses } from "./helpers/seed-state";
+
+// ---------------------------------------------------------------------------
+// upsertWorkspaceStatus — heals stale rows with empty identity fields.
+//
+// The desktop title-bar EditorPicker dropdown is gated on a non-empty
+// `worktreePath` (see DesktopTitleBar.tsx). Some rows in older Band
+// installs were inserted with `worktreePath = ""` (agent started before
+// the project's worktree was persisted, or rows left behind by a prior
+// version). Without healing, those workspaces never get the dropdown
+// even though the worktree path is recoverable from the projects /
+// worktrees tables.
+// ---------------------------------------------------------------------------
+
+describe("upsertWorkspaceStatus — identity healing", () => {
+  let tmp: string;
+  let originalBandHome: string | undefined;
+
+  beforeEach(() => {
+    tmp = realpathSync(mkdtempSync(join(tmpdir(), "band-state-test-")));
+    originalBandHome = process.env.BAND_HOME;
+    process.env.BAND_HOME = join(tmp, ".band");
+  });
+
+  afterEach(() => {
+    closeDb();
+    if (originalBandHome !== undefined) {
+      process.env.BAND_HOME = originalBandHome;
+    } else {
+      delete process.env.BAND_HOME;
+    }
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it("heals an existing row with empty project/branch/worktreePath", () => {
+    const projectName = "kbhq";
+    const branch = "main";
+    const wtPath = join(tmp, "worktrees", "kbhq-main");
+    const workspaceId = toWorkspaceId(projectName, branch);
+
+    // Project state has a real worktree for this workspaceId.
+    seedState(tmp, {
+      projects: [
+        {
+          name: projectName,
+          path: join(tmp, "repos", "kbhq"),
+          defaultBranch: "main",
+          worktrees: [{ branch, path: wtPath }],
+        },
+      ],
+    });
+
+    // workspace_statuses row exists but with empty identity fields,
+    // mirroring the user-reported real-world state.
+    seedWorkspaceStatuses(tmp, [
+      {
+        workspaceId,
+        project: "",
+        branch: "",
+        worktreePath: "",
+        agentStatus: "waiting",
+      },
+    ]);
+
+    const healed = upsertWorkspaceStatus(workspaceId, { status: "waiting" });
+
+    expect(healed.project).toBe(projectName);
+    expect(healed.branch).toBe(branch);
+    expect(healed.worktreePath).toBe(wtPath);
+
+    // Round-trip via getWorkspaceStatus to make sure the update was
+    // actually written to the row, not just returned in-memory.
+    const persisted = getWorkspaceStatus(workspaceId);
+    expect(persisted).not.toBeNull();
+    expect(persisted!.project).toBe(projectName);
+    expect(persisted!.branch).toBe(branch);
+    expect(persisted!.worktreePath).toBe(wtPath);
+  });
+
+  it("heals only the empty subset of identity fields", () => {
+    const projectName = "kbhq";
+    const branch = "main";
+    const wtPath = join(tmp, "worktrees", "kbhq-main");
+    const workspaceId = toWorkspaceId(projectName, branch);
+
+    seedState(tmp, {
+      projects: [
+        {
+          name: projectName,
+          path: join(tmp, "repos", "kbhq"),
+          defaultBranch: "main",
+          worktrees: [{ branch, path: wtPath }],
+        },
+      ],
+    });
+
+    // Pre-existing row has correct project + branch but lost its
+    // worktreePath somehow. Only worktreePath should be healed; the
+    // already-correct fields must be left alone.
+    seedWorkspaceStatuses(tmp, [
+      {
+        workspaceId,
+        project: projectName,
+        branch,
+        worktreePath: "",
+        agentStatus: "waiting",
+      },
+    ]);
+
+    const healed = upsertWorkspaceStatus(workspaceId, { status: "waiting" });
+
+    expect(healed.project).toBe(projectName);
+    expect(healed.branch).toBe(branch);
+    expect(healed.worktreePath).toBe(wtPath);
+  });
+
+  it("does not overwrite non-empty worktreePath even if state.json would resolve differently", () => {
+    const projectName = "kbhq";
+    const branch = "main";
+    const staleButValidPath = "/tmp/some-old-cached-worktree-path";
+    const newPathInState = join(tmp, "worktrees", "kbhq-main");
+    const workspaceId = toWorkspaceId(projectName, branch);
+
+    // state.json (projects/worktrees DB) currently resolves the
+    // workspace to a different path. We should NOT clobber the row.
+    seedState(tmp, {
+      projects: [
+        {
+          name: projectName,
+          path: join(tmp, "repos", "kbhq"),
+          defaultBranch: "main",
+          worktrees: [{ branch, path: newPathInState }],
+        },
+      ],
+    });
+
+    seedWorkspaceStatuses(tmp, [
+      {
+        workspaceId,
+        project: projectName,
+        branch,
+        worktreePath: staleButValidPath,
+        agentStatus: "waiting",
+      },
+    ]);
+
+    const result = upsertWorkspaceStatus(workspaceId, { status: "waiting" });
+
+    // worktreePath stays at the (non-empty) seeded value — healing is
+    // conservative and never overwrites correct data.
+    expect(result.worktreePath).toBe(staleButValidPath);
+    expect(result.project).toBe(projectName);
+    expect(result.branch).toBe(branch);
+  });
+
+  it("leaves an existing row alone when project/worktrees DB has no matching entry", () => {
+    const workspaceId = "unknown-project-main";
+
+    // No projects/worktrees seeded — resolveWorkspaceIdentity returns
+    // null, so the row stays empty (no spurious writes).
+    seedState(tmp, { projects: [] });
+    seedWorkspaceStatuses(tmp, [
+      {
+        workspaceId,
+        project: "",
+        branch: "",
+        worktreePath: "",
+        agentStatus: "waiting",
+      },
+    ]);
+
+    const result = upsertWorkspaceStatus(workspaceId, { status: "waiting" });
+
+    expect(result.project).toBe("");
+    expect(result.branch).toBe("");
+    expect(result.worktreePath).toBe("");
+  });
+});


### PR DESCRIPTION
## Summary
- `upsertWorkspaceStatus` only resolved workspace identity (project / branch / worktreePath) on INSERT, so rows that were ever stored with empty identity fields stayed empty forever — and the desktop title-bar `EditorPicker` (gated on a non-empty `worktreePath` in `DesktopTitleBar.tsx`) never appeared for those workspaces.
- On UPDATE we now re-call `resolveWorkspaceIdentity(workspaceId)` when any of `project` / `branch` / `worktreePath` is currently empty and patch **only** those fields in the same UPDATE — never overwriting non-empty values, so a momentarily out-of-sync projects table can't clobber correct data.
- Real-world repro: project `kbhq` (git project with 1 worktree) had `worktreePath = ''` in `workspace_statuses` and never showed the editor dropdown. After this fix the next status write self-heals the row.

## Test plan
- [x] New black-box integration test `apps/web/tests/state.test.ts` (vitest + real SQLite via the existing `seedState` / `seedWorkspaceStatuses` helpers) covering:
  - Row with all-empty identity is healed end-to-end (and verified via a fresh `getWorkspaceStatus`).
  - Partial empties: only the empty subset is patched.
  - Non-empty `worktreePath` is **not** overwritten even if `state.json` would resolve to a different value (conservative invariant).
  - No matching project/worktree → row left untouched, no spurious writes.
- [x] Confirmed tests **fail without the fix** and **pass with it**.
- [x] `pnpm exec biome check .` clean for the changed files (one pre-existing warning in `DashboardShell.tsx` is unrelated).
- [x] Pre-push hook (biome + cargo fmt/clippy + knip + jscpd) passed on push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)