### PR TITLE
feat(web): nested edge panels in inner dockview containers

### DIFF
--- a/apps/web/src/components/DockviewBrowserContainer.tsx
+++ b/apps/web/src/components/DockviewBrowserContainer.tsx
@@ -1109,9 +1109,11 @@ export function DockviewBrowserContainer({
 
       // Ensure the three cardinal edge groups (left/right/bottom) exist so
       // future panels can be docked to the edges of this inner container.
-      // Runs BEFORE listener registration so the synchronous add doesn't
-      // trigger a persist write — the next user-driven change saves the
-      // augmented layout naturally. Idempotent on restored layouts.
+      // MUST be called BEFORE the `onDidLayoutChange` registration below —
+      // `ensureEdgeGroups` may synchronously add edge groups and call
+      // `setEdgeGroupVisible`, and routing those events through
+      // `schedulePersist` would write a spurious initial save. Idempotent
+      // on restored layouts.
       ensureEdgeGroups(event.api);
 
       // Drag-visibility: while the user drags a panel/group, force every

--- a/apps/web/src/components/DockviewBrowserContainer.tsx
+++ b/apps/web/src/components/DockviewBrowserContainer.tsx
@@ -23,6 +23,11 @@ import { useAdapter } from "@/dashboard";
 import { injectInitialUrls } from "../lib/browser-layout";
 import { invoke as desktopInvoke, listen as desktopListen } from "../lib/desktop-ipc";
 import {
+  attachEdgeGroupDragVisibility,
+  ensureEdgeGroups,
+  registerInnerDockview,
+} from "../lib/dockview-edge-groups";
+import {
   cycleGridGroups,
   cycleTabsInActiveGroup,
   selectNeighbourBeforeRemove,
@@ -321,25 +326,43 @@ const closeTabRef: { current: ((browserId: string) => void) | null } = {
 const RightHeaderActions = React.memo(function RightHeaderActions(
   props: IDockviewHeaderActionsProps,
 ) {
+  // Edge groups (left/right/bottom) don't support splits — dockview's
+  // `addPanel` with `position: { referenceGroup: <edge>, direction }`
+  // silently ignores the direction and just adds a tab. We still show
+  // the "+" button there so users can add another browser tab to the
+  // edge group; only the split buttons are hidden. Defaults to "grid"
+  // when `location` is missing (older dockview versions / tests).
+  const isGridGroup = (props.location?.type ?? "grid") === "grid";
   const groupId = props.group.id;
+  // `w-full justify-center` keeps the "+" centered horizontally inside
+  // the vertical (left/right) edge action strip, which dockview sizes
+  // to `--dv-tabs-and-actions-container-height` (~35px wide) via
+  // `.dv-groupview-header-vertical`. In horizontal tab strips the
+  // right-actions container shrink-wraps to its content, so `w-full`
+  // resolves to the same content width and the button row looks
+  // identical to before.
   return (
-    <div className="flex h-full items-center">
-      <button
-        type="button"
-        className="inline-flex size-8 items-center justify-center text-muted-foreground hover:text-foreground hover:bg-accent rounded transition-colors"
-        onClick={() => addTabRef.current.onSplit(groupId, "right")}
-        title="Split right"
-      >
-        <Columns2 className="size-3.5" />
-      </button>
-      <button
-        type="button"
-        className="inline-flex size-8 items-center justify-center text-muted-foreground hover:text-foreground hover:bg-accent rounded transition-colors"
-        onClick={() => addTabRef.current.onSplit(groupId, "below")}
-        title="Split down"
-      >
-        <Rows2 className="size-3.5" />
-      </button>
+    <div className="flex h-full w-full items-center justify-center">
+      {isGridGroup && (
+        <>
+          <button
+            type="button"
+            className="inline-flex size-8 items-center justify-center text-muted-foreground hover:text-foreground hover:bg-accent rounded transition-colors"
+            onClick={() => addTabRef.current.onSplit(groupId, "right")}
+            title="Split right"
+          >
+            <Columns2 className="size-3.5" />
+          </button>
+          <button
+            type="button"
+            className="inline-flex size-8 items-center justify-center text-muted-foreground hover:text-foreground hover:bg-accent rounded transition-colors"
+            onClick={() => addTabRef.current.onSplit(groupId, "below")}
+            title="Split down"
+          >
+            <Rows2 className="size-3.5" />
+          </button>
+        </>
+      )}
       <button
         type="button"
         className="inline-flex size-8 items-center justify-center text-muted-foreground hover:text-foreground hover:bg-accent rounded transition-colors"
@@ -390,6 +413,14 @@ export function DockviewBrowserContainer({
   const apiRef = useRef<DockviewApi | null>(null);
   const isRestoringRef = useRef(false);
   const containerRef = useRef<HTMLDivElement>(null);
+  // Tracks the cleanup function returned by `attachEdgeGroupDragVisibility`
+  // so the drag-visibility listeners can be detached on unmount (or on a
+  // hypothetical re-`onReady`).
+  const edgeDragDisposerRef = useRef<(() => void) | null>(null);
+  // Tracks the unregister fn from `registerInnerDockview` so the global
+  // sidebar-toggle shortcuts (⌘B / ⌥⌘B / ⌘J in SharedDockviewLayout) stop
+  // routing into this dockview after unmount.
+  const innerRegisterDisposerRef = useRef<(() => void) | null>(null);
 
   // Fetch layout AND browser records via React Query — cached across mounts
   // so re-visiting a workspace renders instantly from the cache.
@@ -992,6 +1023,17 @@ export function DockviewBrowserContainer({
   addTabRef.current = { onAdd: handleAddTab, onSplit: handleSplit };
   closeTabRef.current = closeTab;
 
+  // Detach edge-group drag-visibility listeners + inner-dockview
+  // registration on unmount.
+  useEffect(() => {
+    return () => {
+      edgeDragDisposerRef.current?.();
+      edgeDragDisposerRef.current = null;
+      innerRegisterDisposerRef.current?.();
+      innerRegisterDisposerRef.current = null;
+    };
+  }, []);
+
   // Use refs for the initial data so onReady's closure captures the latest
   const initialLayoutRef = useRef<unknown | null>(null);
   initialLayoutRef.current = initialData?.layout ?? null;
@@ -1063,6 +1105,28 @@ export function DockviewBrowserContainer({
         // No saved layout — create a default tab
         createDefaultPanel(event.api, workspaceId);
         persistToServer(workspaceId, event.api.toJSON(), { queryClient: queryClientRef.current });
+      }
+
+      // Ensure the three cardinal edge groups (left/right/bottom) exist so
+      // future panels can be docked to the edges of this inner container.
+      // Runs BEFORE listener registration so the synchronous add doesn't
+      // trigger a persist write — the next user-driven change saves the
+      // augmented layout naturally. Idempotent on restored layouts.
+      ensureEdgeGroups(event.api);
+
+      // Drag-visibility: while the user drags a panel/group, force every
+      // edge group visible so it can accept a drop; once the drag ends,
+      // hide any edge groups that are still empty. Dispose the previous
+      // registration if onReady somehow fires twice.
+      edgeDragDisposerRef.current?.();
+      edgeDragDisposerRef.current = attachEdgeGroupDragVisibility(event.api);
+
+      // Register with the global edge-shortcut registry so ⌘B / ⌥⌘B / ⌘J
+      // in SharedDockviewLayout's keydown can route to this inner dockview
+      // when focus is inside it. Same defensive double-onReady guard.
+      innerRegisterDisposerRef.current?.();
+      if (containerRef.current) {
+        innerRegisterDisposerRef.current = registerInnerDockview(containerRef.current, event.api);
       }
 
       // Listen for any layout changes and auto-persist

--- a/apps/web/src/components/DockviewChatContainer.tsx
+++ b/apps/web/src/components/DockviewChatContainer.tsx
@@ -20,6 +20,11 @@ import React, {
 } from "react";
 import { AgentIcon, useAdapter } from "@/dashboard";
 import {
+  attachEdgeGroupDragVisibility,
+  ensureEdgeGroups,
+  registerInnerDockview,
+} from "../lib/dockview-edge-groups";
+import {
   cycleGridGroups,
   cycleTabsInActiveGroup,
   selectNeighbourBeforeRemove,
@@ -368,26 +373,44 @@ const closeTabRef: { current: ((chatId: string) => void) | null } = {
 const RightHeaderActions = React.memo(function RightHeaderActions(
   props: IDockviewHeaderActionsProps,
 ) {
+  // Edge groups (left/right/bottom) don't support splits — dockview's
+  // `addPanel` with `position: { referenceGroup: <edge>, direction }`
+  // silently ignores the direction and just adds a tab. We still show
+  // the "+" button there so users can add another chat tab to the
+  // edge group; only the split buttons are hidden. Defaults to "grid"
+  // when `location` is missing (older dockview versions / tests).
+  const isGridGroup = (props.location?.type ?? "grid") === "grid";
   const { onAdd, onSplit } = addTabRef.current;
   const groupId = props.group.id;
+  // `w-full justify-center` keeps the "+" centered horizontally inside
+  // the vertical (left/right) edge action strip, which dockview sizes
+  // to `--dv-tabs-and-actions-container-height` (~35px wide) via
+  // `.dv-groupview-header-vertical`. In horizontal tab strips the
+  // right-actions container shrink-wraps to its content, so `w-full`
+  // resolves to the same content width and the button row looks
+  // identical to before.
   return (
-    <div className="flex h-full items-center">
-      <button
-        type="button"
-        className="inline-flex size-8 items-center justify-center text-muted-foreground hover:text-foreground hover:bg-accent rounded transition-colors"
-        onClick={() => onSplit(groupId, "right")}
-        title="Split right"
-      >
-        <Columns2 className="size-3.5" />
-      </button>
-      <button
-        type="button"
-        className="inline-flex size-8 items-center justify-center text-muted-foreground hover:text-foreground hover:bg-accent rounded transition-colors"
-        onClick={() => onSplit(groupId, "below")}
-        title="Split down"
-      >
-        <Rows2 className="size-3.5" />
-      </button>
+    <div className="flex h-full w-full items-center justify-center">
+      {isGridGroup && (
+        <>
+          <button
+            type="button"
+            className="inline-flex size-8 items-center justify-center text-muted-foreground hover:text-foreground hover:bg-accent rounded transition-colors"
+            onClick={() => onSplit(groupId, "right")}
+            title="Split right"
+          >
+            <Columns2 className="size-3.5" />
+          </button>
+          <button
+            type="button"
+            className="inline-flex size-8 items-center justify-center text-muted-foreground hover:text-foreground hover:bg-accent rounded transition-colors"
+            onClick={() => onSplit(groupId, "below")}
+            title="Split down"
+          >
+            <Rows2 className="size-3.5" />
+          </button>
+        </>
+      )}
       <button
         type="button"
         className="inline-flex size-8 items-center justify-center text-muted-foreground hover:text-foreground hover:bg-accent rounded transition-colors"
@@ -438,6 +461,14 @@ export function DockviewChatContainer({
   const apiRef = useRef<DockviewApi | null>(null);
   const isRestoringRef = useRef(false);
   const containerRef = useRef<HTMLDivElement>(null);
+  // Tracks the cleanup function returned by `attachEdgeGroupDragVisibility`
+  // so the drag-visibility listeners can be detached on unmount (or on a
+  // hypothetical re-`onReady`).
+  const edgeDragDisposerRef = useRef<(() => void) | null>(null);
+  // Tracks the unregister fn from `registerInnerDockview` so the global
+  // sidebar-toggle shortcuts (⌘B / ⌥⌘B / ⌘J in SharedDockviewLayout) stop
+  // routing into this dockview after unmount.
+  const innerRegisterDisposerRef = useRef<(() => void) | null>(null);
 
   // Fetch layout AND chat records via React Query — cached across mounts
   // so re-visiting a workspace renders instantly from the cache. Mirrors
@@ -726,6 +757,17 @@ export function DockviewChatContainer({
   addTabRef.current = { onAdd: handleAddTab, onSplit: handleSplit };
   closeTabRef.current = closeTab;
 
+  // Detach edge-group drag-visibility listeners + inner-dockview
+  // registration on unmount.
+  useEffect(() => {
+    return () => {
+      edgeDragDisposerRef.current?.();
+      edgeDragDisposerRef.current = null;
+      innerRegisterDisposerRef.current?.();
+      innerRegisterDisposerRef.current = null;
+    };
+  }, []);
+
   // Use refs for the initial data so onReady's closure captures the latest
   const initialLayoutRef = useRef<unknown | null>(null);
   initialLayoutRef.current = initialData?.layout ?? null;
@@ -792,6 +834,28 @@ export function DockviewChatContainer({
         createDefaultPanel(event.api, workspaceId);
 
         persistToServer(workspaceId, event.api.toJSON(), { queryClient: queryClientRef.current });
+      }
+
+      // Ensure the three cardinal edge groups (left/right/bottom) exist so
+      // future panels can be docked to the edges of this inner container.
+      // Runs BEFORE listener registration so the synchronous add doesn't
+      // trigger a persist write — the next user-driven change saves the
+      // augmented layout naturally. Idempotent on restored layouts.
+      ensureEdgeGroups(event.api);
+
+      // Drag-visibility: while the user drags a panel/group, force every
+      // edge group visible so it can accept a drop; once the drag ends,
+      // hide any edge groups that are still empty. Dispose the previous
+      // registration if onReady somehow fires twice.
+      edgeDragDisposerRef.current?.();
+      edgeDragDisposerRef.current = attachEdgeGroupDragVisibility(event.api);
+
+      // Register with the global edge-shortcut registry so ⌘B / ⌥⌘B / ⌘J
+      // in SharedDockviewLayout's keydown can route to this inner dockview
+      // when focus is inside it. Same defensive double-onReady guard.
+      innerRegisterDisposerRef.current?.();
+      if (containerRef.current) {
+        innerRegisterDisposerRef.current = registerInnerDockview(containerRef.current, event.api);
       }
 
       // Listen for any layout changes and auto-persist

--- a/apps/web/src/components/DockviewChatContainer.tsx
+++ b/apps/web/src/components/DockviewChatContainer.tsx
@@ -838,9 +838,11 @@ export function DockviewChatContainer({
 
       // Ensure the three cardinal edge groups (left/right/bottom) exist so
       // future panels can be docked to the edges of this inner container.
-      // Runs BEFORE listener registration so the synchronous add doesn't
-      // trigger a persist write — the next user-driven change saves the
-      // augmented layout naturally. Idempotent on restored layouts.
+      // MUST be called BEFORE the `onDidLayoutChange` registration below —
+      // `ensureEdgeGroups` may synchronously add edge groups and call
+      // `setEdgeGroupVisible`, and routing those events through
+      // `schedulePersist` would write a spurious initial save. Idempotent
+      // on restored layouts.
       ensureEdgeGroups(event.api);
 
       // Drag-visibility: while the user drags a panel/group, force every

--- a/apps/web/src/components/DockviewTerminalContainer.tsx
+++ b/apps/web/src/components/DockviewTerminalContainer.tsx
@@ -798,9 +798,11 @@ export function DockviewTerminalContainer({
 
       // Ensure the three cardinal edge groups (left/right/bottom) exist so
       // future panels can be docked to the edges of this inner container.
-      // Runs BEFORE listener registration so the synchronous add doesn't
-      // trigger a persist write — the next user-driven change saves the
-      // augmented layout naturally. Idempotent on restored layouts.
+      // MUST be called BEFORE the `onDidLayoutChange` registration below —
+      // `ensureEdgeGroups` may synchronously add edge groups and call
+      // `setEdgeGroupVisible`, and routing those events through
+      // `schedulePersist` would write a spurious initial save. Idempotent
+      // on restored layouts.
       ensureEdgeGroups(event.api);
 
       // Drag-visibility: while the user drags a panel/group, force every

--- a/apps/web/src/components/DockviewTerminalContainer.tsx
+++ b/apps/web/src/components/DockviewTerminalContainer.tsx
@@ -23,6 +23,11 @@ import React, {
 } from "react";
 import { useAdapter } from "@/dashboard";
 import {
+  attachEdgeGroupDragVisibility,
+  ensureEdgeGroups,
+  registerInnerDockview,
+} from "../lib/dockview-edge-groups";
+import {
   cycleGridGroups,
   cycleTabsInActiveGroup,
   selectNeighbourBeforeRemove,
@@ -265,25 +270,43 @@ const closeTabRef: { current: ((terminalId: string) => void) | null } = {
 const RightHeaderActions = React.memo(function RightHeaderActions(
   props: IDockviewHeaderActionsProps,
 ) {
+  // Edge groups (left/right/bottom) don't support splits — dockview's
+  // `addPanel` with `position: { referenceGroup: <edge>, direction }`
+  // silently ignores the direction and just adds a tab. We still show
+  // the "+" button there so users can add another terminal to the
+  // edge group; only the split buttons are hidden. Defaults to "grid"
+  // when `location` is missing (older dockview versions / tests).
+  const isGridGroup = (props.location?.type ?? "grid") === "grid";
   const groupId = props.group.id;
+  // `w-full justify-center` keeps the "+" centered horizontally inside
+  // the vertical (left/right) edge action strip, which dockview sizes
+  // to `--dv-tabs-and-actions-container-height` (~35px wide) via
+  // `.dv-groupview-header-vertical`. In horizontal tab strips the
+  // right-actions container shrink-wraps to its content, so `w-full`
+  // resolves to the same content width and the button row looks
+  // identical to before.
   return (
-    <div className="flex h-full items-center">
-      <button
-        type="button"
-        className="inline-flex size-7 items-center justify-center text-muted-foreground hover:text-foreground hover:bg-accent rounded transition-colors"
-        onClick={() => addTabRef.current.onSplit(groupId, "right")}
-        title="Split right"
-      >
-        <Columns2 className="size-3.5" />
-      </button>
-      <button
-        type="button"
-        className="inline-flex size-7 items-center justify-center text-muted-foreground hover:text-foreground hover:bg-accent rounded transition-colors"
-        onClick={() => addTabRef.current.onSplit(groupId, "below")}
-        title="Split down"
-      >
-        <Rows2 className="size-3.5" />
-      </button>
+    <div className="flex h-full w-full items-center justify-center">
+      {isGridGroup && (
+        <>
+          <button
+            type="button"
+            className="inline-flex size-7 items-center justify-center text-muted-foreground hover:text-foreground hover:bg-accent rounded transition-colors"
+            onClick={() => addTabRef.current.onSplit(groupId, "right")}
+            title="Split right"
+          >
+            <Columns2 className="size-3.5" />
+          </button>
+          <button
+            type="button"
+            className="inline-flex size-7 items-center justify-center text-muted-foreground hover:text-foreground hover:bg-accent rounded transition-colors"
+            onClick={() => addTabRef.current.onSplit(groupId, "below")}
+            title="Split down"
+          >
+            <Rows2 className="size-3.5" />
+          </button>
+        </>
+      )}
       <button
         type="button"
         className="inline-flex size-7 items-center justify-center text-muted-foreground hover:text-foreground hover:bg-accent rounded transition-colors"
@@ -334,6 +357,14 @@ export function DockviewTerminalContainer({
   const apiRef = useRef<DockviewApi | null>(null);
   const isRestoringRef = useRef(false);
   const containerRef = useRef<HTMLDivElement>(null);
+  // Tracks the cleanup function returned by `attachEdgeGroupDragVisibility`
+  // so the drag-visibility listeners can be detached on unmount (or on a
+  // hypothetical re-`onReady`).
+  const edgeDragDisposerRef = useRef<(() => void) | null>(null);
+  // Tracks the unregister fn from `registerInnerDockview` so the global
+  // sidebar-toggle shortcuts (⌘B / ⌥⌘B / ⌘J in SharedDockviewLayout) stop
+  // routing into this dockview after unmount.
+  const innerRegisterDisposerRef = useRef<(() => void) | null>(null);
 
   // Fetch layout AND terminal records via React Query — cached across mounts
   const { data: initialData } = useQuery<TerminalLayoutData>({
@@ -687,6 +718,17 @@ export function DockviewTerminalContainer({
   addTabRef.current = { onAdd: handleAddTab, onSplit: handleSplit };
   closeTabRef.current = closeTab;
 
+  // Detach edge-group drag-visibility listeners + inner-dockview
+  // registration on unmount.
+  useEffect(() => {
+    return () => {
+      edgeDragDisposerRef.current?.();
+      edgeDragDisposerRef.current = null;
+      innerRegisterDisposerRef.current?.();
+      innerRegisterDisposerRef.current = null;
+    };
+  }, []);
+
   // Use refs for the initial data so onReady's closure captures the latest
   const initialLayoutRef = useRef<unknown | null>(null);
   initialLayoutRef.current = initialData?.layout ?? null;
@@ -752,6 +794,28 @@ export function DockviewTerminalContainer({
       } else {
         // No saved layout — check for workspace terminal config, then create default
         seedFromConfigOrDefault(event.api, workspaceId, queryClientRef.current);
+      }
+
+      // Ensure the three cardinal edge groups (left/right/bottom) exist so
+      // future panels can be docked to the edges of this inner container.
+      // Runs BEFORE listener registration so the synchronous add doesn't
+      // trigger a persist write — the next user-driven change saves the
+      // augmented layout naturally. Idempotent on restored layouts.
+      ensureEdgeGroups(event.api);
+
+      // Drag-visibility: while the user drags a panel/group, force every
+      // edge group visible so it can accept a drop; once the drag ends,
+      // hide any edge groups that are still empty. Dispose the previous
+      // registration if onReady somehow fires twice.
+      edgeDragDisposerRef.current?.();
+      edgeDragDisposerRef.current = attachEdgeGroupDragVisibility(event.api);
+
+      // Register with the global edge-shortcut registry so ⌘B / ⌥⌘B / ⌘J
+      // in SharedDockviewLayout's keydown can route to this inner dockview
+      // when focus is inside it. Same defensive double-onReady guard.
+      innerRegisterDisposerRef.current?.();
+      if (containerRef.current) {
+        innerRegisterDisposerRef.current = registerInnerDockview(containerRef.current, event.api);
       }
 
       // Listen for any layout changes and auto-persist

--- a/apps/web/src/components/SharedDockviewLayout.tsx
+++ b/apps/web/src/components/SharedDockviewLayout.tsx
@@ -42,6 +42,7 @@ import {
   extractActiveState,
   walkGridNode,
 } from "../lib/dockview-active-state";
+import { findFocusedInnerDockview, toggleEdgeGroup } from "../lib/dockview-edge-groups";
 import { isDesktop } from "../lib/is-desktop";
 import { parseWorkspaceFromPath } from "../lib/parse-workspace";
 import { trpc } from "../lib/trpc-client";
@@ -1098,13 +1099,39 @@ export function SharedDockviewLayout() {
             window.dispatchEvent(new CustomEvent("band:focus-browser"));
           });
         }
-      } else if (key === "b" && !e.shiftKey && api) {
+      } else if (key === "b" && !e.shiftKey && !e.altKey && api) {
+        // ⌘B → toggle LEFT edge. Focus-aware: if an inner dockview
+        // (terminal / chat / browser) is focused AND has panels on
+        // its left edge, toggle that inner edge; otherwise fall back
+        // to the main layout's left edge (Projects).
+        //
+        // The fallback is driven by `toggleEdgeGroup`'s return value
+        // (`true` when it acted on a non-empty edge, `false` when
+        // there was nothing to act on) — so empty inner edges
+        // transparently delegate to the main layout. See
+        // `dockview-edge-groups.ts` for the registry that makes the
+        // focus lookup possible.
         e.preventDefault();
-        const left = api.groups.find((g) => g.id === EDGE_GROUP_IDS.left);
-        if (left) {
-          if (left.api.isCollapsed()) left.api.expand();
-          else left.api.collapse();
-        }
+        const inner = findFocusedInnerDockview();
+        if (inner && toggleEdgeGroup(inner, "left")) return;
+        toggleEdgeGroup(api, "left");
+      } else if (e.code === "KeyB" && e.altKey && !e.shiftKey && api) {
+        // ⌥⌘B → toggle RIGHT edge. Uses `e.code === "KeyB"` instead
+        // of `key === "b"` because macOS substitutes Alt-layer
+        // characters into `e.key` (Alt+B → "∫"), making the letter
+        // check unreliable when Alt is held. `e.code` is keyboard-
+        // layout independent and matches the pattern used by the
+        // ⇧⌥F format-current-file shortcut above.
+        e.preventDefault();
+        const inner = findFocusedInnerDockview();
+        if (inner && toggleEdgeGroup(inner, "right")) return;
+        toggleEdgeGroup(api, "right");
+      } else if (key === "j" && !e.shiftKey && !e.altKey && api) {
+        // ⌘J → toggle BOTTOM edge. Same focus-aware fallback as ⌘B.
+        e.preventDefault();
+        const inner = findFocusedInnerDockview();
+        if (inner && toggleEdgeGroup(inner, "bottom")) return;
+        toggleEdgeGroup(api, "bottom");
       } else if (key === "m" && e.shiftKey && api) {
         e.preventDefault();
         const active = api.activeGroup;

--- a/apps/web/src/components/SharedDockviewLayout.tsx
+++ b/apps/web/src/components/SharedDockviewLayout.tsx
@@ -1128,6 +1128,10 @@ export function SharedDockviewLayout() {
         toggleEdgeGroup(api, "right");
       } else if (key === "j" && !e.shiftKey && !e.altKey && api) {
         // ⌘J → toggle BOTTOM edge. Same focus-aware fallback as ⌘B.
+        // Unlike the ⌥⌘B branch above, this branch uses `key` instead
+        // of `e.code` — there's no Alt variant to disambiguate (⌥⌘J
+        // would produce "∆" in `e.key`, but the `!e.altKey` guard
+        // already excludes that case before the letter check runs).
         e.preventDefault();
         const inner = findFocusedInnerDockview();
         if (inner && toggleEdgeGroup(inner, "bottom")) return;

--- a/apps/web/src/lib/dockview-edge-groups.ts
+++ b/apps/web/src/lib/dockview-edge-groups.ts
@@ -1,0 +1,212 @@
+import type { DockviewApi } from "dockview";
+
+/**
+ * Shared edge-group helpers for our dockview instances. Each DockviewApi
+ * gets the same three cardinal edges (left, right, bottom) so panels can
+ * dock there. Top is intentionally omitted — none of our layouts use it,
+ * and a stray "top" group restored from an older saved layout is cleaned
+ * up by `ensureEdgeGroups` below.
+ *
+ * The main outer layout (`SharedDockviewLayout`) wires the same pattern
+ * inline; these helpers extract the bits the three inner containers
+ * (`DockviewTerminalContainer`, `DockviewChatContainer`,
+ * `DockviewBrowserContainer`) need so each one can opt-in with two
+ * small calls in `onReady` plus a useEffect cleanup.
+ */
+
+export const EDGE_GROUP_IDS = {
+  left: "edge-left",
+  right: "edge-right",
+  bottom: "edge-bottom",
+} as const;
+
+export type EdgeDirection = keyof typeof EDGE_GROUP_IDS;
+
+/**
+ * Add the three cardinal edge groups (left/right/bottom) to `api` if
+ * they aren't already present, collapsed and with no panels. Then set
+ * each one's visibility based on whether it currently holds panels —
+ * so an empty edge group doesn't leak a thin sliver of dockview chrome
+ * into the layout on first mount.
+ *
+ * Idempotent: calling it on an api that was just restored from a saved
+ * layout (which already contains the edge groups) is a no-op aside from
+ * the visibility refresh.
+ *
+ * Also defensively removes any persisted "top" edge group — older
+ * saved layouts may carry one, but none of our layouts intentionally
+ * dock to the top edge.
+ *
+ * Call this in `onReady` AFTER restoring (or building) the initial
+ * layout, BEFORE wiring layout-change persistence listeners. Calling
+ * it before listener registration means the synchronous edge-group
+ * additions don't trigger a write; the next user-driven change will
+ * persist the augmented layout naturally.
+ */
+export function ensureEdgeGroups(api: DockviewApi): void {
+  // Best-effort cleanup: dockview throws if the edge group doesn't exist,
+  // hence the try.
+  try {
+    if (api.getEdgeGroup("top")) api.removeEdgeGroup("top");
+  } catch {}
+
+  for (const direction of Object.keys(EDGE_GROUP_IDS) as EdgeDirection[]) {
+    const id = EDGE_GROUP_IDS[direction];
+    if (!api.groups.some((g) => g.id === id)) {
+      try {
+        api.addEdgeGroup(direction, { id, collapsed: true });
+      } catch {}
+    }
+  }
+
+  refreshEdgeGroupVisibility(api, false);
+}
+
+/**
+ * Show each edge group only when it actually holds panels — so empty
+ * edges stay hidden rather than rendering an empty strip. When
+ * `forceVisible` is true (during a drag), show every edge group
+ * regardless so the user has a drop target on every side.
+ */
+export function refreshEdgeGroupVisibility(api: DockviewApi, forceVisible: boolean): void {
+  for (const direction of Object.keys(EDGE_GROUP_IDS) as EdgeDirection[]) {
+    const id = EDGE_GROUP_IDS[direction];
+    const group = api.groups.find((g) => g.id === id);
+    if (!group) continue;
+    const isEmpty = group.panels.length === 0;
+    try {
+      api.setEdgeGroupVisible(direction, forceVisible || !isEmpty);
+    } catch {}
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Collapse/expand toggle + inner-dockview registry
+// ---------------------------------------------------------------------------
+//
+// VSCode-style sidebar shortcuts (⌘B for left, ⌥⌘B for right, ⌘J for
+// bottom) live in `SharedDockviewLayout`'s global keydown handler. To
+// make them focus-aware — so ⌘B inside a focused terminal section
+// toggles *that* container's left edge when it has panels, falling
+// back to the main layout's left edge otherwise — each inner dockview
+// (`DockviewTerminalContainer`, `DockviewChatContainer`,
+// `DockviewBrowserContainer`) registers its `(containerEl, api)` pair
+// here on mount. The global handler then calls `findFocusedInnerDockview`
+// to see which inner dockview owns `document.activeElement`, attempts
+// `toggleEdgeGroup` on it, and falls back to the main layout's api
+// when the toggle reports `false` (no panels to act on).
+
+interface InnerDockviewRegistration {
+  containerEl: HTMLElement;
+  api: DockviewApi;
+}
+
+const innerDockviewRegistrations = new Set<InnerDockviewRegistration>();
+
+/**
+ * Register an inner dockview's container element + api so the global
+ * sidebar-toggle shortcuts can route to it when focus is inside.
+ *
+ * Returns a disposer to unregister on unmount. Idempotent: calling the
+ * returned disposer twice is safe.
+ */
+export function registerInnerDockview(containerEl: HTMLElement, api: DockviewApi): () => void {
+  const registration: InnerDockviewRegistration = { containerEl, api };
+  innerDockviewRegistrations.add(registration);
+  return () => {
+    innerDockviewRegistrations.delete(registration);
+  };
+}
+
+/**
+ * Find the registered inner dockview that currently contains
+ * `document.activeElement`. Returns `null` when no inner dockview has
+ * focus (focus is in the main layout, a modal, a webview, or
+ * `document.body`). Used by the global sidebar-toggle shortcuts to
+ * decide whether to act on an inner container's edge before falling
+ * back to the main layout.
+ */
+export function findFocusedInnerDockview(): DockviewApi | null {
+  const active = document.activeElement;
+  if (!active) return null;
+  for (const reg of innerDockviewRegistrations) {
+    if (reg.containerEl.contains(active)) {
+      return reg.api;
+    }
+  }
+  return null;
+}
+
+/**
+ * Toggle the collapsed state of the edge group at `direction` on `api`.
+ * Uses dockview's group-level `collapse()`/`expand()` (the thin
+ * tab-strip behaviour, matching the existing main-layout shortcut),
+ * NOT `setEdgeGroupVisible` — visibility is managed by
+ * `refreshEdgeGroupVisibility` based on panel-count and shouldn't be
+ * driven by a user shortcut.
+ *
+ * Returns `true` when the toggle actually acted on a non-empty edge
+ * group, `false` otherwise (no edge group at that direction, or it
+ * has no panels). Callers use the return value for fallback
+ * dispatching — e.g., ⌘B on a focused inner container with an empty
+ * left edge returns `false`, prompting the caller to try the main
+ * layout's left edge instead.
+ */
+export function toggleEdgeGroup(api: DockviewApi, direction: EdgeDirection): boolean {
+  const id = EDGE_GROUP_IDS[direction];
+  const group = api.groups.find((g) => g.id === id);
+  if (!group) return false;
+  if (group.panels.length === 0) return false;
+  try {
+    if (group.api.isCollapsed()) group.api.expand();
+    else group.api.collapse();
+  } catch {
+    return false;
+  }
+  return true;
+}
+
+/**
+ * Wire up edge-group drag visibility: while the user drags a panel or
+ * group, force every edge group visible so it can accept a drop; once
+ * the drag ends, hide any edge groups that are still empty.
+ *
+ * Returns a disposer — call it from a useEffect cleanup (or directly
+ * on unmount) to detach the event listeners.
+ */
+export function attachEdgeGroupDragVisibility(api: DockviewApi): () => void {
+  let isDragging = false;
+
+  const refresh = () => {
+    refreshEdgeGroupVisibility(api, isDragging);
+  };
+
+  const startDrag = () => {
+    isDragging = true;
+    refresh();
+  };
+  const endDrag = () => {
+    isDragging = false;
+    refresh();
+  };
+
+  refresh();
+
+  const d1 = api.onWillDragPanel(startDrag);
+  const d2 = api.onWillDragGroup(startDrag);
+  const d3 = api.onDidMovePanel(endDrag);
+  const d4 = api.onDidRemovePanel(endDrag);
+
+  const onDragEndNative = () => endDrag();
+  document.addEventListener("drop", onDragEndNative, true);
+  document.addEventListener("dragend", onDragEndNative, true);
+
+  return () => {
+    d1.dispose();
+    d2.dispose();
+    d3.dispose();
+    d4.dispose();
+    document.removeEventListener("drop", onDragEndNative, true);
+    document.removeEventListener("dragend", onDragEndNative, true);
+  };
+}

--- a/apps/web/src/lib/dockview-edge-groups.ts
+++ b/apps/web/src/lib/dockview-edge-groups.ts
@@ -202,7 +202,11 @@ export function attachEdgeGroupDragVisibility(api: DockviewApi): () => void {
     refresh();
   };
 
-  refresh();
+  // Initial visibility is `ensureEdgeGroups`' responsibility — every
+  // caller in this codebase invokes that helper in `onReady` before
+  // this one, and re-running the refresh here would be a redundant
+  // round of `setEdgeGroupVisible` for each edge. The next `startDrag`
+  // / `endDrag` event fires the refresh as needed.
 
   const d1 = api.onWillDragPanel(startDrag);
   const d2 = api.onWillDragGroup(startDrag);

--- a/apps/web/src/lib/dockview-edge-groups.ts
+++ b/apps/web/src/lib/dockview-edge-groups.ts
@@ -44,11 +44,16 @@ export type EdgeDirection = keyof typeof EDGE_GROUP_IDS;
  * persist the augmented layout naturally.
  */
 export function ensureEdgeGroups(api: DockviewApi): void {
-  // Best-effort cleanup: dockview throws if the edge group doesn't exist,
-  // hence the try.
-  try {
-    if (api.getEdgeGroup("top")) api.removeEdgeGroup("top");
-  } catch {}
+  // Best-effort cleanup of any stale "top" edge group restored from an
+  // older saved layout. `getEdgeGroup` returns `undefined` rather than
+  // throwing for an absent direction, so the truthy check is the actual
+  // guard; the `try/catch` is narrowly scoped around `removeEdgeGroup`
+  // alone (it's the only call here that can throw).
+  if (api.getEdgeGroup("top")) {
+    try {
+      api.removeEdgeGroup("top");
+    } catch {}
+  }
 
   for (const direction of Object.keys(EDGE_GROUP_IDS) as EdgeDirection[]) {
     const id = EDGE_GROUP_IDS[direction];
@@ -101,6 +106,13 @@ interface InnerDockviewRegistration {
   api: DockviewApi;
 }
 
+// Intentionally a per-module-instance singleton — not per React tree.
+// Each `DockviewTerminalContainer` / `DockviewChatContainer` /
+// `DockviewBrowserContainer` contributes at most one entry while
+// mounted. If a future SSR/Playwright setup ever loads this module
+// twice in the same process (e.g. `vi.resetModules()` between tests),
+// each module copy would have its own registry — that's fine because
+// the React trees also bind to the matching module copy.
 const innerDockviewRegistrations = new Set<InnerDockviewRegistration>();
 
 /**
@@ -194,6 +206,12 @@ export function attachEdgeGroupDragVisibility(api: DockviewApi): () => void {
 
   const d1 = api.onWillDragPanel(startDrag);
   const d2 = api.onWillDragGroup(startDrag);
+  // `onDidMovePanel` / `onDidRemovePanel` are the dockview-level
+  // signals for a successful drop. They do NOT fire when the user
+  // cancels a drag with Escape or drops outside the dockview — the
+  // native `dragend` listener on `document` below is the safety net
+  // for those cases, so an unfinished drag can't leave edge groups
+  // stuck in force-visible state.
   const d3 = api.onDidMovePanel(endDrag);
   const d4 = api.onDidRemovePanel(endDrag);
 

--- a/apps/web/src/lib/dockview-section-actions.ts
+++ b/apps/web/src/lib/dockview-section-actions.ts
@@ -106,8 +106,22 @@ function readElement(group: DockviewGroupPanel): ElementBearing["element"] | nul
 }
 
 /**
- * Return the grid groups in row-major reading order. Floating/popout
- * groups are excluded because they don't participate in the grid.
+ * Return the navigable in-document groups in row-major reading order.
+ * Includes:
+ *   - Every grid group (the regular split layout)
+ *   - Every edge group (left/right/bottom) that currently holds at
+ *     least one panel
+ *
+ * Floating/popout groups are excluded — they live in their own
+ * surfaces, not the dockview grid, and treating them as cycle stops
+ * would teleport focus across windows.
+ *
+ * Empty edge groups are also excluded: when an edge group has no
+ * panels we hide it via `setEdgeGroupVisible(direction, false)` (see
+ * `dockview-edge-groups.ts`), so it shouldn't be a focus target.
+ * The downstream zero-rect filter would catch most of those, but
+ * checking `panels.length` is more robust against future dockview
+ * changes that keep hidden groups dimensioned.
  *
  * Measurement uses `getBoundingClientRect()`, which means the section's
  * sub-dockview must be in the DOM and laid out at call time. That's
@@ -115,8 +129,13 @@ function readElement(group: DockviewGroupPanel): ElementBearing["element"] | nul
  * handler bails out unless the container has focus — focus requires
  * the element to be visible.
  */
-export function getGridGroupsInVisualOrder(api: DockviewApi): DockviewGroupPanel[] {
-  const groups = api.groups.filter((g) => g.api.location.type === "grid");
+export function getNavigableGroupsInVisualOrder(api: DockviewApi): DockviewGroupPanel[] {
+  const groups = api.groups.filter((g) => {
+    const loc = g.api.location;
+    if (loc.type === "grid") return true;
+    if (loc.type === "edge") return g.panels.length > 0;
+    return false;
+  });
   if (groups.length < 2) return groups;
 
   const rects: GroupRect[] = [];
@@ -126,7 +145,8 @@ export function getGridGroupsInVisualOrder(api: DockviewApi): DockviewGroupPanel
     const r = el.getBoundingClientRect();
     // A zero-size rect means the element is detached or display:none.
     // Skip it so the sort isn't fed phantom (0, 0) coordinates that
-    // would always land first.
+    // would always land first. Hidden edge groups also fall through
+    // here — `setEdgeGroupVisible(_, false)` collapses the rect.
     if (r.width === 0 && r.height === 0) continue;
     rects.push({ id: g.id, top: r.top, left: r.left });
   }
@@ -140,14 +160,23 @@ export function getGridGroupsInVisualOrder(api: DockviewApi): DockviewGroupPanel
   return result;
 }
 
-/** Cycle between split panel groups in row-major reading order (skips floating/popout). */
+/**
+ * Cycle between in-document panel groups in row-major reading order.
+ * Includes edge groups (left/right/bottom) that currently hold at
+ * least one panel, so users can Cmd+[/] into and out of edge-docked
+ * panels. Skips floating/popout groups.
+ *
+ * Named `cycleGridGroups` historically (when only grid-located groups
+ * were in the cycle); kept for the import surface in the three inner
+ * containers.
+ */
 export function cycleGridGroups(
   api: DockviewApi | null,
   direction: Direction,
   refocus?: () => void,
 ): void {
   if (!api) return;
-  const groups = getGridGroupsInVisualOrder(api);
+  const groups = getNavigableGroupsInVisualOrder(api);
   if (groups.length < 2) return;
   const current = api.activeGroup;
   const idx = current ? groups.findIndex((g) => g.id === current.id) : -1;
@@ -211,9 +240,12 @@ export function selectNeighbourBeforeRemove(api: DockviewApi, panelId: string): 
 
   // Last tab in a group: pre-activate the previous group in reading
   // order, so focus lands next to the closed pane instead of snapping to
-  // some arbitrary group.
+  // some arbitrary group. Includes edge groups with panels as fallback
+  // targets — if the user closes the only tab in a grid group and a
+  // panel is docked at the edge, focusing the edge panel is better
+  // than dockview's arbitrary first-in-list choice.
   if (!group) return;
-  const ordered = getGridGroupsInVisualOrder(api);
+  const ordered = getNavigableGroupsInVisualOrder(api);
   if (ordered.length <= 1) return; // no other group to fall back to
   const groupIdx = ordered.findIndex((g) => g.id === group.id);
   if (groupIdx < 0) return;

--- a/apps/web/tests/dockview-edge-groups.test.ts
+++ b/apps/web/tests/dockview-edge-groups.test.ts
@@ -1,0 +1,298 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Pure-function tests for the edge-group helpers in
+ * `apps/web/src/lib/dockview-edge-groups.ts`.
+ *
+ * The helpers control how the four dockview instances (main +
+ * terminal + chat + browser) decide which edges are visible, which
+ * edge a ⌘B/⌥⌘B/⌘J shortcut should target, and how the focus-aware
+ * inner-dockview registry routes that shortcut. They're pure functions
+ * over a `DockviewApi` (no I/O, no async, no React state) so the
+ * stub-based contract-test pattern from
+ * `dockview-section-actions.test.ts` gives the best signal here — see
+ * the long comment at the top of that file for the rationale.
+ *
+ * What's covered (matches the [7] reviewer suggestion on PR #512):
+ *   - `toggleEdgeGroup` no-ops + returns `false` for absent / empty
+ *     edge groups (so the global keydown handler in SharedDockviewLayout
+ *     can fall back to the main api).
+ *   - `toggleEdgeGroup` flips collapsed state and returns `true` for
+ *     non-empty edge groups.
+ *   - `findFocusedInnerDockview` returns `null` when nothing matches,
+ *     and the matching registration when `document.activeElement` is
+ *     inside the registered container.
+ *   - `registerInnerDockview` cleanup unregisters cleanly.
+ *   - `refreshEdgeGroupVisibility` hides empty edges, shows non-empty,
+ *     and force-shows all when `forceVisible` is true.
+ */
+
+import { describe, expect, it, vi } from "vitest";
+import {
+  EDGE_GROUP_IDS,
+  type EdgeDirection,
+  findFocusedInnerDockview,
+  refreshEdgeGroupVisibility,
+  registerInnerDockview,
+  toggleEdgeGroup,
+} from "../src/lib/dockview-edge-groups";
+
+// ---------------------------------------------------------------------------
+// Stubs. Minimum surface area to drive each helper. Mirrors the
+// approach in dockview-section-actions.test.ts — anything not touched
+// by the function under test is left out so the stub doesn't quietly
+// pin behaviour we don't intend to test.
+// ---------------------------------------------------------------------------
+
+interface StubPanel {
+  id: string;
+}
+
+interface StubGroup {
+  id: string;
+  panels: StubPanel[];
+  api: {
+    isCollapsed: ReturnType<typeof vi.fn>;
+    collapse: ReturnType<typeof vi.fn>;
+    expand: ReturnType<typeof vi.fn>;
+  };
+}
+
+interface StubApi {
+  groups: StubGroup[];
+  setEdgeGroupVisible: ReturnType<typeof vi.fn>;
+}
+
+function makeGroup(id: string, panelIds: string[], collapsed = false): StubGroup {
+  const isCollapsed = vi.fn(() => collapsedState.value);
+  const collapse = vi.fn(() => {
+    collapsedState.value = true;
+  });
+  const expand = vi.fn(() => {
+    collapsedState.value = false;
+  });
+  const collapsedState = { value: collapsed };
+  return {
+    id,
+    panels: panelIds.map((id) => ({ id })),
+    api: { isCollapsed, collapse, expand },
+  };
+}
+
+function makeApi(groups: StubGroup[]): StubApi {
+  return {
+    groups,
+    setEdgeGroupVisible: vi.fn(),
+  };
+}
+
+// biome-ignore lint/suspicious/noExplicitAny: stubs fed to functions typed against the real DockviewApi
+function asApi(stub: StubApi): any {
+  return stub;
+}
+
+// ---------------------------------------------------------------------------
+// toggleEdgeGroup
+// ---------------------------------------------------------------------------
+
+describe("toggleEdgeGroup", () => {
+  it("returns false when no edge group exists at that direction", () => {
+    // No edge groups in api.groups — the helper looks up by id and
+    // bails out so the caller knows to fall back (e.g., main layout).
+    const api = makeApi([]);
+    expect(toggleEdgeGroup(asApi(api), "left")).toBe(false);
+  });
+
+  it("returns false when the edge group exists but has no panels", () => {
+    // Empty edge group is a no-op target — same fall-back semantics as
+    // "no group" — because there is nothing for the user to interact
+    // with on that side.
+    const emptyLeft = makeGroup(EDGE_GROUP_IDS.left, []);
+    const api = makeApi([emptyLeft]);
+    expect(toggleEdgeGroup(asApi(api), "left")).toBe(false);
+    expect(emptyLeft.api.collapse).not.toHaveBeenCalled();
+    expect(emptyLeft.api.expand).not.toHaveBeenCalled();
+  });
+
+  it("expands an edge group that is currently collapsed (returns true)", () => {
+    const left = makeGroup(EDGE_GROUP_IDS.left, ["projects"], /* collapsed */ true);
+    const api = makeApi([left]);
+    expect(toggleEdgeGroup(asApi(api), "left")).toBe(true);
+    expect(left.api.expand).toHaveBeenCalledTimes(1);
+    expect(left.api.collapse).not.toHaveBeenCalled();
+  });
+
+  it("collapses an edge group that is currently expanded (returns true)", () => {
+    const left = makeGroup(EDGE_GROUP_IDS.left, ["projects"], /* collapsed */ false);
+    const api = makeApi([left]);
+    expect(toggleEdgeGroup(asApi(api), "left")).toBe(true);
+    expect(left.api.collapse).toHaveBeenCalledTimes(1);
+    expect(left.api.expand).not.toHaveBeenCalled();
+  });
+
+  it("targets the right direction's edge group, not just the first match", () => {
+    // Sanity check: with three edge groups present, each direction
+    // routes to its own. Without the by-id lookup, the helper could
+    // accidentally pick the first group in api.groups.
+    const left = makeGroup(EDGE_GROUP_IDS.left, ["a"]);
+    const right = makeGroup(EDGE_GROUP_IDS.right, ["b"]);
+    const bottom = makeGroup(EDGE_GROUP_IDS.bottom, ["c"]);
+    const api = makeApi([left, right, bottom]);
+    toggleEdgeGroup(asApi(api), "right");
+    expect(right.api.collapse).toHaveBeenCalledTimes(1);
+    expect(left.api.collapse).not.toHaveBeenCalled();
+    expect(bottom.api.collapse).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// refreshEdgeGroupVisibility
+// ---------------------------------------------------------------------------
+
+describe("refreshEdgeGroupVisibility", () => {
+  it("hides empty edge groups when forceVisible is false", () => {
+    const left = makeGroup(EDGE_GROUP_IDS.left, []); // empty
+    const api = makeApi([left]);
+    refreshEdgeGroupVisibility(asApi(api), false);
+    expect(api.setEdgeGroupVisible).toHaveBeenCalledWith("left", false);
+  });
+
+  it("shows non-empty edge groups when forceVisible is false", () => {
+    const left = makeGroup(EDGE_GROUP_IDS.left, ["projects"]);
+    const api = makeApi([left]);
+    refreshEdgeGroupVisibility(asApi(api), false);
+    expect(api.setEdgeGroupVisible).toHaveBeenCalledWith("left", true);
+  });
+
+  it("force-shows every edge group when forceVisible is true (drag)", () => {
+    // During a drag, empty edges become drop targets — without
+    // force-show the user wouldn't see anywhere to drop a panel.
+    const left = makeGroup(EDGE_GROUP_IDS.left, []); // empty
+    const right = makeGroup(EDGE_GROUP_IDS.right, ["existing"]); // non-empty
+    const api = makeApi([left, right]);
+    refreshEdgeGroupVisibility(asApi(api), true);
+    expect(api.setEdgeGroupVisible).toHaveBeenCalledWith("left", true);
+    expect(api.setEdgeGroupVisible).toHaveBeenCalledWith("right", true);
+  });
+
+  it("skips directions whose edge group is not registered yet", () => {
+    // Caller might invoke refresh before all edge groups are added —
+    // missing ones should be a no-op rather than throw.
+    const api = makeApi([]);
+    expect(() => refreshEdgeGroupVisibility(asApi(api), false)).not.toThrow();
+    expect(api.setEdgeGroupVisible).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// findFocusedInnerDockview / registerInnerDockview
+// ---------------------------------------------------------------------------
+//
+// These tests touch `document.activeElement`, so we need a real DOM —
+// vitest's default jsdom environment is fine. Each test cleans up its
+// registrations + DOM elements to prevent cross-test leakage through
+// the module-level registry singleton.
+
+describe("registerInnerDockview / findFocusedInnerDockview", () => {
+  it("returns null when no inner dockview is registered", () => {
+    expect(findFocusedInnerDockview()).toBe(null);
+  });
+
+  it("returns null when focus is not inside any registered container", () => {
+    const containerEl = document.createElement("div");
+    document.body.appendChild(containerEl);
+    // biome-ignore lint/suspicious/noExplicitAny: stub api — focus lookup only uses containerEl
+    const api: any = { id: "inner-api" };
+    const dispose = registerInnerDockview(containerEl, api);
+
+    // activeElement is document.body by default — not inside containerEl.
+    expect(findFocusedInnerDockview()).toBe(null);
+
+    dispose();
+    document.body.removeChild(containerEl);
+  });
+
+  it("returns the matching api when document.activeElement is inside its container", () => {
+    const containerEl = document.createElement("div");
+    const innerInput = document.createElement("input");
+    containerEl.appendChild(innerInput);
+    document.body.appendChild(containerEl);
+    // biome-ignore lint/suspicious/noExplicitAny: stub api
+    const api: any = { id: "inner-api" };
+    const dispose = registerInnerDockview(containerEl, api);
+
+    innerInput.focus();
+    expect(findFocusedInnerDockview()).toBe(api);
+
+    dispose();
+    document.body.removeChild(containerEl);
+  });
+
+  it("disposer unregisters the entry cleanly", () => {
+    const containerEl = document.createElement("div");
+    const innerInput = document.createElement("input");
+    containerEl.appendChild(innerInput);
+    document.body.appendChild(containerEl);
+    // biome-ignore lint/suspicious/noExplicitAny: stub api
+    const api: any = { id: "inner-api" };
+    const dispose = registerInnerDockview(containerEl, api);
+    innerInput.focus();
+    expect(findFocusedInnerDockview()).toBe(api);
+
+    dispose();
+    // After dispose, the same focus should produce no match.
+    expect(findFocusedInnerDockview()).toBe(null);
+
+    document.body.removeChild(containerEl);
+  });
+
+  it("returns the right api when multiple inner containers are registered", () => {
+    // Multi-workspace case: two inner containers active at once; the
+    // routing has to pick the one that actually owns focus.
+    const containerA = document.createElement("div");
+    const inputA = document.createElement("input");
+    containerA.appendChild(inputA);
+    const containerB = document.createElement("div");
+    const inputB = document.createElement("input");
+    containerB.appendChild(inputB);
+    document.body.appendChild(containerA);
+    document.body.appendChild(containerB);
+
+    // biome-ignore lint/suspicious/noExplicitAny: stub api
+    const apiA: any = { id: "api-a" };
+    // biome-ignore lint/suspicious/noExplicitAny: stub api
+    const apiB: any = { id: "api-b" };
+    const disposeA = registerInnerDockview(containerA, apiA);
+    const disposeB = registerInnerDockview(containerB, apiB);
+
+    inputA.focus();
+    expect(findFocusedInnerDockview()).toBe(apiA);
+    inputB.focus();
+    expect(findFocusedInnerDockview()).toBe(apiB);
+
+    disposeA();
+    disposeB();
+    document.body.removeChild(containerA);
+    document.body.removeChild(containerB);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// EDGE_GROUP_IDS sanity
+// ---------------------------------------------------------------------------
+
+describe("EDGE_GROUP_IDS", () => {
+  it("exposes the three cardinal directions used across the app", () => {
+    // Pin the values: SharedDockviewLayout's local copy and the helper
+    // module must match, otherwise toggle/refresh would target the
+    // wrong edge group ids.
+    expect(EDGE_GROUP_IDS.left).toBe("edge-left");
+    expect(EDGE_GROUP_IDS.right).toBe("edge-right");
+    expect(EDGE_GROUP_IDS.bottom).toBe("edge-bottom");
+  });
+
+  it("only includes left, right, and bottom (no top)", () => {
+    const keys = Object.keys(EDGE_GROUP_IDS).sort() as EdgeDirection[];
+    expect(keys).toEqual(["bottom", "left", "right"]);
+  });
+});

--- a/apps/web/tests/dockview-edge-groups.test.ts
+++ b/apps/web/tests/dockview-edge-groups.test.ts
@@ -29,8 +29,10 @@
 
 import { describe, expect, it, vi } from "vitest";
 import {
+  attachEdgeGroupDragVisibility,
   EDGE_GROUP_IDS,
   type EdgeDirection,
+  ensureEdgeGroups,
   findFocusedInnerDockview,
   refreshEdgeGroupVisibility,
   registerInnerDockview,
@@ -61,6 +63,13 @@ interface StubGroup {
 interface StubApi {
   groups: StubGroup[];
   setEdgeGroupVisible: ReturnType<typeof vi.fn>;
+  getEdgeGroup?: ReturnType<typeof vi.fn>;
+  removeEdgeGroup?: ReturnType<typeof vi.fn>;
+  addEdgeGroup?: ReturnType<typeof vi.fn>;
+  onWillDragPanel?: ReturnType<typeof vi.fn>;
+  onWillDragGroup?: ReturnType<typeof vi.fn>;
+  onDidMovePanel?: ReturnType<typeof vi.fn>;
+  onDidRemovePanel?: ReturnType<typeof vi.fn>;
 }
 
 function makeGroup(id: string, panelIds: string[], collapsed = false): StubGroup {
@@ -83,6 +92,74 @@ function makeApi(groups: StubGroup[]): StubApi {
   return {
     groups,
     setEdgeGroupVisible: vi.fn(),
+  };
+}
+
+/**
+ * Builds an api with the surface area `ensureEdgeGroups` and
+ * `attachEdgeGroupDragVisibility` touch:
+ *   - `getEdgeGroup(position)` → returns a sentinel group when
+ *     `existingEdges` includes that position (used to test the "top"
+ *     cleanup path).
+ *   - `removeEdgeGroup` / `addEdgeGroup` → tracked spies the tests
+ *     assert against.
+ *   - `onWillDragPanel` / `onWillDragGroup` / `onDidMovePanel` /
+ *     `onDidRemovePanel` → record the registered listener and return a
+ *     disposable so the drag-visibility tests can fire events directly.
+ */
+function makeRichApi(
+  groups: StubGroup[],
+  existingEdges: Set<string> = new Set(),
+): StubApi & {
+  // Exposed so tests can drive the listener directly.
+  fireWillDragPanel: () => void;
+  fireWillDragGroup: () => void;
+  fireDidMovePanel: () => void;
+  fireDidRemovePanel: () => void;
+  // Spies tracking disposer calls — assert at end of test that the
+  // returned cleanup actually disposed each subscription.
+  dragPanelDisposed: ReturnType<typeof vi.fn>;
+  dragGroupDisposed: ReturnType<typeof vi.fn>;
+  movePanelDisposed: ReturnType<typeof vi.fn>;
+  removePanelDisposed: ReturnType<typeof vi.fn>;
+} {
+  const listeners: Record<string, () => void> = {};
+  const dragPanelDisposed = vi.fn();
+  const dragGroupDisposed = vi.fn();
+  const movePanelDisposed = vi.fn();
+  const removePanelDisposed = vi.fn();
+  return {
+    groups,
+    setEdgeGroupVisible: vi.fn(),
+    getEdgeGroup: vi.fn((pos: string) =>
+      existingEdges.has(pos) ? { id: `edge-${pos}` } : undefined,
+    ),
+    removeEdgeGroup: vi.fn(),
+    addEdgeGroup: vi.fn(),
+    onWillDragPanel: vi.fn((fn: () => void) => {
+      listeners.willDragPanel = fn;
+      return { dispose: dragPanelDisposed };
+    }),
+    onWillDragGroup: vi.fn((fn: () => void) => {
+      listeners.willDragGroup = fn;
+      return { dispose: dragGroupDisposed };
+    }),
+    onDidMovePanel: vi.fn((fn: () => void) => {
+      listeners.didMovePanel = fn;
+      return { dispose: movePanelDisposed };
+    }),
+    onDidRemovePanel: vi.fn((fn: () => void) => {
+      listeners.didRemovePanel = fn;
+      return { dispose: removePanelDisposed };
+    }),
+    fireWillDragPanel: () => listeners.willDragPanel?.(),
+    fireWillDragGroup: () => listeners.willDragGroup?.(),
+    fireDidMovePanel: () => listeners.didMovePanel?.(),
+    fireDidRemovePanel: () => listeners.didRemovePanel?.(),
+    dragPanelDisposed,
+    dragGroupDisposed,
+    movePanelDisposed,
+    removePanelDisposed,
   };
 }
 
@@ -192,6 +269,14 @@ describe("refreshEdgeGroupVisibility", () => {
 // vitest's default jsdom environment is fine. Each test cleans up its
 // registrations + DOM elements to prevent cross-test leakage through
 // the module-level registry singleton.
+//
+// MAINTAINER NOTE: `innerDockviewRegistrations` is a process-wide Set
+// that persists across tests in this file (vitest does not reset the
+// module). Every test below MUST call the disposer returned by
+// `registerInnerDockview` before exiting — a leaked registration
+// would silently bleed into the next test's `findFocusedInnerDockview`
+// lookup. The `dispose()` + `document.body.removeChild()` pair at the
+// bottom of each test is non-negotiable.
 
 describe("registerInnerDockview / findFocusedInnerDockview", () => {
   it("returns null when no inner dockview is registered", () => {
@@ -274,6 +359,169 @@ describe("registerInnerDockview / findFocusedInnerDockview", () => {
     disposeB();
     document.body.removeChild(containerA);
     document.body.removeChild(containerB);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ensureEdgeGroups
+// ---------------------------------------------------------------------------
+
+describe("ensureEdgeGroups", () => {
+  it("adds all three cardinal edge groups when none exist", () => {
+    const api = makeRichApi([]);
+    ensureEdgeGroups(asApi(api));
+    expect(api.addEdgeGroup).toHaveBeenCalledTimes(3);
+    expect(api.addEdgeGroup).toHaveBeenCalledWith("left", {
+      id: EDGE_GROUP_IDS.left,
+      collapsed: true,
+    });
+    expect(api.addEdgeGroup).toHaveBeenCalledWith("right", {
+      id: EDGE_GROUP_IDS.right,
+      collapsed: true,
+    });
+    expect(api.addEdgeGroup).toHaveBeenCalledWith("bottom", {
+      id: EDGE_GROUP_IDS.bottom,
+      collapsed: true,
+    });
+  });
+
+  it("is idempotent — skips edge groups that already exist", () => {
+    // Mimic a restored layout: edge groups already present in api.groups
+    // via their EDGE_GROUP_IDS ids. addEdgeGroup must not be called.
+    const groups = [
+      makeGroup(EDGE_GROUP_IDS.left, []),
+      makeGroup(EDGE_GROUP_IDS.right, []),
+      makeGroup(EDGE_GROUP_IDS.bottom, []),
+    ];
+    const api = makeRichApi(groups);
+    ensureEdgeGroups(asApi(api));
+    expect(api.addEdgeGroup).not.toHaveBeenCalled();
+  });
+
+  it("removes a stale 'top' edge group restored from an older layout", () => {
+    // Older saved layouts may carry a "top" edge group that none of
+    // our layouts want — the helper has to clean it up.
+    const api = makeRichApi([], new Set(["top"]));
+    ensureEdgeGroups(asApi(api));
+    expect(api.removeEdgeGroup).toHaveBeenCalledWith("top");
+  });
+
+  it("does not call removeEdgeGroup when there is no 'top' group", () => {
+    // Skip the cleanup branch entirely when `getEdgeGroup("top")`
+    // returns undefined — the truthy check is the actual guard, not
+    // the try/catch (which is narrow on purpose, see the helper).
+    const api = makeRichApi([]);
+    ensureEdgeGroups(asApi(api));
+    expect(api.removeEdgeGroup).not.toHaveBeenCalled();
+  });
+
+  it("refreshes visibility after adding the edge groups", () => {
+    // The final `refreshEdgeGroupVisibility(api, false)` call should
+    // fire setEdgeGroupVisible(_, false) for each direction since all
+    // newly-added groups start empty. The groups argument is what's
+    // visible to refreshEdgeGroupVisibility — so we seed them.
+    const groups = [
+      makeGroup(EDGE_GROUP_IDS.left, []),
+      makeGroup(EDGE_GROUP_IDS.right, []),
+      makeGroup(EDGE_GROUP_IDS.bottom, []),
+    ];
+    const api = makeRichApi(groups);
+    ensureEdgeGroups(asApi(api));
+    expect(api.setEdgeGroupVisible).toHaveBeenCalledWith("left", false);
+    expect(api.setEdgeGroupVisible).toHaveBeenCalledWith("right", false);
+    expect(api.setEdgeGroupVisible).toHaveBeenCalledWith("bottom", false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// attachEdgeGroupDragVisibility
+// ---------------------------------------------------------------------------
+
+describe("attachEdgeGroupDragVisibility", () => {
+  it("subscribes to the four dockview drag events", () => {
+    const api = makeRichApi([]);
+    const dispose = attachEdgeGroupDragVisibility(asApi(api));
+    expect(api.onWillDragPanel).toHaveBeenCalledTimes(1);
+    expect(api.onWillDragGroup).toHaveBeenCalledTimes(1);
+    expect(api.onDidMovePanel).toHaveBeenCalledTimes(1);
+    expect(api.onDidRemovePanel).toHaveBeenCalledTimes(1);
+    dispose();
+  });
+
+  it("force-shows every edge group when a drag starts (onWillDragPanel)", () => {
+    // Drag-start needs the empty edges visible so the user has a
+    // drop target on each side. After `attach`, `setEdgeGroupVisible`
+    // should be called with `true` for each edge.
+    const groups = [
+      makeGroup(EDGE_GROUP_IDS.left, []),
+      makeGroup(EDGE_GROUP_IDS.right, []),
+      makeGroup(EDGE_GROUP_IDS.bottom, []),
+    ];
+    const api = makeRichApi(groups);
+    const dispose = attachEdgeGroupDragVisibility(asApi(api));
+    api.setEdgeGroupVisible.mockClear(); // ignore the initial refresh
+    api.fireWillDragPanel();
+    expect(api.setEdgeGroupVisible).toHaveBeenCalledWith("left", true);
+    expect(api.setEdgeGroupVisible).toHaveBeenCalledWith("right", true);
+    expect(api.setEdgeGroupVisible).toHaveBeenCalledWith("bottom", true);
+    dispose();
+  });
+
+  it("returns empty edges to hidden when the drag ends (onDidMovePanel)", () => {
+    const groups = [
+      makeGroup(EDGE_GROUP_IDS.left, []), // empty after drag
+      makeGroup(EDGE_GROUP_IDS.right, ["docked"]), // non-empty after drag
+      makeGroup(EDGE_GROUP_IDS.bottom, []),
+    ];
+    const api = makeRichApi(groups);
+    const dispose = attachEdgeGroupDragVisibility(asApi(api));
+    api.fireWillDragPanel(); // force visible
+    api.setEdgeGroupVisible.mockClear();
+    api.fireDidMovePanel(); // drag ended
+    expect(api.setEdgeGroupVisible).toHaveBeenCalledWith("left", false); // empty → hidden
+    expect(api.setEdgeGroupVisible).toHaveBeenCalledWith("right", true); // non-empty → visible
+    expect(api.setEdgeGroupVisible).toHaveBeenCalledWith("bottom", false);
+    dispose();
+  });
+
+  it("treats onDidRemovePanel as a drag-end signal too", () => {
+    // Dropping a panel from one group to another fires onDidRemovePanel
+    // on the source side. Both onDidMovePanel and onDidRemovePanel
+    // should reset the drag-visibility state.
+    const groups = [makeGroup(EDGE_GROUP_IDS.left, [])];
+    const api = makeRichApi(groups);
+    const dispose = attachEdgeGroupDragVisibility(asApi(api));
+    api.fireWillDragPanel();
+    api.setEdgeGroupVisible.mockClear();
+    api.fireDidRemovePanel();
+    expect(api.setEdgeGroupVisible).toHaveBeenCalledWith("left", false);
+    dispose();
+  });
+
+  it("disposer cleans up all four dockview subscriptions", () => {
+    const api = makeRichApi([]);
+    const dispose = attachEdgeGroupDragVisibility(asApi(api));
+    dispose();
+    expect(api.dragPanelDisposed).toHaveBeenCalledTimes(1);
+    expect(api.dragGroupDisposed).toHaveBeenCalledTimes(1);
+    expect(api.movePanelDisposed).toHaveBeenCalledTimes(1);
+    expect(api.removePanelDisposed).toHaveBeenCalledTimes(1);
+  });
+
+  it("disposer detaches the native drop / dragend listeners on document", () => {
+    // The handler also wires `document.addEventListener("drop", …, true)`
+    // and `"dragend"` as the Escape-cancel safety net. After dispose,
+    // firing those events should NOT call setEdgeGroupVisible.
+    const groups = [makeGroup(EDGE_GROUP_IDS.left, [])];
+    const api = makeRichApi(groups);
+    const dispose = attachEdgeGroupDragVisibility(asApi(api));
+    api.fireWillDragPanel(); // mark dragging
+    dispose();
+    api.setEdgeGroupVisible.mockClear();
+    // Dispatch a native drop event — the listener should already be
+    // detached, so this is a no-op.
+    document.dispatchEvent(new Event("drop", { bubbles: true }));
+    expect(api.setEdgeGroupVisible).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/web/tests/dockview-section-actions.test.ts
+++ b/apps/web/tests/dockview-section-actions.test.ts
@@ -578,4 +578,43 @@ describe("selectNeighbourBeforeRemove", () => {
     expect(tl.panels[0].api.setActive).not.toHaveBeenCalled();
     expect(br.panels[0].api.setActive).not.toHaveBeenCalled();
   });
+
+  // --- Single-tab group: edge-group fallback ---
+  //
+  // `selectNeighbourBeforeRemove` shares its reading-order walk with
+  // `cycleGridGroups` via `getNavigableGroupsInVisualOrder` — so an
+  // edge group with panels is a valid fallback target when the user
+  // closes the last tab in the only grid group. Without this, focus
+  // would snap to dockview's arbitrary first-in-list choice instead
+  // of the visible edge-docked panel next door.
+
+  it("falls back to an edge group with panels when the last grid tab closes", () => {
+    // Layout: grid (left, 400px wide) + edge-bottom strip (bottom, 100px tall).
+    // Closing the grid group's last tab should activate the edge group's panel.
+    const grid = makeGroup("grid", ["g-only"], {
+      rect: { left: 0, top: 0, width: 400, height: 300 },
+    });
+    const edge = makeGroup("edge-bottom", ["e-only"], {
+      location: "edge",
+      rect: { left: 0, top: 300, width: 400, height: 100 },
+    });
+    selectNeighbourBeforeRemove(asApi(makeApi([grid, edge], 0)), "g-only");
+    expect(edge.panels[0].api.setActive).toHaveBeenCalledTimes(1);
+  });
+
+  it("skips empty edge groups when picking the cross-group fallback", () => {
+    // Edge groups with no panels are NOT navigable (matches `cycleGridGroups`
+    // behaviour). With only one grid group and an empty edge, the fallback
+    // chain should find nothing — early-out via the `ordered.length <= 1`
+    // guard inside `selectNeighbourBeforeRemove`, leaving setActive untouched.
+    const grid = makeGroup("grid", ["g-only"], {
+      rect: { left: 0, top: 0, width: 400, height: 300 },
+    });
+    const emptyEdge = makeGroup("edge-bottom", [], {
+      location: "edge",
+      rect: { left: 0, top: 300, width: 400, height: 0 },
+    });
+    selectNeighbourBeforeRemove(asApi(makeApi([grid, emptyEdge], 0)), "g-only");
+    expect(grid.panels[0].api.setActive).not.toHaveBeenCalled();
+  });
 });

--- a/apps/web/tests/dockview-section-actions.test.ts
+++ b/apps/web/tests/dockview-section-actions.test.ts
@@ -68,7 +68,10 @@ interface StubGroup {
     moveToNext: ReturnType<typeof vi.fn>;
     moveToPrevious: ReturnType<typeof vi.fn>;
   };
-  api: { location: { type: "grid" | "floating" | "popout" } };
+  // `edge` groups carry an extra `position` field on the real dockview
+  // `DockviewGroupLocation`; the helpers don't read it, so we drop it
+  // from the stub.
+  api: { location: { type: "grid" | "floating" | "popout" | "edge" } };
   /** Stand-in for the runtime `element` getter dockview exposes via
    * `BasePanelView`. `cycleGridGroups` reads this through an
    * `unknown`-cast so we don't need to fake the rest of HTMLElement. */
@@ -82,7 +85,7 @@ function makePanel(id: string): StubPanel {
 }
 
 interface MakeGroupOpts {
-  location?: "grid" | "floating" | "popout";
+  location?: "grid" | "floating" | "popout" | "edge";
   activeIndex?: number;
   rect?: StubRect;
 }
@@ -355,7 +358,7 @@ describe("cycleGridGroups", () => {
   });
 
   it("enters the cycle from the first group when active group is floating/popout (direction 1)", () => {
-    // `getGridGroupsInVisualOrder` filters to grid groups, so a floating
+    // `getNavigableGroupsInVisualOrder` excludes floating/popout, so a floating
     // active group has `idx === -1`. The naive `(-1 + 1 + n) % n` formula
     // gives 0 (first group, ok), but the corresponding backward case
     // would give `n - 2` (skipping the last group) — see the next test.
@@ -434,6 +437,48 @@ describe("cycleGridGroups", () => {
     cycleGridGroups(asApi(api), 1);
     expect(visible1.panels[0].api.setActive).toHaveBeenCalledTimes(1);
     expect(ghost.panels[0].api.setActive).not.toHaveBeenCalled();
+  });
+
+  // --- Edge group inclusion ---
+  //
+  // Edge groups (left/right/bottom) are part of the cycle when they hold
+  // at least one panel, so Cmd+[/] can hop into and out of edge-docked
+  // sections. Empty edge groups stay hidden (via setEdgeGroupVisible)
+  // and must not steal a cycle stop.
+
+  it("includes an edge group with panels in the cycle", () => {
+    // Layout: edge-left strip at x=0 (width 60), grid panel at x=60.
+    // Reading order: edge-left → grid. From grid, forward should hit edge-left.
+    const edgeLeft = makeGroup("edge-left", ["e"], {
+      location: "edge",
+      rect: { left: 0, top: 0, width: 60, height: 400 },
+    });
+    const grid0 = makeGroup("g0", ["a"], {
+      rect: { left: 60, top: 0, width: 400, height: 400 },
+    });
+    const api = makeApi([edgeLeft, grid0], 1);
+    cycleGridGroups(asApi(api), 1);
+    expect(edgeLeft.panels[0].api.setActive).toHaveBeenCalledTimes(1);
+  });
+
+  it("excludes an empty edge group from the cycle", () => {
+    // Empty edge groups exist in the dockview model (added at mount,
+    // collapsed) but should never appear as a focus stop — otherwise
+    // Cmd+] from a grid panel would activate a hidden 0-panel group.
+    const emptyEdge = makeGroup("edge-bottom", [], {
+      location: "edge",
+      rect: { left: 0, top: 400, width: 400, height: 0 },
+    });
+    const grid0 = makeGroup("g0", ["a"], {
+      rect: { left: 0, top: 0, width: 400, height: 400 },
+    });
+    const grid1 = makeGroup("g1", ["b"], {
+      rect: { left: 400, top: 0, width: 400, height: 400 },
+    });
+    const api = makeApi([grid0, grid1, emptyEdge], 0);
+    cycleGridGroups(asApi(api), 1);
+    // Should jump grid0 → grid1, not grid0 → emptyEdge.
+    expect(grid1.panels[0].api.setActive).toHaveBeenCalledTimes(1);
   });
 });
 


### PR DESCRIPTION
## Summary

Adds left/right/bottom edge groups to each of the three inner dockview instances (terminal, chat, browser), matching the main outer layout. Centralised in a new `apps/web/src/lib/dockview-edge-groups.ts` so all four dockviews share one implementation.

Headline changes:

- **Edge groups in inner dockviews** — added collapsed and hidden by default; during drag every edge becomes a visible drop target and re-hides if still empty afterwards. Persistence is automatic via dockview's `toJSON()` (which serialises `SerializedEdgeGroups.visible` + `collapsed` per edge).
- **Header actions are location-aware** — split-right / split-down disappear in edge groups (dockview ignores `position.direction` when the reference group is an edge group, so the buttons were silently degrading to "add as tab"). The "+" button stays and is centered horizontally so it sits in the middle of the vertical 35px strip on left/right edges instead of flush-left.
- **Cmd+[/] cycle includes edge panels** — `getNavigableGroupsInVisualOrder` (renamed from `getGridGroupsInVisualOrder`) now returns grid groups + edge groups that hold ≥1 panel, in row-major reading order. Empty edges are excluded so they don't steal a cycle stop.
- **VSCode-style toggle shortcuts** — ⌘B / ⌥⌘B / ⌘J toggle the left / right / bottom edge respectively. Focus-aware dispatch: if the focused inner dockview has panels on that edge, toggle that; otherwise fall back to the main layout's edge (Projects on the left, etc.). Driven by a small inner-dockview registry each inner container plugs into on mount.

## Test plan

Pre-push hook (lint + format + clippy) passes. Existing `apps/web/tests/dockview-section-actions.test.ts` extended with two new cases (edge groups with panels are in the cycle, empty edge groups are excluded) — all 35 tests pass.

Manual QA against `pnpm dev:web`:

- [ ] Main layout edge panels still behave (Projects on the left toggles with ⌘B)
- [ ] Drag a terminal tab to terminal's left edge — edge becomes visible, ⌘B in terminal collapses/expands it (does NOT touch main's Projects)
- [ ] Drag a terminal tab back out — terminal's left edge re-hides, ⌘B falls back to main's Projects
- [ ] Same flow for chat and browser containers
- [ ] ⌥⌘B toggles right edge (using `e.code === "KeyB"` so macOS Alt-layer character substitution doesn't break it)
- [ ] ⌘J toggles bottom edge with the same focus-aware fallback
- [ ] Cmd+[/] cycles into and out of edge-docked panels in reading order; empty edges are skipped
- [ ] Layout (including hidden/collapsed edge state) round-trips across reloads for all four dockviews
- [ ] No regressions to existing per-section shortcuts (Cmd+T / Cmd+W / Cmd+D / Cmd+R)