### PR TITLE
feat(web): add Resources dashboard page

### DIFF
--- a/apps/web/e2e/pages/ResourcesPage.ts
+++ b/apps/web/e2e/pages/ResourcesPage.ts
@@ -1,0 +1,160 @@
+/**
+ * Page object for the Resources dialog opened from the dashboard
+ * title-bar menu (no dedicated route — the page renders inside a
+ * shared Dialog managed by `ToolbarOverflowProvider`).
+ *
+ * Owns the locators for the server snapshot card and the worktree
+ * usage table, plus a `goto()` that walks the user flow:
+ * dashboard → Menu → Resources.
+ *
+ * Locator priority (per `docs/frontend-testing.md` and the
+ * `write-integration-test` skill):
+ *
+ *   - `getByRole({ name })` for the dashboard title bar Menu trigger
+ *     (the `aria-label="Menu"` value is system-controlled and not
+ *     localisable user copy).
+ *   - `getByTestId(...)` for owned card / button / table elements,
+ *     using the BEM-style `resources-*` prefix the page component sets
+ *     in `ResourcesPage.tsx`, plus `menu__resources` for the menu item
+ *     and `resources-dialog` for the dialog body itself.
+ */
+
+import { expect, type Locator, type Page, test } from "@playwright/test";
+
+export class ResourcesPage {
+  /** The Radix Dialog body wrapping the page. Used as the
+   *  "the dialog opened" visibility anchor. */
+  readonly dialog: Locator;
+  /** Outer server snapshot card (PID, uptime, memory, CPU). */
+  readonly serverCard: Locator;
+  /** PID cell inside the server card — primary "the snapshot loaded"
+   *  assertion target. */
+  readonly serverPid: Locator;
+  /** Refresh button on the server card. */
+  readonly refreshServerButton: Locator;
+  /** Refresh button on the worktrees card. */
+  readonly refreshWorktreesButton: Locator;
+  /** Per-project table. The single rendered table — project rows
+   *  are the top level, expanding a project reveals its worktrees
+   *  as child rows in the same grid. */
+  readonly projectsTable: Locator;
+  /** Grand-total cell inside the per-project rollup's footer. */
+  readonly projectsTotal: Locator;
+  /** Menu trigger button in the desktop title bar. */
+  readonly menuTrigger: Locator;
+  /** Resources entry inside the dashboard menu. */
+  readonly resourcesMenuItem: Locator;
+
+  constructor(
+    private readonly page: Page,
+    private readonly baseUrl: string,
+    private readonly token: string,
+  ) {
+    this.dialog = page.getByTestId("resources-dialog");
+    this.serverCard = page.getByTestId("resources-server-card");
+    this.serverPid = page.getByTestId("resources-server-pid");
+    this.refreshServerButton = page.getByTestId("resources-refresh-server");
+    this.refreshWorktreesButton = page.getByTestId("resources-refresh-worktrees");
+    this.projectsTable = page.getByTestId("resources-projects-table");
+    this.projectsTotal = page.getByTestId("resources-projects-total");
+    // The desktop title bar exposes its hamburger trigger with
+    // `aria-label="Menu"` (see DesktopTitleBar.tsx). System-controlled
+    // ARIA name — getByRole is the preferred locator.
+    this.menuTrigger = page.getByRole("button", { name: "Menu" });
+    this.resourcesMenuItem = page.getByTestId("menu__resources");
+  }
+
+  /** Navigate to the dashboard root, then open the title-bar Menu and
+   *  click Resources. Mirrors the user flow described in the issue.
+   *
+   *  Radix's DropdownMenuTrigger sometimes swallows the first click
+   *  that lands on it inside `asChild` button wrappers during a fast
+   *  Playwright run — the trigger's mousedown handler fires before
+   *  the click's pointerdown bubbles back up, and the dropdown closes
+   *  again. Polling the menu item's visibility via `expect.poll` lets
+   *  us re-click the trigger until the dropdown stays open. */
+  async open(): Promise<void> {
+    await test.step("Open Resources via dashboard menu", async () => {
+      await this.page.goto(`${this.baseUrl}/?token=${this.token}`);
+      await expect(this.menuTrigger).toBeVisible();
+      await expect
+        .poll(
+          async () => {
+            await this.menuTrigger.click();
+            return await this.resourcesMenuItem.isVisible().catch(() => false);
+          },
+          { timeout: 10_000 },
+        )
+        .toBe(true);
+      await this.resourcesMenuItem.click();
+      await expect(this.dialog).toBeVisible();
+    });
+  }
+
+  /** Wait for the initial server card render. The card mounts with a
+   *  Spinner before the query resolves; the pid testid only appears
+   *  once the query data lands. */
+  async waitForReady(): Promise<void> {
+    await expect(this.serverPid).toBeVisible({ timeout: 15_000 });
+  }
+
+  /** Trigger a server-card refresh. */
+  async clickRefreshServer(): Promise<void> {
+    await test.step("Click Refresh on the server card", async () => {
+      await this.refreshServerButton.click();
+    });
+  }
+
+  /** Trigger a worktree-usage refresh. */
+  async clickRefreshWorktrees(): Promise<void> {
+    await test.step("Click Refresh on the worktrees card", async () => {
+      await this.refreshWorktreesButton.click();
+    });
+  }
+
+  /** Locate the table row for a specific worktree by project +
+   *  branch. Worktree rows are only rendered when their parent
+   *  project row has been expanded (clicked). The component
+   *  composes the testid from both parts so that two projects with
+   *  the same branch (`main`) don't produce duplicate testids —
+   *  mirror the sanitisation here so the page object can be called
+   *  with raw values. */
+  getWorktreeRow(project: string, branch: string): Locator {
+    const safe = (s: string) => s.replace(/[^\w-]/g, "_");
+    return this.page.getByTestId(`resources-worktree-row-${safe(project)}__${safe(branch)}`);
+  }
+
+  /** Locate the per-project rollup row by project name. Clicking the
+   *  row toggles its expanded state and reveals the per-worktree
+   *  breakdown immediately below. The test data fixture pins this
+   *  to a known project. */
+  getProjectRow(project: string): Locator {
+    return this.page.getByTestId(`resources-project-row-${project}`);
+  }
+
+  /** Locate the per-project size cell. Starts as a "measuring…"
+   *  spinner while the server's `du` walk is in flight, then
+   *  resolves to the formatted byte total. The cell remains in
+   *  the DOM throughout — only its contents change. */
+  getProjectSize(project: string): Locator {
+    return this.page.getByTestId(`resources-project-size-${project}`);
+  }
+
+  /** Click the project row's toggle button to expand it, revealing
+   *  the per-worktree breakdown. The button lives in the row's
+   *  first cell and bears the project name as its accessible label
+   *  (a real `<button>`, not a row-level click handler, because
+   *  `<button>` can't be a direct child of `<tbody>`). Idempotent in
+   *  the sense that this always *opens* — call on a collapsed row. */
+  async expandProject(project: string): Promise<void> {
+    await test.step(`Expand project row "${project}"`, async () => {
+      await this.getProjectRow(project).getByRole("button", { name: project }).click();
+    });
+  }
+
+  /** Read the numeric PID currently shown in the server card. */
+  async getServerPidValue(): Promise<number> {
+    const text = await this.serverPid.textContent();
+    return Number.parseInt((text ?? "").trim(), 10);
+  }
+}

