### PR TITLE
feat(browser): open page-initiated new-window requests as Band tabs (#488)

### DIFF
--- a/apps/desktop/src/browser/view-manager.ts
+++ b/apps/desktop/src/browser/view-manager.ts
@@ -35,6 +35,7 @@ import {
   type BrowserKeyArg,
   type BrowserNavigateArgs,
   type BrowserNewTabShortcutPayload,
+  type BrowserOpenWindowPayload,
   type BrowserSplitShortcutPayload,
   type BrowserStopFindInPageArgs,
   type BrowserTitleChangedPayload,
@@ -58,6 +59,7 @@ import {
   buildLoadErrorPayload,
   isMainFrameFailure,
 } from "./load-error.js";
+import { decideWindowOpenAction } from "./window-open.js";
 
 const log = createLogger("view-manager");
 
@@ -1174,6 +1176,58 @@ export class BrowserViewManager {
     // is sufficient — confirmed empirically by tracing both events
     // through the pino debug logger during the cert-interstitial
     // implementation (issue #444).
+
+    // ---- New-window requests → new Band browser tab (issue #488) ----
+    // Chromium funnels every page-initiated new-window request
+    // through `setWindowOpenHandler`:
+    //   - `window.open(url)` from page JS
+    //   - `<a target="_blank">` clicks
+    //   - middle-click / Cmd+click on a link
+    //   - `<form target="_blank">` submissions
+    //
+    // Without a handler, Chromium would either spawn a detached
+    // `BrowserWindow` (jarring) or drop the request silently
+    // (also jarring). We unconditionally `deny` the OS window so
+    // no detached browser window can ever appear, then emit a
+    // `browser-open-window` event that the renderer turns into a
+    // new Band browser tab in the same workspace.
+    //
+    // The handler must return SYNCHRONOUSLY — Chromium can't wait
+    // on a promise here. `this.emit` is a synchronous
+    // `webContents.send` that just queues the IPC message, so
+    // emitting from inside the handler is safe.
+    //
+    // We delegate the "should this become a Band tab?" decision
+    // to `decideWindowOpenAction` so the routing rules can be
+    // unit-tested in isolation (no Electron import). The handler
+    // here only owns:
+    //   1. ALWAYS deny — no detached window, ever.
+    //   2. Emit the event only when the helper green-lights the
+    //      URL (`about:blank`, `javascript:`, custom schemes etc.
+    //      are denied without creating a Band tab).
+    view.webContents.setWindowOpenHandler((details) => {
+      const decision = decideWindowOpenAction(details.url);
+      if (decision.kind === "open-in-band") {
+        const payload: BrowserOpenWindowPayload = {
+          browser_id: key,
+          workspace_id: key,
+          url: decision.url,
+          disposition: details.disposition,
+        };
+        this.emit(Events.browserOpenWindow, payload);
+      } else {
+        log.debug(
+          { url: details.url, reason: decision.reason, disposition: details.disposition },
+          "window-open: denied without creating a Band tab",
+        );
+      }
+      // Always deny the native OS window — even for the "ignore"
+      // branch above. The renderer either gets a new Band tab
+      // (open-in-band) or nothing happens (ignore) — never a
+      // detached OS window.
+      return { action: "deny" };
+    });
+
     view.webContents.on("page-title-updated", (_e, title) => {
       const payload: BrowserTitleChangedPayload = {
         browser_id: key,

--- a/apps/desktop/src/browser/window-open.ts
+++ b/apps/desktop/src/browser/window-open.ts
@@ -45,7 +45,7 @@ export function decideWindowOpenAction(url: string): WindowOpenAction {
   // — the page can't script into a `WebContentsView` we never
   // handed back, so the resulting blank tab would just be litter
   // the user has to close manually.
-  if (trimmed === "about:blank" || trimmed.toLowerCase() === "about:blank") {
+  if (trimmed.toLowerCase() === "about:blank") {
     return { kind: "ignore", reason: "about-blank" };
   }
 

--- a/apps/desktop/src/browser/window-open.ts
+++ b/apps/desktop/src/browser/window-open.ts
@@ -1,0 +1,82 @@
+/**
+ * Decide what to do when a page inside a Band browser tab requests a
+ * new window (via `window.open(...)`, `target="_blank"`, or middle /
+ * Cmd+click on a link). Issue #488.
+ *
+ * Chromium fires every one of those through `webContents.setWindowOpenHandler`
+ * — `BrowserViewManager.wireEvents` registers a handler that
+ * unconditionally returns `{ action: "deny" }` (so no detached
+ * OS-level window ever appears) and uses this helper to decide whether
+ * to ALSO emit a `browser-open-window` IPC event that the renderer
+ * turns into a new Band browser tab in the same workspace.
+ *
+ * Extracted as a pure module so the routing rules can be exercised in
+ * `node:test` without an Electron runtime — same pattern as
+ * `cert-error.ts` / `load-error.ts`.
+ */
+
+export type WindowOpenAction =
+  | { kind: "open-in-band"; url: string }
+  | { kind: "ignore"; reason: WindowOpenIgnoreReason };
+
+export type WindowOpenIgnoreReason =
+  | "empty-url"
+  | "about-blank"
+  | "javascript-scheme"
+  | "unsupported-scheme";
+
+/**
+ * URL schemes we'll surface as new Band tabs. Anything outside this
+ * allow-list is denied without creating a tab — `data:`, `file:`,
+ * `chrome:`, custom app schemes etc. would either look broken in a
+ * Band tab (no address-bar affordance) or actively unsafe to surface.
+ */
+const SUPPORTED_SCHEMES = ["http:", "https:"] as const;
+
+export function decideWindowOpenAction(url: string): WindowOpenAction {
+  const trimmed = url?.trim() ?? "";
+
+  if (!trimmed) {
+    return { kind: "ignore", reason: "empty-url" };
+  }
+
+  // `window.open("about:blank")` is the popup-then-document.write
+  // pattern. We deny the OS window AND skip creating a Band tab
+  // — the page can't script into a `WebContentsView` we never
+  // handed back, so the resulting blank tab would just be litter
+  // the user has to close manually.
+  if (trimmed === "about:blank" || trimmed.toLowerCase() === "about:blank") {
+    return { kind: "ignore", reason: "about-blank" };
+  }
+
+  // `javascript:` URLs are page-side-effect calls (bookmarklets etc.)
+  // — there's no navigation target to surface. Denying the OS window
+  // is already the correct user-visible outcome.
+  if (/^javascript:/i.test(trimmed)) {
+    return { kind: "ignore", reason: "javascript-scheme" };
+  }
+
+  // Anything else has to look like a URL we'd be willing to load in
+  // a Band tab. Relative paths (e.g. `/foo`) are technically possible
+  // here too — Chromium resolves them against the opener's origin
+  // before calling the handler in modern versions, but we accept
+  // the raw string and let the renderer / Chromium re-resolve on
+  // navigation. The point of this gate is just to reject
+  // schemes we know we don't want to surface.
+  let parsed: URL;
+  try {
+    // `URL` requires a base for relative paths; supply a sentinel so
+    // we can still inspect the scheme. The sentinel never leaves
+    // this function.
+    parsed = new URL(trimmed, "about:blank");
+  } catch {
+    // Not a parsable URL → not safe to surface.
+    return { kind: "ignore", reason: "unsupported-scheme" };
+  }
+
+  if (!SUPPORTED_SCHEMES.includes(parsed.protocol as (typeof SUPPORTED_SCHEMES)[number])) {
+    return { kind: "ignore", reason: "unsupported-scheme" };
+  }
+
+  return { kind: "open-in-band", url: trimmed };
+}

--- a/apps/desktop/src/preload/index.cts
+++ b/apps/desktop/src/preload/index.cts
@@ -96,6 +96,10 @@ const ALLOWED_EVENT_NAMES = new Set<string>([
   "browser-close-shortcut",
   "browser-cycle-shortcut",
   "browser-host-overridden",
+  // Issue #488: page-initiated window.open / target="_blank" /
+  // middle-click — forwarded by the main process so the renderer
+  // can open a new Band tab instead of a detached OS window.
+  "browser-open-window",
   "window-fullscreen-changed",
   "updater-status-changed",
 ]);

--- a/apps/desktop/src/shared/ipc-channels.ts
+++ b/apps/desktop/src/shared/ipc-channels.ts
@@ -137,6 +137,18 @@ export const Events = {
    *  it stays visible during screencast — this event is only for
    *  the surrounding dashboard chrome. */
   browserHostOverridden: "browser-host-overridden",
+  /** Pushed when a page inside a `WebContentsView` requests a new
+   *  window — `window.open(...)`, `target="_blank"`, middle / Cmd+
+   *  click on a link, etc. The main process *always* denies the
+   *  native OS window (so no detached browser window ever appears)
+   *  and forwards the request here so the renderer can materialize
+   *  the request as a new Band browser tab in the same workspace
+   *  (issue #488). The renderer's `DockviewBrowserContainer` picks
+   *  up the event and calls its existing add-tab flow scoped to the
+   *  source pane's dockview group; events whose `browser_id` isn't
+   *  in this container are ignored, so multiple workspaces don't all
+   *  spawn tabs for one window.open. */
+  browserOpenWindow: "browser-open-window",
   windowFullscreenChanged: "window-fullscreen-changed",
   /** Pushed by the main process when the background updater detects (or
    *  clears) a pending app update. Payload: `PendingUpdate` from

--- a/apps/desktop/src/shared/types.ts
+++ b/apps/desktop/src/shared/types.ts
@@ -233,6 +233,26 @@ export interface BrowserCycleShortcutPayload {
   direction: 1 | -1;
 }
 
+/**
+ * Emitted when a page inside a `WebContentsView` requests a new
+ * window (`window.open(...)`, `target="_blank"`, middle / Cmd+click
+ * on a link, etc — issue #488). The native OS window is always
+ * denied; the renderer turns this event into a new Band browser tab
+ * in the same workspace, opening it next to the source tab.
+ *
+ * `disposition` is the raw Chromium hint about how the page asked
+ * the window to be opened — passed through unchanged so future
+ * renderer logic can distinguish e.g. "new-window" from "background-
+ * tab". Today the renderer treats all of them identically: a new
+ * Band tab focused for the user.
+ */
+export interface BrowserOpenWindowPayload {
+  browser_id: string;
+  workspace_id: string;
+  url: string;
+  disposition: string;
+}
+
 // ---------- macOS shell (camelCase invoke args) ----------
 
 export interface CheckAppExistsArgs {

--- a/apps/desktop/src/shared/types.ts
+++ b/apps/desktop/src/shared/types.ts
@@ -247,6 +247,14 @@ export interface BrowserCycleShortcutPayload {
  * Band tab focused for the user. The union mirrors the one Electron's
  * `webContents.setWindowOpenHandler` callback emits, so any future
  * `switch` on it remains exhaustive.
+ *
+ * Note on `workspace_id`: `BrowserViewManager` is workspace-agnostic
+ * (one singleton per main window) and has no stored workspace id, so
+ * — consistent with every other event in `view-manager.ts` — both
+ * `browser_id` and `workspace_id` carry the same opaque LRU key. The
+ * renderer scopes on `browser_id` via `api.getPanel(sourceId)`; the
+ * duplicate is preserved for symmetry with the two-mode keying
+ * convention documented at the top of `view-manager.ts`.
  */
 export interface BrowserOpenWindowPayload {
   browser_id: string;

--- a/apps/desktop/src/shared/types.ts
+++ b/apps/desktop/src/shared/types.ts
@@ -244,13 +244,21 @@ export interface BrowserCycleShortcutPayload {
  * the window to be opened — passed through unchanged so future
  * renderer logic can distinguish e.g. "new-window" from "background-
  * tab". Today the renderer treats all of them identically: a new
- * Band tab focused for the user.
+ * Band tab focused for the user. The union mirrors the one Electron's
+ * `webContents.setWindowOpenHandler` callback emits, so any future
+ * `switch` on it remains exhaustive.
  */
 export interface BrowserOpenWindowPayload {
   browser_id: string;
   workspace_id: string;
   url: string;
-  disposition: string;
+  disposition:
+    | "default"
+    | "foreground-tab"
+    | "background-tab"
+    | "new-window"
+    | "save-to-disk"
+    | "other";
 }
 
 // ---------- macOS shell (camelCase invoke args) ----------

--- a/apps/desktop/src/shared/types.ts
+++ b/apps/desktop/src/shared/types.ts
@@ -252,13 +252,7 @@ export interface BrowserOpenWindowPayload {
   browser_id: string;
   workspace_id: string;
   url: string;
-  disposition:
-    | "default"
-    | "foreground-tab"
-    | "background-tab"
-    | "new-window"
-    | "save-to-disk"
-    | "other";
+  disposition: "default" | "foreground-tab" | "background-tab" | "new-window" | "other";
 }
 
 // ---------- macOS shell (camelCase invoke args) ----------

--- a/apps/desktop/tests/window-open.test.ts
+++ b/apps/desktop/tests/window-open.test.ts
@@ -1,0 +1,88 @@
+/**
+ * Pure-function tests for `decideWindowOpenAction` (the routing rule
+ * used by `BrowserViewManager`'s `setWindowOpenHandler` to convert
+ * page-initiated new-window requests into Band browser tabs — issue
+ * #488). No Electron deps, so the test runs under `node:test` like
+ * the other desktop unit tests.
+ */
+
+import { strict as assert } from "node:assert";
+import { describe, test } from "node:test";
+
+import { decideWindowOpenAction } from "../src/browser/window-open.ts";
+
+describe("decideWindowOpenAction", () => {
+  test("http URL → open-in-band", () => {
+    const result = decideWindowOpenAction("http://example.com/page");
+    assert.deepEqual(result, { kind: "open-in-band", url: "http://example.com/page" });
+  });
+
+  test("https URL → open-in-band", () => {
+    const result = decideWindowOpenAction("https://example.com/path?q=1");
+    assert.deepEqual(result, { kind: "open-in-band", url: "https://example.com/path?q=1" });
+  });
+
+  test("trims surrounding whitespace before deciding", () => {
+    const result = decideWindowOpenAction("   https://example.com/  ");
+    assert.deepEqual(result, { kind: "open-in-band", url: "https://example.com/" });
+  });
+
+  test("empty string → ignore (empty-url)", () => {
+    const result = decideWindowOpenAction("");
+    assert.deepEqual(result, { kind: "ignore", reason: "empty-url" });
+  });
+
+  test("whitespace-only → ignore (empty-url)", () => {
+    const result = decideWindowOpenAction("   \t\n");
+    assert.deepEqual(result, { kind: "ignore", reason: "empty-url" });
+  });
+
+  test("about:blank → ignore (about-blank)", () => {
+    // Common popup pattern: `const w = window.open("about:blank");
+    // w.document.write(...)`. We deny the OS window and skip making
+    // a Band tab — the page can't script into a WebContentsView we
+    // never handed back, so a fresh tab would just be litter.
+    const result = decideWindowOpenAction("about:blank");
+    assert.deepEqual(result, { kind: "ignore", reason: "about-blank" });
+  });
+
+  test("ABOUT:BLANK (mixed case) → ignore (about-blank)", () => {
+    const result = decideWindowOpenAction("ABOUT:BLANK");
+    assert.deepEqual(result, { kind: "ignore", reason: "about-blank" });
+  });
+
+  test("javascript: URL → ignore (javascript-scheme)", () => {
+    const result = decideWindowOpenAction("javascript:void(0)");
+    assert.deepEqual(result, { kind: "ignore", reason: "javascript-scheme" });
+  });
+
+  test("JavaScript: (mixed case) → ignore (javascript-scheme)", () => {
+    const result = decideWindowOpenAction("JavaScript:alert(1)");
+    assert.deepEqual(result, { kind: "ignore", reason: "javascript-scheme" });
+  });
+
+  test("data: URL → ignore (unsupported-scheme)", () => {
+    // data: would look broken in a Band tab (no address-bar host
+    // affordance, no reload semantics). Deny the OS window and skip
+    // the tab — same outcome as Chrome's popup blocker.
+    const result = decideWindowOpenAction("data:text/html,<p>hi</p>");
+    assert.deepEqual(result, { kind: "ignore", reason: "unsupported-scheme" });
+  });
+
+  test("file: URL → ignore (unsupported-scheme)", () => {
+    const result = decideWindowOpenAction("file:///etc/passwd");
+    assert.deepEqual(result, { kind: "ignore", reason: "unsupported-scheme" });
+  });
+
+  test("chrome: URL → ignore (unsupported-scheme)", () => {
+    const result = decideWindowOpenAction("chrome://settings");
+    assert.deepEqual(result, { kind: "ignore", reason: "unsupported-scheme" });
+  });
+
+  test("custom app: scheme → ignore (unsupported-scheme)", () => {
+    // Common-pattern URL Apple Music etc. use to deep-link out of a
+    // tab — we don't want to surface those as Band tabs.
+    const result = decideWindowOpenAction("itmss://music.apple.com/album/123");
+    assert.deepEqual(result, { kind: "ignore", reason: "unsupported-scheme" });
+  });
+});

--- a/apps/web/src/components/DockviewBrowserContainer.tsx
+++ b/apps/web/src/components/DockviewBrowserContainer.tsx
@@ -779,14 +779,22 @@ export function DockviewBrowserContainer({
         // and Edge use for window.open requests today. Focus
         // follows the new tab (matches `markBrowserFresh` +
         // `addPanel` defaults).
-        void handleAddTab(groupId, { initialUrl: url }).then(() => {
-          requestAnimationFrame(() => {
-            const panel = apiRef.current?.activePanel;
-            panel?.view.content.element
-              .querySelector<HTMLInputElement>("[data-band-address-input]")
-              ?.focus();
+        void handleAddTab(groupId, { initialUrl: url })
+          .then(() => {
+            requestAnimationFrame(() => {
+              const panel = apiRef.current?.activePanel;
+              panel?.view.content.element
+                .querySelector<HTMLInputElement>("[data-band-address-input]")
+                ?.focus();
+            });
+          })
+          .catch((err) => {
+            // Belt-and-suspenders: `handleAddTab` already try/catches
+            // the tRPC mutation, but an unexpected throw (e.g. in the
+            // RAF callback or future refactor of handleAddTab) would
+            // otherwise vanish silently.
+            console.error("[DockviewBrowserContainer] browser-open-window add-tab failed:", err);
           });
-        });
       });
       if (cancelled) fn();
       else unlisten = fn;

--- a/apps/web/src/components/DockviewBrowserContainer.tsx
+++ b/apps/web/src/components/DockviewBrowserContainer.tsx
@@ -762,13 +762,7 @@ export function DockviewBrowserContainer({
         browser_id: string;
         workspace_id: string;
         url: string;
-        disposition:
-          | "default"
-          | "foreground-tab"
-          | "background-tab"
-          | "new-window"
-          | "save-to-disk"
-          | "other";
+        disposition: "default" | "foreground-tab" | "background-tab" | "new-window" | "other";
       }>("browser-open-window", (event) => {
         const api = apiRef.current;
         if (!api) return;

--- a/apps/web/src/components/DockviewBrowserContainer.tsx
+++ b/apps/web/src/components/DockviewBrowserContainer.tsx
@@ -748,12 +748,27 @@ export function DockviewBrowserContainer({
   useEffect(() => {
     if (!isDesktop) return;
     let unlisten: (() => void) | undefined;
+    // Guard against the unmount-before-resolution race: if the
+    // component unmounts while we're awaiting `desktopListen`, the
+    // cleanup closure runs synchronously with `unlisten` still
+    // `undefined`. Without the `cancelled` flag the eventual listener
+    // registration would survive the unmount and keep firing
+    // `handleAddTab` against an already-gone component. Mirrors the
+    // pattern used by the `browser-split-shortcut` / `*-close-shortcut`
+    // / `*-cycle-shortcut` effects below.
+    let cancelled = false;
     void (async () => {
-      unlisten = await desktopListen<{
+      const fn = await desktopListen<{
         browser_id: string;
         workspace_id: string;
         url: string;
-        disposition: string;
+        disposition:
+          | "default"
+          | "foreground-tab"
+          | "background-tab"
+          | "new-window"
+          | "save-to-disk"
+          | "other";
       }>("browser-open-window", (event) => {
         const api = apiRef.current;
         if (!api) return;
@@ -779,8 +794,13 @@ export function DockviewBrowserContainer({
           });
         });
       });
+      if (cancelled) fn();
+      else unlisten = fn;
     })();
-    return () => unlisten?.();
+    return () => {
+      cancelled = true;
+      unlisten?.();
+    };
   }, [handleAddTab]);
 
   // Cmd+D / Cmd+Shift+D, Cmd+W, Cmd+[/], Cmd+Shift+[/], Ctrl+(Shift)+Tab

--- a/apps/web/src/components/DockviewBrowserContainer.tsx
+++ b/apps/web/src/components/DockviewBrowserContainer.tsx
@@ -287,12 +287,25 @@ function BrowserTab(props: IDockviewPanelHeaderProps<BrowserTabParams>) {
 
 const addTabRef: {
   current: {
-    onAdd: (groupId?: string) => void;
+    onAdd: (groupId?: string, options?: AddTabOptions) => void;
     onSplit: (groupId: string, direction: "right" | "below") => void;
   };
 } = {
   current: { onAdd: () => {}, onSplit: () => {} },
 };
+
+/**
+ * Options for `handleAddTab` and `addTabRef.current.onAdd`.
+ *
+ * `initialUrl` lets callers materialize a tab that loads a specific
+ * URL on mount — used by the `browser-open-window` listener (issue
+ * #488) to forward `window.open(url)` / `target="_blank"` clicks
+ * into a new Band tab. When omitted the tab opens blank, matching
+ * the Cmd+T / "+" button UX.
+ */
+interface AddTabOptions {
+  initialUrl?: string;
+}
 
 /** Shared ref for the close-tab action — used by BrowserTab's close button. */
 const closeTabRef: { current: ((browserId: string) => void) | null } = {
@@ -414,14 +427,20 @@ export function DockviewBrowserContainer({
   }, [workspaceId]);
 
   const handleAddTab = useCallback(
-    async (groupId?: string) => {
+    async (groupId?: string, addOptions?: AddTabOptions) => {
       const api = apiRef.current;
       if (!api) return;
 
       const browserId = newBrowserId();
       markBrowserFresh(browserId);
 
-      // Build panel options, targeting the specific group if provided
+      const initialUrl = addOptions?.initialUrl;
+
+      // Build panel options, targeting the specific group if provided.
+      // `initialUrl` (when present) gets injected into the panel's
+      // params so `BrowserPaneComponent` mounts with the URL already
+      // in hand — avoids the create-webview / server-fetch race on
+      // tabs spawned from `window.open` (issue #488).
       const options: Parameters<typeof api.addPanel>[0] = {
         id: browserId,
         component: "browserTab",
@@ -430,6 +449,7 @@ export function DockviewBrowserContainer({
         params: {
           workspaceId,
           browserId,
+          ...(initialUrl ? { initialUrl } : {}),
         },
       };
 
@@ -451,7 +471,14 @@ export function DockviewBrowserContainer({
       api.addPanel(options);
 
       try {
-        await trpc.browsers.create.mutate({ workspaceId, id: browserId });
+        // Persist `initialUrl` to the server-side browser record so
+        // workspace restarts and CLI-side `browsers.get` queries see
+        // the right starting URL.
+        await trpc.browsers.create.mutate({
+          workspaceId,
+          id: browserId,
+          ...(initialUrl ? { url: initialUrl } : {}),
+        });
       } catch (err) {
         console.error("[DockviewBrowserContainer] error pre-creating browser:", err);
       }
@@ -698,6 +725,60 @@ export function DockviewBrowserContainer({
           });
         },
       );
+    })();
+    return () => unlisten?.();
+  }, [handleAddTab]);
+
+  // Issue #488: page-initiated new-window requests (window.open,
+  // target="_blank", middle-click, Cmd+click) get routed by the main
+  // process through `setWindowOpenHandler` — the OS-level window is
+  // always denied, and a `browser-open-window` event is forwarded
+  // here with the requested URL. We materialize each one as a new
+  // Band browser tab in the same dockview group as the source pane
+  // so the navigation stays inside the workspace.
+  //
+  // Scoping: same as `browser-new-tab-shortcut` — multiple workspaces
+  // can have a DockviewBrowserContainer mounted simultaneously, so
+  // ignore events whose source browserId isn't one of ours.
+  //
+  // NOTE: `browser-open-window` must be in the preload's
+  // `ALLOWED_EVENT_NAMES` allowlist (`apps/desktop/src/preload/index.cts`)
+  // — otherwise `desktopListen` rejects synchronously and the listener
+  // never attaches.
+  useEffect(() => {
+    if (!isDesktop) return;
+    let unlisten: (() => void) | undefined;
+    void (async () => {
+      unlisten = await desktopListen<{
+        browser_id: string;
+        workspace_id: string;
+        url: string;
+        disposition: string;
+      }>("browser-open-window", (event) => {
+        const api = apiRef.current;
+        if (!api) return;
+        const sourceId = event.payload.browser_id;
+        const sourcePanel = sourceId ? api.getPanel(sourceId) : undefined;
+        // Ignore events from panes in other DockviewBrowserContainers —
+        // multiple workspaces' containers all receive every event.
+        if (!sourcePanel) return;
+        const groupId = sourcePanel.group?.id;
+        const url = event.payload.url;
+        if (!url) return;
+        // Drop the new tab into the *source* pane's group so the
+        // tab strip stays compact — same group placement Chrome
+        // and Edge use for window.open requests today. Focus
+        // follows the new tab (matches `markBrowserFresh` +
+        // `addPanel` defaults).
+        void handleAddTab(groupId, { initialUrl: url }).then(() => {
+          requestAnimationFrame(() => {
+            const panel = apiRef.current?.activePanel;
+            panel?.view.content.element
+              .querySelector<HTMLInputElement>("[data-band-address-input]")
+              ?.focus();
+          });
+        });
+      });
     })();
     return () => unlisten?.();
   }, [handleAddTab]);


### PR DESCRIPTION
## Summary

Closes #488. Page-initiated new-window requests inside a Band browser tab — `window.open(url)`, `<a target="_blank">`, middle-click, Cmd/Ctrl+click — now open as a new Band browser tab in the source pane's dockview group instead of spawning a detached OS-level window.

- Registers `setWindowOpenHandler` on every spawned `WebContentsView` in `apps/desktop/src/browser/view-manager.ts`. The handler **always** denies the native window, then for http/https URLs emits a new `browser-open-window` IPC event.
- Routing rules (allow `http:` / `https:`; ignore `about:blank`, `javascript:`, `data:`, `file:`, custom schemes) live in a new pure helper `apps/desktop/src/browser/window-open.ts` so they're unit-testable without an Electron runtime (same pattern as `cert-error.ts` / `load-error.ts`).
- Renderer side: `DockviewBrowserContainer` subscribes to `browser-open-window`, scopes the event to its own container (matching the existing `browser-new-tab-shortcut` pattern), and reuses the existing add-tab flow. `handleAddTab` gained an `{ initialUrl }` option that gets injected into the panel params and forwarded to `trpc.browsers.create` so the new tab opens at the requested URL and the server-side record reflects it.
- `browser-open-window` added to the preload's `ALLOWED_EVENT_NAMES` allowlist. (Forgetting this on the first pass was the actual cause of "the tab doesn't open" during testing — `desktopListen` rejected synchronously inside the preload and the renderer's listener never attached.)

## Acceptance criteria (from issue)

- [x] Clicking a link with `target="_blank"` opens a new Band browser tab in the current workspace.
- [x] `window.open(url)` calls from the page open a new Band browser tab pointing at `url`.
- [x] Cmd/Ctrl+click and middle-click on links open a new Band browser tab.
- [x] The newly-created tab is focused (matches the existing add-tab behaviour).
- [x] No detached OS-level browser windows are spawned (handler returns `{ action: "deny" }` unconditionally).

## Test plan

- [x] `pnpm --filter @band-app/desktop test` — 194/194 pass, including 13 new cases in `apps/desktop/tests/window-open.test.ts` covering http/https acceptance and every ignore branch (empty, about:blank, javascript:, data:, file:, chrome:, custom schemes).
- [x] `pnpm --filter @band-app/server test` — 844/844 pass.
- [x] `pnpm -r build` — clean.
- [x] `biome check` / `biome format` — clean on the modified files.
- [x] Manual smoke in the desktop app: a page calling `window.open("https://example.com")` now lands as a new Band tab in the same group; `target="_blank"` links and Cmd+click behave the same; no OS window appears.