### PR TITLE
fix(web): horizontal scroll + mount-once for Changes view editors

### DIFF
--- a/apps/web/e2e/diff-horizontal-scroll.spec.ts
+++ b/apps/web/e2e/diff-horizontal-scroll.spec.ts
@@ -55,11 +55,12 @@ const BRANCH = "main";
 const FILE_PATH = "long-line.txt";
 
 // A line wide enough that it's guaranteed to exceed the editor viewport
-// at our 1280-px viewport, even after accounting for the file tree
-// sidebar, gutters, and padding. Repeating `the_quick_brown_fox_jumps_over_the_lazy_dog_`
-// (44 chars) 30× gives a ~1300-char line, roughly 8000 px in a
-// 13-px monospaced font — well past the ~600 px the editor pane gets
-// inside the dockview at 1280 viewport.
+// at our 2400-px viewport, even after accounting for the project
+// sidebar, chat panel, file tree, gutters, and padding. Repeating
+// `the_quick_brown_fox_jumps_over_the_lazy_dog_` (44 chars) 30× gives a
+// ~1300-char line, roughly 8000 px in a 13-px monospaced font — well
+// past the ~800–900 px the editor pane gets inside the dockview at
+// the 2400 viewport.
 const LONG_LINE = "the_quick_brown_fox_jumps_over_the_lazy_dog_".repeat(30);
 
 // Initial committed content — short enough that there's no horizontal
@@ -203,19 +204,14 @@ async function assertScrollerHorizontallyScrolls(changes: ChangesPanelPage): Pro
   expect(overflowing!.clientHeight).toBeGreaterThan(20);
   expect(overflowing!.scrollHeight).toBeLessThanOrEqual(overflowing!.clientHeight + 1);
 
-  // 4. Round-trip a horizontal scroll. The first scroller may or
-  //    may not be the one with overflow (split mode puts the
-  //    "before" scroller first), so target it explicitly via a
-  //    locator that scrolls the overflowing scroller. Falling back
-  //    to the first scroller is fine in unified mode where there's
-  //    only one. In split mode the overflowing scroller is the
-  //    second one — we round-trip its scrollLeft via the page
-  //    object's all-scrollers locator.
+  // 4. Round-trip a horizontal scroll on the overflowing scroller.
+  //    Unified mode has a single scroller; split mode puts the
+  //    "before" scroller first and the overflowing "after" scroller
+  //    second. The page object owns the locator chain — the spec just
+  //    asks for "scroll the Nth scroller and tell me what scrollLeft
+  //    landed at", per the integration-test doctrine.
   const overflowingIndex = metrics.findIndex((m) => m.scrollWidth > m.clientWidth);
-  const finalScrollLeft = await changes.cmScrollers.nth(overflowingIndex).evaluate((el) => {
-    el.scrollLeft = 200;
-    return el.scrollLeft;
-  });
+  const finalScrollLeft = await changes.roundTripScrollLeftAt(overflowingIndex, 200);
   expect(finalScrollLeft).toBeGreaterThan(0);
 }
 

--- a/apps/web/e2e/diff-horizontal-scroll.spec.ts
+++ b/apps/web/e2e/diff-horizontal-scroll.spec.ts
@@ -6,9 +6,12 @@
  * because the naturalHeight CodeMirror config set
  * `.cm-scroller { overflow: visible }` on both axes. The fix in
  * `baseViewerExtensions` switches the scroller to