--- a/apps/web/e2e/resources.spec.ts
+++ b/apps/web/e2e/resources.spec.ts
@@ -1,0 +1,128 @@
+/**
+ * End-to-end coverage for issue #506 — the Resources dialog.
+ *
+ * Boots the production server bundle against a fresh tmp `~/.band/`,
+ * seeds a real git repo + worktree with a known-size file, then drives
+ * the React UI through `ResourcesPage` (page-object model). The page
+ * is no longer a separate route — it lives inside a Radix Dialog
+ * opened from the dashboard's overflow menu.
+ */
+
+import { execFileSync } from "node:child_process";
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { expect, test } from "@playwright/test";
+import {
+  createTmpHome,
+  type ServerHandle,
+  seedSettings,
+  seedState,
+  startServer,
+} from "./helpers/server";
+import { ResourcesPage } from "./pages/ResourcesPage";
+
+const TOKEN = "e2e-resources-page-token";
+
+const PROJECT = "resources-fixture";
+const BRANCH = "main";
+// 1 MiB of zero bytes — well above the page's `formatBytes` rounding
+// boundary, so the rendered "Total size" cell unambiguously reports
+// MB-class output.
+const SEED_FILE_BYTES = 1024 * 1024;
+
+// Wide viewport so the AppShell renders the desktop title bar (which
+// is where the dashboard menu trigger lives).
+test.use({ viewport: { width: 1280, height: 800 } });
+
+// Definite-assignment in `beforeAll`. The `typeof` guard in
+// `afterAll` covers the only path that could leave it unassigned:
+// `startServer` throwing before resolving. Without the guard, an
+// unrelated `TypeError: Cannot read properties of undefined
+// (reading 'close')` would mask the real boot failure.
+let server!: ServerHandle;
+let tmpHome: string;
+let projectPath: string;
+
+test.beforeAll(async () => {
+  tmpHome = createTmpHome();
+
+  // Initialize a real git repo so `listWorktrees` returns a real row
+  // pointing at the seeded path. The page walks this directory and
+  // sums file sizes — the 1 MiB seed file is the lower bound the
+  // assertion below uses.
+  projectPath = join(tmpHome, PROJECT);
+  mkdirSync(projectPath, { recursive: true });
+  execFileSync("git", ["init", "-q", "--initial-branch", BRANCH], {
+    cwd: projectPath,
+    stdio: "ignore",
+  });
+  execFileSync("git", ["config", "user.email", "e2e@example.com"], {
+    cwd: projectPath,
+    stdio: "ignore",
+  });
+  execFileSync("git", ["config", "user.name", "E2E"], {
+    cwd: projectPath,
+    stdio: "ignore",
+  });
+  writeFileSync(join(projectPath, "seed.bin"), Buffer.alloc(SEED_FILE_BYTES));
+  execFileSync("git", ["add", "."], { cwd: projectPath, stdio: "ignore" });
+  execFileSync("git", ["commit", "-q", "-m", "seed"], {
+    cwd: projectPath,
+    stdio: "ignore",
+  });
+
+  seedState(tmpHome, {
+    projects: [
+      {
+        name: PROJECT,
+        path: projectPath,
+        defaultBranch: BRANCH,
+        worktrees: [{ branch: BRANCH, path: projectPath }],
+      },
+    ],
+  });
+  seedSettings(tmpHome, { tokenSecret: TOKEN });
+  server = await startServer({ tmpHome });
+});
+
+test.afterAll(async () => {
+  if (typeof server !== "undefined") await server.close();
+  rmSync(tmpHome, { recursive: true, force: true });
+});
+
+test.describe("Resources dialog (issue #506)", () => {
+  test("loads server snapshot and worktree usage from the dashboard menu", async ({ page }) => {
+    const resources = new ResourcesPage(page, server.url, TOKEN);
+
+    await resources.open();
+    await resources.waitForReady();
+
+    // Server card: numeric PID present.
+    const pid = await resources.getServerPidValue();
+    expect(Number.isFinite(pid)).toBe(true);
+    expect(pid).toBeGreaterThan(0);
+
+    // Worktrees card: the project row appears immediately on open
+    // (no Refresh click needed). The per-project size cell starts
+    // as a "measuring…" spinner and resolves to MB-class output
+    // when the server's `du` finishes.
+    const projectRow = resources.getProjectRow(PROJECT);
+    await expect(projectRow).toBeVisible({ timeout: 15_000 });
+    const sizeCell = resources.getProjectSize(PROJECT);
+    await expect(sizeCell).toContainText(/MB/, { timeout: 15_000 });
+    await expect(resources.projectsTotal).toContainText(/MB/);
+
+    // Per-worktree breakdown is hidden behind a click on the project
+    // row. Positive anchor first: confirm the table itself has
+    // rendered (so a missing testid distinguishes "row hidden" from
+    // "page never loaded"). Then assert the worktree row is NOT
+    // in the DOM, expand the project, and assert it appears with
+    // its branch + size.
+    await expect(resources.projectsTable).toBeVisible();
+    const worktreeRow = resources.getWorktreeRow(PROJECT, BRANCH);
+    await expect(worktreeRow).not.toBeVisible();
+    await resources.expandProject(PROJECT);
+    await expect(worktreeRow).toBeVisible();
+    await expect(worktreeRow).toContainText(/MB/);
+  });
+});

