### PR TITLE
fix(web): evict deleted workspaces from MultiWorkspacePanelHost cache (#508)

### DIFF
--- a/apps/web/e2e/chat-cancel.spec.ts
+++ b/apps/web/e2e/chat-cancel.spec.ts
@@ -27,11 +27,12 @@
  *   - UI driven through `ChatPanePage`.
  */
 
-import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { expect, test } from "@playwright/test";
 import { toWorkspaceId } from "@/dashboard";
 import {
+  cleanupTmpHome,
   createTmpHome,
   type ServerHandle,
   seedSettings,
@@ -115,7 +116,7 @@ test.beforeAll(async () => {
 
 test.afterAll(async () => {
   await server.close();
-  rmSync(tmpHome, { recursive: true, force: true });
+  cleanupTmpHome(tmpHome);
 });
 
 test.describe("Chat cancel — Stop button aborts the task", () => {

--- a/apps/web/e2e/chat-send-optimistic.spec.ts
+++ b/apps/web/e2e/chat-send-optimistic.spec.ts
@@ -34,11 +34,12 @@
  *     body).
  */
 
-import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { expect, test } from "@playwright/test";
 import { toWorkspaceId } from "@/dashboard";
 import {
+  cleanupTmpHome,
   createTmpHome,
   type ServerHandle,
   seedSettings,
@@ -126,7 +127,7 @@ test.beforeAll(async () => {
 
 test.afterAll(async () => {
   await server.close();
-  rmSync(tmpHome, { recursive: true, force: true });
+  cleanupTmpHome(tmpHome);
 });
 
 test.describe("Chat send — optimistic dispatch (#478)", () => {

--- a/apps/web/e2e/find-in-markdown-preview.spec.ts
+++ b/apps/web/e2e/find-in-markdown-preview.spec.ts
@@ -15,11 +15,12 @@
  */
 
 import { execFileSync } from "node:child_process";
-import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { expect, type Page, test } from "@playwright/test";
 import { toWorkspaceId } from "@/dashboard";
 import {
+  cleanupTmpHome,
   createTmpHome,
   type ServerHandle,
   seedSettings,
@@ -106,7 +107,7 @@ test.beforeAll(async () => {
 
 test.afterAll(async () => {
   await server.close();
-  rmSync(tmpHome, { recursive: true, force: true });
+  cleanupTmpHome(tmpHome);
 });
 
 /**

--- a/apps/web/e2e/helpers/server.ts
+++ b/apps/web/e2e/helpers/server.ts
@@ -1,5 +1,5 @@
 import { spawn } from "node:child_process";
-import { mkdirSync, mkdtempSync, realpathSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from "node:fs";
 import { createServer } from "node:net";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -22,6 +22,25 @@ export function createTmpHome(): string {
   mkdirSync(bandDir, { recursive: true });
   mkdirSync(join(bandDir, "status"), { recursive: true });
   return tmp;
+}
+
+/**
+ * Recursively remove a tmp home directory created with `createTmpHome()`.
+ *
+ * Use this in every `afterAll` instead of a bare `rmSync(tmpHome, {
+ * recursive: true, force: true })`. The `maxRetries`/`retryDelay` options
+ * are Node's documented escape hatch for the `ENOTEMPTY` race that fires
+ * when the server process's background subprocesses (du, branch-status
+ * pollers, SQLite WAL flushers) are still writing to the tree as we
+ * walk it bottom-up — see flake reports on issue #508 and the matching
+ * resources / cache-eviction afterAll failures. `rmSync`'s recursive
+ * walker retries on `EBUSY`, `EMFILE`, `ENFILE`, `ENOTEMPTY`, and
+ * `EPERM`, so 10 × 100 ms gives ~1 s of headroom — well within the
+ * window for `du` to wrap up on a small fixture but short enough that a
+ * truly stuck cleanup still fails fast.
+ */
+export function cleanupTmpHome(tmpHome: string): void {
+  rmSync(tmpHome, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 });
 }
 
 interface SeedProject {
@@ -91,6 +110,16 @@ export async function startServer(
     // The production bundle runs under Node (see apps/web/README.md) and
     // uses Node's built-in `node:sqlite` for storage. Vitest integration
     // tests use the same spawn pattern via `tests/helpers/server-runtime.ts`.
+    //
+    // `detached: true` puts the child in its own process group. The
+    // server spawns grandchildren (`du` for resource accounting, `git`
+    // for the branch-status poller, terminal PTYs, …) and a plain
+    // `child.kill('SIGTERM')` only signals the direct child — the
+    // grandchildren are re-parented to init and keep writing to the
+    // tmp home as we try to `rmSync` it, producing the `ENOTEMPTY`
+    // race documented on the cleanup helper above. Putting the child
+    // in its own group lets us signal the WHOLE TREE via the negative
+    // pid trick in `close()` below.
     const child = spawn("node", ["dist/start-server.mjs"], {
       cwd: PROJECT_ROOT,
       env: {
@@ -101,10 +130,28 @@ export async function startServer(
         ...opts.env,
       },
       stdio: ["pipe", "pipe", "pipe"],
+      detached: true,
     });
 
     let stderr = "";
     let settled = false;
+
+    // Signal the whole process group, not just the direct child, so
+    // grandchildren spawned by the server (du, git, terminal PTYs,
+    // language servers) are torn down before `rmSync(tmpHome)` runs.
+    // `process.kill(-pgid, signal)` with a NEGATIVE pid targets the
+    // group. Falls back to a plain `child.kill` if the pid is missing
+    // (process already exited / never started). Wrapped in try/catch:
+    // a benign ESRCH means "group already gone" — fine to ignore.
+    const killGroup = (signal: NodeJS.Signals) => {
+      const pid = child.pid;
+      try {
+        if (typeof pid === "number") process.kill(-pid, signal);
+        else child.kill(signal);
+      } catch {
+        // group already torn down
+      }
+    };
 
     child.stderr!.on("data", (chunk: Buffer) => {
       stderr += chunk.toString();
@@ -120,7 +167,11 @@ export async function startServer(
           close: () =>
             new Promise<void>((r) => {
               child.on("exit", () => r());
-              child.kill("SIGTERM");
+              killGroup("SIGTERM");
+              // Hard backstop: if the group hasn't drained in 5 s,
+              // escalate to SIGKILL so test teardown can't hang
+              // forever waiting on a stuck PTY or language server.
+              setTimeout(() => killGroup("SIGKILL"), 5_000).unref();
             }),
         });
       }
@@ -143,7 +194,7 @@ export async function startServer(
     setTimeout(() => {
       if (!settled) {
         settled = true;
-        child.kill("SIGTERM");
+        killGroup("SIGTERM");
         reject(new Error(`Server did not start within 15 s.\nstderr: ${stderr}`));
       }
     }, 15_000);

--- a/apps/web/e2e/pages/WorkspacePage.ts
+++ b/apps/web/e2e/pages/WorkspacePage.ts
@@ -41,6 +41,10 @@ export class WorkspacePage {
    *  `terminalInput` for the "wrong tab leaked across workspaces"
    *  regression assertion. */
   readonly changesHeading: Locator;
+  /** "Delete workspace" menu item inside the WorkspaceCard's context
+   *  menu (right-click). Only present for non-default branches of git
+   *  projects. Used by the cache-eviction regression test (issue #508). */
+  readonly deleteWorkspaceMenuItem: Locator;
 
   constructor(
     private readonly page: Page,
@@ -51,6 +55,52 @@ export class WorkspacePage {
     this.restoreButton = page.getByRole("button", { name: "Restore" });
     this.terminalInput = page.getByRole("textbox", { name: "Terminal input" });
     this.changesHeading = page.getByRole("heading", { name: "Files changed" });
+    this.deleteWorkspaceMenuItem = page.getByRole("menuitem", { name: "Delete workspace" });
+  }
+
+  /** Locate a workspace card in the project-list sidebar by its canonical
+   *  workspaceId. The `data-testid` is set by `WorkspaceCard` (see issue
+   *  #508 for the rationale) so a test can drive the per-card context
+   *  menu without depending on visible text that may differ by project. */
+  workspaceCard(workspaceId: string): Locator {
+    return this.page.getByTestId(`project-list__workspace-card--${workspaceId}`);
+  }
+
+  /** Locate the per-panel-host cached entry div for the given workspaceId
+   *  (issue #508). `MultiWorkspacePanelHost` renders one of these per
+   *  workspace it currently caches; the test asserts on their presence /
+   *  absence to verify the LRU map's contents through a public DOM
+   *  surface, without exporting internals. There are multiple panel
+   *  hosts (chat / changes / files / terminal / browser), so each cached
+   *  workspaceId can produce up to five matching elements — the test
+   *  cares about "any" vs "none", not exact count. */
+  cachedPanelEntries(workspaceId: string): Locator {
+    return this.page.getByTestId(`workspace-panel-host__cached-entry--${workspaceId}`);
+  }
+
+  /** Right-click the workspace card to open its context menu, then click
+   *  "Delete workspace". The deletion goes through the real
+   *  `useRemoveWorkspace` mutation — same path the user takes — so the
+   *  reconcile-against-projects effect this test guards must actually
+   *  fire end-to-end. */
+  async deleteWorkspaceFromSidebar(workspaceId: string): Promise<void> {
+    await test.step(`Delete workspace ${workspaceId} via sidebar context menu`, async () => {
+      await this.workspaceCard(workspaceId).click({ button: "right" });
+      await this.deleteWorkspaceMenuItem.click();
+    });
+  }
+
+  /** Click a workspace card to switch to that workspace via the dashboard
+   *  sidebar's client-side navigation. Unlike `goto()`, which does a full
+   *  browser navigation that resets React state (including the
+   *  `MultiWorkspacePanelHost` LRU cache), this uses TanStack Router's
+   *  in-app navigation — the previously-active workspace's panels stay
+   *  mounted, which is what makes them cache candidates in the first
+   *  place. */
+  async switchWorkspace(workspaceId: string): Promise<void> {
+    await test.step(`Switch workspace to ${workspaceId} via sidebar click`, async () => {
+      await this.workspaceCard(workspaceId).click();
+    });
   }
 
   /** Locate a tab in the OUTER shared-dockview tab strip by its panel

--- a/apps/web/e2e/queue-ui.spec.ts
+++ b/apps/web/e2e/queue-ui.spec.ts
@@ -1,6 +1,6 @@
-import { rmSync } from "node:fs";
 import { expect, test } from "@playwright/test";
 import {
+  cleanupTmpHome,
   createTmpHome,
   type ServerHandle,
   seedSettings,
@@ -22,7 +22,7 @@ test.beforeAll(async () => {
 
 test.afterAll(async () => {
   await server.close();
-  rmSync(tmpHome, { recursive: true, force: true });
+  cleanupTmpHome(tmpHome);
 });
 
 // ---------------------------------------------------------------------------

--- a/apps/web/e2e/resources.spec.ts
+++ b/apps/web/e2e/resources.spec.ts
@@ -9,10 +9,11 @@
  */
 
 import { execFileSync } from "node:child_process";
-import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { expect, test } from "@playwright/test";
 import {
+  cleanupTmpHome,
   createTmpHome,
   type ServerHandle,
   seedSettings,
@@ -87,7 +88,7 @@ test.beforeAll(async () => {
 
 test.afterAll(async () => {
   if (typeof server !== "undefined") await server.close();
-  rmSync(tmpHome, { recursive: true, force: true });
+  cleanupTmpHome(tmpHome);
 });
 
 test.describe("Resources dialog (issue #506)", () => {

--- a/apps/web/e2e/session-history.spec.ts
+++ b/apps/web/e2e/session-history.spec.ts
@@ -26,11 +26,12 @@
  *     history button for unsupported agents — left as future work.
  */
 
-import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { expect, test } from "@playwright/test";
 import { toWorkspaceId } from "@/dashboard";
 import {
+  cleanupTmpHome,
   createTmpHome,
   type ServerHandle,
   seedSettings,
@@ -110,7 +111,7 @@ test.beforeAll(async () => {
 
 test.afterAll(async () => {
   await server.close();
-  rmSync(tmpHome, { recursive: true, force: true });
+  cleanupTmpHome(tmpHome);
 });
 
 test.describe("Session history dropdown", () => {

--- a/apps/web/e2e/settings-page.spec.ts
+++ b/apps/web/e2e/settings-page.spec.ts
@@ -1,7 +1,8 @@
-import { readFileSync, rmSync } from "node:fs";
+import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { expect, type Page, test } from "@playwright/test";
 import {
+  cleanupTmpHome,
   createTmpHome,
   type ServerHandle,
   seedSettings,
@@ -35,7 +36,7 @@ test.beforeAll(async () => {
 
 test.afterAll(async () => {
   await server.close();
-  rmSync(tmpHome, { recursive: true, force: true });
+  cleanupTmpHome(tmpHome);
 });
 
 /**

--- a/apps/web/e2e/tasks-page.spec.ts
+++ b/apps/web/e2e/tasks-page.spec.ts
@@ -1,10 +1,10 @@
-import { rmSync } from "node:fs";
 import { join } from "node:path";
 import { DatabaseSync } from "node:sqlite";
 import { expect, type Page, test } from "@playwright/test";
 import { drizzle } from "drizzle-orm/node-sqlite";
 import { migrate } from "drizzle-orm/node-sqlite/migrator";
 import {
+  cleanupTmpHome,
   createTmpHome,
   type ServerHandle,
   seedSettings,
@@ -193,7 +193,7 @@ test.beforeAll(async () => {
 
 test.afterAll(async () => {
   await server.close();
-  rmSync(tmpHome, { recursive: true, force: true });
+  cleanupTmpHome(tmpHome);
 });
 
 test.beforeEach(async ({ page }) => {

--- a/apps/web/e2e/tasks-page.spec.ts
+++ b/apps/web/e2e/tasks-page.spec.ts
@@ -17,6 +17,18 @@ const TOKEN = "e2e-test-token";
 let server: ServerHandle;
 let tmpHome: string;
 
+// All test-side writes to the same `band.db` the server is using must
+// set `busy_timeout` so a concurrent server transaction doesn't fail
+// us with `SQLITE_BUSY: database is locked`. Phase-B cleanup,
+// branch-status-poller writes, and the task store all hold the
+// write lock briefly — on CI with 2 workers the test's open + write
+// can land exactly inside one of those windows and fail outright
+// instead of waiting. 5 s is generous enough to absorb a runner
+// stall but short enough that a truly deadlocked server still fails
+// fast. (Pre-existing flake surfaced by issue #508's e2e test;
+// reads stay readOnly and need no timeout under WAL mode.)
+const DB_BUSY_TIMEOUT_MS = 5_000;
+
 function seedTask(
   tmpHome: string,
   task: {
@@ -34,6 +46,7 @@ function seedTask(
   const dbPath = join(tmpHome, ".band", "band.db");
   const sqlite = new DatabaseSync(dbPath);
   sqlite.exec("PRAGMA journal_mode = WAL");
+  sqlite.exec(`PRAGMA busy_timeout = ${DB_BUSY_TIMEOUT_MS}`);
   const db = drizzle({ client: sqlite });
   migrate(db, { migrationsFolder: join(import.meta.dirname, "../src/lib/db/migrations") });
   sqlite
@@ -70,6 +83,7 @@ function readTaskStatus(tmpHome: string, taskId: string): string | undefined {
 function deleteTask(tmpHome: string, taskId: string): void {
   const sqlite = new DatabaseSync(join(tmpHome, ".band", "band.db"));
   try {
+    sqlite.exec(`PRAGMA busy_timeout = ${DB_BUSY_TIMEOUT_MS}`);
     sqlite.prepare("DELETE FROM tasks WHERE id = ?").run(taskId);
   } finally {
     sqlite.close();

--- a/apps/web/e2e/todo-widget.spec.ts
+++ b/apps/web/e2e/todo-widget.spec.ts
@@ -47,11 +47,12 @@
  * mount) is exercised by the single test below.
  */
 
-import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { expect, test } from "@playwright/test";
 import { toWorkspaceId } from "@/dashboard";
 import {
+  cleanupTmpHome,
   createTmpHome,
   type ServerHandle,
   seedSettings,
@@ -170,7 +171,7 @@ test.beforeAll(async () => {
 
 test.afterAll(async () => {
   await server.close();
-  rmSync(tmpHome, { recursive: true, force: true });
+  cleanupTmpHome(tmpHome);
 });
 
 test.describe("TodoWrite renders as the TaskListWidget", () => {

--- a/apps/web/e2e/workspace-cache-eviction.spec.ts
+++ b/apps/web/e2e/workspace-cache-eviction.spec.ts
@@ -85,13 +85,14 @@ function git(cwd: string, args: string[], home: string): string {
   return execFileSync("git", args, { cwd, env: makeGitEnv(home), encoding: "utf-8" });
 }
 
-// `ServerHandle | undefined` (rather than the definite-assignment `!`
-// shorthand) so TypeScript forces the `if (typeof server !== "undefined")`
-// guard in `afterAll`. Same shape as `resources.spec.ts`. Without it, a
-// `startServer` failure in `beforeAll` would surface as a confusing
-// `TypeError: Cannot read properties of undefined (reading 'close')` in
-// the teardown and mask the real boot error.
-let server: ServerHandle | undefined;
+// Definite-assignment shorthand — matches `resources.spec.ts`, the
+// canonical pattern for specs that need to guard `server` in
+// `afterAll`. The `if (server)` check below covers the only path
+// that could leave it unassigned: `startServer` throwing before
+// resolving in `beforeAll`. Without the guard, an unrelated
+// `TypeError: Cannot read properties of undefined (reading 'close')`
+// would mask the real boot failure.
+let server!: ServerHandle;
 let tmpHome: string;
 let repoPath: string;
 let worktreeAPath: string;
@@ -146,7 +147,7 @@ test.beforeAll(async () => {
 });
 
 test.afterAll(async () => {
-  if (typeof server !== "undefined") await server.close();
+  if (server) await server.close();
   cleanupTmpHome(tmpHome);
 });
 
@@ -205,7 +206,11 @@ test.describe("MultiWorkspacePanelHost cache eviction (issue #508)", () => {
     // Workspace B (the still-active one) must remain cached — eviction
     // is for *disappeared* workspaces only. Without this counter-anchor
     // a buggy implementation that wipes the entire cache would also
-    // pass the negative assertion above.
-    expect(await workspacePage.cachedPanelEntries(WORKSPACE_B).count()).toBeGreaterThan(0);
+    // pass the negative assertion above. Uses `toBeVisible()` (which
+    // auto-retries) rather than a synchronous `.count()` snapshot so
+    // it doesn't race the asynchronous reconcile effect; the test
+    // only needs to prove *some* cached entry for B survives, not a
+    // particular count.
+    await expect(workspacePage.cachedPanelEntries(WORKSPACE_B).first()).toBeVisible();
   });
 });

--- a/apps/web/e2e/workspace-cache-eviction.spec.ts
+++ b/apps/web/e2e/workspace-cache-eviction.spec.ts
@@ -85,7 +85,13 @@ function git(cwd: string, args: string[], home: string): string {
   return execFileSync("git", args, { cwd, env: makeGitEnv(home), encoding: "utf-8" });
 }
 
-let server: ServerHandle;
+// `ServerHandle | undefined` (rather than the definite-assignment `!`
+// shorthand) so TypeScript forces the `if (typeof server !== "undefined")`
+// guard in `afterAll`. Same shape as `resources.spec.ts`. Without it, a
+// `startServer` failure in `beforeAll` would surface as a confusing
+// `TypeError: Cannot read properties of undefined (reading 'close')` in
+// the teardown and mask the real boot error.
+let server: ServerHandle | undefined;
 let tmpHome: string;
 let repoPath: string;
 let worktreeAPath: string;
@@ -140,7 +146,7 @@ test.beforeAll(async () => {
 });
 
 test.afterAll(async () => {
-  await server.close();
+  if (typeof server !== "undefined") await server.close();
   cleanupTmpHome(tmpHome);
 });
 

--- a/apps/web/e2e/workspace-cache-eviction.spec.ts
+++ b/apps/web/e2e/workspace-cache-eviction.spec.ts
@@ -1,0 +1,205 @@
+/**
+ * Regression coverage for issue #508 —
+ * `MultiWorkspacePanelHost`'s LRU cache evicts a workspace as soon as
+ * that workspace disappears from the projects query, not only when a
+ * NEW workspace overflows the capacity-bound.
+ *
+ * Doctrine (`CLAUDE.md` "Testing Strategy" + the `write-integration-test`
+ * skill at `.claude/skills/write-integration-test/SKILL.md`):
+ *
+ *   - The same production binary the user ships runs inside the test
+ *     against a fresh tmp `~/.band/`. Migrations apply to the throwaway
+ *     SQLite DB on boot.
+ *   - The deletion is driven through the dashboard sidebar's
+ *     `WorkspaceCard` context menu — the same flow the user takes — so
+ *     the real `useRemoveWorkspace` mutation runs, the real projects
+ *     query invalidates, and the real reconcile-against-projects effect
+ *     inside `MultiWorkspacePanelHost` fires.
+ *   - No tRPC mocking, no `page.route()` on our own routes, no MSW.
+ *
+ * The cache itself is internal React state — the test asserts on its
+ * SHAPE through a public DOM surface: `MultiWorkspacePanelHost` renders
+ * one `<div data-testid="workspace-panel-host__cached-entry--<id>">`
+ * per workspace it currently caches (multiple, one per panel host,
+ * because the layout mounts five hosts: chat / changes / files /
+ * terminal / browser). The test counts entries with `count() === 0`
+ * to confirm the deleted workspace was fully evicted across every
+ * panel host.
+ */
+
+import { execFileSync } from "node:child_process";
+import { mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { expect, test } from "@playwright/test";
+import { toWorkspaceId } from "@/dashboard";
+import {
+  cleanupTmpHome,
+  createTmpHome,
+  type ServerHandle,
+  seedSettings,
+  seedState,
+  startServer,
+} from "./helpers/server";
+import { WorkspacePage } from "./pages/WorkspacePage";
+
+const TOKEN = "e2e-workspace-cache-eviction-token";
+
+const PROJECT = "cache-eviction-repo";
+const DEFAULT_BRANCH = "main";
+// Two non-default branches so both are deletable via the context menu
+// (the "Delete workspace" item is hidden when `branch === defaultBranch`,
+// see `WorkspaceCard.tsx`).
+const BRANCH_A = "feature-cache-a";
+const BRANCH_B = "feature-cache-b";
+
+const WORKSPACE_A = toWorkspaceId(PROJECT, BRANCH_A);
+const WORKSPACE_B = toWorkspaceId(PROJECT, BRANCH_B);
+
+// Wide viewport so `useIsDesktop()` reports true and the shared dockview
+// renders (matches >= 1024px in `apps/web/src/hooks/useIsDesktop.ts`).
+// Without the dockview the project-list sidebar — and therefore the
+// per-workspace context menu — is not visible.
+test.use({ viewport: { width: 1280, height: 800 } });
+
+// Hermetic git environment: explicit allowlist, no `process.env` spread.
+// A contributor with `GIT_TEMPLATE_DIR`, `GIT_CONFIG_GLOBAL`, or a
+// signing-key config that runs a prompt would otherwise have their host
+// settings leaked into the `git init` / `commit` calls below and
+// potentially hang the test or fail it in confusing ways. Pointing both
+// `GIT_CONFIG_GLOBAL` and `GIT_CONFIG_SYSTEM` at /dev/null guarantees
+// `git` ignores any host config and reads only what we provide here.
+function makeGitEnv(home: string): NodeJS.ProcessEnv {
+  return {
+    PATH: process.env.PATH,
+    HOME: home,
+    GIT_AUTHOR_NAME: "Test",
+    GIT_AUTHOR_EMAIL: "test@test.com",
+    GIT_COMMITTER_NAME: "Test",
+    GIT_COMMITTER_EMAIL: "test@test.com",
+    GIT_CONFIG_GLOBAL: "/dev/null",
+    GIT_CONFIG_SYSTEM: "/dev/null",
+  };
+}
+
+function git(cwd: string, args: string[], home: string): string {
+  return execFileSync("git", args, { cwd, env: makeGitEnv(home), encoding: "utf-8" });
+}
+
+let server: ServerHandle;
+let tmpHome: string;
+let repoPath: string;
+let worktreeAPath: string;
+let worktreeBPath: string;
+
+test.beforeAll(async () => {
+  tmpHome = createTmpHome();
+
+  // Real git repo on disk — required because the server's
+  // `workspaces.remove` mutation calls `git worktree list --porcelain`
+  // against the project path. Without a real repo the mutation throws
+  // and the deletion never propagates back to the projects query.
+  repoPath = join(tmpHome, PROJECT);
+  mkdirSync(repoPath, { recursive: true });
+  git(repoPath, ["init", "-b", DEFAULT_BRANCH], tmpHome);
+  writeFileSync(join(repoPath, "README.md"), "# Cache eviction test\n");
+  git(repoPath, ["add", "."], tmpHome);
+  git(repoPath, ["commit", "-m", "initial commit"], tmpHome);
+
+  // Worktrees live ALONGSIDE the bare repo, both inside `tmpHome` so the
+  // recursive `rmSync(tmpHome, …)` in `afterAll` is sufficient cleanup:
+  // git's bookkeeping (under `repoPath/.git/worktrees/`) is reaped along
+  // with the worktrees themselves, so no explicit `git worktree remove`
+  // is needed. If a future refactor moves worktrees outside `tmpHome`
+  // this teardown will leak.
+  worktreeAPath = join(tmpHome, `${PROJECT}-${BRANCH_A}`);
+  worktreeBPath = join(tmpHome, `${PROJECT}-${BRANCH_B}`);
+  git(repoPath, ["worktree", "add", "-b", BRANCH_A, worktreeAPath], tmpHome);
+  git(repoPath, ["worktree", "add", "-b", BRANCH_B, worktreeBPath], tmpHome);
+
+  seedState(tmpHome, {
+    projects: [
+      {
+        name: PROJECT,
+        path: repoPath,
+        defaultBranch: DEFAULT_BRANCH,
+        worktrees: [
+          { branch: DEFAULT_BRANCH, path: repoPath },
+          { branch: BRANCH_A, path: worktreeAPath },
+          { branch: BRANCH_B, path: worktreeBPath },
+        ],
+      },
+    ],
+  });
+  // Pin `maxCachedWorkspaces` explicitly so the test's "neither workspace
+  // is LRU-evicted by capacity" assumption can't be invalidated by a
+  // future PR lowering `DEFAULT_MAX_CACHED_WORKSPACES`. The test needs
+  // capacity >= 2 (one cached + one active) to keep both alive at the
+  // assertion point.
+  seedSettings(tmpHome, { tokenSecret: TOKEN, maxCachedWorkspaces: 3 });
+  server = await startServer({ tmpHome });
+});
+
+test.afterAll(async () => {
+  await server.close();
+  cleanupTmpHome(tmpHome);
+});
+
+test.describe("MultiWorkspacePanelHost cache eviction (issue #508)", () => {
+  test("evicts a deleted workspace from the LRU cache after deletion via the sidebar", async ({
+    page,
+  }) => {
+    const workspacePage = new WorkspacePage(page, server.url, TOKEN);
+
+    // Land on workspace A via a real navigation, then switch to B via a
+    // CLIENT-SIDE click on B's sidebar card. The distinction matters:
+    // `goto()` triggers a full browser navigation that wipes React
+    // state, including `MultiWorkspacePanelHost`'s LRU cache. The
+    // bug we're guarding is "deleted workspace stays cached", which
+    // only manifests when the cache survives a workspace switch — so
+    // the test must use the SAME in-app switch path the user takes
+    // (TanStack Router via the workspace card's onClick), not a full
+    // page navigation. With the default `maxCachedWorkspaces = 3`,
+    // neither workspace is LRU-evicted by capacity, so any later
+    // eviction is unambiguously attributable to the reconcile-against-
+    // projects effect being tested.
+    await workspacePage.goto(WORKSPACE_A);
+    await workspacePage.waitForReady();
+    // Wait for the projects-query to land so the workspace cards exist
+    // before we try to click one. Without this the click resolves
+    // against the still-empty project list and silently no-ops.
+    await expect(workspacePage.workspaceCard(WORKSPACE_B)).toBeVisible();
+    await expect(workspacePage.cachedPanelEntries(WORKSPACE_A).first()).toBeVisible();
+
+    await workspacePage.switchWorkspace(WORKSPACE_B);
+    await expect(workspacePage.cachedPanelEntries(WORKSPACE_B).first()).toBeVisible();
+
+    // Positive anchor: BOTH workspaces are cached at this point.
+    // `MultiWorkspacePanelHost` is mounted once per outer dockview panel
+    // (chat, changes, files, terminal, browser = 5 hosts), so every
+    // cached workspaceId produces multiple matching elements — assert
+    // ">= 1" to stay robust to layout-config changes.
+    expect(await workspacePage.cachedPanelEntries(WORKSPACE_A).count()).toBeGreaterThan(0);
+    expect(await workspacePage.cachedPanelEntries(WORKSPACE_B).count()).toBeGreaterThan(0);
+
+    // Drive the deletion via the same path the user takes: right-click
+    // the workspace card in the dashboard sidebar (visible while B is
+    // active), then click "Delete workspace". This fires the real
+    // `useRemoveWorkspace` mutation, which invalidates the projects
+    // query, which triggers `useProjects()` to refetch, which produces
+    // a new `projects` reference, which fires the reconcile effect in
+    // `MultiWorkspacePanelHost`.
+    await workspacePage.deleteWorkspaceFromSidebar(WORKSPACE_A);
+
+    // The reconcile effect must drop A's cache entries from every panel
+    // host. `expect(...).toHaveCount(0)` auto-retries up to the
+    // expect-timeout, so we don't need to predict how long the
+    // mutation → invalidate → refetch → effect chain takes.
+    await expect(workspacePage.cachedPanelEntries(WORKSPACE_A)).toHaveCount(0);
+
+    // Workspace B (the still-active one) must remain cached — eviction
+    // is for *disappeared* workspaces only. Without this counter-anchor
+    // a buggy implementation that wipes the entire cache would also
+    // pass the negative assertion above.
+    expect(await workspacePage.cachedPanelEntries(WORKSPACE_B).count()).toBeGreaterThan(0);
+  });
+});

--- a/apps/web/e2e/workspace-maximize-state.spec.ts
+++ b/apps/web/e2e/workspace-maximize-state.spec.ts
@@ -23,10 +23,10 @@
  * restored when the user later exits maximize).
  */
 
-import { rmSync } from "node:fs";
 import { expect, test } from "@playwright/test";
 import { toWorkspaceId } from "@/dashboard";
 import {
+  cleanupTmpHome,
   createTmpHome,
   type ServerHandle,
   seedSettings,
@@ -75,7 +75,7 @@ test.beforeAll(async () => {
 
 test.afterAll(async () => {
   await server.close();
-  rmSync(tmpHome, { recursive: true, force: true });
+  cleanupTmpHome(tmpHome);
 });
 
 // Each test starts on a clean slate so it doesn't observe state another
@@ -318,8 +318,14 @@ test.describe("Workspace maximize state (issue #490)", () => {
     // the `Terminal input` aria-name) which can take multiple
     // seconds in CI even when correctness is fine, so we give the
     // textbox a generous timeout instead of relying on Playwright's
-    // 5 s default.
+    // 5 s default. The 25 s bound is a relaxation of the original
+    // 15 s after the suite started racing against the new
+    // workspace-cache-eviction.spec — under that load the xterm
+    // boot occasionally exceeded the 15 s budget despite passing
+    // correctness; bumping the budget keeps the fast path
+    // identical (toBeVisible() returns immediately when ready) while
+    // tolerating worst-case scheduler latency.
     await expect(workspacePage.changesHeading).not.toBeVisible();
-    await expect(workspacePage.terminalInput).toBeVisible({ timeout: 15_000 });
+    await expect(workspacePage.terminalInput).toBeVisible({ timeout: 25_000 });
   });
 });

--- a/apps/web/e2e/workspace-switch-changes.spec.ts
+++ b/apps/web/e2e/workspace-switch-changes.spec.ts
@@ -13,10 +13,10 @@
  * multi-workspace fixture, no real git repos needed.
  */
 
-import { rmSync } from "node:fs";
 import { expect, type Page, test } from "@playwright/test";
 import { toWorkspaceId } from "@/dashboard";
 import {
+  cleanupTmpHome,
   createTmpHome,
   type ServerHandle,
   seedSettings,
@@ -56,7 +56,7 @@ test.beforeAll(async () => {
 
 test.afterAll(async () => {
   await server.close();
-  rmSync(tmpHome, { recursive: true, force: true });
+  cleanupTmpHome(tmpHome);
 });
 
 interface DiffSummaryCounters {

--- a/apps/web/e2e/workspace-switch-scroll.spec.ts
+++ b/apps/web/e2e/workspace-switch-scroll.spec.ts
@@ -25,10 +25,10 @@
  * a long list of projects and the workspace card click → URL nav loop.
  */
 
-import { rmSync } from "node:fs";
 import { expect, type Page, test } from "@playwright/test";
 import { toWorkspaceId } from "@/dashboard";
 import {
+  cleanupTmpHome,
   createTmpHome,
   type ServerHandle,
   seedSettings,
@@ -91,7 +91,7 @@ test.beforeAll(async () => {
 
 test.afterAll(async () => {
   await server.close();
-  rmSync(tmpHome, { recursive: true, force: true });
+  cleanupTmpHome(tmpHome);
 });
 
 /**

--- a/apps/web/e2e/workspace-tab-switch-stability.spec.ts
+++ b/apps/web/e2e/workspace-tab-switch-stability.spec.ts
@@ -59,10 +59,10 @@
  * description for the steps.
  */
 
-import { rmSync } from "node:fs";
 import { expect, test } from "@playwright/test";
 import { toWorkspaceId } from "@/dashboard";
 import {
+  cleanupTmpHome,
   createTmpHome,
   type ServerHandle,
   seedSettings,
@@ -103,7 +103,7 @@ test.beforeAll(async () => {
 
 test.afterAll(async () => {
   await server.close();
-  rmSync(tmpHome, { recursive: true, force: true });
+  cleanupTmpHome(tmpHome);
 });
 
 test.beforeEach(async ({ page }) => {

--- a/apps/web/src/components/MultiWorkspacePanelHost.tsx
+++ b/apps/web/src/components/MultiWorkspacePanelHost.tsx
@@ -1,6 +1,6 @@
 import { useRouterState } from "@tanstack/react-router";
 import { useEffect, useRef, useState } from "react";
-import { useSettingsQuery } from "@/dashboard";
+import { toWorkspaceId, useProjects, useSettingsQuery } from "@/dashboard";
 import { parseWorkspaceFromPath } from "../lib/parse-workspace";
 import { clearPerWorkspaceState } from "./per-workspace-state-store";
 
@@ -123,6 +123,71 @@ export function MultiWorkspacePanelHost({ emptyState, children }: MultiWorkspace
     });
   }, [activeWorkspaceId]);
 
+  // Reconcile the cache against the projects query (issue #508). Capacity-based
+  // LRU eviction only fires when a NEW workspace is added — it never notices
+  // when a workspace *disappears* from the projects list. Without this effect a
+  // deleted workspace's chat/file/terminal/browser subtrees stay mounted
+  // forever, keeping their tRPC subscriptions, event listeners, stuck
+  // "in-progress" tool-call animations, and React state alive against a
+  // workspaceId the server no longer recognises (renderer observed at 1.68 GB
+  // heap, 167k listeners, 656 stuck animate-pulse spans after ~2 days of use).
+  //
+  // Using the projects query as the source of truth self-heals for ANY
+  // disappearance path — dashboard delete button, manual worktree rm, external
+  // git operation — not just `useRemoveWorkspace`.
+  //
+  // The `id !== activeWorkspaceId` guard is structural, not a UX nicety.
+  // `activeWorkspaceId` is URL-derived (`parseWorkspaceFromPath(pathname)`),
+  // so it stays pointing at a deleted workspace until the user navigates
+  // away — `useRemoveWorkspace.onSuccess` only updates the Zustand store's
+  // `activeWorkspaceId`, not the URL, so the two diverge during the
+  // delete-the-active-workspace window. Without the guard:
+  //   1. Effect notices the active workspace isn't in `validIds`, evicts.
+  //   2. The synchronous "add active workspace to cache" branch above re-
+  //      adds it on the next render.
+  //   3. Effect runs again, evicts again. Infinite render loop.
+  // Consequence: deleting the *currently-active* workspace leaves its
+  // cache entry alive until the user navigates somewhere else (clicking
+  // any other card in the sidebar fires the eviction on the next render).
+  // That's an acceptable trade-off — the original bug was about *non-
+  // active* cached workspaces accumulating across days of use; the active
+  // case self-heals at the next workspace switch.
+  //
+  // The `isLoading` guard distinguishes "query hasn't resolved yet" from
+  // "query resolved to an empty list". `useProjects()` returns the empty
+  // array fallback in both cases, so without this guard the initial render
+  // before the query resolves would evict every cached workspace.
+  const { projects, isLoading } = useProjects();
+  useEffect(() => {
+    if (isLoading) return;
+    const validIds = new Set<string>();
+    for (const project of projects) {
+      for (const worktree of project.worktrees) {
+        validIds.add(toWorkspaceId(project.name, worktree.branch));
+      }
+    }
+    setCache((prev) => {
+      // Steady-state fast-path: the projects query refetches every 30 s,
+      // so this effect fires repeatedly with no actual eviction work to
+      // do. Scan once to detect a stale id before allocating the new Map.
+      let hasStale = false;
+      for (const id of prev.keys()) {
+        if (!validIds.has(id) && id !== activeWorkspaceId) {
+          hasStale = true;
+          break;
+        }
+      }
+      if (!hasStale) return prev;
+      const next = new Map(prev);
+      for (const id of next.keys()) {
+        if (!validIds.has(id) && id !== activeWorkspaceId) {
+          next.delete(id);
+        }
+      }
+      return next;
+    });
+  }, [projects, isLoading, activeWorkspaceId]);
+
   // Detect evictions by diffing the cache key set across commits and clear
   // the dropped workspaces' cross-panel state. Lives in an effect (not the
   // setState updater) so React-driven double-invocations don't repeatedly
@@ -155,6 +220,17 @@ export function MultiWorkspacePanelHost({ emptyState, children }: MultiWorkspace
         return (
           <div
             key={workspaceId}
+            // The testid exposes the LRU cache shape to integration tests
+            // (see `apps/web/e2e/workspace-cache-eviction.spec.ts`): one
+            // entry per cached workspace makes "did the cache evict this
+            // deleted workspace?" observable through the DOM without
+            // exporting internals. Embedding the workspaceId in the
+            // attribute lets a test target a specific entry directly.
+            // No `data-active` here — `WorkspaceCard` already exposes
+            // that attribute on the sidebar card, and adding it to the
+            // cached entry divs would multiply-match the existing
+            // `locator('[data-active="true"]')` queries other specs use.
+            data-testid={`workspace-panel-host__cached-entry--${workspaceId}`}
             className="absolute inset-0 transition-opacity duration-150 ease-out"
             style={{
               opacity: isActive ? 1 : 0,

--- a/apps/web/src/components/MultiWorkspacePanelHost.tsx
+++ b/apps/web/src/components/MultiWorkspacePanelHost.tsx
@@ -157,9 +157,15 @@ export function MultiWorkspacePanelHost({ emptyState, children }: MultiWorkspace
   // "query resolved to an empty list". `useProjects()` returns the empty
   // array fallback in both cases, so without this guard the initial render
   // before the query resolves would evict every cached workspace.
-  const { projects, isLoading } = useProjects();
+  //
+  // The `error` guard covers the same shape but for the FAILURE path:
+  // `isLoading: false` + `data: undefined` (e.g. network blip, server
+  // not yet ready) also collapses to `projects: EMPTY_PROJECTS`, which
+  // would otherwise evict every cached workspace on a transient hiccup.
+  // We keep the cache as-is until the next successful fetch heals it.
+  const { projects, isLoading, error } = useProjects();
   useEffect(() => {
-    if (isLoading) return;
+    if (isLoading || error) return;
     const validIds = new Set<string>();
     for (const project of projects) {
       for (const worktree of project.worktrees) {
@@ -186,7 +192,7 @@ export function MultiWorkspacePanelHost({ emptyState, children }: MultiWorkspace
       }
       return next;
     });
-  }, [projects, isLoading, activeWorkspaceId]);
+  }, [projects, isLoading, error, activeWorkspaceId]);
 
   // Detect evictions by diffing the cache key set across commits and clear
   // the dropped workspaces' cross-panel state. Lives in an effect (not the

--- a/apps/web/src/dashboard/components/WorkspaceCard.tsx
+++ b/apps/web/src/dashboard/components/WorkspaceCard.tsx
@@ -177,6 +177,11 @@ export const WorkspaceCard = memo(function WorkspaceCard({
     // "currently-active link in a list of related links".
     "data-active": isActive || undefined,
     "aria-current": isActive ? ("page" as const) : undefined,
+    // Stable test hook keyed by workspaceId so integration tests can right-
+    // click the specific card (issue #508). Branches with `/` in them are
+    // collapsed to `-` by `toWorkspaceId` so the attribute value matches
+    // the canonical workspace id used everywhere else in the UI.
+    "data-testid": `project-list__workspace-card--${workspaceId}`,
     onClick: (e: React.MouseEvent) => {
       e.stopPropagation();
       handleClick();

--- a/apps/web/src/dashboard/hooks/use-projects.ts
+++ b/apps/web/src/dashboard/hooks/use-projects.ts
@@ -3,6 +3,13 @@ import { useAdapter } from "../context";
 import { queryKeys } from "../query-client";
 import type { ProjectInfo } from "../types";
 
+// Module-level constant so the fallback returned while `data` is undefined
+// is reference-stable across renders. Callers that put `projects` in a
+// `useEffect`/`useMemo` dependency list would otherwise see a fresh `[]`
+// allocation on every render during the loading window, re-firing their
+// effect even though the value is semantically unchanged.
+const EMPTY_PROJECTS: readonly ProjectInfo[] = Object.freeze([]);
+
 export function useProjects() {
   const adapter = useAdapter();
   const { data, isLoading, error } = useQuery({
@@ -11,7 +18,7 @@ export function useProjects() {
     refetchInterval: 30_000,
   });
   return {
-    projects: data ?? ([] as ProjectInfo[]),
+    projects: data ?? (EMPTY_PROJECTS as ProjectInfo[]),
     isLoading,
     error: error ? String(error) : null,
   };


### PR DESCRIPTION
## Summary

- `MultiWorkspacePanelHost`'s LRU cache only evicted on capacity overflow, so deleted workspaces' subtrees stayed mounted forever — tRPC subscriptions, listeners, and stuck `animate-pulse` tool-call indicators all alive against a workspaceId the server no longer recognised (reported state after ~2 days of use: 1.68 GB heap, 167k listeners, 656 stuck pulses, 359% CPU).
- Implements Option A from the issue: a new effect reconciles the cache against `useProjects()` so any workspace that disappears from the projects list — dashboard delete, manual `rm -rf`, external git ops — is evicted from every panel host. Self-healing across every disappearance path.
- Drive-by test-infra hardening: spawn the e2e server in its own process group, kill the whole group on close, and add a `cleanupTmpHome()` helper to fix the `afterAll` `ENOTEMPTY` flakes that surfaced while authoring the new test.

## Test plan

- [x] New integration test `apps/web/e2e/workspace-cache-eviction.spec.ts` — boots the real production server, creates a real git repo + worktrees, drives deletion through the right-click context menu, asserts the deleted workspace's cache entries are gone and the active one remains.
- [x] Confirmed the test FAILS when the reconcile effect is reverted (2 stuck cached entries observed — exact bug reproduction).
- [x] Confirmed the test PASSES with the fix applied.
- [x] 8 consecutive green runs of the full e2e suite after the flake fixes (was ~50% flake rate before).
- [x] `pnpm check` clean (biome + cargo fmt + clippy -D warnings).
- [x] Pre-push hooks pass.

## Secondary fixes from #508 — explicitly out of scope

The issue's "Secondary fixes worth bundling" list (pause animations in hidden workspaces, drop `approval-responded` from `IN_PROGRESS_STATES`, synthesise terminal states on chat-subscription disconnect) are symptom mitigations rather than the root cause and have UX trade-offs worth discussing separately. They'll be handled in follow-up PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)