- * `overflowX: auto, overflowY: visible, height: auto` so horizontal
- * scrolling works while the vertical axis still flows with the
- * auto-height parent chain (no regression of PR #501).
+ * `overflowX: auto, height: auto` (overflowY is left to default to
+ * `visible` so the browser's CSS Overflow L3 resolution to `auto` is
+ * what lands at runtime — see `codemirror-setup.ts` for the full
+ * rationale). Horizontal scrolling works while the vertical axis
+ * still flows with the auto-height parent chain (no regression of
+ * PR #501).
  *
  * Both viewModes are exercised:
  *  - "unified" (the default) — one `.cm-scroller` per file.

--- a/apps/web/e2e/diff-horizontal-scroll.spec.ts
+++ b/apps/web/e2e/diff-horizontal-scroll.spec.ts
@@ -23,12 +23,13 @@
  * doctrine.
  */
 
-import { execFileSync } from "node:child_process";
-import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { expect, type Page, test } from "@playwright/test";
 import { toWorkspaceId } from "@/dashboard";
+import { git } from "./helpers/git";
 import {
+  cleanupTmpHome,
   createTmpHome,
   type ServerHandle,
   seedSettings,
@@ -72,18 +73,6 @@ let server: ServerHandle;
 let tmpHome: string;
 let workspaceId: string;
 
-const gitEnv = {
-  ...process.env,
-  GIT_AUTHOR_NAME: "Test",
-  GIT_AUTHOR_EMAIL: "test@test.com",
-  GIT_COMMITTER_NAME: "Test",
-  GIT_COMMITTER_EMAIL: "test@test.com",
-};
-
-function git(cwd: string, args: string[]): void {
-  execFileSync("git", args, { cwd, env: gitEnv });
-}
-
 test.beforeAll(async () => {
   tmpHome = createTmpHome();
   const repoPath = join(tmpHome, REPO_NAME);
@@ -117,17 +106,7 @@ test.beforeAll(async () => {
 
 test.afterAll(async () => {
   await server.close();
-  // The Band server writes status files in the background (HTTP /healthz
-  // probes, branch-status SSE, etc.) and a SIGTERM cleanup race can leave
-  // a fresh file in `~/.band/status` between our final `await` and the
-  // `rmSync`. Swallowing the ENOTEMPTY keeps the test result anchored on
-  // the assertions rather than tmp-cleanup noise — Playwright's per-run
-  // tmp isolation means we don't accumulate cruft across runs anyway.
-  try {
-    rmSync(tmpHome, { recursive: true, force: true });
-  } catch {
-    /* tmp directory cleanup is best-effort */
-  }
+  cleanupTmpHome(tmpHome);
 });
 
 /**
@@ -211,15 +190,18 @@ async function assertScrollerHorizontallyScrolls(changes: ChangesPanelPage): Pro
   const overflowing = metrics.find((m) => m.scrollWidth > m.clientWidth);
   expect(overflowing).toBeDefined();
   // 3. Natural-height guard on the overflowing scroller — no
-  //    internal vertical scrollbar (`scrollHeight` matches
-  //    `clientHeight`) and a non-trivial height. This is what
-  //    guards against PR #501's natural-height fix regressing in
-  //    tandem with this horizontal-scroll change — if `height: auto`
-  //    ever dropped off `.cm-scroller`, content would overflow
-  //    vertically and `scrollHeight` would diverge from
-  //    `clientHeight`.
+  //    internal vertical scrollbar (`scrollHeight` ≈ `clientHeight`)
+  //    and a non-trivial height. This is what guards against PR
+  //    #501's natural-height fix regressing in tandem with this
+  //    horizontal-scroll change — if `height: auto` ever dropped off
+  //    `.cm-scroller`, content would overflow vertically and
+  //    `scrollHeight` would diverge from `clientHeight` by far more
+  //    than the 1-px subpixel-rounding tolerance below. We allow
+  //    that 1-px slop because some browsers / device-pixel ratios
+  //    round `scrollHeight` up by one even when there's no actual
+  //    overflow.
   expect(overflowing!.clientHeight).toBeGreaterThan(20);
-  expect(overflowing!.scrollHeight).toBe(overflowing!.clientHeight);
+  expect(overflowing!.scrollHeight).toBeLessThanOrEqual(overflowing!.clientHeight + 1);
 
   // 4. Round-trip a horizontal scroll. The first scroller may or
   //    may not be the one with overflow (split mode puts the

--- a/apps/web/e2e/diff-horizontal-scroll.spec.ts
+++ b/apps/web/e2e/diff-horizontal-scroll.spec.ts
@@ -25,7 +25,7 @@
 
 import { mkdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
-import { expect, type Page, test } from "@playwright/test";
+import { expect, test } from "@playwright/test";
 import { toWorkspaceId } from "@/dashboard";
 import { git } from "./helpers/git";
 import {
@@ -36,7 +36,7 @@ import {
   seedState,
   startServer,
 } from "./helpers/server";
-import { ChangesPanelPage, type DiffViewMode } from "./pages/ChangesPanelPage";
+import { ChangesPanelPage } from "./pages/ChangesPanelPage";
 
 // Wide viewport so `useIsDesktop()` reports true and the shared dockview
 // renders. The default dockview layout splits horizontally between the
@@ -109,31 +109,6 @@ test.afterAll(async () => {
   await server.close();
   cleanupTmpHome(tmpHome);
 });
-
-/**
- * Open the workspace's Changes panel with `expandAll` on (so the file's
- * editor mounts on first paint), then switch to the requested viewMode
- * via its toggle button. We switch via the toggle rather than seeding
- * localStorage because DiffView's `effectiveViewMode` can silently
- * downgrade split → unified on narrow scroll containers — the toggle
- * exposes the same surface a real user has, and the resulting UI
- * state is what we want to assert against.
- */
-async function openChangesWithFileExpanded(
-  page: Page,
-  viewMode: DiffViewMode,
-): Promise<ChangesPanelPage> {
-  const changes = new ChangesPanelPage(page, server.url, TOKEN);
-  await changes.openWorkspace(workspaceId, { expandAll: true });
-  // The file row appears in two places (the file tree sidebar AND the
-  // diff row header button) — wait for the diff row button explicitly
-  // since that's the surface the editor hangs off.
-  await expect(changes.fileRowButton(FILE_PATH, "M")).toBeVisible({ timeout: 15_000 });
-  if (viewMode === "split") {
-    await changes.setViewMode("split");
-  }
-  return changes;
-}
 
 /**
  * Assert horizontal scrolling works.
@@ -216,14 +191,30 @@ async function assertScrollerHorizontallyScrolls(changes: ChangesPanelPage): Pro
 }
 
 test("Changes view scrolls horizontally (unified mode)", async ({ page }) => {
-  const changes = await openChangesWithFileExpanded(page, "unified");
+  const changes = await ChangesPanelPage.openWithFileExpanded({
+    page,
+    baseUrl: server.url,
+    token: TOKEN,
+    workspaceId,
+    filename: FILE_PATH,
+    fileStatus: "M",
+    viewMode: "unified",
+  });
   // Unified mode renders one `.cm-scroller` per visible expanded file.
   await expect(changes.cmScrollers).toHaveCount(1, { timeout: 15_000 });
   await assertScrollerHorizontallyScrolls(changes);
 });
 
 test("Changes view scrolls horizontally (split mode)", async ({ page }) => {
-  const changes = await openChangesWithFileExpanded(page, "split");
+  const changes = await ChangesPanelPage.openWithFileExpanded({
+    page,
+    baseUrl: server.url,
+    token: TOKEN,
+    workspaceId,
+    filename: FILE_PATH,
+    fileStatus: "M",
+    viewMode: "split",
+  });
   // Split mode (MergeView) renders TWO scrollers per file — one for
   // the "before" side and one for the "after" side. The fix has to
   // apply to both since both editors go through

--- a/apps/web/e2e/diff-horizontal-scroll.spec.ts
+++ b/apps/web/e2e/diff-horizontal-scroll.spec.ts
@@ -1,0 +1,252 @@
+/**
+ * End-to-end coverage for horizontal scrolling in the Changes view.
+ *
+ * Long lines (minified JS, generated SQL, base64 payloads, etc.) used
+ * to be silently clipped by `overflow-clip` on `LazyFileRow`'s root
+ * because the naturalHeight CodeMirror config set
+ * `.cm-scroller { overflow: visible }` on both axes. The fix in
+ * `baseViewerExtensions` switches the scroller to
+ * `overflowX: auto, overflowY: visible, height: auto` so horizontal
+ * scrolling works while the vertical axis still flows with the
+ * auto-height parent chain (no regression of PR #501).
+ *
+ * Both viewModes are exercised:
+ *  - "unified" (the default) — one `.cm-scroller` per file.
+ *  - "split"  — MergeView renders two `.cm-scroller` instances per
+ *    file; the fix has to apply equally to both, since both go through
+ *    `baseViewerExtensions(isDark, { naturalHeight: true })`.
+ *
+ * Drives a real Band server against an on-disk worktree so the diff
+ * payload reaches CodeMirror through the same git pipeline production
+ * uses — no tRPC mocking. All locators and setup live in
+ * `pages/ChangesPanelPage.ts` per the `write-integration-test`
+ * doctrine.
+ */
+
+import { execFileSync } from "node:child_process";
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { expect, type Page, test } from "@playwright/test";
+import { toWorkspaceId } from "@/dashboard";
+import {
+  createTmpHome,
+  type ServerHandle,
+  seedSettings,
+  seedState,
+  startServer,
+} from "./helpers/server";
+import { ChangesPanelPage, type DiffViewMode } from "./pages/ChangesPanelPage";
+
+// Wide viewport so `useIsDesktop()` reports true and the shared dockview
+// renders. The default dockview layout splits horizontally between the
+// project sidebar, the chat panel and the right group (where Changes
+// lives), with a file-tree sub-panel inside the Changes group at desktop
+// widths. At 1920 px the Changes scroll container lands around 620 px —
+// just under the 640-px `SPLIT_VIEW_MIN_WIDTH` floor in DiffView, where
+// it's silently downgraded to unified. 2400 px clears the threshold
+// comfortably (Changes panel ≈ 800–900 px), so the "split" parameter
+// case actually renders a MergeView.
+test.use({ viewport: { width: 2400, height: 800 } });
+
+const TOKEN = "e2e-diff-hscroll-token";
+const REPO_NAME = "hscroll-repo";
+const BRANCH = "main";
+const FILE_PATH = "long-line.txt";
+
+// A line wide enough that it's guaranteed to exceed the editor viewport
+// at our 1280-px viewport, even after accounting for the file tree
+// sidebar, gutters, and padding. Repeating `the_quick_brown_fox_jumps_over_the_lazy_dog_`
+// (44 chars) 30× gives a ~1300-char line, roughly 8000 px in a
+// 13-px monospaced font — well past the ~600 px the editor pane gets
+// inside the dockview at 1280 viewport.
+const LONG_LINE = "the_quick_brown_fox_jumps_over_the_lazy_dog_".repeat(30);
+
+// Initial committed content — short enough that there's no horizontal
+// overflow at HEAD. The uncommitted modification below adds the long
+// line so the diff payload reaches CodeMirror with content wider than
+// its container.
+const INITIAL_CONTENT = "first line\nsecond line\nthird line\n";
+const MODIFIED_CONTENT = `first line\nsecond line\nthird line\n${LONG_LINE}\n`;
+
+let server: ServerHandle;
+let tmpHome: string;
+let workspaceId: string;
+
+const gitEnv = {
+  ...process.env,
+  GIT_AUTHOR_NAME: "Test",
+  GIT_AUTHOR_EMAIL: "test@test.com",
+  GIT_COMMITTER_NAME: "Test",
+  GIT_COMMITTER_EMAIL: "test@test.com",
+};
+
+function git(cwd: string, args: string[]): void {
+  execFileSync("git", args, { cwd, env: gitEnv });
+}
+
+test.beforeAll(async () => {
+  tmpHome = createTmpHome();
+  const repoPath = join(tmpHome, REPO_NAME);
+  mkdirSync(repoPath, { recursive: true });
+
+  // Seed a real git repo with the file committed at HEAD, then leave a
+  // modified version on disk so `git diff` produces an uncommitted hunk
+  // containing the long line. The Changes view fetches that hunk via
+  // `workspace.getFileDiff` exactly the way production does — no mock
+  // layer.
+  git(repoPath, ["init", "-b", BRANCH]);
+  writeFileSync(join(repoPath, FILE_PATH), INITIAL_CONTENT);
+  git(repoPath, ["add", "."]);
+  git(repoPath, ["commit", "-m", "initial"]);
+  writeFileSync(join(repoPath, FILE_PATH), MODIFIED_CONTENT);
+
+  seedState(tmpHome, {
+    projects: [
+      {
+        name: REPO_NAME,
+        path: repoPath,
+        defaultBranch: BRANCH,
+        worktrees: [{ branch: BRANCH, path: repoPath }],
+      },
+    ],
+  });
+  seedSettings(tmpHome, { tokenSecret: TOKEN });
+  server = await startServer({ tmpHome });
+  workspaceId = toWorkspaceId(REPO_NAME, BRANCH);
+});
+
+test.afterAll(async () => {
+  await server.close();
+  // The Band server writes status files in the background (HTTP /healthz
+  // probes, branch-status SSE, etc.) and a SIGTERM cleanup race can leave
+  // a fresh file in `~/.band/status` between our final `await` and the
+  // `rmSync`. Swallowing the ENOTEMPTY keeps the test result anchored on
+  // the assertions rather than tmp-cleanup noise — Playwright's per-run
+  // tmp isolation means we don't accumulate cruft across runs anyway.
+  try {
+    rmSync(tmpHome, { recursive: true, force: true });
+  } catch {
+    /* tmp directory cleanup is best-effort */
+  }
+});
+
+/**
+ * Open the workspace's Changes panel with `expandAll` on (so the file's
+ * editor mounts on first paint), then switch to the requested viewMode
+ * via its toggle button. We switch via the toggle rather than seeding
+ * localStorage because DiffView's `effectiveViewMode` can silently
+ * downgrade split → unified on narrow scroll containers — the toggle
+ * exposes the same surface a real user has, and the resulting UI
+ * state is what we want to assert against.
+ */
+async function openChangesWithFileExpanded(
+  page: Page,
+  viewMode: DiffViewMode,
+): Promise<ChangesPanelPage> {
+  const changes = new ChangesPanelPage(page, server.url, TOKEN);
+  await changes.openWorkspace(workspaceId, { expandAll: true });
+  // The file row appears in two places (the file tree sidebar AND the
+  // diff row header button) — wait for the diff row button explicitly
+  // since that's the surface the editor hangs off.
+  await expect(changes.fileRowButton(FILE_PATH, "M")).toBeVisible({ timeout: 15_000 });
+  if (viewMode === "split") {
+    await changes.setViewMode("split");
+  }
+  return changes;
+}
+
+/**
+ * Assert horizontal scrolling works.
+ *
+ * The fix applies STRUCTURALLY to every scroller in `naturalHeight`
+ * mode (every `.cm-scroller` gets `overflow-x: auto`), but only
+ * scrollers whose content is wider than their viewport will
+ * *demonstrate* the fix at runtime. In unified mode there's one
+ * scroller and it carries the long line; in split mode there are two
+ * scrollers and only the "after" side has the long line (the "before"
+ * side has the short pre-edit text).
+ *
+ * The assertions split along that fault line:
+ *  1. Structural: every scroller computes `overflow-x: auto`.
+ *  2. Behavioural: at least one scroller has `scrollWidth > clientWidth`
+ *     AND its `scrollLeft` round-trips a non-zero write.
+ *  3. Natural-height guard: that same scroller's `scrollHeight ===
+ *     clientHeight` (no internal vertical scrollbar), proving PR #501's
+ *     natural-height behaviour wasn't regressed by this fix.
+ */
+async function assertScrollerHorizontallyScrolls(changes: ChangesPanelPage): Promise<void> {
+  // Wait for CodeMirror's async setup (load language → mount view →
+  // first paint) to settle so the scrollers have real measurements.
+  // Polling on "at least one scroller has horizontal overflow" is
+  // deterministic — until CodeMirror lays out, scrollWidth equals
+  // clientWidth, so the predicate stays false; once the long line is
+  // typeset, exactly one scroller flips true.
+  await expect
+    .poll(
+      async () => {
+        const metrics = await changes.allScrollerMetrics();
+        if (metrics.length === 0) return false;
+        return metrics.some((m) => m.scrollWidth > m.clientWidth && m.clientHeight > 20);
+      },
+      {
+        message:
+          "at least one cm-scroller should report content wider than its viewport and non-zero height",
+        timeout: 10_000,
+      },
+    )
+    .toBe(true);
+
+  const metrics = await changes.allScrollerMetrics();
+  // 1. Structural: the fix applies to every scroller. `overflow-x:
+  //    auto` lets the browser show a scrollbar and accept
+  //    `scrollLeft` writes, so this is the single most direct
+  //    assertion against the pre-fix `overflow: visible` state.
+  for (const m of metrics) {
+    expect(m.computedOverflowX).toMatch(/auto|scroll/);
+  }
+
+  // 2. Behavioural: at least one scroller has horizontal overflow
+  //    (the "after" side in split mode, or the only scroller in
+  //    unified mode). Pull that scroller's full metrics including
+  //    scrollHeight for the natural-height guard below.
+  const overflowing = metrics.find((m) => m.scrollWidth > m.clientWidth);
+  expect(overflowing).toBeDefined();
+  // 3. Natural-height guard on the overflowing scroller — no
+  //    internal vertical scrollbar (scrollHeight matches
+  //    clientHeight). This is what guards against the PR #501
+  //    natural-height regression coming back together with the
+  //    horizontal-scroll fix.
+  expect(overflowing!.clientHeight).toBeGreaterThan(20);
+
+  // 4. Round-trip a horizontal scroll. The first scroller may or
+  //    may not be the one with overflow (split mode puts the
+  //    "before" scroller first), so target it explicitly via a
+  //    locator that scrolls the overflowing scroller. Falling back
+  //    to the first scroller is fine in unified mode where there's
+  //    only one. In split mode the overflowing scroller is the
+  //    second one — we round-trip its scrollLeft via the page
+  //    object's all-scrollers locator.
+  const overflowingIndex = metrics.findIndex((m) => m.scrollWidth > m.clientWidth);
+  const finalScrollLeft = await changes.cmScrollers.nth(overflowingIndex).evaluate((el) => {
+    el.scrollLeft = 200;
+    return el.scrollLeft;
+  });
+  expect(finalScrollLeft).toBeGreaterThan(0);
+}
+
+test("Changes view scrolls horizontally (unified mode)", async ({ page }) => {
+  const changes = await openChangesWithFileExpanded(page, "unified");
+  // Unified mode renders one `.cm-scroller` per visible expanded file.
+  await expect(changes.cmScrollers).toHaveCount(1, { timeout: 15_000 });
+  await assertScrollerHorizontallyScrolls(changes);
+});
+
+test("Changes view scrolls horizontally (split mode)", async ({ page }) => {
+  const changes = await openChangesWithFileExpanded(page, "split");
+  // Split mode (MergeView) renders TWO scrollers per file — one for
+  // the "before" side and one for the "after" side. The fix has to
+  // apply to both since both editors go through
+  // `baseViewerExtensions(..., { naturalHeight: true })`.
+  await expect(changes.cmScrollers).toHaveCount(2, { timeout: 15_000 });
+  await assertScrollerHorizontallyScrolls(changes);
+});

--- a/apps/web/e2e/diff-horizontal-scroll.spec.ts
+++ b/apps/web/e2e/diff-horizontal-scroll.spec.ts
@@ -207,16 +207,19 @@ async function assertScrollerHorizontallyScrolls(changes: ChangesPanelPage): Pro
 
   // 2. Behavioural: at least one scroller has horizontal overflow
   //    (the "after" side in split mode, or the only scroller in
-  //    unified mode). Pull that scroller's full metrics including
-  //    scrollHeight for the natural-height guard below.
+  //    unified mode).
   const overflowing = metrics.find((m) => m.scrollWidth > m.clientWidth);
   expect(overflowing).toBeDefined();
   // 3. Natural-height guard on the overflowing scroller — no
-  //    internal vertical scrollbar (scrollHeight matches
-  //    clientHeight). This is what guards against the PR #501
-  //    natural-height regression coming back together with the
-  //    horizontal-scroll fix.
+  //    internal vertical scrollbar (`scrollHeight` matches
+  //    `clientHeight`) and a non-trivial height. This is what
+  //    guards against PR #501's natural-height fix regressing in
+  //    tandem with this horizontal-scroll change — if `height: auto`
+  //    ever dropped off `.cm-scroller`, content would overflow
+  //    vertically and `scrollHeight` would diverge from
+  //    `clientHeight`.
   expect(overflowing!.clientHeight).toBeGreaterThan(20);
+  expect(overflowing!.scrollHeight).toBe(overflowing!.clientHeight);
 
   // 4. Round-trip a horizontal scroll. The first scroller may or
   //    may not be the one with overflow (split mode puts the

--- a/apps/web/e2e/diff-mount-once.spec.ts
+++ b/apps/web/e2e/diff-mount-once.spec.ts
@@ -121,7 +121,12 @@ test("LazyFileRow keeps the CodeMirror editor mounted across scroll-aways", asyn
   // chrome past ~600 px tall, the spacer might no longer auto-mount
   // and the assertion below would time out — that's the layout
   // dependency to revisit.
-  await expect(changes.cmEditors).toHaveCount(2, { timeout: 15_000 });
+  await expect
+    .poll(async () => await changes.mountedEditorCount(), {
+      message: "both file rows should have mounted editors on first paint",
+      timeout: 15_000,
+    })
+    .toBe(2);
 
   // Tag the first file's editor (`a.txt` — alphabetical first per the
   // tree flatten order) with a stable marker so we can verify DOM
@@ -171,5 +176,5 @@ test("LazyFileRow keeps the CodeMirror editor mounted across scroll-aways", asyn
   // Sanity: only two editors are mounted (one per file), so the LRU
   // cap is nowhere near triggered. This is a defensive check that
   // the test isn't accidentally exercising an eviction code path.
-  await expect(changes.cmEditors).toHaveCount(2);
+  expect(await changes.mountedEditorCount()).toBe(2);
 });

--- a/apps/web/e2e/diff-mount-once.spec.ts
+++ b/apps/web/e2e/diff-mount-once.spec.ts
@@ -1,0 +1,184 @@
+/**
+ * End-to-end coverage for the mount-once policy in DiffView's `LazyFileRow`.
+ *
+ * Before this change, each row's CodeMirror editor was torn down whenever
+ * the row scrolled outside the IntersectionObserver's 800-px rootMargin
+ * zone and re-mounted on return — paying the `loadLanguage` + new
+ * MergeView + first-paint cost every time, with a one-frame flicker
+ * between placeholder and re-mounted editor. The new policy keeps any
+ * editor that has been scrolled into view alive for the rest of the
+ * workspace session (bounded by `MAX_MOUNTED_EDITORS` in DiffView), so
+ * subsequent scroll-backs hit the same DOM instance with no re-mount.
+ *
+ * Test shape:
+ *  1. Create a real git repo with a small file ("a.txt") and a tall file
+ *     ("b-spacer.txt") whose diff is large enough to push a.txt well
+ *     outside the 800-px IO zone when scrolled past.
+ *  2. Open the workspace's Changes panel with expand-all on, so both
+ *     files mount automatically as the user scrolls.
+ *  3. Tag a.txt's `.cm-editor` with a unique JS property on first paint.
+ *  4. Scroll the diff scroller past b-spacer so a.txt is far above the
+ *     viewport (well beyond the IO zone), then scroll back.
+ *  5. Assert (a) the editor count stays at 2 across the scroll-away
+ *     (so neither editor was torn down) and (b) the tag is still on the
+ *     same `.cm-editor` element after scroll-back (DOM identity proof).
+ *
+ * Anti-pattern: do NOT assert on absolute pixel offsets or scroll
+ * latency. Use `expect.poll` and DOM identity checks per the
+ * `write-integration-test` skill. All locators / setup live in
+ * `pages/ChangesPanelPage.ts` per the same doctrine.
+ */
+
+import { execFileSync } from "node:child_process";
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { expect, test } from "@playwright/test";
+import { toWorkspaceId } from "@/dashboard";
+import {
+  createTmpHome,
+  type ServerHandle,
+  seedSettings,
+  seedState,
+  startServer,
+} from "./helpers/server";
+import { ChangesPanelPage } from "./pages/ChangesPanelPage";
+
+test.use({ viewport: { width: 1280, height: 800 } });
+
+const TOKEN = "e2e-diff-mount-once-token";
+const REPO_NAME = "mount-once-repo";
+const BRANCH = "main";
+const SMALL_FILE = "a.txt";
+const SPACER_FILE = "b-spacer.txt";
+
+// Tall enough diff that scrolling past it pushes `a.txt` well beyond
+// the IO observer's 800-px rootMargin zone. 400 lines × ~16 px/line
+// ≈ 6400 px — comfortable headroom over the threshold.
+const SPACER_NEW_LINES = Array.from({ length: 400 }, (_, i) => `spacer line ${i}`).join("\n");
+
+let server: ServerHandle;
+let tmpHome: string;
+let workspaceId: string;
+
+const gitEnv = {
+  ...process.env,
+  GIT_AUTHOR_NAME: "Test",
+  GIT_AUTHOR_EMAIL: "test@test.com",
+  GIT_COMMITTER_NAME: "Test",
+  GIT_COMMITTER_EMAIL: "test@test.com",
+};
+
+function git(cwd: string, args: string[]): void {
+  execFileSync("git", args, { cwd, env: gitEnv });
+}
+
+test.beforeAll(async () => {
+  tmpHome = createTmpHome();
+  const repoPath = join(tmpHome, REPO_NAME);
+  mkdirSync(repoPath, { recursive: true });
+
+  // Two committed files; uncommitted modifications produce the diff
+  // hunks the Changes panel renders. The diff for `a.txt` is short (one
+  // line added) while `b-spacer.txt`'s is intentionally tall so it
+  // dominates the scroll height.
+  git(repoPath, ["init", "-b", BRANCH]);
+  writeFileSync(join(repoPath, SMALL_FILE), "original line\n");
+  writeFileSync(join(repoPath, SPACER_FILE), "spacer original\n");
+  git(repoPath, ["add", "."]);
+  git(repoPath, ["commit", "-m", "initial"]);
+  // Modify both files so each has an uncommitted diff
+  writeFileSync(join(repoPath, SMALL_FILE), "original line\nadded line\n");
+  writeFileSync(join(repoPath, SPACER_FILE), `spacer original\n${SPACER_NEW_LINES}\n`);
+
+  seedState(tmpHome, {
+    projects: [
+      {
+        name: REPO_NAME,
+        path: repoPath,
+        defaultBranch: BRANCH,
+        worktrees: [{ branch: BRANCH, path: repoPath }],
+      },
+    ],
+  });
+  seedSettings(tmpHome, { tokenSecret: TOKEN });
+  server = await startServer({ tmpHome });
+  workspaceId = toWorkspaceId(REPO_NAME, BRANCH);
+});
+
+test.afterAll(async () => {
+  await server.close();
+  // Best-effort tmp cleanup — see diff-horizontal-scroll.spec.ts for
+  // the rationale on swallowing ENOTEMPTY here.
+  try {
+    rmSync(tmpHome, { recursive: true, force: true });
+  } catch {
+    /* tmp directory cleanup is best-effort */
+  }
+});
+
+test("LazyFileRow keeps the CodeMirror editor mounted across scroll-aways", async ({ page }) => {
+  const changes = new ChangesPanelPage(page, server.url, TOKEN);
+  await changes.openWorkspace(workspaceId, { expandAll: true });
+
+  // Both file headers should be in the DOM (auto-expanded). Wait on
+  // the spacer's row to ensure the summary fetch has resolved and the
+  // file list is rendered.
+  await expect(changes.fileRowButton(SPACER_FILE, "M")).toBeVisible({ timeout: 15_000 });
+  await expect(changes.scroller).toBeVisible();
+
+  // Wait for both editors to mount on first paint. With expand-all on
+  // and the spacer being long, the first row's editor mounts immediately
+  // (it intersects the viewport) and the spacer's mounts because its
+  // top edge is inside the 800-px IO rootMargin.
+  await expect(changes.cmEditors).toHaveCount(2, { timeout: 15_000 });
+
+  // Tag the first file's editor (`a.txt` — alphabetical first per the
+  // tree flatten order) with a stable marker so we can verify DOM
+  // identity after a scroll dance. If the row's editor is destroyed
+  // and re-mounted, the new `.cm-editor` element won't carry the
+  // marker.
+  await changes.tagFirstEditor("alive");
+
+  // Scroll well past the spacer file so `a.txt`'s row is far above the
+  // viewport (way beyond the 800-px IO rootMargin). 5000 px is plenty
+  // — the spacer's editor body alone is ~6400 px tall.
+  await changes.scrollTo(5000);
+
+  // Wait for the IntersectionObserver to react to the scroll. The
+  // observer fires asynchronously after the layout settles; polling
+  // on `.cm-editor` count is deterministic because the count is a
+  // direct effect of the IO callback. With mount-once, the count
+  // stays at 2 (both editors alive) even when one row is far
+  // outside the viewport. With the pre-mount-once behaviour the IO
+  // would have torn down `a.txt`'s editor here, dropping the count
+  // to 1 — so this is the assertion that catches the regression
+  // most directly.
+  await expect
+    .poll(async () => await changes.mountedEditorCount(), {
+      message: "editor count should stay at 2 across scroll-away (mount-once)",
+      timeout: 5_000,
+    })
+    .toBe(2);
+
+  // Belt-and-braces: the first editor's DOM element is STILL the one
+  // we tagged at the start (same JS identity, not a freshly remounted
+  // instance that happens to be at position 0 in the locator).
+  expect(await changes.firstEditorMarker()).toBe("alive");
+
+  // Scroll back to the top and confirm the marker is STILL the same
+  // element we marked originally (not a freshly mounted instance).
+  await changes.scrollTo(0);
+  await expect
+    .poll(async () => await changes.scrollTop(), {
+      message: "scroller should have committed the scroll-back",
+      timeout: 5_000,
+    })
+    .toBeLessThan(50);
+
+  expect(await changes.firstEditorMarker()).toBe("alive");
+
+  // Sanity: only two editors are mounted (one per file), so the LRU
+  // cap is nowhere near triggered. This is a defensive check that
+  // the test isn't accidentally exercising an eviction code path.
+  await expect(changes.cmEditors).toHaveCount(2);
+});

--- a/apps/web/e2e/diff-mount-once.spec.ts
+++ b/apps/web/e2e/diff-mount-once.spec.ts
@@ -110,9 +110,17 @@ test("LazyFileRow keeps the CodeMirror editor mounted across scroll-aways", asyn
   await expect(changes.scroller).toBeVisible();
 
   // Wait for both editors to mount on first paint. With expand-all on
-  // and the spacer being long, the first row's editor mounts immediately
-  // (it intersects the viewport) and the spacer's mounts because its
-  // top edge is inside the 800-px IO rootMargin.
+  // and the 1280×800 viewport: the Changes panel takes the bottom of
+  // the dockview right group, so its scroll container starts roughly
+  // 80–100 px below the viewport top (header + toolbar chrome). The
+  // first row's editor (a.txt, one-line diff ≈ 80 px) mounts
+  // immediately — it intersects the viewport. The spacer's header
+  // button is positioned right under it, so its top edge lands well
+  // inside the 800-px IO rootMargin zone and its editor auto-mounts
+  // on the same paint. If a future layout change pushes the panel
+  // chrome past ~600 px tall, the spacer might no longer auto-mount
+  // and the assertion below would time out — that's the layout
+  // dependency to revisit.
   await expect(changes.cmEditors).toHaveCount(2, { timeout: 15_000 });
 
   // Tag the first file's editor (`a.txt` — alphabetical first per the

--- a/apps/web/e2e/diff-mount-once.spec.ts
+++ b/apps/web/e2e/diff-mount-once.spec.ts
@@ -29,12 +29,13 @@
  * `pages/ChangesPanelPage.ts` per the same doctrine.
  */
 
-import { execFileSync } from "node:child_process";
-import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { expect, test } from "@playwright/test";
 import { toWorkspaceId } from "@/dashboard";
+import { git } from "./helpers/git";
 import {
+  cleanupTmpHome,
   createTmpHome,
   type ServerHandle,
   seedSettings,
@@ -59,18 +60,6 @@ const SPACER_NEW_LINES = Array.from({ length: 400 }, (_, i) => `spacer line ${i}
 let server: ServerHandle;
 let tmpHome: string;
 let workspaceId: string;
-
-const gitEnv = {
-  ...process.env,
-  GIT_AUTHOR_NAME: "Test",
-  GIT_AUTHOR_EMAIL: "test@test.com",
-  GIT_COMMITTER_NAME: "Test",
-  GIT_COMMITTER_EMAIL: "test@test.com",
-};
-
-function git(cwd: string, args: string[]): void {
-  execFileSync("git", args, { cwd, env: gitEnv });
-}
 
 test.beforeAll(async () => {
   tmpHome = createTmpHome();
@@ -107,13 +96,7 @@ test.beforeAll(async () => {
 
 test.afterAll(async () => {
   await server.close();
-  // Best-effort tmp cleanup — see diff-horizontal-scroll.spec.ts for
-  // the rationale on swallowing ENOTEMPTY here.
-  try {
-    rmSync(tmpHome, { recursive: true, force: true });
-  } catch {
-    /* tmp directory cleanup is best-effort */
-  }
+  cleanupTmpHome(tmpHome);
 });
 
 test("LazyFileRow keeps the CodeMirror editor mounted across scroll-aways", async ({ page }) => {

--- a/apps/web/e2e/find-in-markdown-preview.spec.ts
+++ b/apps/web/e2e/find-in-markdown-preview.spec.ts
@@ -14,11 +14,11 @@
  * the no-paint path.
  */
 
-import { execFileSync } from "node:child_process";
 import { mkdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { expect, type Page, test } from "@playwright/test";
 import { toWorkspaceId } from "@/dashboard";
+import { git } from "./helpers/git";
 import {
   cleanupTmpHome,
   createTmpHome,
@@ -63,18 +63,6 @@ const MARKDOWN_CONTENT = [
 let server: ServerHandle;
 let tmpHome: string;
 let workspaceId: string;
-
-const gitEnv = {
-  ...process.env,
-  GIT_AUTHOR_NAME: "Test",
-  GIT_AUTHOR_EMAIL: "test@test.com",
-  GIT_COMMITTER_NAME: "Test",
-  GIT_COMMITTER_EMAIL: "test@test.com",
-};
-
-function git(cwd: string, args: string[]): void {
-  execFileSync("git", args, { cwd, env: gitEnv });
-}
 
 test.beforeAll(async () => {
   tmpHome = createTmpHome();

--- a/apps/web/e2e/helpers/git.ts
+++ b/apps/web/e2e/helpers/git.ts
@@ -1,0 +1,27 @@
+/**
+ * Shared git helpers for e2e tests that need a real on-disk repository
+ * as a fixture. The existing `find-in-markdown-preview.spec.ts`,
+ * `diff-horizontal-scroll.spec.ts`, and `diff-mount-once.spec.ts` all
+ * built their own copy of these — centralised here so future tests
+ * don't keep duplicating the same git-identity env block.
+ */
+
+import { execFileSync } from "node:child_process";
+
+/** Git environment with deterministic author/committer identity so
+ *  commits hashes are reproducible across runs (and CI doesn't need
+ *  `user.name` / `user.email` set globally). */
+export const gitEnv = {
+  ...process.env,
+  GIT_AUTHOR_NAME: "Test",
+  GIT_AUTHOR_EMAIL: "test@test.com",
+  GIT_COMMITTER_NAME: "Test",
+  GIT_COMMITTER_EMAIL: "test@test.com",
+};
+
+/** Run a git command in the given working directory, throwing on
+ *  failure. Thin wrapper around `execFileSync` that pins the env so
+ *  every test's git output is reproducible. */
+export function git(cwd: string, args: string[]): void {
+  execFileSync("git", args, { cwd, env: gitEnv });
+}

--- a/apps/web/e2e/helpers/git.ts
+++ b/apps/web/e2e/helpers/git.ts
@@ -1,9 +1,10 @@
 /**
  * Shared git helpers for e2e tests that need a real on-disk repository
- * as a fixture. The existing `find-in-markdown-preview.spec.ts`,
- * `diff-horizontal-scroll.spec.ts`, and `diff-mount-once.spec.ts` all
- * built their own copy of these — centralised here so future tests
- * don't keep duplicating the same git-identity env block.
+ * as a fixture. Extracted from `find-in-markdown-preview.spec.ts`,
+ * which had carried its own inline copy of the identity env + the
+ * `git()` shell-out wrapper. `diff-horizontal-scroll.spec.ts` and
+ * `diff-mount-once.spec.ts` use this helper from the start so the
+ * pattern doesn't keep duplicating itself across the test suite.
  */
 
 import { execFileSync } from "node:child_process";

--- a/apps/web/e2e/pages/ChangesPanelPage.ts
+++ b/apps/web/e2e/pages/ChangesPanelPage.ts
@@ -39,12 +39,20 @@ export class ChangesPanelPage {
   readonly scroller: Locator;
   /** Every `.cm-editor` rendered inside the panel. In unified mode
    *  there's one per visible expanded file; in split mode each visible
-   *  expanded file contributes two (one per side of the MergeView). */
+   *  expanded file contributes two (one per side of the MergeView).
+   *
+   *  FRAGILITY: this is a CSS-class locator against a class owned by
+   *  CodeMirror (`@codemirror/view`'s baseTheme), which the doctrine
+   *  prefers we avoid for elements we own. CodeMirror doesn't expose a
+   *  testid hook on its own DOM, so this is the least-bad anchor —
+   *  but a major-version upgrade that renames `.cm-editor` (or splits
+   *  it into multiple class names) silently breaks every test that
+   *  uses this locator. The mitigation is to centralise the literal
+   *  here so a CM upgrade flows through one file. */
   readonly cmEditors: Locator;
   /** Every `.cm-scroller` rendered inside the panel. Same per-file
-   *  cardinality as `cmEditors`. The class is owned by CodeMirror; we
-   *  hide that fact behind this locator so the test body doesn't
-   *  reach for the literal class name. */
+   *  cardinality as `cmEditors`, same FRAGILITY caveat against
+   *  CodeMirror class-name renames in major upgrades. */
   readonly cmScrollers: Locator;
 
   constructor(
@@ -97,7 +105,18 @@ export class ChangesPanelPage {
    *  (e.g. `▶ src/foo.ts M`), so we anchor on the leading `▶` to
    *  disambiguate from the file tree sidebar's same-named button,
    *  which exposes the bare `<filename> <status>` name. The role-name
-   *  match is the locator the doctrine prefers over text / CSS. */
+   *  match is the locator the doctrine prefers over text / CSS.
+   *
+   *  FRAGILITY: the `▶` Unicode triangle is rendered text in
+   *  `DiffView.tsx`'s JSX, not a system-controlled ARIA label. If the
+   *  disclosure indicator is ever swapped for an SVG icon (which
+   *  wouldn't contribute to the accessible name), this locator
+   *  silently matches nothing. The mitigation would be to add a stable
+   *  `data-testid` on the row button — left out for now because the
+   *  current JSX has been stable across several refactors and
+   *  introducing a testid just to defend against a hypothetical icon
+   *  change is over-engineering. Revisit if/when DiffView's
+   *  disclosure UI is reworked. */
   fileRowButton(filename: string, status: string): Locator {
     // Escape `.` and other regex meta-characters in the filename so a
     // path like `src/foo.ts` doesn't accidentally match

--- a/apps/web/e2e/pages/ChangesPanelPage.ts
+++ b/apps/web/e2e/pages/ChangesPanelPage.ts
@@ -23,7 +23,7 @@
  *    reload step that activates them.
  */
 
-import { type Locator, type Page, test } from "@playwright/test";
+import { expect, type Locator, type Page, test } from "@playwright/test";
 
 /** localStorage keys read on first paint by DiffView. */
 const EXPAND_ALL_KEY = "band:diff-expand-all";
@@ -55,6 +55,40 @@ export class ChangesPanelPage {
     this.scroller = page.getByTestId("diff-view__scroller");
     this.cmEditors = page.locator(".cm-editor");
     this.cmScrollers = page.locator(".cm-scroller");
+  }
+
+  /** Factory method that bundles the common "open the Changes panel
+   *  with expand-all on, then optionally switch to split mode" setup
+   *  used by both `diff-horizontal-scroll.spec.ts` and any future spec
+   *  that needs a populated diff view. Owning this on the page object
+   *  (rather than as a module-level helper in the spec file) keeps the
+   *  navigation + locator-await logic inside the page-object layer per
+   *  the `write-integration-test` doctrine.
+   *
+   *  Returns the constructed `ChangesPanelPage` so the caller can
+   *  continue driving the panel via instance methods. */
+  static async openWithFileExpanded(opts: {
+    page: Page;
+    baseUrl: string;
+    token: string;
+    workspaceId: string;
+    filename: string;
+    /** Git status badge expected on the file row (e.g. `"M"`). */
+    fileStatus: string;
+    viewMode: DiffViewMode;
+  }): Promise<ChangesPanelPage> {
+    const changes = new ChangesPanelPage(opts.page, opts.baseUrl, opts.token);
+    await changes.openWorkspace(opts.workspaceId, { expandAll: true });
+    // The file row appears in two places (the file tree sidebar AND
+    // the diff row header button) — wait on the diff row explicitly
+    // since that's the surface the editor hangs off.
+    await expect(changes.fileRowButton(opts.filename, opts.fileStatus)).toBeVisible({
+      timeout: 15_000,
+    });
+    if (opts.viewMode === "split") {
+      await changes.setViewMode("split");
+    }
+    return changes;
   }
 
   /** Locate the diff-row header button for a specific filename + git

--- a/apps/web/e2e/pages/ChangesPanelPage.ts
+++ b/apps/web/e2e/pages/ChangesPanelPage.ts
@@ -174,69 +174,35 @@ export class ChangesPanelPage {
       );
   }
 
-  /** Measurements of the first rendered `.cm-scroller` — used by the
-   *  horizontal-scroll test. Returns the geometric properties as a
-   *  single object so the test only pays one round-trip per assertion
-   *  block. */
-  async firstScrollerMetrics(): Promise<{
-    scrollWidth: number;
-    clientWidth: number;
-    clientHeight: number;
-    scrollHeight: number;
-    computedOverflowX: string;
-    computedOverflowY: string;
-  }> {
-    return await this.cmScrollers.first().evaluate((el) => ({
-      scrollWidth: el.scrollWidth,
-      clientWidth: el.clientWidth,
-      clientHeight: el.clientHeight,
-      scrollHeight: el.scrollHeight,
-      computedOverflowX: window.getComputedStyle(el).overflowX,
-      computedOverflowY: window.getComputedStyle(el).overflowY,
-    }));
-  }
-
   /** Per-scroller metrics for ALL rendered `.cm-scroller` elements.
    *  Used by the split-mode assertion path — MergeView renders one
    *  scroller per side, and both should report horizontal-scroll
-   *  capability for the fix to be considered complete. */
+   *  capability for the fix to be considered complete.
+   *
+   *  Implemented via `locator.evaluateAll` (single round-trip across
+   *  the page boundary) rather than `elementHandles` (one round-trip
+   *  per element + holds JS handles across the serialisation
+   *  boundary). `scrollHeight` is included so the test can assert
+   *  it equals `clientHeight` — the natural-height regression guard
+   *  for PR #501.
+   */
   async allScrollerMetrics(): Promise<
     Array<{
       scrollWidth: number;
       clientWidth: number;
       clientHeight: number;
+      scrollHeight: number;
       computedOverflowX: string;
     }>
   > {
-    const handles = await this.cmScrollers.elementHandles();
-    const out: Array<{
-      scrollWidth: number;
-      clientWidth: number;
-      clientHeight: number;
-      computedOverflowX: string;
-    }> = [];
-    for (const handle of handles) {
-      out.push(
-        await handle.evaluate((el) => ({
-          scrollWidth: el.scrollWidth,
-          clientWidth: el.clientWidth,
-          clientHeight: el.clientHeight,
-          computedOverflowX: window.getComputedStyle(el).overflowX,
-        })),
-      );
-    }
-    return out;
-  }
-
-  /** Write to the first scroller's `scrollLeft` and read back the
-   *  committed value. The round-trip is what the horizontal-scroll
-   *  test uses to prove the scroller actually accepts horizontal
-   *  scroll input (the pre-fix `overflow: visible` path silently
-   *  clamps the write to 0). */
-  async roundTripFirstScrollLeft(value: number): Promise<number> {
-    return await this.cmScrollers.first().evaluate((el, target) => {
-      el.scrollLeft = target;
-      return el.scrollLeft;
-    }, value);
+    return await this.cmScrollers.evaluateAll((els) =>
+      els.map((el) => ({
+        scrollWidth: el.scrollWidth,
+        clientWidth: el.clientWidth,
+        clientHeight: el.clientHeight,
+        scrollHeight: el.scrollHeight,
+        computedOverflowX: window.getComputedStyle(el).overflowX,
+      })),
+    );
   }
 }

--- a/apps/web/e2e/pages/ChangesPanelPage.ts
+++ b/apps/web/e2e/pages/ChangesPanelPage.ts
@@ -1,0 +1,242 @@
+/**
+ * Page object for the Changes panel inside a workspace's shared dockview.
+ *
+ * Centralises the locators and the "navigate + seed expand-all + reload"
+ * dance so individual spec files don't reach into `localStorage` /
+ * `page.goto` directly. Per `CLAUDE.md` and the `write-integration-test`
+ * skill, test bodies should drive UI exclusively through methods on a
+ * page object — the test body stays focused on assertions instead of
+ * setup plumbing.
+ *
+ * What lives here:
+ *  - The diff scroller (matched via `getByTestId("diff-view__scroller")`).
+ *  - The per-file header buttons (matched via `getByRole("button",
+ *    { name: /<filename>\s+<status>/ })` — the file row exposes its
+ *    filename + status as the button's accessible name).
+ *  - The CodeMirror editor / scroller elements rendered inside each
+ *    expanded file. These are 3rd-party CodeMirror class selectors
+ *    (`.cm-editor`, `.cm-scroller`) — we don't own those names, but we
+ *    encapsulate them here so the spec body never repeats the literal
+ *    selector and a future CodeMirror upgrade flows through one file.
+ *  - Setup helpers for the expand-all and split-mode localStorage flags
+ *    (`band:diff-expand-all`, `band:diff-view-mode`), and the seed-and-
+ *    reload step that activates them.
+ */
+
+import { type Locator, type Page, test } from "@playwright/test";
+
+/** localStorage keys read on first paint by DiffView. */
+const EXPAND_ALL_KEY = "band:diff-expand-all";
+const VIEW_MODE_KEY = "band:diff-view-mode";
+
+export type DiffViewMode = "unified" | "split";
+
+export class ChangesPanelPage {
+  /** Scroll container around the file rows — used to programmatically
+   *  scroll the panel in the mount-once test. `data-testid` is set in
+   *  DiffView.tsx so the locator stays anchored if the layout markup
+   *  shifts around it. */
+  readonly scroller: Locator;
+  /** Every `.cm-editor` rendered inside the panel. In unified mode
+   *  there's one per visible expanded file; in split mode each visible
+   *  expanded file contributes two (one per side of the MergeView). */
+  readonly cmEditors: Locator;
+  /** Every `.cm-scroller` rendered inside the panel. Same per-file
+   *  cardinality as `cmEditors`. The class is owned by CodeMirror; we
+   *  hide that fact behind this locator so the test body doesn't
+   *  reach for the literal class name. */
+  readonly cmScrollers: Locator;
+
+  constructor(
+    private readonly page: Page,
+    private readonly baseUrl: string,
+    private readonly token: string,
+  ) {
+    this.scroller = page.getByTestId("diff-view__scroller");
+    this.cmEditors = page.locator(".cm-editor");
+    this.cmScrollers = page.locator(".cm-scroller");
+  }
+
+  /** Locate the diff-row header button for a specific filename + git
+   *  status (e.g. `M` for modified). The accessible name is built from
+   *  the disclosure arrow + filename + status badge in `LazyFileRow`
+   *  (e.g. `▶ src/foo.ts M`), so we anchor on the leading `▶` to
+   *  disambiguate from the file tree sidebar's same-named button,
+   *  which exposes the bare `<filename> <status>` name. The role-name
+   *  match is the locator the doctrine prefers over text / CSS. */
+  fileRowButton(filename: string, status: string): Locator {
+    // Escape `.` and other regex meta-characters in the filename so a
+    // path like `src/foo.ts` doesn't accidentally match
+    // `src/foo<anychar>ts`.
+    const escapedFilename = filename.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    return this.page.getByRole("button", {
+      name: new RegExp(`▶\\s+${escapedFilename}\\s+${status}`),
+    });
+  }
+
+  /** Navigate to the workspace's Changes panel with one or more
+   *  client-side defaults pre-seeded in `localStorage`. Uses
+   *  `addInitScript` so the seed runs before any page script — DiffView
+   *  reads `band:diff-view-mode` / `band:diff-expand-all` in
+   *  `useState(getStoredViewMode)` / `useState(getStoredExpandAll)`
+   *  during its FIRST render, so the seed has to land before that
+   *  point or the lazy initializer captures the default (`unified` /
+   *  `false`) and never re-reads.
+   *
+   *  The init script is keyed via the (filename, status) shape that
+   *  comes from `JSON.stringify` so re-calling `openWorkspace` with
+   *  different options on the same `Page` is idempotent — each call
+   *  re-registers a new init script that runs on subsequent
+   *  navigations (Playwright doesn't deregister old init scripts, so
+   *  this would compose: last value wins because writes overwrite).
+   */
+  async openWorkspace(
+    workspaceId: string,
+    options: { expandAll?: boolean; viewMode?: DiffViewMode } = {},
+  ): Promise<void> {
+    const url = `${this.baseUrl}/workspace/${encodeURIComponent(workspaceId)}?token=${this.token}`;
+    await test.step(`Open Changes panel for ${workspaceId}`, async () => {
+      const { expandAll, viewMode } = options;
+      if (expandAll != null || viewMode != null) {
+        await this.page.addInitScript(
+          ({ expandAll, viewMode, expandAllKey, viewModeKey }) => {
+            if (expandAll != null) {
+              localStorage.setItem(expandAllKey, expandAll ? "true" : "false");
+            }
+            if (viewMode != null) localStorage.setItem(viewModeKey, viewMode);
+          },
+          {
+            expandAll,
+            viewMode,
+            expandAllKey: EXPAND_ALL_KEY,
+            viewModeKey: VIEW_MODE_KEY,
+          },
+        );
+      }
+      await this.page.goto(url);
+    });
+  }
+
+  /** Scroll the diff panel to a specific pixel offset. Used in the
+   *  mount-once test to push a row well outside the IntersectionObserver
+   *  rootMargin zone. */
+  async scrollTo(offsetPx: number): Promise<void> {
+    await this.scroller.evaluate((el, top) => {
+      (el as HTMLDivElement).scrollTop = top;
+    }, offsetPx);
+  }
+
+  /** Current `scrollTop` of the diff panel. Useful for polling on
+   *  scroll commit without relying on `waitForTimeout`. */
+  async scrollTop(): Promise<number> {
+    return await this.scroller.evaluate((el) => (el as HTMLDivElement).scrollTop);
+  }
+
+  /** Count of currently-mounted `.cm-editor` elements across all
+   *  visible file rows. Used as a direct proxy for mount-once: the
+   *  count stays stable across scroll-away with mount-once, but drops
+   *  under the pre-mount-once behaviour. */
+  async mountedEditorCount(): Promise<number> {
+    return await this.cmEditors.count();
+  }
+
+  /** Click the "Split view" / "Unified view" toggle. The buttons are
+   *  rendered with aria-name "Split view" / "Unified view" by
+   *  `DiffViewModeToggle`, so the role-name locator is the doctrine-
+   *  preferred path. Using the visible toggle (rather than seeding
+   *  localStorage) is more reliable across the app's auto-downgrade
+   *  rules (e.g. `effectiveViewMode` collapses split → unified when the
+   *  scroll container is narrower than `SPLIT_VIEW_MIN_WIDTH`) — the
+   *  toggle exposes the same control surface the user has. */
+  async setViewMode(mode: DiffViewMode): Promise<void> {
+    const label = mode === "split" ? "Split view" : "Unified view";
+    await this.page.getByRole("button", { name: label, exact: true }).click();
+  }
+
+  /** Mark the first rendered `.cm-editor` element with a JS property so
+   *  later assertions can verify DOM identity preservation across
+   *  scroll-away/back. If the editor is destroyed and re-mounted, the
+   *  marker is lost on the new element. */
+  async tagFirstEditor(marker: string): Promise<void> {
+    await this.cmEditors.first().evaluate((el, value) => {
+      (el as HTMLElement & { __bandMountOnceMarker?: string }).__bandMountOnceMarker = value;
+    }, marker);
+  }
+
+  /** Read the marker set by `tagFirstEditor` from the first rendered
+   *  `.cm-editor`. Returns `undefined` if the element no longer carries
+   *  it (i.e. it's a fresh re-mount). */
+  async firstEditorMarker(): Promise<string | undefined> {
+    return await this.cmEditors
+      .first()
+      .evaluate(
+        (el) => (el as HTMLElement & { __bandMountOnceMarker?: string }).__bandMountOnceMarker,
+      );
+  }
+
+  /** Measurements of the first rendered `.cm-scroller` — used by the
+   *  horizontal-scroll test. Returns the geometric properties as a
+   *  single object so the test only pays one round-trip per assertion
+   *  block. */
+  async firstScrollerMetrics(): Promise<{
+    scrollWidth: number;
+    clientWidth: number;
+    clientHeight: number;
+    scrollHeight: number;
+    computedOverflowX: string;
+    computedOverflowY: string;
+  }> {
+    return await this.cmScrollers.first().evaluate((el) => ({
+      scrollWidth: el.scrollWidth,
+      clientWidth: el.clientWidth,
+      clientHeight: el.clientHeight,
+      scrollHeight: el.scrollHeight,
+      computedOverflowX: window.getComputedStyle(el).overflowX,
+      computedOverflowY: window.getComputedStyle(el).overflowY,
+    }));
+  }
+
+  /** Per-scroller metrics for ALL rendered `.cm-scroller` elements.
+   *  Used by the split-mode assertion path — MergeView renders one
+   *  scroller per side, and both should report horizontal-scroll
+   *  capability for the fix to be considered complete. */
+  async allScrollerMetrics(): Promise<
+    Array<{
+      scrollWidth: number;
+      clientWidth: number;
+      clientHeight: number;
+      computedOverflowX: string;
+    }>
+  > {
+    const handles = await this.cmScrollers.elementHandles();
+    const out: Array<{
+      scrollWidth: number;
+      clientWidth: number;
+      clientHeight: number;
+      computedOverflowX: string;
+    }> = [];
+    for (const handle of handles) {
+      out.push(
+        await handle.evaluate((el) => ({
+          scrollWidth: el.scrollWidth,
+          clientWidth: el.clientWidth,
+          clientHeight: el.clientHeight,
+          computedOverflowX: window.getComputedStyle(el).overflowX,
+        })),
+      );
+    }
+    return out;
+  }
+
+  /** Write to the first scroller's `scrollLeft` and read back the
+   *  committed value. The round-trip is what the horizontal-scroll
+   *  test uses to prove the scroller actually accepts horizontal
+   *  scroll input (the pre-fix `overflow: visible` path silently
+   *  clamps the write to 0). */
+  async roundTripFirstScrollLeft(value: number): Promise<number> {
+    return await this.cmScrollers.first().evaluate((el, target) => {
+      el.scrollLeft = target;
+      return el.scrollLeft;
+    }, value);
+  }
+}

--- a/apps/web/e2e/pages/ChangesPanelPage.ts
+++ b/apps/web/e2e/pages/ChangesPanelPage.ts
@@ -150,7 +150,9 @@ export class ChangesPanelPage {
    *  toggle exposes the same control surface the user has. */
   async setViewMode(mode: DiffViewMode): Promise<void> {
     const label = mode === "split" ? "Split view" : "Unified view";
-    await this.page.getByRole("button", { name: label, exact: true }).click();
+    await test.step(`Set diff view mode to ${mode}`, async () => {
+      await this.page.getByRole("button", { name: label, exact: true }).click();
+    });
   }
 
   /** Mark the first rendered `.cm-editor` element with a JS property so
@@ -172,6 +174,19 @@ export class ChangesPanelPage {
       .evaluate(
         (el) => (el as HTMLElement & { __bandMountOnceMarker?: string }).__bandMountOnceMarker,
       );
+  }
+
+  /** Write to the `scrollLeft` of the Nth `.cm-scroller` and read the
+   *  committed value back. The round-trip is what the horizontal-
+   *  scroll test uses to prove the scroller actually accepts
+   *  horizontal-scroll input — the pre-fix `overflow: visible` path
+   *  silently clamps the write to 0, so a non-zero read here is the
+   *  most direct behavioural assertion of the fix. */
+  async roundTripScrollLeftAt(index: number, target: number): Promise<number> {
+    return await this.cmScrollers.nth(index).evaluate((el, value) => {
+      el.scrollLeft = value;
+      return el.scrollLeft;
+    }, target);
   }
 
   /** Per-scroller metrics for ALL rendered `.cm-scroller` elements.

--- a/apps/web/e2e/pages/ChangesPanelPage.ts
+++ b/apps/web/e2e/pages/ChangesPanelPage.ts
@@ -100,30 +100,24 @@ export class ChangesPanelPage {
   }
 
   /** Locate the diff-row header button for a specific filename + git
-   *  status (e.g. `M` for modified). The accessible name is built from
-   *  the disclosure arrow + filename + status badge in `LazyFileRow`
-   *  (e.g. `▶ src/foo.ts M`), so we anchor on the leading `▶` to
-   *  disambiguate from the file tree sidebar's same-named button,
-   *  which exposes the bare `<filename> <status>` name. The role-name
-   *  match is the locator the doctrine prefers over text / CSS.
-   *
-   *  FRAGILITY: the `▶` Unicode triangle is rendered text in
-   *  `DiffView.tsx`'s JSX, not a system-controlled ARIA label. If the
-   *  disclosure indicator is ever swapped for an SVG icon (which
-   *  wouldn't contribute to the accessible name), this locator
-   *  silently matches nothing. The mitigation would be to add a stable
-   *  `data-testid` on the row button — left out for now because the
-   *  current JSX has been stable across several refactors and
-   *  introducing a testid just to defend against a hypothetical icon
-   *  change is over-engineering. Revisit if/when DiffView's
-   *  disclosure UI is reworked. */
+   *  status (e.g. `M` for modified). The row's `<button>` carries a
+   *  `data-testid="diff-view__file-row-toggle"` set in
+   *  `LazyFileRow`'s JSX — that's the system-controlled anchor the
+   *  doctrine prefers. We then filter by the accessible name (which
+   *  is the disclosure arrow + filename + status, e.g.
+   *  `▶ src/foo.ts M`) so callers can target a specific row when
+   *  multiple file rows are visible. Filtering instead of matching the
+   *  full name keeps the locator tolerant of changes to the
+   *  disclosure indicator (SVG icon swap, label tweaks, etc.) — only
+   *  the filename + status badge have to remain in the accessible
+   *  name for the locator to keep working. */
   fileRowButton(filename: string, status: string): Locator {
     // Escape `.` and other regex meta-characters in the filename so a
     // path like `src/foo.ts` doesn't accidentally match
     // `src/foo<anychar>ts`.
     const escapedFilename = filename.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-    return this.page.getByRole("button", {
-      name: new RegExp(`▶\\s+${escapedFilename}\\s+${status}`),
+    return this.page.getByTestId("diff-view__file-row-toggle").filter({
+      hasText: new RegExp(`${escapedFilename}\\s+${status}`),
     });
   }
 

--- a/apps/web/src/dashboard/components/DiffView.tsx
+++ b/apps/web/src/dashboard/components/DiffView.tsx
@@ -93,6 +93,21 @@ const UNCOMMITTED_VALUE = "__uncommitted__";
 
 const EXPAND_ALL_KEY = "band:diff-expand-all";
 
+/**
+ * Soft cap on how many editors stay alive per workspace under the
+ * mount-once policy in `LazyFileRow`. Sized so a typical reviewer
+ * pays for what they've actually visited (10–30 files in a normal
+ * PR) without growing unbounded on a 200-file refactor — the (cap+1)th
+ * distinct file scrolled into view evicts the LRU one. The cap is
+ * intentionally generous: each MergeView is on the order of hundreds
+ * of KB of JS state, so 50 instances is well inside the memory budget
+ * of a modern dashboard tab, and the cost of evicting (a re-mount +
+ * re-paint on scroll-back) is what we're spending the headroom to
+ * avoid in the common case. Hoisted to module scope so the tuning is
+ * discoverable without reading the component internals.
+ */
+const MAX_MOUNTED_EDITORS = 50;
+
 function getStoredExpandAll(): boolean {
   try {
     return localStorage.getItem(EXPAND_ALL_KEY) === "true";
@@ -957,6 +972,7 @@ function LazyFileRow({
       <button
         type="button"
         onClick={toggle}
+        data-testid="diff-view__file-row-toggle"
         className="sticky top-0 z-10 flex w-full items-center gap-2 bg-muted px-4 py-2.5 text-left text-sm hover:bg-accent"
       >
         <span
@@ -1266,16 +1282,6 @@ export function DiffView({
   // even when two rows enter the viewport within the same millisecond.
   const mountRecencyRef = useRef<Map<string, number>>(new Map());
   const recencyCounterRef = useRef<number>(0);
-  // Soft cap on how many editors stay alive per workspace. Sized so a
-  // typical reviewer pays for what they've actually visited (10–30 files
-  // in a normal PR) without growing unbounded on a 200-file refactor —
-  // the 51st distinct file scrolled into view evicts the LRU one. The
-  // cap is intentionally generous: each MergeView is on the order of
-  // hundreds of KB of JS state, so 50 instances is well inside the
-  // memory budget of a modern dashboard tab, and the cost of evicting
-  // (a re-mount + re-paint on scroll-back) is what we're spending the
-  // headroom to avoid in the common case.
-  const MAX_MOUNTED_EDITORS = 50;
   // Called by `LazyFileRow` on every IntersectionObserver `isIntersecting`
   // event. Bumps the recency counter for `filename`, adds it to
   // `mountedFiles` if it's not already in, and evicts the LRU member when

--- a/apps/web/src/dashboard/components/DiffView.tsx
+++ b/apps/web/src/dashboard/components/DiffView.tsx
@@ -1287,6 +1287,13 @@ export function DiffView({
     recencyCounterRef.current += 1;
     mountRecencyRef.current.set(filename, recencyCounterRef.current);
     setMountedFiles((prev) => {
+      // Short-circuit when the filename is already tracked AND the set
+      // is at or under the cap — there's nothing for the updater to do
+      // (recency was already bumped above, and no eviction is needed
+      // because no new entry is being added). The `<=` is deliberate:
+      // when `prev.size === MAX_MOUNTED_EDITORS` and `filename` is
+      // already in `prev`, this branch correctly avoids reallocating
+      // the Set just to re-add an existing key.
       if (prev.has(filename) && prev.size <= MAX_MOUNTED_EDITORS) return prev;
       const next = new Set(prev);
       next.add(filename);

--- a/apps/web/src/dashboard/components/DiffView.tsx
+++ b/apps/web/src/dashboard/components/DiffView.tsx
@@ -700,11 +700,22 @@ function LazyFileRow({
   // back to false when the row scrolls out of the zone. We hold the
   // editor alive across scroll-aways so a return to the same row is
   // instant (no `loadLanguage` re-await, no MergeView re-construction).
-  // The only paths back to false are:
-  //   1. The user collapses the row (`isOpen = false`).
-  //   2. The parent's LRU evicts this filename (`isMountedAllowed = false`).
-  //   3. The diff target / workspace changes (DiffView clears state).
-  // In all three cases the row's effects fire below to reset this.
+  //
+  // The render gate is `shouldRender = everMounted && isMountedAllowed`,
+  // so these two flags drive different unmount paths:
+  //   - `isMountedAllowed = false` (parent LRU evicts this filename):
+  //     `shouldRender` flips false, `DiffFileContent` unmounts and tears
+  //     down the editor — but `everMounted` stays true. A future re-add
+  //     to the LRU (parent calls `handleRowVisible` again, typically
+  //     after the next IO intersect) restores `isMountedAllowed = true`
+  //     and the editor remounts. This is the cap-driven recycle path.
+  //   - `everMounted = false` happens in only two situations:
+  //       1. The user collapses the row (`isOpen = false`) — the
+  //          `useEffect` below resets `everMounted` so the next expand
+  //          starts fresh.
+  //       2. The row's React component itself unmounts (diff target
+  //          change drops the row from the `filenames` list, workspace
+  //          tab close, etc.) — local state is gone with the component.
   const [everMounted, setEverMounted] = useState(false);
   // Whether the editor renders right now. Folds the row's own
   // `everMounted` with the parent's LRU gate so eviction (or a never-

--- a/apps/web/src/dashboard/components/DiffView.tsx
+++ b/apps/web/src/dashboard/components/DiffView.tsx
@@ -627,6 +627,29 @@ interface LazyFileRowProps {
    * CodeMirror editors the user can't even see.
    */
   scrollContainerEl: HTMLDivElement | null;
+  /**
+   * Parent-owned gate on whether this row's CodeMirror editor should be
+   * mounted right now. True means the parent's mount-once LRU is keeping
+   * this filename alive — combined with the row's local `everMounted`
+   * flag, this is what controls whether `<DiffFileContent>` renders or
+   * a placeholder takes its place.
+   *
+   * False can happen in two situations:
+   *  - The row hasn't been scrolled into view yet (so the parent's LRU
+   *    has no entry for it). The row mounts on first IO intersect.
+   *  - The parent's LRU evicted this filename (cap exceeded, or diff
+   *    target / summary turnover cleared the set). The row tears its
+   *    editor down via DiffFileContent's cleanup and reverts to the
+   *    placeholder; a subsequent scroll-into-view re-adds it.
+   */
+  isMountedAllowed: boolean;
+  /**
+   * Called by this row on every IntersectionObserver `isIntersecting`
+   * fire — both the initial cross-into-zone and subsequent re-entries
+   * after a scroll-away. Bumps the parent's LRU recency and ensures the
+   * filename is in `mountedFiles` (evicting another file if needed).
+   */
+  onRowVisible: (filename: string) => void;
   onToggle: (filename: string) => void;
   onLoadMoreContext: (filename: string) => void;
   onShowFullFile: (filename: string) => void;
@@ -649,6 +672,8 @@ function LazyFileRow({
   isOpen,
   isActive,
   scrollContainerEl,
+  isMountedAllowed,
+  onRowVisible,
   onToggle,
   onLoadMoreContext,
   onShowFullFile,
@@ -668,23 +693,35 @@ function LazyFileRow({
   // unmount/remount cycles (scroll, dockview tab switch) produce zero
   // layout shift after the first paint.
   const diffBodyRef = useRef<HTMLDivElement>(null);
-  // Whether this row's CodeMirror editor should be mounted right now.
-  // Driven by an IntersectionObserver scoped to the scroll container: we
-  // mount when the row is within `rootMargin` of the viewport (so editors
-  // are ready by the time the user scrolls to them), and unmount once it
-  // leaves that zone so a workspace with 100+ expanded diffs only ever
-  // pays for the handful of editors actually near the screen.
-  const [shouldMount, setShouldMount] = useState(false);
+  // Whether this row's CodeMirror editor has *ever* been mounted in its
+  // current open-state lifetime. Flips true the first time the
+  // IntersectionObserver reports the row inside the rootMargin zone, and
+  // — unlike the pre-mount-once `shouldMount` it replaces — does NOT flip
+  // back to false when the row scrolls out of the zone. We hold the
+  // editor alive across scroll-aways so a return to the same row is
+  // instant (no `loadLanguage` re-await, no MergeView re-construction).
+  // The only paths back to false are:
+  //   1. The user collapses the row (`isOpen = false`).
+  //   2. The parent's LRU evicts this filename (`isMountedAllowed = false`).
+  //   3. The diff target / workspace changes (DiffView clears state).
+  // In all three cases the row's effects fire below to reset this.
+  const [everMounted, setEverMounted] = useState(false);
+  // Whether the editor renders right now. Folds the row's own
+  // `everMounted` with the parent's LRU gate so eviction (or a never-
+  // visited row) shows the placeholder, while a visited-but-currently-
+  // off-screen row keeps its CodeMirror alive at its natural height —
+  // the whole point of mount-once.
+  const shouldRender = everMounted && isMountedAllowed;
   // Tracks whether the CodeMirror editor has finished its first paint.
-  // Distinct from `shouldMount`: between the moment the wrapper renders
-  // (shouldMount=true → placeholder gone) and the moment CodeMirror's
+  // Distinct from `shouldRender`: between the moment the wrapper renders
+  // (shouldRender=true → placeholder gone) and the moment CodeMirror's
   // async setup finishes (await loadLanguage + new MergeView + first
   // layout pass), the wrapper would otherwise be auto-height and
   // collapse to the "Show full file" bar (~30px), pushing rows below it
   // upward. Once the editor reports it has views, we drop the
   // placeholder-height hold on the wrapper and let the editor's natural
   // height drive layout. Re-armed on every unmount so a remount in the
-  // same row (scroll-away/back, viewMode change) still benefits.
+  // same row (LRU eviction → return-trip, viewMode change) still benefits.
   const [editorRendered, setEditorRendered] = useState(false);
   // Pending raf for the editorRendered transition. Held in a ref so the
   // cleanup effect can cancel it on unmount, avoiding a setState into a
@@ -700,9 +737,22 @@ function LazyFileRow({
     };
   }, []);
 
+  // Hold a ref to the latest `onRowVisible` so the IO callback always
+  // hits the parent's current closure even though the effect below is
+  // only keyed on stable inputs (the prop's identity is unstable
+  // because it's bound to a `useCallback` whose own deps may change).
+  const onRowVisibleRef = useRef(onRowVisible);
+  onRowVisibleRef.current = onRowVisible;
+
   useEffect(() => {
     if (!isOpen) {
-      setShouldMount(false);
+      // Collapsing the row resets the mount-once flag so the next
+      // expansion starts fresh — the editor is torn down via
+      // DiffFileContent's cleanup, and a future expand-and-scroll-into-
+      // view path re-mounts cleanly. (The parent's LRU entry for this
+      // filename is left in place; the row simply won't render the
+      // editor while `isOpen` is false.)
+      setEverMounted(false);
       return;
     }
     const el = containerRef.current;
@@ -732,7 +782,20 @@ function LazyFileRow({
         // of flipping everything to unmounted.
         const root = entry.rootBounds;
         if (root && root.width === 0 && root.height === 0) return;
-        setShouldMount(entry.isIntersecting);
+        if (entry.isIntersecting) {
+          // Mount-once: flag this row as "ever mounted" so the editor
+          // stays alive across subsequent scroll-aways. The parent is
+          // the source of truth for whether the editor is *actually*
+          // allowed to render (via `isMountedAllowed`); the IO fire here
+          // also signals "user is paying attention" so the parent's LRU
+          // can keep this filename anchored as recent.
+          setEverMounted(true);
+          onRowVisibleRef.current(filename);
+        }
+        // Crucially, the `false` branch from `entry.isIntersecting` does
+        // NOT flip `everMounted` back to false. That's the entire point
+        // of the change — scrolling past should leave the editor mounted
+        // so the return trip is instant.
       },
       {
         root: scrollContainerEl,
@@ -745,10 +808,10 @@ function LazyFileRow({
     );
     observer.observe(el);
     return () => observer.disconnect();
-  }, [isOpen, scrollContainerEl]);
+  }, [isOpen, scrollContainerEl, filename]);
 
   // Measure the rendered diff body whenever CodeMirror is mounted, and
-  // forward the height to the parent. We only observe while `shouldMount`
+  // forward the height to the parent. We only observe while `shouldRender`
   // is true AND the editor has actually painted (`editorRendered`),
   // because:
   //   - The placeholder branch deliberately renders the cached height —
@@ -766,7 +829,7 @@ function LazyFileRow({
   // frames). Without this, each fire would dispatch a setState in the
   // parent and trigger a re-render of every row in the list.
   useEffect(() => {
-    if (!shouldMount || !editorRendered || !onMeasureHeight) return;
+    if (!shouldRender || !editorRendered || !onMeasureHeight) return;
     const el = diffBodyRef.current;
     if (!el) return;
     if (typeof ResizeObserver === "undefined") return;
@@ -795,7 +858,7 @@ function LazyFileRow({
       if (frame != null) cancelAnimationFrame(frame);
       observer.disconnect();
     };
-  }, [shouldMount, editorRendered, filename, onMeasureHeight]);
+  }, [shouldRender, editorRendered, filename, onMeasureHeight]);
 
   const handleEditorViews = useCallback(
     (views: EditorView[]) => {
@@ -837,11 +900,11 @@ function LazyFileRow({
   // would run the previous render's cleanup AND the new body, hitting
   // the parent twice on every collapse / mount-toggle.
   useEffect(() => {
-    if (!isOpen || !shouldMount) return;
+    if (!isOpen || !shouldRender) return;
     return () => {
       onEditorViews?.(filename, []);
     };
-  }, [isOpen, shouldMount, filename, onEditorViews]);
+  }, [isOpen, shouldRender, filename, onEditorViews]);
 
   const toggle = useCallback(() => {
     onToggle(filename);
@@ -987,26 +1050,39 @@ function LazyFileRow({
         <div className="border-t border-border/20 bg-muted/30">
           {diffError && <div className="px-4 py-4 text-sm text-destructive">{diffError}</div>}
           {diff !== null &&
-            (shouldMount ? (
+            (shouldRender ? (
               // Wrapper is observed by the ResizeObserver in the effect
               // above. Its rendered height — "Show full file" bar plus the
               // CodeMirror editor — is reported back as
               // `measuredHeight`, then reused verbatim as the placeholder
-              // height on the next unmount cycle.
+              // height on the next unmount cycle (a never-visited row or
+              // an LRU-evicted one).
               //
               // The `minHeight` hold prevents a layout shift during the
-              // window between (a) shouldMount flipping to true and (b)
-              // the editor's async `setup` finishing (loadLanguage await
-              // + new MergeView() + first paint). Without it the wrapper
-              // is empty-auto-height for that window, collapsing the row
-              // to the "Show full file" bar (~30px) and pushing every
-              // row below it upward; when the editor paints they snap
-              // back down. We pin the wrapper to the cached/estimated
-              // height (the same value the placeholder uses) until
-              // `editorRendered` flips, then let the editor's natural
-              // height take over. The ResizeObserver only attaches once
-              // `editorRendered` is true (see deps above), so the held
-              // value never bleeds into the measuredHeight cache.
+              // window between (a) `shouldRender` flipping to true and
+              // (b) the editor's async `setup` finishing (loadLanguage
+              // await + new MergeView() + first paint). Without it the
+              // wrapper is empty-auto-height for that window, collapsing
+              // the row to the "Show full file" bar (~30px) and pushing
+              // every row below it upward; when the editor paints they
+              // snap back down. We pin the wrapper to the
+              // cached/estimated height (the same value the placeholder
+              // uses) until `editorRendered` flips, then let the
+              // editor's natural height take over. The ResizeObserver
+              // only attaches once `editorRendered` is true (see deps
+              // above), so the held value never bleeds into the
+              // measuredHeight cache.
+              //
+              // Mount-once: once `shouldRender` flips true, it stays
+              // true across scroll-aways. The editor's natural height
+              // remains in the layout — the row stays the same size
+              // whether the user is currently looking at it or
+              // scrolled past — so there's no scroll-shift trade-off
+              // to manage. The browser handles culling offscreen tiles
+              // cheaply; the only thing that brings `shouldRender`
+              // back to false is collapse / LRU eviction / target
+              // change, all of which deliberately tear the editor
+              // down.
               <div
                 ref={diffBodyRef}
                 style={editorRendered ? undefined : { minHeight: placeholderHeight }}
@@ -1033,10 +1109,12 @@ function LazyFileRow({
             ) : (
               // Placeholder occupying the SAME pixel height the CodeMirror
               // editor would render at, so the row's overall size doesn't
-              // change when the observer mounts/unmounts the editor. Without
-              // this, scrolling past a row would collapse it back to header
-              // size and push everything below upward — visually identical
-              // to a layout shift, even though no content actually moved.
+              // change when LRU eviction tears the editor down (or while
+              // a never-visited row waits for its first IO intersect).
+              // Without this, switching the body between editor and
+              // placeholder would push everything below upward —
+              // visually identical to a layout shift, even though no
+              // content actually moved.
               <div aria-hidden style={{ height: placeholderHeight }} />
             ))}
         </div>
@@ -1054,13 +1132,21 @@ function LazyFileRow({
  * traversed in `filenames` order so the match counter ("3 of 17") is
  * stable across navigations.
  *
- * KNOWN LIMITATION (introduced by virtualization, issue #489): only mounted
- * rows contribute matches. A file that's marked "expanded" but scrolled
- * far enough offscreen to be virtualized away has no live `EditorView`,
- * so its diff isn't searched until the user scrolls it back into view.
- * This is a deliberate trade-off — the alternative was keeping dozens of
- * `MergeView` instances alive at once, which made scrolling unusably
- * janky on large workspaces.
+ * Search coverage caveat (issue #489): only files whose `EditorView` is
+ * live at search time contribute matches. The "mount-once + LRU cap"
+ * policy in `DiffView` keeps any file the user has already scrolled into
+ * view alive for the rest of the workspace session (up to
+ * MAX_MOUNTED_EDITORS), so the practical impact is narrow:
+ *  - Files the user has never scrolled past contribute nothing. Their
+ *    placeholder is in the DOM but the editor isn't mounted.
+ *  - Files evicted by the LRU cap (only possible on workspaces with
+ *    >50 distinct visited files in one session) drop out until the
+ *    user scrolls back to them.
+ * In both cases the fix is the same — scroll the row into view, which
+ * (re-)mounts its editor and the next match-count refresh picks it up.
+ * The trade-off rejected here was "mount everything upfront", which
+ * blew out scroll perf on large workspaces; see the rationale comment
+ * on the `mountedFiles` / `MAX_MOUNTED_EDITORS` block in DiffView.
  */
 function collectAllMatches(
   editorViewsMap: Map<string, EditorView[]>,
@@ -1136,9 +1222,11 @@ export function DiffView({
   const diffCacheRef = useRef<Map<string, FileDiffCacheEntry>>(new Map());
   diffCacheRef.current = diffCache;
   // Tracks which files are currently expanded. State (not just a ref) because
-  // it drives `isOpen` on each LazyFileRow — virtualization unmounts and
-  // remounts rows as they scroll in/out of view, so this state has to live
-  // here in the parent for the open/closed status to survive the round trip.
+  // it drives `isOpen` on each LazyFileRow — the mount-once policy may
+  // unmount and remount a row's CodeMirror editor (LRU eviction, target
+  // change), and the per-row React component itself does unmount when the
+  // workspace switches into the LRU's evicted slot in MultiWorkspacePanelHost,
+  // so this state lives in the parent to survive both round trips.
   const [expandedFiles, setExpandedFiles] = useState<Set<string>>(new Set());
   // Ref mirror so callbacks (fetchFileDiff, fetchSummary, expandAll toggle)
   // can read the latest set without depending on the state. The fetch effect
@@ -1146,6 +1234,73 @@ export function DiffView({
   // set to re-request diffs for files that should still be open.
   const expandedFilesRef = useRef<Set<string>>(expandedFiles);
   expandedFilesRef.current = expandedFiles;
+  // ---------------------------------------------------------------------------
+  // Mount-once + LRU cap for CodeMirror editors
+  // ---------------------------------------------------------------------------
+  // Files whose CodeMirror editor should stay mounted right now. Pre-mount,
+  // a filename isn't here at all — the IntersectionObserver in `LazyFileRow`
+  // signals "I just entered the viewport" via `handleRowVisible`, which adds
+  // the filename. The row then mounts its editor and keeps it mounted across
+  // subsequent scroll-aways: only an explicit eviction (LRU cap exceeded, file
+  // collapsed, or summary turnover) flips the filename back out, which is what
+  // the row's `isMountedAllowed` prop reads. State (not just a ref) because
+  // toggling `isMountedAllowed` for any single row has to trigger that row's
+  // re-render — the eviction path uses setState to fan out to React.
+  const [mountedFiles, setMountedFiles] = useState<Set<string>>(() => new Set());
+  // Recency map for LRU ordering. Updated on every IO entry (not just first
+  // mount) so a row the user scrolls past and comes back to gets re-anchored
+  // as "recent" — keeping the LRU semantics aligned with what the user is
+  // actually paying attention to, not what they happened to mount first.
+  // A monotonic counter beats `Date.now()` because the counter never repeats
+  // even when two rows enter the viewport within the same millisecond.
+  const mountRecencyRef = useRef<Map<string, number>>(new Map());
+  const recencyCounterRef = useRef<number>(0);
+  // Soft cap on how many editors stay alive per workspace. Sized so a
+  // typical reviewer pays for what they've actually visited (10–30 files
+  // in a normal PR) without growing unbounded on a 200-file refactor —
+  // the 51st distinct file scrolled into view evicts the LRU one. The
+  // cap is intentionally generous: each MergeView is on the order of
+  // hundreds of KB of JS state, so 50 instances is well inside the
+  // memory budget of a modern dashboard tab, and the cost of evicting
+  // (a re-mount + re-paint on scroll-back) is what we're spending the
+  // headroom to avoid in the common case.
+  const MAX_MOUNTED_EDITORS = 50;
+  // Called by `LazyFileRow` on every IntersectionObserver `isIntersecting`
+  // event. Bumps the recency counter for `filename`, adds it to
+  // `mountedFiles` if it's not already in, and evicts the LRU member when
+  // the set exceeds `MAX_MOUNTED_EDITORS`. Eviction is via setState so the
+  // evicted row's `isMountedAllowed` prop flips false and that row tears
+  // down its editor (the standard cleanup path — same as the
+  // pre-mount-once code).
+  const handleRowVisible = useCallback((filename: string) => {
+    recencyCounterRef.current += 1;
+    mountRecencyRef.current.set(filename, recencyCounterRef.current);
+    setMountedFiles((prev) => {
+      if (prev.has(filename) && prev.size <= MAX_MOUNTED_EDITORS) return prev;
+      const next = new Set(prev);
+      next.add(filename);
+      if (next.size > MAX_MOUNTED_EDITORS) {
+        // Find the LRU entry currently in the set and drop it. Pulling
+        // from `mountRecencyRef` (rather than tracking insertion order on
+        // the Set itself) lets us measure recency against IntersectionObserver
+        // fires — the most useful proxy for "user is paying attention" —
+        // rather than "first time we ever saw this file". A file the user
+        // hasn't looked at in a while is the right one to evict, even if
+        // it was mounted before any of the currently-in-view rows.
+        let oldestFilename: string | null = null;
+        let oldestRecency = Number.POSITIVE_INFINITY;
+        for (const candidate of next) {
+          const r = mountRecencyRef.current.get(candidate) ?? 0;
+          if (r < oldestRecency) {
+            oldestRecency = r;
+            oldestFilename = candidate;
+          }
+        }
+        if (oldestFilename !== null) next.delete(oldestFilename);
+      }
+      return next;
+    });
+  }, []);
   // Tracks the filename set we last saw, so the "auto-expand new entries
   // when expand-all is on" effect (declared further down) can detect
   // which filenames are genuinely new vs carried over. Declared up here
@@ -1823,6 +1978,13 @@ export function DiffView({
     // Clear diff cache when this effect re-runs (e.g. diffMode change)
     setDiffCache(new Map());
     setExpandedFiles(new Set());
+    // Reset the mount-once LRU too — the filenames in the new diff target
+    // are not the same set of files (and even where they are, their diff
+    // content has changed), so any live editor for the previous target is
+    // stale. Letting the row unmount via `isMountedAllowed=false` is what
+    // triggers `DiffFileContent`'s cleanup and frees the MergeView.
+    setMountedFiles(new Set());
+    mountRecencyRef.current.clear();
     // Reset the "previously-seen filenames" record too — otherwise after a
     // ref switch (diffMode / compareBranch), any filename that exists in
     // both the old AND new targets (e.g. src/index.ts modified on both
@@ -2159,6 +2321,31 @@ export function DiffView({
       if (shouldDispatchFetch(diffCacheRef.current.get(n))) fetchFileDiff(n);
     }
   }, [filenames, expandAll, fetchFileDiff]);
+
+  // Drop mount-once LRU entries whose filename no longer appears in the
+  // summary (e.g. user reverted a file, or branch advanced past the
+  // change). The row that owned the editor unmounts anyway — its
+  // `key={filename}` is gone from the list — so the editor itself is
+  // already destroyed via DiffFileContent's cleanup; this prune just
+  // keeps the `mountedFiles` Set and `mountRecencyRef` Map from growing
+  // monotonically across summary refreshes.
+  useEffect(() => {
+    const live = new Set(filenames);
+    setMountedFiles((prev) => {
+      let changed = false;
+      const next = new Set(prev);
+      for (const name of prev) {
+        if (!live.has(name)) {
+          next.delete(name);
+          changed = true;
+        }
+      }
+      return changed ? next : prev;
+    });
+    for (const name of Array.from(mountRecencyRef.current.keys())) {
+      if (!live.has(name)) mountRecencyRef.current.delete(name);
+    }
+  }, [filenames]);
 
   // Jump-to-file from ChangesFileTree.
   //
@@ -2652,14 +2839,22 @@ export function DiffView({
           </div>
         )}
         {hasChanges && (
-          <div ref={setScrollContainerNode} className="min-h-0 flex-1 overflow-y-auto">
+          <div
+            ref={setScrollContainerNode}
+            data-testid="diff-view__scroller"
+            className="min-h-0 flex-1 overflow-y-auto"
+          >
             {/* Every row is rendered as a lightweight wrapper card; the
                 expensive CodeMirror editor inside each one is gated by a
-                per-row IntersectionObserver (see LazyFileRow). That keeps
-                the DOM structure simple — native scroll, sticky headers,
-                scrollIntoView all just work — while still capping the
-                number of live editors to whatever fits in the viewport
-                plus a small overscan zone. See issue #489. */}
+                per-row IntersectionObserver (see LazyFileRow). Mount
+                policy is "lazy on first scroll-into-view, then sticky
+                until LRU eviction": rows the user has never scrolled
+                near show only a placeholder, rows the user has visited
+                stay mounted across subsequent scroll-aways so a return
+                trip is instant, and the parent's LRU cap
+                (`MAX_MOUNTED_EDITORS`) bounds memory growth on
+                workspaces with hundreds of changed files. See issue
+                #489. */}
             <div className="flex flex-col gap-3 p-3">
               {filenames.map((filename, index) => {
                 const isLast = index === filenames.length - 1;
@@ -2673,6 +2868,8 @@ export function DiffView({
                     isOpen={expandedFiles.has(filename)}
                     isActive={activeFile === filename}
                     scrollContainerEl={scrollContainerEl}
+                    isMountedAllowed={mountedFiles.has(filename)}
+                    onRowVisible={handleRowVisible}
                     onToggle={handleToggleFile}
                     onLoadMoreContext={handleLoadMoreContext}
                     onShowFullFile={handleShowFullFile}

--- a/apps/web/src/dashboard/lib/codemirror-setup.ts
+++ b/apps/web/src/dashboard/lib/codemirror-setup.ts
@@ -181,22 +181,25 @@ export function baseViewerExtensions(
   // on `LazyFileRow`'s root and the user can't reach it (issue: Changes
   // view doesn't scroll horizontally).
   //
-  // The load-bearing invariant is `height: auto`, NOT the authored
-  // `overflowY: "visible"`. Per CSS Overflow L3, `overflowY: visible`
-  // resolves to `auto` whenever the orthogonal axis is non-`visible`,
-  // so the *computed* style is `overflowX: auto, overflowY: auto` —
-  // the authored `visible` is purely documentary intent. What actually
-  // prevents PR #501's collapse-to-0 bug from coming back is the
-  // explicit `height: auto`: CodeMirror's base theme sets
-  // `.cm-scroller { height: 100% }`, and the moment the scroller is
-  // treated as a scroll container that percentage resolves to 0
-  // against an auto-height `.cm-editor` parent. Overriding `height` to
-  // `auto` breaks the percentage chain so the scroller sizes to its
-  // content — no vertical scrollbar ever appears (content fits
-  // exactly), while horizontal still scrolls when a line is wider than
-  // the viewport.
+  // Only `overflowX: auto` is authored explicitly. `overflow-y` defaults
+  // to `visible`, which per CSS Overflow L3 resolves to `auto` whenever
+  // the orthogonal axis is non-`visible` — so the *computed* style is
+  // `overflowX: auto, overflowY: auto` regardless. Authoring it as
+  // `visible` would diverge from the computed value and become a
+  // footgun the next reader has to reason past; omitting it lets the
+  // browser do the resolution and the object literal matches reality.
+  //
+  // The load-bearing invariant is `height: auto`. What actually
+  // prevents PR #501's collapse-to-0 bug from coming back is this
+  // explicit override of CodeMirror's base theme `.cm-scroller {
+  // height: 100% }`: the moment the scroller becomes a scroll
+  // container (overflowX != visible), that percentage resolves to 0
+  // against an auto-height `.cm-editor` parent. `height: auto` breaks
+  // the percentage chain so the scroller sizes to its content — no
+  // vertical scrollbar ever appears (content fits exactly), while
+  // horizontal still scrolls when a line is wider than the viewport.
   const scrollerStyles: Record<string, string> = naturalHeight
-    ? { overflowX: "auto", overflowY: "visible", height: "auto" }
+    ? { overflowX: "auto", height: "auto" }
     : { overflow: "auto" };
 
   return [

--- a/apps/web/src/dashboard/lib/codemirror-setup.ts
+++ b/apps/web/src/dashboard/lib/codemirror-setup.ts
@@ -181,18 +181,20 @@ export function baseViewerExtensions(
   // on `LazyFileRow`'s root and the user can't reach it (issue: Changes
   // view doesn't scroll horizontally).
   //
-  // The subtlety: per CSS Overflow L3, setting `overflowX: auto,
-  // overflowY: visible` computes to `auto, auto` because `visible`
-  // resolves to `auto` whenever the orthogonal axis is non-`visible`.
-  // That alone would re-introduce the bug PR #501 fixed — CodeMirror's
-  // base theme sets `.cm-scroller { height: 100% }`, and a 100%
-  // percentage against an auto-height `.cm-editor` collapses to ~0 the
-  // moment `.cm-scroller` becomes a scroll container. The fix is to
-  // *also* override the scroller's `height` to `auto`, so the percentage
-  // chain is broken and the scroller sizes to its content. With
-  // `height: auto`, the computed `overflowY: auto` is harmless — content
-  // fits exactly, so no vertical scrollbar ever appears, while
-  // horizontal still scrolls when a line is wider than the viewport.
+  // The load-bearing invariant is `height: auto`, NOT the authored
+  // `overflowY: "visible"`. Per CSS Overflow L3, `overflowY: visible`
+  // resolves to `auto` whenever the orthogonal axis is non-`visible`,
+  // so the *computed* style is `overflowX: auto, overflowY: auto` —
+  // the authored `visible` is purely documentary intent. What actually
+  // prevents PR #501's collapse-to-0 bug from coming back is the
+  // explicit `height: auto`: CodeMirror's base theme sets
+  // `.cm-scroller { height: 100% }`, and the moment the scroller is
+  // treated as a scroll container that percentage resolves to 0
+  // against an auto-height `.cm-editor` parent. Overriding `height` to
+  // `auto` breaks the percentage chain so the scroller sizes to its
+  // content — no vertical scrollbar ever appears (content fits
+  // exactly), while horizontal still scrolls when a line is wider than
+  // the viewport.
   const scrollerStyles: Record<string, string> = naturalHeight
     ? { overflowX: "auto", overflowY: "visible", height: "auto" }
     : { overflow: "auto" };

--- a/apps/web/src/dashboard/lib/codemirror-setup.ts
+++ b/apps/web/src/dashboard/lib/codemirror-setup.ts
@@ -175,17 +175,26 @@ export function baseViewerExtensions(
     rootLightStyles.height = "100%";
   }
   // Natural-height callers need `.cm-scroller` to flow with its content
-  // instead of becoming a fixed-height scroll container. Per CSS Overflow
-  // L3 spec, mixing `visible` with a non-`visible`/`clip` value on the
-  // orthogonal axis (e.g. `overflowX: auto, overflowY: visible`) makes
-  // the `visible` compute as `auto` in every browser — silently
-  // re-introducing the fixed-height scroller that breaks our parent's
-  // auto-height chain. So both axes must be `visible`. Long lines fall
-  // back to the existing `overflow-clip` on `LazyFileRow`'s root, which
-  // is the same horizontal-clipping behaviour the codebase had before
-  // this PR (no regression).
+  // *vertically* (no fixed scrolling container) but still let long lines
+  // scroll *horizontally* — otherwise minified JS, generated SQL, or any
+  // unwrapped long line in a diff is silently clipped by `overflow-clip`
+  // on `LazyFileRow`'s root and the user can't reach it (issue: Changes
+  // view doesn't scroll horizontally).
+  //
+  // The subtlety: per CSS Overflow L3, setting `overflowX: auto,
+  // overflowY: visible` computes to `auto, auto` because `visible`
+  // resolves to `auto` whenever the orthogonal axis is non-`visible`.
+  // That alone would re-introduce the bug PR #501 fixed — CodeMirror's
+  // base theme sets `.cm-scroller { height: 100% }`, and a 100%
+  // percentage against an auto-height `.cm-editor` collapses to ~0 the
+  // moment `.cm-scroller` becomes a scroll container. The fix is to
+  // *also* override the scroller's `height` to `auto`, so the percentage
+  // chain is broken and the scroller sizes to its content. With
+  // `height: auto`, the computed `overflowY: auto` is harmless — content
+  // fits exactly, so no vertical scrollbar ever appears, while
+  // horizontal still scrolls when a line is wider than the viewport.
   const scrollerStyles: Record<string, string> = naturalHeight
-    ? { overflow: "visible" }
+    ? { overflowX: "auto", overflowY: "visible", height: "auto" }
     : { overflow: "auto" };
 
   return [


### PR DESCRIPTION
## Summary

Two layered changes in the Changes panel's CodeMirror lifecycle.

**1. Horizontal scrolling for long unwrapped lines.** `.cm-scroller` in `naturalHeight` mode used `overflow: visible` on both axes, so long lines (minified JS, generated SQL, base64 payloads) were silently clipped by `overflow-clip` on `LazyFileRow`. Switch to `overflowX: auto, overflowY: visible, height: auto`. The explicit `height: auto` is what keeps PR #501's natural-height behaviour intact — without it, the percentage in CodeMirror's base theme (`.cm-scroller { height: 100% }`) would collapse to 0 the moment the scroller becomes a scroll container.

**2. Mount-once + LRU eviction for editors.** Previously each `LazyFileRow` tore down its `MergeView` whenever the row scrolled outside the 800-px IntersectionObserver rootMargin zone and re-mounted on return — paying the `loadLanguage` + new MergeView + first-paint cost every time, with a one-frame flicker. New policy: row stays mounted after first scroll-into-view; `DiffView` keeps a `mountedFiles` set with a soft cap of 50 LRU-evicted entries to bound memory growth on workspaces with hundreds of changed files. Search (`collectAllMatches`) now covers every visited file in the session, not just currently-visible rows.

## Test plan

- [x] `pnpm check` clean (biome + cargo fmt + clippy -D warnings)
- [x] Full e2e suite (35 tests) — passes
- [x] New `diff-horizontal-scroll.spec.ts` exercises both unified and split mode, asserts structural `overflow-x: auto` on every scroller + horizontal scrollLeft round-trip on the overflowing one
- [x] New `diff-mount-once.spec.ts` tags the first `.cm-editor`, scrolls 5000 px past the IO zone, asserts editor count stays at 2 + DOM identity preserved after scroll-back
- [x] New `ChangesPanelPage` page object so tests follow the `write-integration-test` doctrine

🤖 Generated with [Claude Code](https://claude.com/claude-code)