--- a/apps/web/src/components/ResourcesPage.tsx
+++ b/apps/web/src/components/ResourcesPage.tsx
@@ -1,0 +1,521 @@
+import { Button, ScrollArea, Spinner } from "@band-app/ui";
+import { useQuery } from "@tanstack/react-query";
+import { ChevronRight, RefreshCw } from "lucide-react";
+import { Fragment, useCallback, useEffect, useMemo, useState } from "react";
+import { trpc } from "../lib/trpc-client";
+
+interface ServerSnapshot {
+  pid: number;
+  uptimeSeconds: number;
+  nodeVersion: string;
+  platform: string;
+  arch: string;
+  memory: {
+    rssBytes: number;
+    heapTotalBytes: number;
+    heapUsedBytes: number;
+    externalBytes: number;
+    arrayBuffersBytes: number;
+  };
+  cpu: {
+    userMicros: number;
+    systemMicros: number;
+  };
+}
+
+interface ProjectListing {
+  project: string;
+  path: string;
+  worktrees: Array<{ branch: string; path: string }>;
+  error?: string;
+}
+
+interface ProjectsResponse {
+  projects: ProjectListing[];
+}
+
+interface WorktreeSize {
+  branch: string;
+  path: string;
+  sizeBytes: number;
+  error?: string;
+}
+
+interface ProjectSize {
+  project: string;
+  sizeBytes: number;
+  worktrees: WorktreeSize[];
+  error?: string;
+}
+
+const BYTES_PER_MB = 1024 * 1024;
+
+function formatMB(bytes: number): string {
+  return `${(bytes / BYTES_PER_MB).toFixed(1)} MB`;
+}
+
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < BYTES_PER_MB) return `${(bytes / 1024).toFixed(1)} KB`;
+  if (bytes < BYTES_PER_MB * 1024) return `${(bytes / BYTES_PER_MB).toFixed(1)} MB`;
+  return `${(bytes / (BYTES_PER_MB * 1024)).toFixed(2)} GB`;
+}
+
+function formatUptime(seconds: number): string {
+  const s = Math.floor(seconds % 60);
+  const m = Math.floor((seconds / 60) % 60);
+  const h = Math.floor((seconds / 3600) % 24);
+  const d = Math.floor(seconds / 86400);
+  const parts: string[] = [];
+  if (d > 0) parts.push(`${d}d`);
+  if (h > 0) parts.push(`${h}h`);
+  if (m > 0) parts.push(`${m}m`);
+  parts.push(`${s}s`);
+  return parts.join(" ");
+}
+
+function formatCpuMs(micros: number): string {
+  const ms = micros / 1000;
+  if (ms < 1000) return `${ms.toFixed(1)} ms`;
+  return `${(ms / 1000).toFixed(2)} s`;
+}
+
+/**
+ * Make a project + branch pair safe to embed in a `data-testid`.
+ * Git allows `/`, `.`, and other chars that are legal in an
+ * attribute value but awkward to grep, and the two halves need to
+ * be combined uniquely — two projects with a `main` branch would
+ * otherwise collide on `resources-worktree-row-main` and break
+ * Playwright strict-mode locators. Replace anything outside
+ * `[A-Za-z0-9_-]` with `_`, then join with `__`.
+ */
+function testIdForWorktree(project: string, branch: string): string {
+  const safe = (s: string) => s.replace(/[^\w-]/g, "_");
+  return `${safe(project)}__${safe(branch)}`;
+}
+
+/**
+ * Bound on simultaneous in-flight per-project `du` requests. The
+ * server walks each request as `Promise.all` over that project's
+ * worktrees (one `du -sk` process per worktree), so this is the
+ * client-side "how many projects should we be measuring at once"
+ * — not the total `du` process count. 3 keeps the spinner pattern
+ * visibly progressive on a 5-10 project setup, doesn't bury a
+ * shared SSD in random reads, and means a slow project can't
+ * starve the whole queue.
+ */
+const PROJECT_FETCH_CONCURRENCY = 3;
+
+/**
+ * Run `fn` over every item with at most `limit` running at once.
+ * Returns when all items have been processed (or `cancelled` flips
+ * true, in which case still-pending iterations are skipped).
+ *
+ * Inline worker-pool — pulling in `p-limit` for ~20 lines would
+ * be overkill, and React Query doesn't offer this primitive out
+ * of the box (its `useQueries` would fire everything at once).
+ */
+async function runWithLimit<T>(
+  items: T[],
+  limit: number,
+  fn: (item: T) => Promise<void>,
+  isCancelled: () => boolean,
+): Promise<void> {
+  let nextIdx = 0;
+  async function worker() {
+    while (true) {
+      if (isCancelled()) return;
+      const idx = nextIdx++;
+      if (idx >= items.length) return;
+      await fn(items[idx]);
+    }
+  }
+  await Promise.all(Array.from({ length: Math.min(limit, items.length) }, () => worker()));
+}
+
+export function ResourcesPage() {
+  const serverQuery = useQuery<ServerSnapshot>({
+    queryKey: ["resources", "server"],
+    queryFn: () => trpc.services.resourcesServer.query(),
+  });
+
+  // Cheap query — just `git worktree list --porcelain` per project,
+  // no disk walks. Fires on mount automatically.
+  const projectsQuery = useQuery<ProjectsResponse>({
+    queryKey: ["resources", "projects"],
+    queryFn: () => trpc.services.resourcesProjects.query(),
+    refetchOnWindowFocus: false,
+    refetchOnReconnect: false,
+    refetchInterval: false,
+    staleTime: Number.POSITIVE_INFINITY,
+  });
+
+  // Per-project disk-usage cache, populated as `du` calls finish.
+  // Key absent = not yet measured (show spinner). Cleared on
+  // Refresh + on initial mount of a fresh project list.
+  const [sizes, setSizes] = useState<Map<string, ProjectSize>>(() => new Map());
+  // Bumped by the Refresh button to force the size-fetch effect to
+  // re-run even if the underlying projects list hasn't changed.
+  const [refreshKey, setRefreshKey] = useState(0);
+
+  const server = serverQuery.data;
+  const projects = projectsQuery.data?.projects ?? [];
+
+  // Stable identity for the projects list — keyed only on project
+  // names, not the array reference. Without this, every render
+  // before the query resolves hands `useEffect` a fresh `[]`
+  // literal, and any future refetch (window focus, manual
+  // `invalidateQueries`, …) flaps the cache by re-issuing the
+  // whole `setSizes(new Map())` + queue dispatch. The `useMemo`
+  // freezes the list while the underlying project set is stable.
+  //
+  // `projects` is intentionally NOT in the dep list — the join'd
+  // names string is the stable identity we're keying on. Biome's
+  // exhaustive-deps rule reads that as a missing dep; suppressing
+  // is the correct call.
+  const projectNames = projects.map((p) => p.project).join("\n");
+  // biome-ignore lint/correctness/useExhaustiveDependencies: projectNames is the intentional stable-identity key
+  const projectsRef = useMemo(() => projects, [projectNames]);
+
+  // Kick off per-project size fetches in a concurrency-limited loop
+  // whenever the projects set actually changes or the user hits
+  // Refresh. `cancelled` guards against state writes after the
+  // dialog unmounts or another refresh fires mid-flight.
+  //
+  // `refreshKey` is a deliberate re-run trigger (no body read), so
+  // biome's exhaustive-deps rule flags it as "extra" — but forcing
+  // the re-run is the entire point on Refresh.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: refreshKey is the re-run trigger
+  useEffect(() => {
+    if (projectsRef.length === 0) return;
+    let cancelled = false;
+    setSizes(new Map());
+
+    void runWithLimit(
+      projectsRef,
+      PROJECT_FETCH_CONCURRENCY,
+      async (p) => {
+        try {
+          const data = await trpc.services.resourcesProjectSize.query({ project: p.project });
+          if (cancelled) return;
+          setSizes((prev) => {
+            const next = new Map(prev);
+            next.set(p.project, data);
+            return next;
+          });
+        } catch (err) {
+          if (cancelled) return;
+          setSizes((prev) => {
+            const next = new Map(prev);
+            next.set(p.project, {
+              project: p.project,
+              sizeBytes: 0,
+              worktrees: [],
+              error: err instanceof Error ? err.message : String(err),
+            });
+            return next;
+          });
+        }
+      },
+      () => cancelled,
+    );
+
+    return () => {
+      cancelled = true;
+    };
+  }, [projectsRef, refreshKey]);
+
+  const handleRefreshSizes = useCallback(async () => {
+    await projectsQuery.refetch();
+    setRefreshKey((k) => k + 1);
+  }, [projectsQuery]);
+
+  const [expandedProjects, setExpandedProjects] = useState<Set<string>>(() => new Set());
+  const toggleProject = (project: string) => {
+    setExpandedProjects((prev) => {
+      const next = new Set(prev);
+      if (next.has(project)) next.delete(project);
+      else next.add(project);
+      return next;
+    });
+  };
+
+  // Sorted view of the projects list — known sizes first (largest
+  // to smallest by `sizeBytes`), then everything still loading in
+  // its incoming order so the spinners don't reshuffle as data
+  // arrives. Note: a project whose `du` walk errored is recorded
+  // with `sizeBytes: 0`, which sorts identically to a real
+  // zero-byte project; both end up at the bottom of the
+  // size-known group. We treat that as acceptable because errors
+  // are also surfaced inline (the size cell renders "error").
+  const sortedProjects = [...projects].sort((a, b) => {
+    const sa = sizes.get(a.project);
+    const sb = sizes.get(b.project);
+    if (sa && sb) return sb.sizeBytes - sa.sizeBytes;
+    if (sa && !sb) return -1;
+    if (!sa && sb) return 1;
+    return 0;
+  });
+
+  const knownTotalBytes = Array.from(sizes.values()).reduce((sum, s) => sum + s.sizeBytes, 0);
+  // "All sizes accounted for" — true when every project has either
+  // a known size or there are no projects at all. The latter case
+  // matters because the user with zero tracked repos would
+  // otherwise see a perpetually-spinning Refresh button (sizes.size
+  // === 0 === projects.length, but the previous `> 0` guard
+  // excluded that path).
+  const allLoaded = sizes.size === projects.length;
+
+  return (
+    <ScrollArea className="h-full w-full">
+      <div className="mx-auto flex max-w-5xl flex-col gap-8 px-6 py-4">
+        <section data-testid="resources-server-card" className="space-y-3">
+          <div className="flex flex-row items-start justify-between gap-2">
+            <div className="space-y-1">
+              <h2 className="text-base font-semibold leading-none">Server</h2>
+              <p className="text-sm text-muted-foreground">
+                The Node process serving the Band dashboard ({server ? `pid ${server.pid}` : "…"}).
+              </p>
+            </div>
+            <Button
+              variant="outline"
+              size="sm"
+              data-testid="resources-refresh-server"
+              onClick={() => serverQuery.refetch()}
+              disabled={serverQuery.isFetching}
+            >
+              {serverQuery.isFetching ? (
+                <Spinner className="size-3.5" />
+              ) : (
+                <RefreshCw className="size-3.5" />
+              )}
+              Refresh
+            </Button>
+          </div>
+          {serverQuery.isError ? (
+            <p className="text-sm text-destructive">
+              Failed to load server snapshot: {String(serverQuery.error)}
+            </p>
+          ) : !server ? (
+            <div className="flex items-center gap-2 text-sm text-muted-foreground">
+              <Spinner className="size-4" />
+              Loading…
+            </div>
+          ) : (
+            <div className="grid grid-cols-2 gap-x-6 gap-y-2 text-sm md:grid-cols-3">
+              <ServerField label="PID">
+                <span data-testid="resources-server-pid">{server.pid}</span>
+              </ServerField>
+              <ServerField label="Uptime">{formatUptime(server.uptimeSeconds)}</ServerField>
+              <ServerField label="Node">{server.nodeVersion}</ServerField>
+              <ServerField label="Platform">
+                {server.platform} ({server.arch})
+              </ServerField>
+              <ServerField label="RSS">{formatMB(server.memory.rssBytes)}</ServerField>
+              <ServerField label="Heap used">{formatMB(server.memory.heapUsedBytes)}</ServerField>
+              <ServerField label="Heap total">{formatMB(server.memory.heapTotalBytes)}</ServerField>
+              <ServerField label="External">{formatMB(server.memory.externalBytes)}</ServerField>
+              <ServerField label="Array buffers">
+                {formatMB(server.memory.arrayBuffersBytes)}
+              </ServerField>
+              <ServerField label="Total CPU time (user)">
+                {formatCpuMs(server.cpu.userMicros)}
+              </ServerField>
+              <ServerField label="Total CPU time (system)">
+                {formatCpuMs(server.cpu.systemMicros)}
+              </ServerField>
+            </div>
+          )}
+        </section>
+
+        <section data-testid="resources-worktrees-card" className="space-y-3">
+          <div className="flex flex-row items-start justify-between gap-2">
+            <div className="space-y-1">
+              <h2 className="text-base font-semibold leading-none">Worktrees</h2>
+              <p className="text-sm text-muted-foreground">
+                Disk usage per tracked git project (allocated blocks, as reported by{" "}
+                <code className="rounded bg-muted px-1 py-0.5 text-xs">du</code>). Sizes load per
+                project in batches of {PROJECT_FETCH_CONCURRENCY}. Click a project to see its
+                per-worktree breakdown.
+              </p>
+            </div>
+            <Button
+              variant="outline"
+              size="sm"
+              data-testid="resources-refresh-worktrees"
+              onClick={handleRefreshSizes}
+              disabled={projectsQuery.isFetching || !allLoaded}
+            >
+              {projectsQuery.isFetching || !allLoaded ? (
+                <Spinner className="size-3.5" />
+              ) : (
+                <RefreshCw className="size-3.5" />
+              )}
+              Refresh
+            </Button>
+          </div>
+          {projectsQuery.isError ? (
+            <p className="text-sm text-destructive">
+              Failed to load projects: {String(projectsQuery.error)}
+            </p>
+          ) : (
+            <div className="relative overflow-x-auto">
+              <table
+                data-testid="resources-projects-table"
+                className="w-full border-collapse text-sm"
+              >
+                <thead>
+                  <tr className="border-b border-border text-left text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                    <th className="py-2 pr-3">Project</th>
+                    <th className="py-2 pr-3 text-right">Worktrees</th>
+                    <th className="py-2 pr-3 text-right">Total size</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {sortedProjects.length === 0 ? (
+                    <tr>
+                      <td colSpan={3} className="py-6 text-center text-sm text-muted-foreground">
+                        {projectsQuery.isFetching ? "Loading…" : "No git projects found"}
+                      </td>
+                    </tr>
+                  ) : (
+                    sortedProjects.map((project) => {
+                      const size = sizes.get(project.project);
+                      const isExpanded = expandedProjects.has(project.project);
+                      return (
+                        <Fragment key={project.project}>
+                          {/* See the cell-scoped <button> below — a
+                              row-level click handler can't be a
+                              real <button> (must be a direct
+                              <tbody> child), so we put the button
+                              in the first cell and let it span the
+                              click target. */}
+                          <tr
+                            data-testid={`resources-project-row-${project.project}`}
+                            data-expanded={isExpanded ? "true" : "false"}
+                            className="border-b border-border/60 last:border-0 hover:bg-muted/40"
+                          >
+                            <td className="py-2 pr-3 font-medium">
+                              <button
+                                type="button"
+                                aria-expanded={isExpanded}
+                                onClick={() => toggleProject(project.project)}
+                                className="inline-flex w-full cursor-pointer items-center gap-1 text-left"
+                              >
+                                <ChevronRight
+                                  className={`size-3.5 shrink-0 transition-transform ${
+                                    isExpanded ? "rotate-90" : ""
+                                  }`}
+                                />
+                                {project.project}
+                              </button>
+                            </td>
+                            <td className="py-2 pr-3 text-right tabular-nums">
+                              {project.worktrees.length}
+                            </td>
+                            <td
+                              className="py-2 pr-3 text-right tabular-nums"
+                              data-testid={`resources-project-size-${project.project}`}
+                            >
+                              {size === undefined ? (
+                                <span className="inline-flex items-center justify-end gap-1.5 text-muted-foreground">
+                                  <Spinner className="size-3.5" />
+                                  <span className="text-xs">measuring…</span>
+                                </span>
+                              ) : size.error ? (
+                                <span className="text-destructive" title={size.error}>
+                                  error
+                                </span>
+                              ) : (
+                                formatBytes(size.sizeBytes)
+                              )}
+                            </td>
+                          </tr>
+                          {isExpanded &&
+                            (size === undefined ? (
+                              // Sizes haven't landed yet — show one
+                              // child row with a spinner so the
+                              // expand isn't an empty void.
+                              <tr className="border-b border-border/40 bg-muted/20">
+                                <td colSpan={3} className="py-2 pl-8 pr-3">
+                                  <span className="inline-flex items-center gap-2 text-xs text-muted-foreground">
+                                    <Spinner className="size-3.5" />
+                                    Measuring worktrees…
+                                  </span>
+                                </td>
+                              </tr>
+                            ) : size.worktrees.length === 0 ? (
+                              <tr className="border-b border-border/40 bg-muted/20">
+                                <td
+                                  colSpan={3}
+                                  className="py-2 pl-8 pr-3 text-xs text-muted-foreground"
+                                >
+                                  No worktrees
+                                </td>
+                              </tr>
+                            ) : (
+                              size.worktrees.map((wt) => (
+                                <tr
+                                  key={`${project.project}::${wt.branch}::${wt.path}`}
+                                  data-testid={`resources-worktree-row-${testIdForWorktree(project.project, wt.branch)}`}
+                                  className="border-b border-border/40 bg-muted/20 last:border-0"
+                                >
+                                  <td className="py-1.5 pl-8 pr-3">
+                                    <div className="flex flex-col">
+                                      <span className="font-mono text-xs">{wt.branch || "—"}</span>
+                                      <span className="truncate font-mono text-[11px] text-muted-foreground">
+                                        {wt.path}
+                                      </span>
+                                    </div>
+                                  </td>
+                                  <td className="py-1.5 pr-3" />
+                                  <td className="py-1.5 pr-3 text-right tabular-nums">
+                                    {wt.error ? (
+                                      <span className="text-destructive">error</span>
+                                    ) : (
+                                      formatBytes(wt.sizeBytes)
+                                    )}
+                                  </td>
+                                </tr>
+                              ))
+                            ))}
+                        </Fragment>
+                      );
+                    })
+                  )}
+                </tbody>
+                {projects.length > 0 && (
+                  <tfoot>
+                    <tr className="border-t-2 border-border font-medium">
+                      <td className="py-2 pr-3">Total{allLoaded ? "" : " (partial)"}</td>
+                      <td className="py-2 pr-3 text-right tabular-nums">
+                        {projects.reduce((sum, p) => sum + p.worktrees.length, 0)}
+                      </td>
+                      <td
+                        className="py-2 pr-3 text-right tabular-nums"
+                        data-testid="resources-projects-total"
+                      >
+                        {formatBytes(knownTotalBytes)}
+                      </td>
+                    </tr>
+                  </tfoot>
+                )}
+              </table>
+            </div>
+          )}
+        </section>
+      </div>
+    </ScrollArea>
+  );
+}
+
+function ServerField({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div className="flex flex-col gap-0.5">
+      <span className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+        {label}
+      </span>
+      <span className="font-mono text-sm">{children}</span>
+    </div>
+  );
+}

