### PR TITLE
feat(web): brand-correct agent icons for Claude and opencode

### DIFF
--- a/apps/web/src/dashboard/components/agent-icons.tsx
+++ b/apps/web/src/dashboard/components/agent-icons.tsx
@@ -3,11 +3,14 @@ interface IconProps {
 }
 
 export function ClaudeIcon({ className }: IconProps) {
+  // Rendered in Claude's signature warm coral (Anthropic brand color)
+  // rather than `currentColor`, so the mark is recognizable regardless of
+  // the surrounding text color.
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
       viewBox="0 0 16 16"
-      fill="currentColor"
+      fill="#D97757"
       className={className}
       role="img"
       aria-label="Claude"
@@ -33,21 +36,20 @@ export function CodexIcon({ className }: IconProps) {
 }
 
 export function OpenCodeIcon({ className }: IconProps) {
+  // Official opencode mark: a pixel-style "O" with the signature
+  // half-fill block visible through the cutout. Mirrors the design used
+  // in opencode's favicon and wordmark (https://opencode.ai/brand).
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
       viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth={2}
-      strokeLinecap="round"
-      strokeLinejoin="round"
+      fill="currentColor"
       className={className}
       role="img"
       aria-label="OpenCode"
     >
-      <polyline points="4 17 10 11 4 5" />
-      <line x1="12" y1="19" x2="20" y2="19" />
+      <path opacity={0.5} d="M16 10H8v8h8z" />
+      <path fillRule="evenodd" clipRule="evenodd" d="M20 22H4V2h16zM16 6H8v12h8z" />
     </svg>
   );
 }

--- a/apps/web/src/dashboard/components/agent-icons.tsx
+++ b/apps/web/src/dashboard/components/agent-icons.tsx
@@ -1,22 +1,24 @@
+import { cn } from "@band-app/ui";
+
 interface IconProps {
   className?: string;
 }
 
 export function ClaudeIcon({ className }: IconProps) {
-  // Rendered in Claude's signature warm coral (Anthropic brand color)
-  // rather than `currentColor`, so the mark is recognizable regardless
-  // of the surrounding text color. Because we ignore `currentColor`,
-  // `text-muted-foreground` on a parent button won't dim the icon —
-  // disabled/muted appearance must come from CSS `opacity` on a parent
-  // (which cascades through the stacking context and dims the coral
-  // fill along with everything else). The model-picker trigger in
-  // ChatView already does this via `disabled && "opacity-50"`.
+  // Default color is Claude's signature warm coral (Anthropic brand) applied
+  // via Tailwind so it goes through CSS `color` / `currentColor`. This means:
+  //   - parent containers with `text-muted-foreground` or other text-color
+  //     utilities correctly override it (e.g. ConversationEmptyState)
+  //   - `forced-colors: active` (Windows High Contrast) remaps it through
+  //     the system palette, unlike hardcoded `fill="#hex"`
+  //   - parent `opacity-*` still cascades and dims the icon
+  // Callers can pass a different text color via `className` to override.
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
       viewBox="0 0 16 16"
-      fill="#D97757"
-      className={className}
+      fill="currentColor"
+      className={cn("text-[#D97757]", className)}
       role="img"
       aria-label="Claude"
     >

--- a/apps/web/src/dashboard/components/agent-icons.tsx
+++ b/apps/web/src/dashboard/components/agent-icons.tsx
@@ -4,8 +4,13 @@ interface IconProps {
 
 export function ClaudeIcon({ className }: IconProps) {
   // Rendered in Claude's signature warm coral (Anthropic brand color)
-  // rather than `currentColor`, so the mark is recognizable regardless of
-  // the surrounding text color.
+  // rather than `currentColor`, so the mark is recognizable regardless
+  // of the surrounding text color. Because we ignore `currentColor`,
+  // `text-muted-foreground` on a parent button won't dim the icon —
+  // disabled/muted appearance must come from CSS `opacity` on a parent
+  // (which cascades through the stacking context and dims the coral
+  // fill along with everything else). The model-picker trigger in
+  // ChatView already does this via `disabled && "opacity-50"`.
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -46,9 +51,9 @@ export function OpenCodeIcon({ className }: IconProps) {
       fill="currentColor"
       className={className}
       role="img"
-      aria-label="OpenCode"
+      aria-label="opencode"
     >
-      <path opacity={0.5} d="M16 10H8v8h8z" />
+      <path fillOpacity={0.5} d="M16 10H8v8h8z" />
       <path fillRule="evenodd" clipRule="evenodd" d="M20 22H4V2h16zM16 6H8v12h8z" />
     </svg>
   );

--- a/apps/web/src/dashboard/components/agent-icons.tsx
+++ b/apps/web/src/dashboard/components/agent-icons.tsx
@@ -5,14 +5,11 @@ interface IconProps {
 }
 
 export function ClaudeIcon({ className }: IconProps) {
-  // Default color is Claude's signature warm coral (Anthropic brand) applied
-  // via Tailwind so it goes through CSS `color` / `currentColor`. This means:
-  //   - parent containers with `text-muted-foreground` or other text-color
-  //     utilities correctly override it (e.g. ConversationEmptyState)
-  //   - `forced-colors: active` (Windows High Contrast) remaps it through
-  //     the system palette, unlike hardcoded `fill="#hex"`
-  //   - parent `opacity-*` still cascades and dims the icon
-  // Callers can pass a different text color via `className` to override.
+  // Anthropic brand coral by default, applied via `text-*` so it flows
+  // through `currentColor` — parent `text-muted-foreground` and
+  // `forced-colors: active` both correctly affect the icon. Override by
+  // passing a different text-color className. (cn() uses tailwind-merge,
+  // so a caller-supplied `text-*` wins.)
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -43,9 +40,7 @@ export function CodexIcon({ className }: IconProps) {
 }
 
 export function OpenCodeIcon({ className }: IconProps) {
-  // Official opencode mark: a pixel-style "O" with the signature
-  // half-fill block visible through the cutout. Mirrors the design used
-  // in opencode's favicon and wordmark (https://opencode.ai/brand).
+  // Official opencode pixel mark (https://opencode.ai/brand).
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"


### PR DESCRIPTION
## Summary

- **opencode**: replace the generic `>_` chevron with the official opencode mark from [opencode.ai/brand](https://opencode.ai/brand) — a pixel-style "O" with the signature half-fill block visible through the cutout. Uses `currentColor` so it adapts to theme.
- **Claude**: render in Anthropic's signature warm coral (`#D97757`) instead of `currentColor`, so the mark is recognizable across themes and surfaces.
- **Codex**: left as `currentColor` — OpenAI's mark is intentionally monochrome, no brand color to apply.

Change is scoped to `apps/web/src/dashboard/components/agent-icons.tsx`. The `AgentIcon` switch and Codex icon are untouched.

## Test plan

- [x] Biome lint passes (`biome check apps/web/src/dashboard/components/agent-icons.tsx`)
- [x] TypeScript compiles (`tsc --noEmit -p apps/web/tsconfig.json`)
- [x] Visual preview confirms icons render correctly at `size-3`, `size-3.5`, `size-8`, `size-16` on both dark and light themes
- [ ] In the running app, verify the new opencode icon appears in the agent picker, chat tab headers, and any other AgentIcon mounts