### PR TITLE
feat(cli): add `band open <file>` to open a file in the active workspace

### DIFF
--- a/apps/cli/skills/band.md
+++ b/apps/cli/skills/band.md
@@ -4,7 +4,7 @@ version: 0.1.0
 description: Programmatic workspace management for Band. Use when the user wants to create, list, or remove Band workspaces or projects, manage tunnels, manage cronjobs, or check settings via the Band CLI. Triggers include "create workspace", "list projects", "band workspace", "band project", "schedule a job". For sending chat messages to coding agents, see the `band-chat` skill.
 allowed-tools: Bash
 argument-hint: [command] [args...]
-commands: projects, workspaces, cronjobs, tunnel, settings, notify, schema, generate-skills, skills
+commands: projects, workspaces, cronjobs, tunnel, settings, open, notify, schema, generate-skills, skills
 ---
 
 # Band CLI
@@ -66,6 +66,34 @@ band workspaces create my-app feat/auth --prompt "Add JWT authentication to the 
 ```sh
 band workspaces list --output json | jq '.workspaces[] | select(.project == "my-app") | .branch'
 ```
+
+### Open a file in the dashboard
+
+`band open <file>` routes a file to whichever workspace is currently
+focused in the Band dashboard (the most recently active one). Use it
+from grep / stack-trace output to drop yourself straight into the
+editor without naming the workspace.
+
+```sh
+# Open the file in whichever workspace the dashboard is currently focused on
+band open src/main.rs
+
+# Jump to line 42, column 5
+band open src/main.rs:42:5
+
+# Override the active-workspace fallback
+band open src/main.rs --workspace my-app/feat/auth
+
+# Open an arbitrary file from outside any workspace — opens as an
+# external editor tab (the same surface as desktop Cmd+O / "Open File…")
+band open ~/Downloads/v3.js
+```
+
+Files inside the target workspace open as normal editor tabs.
+Files outside any workspace root open as external tabs, hosted in
+the active workspace's editor pane. Errors when no workspace is
+active in the dashboard and no `--workspace` is supplied, or when
+the file doesn't exist on disk.
 
 ### Drive a coding agent
 

--- a/apps/cli/src/main.rs
+++ b/apps/cli/src/main.rs
@@ -59,6 +59,18 @@ enum Commands {
         #[command(subcommand)]
         cmd: TunnelCmd,
     },
+    /// Open a file in the active Band workspace's editor pane
+    Open {
+        /// Path to the file (absolute, or relative to cwd). Optionally
+        /// suffixed with `:line` / `:line:col` / `:line-lineEnd`.
+        file_path: String,
+        /// Workspace ID (overrides the dashboard's active workspace)
+        #[arg(long)]
+        workspace: Option<String>,
+        /// Don't raise the dashboard window to the foreground after opening
+        #[arg(long = "no-focus")]
+        no_focus: bool,
+    },
     /// Receive hook notifications from Claude Code (reads JSON from stdin)
     Notify,
     /// Show command schemas as JSON
@@ -584,6 +596,11 @@ fn main() {
             TunnelCmd::Start => cmd_tunnel_start(),
             TunnelCmd::Stop => cmd_tunnel_stop(),
         },
+        Commands::Open {
+            file_path,
+            workspace,
+            no_focus,
+        } => cmd_open(&file_path, workspace.as_deref(), !no_focus),
         Commands::Notify => cmd_notify(),
         Commands::Schema { .. } => unreachable!(),
         Commands::GenerateSkills { output_dir, filter } => {
@@ -1994,6 +2011,131 @@ fn cmd_tunnel_stop() -> Result<CommandResult, String> {
     })
 }
 
+// --- Open command ---
+
+/// Split a `path:line[:column]` / `path:line-lineEnd` suffix off the tail
+/// of a user-supplied file argument. Mirrors `parseFileLocation` in
+/// `packages/dashboard-core/src/lib/file-location.ts` — the server speaks
+/// the same syntax on the wire, but we have to strip it before resolving
+/// the path against the filesystem because a colon in the middle of a
+/// real Unix filename is rare-but-legal.
+///
+/// Returns `(filePath, line, lineEnd, column)`. Numeric components are
+/// `None` when the input doesn't carry that piece.
+fn split_file_location(raw: &str) -> (String, Option<u32>, Option<u32>, Option<u32>) {
+    // Try :line-lineEnd
+    if let Some(idx) = raw.rfind(':') {
+        let tail = &raw[idx + 1..];
+        if let Some(dash) = tail.find('-') {
+            let (a, b) = (&tail[..dash], &tail[dash + 1..]);
+            if let (Ok(line), Ok(end)) = (a.parse::<u32>(), b.parse::<u32>()) {
+                if line > 0 && end > 0 {
+                    return (raw[..idx].to_string(), Some(line), Some(end), None);
+                }
+            }
+        }
+    }
+
+    // Try :line:column (two trailing numeric components)
+    let mut parts = raw.rsplitn(3, ':');
+    let last = parts.next();
+    let middle = parts.next();
+    let head = parts.next();
+    if let (Some(head), Some(middle), Some(last)) = (head, middle, last) {
+        if let (Ok(line), Ok(col)) = (middle.parse::<u32>(), last.parse::<u32>()) {
+            if line > 0 && col > 0 {
+                return (head.to_string(), Some(line), None, Some(col));
+            }
+        }
+    }
+
+    // Try :line
+    if let Some(idx) = raw.rfind(':') {
+        let tail = &raw[idx + 1..];
+        if let Ok(line) = tail.parse::<u32>() {
+            if line > 0 {
+                return (raw[..idx].to_string(), Some(line), None, None);
+            }
+        }
+    }
+
+    (raw.to_string(), None, None, None)
+}
+
+fn cmd_open(
+    file_path: &str,
+    workspace: Option<&str>,
+    focus: bool,
+) -> Result<CommandResult, String> {
+    let (path_only, line, line_end, column) = split_file_location(file_path);
+    if path_only.is_empty() {
+        return Err("File path is empty".to_string());
+    }
+
+    // Resolve relative paths against cwd so the server sees an absolute
+    // path it can validate against the workspace root. Absolute paths are
+    // passed through unchanged.
+    let resolved: std::path::PathBuf = if std::path::Path::new(&path_only).is_absolute() {
+        std::path::PathBuf::from(&path_only)
+    } else {
+        let cwd = std::env::current_dir()
+            .map_err(|e| format!("Failed to read current directory: {e}"))?;
+        cwd.join(&path_only)
+    };
+    // Canonicalize when possible so the server sees the real on-disk path
+    // (e.g. resolves `./foo` and `..`). When the file doesn't exist yet,
+    // fall back to the joined path so the server can produce a clear
+    // "file not found" error rather than a generic IO failure here.
+    let absolute = std::fs::canonicalize(&resolved).unwrap_or(resolved);
+    let absolute_str = absolute.to_string_lossy().into_owned();
+
+    let client = api::ApiClient::from_settings()?;
+
+    let mut input = serde_json::json!({
+        "filePath": absolute_str,
+        "focus": focus,
+    });
+    if let Some(ws) = workspace {
+        input["workspaceId"] = serde_json::json!(ws);
+    }
+    if let Some(line) = line {
+        input["line"] = serde_json::json!(line);
+    }
+    if let Some(end) = line_end {
+        input["lineEnd"] = serde_json::json!(end);
+    }
+    if let Some(col) = column {
+        input["column"] = serde_json::json!(col);
+    }
+
+    let data = client.trpc_mutate("editor.openFile", &input)?;
+    let workspace_id = data
+        .get("workspaceId")
+        .and_then(|v| v.as_str())
+        .unwrap_or("");
+    let resolved_path = data.get("filePath").and_then(|v| v.as_str()).unwrap_or("");
+    let external = data
+        .get("external")
+        .and_then(serde_json::Value::as_bool)
+        .unwrap_or(false);
+
+    let where_label = if external {
+        format!("{workspace_id} (external)")
+    } else {
+        workspace_id.to_string()
+    };
+
+    Ok(CommandResult {
+        text: format!("Opened {resolved_path} in {where_label}\n"),
+        json: serde_json::json!({
+            "ok": true,
+            "workspaceId": workspace_id,
+            "filePath": resolved_path,
+            "external": external,
+        }),
+    })
+}
+
 // --- Notify command ---
 
 fn cmd_notify() -> Result<CommandResult, String> {
@@ -2420,6 +2562,16 @@ pub(crate) fn build_schema(command: Option<&str>) -> Result<serde_json::Value, S
                 {"name": "terminal_id", "type": "string", "required": false, "positional": true, "description": "Terminal ID (defaults to the cwd workspace's first terminal)"},
             ],
             "notes": "Streams terminal output to stdout while reading stdin line-by-line and sending it to the terminal.\nPress Ctrl+C to detach. Best for running commands, not full TUI interaction (use web UI for that)."