--- a/apps/web/src/components/ToolbarButtons.tsx
+++ b/apps/web/src/components/ToolbarButtons.tsx
@@ -1,9 +1,10 @@
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DropdownMenuItem } from "@band-app/ui";
-import { Globe, ListTodo, Timer } from "lucide-react";
+import { Activity, Globe, ListTodo, Timer } from "lucide-react";
 import { createContext, type ReactNode, useCallback, useContext, useMemo, useState } from "react";
 import { useTunnel } from "@/hooks/use-tunnel";
 import { CronjobsPageContent } from "./CronjobsPageContent";
 import { PrereqDialog } from "./PrereqDialog";
+import { ResourcesPage } from "./ResourcesPage";
 import { TasksPageContent } from "./TasksPageContent";
 import { TunnelDialog } from "./TunnelDialog";
 
@@ -11,11 +12,13 @@ interface ToolbarOverflowContextValue {
   openTasks: () => void;
   openCronjobs: () => void;
   openTunnel: () => void;
+  openResources: () => void;
   /** Tunnel state hint for the menu item (so we can show running/error coloring). */
   tunnelStatus: "idle" | "running" | "error";
-  /** True when any toolbar dialog (Tasks, Cronjobs, Tunnel, Prereq) is open.
-   *  SharedDockviewLayout merges this with its own dialog state to hide
-   *  Electron BrowserView webviews that would otherwise render on top. */
+  /** True when any toolbar dialog (Tasks, Cronjobs, Tunnel, Prereq,
+   *  Resources) is open. SharedDockviewLayout merges this with its
+   *  own dialog state to hide Electron BrowserView webviews that
+   *  would otherwise render on top. */
   anyDialogOpen: boolean;
 }
 
@@ -37,6 +40,7 @@ export function useAnyToolbarDialogOpen(): boolean {
 export function ToolbarOverflowProvider({ children }: { children: ReactNode }) {
   const [showTasksDialog, setShowTasksDialog] = useState(false);
   const [showCronjobsDialog, setShowCronjobsDialog] = useState(false);
+  const [showResourcesDialog, setShowResourcesDialog] = useState(false);
 
   const {
     webServerRunning,
@@ -55,6 +59,7 @@ export function ToolbarOverflowProvider({ children }: { children: ReactNode }) {
   const openTasks = useCallback(() => setShowTasksDialog(true), []);
   const openCronjobs = useCallback(() => setShowCronjobsDialog(true), []);
   const openTunnel = useCallback(() => openTunnelDialog(), [openTunnelDialog]);
+  const openResources = useCallback(() => setShowResourcesDialog(true), []);
 
   const tunnelStatus: ToolbarOverflowContextValue["tunnelStatus"] = tunnelError
     ? "error"
@@ -62,11 +67,19 @@ export function ToolbarOverflowProvider({ children }: { children: ReactNode }) {
       ? "running"
       : "idle";
 
-  const anyDialogOpen = showTasksDialog || showCronjobsDialog || showTunnelDialog || showPrereq;
+  const anyDialogOpen =
+    showTasksDialog || showCronjobsDialog || showTunnelDialog || showPrereq || showResourcesDialog;
 
   const value = useMemo(
-    () => ({ openTasks, openCronjobs, openTunnel, tunnelStatus, anyDialogOpen }),
-    [openTasks, openCronjobs, openTunnel, tunnelStatus, anyDialogOpen],
+    () => ({
+      openTasks,
+      openCronjobs,
+      openTunnel,
+      openResources,
+      tunnelStatus,
+      anyDialogOpen,
+    }),
+    [openTasks, openCronjobs, openTunnel, openResources, tunnelStatus, anyDialogOpen],
   );
 
   return (
@@ -90,6 +103,20 @@ export function ToolbarOverflowProvider({ children }: { children: ReactNode }) {
             <DialogTitle>Cronjobs</DialogTitle>
           </DialogHeader>
           <CronjobsPageContent />
+        </DialogContent>
+      </Dialog>
+
+      <Dialog open={showResourcesDialog} onOpenChange={setShowResourcesDialog}>
+        <DialogContent
+          className="sm:max-w-6xl h-[80vh] flex flex-col p-0 gap-0"
+          data-testid="resources-dialog"
+        >
+          <DialogHeader className="px-6 pt-6 pb-4 border-b border-border/50 shrink-0">
+            <DialogTitle>Resources</DialogTitle>
+          </DialogHeader>
+          <div className="flex-1 min-h-0">
+            <ResourcesPage />
+          </div>
         </DialogContent>
       </Dialog>
 
@@ -138,6 +165,10 @@ export function ToolbarOverflowMenuItems() {
           }
         />
         {ctx.tunnelStatus === "running" ? "Mobile access" : "Start tunnel"}
+      </DropdownMenuItem>
+      <DropdownMenuItem onClick={ctx.openResources} data-testid="menu__resources">
+        <Activity className="size-4" />
+        Resources
       </DropdownMenuItem>
     </>
   );

--- a/apps/web/src/lib/disk-usage.ts
+++ b/apps/web/src/lib/disk-usage.ts
@@ -1,0 +1,112 @@
+import { execFile } from "node:child_process";
+
+/**
+ * Maximum buffer size for `du` stdout. `du -sk` prints a single
+ * summary line (kilobytes + path), so 10 MB is overkill — but
+ * defensible against pathological paths.
+ */
+const MAX_BUFFER = 10 * 1024 * 1024;
+
+/**
+ * Hard wall-clock cap on a single `du` invocation. The procedure
+ * fanout already runs worktrees in parallel, so on a healthy disk
+ * each `du` finishes in single-digit seconds; if any one call
+ * exceeds this it almost certainly means a stalled NFS / CIFS
+ * mount, and we'd rather surface "error" in one row than hang the
+ * tRPC handler forever. `execFile`'s `timeout` option sends
+ * `SIGTERM` to the child after this elapses, which surfaces as a
+ * rejected promise.
+ */
+const DU_TIMEOUT_MS = 30_000;
+
+/**
+ * Process-wide cap on simultaneous `du` invocations. The client
+ * caps its own fan-out at 3 projects in flight, but multiple open
+ * tabs or rapid Refresh clicks could otherwise spawn dozens of
+ * `du` processes concurrently and exhaust the per-process FD
+ * limit. 8 keeps the cap above the client's-3 plus a safety
+ * margin for parallel callers, while bounding worst-case process
+ * count when usage spikes.
+ */
+const DU_GLOBAL_CONCURRENCY = 8;
+
+// Simple FIFO semaphore around `duBytes`. Inline rather than a
+// helper because this is the only consumer in the package.
+let inFlight = 0;
+const waiting: Array<() => void> = [];
+
+function acquireSlot(): Promise<() => void> {
+  return new Promise((resolve) => {
+    const grant = () => {
+      inFlight++;
+      resolve(() => {
+        inFlight--;
+        const next = waiting.shift();
+        if (next) next();
+      });
+    };
+    if (inFlight < DU_GLOBAL_CONCURRENCY) grant();
+    else waiting.push(grant);
+  });
+}
+
+/**
+ * Run `du -sk PATH` and return the allocated byte total. We tried a
+ * Node-side recursive `opendir` + `stat` walker first and a
+ * "parallelised" variant on top of that, but both were unusably
+ * slow on real worktree trees (~2 minutes for 33 GB). `du` is the
+ * optimised native answer the OS already ships — single-digit
+ * seconds on the same input, and even better when run as multiple
+ * concurrent processes because each is its own scheduler slot.
+ *
+ * Returned bytes are *allocated* (du default), not apparent file
+ * sizes. They differ by < 5% for typical content. POSIX-compatible
+ * — works the same on macOS BSD `du` and GNU coreutils `du`. The
+ * `-k` flag forces 1024-byte block output; `-s` collapses to a
+ * single summary line.
+ *
+ * `du` is invoked directly via `execFile` (no shell): if any
+ * descendant directory is unreadable (EACCES on a `chmod 000` /
+ * vendored Docker volume / mount-point owned by another user), `du`
+ * exits with a non-zero code AND still writes the partial summary
+ * to stdout. The default `promisify(execFile)` would reject and
+ * drop that partial line, so we use the callback form and parse
+ * stdout regardless of exit status. The total then represents
+ * everything we *could* see — strictly better than returning 0
+ * because one subtree was off-limits.
+ */
+export async function duBytes(path: string): Promise<number> {
+  const release = await acquireSlot();
+  try {
+    const stdout = await new Promise<string>((resolve, reject) => {
+      execFile(
+        "du",
+        ["-sk", path],
+        { maxBuffer: MAX_BUFFER, timeout: DU_TIMEOUT_MS },
+        (err, out) => {
+          // Permission-on-descendant: exit code 1, stderr has the
+          // "permission denied" lines, stdout has the partial
+          // total. Use whatever stdout we got and let the caller
+          // see a (truncated) number rather than fail the whole
+          // worktree.
+          if (err && !out) {
+            reject(err);
+            return;
+          }
+          resolve(out);
+        },
+      );
+    });
+    // Output: `<kb>\t<path>\n`. Split on whitespace and take the
+    // first token rather than relying on the exact tab so BSD/GNU
+    // formatting drift doesn't bite.
+    const kbStr = stdout.trim().split(/\s+/)[0];
+    const kb = Number.parseInt(kbStr, 10);
+    if (!Number.isFinite(kb)) {
+      throw new Error(`du output not numeric: ${JSON.stringify(stdout)}`);
+    }
+    return kb * 1024;
+  } finally {
+    release();
+  }
+}

--- a/apps/web/src/trpc/router.ts
+++ b/apps/web/src/trpc/router.ts
@@ -81,6 +81,7 @@ import {
   saveCronjobFile,
 } from "../lib/cronjob-store";
 import type { CronjobDefinition } from "../lib/cronjob-types";
+import { duBytes } from "../lib/disk-usage";
 import { subscribeToFileChanges } from "../lib/file-watcher";
 import { FormatterError, formatFile } from "../lib/formatter";
 import { fuzzyScore } from "../lib/fuzzy-score";
@@ -2742,6 +2743,139 @@ const servicesRouter = t.router({
       return { activity: input.activity };
     }),
   getActivity: publicProcedure.query(() => ({ activity: getPollerActivity() })),
+  // Resources dashboard — server CPU/memory snapshot (cheap, instant).
+  // `process.cpuUsage()` is cumulative since process start; the UI labels
+  // it "Total CPU time" so callers don't read it as instantaneous load.
+  resourcesServer: publicProcedure.query(() => {
+    const mem = process.memoryUsage();
+    const cpu = process.cpuUsage();
+    return {
+      pid: process.pid,
+      uptimeSeconds: process.uptime(),
+      nodeVersion: process.version,
+      platform: process.platform,
+      arch: process.arch,
+      memory: {
+        rssBytes: mem.rss,
+        heapTotalBytes: mem.heapTotal,
+        heapUsedBytes: mem.heapUsed,
+        externalBytes: mem.external,
+        arrayBuffersBytes: mem.arrayBuffers,
+      },
+      cpu: {
+        userMicros: cpu.user,
+        systemMicros: cpu.system,
+      },
+    };
+  }),
+  // Resources dashboard — list every tracked git project + its
+  // worktree paths *without* doing any disk walks. Instant: just
+  // reads state + a single `git worktree list --porcelain` per
+  // project (in parallel). The client uses this to paint rows
+  // immediately, then fetches each project's size individually
+  // via `resourcesProjectSize` so the slow `du` work is amortised
+  // and observable per-row.
+  resourcesProjects: publicProcedure.query(async () => {
+    const state = loadState();
+    const projects = await Promise.all(
+      state.projects
+        .filter((p) => p.kind === "git")
+        .map(async (project) => {
+          try {
+            const list = await listWorktrees(project.path);
+            const worktrees = list
+              .filter((wt) => !wt.isBare)
+              .map((wt) => ({
+                // Detached HEAD (mid-rebase, mid-bisect, or
+                // explicit `git checkout <sha>`) produces an empty
+                // branch string. Keep the row with a sentinel
+                // label so the size still gets counted — silently
+                // dropping it would make a developer's largest
+                // worktree disappear from the accounting whenever
+                // they happened to be on a detached HEAD.
+                branch: wt.branch || "(detached HEAD)",
+                path: wt.path,
+              }));
+            return {
+              project: project.name,
+              path: project.path,
+              worktrees,
+              error: undefined as string | undefined,
+            };
+          } catch (err) {
+            return {
+              project: project.name,
+              path: project.path,
+              worktrees: [] as { branch: string; path: string }[],
+              error: err instanceof Error ? err.message : String(err),
+            };
+          }
+        }),
+    );
+    return { projects };
+  }),
+  // Resources dashboard — measure disk usage for a single project.
+  //
+  // Slow: runs `du -sk` once per worktree, in parallel via
+  // Promise.all. The client fan-outs are concurrency-limited so the
+  // server doesn't see a thundering herd of `du` processes from a
+  // single page open. Per-worktree errors are absorbed into the
+  // response (sizeBytes 0, `error` populated) so a single broken
+  // worktree doesn't fail the whole query.
+  resourcesProjectSize: publicProcedure
+    .input(z.object({ project: z.string() }))
+    .query(async ({ input }) => {
+      const state = loadState();
+      const project = state.projects.find((p) => p.name === input.project && p.kind === "git");
+      if (!project) {
+        throw new TRPCError({ code: "NOT_FOUND", message: "Project not found" });
+      }
+
+      let worktreePaths: { branch: string; path: string }[];
+      try {
+        const list = await listWorktrees(project.path);
+        worktreePaths = list
+          .filter((wt) => !wt.isBare)
+          .map((wt) => ({
+            // See `resourcesProjects` above — detached HEAD gets a
+            // sentinel label rather than being dropped.
+            branch: wt.branch || "(detached HEAD)",
+            path: wt.path,
+          }));
+      } catch (err) {
+        return {
+          project: project.name,
+          sizeBytes: 0,
+          worktrees: [] as Array<{
+            branch: string;
+            path: string;
+            sizeBytes: number;
+            error?: string;
+          }>,
+          error: err instanceof Error ? err.message : String(err),
+        };
+      }
+
+      const worktrees = await Promise.all(
+        worktreePaths.map(async (wt) => {
+          try {
+            const sizeBytes = await duBytes(wt.path);
+            return { branch: wt.branch, path: wt.path, sizeBytes };
+          } catch (err) {
+            return {
+              branch: wt.branch,
+              path: wt.path,
+              sizeBytes: 0,
+              error: err instanceof Error ? err.message : String(err),
+            };
+          }
+        }),
+      );
+
+      worktrees.sort((a, b) => b.sizeBytes - a.sizeBytes);
+      const sizeBytes = worktrees.reduce((sum, wt) => sum + wt.sizeBytes, 0);
+      return { project: project.name, sizeBytes, worktrees };
+    }),
 });
 
 // ---------------------------------------------------------------------------

--- a/apps/web/tests/resources.test.ts
+++ b/apps/web/tests/resources.test.ts
@@ -1,0 +1,299 @@
+/**
+ * Backend integration test for the Resources dashboard (issue #506).
+ *
+ * Boots the real production server bundle against a fresh tmp HOME,
+ * seeds a real git repo + worktree, and calls the three tRPC
+ * procedures (`services.resourcesServer`, `services.resourcesProjects`,
+ * `services.resourcesProjectSize`) over HTTP. No mocking — the test
+ * exercises the same code path the dashboard hits in production.
+ *
+ * Per `CLAUDE.md`, `apps/web` is the one package in the repo that
+ * standardised on vitest before the node:test convention was written
+ * down, so we follow the existing vitest convention here.
+ */
+
+import { execFileSync, spawn } from "node:child_process";
+import { mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from "node:fs";
+import { createServer } from "node:net";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { seedSettings, seedState } from "./helpers/seed-state";
+import { SERVER_RUNTIME, SERVER_SCRIPT } from "./helpers/server-runtime";
+
+const PROJECT_ROOT = join(import.meta.dirname, "..");
+const TOKEN = "test-token-resources";
+const PROJECT = "resources-fixture";
+const BRANCH = "main";
+const SEED_FILE_BYTES = 1024 * 1024; // 1 MiB
+
+interface ServerHandle {
+  url: string;
+  home: string;
+  close: () => Promise<void>;
+}
+
+function createTmpHome(): string {
+  // `mkdtempSync` on macOS returns a path under `/var/folders/...`
+  // but the OS canonical form is `/private/var/folders/...`. `git`
+  // and `du` will follow that symlink and report the canonical
+  // path, which then mismatches our assertions. Canonicalise at
+  // construction so the seed path matches what subprocesses see.
+  const tmp = realpathSync(mkdtempSync(join(tmpdir(), "band-test-resources-")));
+  mkdirSync(join(tmp, ".band"), { recursive: true });
+  return tmp;
+}
+
+function getRandomPort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const srv = createServer();
+    srv.listen(0, "127.0.0.1", () => {
+      const { port } = srv.address() as { port: number };
+      srv.close(() => resolve(port));
+    });
+    srv.on("error", reject);
+  });
+}
+
+async function startServer(opts: { tmpHome: string }): Promise<ServerHandle> {
+  const port = await getRandomPort();
+  return new Promise((resolve, reject) => {
+    const child = spawn(SERVER_RUNTIME, [SERVER_SCRIPT], {
+      cwd: PROJECT_ROOT,
+      env: {
+        ...process.env,
+        HOME: opts.tmpHome,
+        PORT: String(port),
+        NODE_ENV: "production",
+      },
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+
+    let stderr = "";
+    let settled = false;
+    child.stderr!.on("data", (chunk: Buffer) => {
+      stderr += chunk.toString();
+    });
+    child.stdout!.on("data", (chunk: Buffer) => {
+      if (chunk.toString().includes("listening") && !settled) {
+        settled = true;
+        resolve({
+          url: `http://127.0.0.1:${port}`,
+          home: opts.tmpHome,
+          close: () =>
+            new Promise<void>((r) => {
+              child.on("exit", () => r());
+              child.kill("SIGTERM");
+            }),
+        });
+      }
+    });
+    child.on("error", (err) => {
+      if (!settled) {
+        settled = true;
+        reject(err);
+      }
+    });
+    child.on("exit", (code) => {
+      if (!settled) {
+        settled = true;
+        reject(new Error(`Server exited with code ${code}.\nstderr: ${stderr}`));
+      }
+    });
+    setTimeout(() => {
+      if (!settled) {
+        settled = true;
+        child.kill("SIGTERM");
+        reject(new Error(`Server did not start within 15s.\nstderr: ${stderr}`));
+      }
+    }, 15_000);
+  });
+}
+
+async function trpcQuery(
+  url: string,
+  procedure: string,
+  token: string,
+  input?: unknown,
+): Promise<Response> {
+  const suffix = input !== undefined ? `?input=${encodeURIComponent(JSON.stringify(input))}` : "";
+  return fetch(`${url}/trpc/${procedure}${suffix}`, {
+    headers: { Cookie: `band_token=${token}` },
+  });
+}
+
+async function trpcData<T>(res: Response): Promise<T> {
+  const body = (await res.json()) as { result: { data: T } };
+  return body.result.data;
+}
+
+describe("services.resourcesServer + resourcesProjects + resourcesProjectSize (issue #506)", () => {
+  // Definite-assignment in `beforeAll`. The `typeof` guard in
+  // `afterAll` covers the only path that could leave it
+  // unassigned: `startServer` throwing before resolving. Without
+  // the guard, an unrelated `TypeError: Cannot read properties of
+  // undefined (reading 'close')` would mask the real boot failure.
+  let server!: ServerHandle;
+  let tmpHome: string;
+  let projectPath: string;
+
+  beforeAll(async () => {
+    tmpHome = createTmpHome();
+
+    // Real git repo with a known-size seed file. The server walks
+    // this directory at request time — no fixtures-on-disk shortcut.
+    projectPath = join(tmpHome, PROJECT);
+    mkdirSync(projectPath, { recursive: true });
+    execFileSync("git", ["init", "-q", "--initial-branch", BRANCH], {
+      cwd: projectPath,
+      stdio: "ignore",
+    });
+    execFileSync("git", ["config", "user.email", "test@example.com"], {
+      cwd: projectPath,
+      stdio: "ignore",
+    });
+    execFileSync("git", ["config", "user.name", "Test"], {
+      cwd: projectPath,
+      stdio: "ignore",
+    });
+    writeFileSync(join(projectPath, "seed.bin"), Buffer.alloc(SEED_FILE_BYTES));
+    execFileSync("git", ["add", "."], { cwd: projectPath, stdio: "ignore" });
+    execFileSync("git", ["commit", "-q", "-m", "seed"], {
+      cwd: projectPath,
+      stdio: "ignore",
+    });
+
+    seedState(tmpHome, {
+      projects: [
+        {
+          name: PROJECT,
+          path: projectPath,
+          defaultBranch: BRANCH,
+          worktrees: [{ branch: BRANCH, path: projectPath }],
+        },
+      ],
+    });
+    seedSettings(tmpHome, { tokenSecret: TOKEN });
+    server = await startServer({ tmpHome });
+  });
+
+  afterAll(async () => {
+    if (typeof server !== "undefined") await server.close();
+    rmSync(tmpHome, { recursive: true, force: true });
+  });
+
+  it("resourcesServer returns a process snapshot with positive pid + memory", async () => {
+    const res = await trpcQuery(server.url, "services.resourcesServer", TOKEN);
+    expect(res.status).toBe(200);
+    const data = await trpcData<{
+      pid: number;
+      uptimeSeconds: number;
+      nodeVersion: string;
+      platform: string;
+      arch: string;
+      memory: {
+        rssBytes: number;
+        heapTotalBytes: number;
+        heapUsedBytes: number;
+        externalBytes: number;
+        arrayBuffersBytes: number;
+      };
+      cpu: { userMicros: number; systemMicros: number };
+    }>(res);
+
+    expect(data.pid).toBeGreaterThan(0);
+    expect(data.uptimeSeconds).toBeGreaterThan(0);
+    expect(data.nodeVersion).toMatch(/^v\d+\./);
+    expect(typeof data.platform).toBe("string");
+    expect(data.memory.rssBytes).toBeGreaterThan(0);
+    expect(data.memory.heapTotalBytes).toBeGreaterThan(0);
+    expect(data.memory.heapUsedBytes).toBeGreaterThan(0);
+    expect(data.cpu.userMicros).toBeGreaterThanOrEqual(0);
+    expect(data.cpu.systemMicros).toBeGreaterThanOrEqual(0);
+  });
+
+  it("resourcesProjects returns the seeded project + worktree paths without doing disk walks", async () => {
+    const res = await trpcQuery(server.url, "services.resourcesProjects", TOKEN);
+    expect(res.status).toBe(200);
+    const data = await trpcData<{
+      projects: Array<{
+        project: string;
+        path: string;
+        worktrees: Array<{ branch: string; path: string }>;
+        error?: string;
+      }>;
+    }>(res);
+
+    expect(data.projects.length).toBeGreaterThanOrEqual(1);
+    const proj = data.projects.find((p) => p.project === PROJECT);
+    expect(proj).toBeDefined();
+    expect(proj?.error).toBeUndefined();
+    expect(proj?.worktrees.length).toBe(1);
+    const wt = proj?.worktrees[0];
+    expect(wt?.branch).toBe(BRANCH);
+    // `git worktree list --porcelain` returns the canonical (realpath)
+    // path; macOS tmp dirs are symlinks (`/var/...` → `/private/var/...`).
+    expect(wt?.path).toBe(realpathSync(projectPath));
+  });
+
+  it("resourcesProjectSize returns the seeded project's worktree sizes >= seed file size", async () => {
+    const res = await trpcQuery(server.url, "services.resourcesProjectSize", TOKEN, {
+      project: PROJECT,
+    });
+    expect(res.status).toBe(200);
+    const data = await trpcData<{
+      project: string;
+      sizeBytes: number;
+      worktrees: Array<{
+        branch: string;
+        path: string;
+        sizeBytes: number;
+        error?: string;
+      }>;
+      error?: string;
+    }>(res);
+
+    expect(data.project).toBe(PROJECT);
+    expect(data.error).toBeUndefined();
+    expect(data.worktrees.length).toBe(1);
+    const wt = data.worktrees[0];
+    expect(wt.branch).toBe(BRANCH);
+    expect(wt.error).toBeUndefined();
+    expect(wt.path).toBe(realpathSync(projectPath));
+    // Walk must include the 1 MiB seed file plus git plumbing (.git
+    // objects, index, etc.) — strictly greater is the safest lower
+    // bound that's still a real assertion.
+    expect(wt.sizeBytes).toBeGreaterThanOrEqual(SEED_FILE_BYTES);
+
+    // Project total must equal the sum of its worktree sizes.
+    const expectedTotal = data.worktrees.reduce((sum, w) => sum + w.sizeBytes, 0);
+    expect(data.sizeBytes).toBe(expectedTotal);
+  });
+
+  it("resourcesProjectSize returns NOT_FOUND for an unknown project", async () => {
+    const res = await trpcQuery(server.url, "services.resourcesProjectSize", TOKEN, {
+      project: "this-project-does-not-exist",
+    });
+    expect(res.status).toBe(404);
+  });
+
+  // The Resources surface returns process internals (PID, memory,
+  // worktree paths). Lock in the contract that all three procedures
+  // reject unauthenticated requests when the server has a token
+  // configured — a regression here would leak data to anyone who
+  // can reach the port.
+  it("rejects unauthenticated requests on every resources procedure", async () => {
+    const serverRes = await fetch(`${server.url}/trpc/services.resourcesServer`);
+    expect(serverRes.status).toBe(401);
+
+    const projectsRes = await fetch(`${server.url}/trpc/services.resourcesProjects`);
+    expect(projectsRes.status).toBe(401);
+
+    const sizeRes = await fetch(
+      `${server.url}/trpc/services.resourcesProjectSize?input=${encodeURIComponent(
+        JSON.stringify({ project: PROJECT }),
+      )}`,
+    );
+    expect(sizeRes.status).toBe(401);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #506.

Adds a **Resources dialog** (Menu → Resources) that surfaces:

- **Server snapshot** — PID, uptime, Node version, platform, memory (RSS / heap / external / array buffers), and cumulative CPU time. Cheap, refreshable.
- **Per-project disk usage** with an expandable per-worktree breakdown. Sizes load progressively: every project row paints immediately with a "measuring…" spinner, then flips to a byte total as the per-project `du` walk finishes. Concurrency capped at 3 projects in flight. Click any project to expand its worktrees in place.

## What ships

Note: this PR diverges from the original spec in #506 — see "Deviations" below.

### Backend (`apps/web`)

- `services.resourcesServer` — instant process snapshot.
- `services.resourcesProjects` — instant project + worktree path listing (one `git worktree list` per project, parallel).
- `services.resourcesProjectSize({ project })` — slow, measures one project: runs `du -sk` over each worktree in parallel, returns total + per-worktree breakdown.
- `lib/disk-usage.ts` — thin `duBytes(path)` wrapper. Uses the callback form of `execFile` so partial stdout from `du` (e.g. one unreadable subtree returning exit code 1) is still accepted — strictly better than zeroing the whole worktree.

### Frontend

- `ResourcesPage` lives inside a `Dialog` opened from `ToolbarOverflowMenuItems` (same shape as Tasks / Cronjobs). Both the desktop title-bar menu and the mobile `DashboardShell` overflow pick it up automatically.
- Per-project size fetches dispatched via an inline `runWithLimit` worker pool (concurrency 3).
- Project list is memoised on a stable join'd-names key so `useQuery` refetches don't flap the size cache.
- Refresh button re-fetches the projects list AND bumps a counter to restart the per-project size loop.

### Tests

- `tests/resources.test.ts` (vitest, real-server boot, 1 MiB seed git repo): covers all three procedures, NOT_FOUND for unknown projects, and a 401 negative case asserting unauthenticated access is rejected on every procedure.
- `e2e/resources.spec.ts` (Playwright + page-object model): drives the menu flow, asserts the project row paints immediately, the size cell resolves to MB-class output, and expanding reveals the per-worktree row. Branch names sanitized to `_` in `data-testid` so future `feature/foo`-style branches don't break locators.

## Deviations from issue #506

These are intentional and decided during implementation review:

- **Dialog, not a `/resources` route.** Slots in the same way Tasks / Cronjobs already do — no new file-route, no extra layout-aware overlay logic.
- **`node_modules` column dropped.** Single `du -sk` per worktree gives the answer that matters; the broken-out subtotal added a `find -prune` + N extra `du`s per worktree for little user-facing payoff.
- **`measuredAt` / `durationMs` not returned.** Sizes refresh on click; no use case yet for surfacing measurement metadata in the UI.

If we want any of these back, they're additive (issue #506 can be reopened or follow-up issues filed). Please update issue #506 (or amend below) to match the shipped scope before merging.

## Performance

Tried three approaches; landed on `du`:

| Walker | Time on 33 GB worktrees dir |
|---|---|
| Node `opendir`+`stat` (serial) | ~113 s |
| Node `opendir`+`stat` (parallel via semaphore) | ~222 s (cache thrash) |
| `du -sk` per worktree, fanout via `Promise.all` | ~2.3 s |

Bonus: `du` correctly counts hardlinks once per inode, which is what pnpm stores actually cost on disk.

## Test plan

- [x] `pnpm --filter @band-app/server test` (backend integration — 5/5 incl. new 401 case)
- [x] `pnpm --filter @band-app/server test:e2e` (Playwright — 1/1)
- [x] `pnpm check` (biome + clippy + cargo fmt — clean)
- [x] Local PR review (`/pr-review-local`) — fixes applied; 3 "blockers" surfaced as intentional scope changes (see above)
- [x] Manual smoke: dialog opens, project rows paint immediately with spinners, sizes resolve, expand shows worktree breakdown, Refresh restarts the loop

🤖 Generated with [Claude Code](https://claude.com/claude-code)