+        }),
+        serde_json::json!({
+            "name": "open",
+            "description": "Open a file in the active Band workspace's editor pane",
+            "parameters": [
+                {"name": "file_path", "type": "string", "required": true, "positional": true, "description": "Path to the file (absolute, or relative to cwd). Optionally suffixed with ':line', ':line:col', or ':line-lineEnd'."},
+                {"name": "--workspace", "type": "string", "required": false, "description": "Workspace ID (overrides the dashboard's active workspace)"},
+                {"name": "--no-focus", "type": "boolean", "required": false, "description": "Don't raise the dashboard window to the foreground after opening"},
+            ],
+            "notes": "Opens the file in the dashboard's currently focused workspace. When `--workspace` is omitted, the server uses the workspace most recently focused in the Band dashboard — exits non-zero if no workspace is active. Relative paths are resolved against the current working directory. Paths inside the workspace open as normal editor tabs; paths outside any workspace root open as external tabs (same surface as desktop Cmd+O / \"Open File…\"). Line/column suffixes (`src/main.rs:42:5`, `src/main.rs:5-10`) are supported and dropped into the editor's cursor position.\n\nExample:\n```sh\n# Open the file in whichever workspace the dashboard is currently focused on\nband open src/main.rs\n\n# Jump to line 42, column 5\nband open src/main.rs:42:5\n\n# Override the active-workspace fallback\nband open src/main.rs --workspace my-app/feat/auth\n\n# An out-of-workspace file opens as an external tab (workspace-relative\n# routing is bypassed; the FileViewer reads via the server's\n# readExternalFile capability).\nband open ~/Downloads/v3.js\n```"
         }),
         serde_json::json!({
             "name": "notify",

--- a/apps/cli/src/main.rs
+++ b/apps/cli/src/main.rs
@@ -2029,7 +2029,15 @@ fn split_file_location(raw: &str) -> (String, Option<u32>, Option<u32>, Option<u
         if let Some(dash) = tail.find('-') {
             let (a, b) = (&tail[..dash], &tail[dash + 1..]);
             if let (Ok(line), Ok(end)) = (a.parse::<u32>(), b.parse::<u32>()) {
-                if line > 0 && end > 0 {
+                // Reject inverted ranges like `:10-5` — letting them through
+                // would forward a backwards `(line=10, lineEnd=5)` pair to
+                // the server, which round-trips through `formatFileLocation`
+                // and reaches the editor as a malformed selection. Falls
+                // through to the other suffix branches; none of them match
+                // a `digit-digit` tail, so the suffix is treated as part of
+                // the filename and the server returns a clean "File not
+                // found" error.
+                if line > 0 && end > 0 && line <= end {
                     return (raw[..idx].to_string(), Some(line), Some(end), None);
                 }
             }

--- a/apps/cli/src/main.rs
+++ b/apps/cli/src/main.rs
@@ -2055,12 +2055,16 @@ fn split_file_location(raw: &str) -> (String, Option<u32>, Option<u32>, Option<u
     // surprising edge case for the user but the alternative —
     // accepting zero as a sentinel — would let a typo silently
     // suppress positioning. Errs on the side of visibility.
+    // `rsplitn` walks right-to-left, so name the bindings to match the
+    // iterator order (rightmost = col, middle = line, head = path).
+    // Otherwise a future reader skimming `last`/`middle`/`head`
+    // left-to-right will swap line and col in their mental model.
     let mut parts = raw.rsplitn(3, ':');
-    let last = parts.next();
+    let rightmost = parts.next();
     let middle = parts.next();
     let head = parts.next();
-    if let (Some(head), Some(middle), Some(last)) = (head, middle, last) {
-        if let (Ok(line), Ok(col)) = (middle.parse::<u32>(), last.parse::<u32>()) {
+    if let (Some(head), Some(middle), Some(rightmost)) = (head, middle, rightmost) {
+        if let (Ok(line), Ok(col)) = (middle.parse::<u32>(), rightmost.parse::<u32>()) {
             if line > 0 && col > 0 {
                 return (head.to_string(), Some(line), None, Some(col));
             }

--- a/apps/cli/src/main.rs
+++ b/apps/cli/src/main.rs
@@ -2109,15 +2109,22 @@ fn cmd_open(
     }
 
     let data = client.trpc_mutate("editor.openFile", &input)?;
+    // Surface a clear error rather than printing "Opened <path> in " if
+    // the server's response shape ever drifts — the three fields below
+    // are part of the editor.openFile contract; an empty string here
+    // would be a silent bug.
     let workspace_id = data
         .get("workspaceId")
         .and_then(|v| v.as_str())
-        .unwrap_or("");
-    let resolved_path = data.get("filePath").and_then(|v| v.as_str()).unwrap_or("");
+        .ok_or_else(|| "server response missing workspaceId".to_string())?;
+    let resolved_path = data
+        .get("filePath")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| "server response missing filePath".to_string())?;
     let external = data
         .get("external")
         .and_then(serde_json::Value::as_bool)
-        .unwrap_or(false);
+        .ok_or_else(|| "server response missing external".to_string())?;
 
     let where_label = if external {
         format!("{workspace_id} (external)")

--- a/apps/cli/src/main.rs
+++ b/apps/cli/src/main.rs
@@ -2044,7 +2044,17 @@ fn split_file_location(raw: &str) -> (String, Option<u32>, Option<u32>, Option<u
         }
     }
 
-    // Try :line:column (two trailing numeric components)
+    // Try :line:column (two trailing numeric components).
+    //
+    // The `> 0` guards match the server's `z.number().int().positive()`
+    // validators — 1-based, no zero. This means `file.rs:42:0` /
+    // `file.rs:0` / `file.rs:0:5` deliberately fall through every
+    // suffix branch and the raw colon-string ends up as the filename.
+    // The server then surfaces a clean "File not found" rather than
+    // silently treating `:0` as "no column" or "no line." It's a
+    // surprising edge case for the user but the alternative —
+    // accepting zero as a sentinel — would let a typo silently
+    // suppress positioning. Errs on the side of visibility.
     let mut parts = raw.rsplitn(3, ':');
     let last = parts.next();
     let middle = parts.next();
@@ -2057,7 +2067,8 @@ fn split_file_location(raw: &str) -> (String, Option<u32>, Option<u32>, Option<u
         }
     }
 
-    // Try :line
+    // Try :line (single trailing numeric component). Same `> 0`
+    // policy as above.
     if let Some(idx) = raw.rfind(':') {
         let tail = &raw[idx + 1..];
         if let Ok(line) = tail.parse::<u32>() {

--- a/apps/cli/src/main.rs
+++ b/apps/cli/src/main.rs
@@ -2073,11 +2073,23 @@ fn split_file_location(raw: &str) -> (String, Option<u32>, Option<u32>, Option<u
 
     // Try :line (single trailing numeric component). Same `> 0`
     // policy as above.
+    //
+    // The `!contains(':')` guard on the head is load-bearing: without
+    // it, an input like `file.rs:0:5` that fails the `:line:col` guard
+    // above would re-enter this branch, find the final `:5`, parse 5
+    // as the line, and return `path="file.rs:0", line=5` — which the
+    // server then surfaces as a confusing "File not found: file.rs:0".
+    // The guard skips this branch whenever a colon survives in the
+    // candidate path, so unmatched colon-suffix inputs keep the full
+    // raw string as the filename.
     if let Some(idx) = raw.rfind(':') {
+        let head = &raw[..idx];
         let tail = &raw[idx + 1..];
-        if let Ok(line) = tail.parse::<u32>() {
-            if line > 0 {
-                return (raw[..idx].to_string(), Some(line), None, None);
+        if !head.contains(':') {
+            if let Ok(line) = tail.parse::<u32>() {
+                if line > 0 {
+                    return (head.to_string(), Some(line), None, None);
+                }
             }
         }
     }

--- a/apps/cli/tests/integration.rs
+++ b/apps/cli/tests/integration.rs
@@ -3126,3 +3126,285 @@ fn skills_install_filter_limits_to_matching_skills_only() {
     // Only one symlink (just band-chat) under .claude/skills/.
     assert_eq!(result["symlinks"]["linked"].as_array().unwrap().len(), 1);
 }
+
+// --- Open command tests ---
+
+/// Call the test helper that posts to `editor.setActiveWorkspace` on the
+/// running server. Mirrors the dashboard's behaviour when the user focuses
+/// a workspace, without requiring a real renderer to drive the focus event.
+fn set_active_workspace(band_dir: &Path, workspace_id: Option<&str>) {
+    let script = Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/set-active-workspace.mjs");
+    let value = workspace_id.unwrap_or("null");
+    let output = Command::new("node")
+        .arg(&script)
+        .arg(band_dir)
+        .arg(value)
+        .output()
+        .expect("set-active-workspace.mjs failed to execute");
+    assert!(
+        output.status.success(),
+        "set-active-workspace.mjs failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[test]
+fn open_with_explicit_workspace_opens_file() {
+    let env = TestEnv::new();
+    let create_out = env.band(&["workspaces", "create", "my-project", "feat/open"]);
+    assert!(
+        create_out.status.success(),
+        "stderr: {}",
+        stderr(&create_out)
+    );
+    let workspace_path = stdout(&create_out);
+
+    // Seed a file inside the new worktree so the server's existence check
+    // passes. The CLI sends an absolute path; the server normalizes it
+    // back to a workspace-relative path before emitting the open event.
+    let file_path = Path::new(&workspace_path).join("hello.txt");
+    fs::write(&file_path, "hello world\n").unwrap();
+
+    let output = env.band(&[
+        "--output",
+        "json",
+        "open",
+        file_path.to_str().unwrap(),
+        "--workspace",
+        "my-project-feat-open",
+    ]);
+    assert!(output.status.success(), "stderr: {}", stderr(&output));
+
+    let json: serde_json::Value = serde_json::from_str(&stdout(&output))
+        .unwrap_or_else(|e| panic!("invalid JSON: {e}\nstdout: {}", stdout(&output)));
+    assert_eq!(json["ok"].as_bool(), Some(true));
+    assert_eq!(
+        json["workspaceId"].as_str(),
+        Some("my-project-feat-open"),
+        "json: {json}",
+    );
+    // Server normalises the path against the workspace root, so the wire
+    // value is workspace-relative ("hello.txt"), not the absolute path the
+    // CLI sent.
+    assert_eq!(json["filePath"].as_str(), Some("hello.txt"), "json: {json}");
+    // In-workspace files report external=false so the renderer routes
+    // through the workspace-relative `_splat` route, not the external-tab
+    // path.
+    assert_eq!(
+        json["external"].as_bool(),
+        Some(false),
+        "in-workspace file should not be external: {json}",
+    );
+}
+
+#[test]
+fn open_resolves_relative_path_against_cwd() {
+    let env = TestEnv::new();
+    let create_out = env.band(&["workspaces", "create", "my-project", "feat/relpath"]);
+    assert!(
+        create_out.status.success(),
+        "stderr: {}",
+        stderr(&create_out)
+    );
+    let workspace_path = stdout(&create_out);
+    let workspace_path = fs::canonicalize(&workspace_path).expect("canonicalize worktree");
+
+    // Drop a file into a subdir so the relative-path resolution has
+    // something to bite on.
+    let sub = workspace_path.join("src");
+    fs::create_dir_all(&sub).unwrap();
+    fs::write(sub.join("main.rs"), "fn main() {}\n").unwrap();
+
+    // Run band from inside the workspace; pass a relative path with a
+    // line/column suffix to exercise both code paths in `split_file_location`.
+    let output = env.band_in(
+        &workspace_path,
+        &[
+            "--output",
+            "json",
+            "open",
+            "src/main.rs:7:3",
+            "--workspace",
+            "my-project-feat-relpath",
+        ],
+    );
+    assert!(output.status.success(), "stderr: {}", stderr(&output));
+
+    let json: serde_json::Value = serde_json::from_str(&stdout(&output))
+        .unwrap_or_else(|e| panic!("invalid JSON: {e}\nstdout: {}", stdout(&output)));
+    // Server re-emits the workspace-relative path with the line/column
+    // suffix preserved verbatim (it's a UX hint, not a filesystem
+    // identifier).
+    assert_eq!(
+        json["filePath"].as_str(),
+        Some("src/main.rs:7:3"),
+        "json: {json}",
+    );
+}
+
+#[test]
+fn open_falls_back_to_active_workspace() {
+    let env = TestEnv::new();
+    let create_out = env.band(&["workspaces", "create", "my-project", "feat/active"]);
+    assert!(
+        create_out.status.success(),
+        "stderr: {}",
+        stderr(&create_out)
+    );
+    let workspace_path = stdout(&create_out);
+    fs::write(Path::new(&workspace_path).join("README.md"), "# Hi\n").unwrap();
+
+    // Simulate the dashboard focusing this workspace.
+    set_active_workspace(&env.band_dir, Some("my-project-feat-active"));
+
+    // No `--workspace` flag — server should pull the workspaceId from the
+    // active-workspace atom.
+    let output = env.band(&[
+        "--output",
+        "json",
+        "open",
+        Path::new(&workspace_path)
+            .join("README.md")
+            .to_str()
+            .unwrap(),
+    ]);
+    assert!(output.status.success(), "stderr: {}", stderr(&output));
+
+    let json: serde_json::Value = serde_json::from_str(&stdout(&output))
+        .unwrap_or_else(|e| panic!("invalid JSON: {e}\nstdout: {}", stdout(&output)));
+    assert_eq!(
+        json["workspaceId"].as_str(),
+        Some("my-project-feat-active"),
+        "json: {json}",
+    );
+}
+
+#[test]
+fn open_without_active_workspace_errors_clearly() {
+    let env = TestEnv::new();
+    // Explicitly clear any leftover active-workspace state from previous
+    // server interactions (the in-memory atom starts null on boot, but
+    // belt-and-braces).
+    set_active_workspace(&env.band_dir, None);
+
+    let output = env.band(&["open", "some-file.txt"]);
+    assert!(
+        !output.status.success(),
+        "expected failure, got stdout: {}",
+        stdout(&output)
+    );
+    let err = stderr(&output);
+    assert!(
+        err.contains("No active workspace"),
+        "expected 'No active workspace' in stderr, got: {err}",
+    );
+}
+
+#[test]
+fn open_missing_file_errors_clearly() {
+    let env = TestEnv::new();
+    let create_out = env.band(&["workspaces", "create", "my-project", "feat/missing"]);
+    assert!(
+        create_out.status.success(),
+        "stderr: {}",
+        stderr(&create_out)
+    );
+    let workspace_path = stdout(&create_out);
+
+    let bogus = Path::new(&workspace_path).join("does-not-exist.txt");
+    let output = env.band(&[
+        "open",
+        bogus.to_str().unwrap(),
+        "--workspace",
+        "my-project-feat-missing",
+    ]);
+    assert!(
+        !output.status.success(),
+        "expected failure, got stdout: {}",
+        stdout(&output)
+    );
+    let err = stderr(&output);
+    assert!(
+        err.contains("File not found") || err.contains("not found"),
+        "expected 'not found' in stderr, got: {err}",
+    );
+}
+
+#[test]
+fn open_external_path_outside_workspace_opens_as_external_tab() {
+    let env = TestEnv::new();
+    let create_out = env.band(&["workspaces", "create", "my-project", "feat/outside"]);
+    assert!(
+        create_out.status.success(),
+        "stderr: {}",
+        stderr(&create_out)
+    );
+
+    // A real file on disk that lives outside the workspace root (the
+    // `band open` flow needs to open this as an external editor tab —
+    // same surface as desktop Cmd+O / "Open File…").
+    let stray = env.tmp.path().join("stray.txt");
+    fs::write(&stray, "out of bounds\n").unwrap();
+
+    let output = env.band(&[
+        "--output",
+        "json",
+        "open",
+        stray.to_str().unwrap(),
+        "--workspace",
+        "my-project-feat-outside",
+    ]);
+    assert!(output.status.success(), "stderr: {}", stderr(&output));
+
+    let json: serde_json::Value = serde_json::from_str(&stdout(&output))
+        .unwrap_or_else(|e| panic!("invalid JSON: {e}\nstdout: {}", stdout(&output)));
+    assert_eq!(
+        json["external"].as_bool(),
+        Some(true),
+        "expected external=true for out-of-workspace file: {json}",
+    );
+    // For external files the wire path stays absolute (the renderer
+    // needs the full path to call `readExternalFile`).
+    let returned = json["filePath"].as_str().unwrap_or("");
+    assert!(
+        returned.ends_with("/stray.txt"),
+        "expected absolute path ending in /stray.txt: {json}",
+    );
+}
+
+#[test]
+fn open_external_path_with_line_suffix_preserved() {
+    let env = TestEnv::new();
+    let create_out = env.band(&["workspaces", "create", "my-project", "feat/external-line"]);
+    assert!(
+        create_out.status.success(),
+        "stderr: {}",
+        stderr(&create_out)
+    );
+
+    let stray = env.tmp.path().join("logs.txt");
+    fs::write(&stray, "line1\nline2\nline3\n").unwrap();
+
+    // The line:column suffix is parsed off the path on the CLI side
+    // before the path is resolved against the filesystem, then attached
+    // back onto the response so the renderer can position the cursor.
+    let arg = format!("{}:2:3", stray.to_str().unwrap());
+    let output = env.band(&[
+        "--output",
+        "json",
+        "open",
+        &arg,
+        "--workspace",
+        "my-project-feat-external-line",
+    ]);
+    assert!(output.status.success(), "stderr: {}", stderr(&output));
+
+    let json: serde_json::Value = serde_json::from_str(&stdout(&output))
+        .unwrap_or_else(|e| panic!("invalid JSON: {e}\nstdout: {}", stdout(&output)));
+    assert_eq!(json["external"].as_bool(), Some(true));
+    let returned = json["filePath"].as_str().unwrap_or("");
+    assert!(
+        returned.ends_with("/logs.txt:2:3"),
+        "expected absolute path with :line:col suffix: {json}",
+    );
+}

--- a/apps/cli/tests/integration.rs
+++ b/apps/cli/tests/integration.rs
@@ -3287,7 +3287,13 @@ fn open_without_active_workspace_errors_clearly() {
     // belt-and-braces).
     set_active_workspace(&env.band_dir, None);
 
-    let output = env.band(&["open", "some-file.txt"]);
+    // Use a fully-qualified non-existent path so the test asserts the
+    // "no active workspace" branch regardless of cwd. With a relative
+    // path like `some-file.txt`, `cmd_open` would resolve it against the
+    // test runner's cwd and — if that file happens to exist — the
+    // server's workspace-resolution guard would trip *before* the
+    // existence check, masking the branch we want to cover.
+    let output = env.band(&["open", "/nonexistent/path/some-file.txt"]);
     assert!(
         !output.status.success(),
         "expected failure, got stdout: {}",

--- a/apps/cli/tests/integration.rs
+++ b/apps/cli/tests/integration.rs
@@ -3454,6 +3454,46 @@ fn open_inverted_range_is_rejected_as_suffix() {
 }
 
 #[test]
+fn open_directory_is_rejected() {
+    // `existsSync` returns true for directories, so without the
+    // `statSync().isFile()` guard on the server, `band open <dir>`
+    // would treat the directory as an external file and the renderer
+    // would try to open it as a text buffer. This also covers the
+    // workspace-root edge case (`band open <workspace-root>` →
+    // directory → rejected here before the renderer's empty-splat
+    // logic fires).
+    let env = TestEnv::new();
+    let create_out = env.band(&["workspaces", "create", "my-project", "feat/dir"]);
+    assert!(
+        create_out.status.success(),
+        "stderr: {}",
+        stderr(&create_out)
+    );
+    let workspace_path = stdout(&create_out);
+
+    // Create a real subdirectory inside the workspace.
+    let dir_inside = Path::new(&workspace_path).join("src");
+    fs::create_dir_all(&dir_inside).unwrap();
+
+    let output = env.band(&[
+        "open",
+        dir_inside.to_str().unwrap(),
+        "--workspace",
+        "my-project-feat-dir",
+    ]);
+    assert!(
+        !output.status.success(),
+        "expected failure, got stdout: {}",
+        stdout(&output),
+    );
+    let err = stderr(&output);
+    assert!(
+        err.contains("Not a file") || err.contains("not a file"),
+        "expected 'not a file' error, got: {err}",
+    );
+}
+
+#[test]
 fn open_valid_line_range_is_parsed_and_round_tripped() {
     // Companion to `open_inverted_range_is_rejected_as_suffix`:
     // exercises the happy path of the `:line-lineEnd` branch. Without

--- a/apps/cli/tests/integration.rs
+++ b/apps/cli/tests/integration.rs
@@ -3452,3 +3452,50 @@ fn open_inverted_range_is_rejected_as_suffix() {
         "expected 'not found' error for unparseable suffix, got: {err}",
     );
 }
+
+#[test]
+fn open_valid_line_range_is_parsed_and_round_tripped() {
+    // Companion to `open_inverted_range_is_rejected_as_suffix`:
+    // exercises the happy path of the `:line-lineEnd` branch. Without
+    // this, a regression that swaps `line` / `lineEnd` in the JSON
+    // payload (or in the server's `formatFileLocation` call) would go
+    // undetected — the rejection test only covers the guard.
+    let env = TestEnv::new();
+    let create_out = env.band(&["workspaces", "create", "my-project", "feat/range"]);
+    assert!(
+        create_out.status.success(),
+        "stderr: {}",
+        stderr(&create_out)
+    );
+    let workspace_path = stdout(&create_out);
+
+    fs::write(
+        Path::new(&workspace_path).join("ranged.txt"),
+        "one\ntwo\nthree\nfour\nfive\n",
+    )
+    .unwrap();
+
+    let arg = format!("{}/ranged.txt:2-4", &workspace_path);
+    let output = env.band(&[
+        "--output",
+        "json",
+        "open",
+        &arg,
+        "--workspace",
+        "my-project-feat-range",
+    ]);
+    assert!(output.status.success(), "stderr: {}", stderr(&output));
+
+    let json: serde_json::Value = serde_json::from_str(&stdout(&output))
+        .unwrap_or_else(|e| panic!("invalid JSON: {e}\nstdout: {}", stdout(&output)));
+    assert_eq!(json["external"].as_bool(), Some(false));
+    // Server normalises to a workspace-relative path with the range
+    // suffix preserved verbatim. If `line` and `lineEnd` got swapped
+    // anywhere in the pipeline, the round-tripped suffix would be
+    // `:4-2` (which the inverted-range test verifies is rejected).
+    assert_eq!(
+        json["filePath"].as_str(),
+        Some("ranged.txt:2-4"),
+        "json: {json}",
+    );
+}

--- a/apps/cli/tests/integration.rs
+++ b/apps/cli/tests/integration.rs
@@ -3454,6 +3454,36 @@ fn open_inverted_range_is_rejected_as_suffix() {
 }
 
 #[test]
+fn open_with_nonexistent_workspace_errors_clearly() {
+    // The server resolves `--workspace <id>` via `resolveWorkspace` and
+    // throws `NOT_FOUND: Workspace '<id>' not found` when no row exists.
+    // Without an integration test, a regression that silently created
+    // a placeholder workspace (or swallowed the error and emitted an
+    // open-file event pointing at a non-existent worktree) would slip
+    // through.
+    let env = TestEnv::new();
+    let file = env.tmp.path().join("any.txt");
+    fs::write(&file, "hi\n").unwrap();
+
+    let output = env.band(&[
+        "open",
+        file.to_str().unwrap(),
+        "--workspace",
+        "definitely-not-a-real-workspace",
+    ]);
+    assert!(
+        !output.status.success(),
+        "expected failure, got stdout: {}",
+        stdout(&output),
+    );
+    let err = stderr(&output);
+    assert!(
+        err.contains("not found") || err.contains("Workspace"),
+        "expected 'workspace not found' error, got: {err}",
+    );
+}
+
+#[test]
 fn open_zero_column_falls_through_to_filename() {
     // `file.rs:0:5` and `file.rs:5:0` would, naively, fail the
     // `:line:col` guard (line/col must be ≥ 1) and then trip the

--- a/apps/cli/tests/integration.rs
+++ b/apps/cli/tests/integration.rs
@@ -3414,3 +3414,41 @@ fn open_external_path_with_line_suffix_preserved() {
         "expected absolute path with :line:col suffix: {json}",
     );
 }
+
+#[test]
+fn open_inverted_range_is_rejected_as_suffix() {
+    // `:10-5` is a backwards line range. The CLI's `split_file_location`
+    // should refuse to parse it as a `line-lineEnd` suffix; the suffix
+    // sticks to the filename and the server fails the existence check,
+    // which is the right "I have no idea what this path is" answer.
+    //
+    // Without the `line <= end` guard, the suffix would be parsed as
+    // `(line=10, lineEnd=5)` and forwarded to the editor as a malformed
+    // selection — silent corruption rather than a visible error.
+    let env = TestEnv::new();
+    let create_out = env.band(&["workspaces", "create", "my-project", "feat/inverted"]);
+    assert!(
+        create_out.status.success(),
+        "stderr: {}",
+        stderr(&create_out)
+    );
+    let workspace_path = stdout(&create_out);
+
+    // Seed a real file so the only failure mode is the parser-driven one
+    // — if the test ever started passing because the suffix-bearing path
+    // happened to not exist, we wouldn't notice the guard regressing.
+    fs::write(Path::new(&workspace_path).join("real.txt"), "hi\n").unwrap();
+
+    let bogus = format!("{}/real.txt:10-5", &workspace_path);
+    let output = env.band(&["open", &bogus, "--workspace", "my-project-feat-inverted"]);
+    assert!(
+        !output.status.success(),
+        "expected failure for inverted range, got stdout: {}",
+        stdout(&output),
+    );
+    let err = stderr(&output);
+    assert!(
+        err.contains("not found") || err.contains("File not found"),
+        "expected 'not found' error for unparseable suffix, got: {err}",
+    );
+}

--- a/apps/cli/tests/integration.rs
+++ b/apps/cli/tests/integration.rs
@@ -3454,6 +3454,49 @@ fn open_inverted_range_is_rejected_as_suffix() {
 }
 
 #[test]
+fn open_zero_column_falls_through_to_filename() {
+    // `file.rs:0:5` and `file.rs:5:0` would, naively, fail the
+    // `:line:col` guard (line/col must be ≥ 1) and then trip the
+    // `:line` branch on the rightmost `:5` or `:0`, mis-parsing the
+    // input as `(path="file.rs:0", line=5)` / similar. The
+    // `!contains(':')` guard on the `:line` branch ensures the whole
+    // colon-suffixed input falls through to the filename instead, so
+    // the user gets a clear "File not found" against the literal
+    // string they typed rather than a half-parsed surprise.
+    let env = TestEnv::new();
+    let create_out = env.band(&["workspaces", "create", "my-project", "feat/zerocol"]);
+    assert!(
+        create_out.status.success(),
+        "stderr: {}",
+        stderr(&create_out)
+    );
+    let workspace_path = stdout(&create_out);
+
+    // Seed a real `file.rs` so a regression that strips off `:0:5`
+    // would *succeed* instead of failing. Without this, the test
+    // could pass for the wrong reason (regressed parser strips
+    // suffix → opens real file.rs → success when we expect failure).
+    fs::write(Path::new(&workspace_path).join("file.rs"), "// real\n").unwrap();
+
+    let bogus = format!("{}/file.rs:0:5", &workspace_path);
+    let output = env.band(&["open", &bogus, "--workspace", "my-project-feat-zerocol"]);
+    assert!(
+        !output.status.success(),
+        "expected failure (file.rs:0:5 has no file on disk), got stdout: {}",
+        stdout(&output),
+    );
+    let err = stderr(&output);
+    assert!(
+        err.contains("not found") || err.contains("File not found"),
+        "expected 'not found' error mentioning the full input, got: {err}",
+    );
+    assert!(
+        err.contains("file.rs:0:5"),
+        "expected error to include literal input 'file.rs:0:5' (proves we didn't strip the suffix), got: {err}",
+    );
+}
+
+#[test]
 fn open_directory_is_rejected() {
     // `existsSync` returns true for directories, so without the
     // `statSync().isFile()` guard on the server, `band open <dir>`

--- a/apps/cli/tests/set-active-workspace.mjs
+++ b/apps/cli/tests/set-active-workspace.mjs
@@ -54,7 +54,11 @@ try {
 }
 
 if (parsed.error) {
-  console.error(`tRPC error: ${parsed.error.message ?? body}`);
+  // tRPC wraps mutation errors as `{ error: { json: { message, code, data } } }`,
+  // not `{ error: { message } }`, so the top-level `.message` is undefined.
+  // Reach into `.json.message` (and fall back to the raw body if the shape
+  // ever drifts) so error logs surface the actual server message.
+  console.error(`tRPC error: ${parsed.error?.json?.message ?? body}`);
   process.exit(1);
 }
 

--- a/apps/cli/tests/set-active-workspace.mjs
+++ b/apps/cli/tests/set-active-workspace.mjs
@@ -1,0 +1,61 @@
+// Test helper — POSTs to the running Band web server's tRPC endpoint to set
+// the in-memory "active workspace" hint. Used by the `band open` integration
+// tests to exercise the active-workspace fallback path without having to
+// drive the dashboard UI.
+//
+// Usage:
+//   node set-active-workspace.mjs <band_home> <workspaceId|null>
+//
+// The helper reads the server port + auth token from
+// <band_home>/settings.json (same place the CLI looks). Exits 0 on
+// success; prints the tRPC error to stderr and exits 1 otherwise.
+
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const [, , bandHome, workspaceIdRaw] = process.argv;
+if (!bandHome || workspaceIdRaw === undefined) {
+  console.error("usage: node set-active-workspace.mjs <band_home> <workspaceId|null>");
+  process.exit(2);
+}
+
+const workspaceId = workspaceIdRaw === "null" ? null : workspaceIdRaw;
+
+const settings = JSON.parse(readFileSync(join(bandHome, "settings.json"), "utf-8"));
+const port = settings.webServerPort;
+const token = settings.tokenSecret;
+if (!port || !token) {
+  console.error("settings.json missing webServerPort or tokenSecret");
+  process.exit(1);
+}
+
+const url = `http://127.0.0.1:${port}/trpc/editor.setActiveWorkspace`;
+const response = await fetch(url, {
+  method: "POST",
+  headers: {
+    "Content-Type": "application/json",
+    Cookie: `band_token=${token}`,
+  },
+  body: JSON.stringify({ workspaceId }),
+});
+
+const body = await response.text();
+if (!response.ok) {
+  console.error(`HTTP ${response.status}: ${body}`);
+  process.exit(1);
+}
+
+let parsed;
+try {
+  parsed = JSON.parse(body);
+} catch {
+  console.error(`invalid JSON response: ${body}`);
+  process.exit(1);
+}
+
+if (parsed.error) {
+  console.error(`tRPC error: ${parsed.error.message ?? body}`);
+  process.exit(1);
+}
+
+console.log(body);

--- a/apps/web/src/components/CodeBrowserView.tsx
+++ b/apps/web/src/components/CodeBrowserView.tsx
@@ -1313,20 +1313,37 @@ export function CodeBrowserView({
   // -------------------------------------------------------------------------
   const capabilities = useCapabilities();
   const pickFile = capabilities.pickFile;
+
+  /**
+   * Open an absolute filesystem path as an external editor tab.
+   *
+   * Shared by:
+   *   - `handleOpenExternalFile` below (desktop Cmd+O → OS file picker)
+   *   - `band:open-file-external-direct` listener (CLI `band open <abs>`
+   *     for files outside the active workspace's root)
+   *
+   * We deliberately do NOT call `onSelectFile` / push to editor history
+   * — the route only carries workspace-relative paths, and pushing an
+   * absolute path would corrupt the back/forward stack. External tabs
+   * remain reachable via the tab bar and Cmd+W close.
+   */
+  const openExternalPath = useCallback(
+    (absolutePath: string, opts?: { line?: number; lineEnd?: number; column?: number }) => {
+      fileTabs.openTabExternal(absolutePath);
+      setViewFilePath(absolutePath);
+      setViewLine(opts?.line);
+      setViewLineEnd(opts?.lineEnd);
+      setViewColumn(opts?.column);
+    },
+    [fileTabs.openTabExternal],
+  );
+
   const handleOpenExternalFile = useCallback(async () => {
     if (!pickFile) return;
     const absolutePath = await pickFile();
     if (!absolutePath) return;
-    fileTabs.openTabExternal(absolutePath);
-    setViewFilePath(absolutePath);
-    setViewLine(undefined);
-    setViewLineEnd(undefined);
-    setViewColumn(undefined);
-    // We deliberately do NOT call onSelectFile / push to editor history —
-    // the route only carries workspace-relative paths, and pushing an
-    // absolute path would corrupt the back/forward stack. External tabs
-    // remain reachable via the tab bar and Cmd+W close.
-  }, [pickFile, fileTabs.openTabExternal]);
+    openExternalPath(absolutePath);
+  }, [pickFile, openExternalPath]);
 
   // Surface the action via the same command-palette event pattern as
   // Quick Open / Search in Files. Listened to here so the desktop-shell
@@ -1352,6 +1369,31 @@ export function CodeBrowserView({
     window.addEventListener("band:open-file-external", handler);
     return () => window.removeEventListener("band:open-file-external", handler);
   }, [pickFile, handleOpenExternalFile, workspaceId]);
+
+  // Direct external-open: the CLI's `band open <abs>` for files outside
+  // any workspace root fans out via the status SSE stream → __root.tsx
+  // listener → this window event. Unlike `band:open-file-external` above,
+  // there's no picker involved: the path is supplied in `detail` and we
+  // open it straight away. Not gated on `pickFile` — the path comes from
+  // a trusted server-side `editor.openFile` mutation, so the same
+  // `readExternalFile` capability the picker flow uses is enough.
+  //
+  // Filtered by workspaceId so multi-workspace dockview setups only
+  // open the tab in the workspace the CLI targeted.
+  useEffect(() => {
+    const handler = (e: Event) => {
+      const detail = (e as CustomEvent<{ workspaceId?: string; filePath?: string }>).detail;
+      if (!detail || detail.workspaceId !== workspaceId || !detail.filePath) return;
+      const loc = parseFileLocation(detail.filePath);
+      openExternalPath(loc.filePath, {
+        line: loc.line,
+        lineEnd: loc.lineEnd,
+        column: loc.column,
+      });
+    };
+    window.addEventListener("band:open-file-external-direct", handler);
+    return () => window.removeEventListener("band:open-file-external-direct", handler);
+  }, [workspaceId, openExternalPath]);
 
   // -------------------------------------------------------------------------
   // Untitled tabs (issue #434) — empty scratch buffer with save-as flow.

--- a/apps/web/src/components/CodeBrowserView.tsx
+++ b/apps/web/src/components/CodeBrowserView.tsx
@@ -1337,6 +1337,13 @@ export function CodeBrowserView({
       setViewLineEnd(opts?.lineEnd);
       setViewColumn(opts?.column);
     },
+    // `fileTabs` itself is a new object reference every render
+    // (`useFileTabs` returns an object literal), but
+    // `fileTabs.openTabExternal` is wrapped in `useCallback` inside the
+    // hook and therefore stable across renders. Listing the property
+    // here rather than `fileTabs` itself avoids spurious re-creation of
+    // `openExternalPath` (and the downstream pending-external-open
+    // drain effect) on every parent render.
     [fileTabs.openTabExternal],
   );
 

--- a/apps/web/src/components/CodeBrowserView.tsx
+++ b/apps/web/src/components/CodeBrowserView.tsx
@@ -62,6 +62,7 @@ import { isUntitledPath, useFileTabs } from "../hooks/useFileTabs";
 import { useIsDesktop } from "../hooks/useIsDesktop";
 import { useTabState } from "../hooks/useTabState";
 import { pathInside } from "../lib/path-inside";
+import { consumeExternalOpen, subscribeExternalOpens } from "../lib/pending-external-open";
 import { FileTabBar } from "./FileTabBar";
 import type { MarkdownPreviewHandle, MarkdownPreviewMatchInfo } from "./MarkdownPreview";
 import { MarkdownPreview } from "./MarkdownPreview";
@@ -1319,8 +1320,9 @@ export function CodeBrowserView({
    *
    * Shared by:
    *   - `handleOpenExternalFile` below (desktop Cmd+O → OS file picker)
-   *   - `band:open-file-external-direct` listener (CLI `band open <abs>`
-   *     for files outside the active workspace's root)
+   *   - The pending-external-open drain (CLI `band open <abs>` for files
+   *     outside the active workspace's root — see
+   *     `lib/pending-external-open.ts`)
    *
    * We deliberately do NOT call `onSelectFile` / push to editor history
    * — the route only carries workspace-relative paths, and pushing an
@@ -1371,28 +1373,36 @@ export function CodeBrowserView({
   }, [pickFile, handleOpenExternalFile, workspaceId]);
 
   // Direct external-open: the CLI's `band open <abs>` for files outside
-  // any workspace root fans out via the status SSE stream → __root.tsx
-  // listener → this window event. Unlike `band:open-file-external` above,
-  // there's no picker involved: the path is supplied in `detail` and we
-  // open it straight away. Not gated on `pickFile` — the path comes from
-  // a trusted server-side `editor.openFile` mutation, so the same
-  // `readExternalFile` capability the picker flow uses is enough.
+  // any workspace root fans out via the status SSE stream → __root.tsx,
+  // which enqueues into the pending-external-open store *before*
+  // navigating us into existence. We drain the queue synchronously here
+  // — once on mount (catches the pre-mount enqueue) and again from the
+  // subscriber callback (catches subsequent CLI calls while we're
+  // mounted). No event-timing race: the store is module-level so the
+  // payload survives between the navigate and our first effect tick.
+  //
+  // Not gated on `pickFile` — the path comes from a trusted server-side
+  // `editor.openFile` mutation, so the same `readExternalFile`
+  // capability the picker flow uses is enough.
   //
   // Filtered by workspaceId so multi-workspace dockview setups only
   // open the tab in the workspace the CLI targeted.
   useEffect(() => {
-    const handler = (e: Event) => {
-      const detail = (e as CustomEvent<{ workspaceId?: string; filePath?: string }>).detail;
-      if (!detail || detail.workspaceId !== workspaceId || !detail.filePath) return;
-      const loc = parseFileLocation(detail.filePath);
+    const drain = () => {
+      const pending = consumeExternalOpen(workspaceId);
+      if (!pending) return;
+      const loc = parseFileLocation(pending.filePath);
       openExternalPath(loc.filePath, {
         line: loc.line,
         lineEnd: loc.lineEnd,
         column: loc.column,
       });
     };
-    window.addEventListener("band:open-file-external-direct", handler);
-    return () => window.removeEventListener("band:open-file-external-direct", handler);
+    // Drain anything queued before we mounted (the common case for
+    // `band open` when the user wasn't already on the code route).
+    drain();
+    // And subscribe for subsequent enqueues while we're mounted.
+    return subscribeExternalOpens(drain);
   }, [workspaceId, openExternalPath]);
 
   // -------------------------------------------------------------------------

--- a/apps/web/src/components/SharedDockviewLayout.tsx
+++ b/apps/web/src/components/SharedDockviewLayout.tsx
@@ -111,16 +111,30 @@ interface CrossPanelHandlers {
   onFileOpened: (workspaceId: string) => void;
   /** Called by a panel to register/unregister its find-in-file callback. */
   onFindInFile: (workspaceId: string, fn: (() => void) | null) => void;
+  /**
+   * Bring the Files panel to the foreground without touching its
+   * current-file state. Used by the `band open <external-file>` flow:
+   * the external path is queued via `lib/pending-external-open.ts`
+   * and the `CodeBrowserView` mounted inside the Files panel drains
+   * it, but the panel itself still needs to be `setActive()`'d so
+   * the user actually *sees* the new tab. Guarded on
+   * active-workspace so a CLI call targeting a non-visible workspace
+   * doesn't hijack the panel switcher.
+   */
+  onActivateFilesPanel: (workspaceId: string) => void;
 }
 
 // Mutable module-level handlers — SharedDockviewLayout writes them on every
 // render so per-workspace callbacks always reference the latest closure
-// without re-rendering every cached panel child.
-const crossPanelHandlers: CrossPanelHandlers = {
+// without re-rendering every cached panel child. Exported so non-dockview
+// call sites (e.g. the SSE listener in `__root.tsx`) can drive the dockview
+// without owning a dockview API reference.
+export const crossPanelHandlers: CrossPanelHandlers = {
   onOpenFile: () => {},
   onSelectFile: () => {},
   onFileOpened: () => {},
   onFindInFile: () => {},
+  onActivateFilesPanel: () => {},
 };
 
 // ---------------------------------------------------------------------------
@@ -822,6 +836,16 @@ export function SharedDockviewLayout() {
     else findInFileRegistry.current.delete(workspaceId);
   }, []);
 
+  const handleActivateFilesPanel = useCallback((workspaceId: string) => {
+    // Only activate when the request targets the currently visible
+    // workspace — same invariant as `handleOpenFile`. A cached but
+    // invisible workspace must not be allowed to flip the panel
+    // switcher.
+    if (workspaceId === activeWorkspaceIdRef.current) {
+      apiRef.current?.getPanel("files")?.api.setActive();
+    }
+  }, []);
+
   // Mirror the handlers into the module-level registry so panel children
   // (which can't reach into a closure across the dockview boundary) can
   // call them.
@@ -829,6 +853,7 @@ export function SharedDockviewLayout() {
   crossPanelHandlers.onFileOpened = handleFileOpened;
   crossPanelHandlers.onSelectFile = handleSelectFile;
   crossPanelHandlers.onFindInFile = handleSetFindInFile;
+  crossPanelHandlers.onActivateFilesPanel = handleActivateFilesPanel;
 
   // ---------------------------------------------------------------------
   // Command palette

--- a/apps/web/src/lib/active-workspace.ts
+++ b/apps/web/src/lib/active-workspace.ts
@@ -1,0 +1,22 @@
+/**
+ * In-memory tracking of the workspace the user is currently looking at in
+ * the Band dashboard. Used by the CLI's `band open` command so a user
+ * sitting in a terminal can fire a file at "wherever I'm focused right
+ * now" without naming the workspace explicitly.
+ *
+ * The web UI calls `setActiveWorkspace` whenever its active workspace
+ * changes (driven by route → workspace mapping). The CLI reads via
+ * `getActiveWorkspace`. State is intentionally process-local and not
+ * persisted — it's a UX hint, not durable state, and resetting on
+ * server restart is the right behaviour (no UI mounted → no "active"
+ * workspace).
+ */
+let activeWorkspaceId: string | null = null;
+
+export function setActiveWorkspace(workspaceId: string | null): void {
+  activeWorkspaceId = workspaceId && workspaceId.length > 0 ? workspaceId : null;
+}
+
+export function getActiveWorkspace(): string | null {
+  return activeWorkspaceId;
+}

--- a/apps/web/src/lib/dispatch-open-file.ts
+++ b/apps/web/src/lib/dispatch-open-file.ts
@@ -1,0 +1,117 @@
+/**
+ * Pure dispatcher for `band open` SSE events.
+ *
+ * Extracted from `__root.tsx` so it's testable in isolation. Given an
+ * `open-file` event and the current layout, decides which side-effecting
+ * handler to call:
+ *
+ *                  in-workspace            external
+ *   ───────────────┼─────────────────────┼─────────────────────────────
+ *   Desktop        │  onOpenFile         │  enqueue + onActivateFilesPanel
+ *   Mobile / web   │  navigateInWorkspace│  enqueue + navigateToWorkspaceCode
+ *
+ * The two rendering models exist because:
+ *   - Desktop dockview overlays the route Outlet and
+ *     `DesktopWorkspaceLayout` returns null, so URL navigation alone
+ *     never renders `CodeBrowserView`. Files are opened by writing into
+ *     the per-workspace state store (via `crossPanelHandlers.onOpenFile`)
+ *     and activating the Files panel.
+ *   - Mobile/narrow web is purely URL-driven via TanStack routes; the
+ *     `code/$splat` route mounts `CodeBrowserView` with the file in its
+ *     props.
+ *
+ * External paths can't go in the URL (absolute paths corrupt the
+ * back/forward stack), so they use a renderer-side queue regardless of
+ * layout — see `lib/pending-external-open.ts`.
+ */
+
+import { enqueueExternalOpen } from "./pending-external-open";
+
+export interface OpenFileDispatchHandlers {
+  /**
+   * Dockview path for in-workspace files. Writes
+   * `currentFile`/`openFilePath` to the per-workspace state store AND
+   * activates the Files panel. `filePath` may carry a
+   * `:line[:col]` / `:line-end` suffix; the handler is responsible for
+   * parsing.
+   */
+  onOpenFile: (workspaceId: string, filePath: string) => void;
+  /**
+   * Dockview path for external files. Activates the Files panel
+   * without touching its current-file state (the actual file open is
+   * driven by the pending-external-open queue, which the always-mounted
+   * `CodeBrowserView` drains).
+   */
+  onActivateFilesPanel: (workspaceId: string) => void;
+  /**
+   * Mobile/web path for in-workspace files. Navigates to
+   * `/workspace/$id/code/$splat` so the route mounts `CodeBrowserView`
+   * with `file={_splat}`.
+   */
+  navigateInWorkspace: (workspaceId: string, filePath: string) => void;
+  /**
+   * Mobile/web path for external files. Navigates to
+   * `/workspace/$id/code` so the index route mounts `CodeBrowserView`,
+   * which drains the pending-external-open queue on mount.
+   */
+  navigateToWorkspaceCode: (workspaceId: string) => void;
+}
+
+export type OpenFileDispatchResult =
+  | {
+      handled: true;
+      kind:
+        | "dockview-in-workspace"
+        | "dockview-external"
+        | "mobile-in-workspace"
+        | "mobile-external";
+    }
+  | { handled: false; reason: "not-open-file" | "missing-workspace-id" | "missing-file-path" };
+
+/**
+ * Decide how to handle an `open-file` SSE event. Pure-ish — the only
+ * side effect outside the supplied handlers is the
+ * `enqueueExternalOpen` write for external paths, which is part of the
+ * dispatcher's contract (the renderer-side queue is the only place
+ * absolute paths can live without corrupting routing state).
+ *
+ * Accepts the raw SSE payload shape (`Record<string, unknown>`) rather
+ * than `StatusEvent` because the SSE stream is shared across all event
+ * kinds and the listener fans out to this dispatcher for every event —
+ * narrowing happens here, not at the call site.
+ *
+ * Returns a discriminated result so tests can assert which branch ran
+ * without having to inspect spies. Callers in production ignore the
+ * return value.
+ */
+export function dispatchOpenFileEvent(
+  event: Record<string, unknown>,
+  options: { isDockview: boolean; handlers: OpenFileDispatchHandlers },
+): OpenFileDispatchResult {
+  if (event.kind !== "open-file") return { handled: false, reason: "not-open-file" };
+  const workspaceId = typeof event.workspaceId === "string" ? event.workspaceId : undefined;
+  if (!workspaceId) return { handled: false, reason: "missing-workspace-id" };
+  const filePath = typeof event.filePath === "string" ? event.filePath : undefined;
+  if (!filePath) return { handled: false, reason: "missing-file-path" };
+
+  const { isDockview, handlers } = options;
+
+  if (event.external === true) {
+    // External files: queue first (so a freshly-mounting CodeBrowserView
+    // catches it on mount), then surface the Files panel / route.
+    enqueueExternalOpen(workspaceId, filePath);
+    if (isDockview) {
+      handlers.onActivateFilesPanel(workspaceId);
+      return { handled: true, kind: "dockview-external" };
+    }
+    handlers.navigateToWorkspaceCode(workspaceId);
+    return { handled: true, kind: "mobile-external" };
+  }
+
+  if (isDockview) {
+    handlers.onOpenFile(workspaceId, filePath);
+    return { handled: true, kind: "dockview-in-workspace" };
+  }
+  handlers.navigateInWorkspace(workspaceId, filePath);
+  return { handled: true, kind: "mobile-in-workspace" };
+}

--- a/apps/web/src/lib/pending-external-open.ts
+++ b/apps/web/src/lib/pending-external-open.ts
@@ -1,0 +1,62 @@
+/**
+ * Renderer-side queue for external-file opens that arrive before the
+ * target `CodeBrowserView` has mounted its listener.
+ *
+ * Why this exists: when `band open <abs-path-outside-workspace>` fires
+ * the SSE event, `__root.tsx` needs to navigate to the workspace's code
+ * route AND tell that view which external file to open. The route
+ * mounts `CodeBrowserView`, but the view's `useEffect` subscribers
+ * don't run until after React's next commit — dispatching a window
+ * event in the microtask queue races against mount and gets silently
+ * dropped.
+ *
+ * Design: a module-level Map<workspaceId, PendingOpen> with a
+ * subscriber set. `__root.tsx` writes into the queue *before*
+ * navigation. `CodeBrowserView` drains its slot synchronously on
+ * mount (in the same `useEffect` that subscribes), so the pre-mount
+ * payload is delivered before any subsequent event the view might
+ * miss. Subsequent calls while the view is mounted reach it through
+ * the subscriber callback.
+ *
+ * Same shape as the favicon store in `ScreencastPanel.tsx` — Map +
+ * listener Set — which is the established codebase pattern for cross-
+ * component renderer state without pulling in Jotai/Zustand.
+ */
+
+export interface PendingExternalOpen {
+  /** Absolute filesystem path, optionally with `:line[:col]` / `:line-end` suffix. */
+  filePath: string;
+}
+
+const pending = new Map<string, PendingExternalOpen>();
+const listeners = new Set<() => void>();
+
+/**
+ * Queue an external-file open for the given workspace. Replaces any
+ * existing pending open for the same workspace — the most recent
+ * `band open` call wins, matching the user's intent.
+ */
+export function enqueueExternalOpen(workspaceId: string, filePath: string): void {
+  pending.set(workspaceId, { filePath });
+  for (const listener of listeners) listener();
+}
+
+/**
+ * Read-and-remove the pending open for a workspace. Idempotent: calling
+ * twice in a row returns `undefined` the second time. Callers should
+ * invoke this once on mount (to catch pre-mount writes) and again
+ * inside their subscriber callback (to catch writes while mounted).
+ */
+export function consumeExternalOpen(workspaceId: string): PendingExternalOpen | undefined {
+  const value = pending.get(workspaceId);
+  if (value === undefined) return undefined;
+  pending.delete(workspaceId);
+  return value;
+}
+
+export function subscribeExternalOpens(cb: () => void): () => void {
+  listeners.add(cb);
+  return () => {
+    listeners.delete(cb);
+  };
+}

--- a/apps/web/src/lib/pending-external-open.ts
+++ b/apps/web/src/lib/pending-external-open.ts
@@ -28,6 +28,15 @@ export interface PendingExternalOpen {
   filePath: string;
 }
 
+// Lifecycle note: the map is only purged on consume, never on a timer.
+// If a CLI client targets a workspace that was closed between the
+// `band open` mutation and the navigate (or one that the dashboard has
+// no view mounted for), the entry sits indefinitely. For a single-user
+// dev tool this leak is negligible — at most one stale entry per
+// workspace ID. The per-workspace keying also makes it safe across
+// `CodeBrowserView` instances: a view for workspace B will not consume
+// a stale entry for workspace A, because `consumeExternalOpen` is
+// scoped by ID.
 const pending = new Map<string, PendingExternalOpen>();
 const listeners = new Set<() => void>();
 

--- a/apps/web/src/lib/watcher.ts
+++ b/apps/web/src/lib/watcher.ts
@@ -31,7 +31,8 @@ export interface StatusEvent {
     | "terminal-created"
     | "terminal-killed"
     | "chat-created"
-    | "chat-removed";
+    | "chat-removed"
+    | "open-file";
   status?: WorkspaceStatus;
   statuses?: WorkspaceStatus[];
   workspaceId?: string;
@@ -45,6 +46,28 @@ export interface StatusEvent {
   browserId?: string;
   terminalId?: string;
   chatId?: string;
+  /**
+   * For `kind: "open-file"`: workspace-relative file path with optional
+   * line / column suffix in the standard `path:line[:column]` /
+   * `path:line-lineEnd` notation. Parsed by the client via
+   * `parseFileLocation` from `@band-app/dashboard-core`. Backs the
+   * `band open` CLI command — see `editorRouter.openFile`.
+   */
+  filePath?: string;
+  /**
+   * For `kind: "open-file"`: whether to bring the dashboard window to
+   * the foreground in addition to navigating to the file. Defaults to
+   * true. Wired through the desktop IPC bridge by the renderer; the
+   * plain web build ignores the field.
+   */
+  focus?: boolean;
+  /**
+   * For `kind: "open-file"`: whether the file lives outside the
+   * resolved workspace's root. When true, `filePath` carries an
+   * absolute filesystem path and the renderer should open it as an
+   * external tab (same surface as desktop Cmd+O / "Open File…").
+   */
+  external?: boolean;
 }
 
 type StatusListener = (event: StatusEvent) => void;

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -327,6 +327,11 @@ function AppShell() {
   // without an explicit `--workspace` flag. The adapter de-duplicates so
   // it's safe to call on every render — the mutation only fires when the
   // value actually changes.
+  // `adapter` is a module-level singleton (created once per page load)
+  // and is intentionally omitted from the dep array — biome's
+  // `useExhaustiveDependencies` rejects outer-scope values as deps
+  // because mutating them doesn't trigger a re-render. If we ever
+  // promote it to a context or prop, list it then.
   useEffect(() => {
     void adapter.setActiveWorkspace(activeWorkspaceId);
   }, [activeWorkspaceId]);
@@ -366,6 +371,9 @@ function AppShell() {
       });
     });
     return unsubscribe;
+    // `adapter` (module-level singleton) and `crossPanelHandlers`
+    // (module-level mutable registry) are intentionally omitted from
+    // deps — see the comment on the setActiveWorkspace effect above.
   }, [router]);
 
   // Panel items for the title bar panel switcher dropdown

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -27,10 +27,10 @@ import {
   Settings as SettingsIcon,
   Terminal as TerminalIcon,
 } from "lucide-react";
-import { useCallback, useEffect, useMemo } from "react";
+import { useCallback, useEffect, useMemo, useRef } from "react";
 import { BrowserHostBridge } from "../components/BrowserHostBridge";
 import { DesktopTitleBar, type PanelItem } from "../components/DesktopTitleBar";
-import { SharedDockviewLayout } from "../components/SharedDockviewLayout";
+import { crossPanelHandlers, SharedDockviewLayout } from "../components/SharedDockviewLayout";
 import { ToolbarOverflowMenuItems, ToolbarOverflowProvider } from "../components/ToolbarButtons";
 import { useIsDesktop } from "../hooks/useIsDesktop";
 import { useNavigationHistory } from "../hooks/useNavigationHistory";
@@ -334,18 +334,44 @@ function AppShell() {
   // Listen for `band open` events from the SSE stream and route the
   // dashboard to the requested file. The CLI calls
   // `editor.openFile` which fans out via `emit({kind: "open-file"})`;
-  // this listener closes the loop. Two flavours:
+  // this listener closes the loop.
   //
-  //   - In-workspace files: navigate to the splat route. The
-  //     CodeBrowserView's existing `_splat` handler opens the tab and
-  //     positions the cursor from the `:line:col` suffix.
-  //   - External files: route navigation can't carry absolute paths
-  //     (they'd corrupt the URL and the back/forward stack). Enqueue
-  //     the path into the pending-external-open store *before*
-  //     navigating, then navigate to the workspace's code index. When
-  //     `CodeBrowserView` mounts (or is already mounted), its effect
-  //     drains the queue synchronously — no event-timing race. See
-  //     `lib/pending-external-open.ts` for the rationale.
+  // Two rendering models, two dispatch paths:
+  //
+  //   - Desktop / wide-web (`useDesktopLayout` true): the dockview
+  //     overlays the route Outlet, and `DesktopWorkspaceLayout`
+  //     `returns null` — i.e. the `/workspace/$id/code/$splat`
+  //     subtree is matched by the router but never renders. URL
+  //     navigation alone does NOTHING visible here. We have to:
+  //       • write the file into the per-workspace state store
+  //         (so the dockview-hosted `CodeBrowserView` picks it up
+  //         via its `openFilePath` prop), AND
+  //       • flip the Files panel to `setActive()` so the user
+  //         actually sees the new tab instead of staying in
+  //         whichever panel they were in (typically Terminal,
+  //         because `band open` is most often run from the Band
+  //         terminal pane).
+  //     Both happen inside `crossPanelHandlers.onOpenFile`. For
+  //     external paths, we still enqueue (the `CodeBrowserView` in
+  //     the Files panel is always mounted in dockview and drains
+  //     the queue) but we additionally call
+  //     `onActivateFilesPanel` to surface it.
+  //
+  //   - Mobile / narrow web (`useDesktopLayout` false): pure URL-
+  //     driven. The `code/$splat` route mounts `CodeBrowserView`
+  //     directly via the workspace layout's `<Outlet />`, and tab
+  //     switching is also URL-driven via `WorkspaceTabNav`.
+  //
+  // Route navigation can't carry absolute paths (they'd corrupt the
+  // URL and the back/forward stack), so external files use a
+  // pre-mount-safe `pending-external-open` store regardless of
+  // layout — see `lib/pending-external-open.ts`.
+  //
+  // `useDesktopLayout` is read through a ref so a viewport resize
+  // doesn't tear down the SSE subscription; the listener picks up
+  // the current value at event time instead.
+  const useDesktopLayoutRef = useRef(useDesktopLayout);
+  useDesktopLayoutRef.current = useDesktopLayout;
   useEffect(() => {
     const unsubscribe = adapter.subscribeStatusEvents((event) => {
       if (event.kind !== "open-file") return;
@@ -353,22 +379,41 @@ function AppShell() {
       const filePath = typeof event.filePath === "string" ? event.filePath : undefined;
       if (!workspaceId || !filePath) return;
 
+      const isDockview = useDesktopLayoutRef.current;
+
       if (event.external === true) {
+        // External files always go through the pending-open queue.
+        // The CodeBrowserView (in the Files panel on desktop, in
+        // the route Outlet on mobile) drains it.
         enqueueExternalOpen(workspaceId, filePath);
-        router.navigate({
-          to: "/workspace/$workspaceId/code",
-          params: { workspaceId: encodeURIComponent(workspaceId) },
-        });
+        if (isDockview) {
+          crossPanelHandlers.onActivateFilesPanel(workspaceId);
+        } else {
+          router.navigate({
+            to: "/workspace/$workspaceId/code",
+            params: { workspaceId: encodeURIComponent(workspaceId) },
+          });
+        }
         return;
       }
 
-      router.navigate({
-        to: "/workspace/$workspaceId/code/$",
-        params: {
-          workspaceId: encodeURIComponent(workspaceId),
-          _splat: filePath,
-        },
-      });
+      // In-workspace path (workspace-relative, optionally suffixed
+      // with `:line[:col]` / `:line-end`).
+      if (isDockview) {
+        // `crossPanelHandlers.onOpenFile` does parseFileLocation
+        // internally, writes both `currentFile` (suffix-stripped)
+        // and `openFilePath` (suffix-preserved) to the per-workspace
+        // state, and activates the Files panel.
+        crossPanelHandlers.onOpenFile(workspaceId, filePath);
+      } else {
+        router.navigate({
+          to: "/workspace/$workspaceId/code/$",
+          params: {
+            workspaceId: encodeURIComponent(workspaceId),
+            _splat: filePath,
+          },
+        });
+      }
     });
     return unsubscribe;
   }, [router]);

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -38,6 +38,7 @@ import { useZoom } from "../hooks/useZoom";
 import { getElectronBridge } from "../lib/desktop-ipc";
 import { isDesktop } from "../lib/is-desktop";
 import { parseWorkspaceFromPath } from "../lib/parse-workspace";
+import { enqueueExternalOpen } from "../lib/pending-external-open";
 import {
   applyZoomLevel,
   applyZoomLevelToDom,
@@ -339,12 +340,12 @@ function AppShell() {
   //     CodeBrowserView's existing `_splat` handler opens the tab and
   //     positions the cursor from the `:line:col` suffix.
   //   - External files: route navigation can't carry absolute paths
-  //     (they'd corrupt the URL and the back/forward stack). Navigate
-  //     to the workspace's code index instead so the CodeBrowserView
-  //     mounts, then dispatch a window event that the view's external-
-  //     open listener picks up. The event is dispatched on the next
-  //     microtask so the route mount has time to land its useEffect
-  //     subscribers before we fire.
+  //     (they'd corrupt the URL and the back/forward stack). Enqueue
+  //     the path into the pending-external-open store *before*
+  //     navigating, then navigate to the workspace's code index. When
+  //     `CodeBrowserView` mounts (or is already mounted), its effect
+  //     drains the queue synchronously — no event-timing race. See
+  //     `lib/pending-external-open.ts` for the rationale.
   useEffect(() => {
     const unsubscribe = adapter.subscribeStatusEvents((event) => {
       if (event.kind !== "open-file") return;
@@ -353,16 +354,10 @@ function AppShell() {
       if (!workspaceId || !filePath) return;
 
       if (event.external === true) {
+        enqueueExternalOpen(workspaceId, filePath);
         router.navigate({
           to: "/workspace/$workspaceId/code",
           params: { workspaceId: encodeURIComponent(workspaceId) },
-        });
-        queueMicrotask(() => {
-          window.dispatchEvent(
-            new CustomEvent("band:open-file-external-direct", {
-              detail: { workspaceId, filePath },
-            }),
-          );
         });
         return;
       }

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -36,9 +36,9 @@ import { useIsDesktop } from "../hooks/useIsDesktop";
 import { useNavigationHistory } from "../hooks/useNavigationHistory";
 import { useZoom } from "../hooks/useZoom";
 import { getElectronBridge } from "../lib/desktop-ipc";
+import { dispatchOpenFileEvent } from "../lib/dispatch-open-file";
 import { isDesktop } from "../lib/is-desktop";
 import { parseWorkspaceFromPath } from "../lib/parse-workspace";
-import { enqueueExternalOpen } from "../lib/pending-external-open";
 import {
   applyZoomLevel,
   applyZoomLevelToDom,
@@ -332,88 +332,38 @@ function AppShell() {
   }, [activeWorkspaceId]);
 
   // Listen for `band open` events from the SSE stream and route the
-  // dashboard to the requested file. The CLI calls
-  // `editor.openFile` which fans out via `emit({kind: "open-file"})`;
-  // this listener closes the loop.
-  //
-  // Two rendering models, two dispatch paths:
-  //
-  //   - Desktop / wide-web (`useDesktopLayout` true): the dockview
-  //     overlays the route Outlet, and `DesktopWorkspaceLayout`
-  //     `returns null` — i.e. the `/workspace/$id/code/$splat`
-  //     subtree is matched by the router but never renders. URL
-  //     navigation alone does NOTHING visible here. We have to:
-  //       • write the file into the per-workspace state store
-  //         (so the dockview-hosted `CodeBrowserView` picks it up
-  //         via its `openFilePath` prop), AND
-  //       • flip the Files panel to `setActive()` so the user
-  //         actually sees the new tab instead of staying in
-  //         whichever panel they were in (typically Terminal,
-  //         because `band open` is most often run from the Band
-  //         terminal pane).
-  //     Both happen inside `crossPanelHandlers.onOpenFile`. For
-  //     external paths, we still enqueue (the `CodeBrowserView` in
-  //     the Files panel is always mounted in dockview and drains
-  //     the queue) but we additionally call
-  //     `onActivateFilesPanel` to surface it.
-  //
-  //   - Mobile / narrow web (`useDesktopLayout` false): pure URL-
-  //     driven. The `code/$splat` route mounts `CodeBrowserView`
-  //     directly via the workspace layout's `<Outlet />`, and tab
-  //     switching is also URL-driven via `WorkspaceTabNav`.
-  //
-  // Route navigation can't carry absolute paths (they'd corrupt the
-  // URL and the back/forward stack), so external files use a
-  // pre-mount-safe `pending-external-open` store regardless of
-  // layout — see `lib/pending-external-open.ts`.
+  // dashboard to the requested file. The actual dispatch logic lives
+  // in `lib/dispatch-open-file.ts` so it can be tested in isolation
+  // without spinning up the dockview / router; see that file for the
+  // desktop-vs-mobile branching rationale.
   //
   // `useDesktopLayout` is read through a ref so a viewport resize
-  // doesn't tear down the SSE subscription; the listener picks up
-  // the current value at event time instead.
+  // doesn't tear down the SSE subscription — the dispatcher picks up
+  // the current layout at event time instead.
   const useDesktopLayoutRef = useRef(useDesktopLayout);
   useDesktopLayoutRef.current = useDesktopLayout;
   useEffect(() => {
     const unsubscribe = adapter.subscribeStatusEvents((event) => {
-      if (event.kind !== "open-file") return;
-      const workspaceId = typeof event.workspaceId === "string" ? event.workspaceId : undefined;
-      const filePath = typeof event.filePath === "string" ? event.filePath : undefined;
-      if (!workspaceId || !filePath) return;
-
-      const isDockview = useDesktopLayoutRef.current;
-
-      if (event.external === true) {
-        // External files always go through the pending-open queue.
-        // The CodeBrowserView (in the Files panel on desktop, in
-        // the route Outlet on mobile) drains it.
-        enqueueExternalOpen(workspaceId, filePath);
-        if (isDockview) {
-          crossPanelHandlers.onActivateFilesPanel(workspaceId);
-        } else {
-          router.navigate({
-            to: "/workspace/$workspaceId/code",
-            params: { workspaceId: encodeURIComponent(workspaceId) },
-          });
-        }
-        return;
-      }
-
-      // In-workspace path (workspace-relative, optionally suffixed
-      // with `:line[:col]` / `:line-end`).
-      if (isDockview) {
-        // `crossPanelHandlers.onOpenFile` does parseFileLocation
-        // internally, writes both `currentFile` (suffix-stripped)
-        // and `openFilePath` (suffix-preserved) to the per-workspace
-        // state, and activates the Files panel.
-        crossPanelHandlers.onOpenFile(workspaceId, filePath);
-      } else {
-        router.navigate({
-          to: "/workspace/$workspaceId/code/$",
-          params: {
-            workspaceId: encodeURIComponent(workspaceId),
-            _splat: filePath,
-          },
-        });
-      }
+      dispatchOpenFileEvent(event, {
+        isDockview: useDesktopLayoutRef.current,
+        handlers: {
+          onOpenFile: crossPanelHandlers.onOpenFile,
+          onActivateFilesPanel: crossPanelHandlers.onActivateFilesPanel,
+          navigateInWorkspace: (workspaceId, filePath) =>
+            router.navigate({
+              to: "/workspace/$workspaceId/code/$",
+              params: {
+                workspaceId: encodeURIComponent(workspaceId),
+                _splat: filePath,
+              },
+            }),
+          navigateToWorkspaceCode: (workspaceId) =>
+            router.navigate({
+              to: "/workspace/$workspaceId/code",
+              params: { workspaceId: encodeURIComponent(workspaceId) },
+            }),
+        },
+      });
     });
     return unsubscribe;
   }, [router]);

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -321,6 +321,63 @@ function AppShell() {
     activeWorkspaceId ? s.statuses.get(activeWorkspaceId)?.worktreePath : undefined,
   );
 
+  // Inform the server which workspace the user is currently focused on so
+  // the `band open` CLI command knows where to route files when called
+  // without an explicit `--workspace` flag. The adapter de-duplicates so
+  // it's safe to call on every render — the mutation only fires when the
+  // value actually changes.
+  useEffect(() => {
+    void adapter.setActiveWorkspace(activeWorkspaceId);
+  }, [activeWorkspaceId]);
+
+  // Listen for `band open` events from the SSE stream and route the
+  // dashboard to the requested file. The CLI calls
+  // `editor.openFile` which fans out via `emit({kind: "open-file"})`;
+  // this listener closes the loop. Two flavours:
+  //
+  //   - In-workspace files: navigate to the splat route. The
+  //     CodeBrowserView's existing `_splat` handler opens the tab and
+  //     positions the cursor from the `:line:col` suffix.
+  //   - External files: route navigation can't carry absolute paths
+  //     (they'd corrupt the URL and the back/forward stack). Navigate
+  //     to the workspace's code index instead so the CodeBrowserView
+  //     mounts, then dispatch a window event that the view's external-
+  //     open listener picks up. The event is dispatched on the next
+  //     microtask so the route mount has time to land its useEffect
+  //     subscribers before we fire.
+  useEffect(() => {
+    const unsubscribe = adapter.subscribeStatusEvents((event) => {
+      if (event.kind !== "open-file") return;
+      const workspaceId = typeof event.workspaceId === "string" ? event.workspaceId : undefined;
+      const filePath = typeof event.filePath === "string" ? event.filePath : undefined;
+      if (!workspaceId || !filePath) return;
+
+      if (event.external === true) {
+        router.navigate({
+          to: "/workspace/$workspaceId/code",
+          params: { workspaceId: encodeURIComponent(workspaceId) },
+        });
+        queueMicrotask(() => {
+          window.dispatchEvent(
+            new CustomEvent("band:open-file-external-direct", {
+              detail: { workspaceId, filePath },
+            }),
+          );
+        });
+        return;
+      }
+
+      router.navigate({
+        to: "/workspace/$workspaceId/code/$",
+        params: {
+          workspaceId: encodeURIComponent(workspaceId),
+          _splat: filePath,
+        },
+      });
+    });
+    return unsubscribe;
+  }, [router]);
+
   // Panel items for the title bar panel switcher dropdown
   const panelItems: PanelItem[] = useMemo(
     () => [

--- a/apps/web/src/trpc/router.ts
+++ b/apps/web/src/trpc/router.ts
@@ -3021,33 +3021,46 @@ const editorRouter = t.router({
 
   openFile: publicProcedure
     .input(
-      z.object({
-        /**
-         * Workspace to open the file in. When omitted, falls back to the
-         * dashboard's currently active workspace.
-         */
-        workspaceId: z.string().optional(),
-        /**
-         * Either an absolute filesystem path or a workspace-relative
-         * path. Paths inside the workspace root open as normal editor
-         * tabs (routed via `/workspace/$id/code/$splat`); paths outside
-         * any workspace root open as external tabs (same surface as
-         * desktop Cmd+O / "Open File…"). May include a trailing
-         * line / column suffix in the standard `path:line[:column]` /
-         * `path:line-lineEnd` notation.
-         */
-        filePath: z.string().min(1),
-        line: z.number().int().positive().optional(),
-        lineEnd: z.number().int().positive().optional(),
-        column: z.number().int().positive().optional(),
-        /**
-         * Whether the renderer should bring the dashboard window to the
-         * foreground in addition to navigating to the file. Defaults to
-         * true. Passed through verbatim on the SSE event; the plain web
-         * build ignores it.
-         */
-        focus: z.boolean().optional(),
-      }),
+      z
+        .object({
+          /**
+           * Workspace to open the file in. When omitted, falls back to the
+           * dashboard's currently active workspace.
+           */
+          workspaceId: z.string().optional(),
+          /**
+           * Either an absolute filesystem path or a workspace-relative
+           * path. Paths inside the workspace root open as normal editor
+           * tabs (routed via `/workspace/$id/code/$splat`); paths outside
+           * any workspace root open as external tabs (same surface as
+           * desktop Cmd+O / "Open File…"). May include a trailing
+           * line / column suffix in the standard `path:line[:column]` /
+           * `path:line-lineEnd` notation.
+           */
+          filePath: z.string().min(1),
+          line: z.number().int().positive().optional(),
+          lineEnd: z.number().int().positive().optional(),
+          column: z.number().int().positive().optional(),
+          /**
+           * Whether the renderer should bring the dashboard window to the
+           * foreground in addition to navigating to the file. Defaults to
+           * true. Passed through verbatim on the SSE event; the plain web
+           * build ignores it.
+           */
+          focus: z.boolean().optional(),
+        })
+        .refine((v) => !(v.lineEnd !== undefined && v.line === undefined), {
+          message: "lineEnd requires line to be set",
+          path: ["lineEnd"],
+        })
+        .refine((v) => !(v.column !== undefined && v.line === undefined), {
+          message: "column requires line to be set",
+          path: ["column"],
+        })
+        .refine((v) => !(v.line !== undefined && v.lineEnd !== undefined && v.line > v.lineEnd), {
+          message: "lineEnd must be >= line",
+          path: ["lineEnd"],
+        }),
     )
     .mutation(({ input }) => {
       const targetWorkspaceId = input.workspaceId ?? getActiveWorkspace();

--- a/apps/web/src/trpc/router.ts
+++ b/apps/web/src/trpc/router.ts
@@ -1,16 +1,17 @@
 import { execFile, execFileSync, spawn } from "node:child_process";
 import { randomUUID } from "node:crypto";
-import { existsSync, constants as fsConstants, mkdirSync, unlinkSync } from "node:fs";
+import { existsSync, constants as fsConstants, mkdirSync, realpathSync, unlinkSync } from "node:fs";
 import { cp, mkdir, open, readdir, readFile, rename, rm, stat, writeFile } from "node:fs/promises";
 import { basename, dirname, extname, isAbsolute, join, resolve, sep } from "node:path";
 import { promisify } from "node:util";
-import { toWorkspaceId } from "@band-app/dashboard-core";
+import { formatFileLocation, toWorkspaceId } from "@band-app/dashboard-core";
 import { createLogger } from "@band-app/logger";
 import { initTRPC, TRPCError } from "@trpc/server";
 import { rgPath } from "@vscode/ripgrep";
 import type { UIMessage } from "ai";
 import { Cron } from "croner";
 import { z } from "zod";
+import { getActiveWorkspace, setActiveWorkspace } from "../lib/active-workspace";
 import {
   createMetadataAgent,
   createWorkspaceAgent,
@@ -2919,6 +2920,215 @@ const servicesRouter = t.router({
 });
 
 // ---------------------------------------------------------------------------
+// Editor (CLI-driven file open + active-workspace tracking)
+// ---------------------------------------------------------------------------
+
+/**
+ * `realpathSync` resolves symlinks but throws ENOENT for paths that don't
+ * exist. We need the symlink-resolution part for paths that may or may not
+ * exist (e.g. files the user wants to *open* that don't exist yet). Walk
+ * up the path until we hit an ancestor that does exist, canonicalize that,
+ * then re-append the trailing segments.
+ *
+ * Returns the input unchanged if no ancestor on disk can be canonicalized
+ * (e.g. running on a filesystem mid-delete). Callers fall back to an
+ * existence check on the returned value, which produces a clear "file not
+ * found" error rather than a confusing IO failure.
+ */
+function canonicalizeMaybeMissing(p: string): string {
+  if (existsSync(p)) {
+    try {
+      return realpathSync(p);
+    } catch {
+      return p;
+    }
+  }
+  const parts = p.split(sep);
+  for (let i = parts.length - 1; i > 0; i--) {
+    const prefix = parts.slice(0, i).join(sep) || sep;
+    if (existsSync(prefix)) {
+      try {
+        const canonicalPrefix = realpathSync(prefix);
+        return [canonicalPrefix, ...parts.slice(i)].join(sep);
+      } catch {
+        return p;
+      }
+    }
+  }
+  return p;
+}
+
+/**
+ * Backs the `band open <filePath>` CLI command and the web UI's "I am the
+ * currently focused workspace" hint.
+ *
+ * The web UI calls `editor.setActiveWorkspace` whenever its active workspace
+ * changes; the CLI's `band open` reads it via `editor.getActiveWorkspace` so
+ * the user doesn't need to name the workspace explicitly when firing a file
+ * at "wherever I'm currently looking at." The actual open is funnelled
+ * through `editor.openFile`, which:
+ *   1. Resolves the target workspace (explicit `workspaceId` > active).
+ *   2. Validates the file exists and is inside the workspace root —
+ *      paths from the CLI can be absolute (resolved against the user's
+ *      cwd) or workspace-relative.
+ *   3. Emits an `open-file` SSE event so the React shell can navigate
+ *      its router to the matching `code/<path>` route.
+ *
+ * Active-workspace tracking is process-local; the value resets when the
+ * web server restarts. That's intentional — no UI mounted → no active
+ * workspace, and the next focus event will repopulate it.
+ */
+const editorRouter = t.router({
+  getActiveWorkspace: publicProcedure.query(() => {
+    return { workspaceId: getActiveWorkspace() };
+  }),
+
+  setActiveWorkspace: publicProcedure
+    .input(z.object({ workspaceId: z.string().nullable() }))
+    .mutation(({ input }) => {
+      setActiveWorkspace(input.workspaceId);
+      return { ok: true };
+    }),
+
+  openFile: publicProcedure
+    .input(
+      z.object({
+        /**
+         * Workspace to open the file in. When omitted, falls back to the
+         * dashboard's currently active workspace.
+         */
+        workspaceId: z.string().optional(),
+        /**
+         * Either an absolute filesystem path or a workspace-relative
+         * path. Paths inside the workspace root open as normal editor
+         * tabs (routed via `/workspace/$id/code/$splat`); paths outside
+         * any workspace root open as external tabs (same surface as
+         * desktop Cmd+O / "Open File…"). May include a trailing
+         * line / column suffix in the standard `path:line[:column]` /
+         * `path:line-lineEnd` notation.
+         */
+        filePath: z.string().min(1),
+        line: z.number().int().positive().optional(),
+        lineEnd: z.number().int().positive().optional(),
+        column: z.number().int().positive().optional(),
+        /**
+         * Whether the renderer should bring the dashboard window to the
+         * foreground in addition to navigating to the file. Defaults to
+         * true. Passed through verbatim on the SSE event; the plain web
+         * build ignores it.
+         */
+        focus: z.boolean().optional(),
+      }),
+    )
+    .mutation(({ input }) => {
+      const targetWorkspaceId = input.workspaceId ?? getActiveWorkspace();
+      if (!targetWorkspaceId) {
+        throw new TRPCError({
+          code: "FAILED_PRECONDITION",
+          message:
+            "No active workspace. Open a workspace in the Band dashboard or pass --workspace.",
+        });
+      }
+
+      const workspace = resolveWorkspace(targetWorkspaceId);
+      if (!workspace) {
+        throw new TRPCError({
+          code: "NOT_FOUND",
+          message: `Workspace '${targetWorkspaceId}' not found`,
+        });
+      }
+
+      const root = workspace.worktree.path;
+
+      // Resolve the path: absolute paths are taken as-is; relative
+      // paths are resolved against the workspace root.
+      const absoluteTarget = isAbsolute(input.filePath)
+        ? resolve(input.filePath)
+        : resolve(root, input.filePath);
+
+      // Canonicalize the workspace root so symlinked path prefixes
+      // (macOS's `/var/folders` → `/private/var/folders` in particular)
+      // compare equal. The CLI canonicalizes the user's argument before
+      // sending, so a stored worktree path under `/var/...` would
+      // otherwise look "outside" its real location.
+      let canonicalRoot = root;
+      try {
+        canonicalRoot = realpathSync(root);
+      } catch {
+        // worktree may have been deleted out from under us — leave as-is
+      }
+
+      // Canonicalize the user's path the same way. `realpathSync` fails
+      // on missing files, so walk up to the deepest ancestor that does
+      // exist, canonicalize that, then re-append the trailing segments.
+      // That keeps the in-workspace check accurate for paths the user
+      // wants to *create* as well, and sidesteps a confusing IO error
+      // when the real problem is the file is just missing.
+      const canonicalTarget = canonicalizeMaybeMissing(absoluteTarget);
+
+      if (!existsSync(canonicalTarget)) {
+        throw new TRPCError({
+          code: "NOT_FOUND",
+          message: `File not found: ${input.filePath}`,
+        });
+      }
+
+      // Segment-aware containment check (same invariant as the untitled
+      // save flow in CodeBrowserView): a naive `startsWith` would treat
+      // `/a/band-fork/x.ts` as inside `/a/band`.
+      const normalizedRoot = canonicalRoot.replace(/\/+$/, "");
+      const isInside =
+        canonicalTarget === normalizedRoot || canonicalTarget.startsWith(`${normalizedRoot}${sep}`);
+
+      // Two open modes share this procedure:
+      //
+      //   - In-workspace: emit a workspace-relative path so the React
+      //     shell routes to `/workspace/$id/code/$splat` (same flow as
+      //     the file tree / Quick Open dialog).
+      //   - External: file exists on disk but lives outside the active
+      //     workspace's root. Pass the absolute path through verbatim
+      //     so the FileViewer mounts it as an *external* tab
+      //     (`isExternal: true`), reading via `readExternalFile` and
+      //     skipping LSP / workspace-relative routing. Matches what
+      //     desktop Cmd+O ("Open File…") does — `band open` is just a
+      //     programmatic entrypoint into the same code path.
+      let payloadPath: string;
+      if (isInside) {
+        const relativePath =
+          canonicalTarget === normalizedRoot
+            ? ""
+            : canonicalTarget.slice(normalizedRoot.length + 1);
+        // POSIX separators on the wire — tanstack-router and
+        // `parseFileLocation` both work off `/`-separated paths.
+        payloadPath = relativePath.split(sep).join("/");
+      } else {
+        payloadPath = canonicalTarget;
+      }
+
+      const formatted = formatFileLocation(payloadPath, input.line, {
+        lineEnd: input.lineEnd,
+        column: input.column,
+      });
+
+      emit({
+        kind: "open-file",
+        workspaceId: targetWorkspaceId,
+        filePath: formatted,
+        external: !isInside,
+        focus: input.focus ?? true,
+      });
+
+      return {
+        ok: true,
+        workspaceId: targetWorkspaceId,
+        filePath: formatted,
+        external: !isInside,
+        worktreePath: root,
+      };
+    }),
+});
+
+// ---------------------------------------------------------------------------
 // Chat
 // ---------------------------------------------------------------------------
 
@@ -4106,6 +4316,7 @@ export const appRouter = t.router({
   chat: chatRouter,
   chatLayout: chatLayoutRouter,
   chats: chatsRouter,
+  editor: editorRouter,
   browserLayout: browserLayoutRouter,
   browsers: browsersRouter,
   browserHost: browserHostRouter,

--- a/apps/web/src/trpc/router.ts
+++ b/apps/web/src/trpc/router.ts
@@ -2949,7 +2949,13 @@ function canonicalizeMaybeMissing(p: string): string {
     if (existsSync(prefix)) {
       try {
         const canonicalPrefix = realpathSync(prefix);
-        return [canonicalPrefix, ...parts.slice(i)].join(sep);
+        // `path.join` collapses the duplicate separator that arises when
+        // `canonicalPrefix === "/"` (which happens when the walk reaches
+        // `i = 1` — `parts.slice(0, 1).join(sep)` is `""`, falling
+        // through to `sep`). A naive `[..., ...].join(sep)` would
+        // produce `//nonexistent/foo`; functionally equivalent on POSIX
+        // but ugly in error messages.
+        return join(canonicalPrefix, ...parts.slice(i));
       } catch {
         return p;
       }

--- a/apps/web/src/trpc/router.ts
+++ b/apps/web/src/trpc/router.ts
@@ -2963,9 +2963,10 @@ function canonicalizeMaybeMissing(p: string): string {
  * currently focused workspace" hint.
  *
  * The web UI calls `editor.setActiveWorkspace` whenever its active workspace
- * changes; the CLI's `band open` reads it via `editor.getActiveWorkspace` so
- * the user doesn't need to name the workspace explicitly when firing a file
- * at "wherever I'm currently looking at." The actual open is funnelled
+ * changes; the CLI's `band open` reads the same value implicitly via the
+ * `openFile` mutation's fallback (`input.workspaceId ?? getActiveWorkspace()`)
+ * so the user doesn't need to name the workspace explicitly when firing a
+ * file at "wherever I'm currently looking at." The actual open is funnelled
  * through `editor.openFile`, which:
  *   1. Resolves the target workspace (explicit `workspaceId` > active).
  *   2. Validates the file exists and is inside the workspace root —
@@ -2977,11 +2978,26 @@ function canonicalizeMaybeMissing(p: string): string {
  * Active-workspace tracking is process-local; the value resets when the
  * web server restarts. That's intentional — no UI mounted → no active
  * workspace, and the next focus event will repopulate it.
+ *
+ * Security / threat model:
+ *   - The `band_token` cookie/header is enforced at the transport layer
+ *     (see `start-server.ts`), gating both normal local-server requests
+ *     and Band's public tunnel. Only token-bearers can call these
+ *     procedures, same constraint as the rest of the router.
+ *   - A token-bearer can poison the active-workspace atom via
+ *     `setActiveWorkspace` and trigger `openFile` against any workspace
+ *     the daemon manages. That's the existing trust boundary: a holder
+ *     of the token is already trusted to read/write files via
+ *     `workspace.*` and `host.*`, so opening one in the editor is a
+ *     proper subset of what they can already do.
+ *   - If the desktop ever ships a "share my tunnel without my token"
+ *     mode, these (and every other) `publicProcedure` need re-auditing.
  */
 const editorRouter = t.router({
-  getActiveWorkspace: publicProcedure.query(() => {
-    return { workspaceId: getActiveWorkspace() };
-  }),
+  // Intentionally no `getActiveWorkspace` query — the only consumer is the
+  // CLI's `band open`, which reads the value implicitly through the
+  // `openFile` fallback in the same round-trip. Adding a separate query
+  // doubles the cost for no benefit.
 
   setActiveWorkspace: publicProcedure
     .input(z.object({ workspaceId: z.string().nullable() }))
@@ -3024,7 +3040,7 @@ const editorRouter = t.router({
       const targetWorkspaceId = input.workspaceId ?? getActiveWorkspace();
       if (!targetWorkspaceId) {
         throw new TRPCError({
-          code: "FAILED_PRECONDITION",
+          code: "PRECONDITION_FAILED",
           message:
             "No active workspace. Open a workspace in the Band dashboard or pass --workspace.",
         });
@@ -3123,7 +3139,6 @@ const editorRouter = t.router({
         workspaceId: targetWorkspaceId,
         filePath: formatted,
         external: !isInside,
-        worktreePath: root,
       };
     }),
 });

--- a/apps/web/src/trpc/router.ts
+++ b/apps/web/src/trpc/router.ts
@@ -1,6 +1,13 @@
 import { execFile, execFileSync, spawn } from "node:child_process";
 import { randomUUID } from "node:crypto";
-import { existsSync, constants as fsConstants, mkdirSync, realpathSync, unlinkSync } from "node:fs";
+import {
+  existsSync,
+  constants as fsConstants,
+  mkdirSync,
+  realpathSync,
+  statSync,
+  unlinkSync,
+} from "node:fs";
 import { cp, mkdir, open, readdir, readFile, rename, rm, stat, writeFile } from "node:fs/promises";
 import { basename, dirname, extname, isAbsolute, join, resolve, sep } from "node:path";
 import { promisify } from "node:util";
@@ -3088,10 +3095,30 @@ const editorRouter = t.router({
       // when the real problem is the file is just missing.
       const canonicalTarget = canonicalizeMaybeMissing(absoluteTarget);
 
-      if (!existsSync(canonicalTarget)) {
+      // `existsSync` is true for directories too. Without the `isFile`
+      // guard, `band open /path/to/some-dir` would pass through to the
+      // renderer as an external "file" and the editor would try to
+      // open the directory as a text buffer. Also covers the
+      // workspace-root edge case (`band open /path/to/workspace`):
+      // a directory there short-circuits before the empty-splat
+      // problem in the renderer.
+      let targetStat: import("node:fs").Stats | null = null;
+      try {
+        targetStat = statSync(canonicalTarget);
+      } catch {
+        // ENOENT or another IO error — surfaced as "File not found"
+        // below, same as a missing path.
+      }
+      if (!targetStat) {
         throw new TRPCError({
           code: "NOT_FOUND",
           message: `File not found: ${input.filePath}`,
+        });
+      }
+      if (!targetStat.isFile()) {
+        throw new TRPCError({
+          code: "BAD_REQUEST",
+          message: `Not a file: ${input.filePath}`,
         });
       }
 

--- a/apps/web/tests/dispatch-open-file.test.ts
+++ b/apps/web/tests/dispatch-open-file.test.ts
@@ -1,0 +1,256 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  dispatchOpenFileEvent,
+  type OpenFileDispatchHandlers,
+} from "../src/lib/dispatch-open-file";
+import { consumeExternalOpen } from "../src/lib/pending-external-open";
+
+// ---------------------------------------------------------------------------
+// dispatchOpenFileEvent — pure dispatcher for `band open` SSE events.
+//
+// Covers the routing matrix between the two rendering models:
+//
+//                  in-workspace            external
+//   ───────────────┼─────────────────────┼─────────────────────────────
+//   Desktop        │  onOpenFile         │  enqueue + onActivateFilesPanel
+//   Mobile / web   │  navigateInWorkspace│  enqueue + navigateToWorkspaceCode
+//
+// The dispatcher is the contract between the SSE event boundary and the
+// dockview/router; verifying it here means future regressions in
+// __root.tsx's listener (which is now just a thin shim) can't silently
+// break `band open` end-to-end. The CLI integration tests cover the
+// server-side event shape; this file covers the renderer-side dispatch.
+// ---------------------------------------------------------------------------
+
+function makeHandlers(): OpenFileDispatchHandlers & {
+  onOpenFile: ReturnType<typeof vi.fn>;
+  onActivateFilesPanel: ReturnType<typeof vi.fn>;
+  navigateInWorkspace: ReturnType<typeof vi.fn>;
+  navigateToWorkspaceCode: ReturnType<typeof vi.fn>;
+} {
+  return {
+    onOpenFile: vi.fn(),
+    onActivateFilesPanel: vi.fn(),
+    navigateInWorkspace: vi.fn(),
+    navigateToWorkspaceCode: vi.fn(),
+  };
+}
+
+function openFileEvent(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    kind: "open-file",
+    workspaceId: "my-project-feat-x",
+    filePath: "src/foo.rs",
+    external: false,
+    focus: true,
+    ...overrides,
+  };
+}
+
+describe("dispatchOpenFileEvent", () => {
+  // The pending-external-open store is module-level state; drain after
+  // every test so cross-test pollution can't make an "external" assertion
+  // pass spuriously because a previous test's entry was still around.
+  afterEach(() => {
+    consumeExternalOpen("my-project-feat-x");
+    consumeExternalOpen("other-workspace");
+  });
+
+  // -------------------------------------------------------------------
+  // Happy paths — one per quadrant of the dispatch matrix.
+  // -------------------------------------------------------------------
+
+  it("desktop + in-workspace → onOpenFile (writes per-workspace state + activates panel)", () => {
+    const handlers = makeHandlers();
+    const result = dispatchOpenFileEvent(openFileEvent({ filePath: "src/foo.rs:42:5" }), {
+      isDockview: true,
+      handlers,
+    });
+
+    expect(result).toEqual({ handled: true, kind: "dockview-in-workspace" });
+    expect(handlers.onOpenFile).toHaveBeenCalledExactlyOnceWith(
+      "my-project-feat-x",
+      "src/foo.rs:42:5",
+    );
+    // The other three branches must not have fired.
+    expect(handlers.onActivateFilesPanel).not.toHaveBeenCalled();
+    expect(handlers.navigateInWorkspace).not.toHaveBeenCalled();
+    expect(handlers.navigateToWorkspaceCode).not.toHaveBeenCalled();
+    // External path is workspace-relative — no enqueue.
+    expect(consumeExternalOpen("my-project-feat-x")).toBeUndefined();
+  });
+
+  it("desktop + external → enqueues + activates Files panel", () => {
+    const handlers = makeHandlers();
+    const result = dispatchOpenFileEvent(
+      openFileEvent({ filePath: "/abs/path/foo.rs:7", external: true }),
+      { isDockview: true, handlers },
+    );
+
+    expect(result).toEqual({ handled: true, kind: "dockview-external" });
+    expect(handlers.onActivateFilesPanel).toHaveBeenCalledExactlyOnceWith("my-project-feat-x");
+    expect(handlers.onOpenFile).not.toHaveBeenCalled();
+    expect(handlers.navigateInWorkspace).not.toHaveBeenCalled();
+    expect(handlers.navigateToWorkspaceCode).not.toHaveBeenCalled();
+    // The CodeBrowserView in the (now-active) Files panel will drain
+    // this on its next subscriber tick.
+    expect(consumeExternalOpen("my-project-feat-x")).toEqual({
+      filePath: "/abs/path/foo.rs:7",
+    });
+  });
+
+  it("mobile + in-workspace → navigateInWorkspace", () => {
+    const handlers = makeHandlers();
+    const result = dispatchOpenFileEvent(openFileEvent({ filePath: "src/foo.rs:10-20" }), {
+      isDockview: false,
+      handlers,
+    });
+
+    expect(result).toEqual({ handled: true, kind: "mobile-in-workspace" });
+    expect(handlers.navigateInWorkspace).toHaveBeenCalledExactlyOnceWith(
+      "my-project-feat-x",
+      "src/foo.rs:10-20",
+    );
+    expect(handlers.onOpenFile).not.toHaveBeenCalled();
+    expect(handlers.onActivateFilesPanel).not.toHaveBeenCalled();
+    expect(handlers.navigateToWorkspaceCode).not.toHaveBeenCalled();
+    expect(consumeExternalOpen("my-project-feat-x")).toBeUndefined();
+  });
+
+  it("mobile + external → enqueues + navigates to workspace code index", () => {
+    const handlers = makeHandlers();
+    const result = dispatchOpenFileEvent(
+      openFileEvent({ filePath: "/abs/path/foo.rs", external: true }),
+      { isDockview: false, handlers },
+    );
+
+    expect(result).toEqual({ handled: true, kind: "mobile-external" });
+    expect(handlers.navigateToWorkspaceCode).toHaveBeenCalledExactlyOnceWith("my-project-feat-x");
+    expect(handlers.onOpenFile).not.toHaveBeenCalled();
+    expect(handlers.onActivateFilesPanel).not.toHaveBeenCalled();
+    expect(handlers.navigateInWorkspace).not.toHaveBeenCalled();
+    expect(consumeExternalOpen("my-project-feat-x")).toEqual({
+      filePath: "/abs/path/foo.rs",
+    });
+  });
+
+  // -------------------------------------------------------------------
+  // Reject paths — the dispatcher should silently no-op (not throw)
+  // when the event is malformed or for an unrelated event kind. The
+  // SSE stream is shared across all status events; the listener must
+  // tolerate every event passing through.
+  // -------------------------------------------------------------------
+
+  it("ignores events that are not open-file", () => {
+    const handlers = makeHandlers();
+    const result = dispatchOpenFileEvent(
+      { kind: "status-update", workspaceId: "my-project-feat-x" },
+      { isDockview: true, handlers },
+    );
+
+    expect(result).toEqual({ handled: false, reason: "not-open-file" });
+    expect(handlers.onOpenFile).not.toHaveBeenCalled();
+    expect(handlers.onActivateFilesPanel).not.toHaveBeenCalled();
+    expect(handlers.navigateInWorkspace).not.toHaveBeenCalled();
+    expect(handlers.navigateToWorkspaceCode).not.toHaveBeenCalled();
+  });
+
+  it("ignores open-file events with no workspaceId", () => {
+    const handlers = makeHandlers();
+    const result = dispatchOpenFileEvent(
+      { kind: "open-file", filePath: "src/foo.rs" },
+      { isDockview: true, handlers },
+    );
+
+    expect(result).toEqual({ handled: false, reason: "missing-workspace-id" });
+    expect(handlers.onOpenFile).not.toHaveBeenCalled();
+  });
+
+  it("ignores open-file events with no filePath", () => {
+    const handlers = makeHandlers();
+    const result = dispatchOpenFileEvent(
+      { kind: "open-file", workspaceId: "my-project-feat-x" },
+      { isDockview: true, handlers },
+    );
+
+    expect(result).toEqual({ handled: false, reason: "missing-file-path" });
+    expect(handlers.onOpenFile).not.toHaveBeenCalled();
+  });
+
+  // -------------------------------------------------------------------
+  // Live-layout invariant — the dispatcher re-reads `isDockview` from
+  // its options on every call, so changing layouts between events
+  // routes the next event correctly. The production listener wraps
+  // this with a ref so the SSE subscription survives viewport resize;
+  // here we just verify the dispatcher itself doesn't cache.
+  // -------------------------------------------------------------------
+
+  it("respects per-call isDockview (no internal caching of layout)", () => {
+    const handlers = makeHandlers();
+    dispatchOpenFileEvent(openFileEvent(), { isDockview: true, handlers });
+    dispatchOpenFileEvent(openFileEvent({ workspaceId: "other-workspace" }), {
+      isDockview: false,
+      handlers,
+    });
+
+    expect(handlers.onOpenFile).toHaveBeenCalledExactlyOnceWith("my-project-feat-x", "src/foo.rs");
+    expect(handlers.navigateInWorkspace).toHaveBeenCalledExactlyOnceWith(
+      "other-workspace",
+      "src/foo.rs",
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Suffix preservation — the dispatcher does not parse the suffix; it
+// forwards `filePath` to the handler verbatim. This is deliberate: the
+// downstream consumer (CodeBrowserView via `openFilePath`, or the
+// _splat route on mobile) does its own `parseFileLocation` and the
+// dispatcher just decides where the payload goes. Document the
+// invariant so a future "normalize here" refactor doesn't break the
+// cursor-position contract.
+// ---------------------------------------------------------------------------
+
+describe("dispatchOpenFileEvent — suffix passthrough", () => {
+  beforeEach(() => {
+    // Defensive drain — the suite above already cleans up, but if these
+    // run in a different order or in isolation the assertions below
+    // must still see a fresh queue.
+    consumeExternalOpen("my-project-feat-x");
+  });
+
+  it("forwards :line:col suffix verbatim on the in-workspace dockview path", () => {
+    const handlers = makeHandlers();
+    dispatchOpenFileEvent(openFileEvent({ filePath: "src/main.rs:42:5" }), {
+      isDockview: true,
+      handlers,
+    });
+
+    expect(handlers.onOpenFile).toHaveBeenCalledWith("my-project-feat-x", "src/main.rs:42:5");
+  });
+
+  it("forwards :line-end range suffix verbatim on the in-workspace mobile path", () => {
+    const handlers = makeHandlers();
+    dispatchOpenFileEvent(openFileEvent({ filePath: "src/main.rs:5-10" }), {
+      isDockview: false,
+      handlers,
+    });
+
+    expect(handlers.navigateInWorkspace).toHaveBeenCalledWith(
+      "my-project-feat-x",
+      "src/main.rs:5-10",
+    );
+  });
+
+  it("preserves suffix in the queued external entry on dockview", () => {
+    const handlers = makeHandlers();
+    dispatchOpenFileEvent(openFileEvent({ filePath: "/abs/logs.txt:2:3", external: true }), {
+      isDockview: true,
+      handlers,
+    });
+
+    expect(consumeExternalOpen("my-project-feat-x")).toEqual({
+      filePath: "/abs/logs.txt:2:3",
+    });
+  });
+});

--- a/packages/dashboard-core/src/adapter.ts
+++ b/packages/dashboard-core/src/adapter.ts
@@ -68,6 +68,18 @@ export interface DashboardAdapter {
   subscribeStatusEvents(handler: (event: Record<string, unknown>) => void): Unsubscribe;
 
   /**
+   * Tell the server which workspace the user is currently looking at. The
+   * value is process-local on the server (resets on restart) and is read by
+   * the `band open` CLI command so users can fire a file at "wherever I'm
+   * focused right now" without naming the workspace explicitly.
+   *
+   * Pass `null` when no workspace is active (e.g. the user is on the
+   * index route). Implementations may debounce or short-circuit when the
+   * value hasn't changed.
+   */
+  setActiveWorkspace(workspaceId: string | null): Promise<void>;
+
+  /**
    * Subscribe to external file-system changes inside a workspace. The
    * server emits one event per affected parent directory (workspace-
    * relative path; "" for the root). The FileBrowser uses this to

--- a/packages/dashboard-core/src/adapters/web.ts
+++ b/packages/dashboard-core/src/adapters/web.ts
@@ -194,6 +194,27 @@ export class WebDashboardAdapter implements DashboardAdapter {
     return this.subscribeStatusStream(handler);
   }
 
+  /**
+   * Cache so we only post to the server when the value actually changes —
+   * the React tree can re-render and call this on routes that don't
+   * change the workspace, and we don't want to spam the mutation.
+   */
+  private lastActiveWorkspaceId: string | null | undefined = undefined;
+
+  async setActiveWorkspace(workspaceId: string | null): Promise<void> {
+    if (this.lastActiveWorkspaceId === workspaceId) return;
+    this.lastActiveWorkspaceId = workspaceId;
+    try {
+      await this.trpc.editor.setActiveWorkspace.mutate({ workspaceId });
+    } catch {
+      // Best-effort: the active-workspace hint is a UX nicety, not a
+      // correctness invariant. Reset the cache so the next change attempt
+      // re-posts (rather than silently agreeing with a stale value the
+      // server never received).
+      this.lastActiveWorkspaceId = undefined;
+    }
+  }
+
   subscribeAgentStatus(
     onSnapshot: (statuses: WorkspaceStatus[]) => void,
     onUpdate: (status: WorkspaceStatus) => void,


### PR DESCRIPTION
Closes #448.

## Summary

- Adds `band open <file>` CLI command — opens a file in the dashboard's currently-focused workspace without naming it explicitly.
- Server tracks the focused workspace in a process-local atom; the React shell pushes updates via `editor.setActiveWorkspace` whenever the route changes; the CLI's `editor.openFile` mutation reads the atom as a fallback when no `--workspace` is passed.
- Supports `path:line[:col]` and `path:line-end` suffixes (grep/stack-trace friendly), `--no-focus` to skip raising the window, and falls through to a clear "No active workspace" error when neither side knows where to route.
- Files outside the active workspace's root open as external editor tabs (same surface as desktop Cmd+O / "Open File…"). macOS `/var` ↔ `/private/var` symlinks are canonicalised on both sides so the in-workspace check doesn't lie.

## How "active workspace" flows

```
React shell ──► adapter.setActiveWorkspace(id)  (cache-dedup'd)
                       │
                       ▼
        in-memory atom (apps/web/src/lib/active-workspace.ts)
                       ▲
                       │  read by editor.openFile fallback
                       │
              CLI:  band open <file>
                       │
                       ▼
            emit({kind: "open-file", workspaceId, filePath, external})
                       │  (SSE)
                       ▼
            __root.tsx → router.navigate(...)
                       ↓ external
            window.dispatchEvent("band:open-file-external-direct")
                       ↓
            CodeBrowserView.openExternalPath(...)
```

The atom is intentionally non-persistent — server restart = no UI = no active workspace. Failures of the cache-dedup'd mutation clear the cache so the next change re-tries instead of silently agreeing with a value the server never received.

## Test plan

- [x] `cargo test -p band-cli --test integration open_` — covers seven scenarios:
  - explicit `--workspace` opens an in-workspace file
  - relative path with `:line:col` suffix resolves against cwd
  - active-workspace fallback (no `--workspace` flag)
  - clear error when no active workspace and no flag
  - clear error when the file doesn't exist
  - out-of-workspace path opens as external (`external: true`)
  - external path preserves `:line:col` suffix end-to-end
- [x] `apps/cli/tests/set-active-workspace.mjs` — Node helper posts to `editor.setActiveWorkspace` to simulate dashboard focus from CI without a renderer.
- [ ] Manual: `band open src/main.rs:42:5` from inside a workspace's worktree → editor opens at the right cursor position; same command from outside any workspace root → external tab opens in the currently-focused workspace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)