### PR TITLE
feat(web): restore last-used workspace when switching labels (#505)

### DIFF
--- a/apps/web/e2e/label-restore-last-workspace.spec.ts
+++ b/apps/web/e2e/label-restore-last-workspace.spec.ts
@@ -110,9 +110,12 @@ test.afterAll(async () => {
 // Clear the per-test state we care about — the label filter and the
 // "last workspace" map both live in localStorage. The page hasn't
 // navigated yet, so land on a workspace first (any will do) to get
-// access to localStorage in the right origin.
+// access to localStorage in the right origin. Routed through
+// `WorkspacePage.goto` so URL construction stays inside the page
+// object per the integration-test doctrine.
 test.beforeEach(async ({ page }) => {
-  await page.goto(`${server.url}/workspace/${encodeURIComponent(WS_PERSONAL_1)}?token=${TOKEN}`);
+  const workspacePage = new WorkspacePage(page, server.url, TOKEN);
+  await workspacePage.goto(WS_PERSONAL_1);
   await page.evaluate(
     ([filterKey, mapKey]) => {
       localStorage.removeItem(filterKey);

--- a/apps/web/e2e/label-restore-last-workspace.spec.ts
+++ b/apps/web/e2e/label-restore-last-workspace.spec.ts
@@ -19,9 +19,7 @@
  */
 
 import { expect, test } from "@playwright/test";
-import { toWorkspaceId } from "@/dashboard";
-import { LABEL_FILTER_KEY } from "../src/dashboard/hooks/use-label-filter";
-import { LABEL_LAST_WORKSPACE_KEY } from "../src/dashboard/hooks/use-label-last-workspace";
+import { LABEL_FILTER_KEY, LABEL_LAST_WORKSPACE_KEY, toWorkspaceId } from "@/dashboard";
 import {
   cleanupTmpHome,
   createTmpHome,

--- a/apps/web/e2e/label-restore-last-workspace.spec.ts
+++ b/apps/web/e2e/label-restore-last-workspace.spec.ts
@@ -190,8 +190,11 @@ test.describe("Label switch restores last-used workspace (issue #505)", () => {
     await expect(page).toHaveURL(new RegExp(encodeURIComponent(WS_WORK_2)));
 
     // Sanity check: no per-label entry has been recorded yet — selecting
-    // a workspace while on ALL must not write to the map.
-    expect(await workspacePage.readLabelLastWorkspaces()).toEqual({});
+    // a workspace while on ALL must not write to the map. `expect.poll`
+    // here (rather than a bare `expect(await ...)`) so a micro-task
+    // delay between the user click and the `localStorage` write doesn't
+    // race the assertion.
+    await expect.poll(() => workspacePage.readLabelLastWorkspaces()).toEqual({});
 
     // Switch to Personal — no history yet, so the workspace shouldn't
     // change. (We assert this so the next step's "ALL keeps current
@@ -211,8 +214,9 @@ test.describe("Label switch restores last-used workspace (issue #505)", () => {
     // → ALL, which records Personal's outgoing activeWorkspaceId — but
     // WS_WORK_2's project is labelled Work, not Personal, so the
     // "only save when project matches outgoing label" guard skips the
-    // write entirely. The map stays empty.
-    expect(await workspacePage.readLabelLastWorkspaces()).toEqual({});
+    // write entirely. The map stays empty. Use `expect.poll` to ride
+    // out the React state→localStorage write micro-task.
+    await expect.poll(() => workspacePage.readLabelLastWorkspaces()).toEqual({});
   });
 
   test("keyboard shortcut path shares the same restore logic as the dropdown", async ({ page }) => {

--- a/apps/web/e2e/label-restore-last-workspace.spec.ts
+++ b/apps/web/e2e/label-restore-last-workspace.spec.ts
@@ -1,0 +1,298 @@
+/**
+ * End-to-end coverage for issue #505 — switching labels restores the
+ * workspace last viewed under that label, while ALL keeps the current
+ * selection.
+ *
+ * Architecture (per `docs/frontend-testing.md` + the
+ * `write-integration-test` skill):
+ *
+ *   - Real production binary runs against a fresh tmp `~/.band/`.
+ *     Migrations apply against the throwaway SQLite DB on boot.
+ *   - No tRPC mocks. Two labels are seeded into `settings.json`, four
+ *     projects (two per label) into the SQLite DB. Background git calls
+ *     fail gracefully against the bogus paths but every UI surface
+ *     this test touches (sidebar, label dropdown, workspace navigation
+ *     via URL) lives on top of the real backend's `projects.list` and
+ *     `settings.get` responses.
+ *   - All interactions go through `WorkspacePage` per the doctrine — no
+ *     raw `getByTestId` / `page.goto` in the test body.
+ */
+
+import { expect, test } from "@playwright/test";
+import { toWorkspaceId } from "@/dashboard";
+import {
+  cleanupTmpHome,
+  createTmpHome,
+  type ServerHandle,
+  seedSettings,
+  seedState,
+  startServer,
+} from "./helpers/server";
+import { WorkspacePage } from "./pages/WorkspacePage";
+
+const TOKEN = "e2e-label-restore-last-workspace-token";
+
+// Label ids match the test fixture in apps/web/tests/trpc.test.ts so the
+// reader can see the convention at a glance: lbl_<short_name>.
+const LABEL_PERSONAL = "lbl_personal";
+const LABEL_WORK = "lbl_work";
+
+const PROJECT_PERSONAL_1 = "alpha-personal";
+const PROJECT_PERSONAL_2 = "beta-personal";
+const PROJECT_WORK_1 = "alpha-work";
+const PROJECT_WORK_2 = "beta-work";
+
+const WS_PERSONAL_1 = toWorkspaceId(PROJECT_PERSONAL_1, "main");
+const WS_PERSONAL_2 = toWorkspaceId(PROJECT_PERSONAL_2, "main");
+const WS_WORK_1 = toWorkspaceId(PROJECT_WORK_1, "main");
+const WS_WORK_2 = toWorkspaceId(PROJECT_WORK_2, "main");
+
+// Wide viewport so `useIsDesktop()` reports true and the shared dockview
+// renders, matching the platform where users actually run into this
+// behaviour (the label dropdown is also visible on mobile, but the
+// workspace URL nav lives in the desktop shell).
+test.use({ viewport: { width: 1280, height: 800 } });
+
+let server: ServerHandle;
+let tmpHome: string;
+
+test.beforeAll(async () => {
+  tmpHome = createTmpHome();
+  seedState(tmpHome, {
+    projects: [
+      {
+        name: PROJECT_PERSONAL_1,
+        path: `/tmp/fake/${PROJECT_PERSONAL_1}`,
+        defaultBranch: "main",
+        label: LABEL_PERSONAL,
+        worktrees: [{ branch: "main", path: `/tmp/fake/${PROJECT_PERSONAL_1}` }],
+      },
+      {
+        name: PROJECT_PERSONAL_2,
+        path: `/tmp/fake/${PROJECT_PERSONAL_2}`,
+        defaultBranch: "main",
+        label: LABEL_PERSONAL,
+        worktrees: [{ branch: "main", path: `/tmp/fake/${PROJECT_PERSONAL_2}` }],
+      },
+      {
+        name: PROJECT_WORK_1,
+        path: `/tmp/fake/${PROJECT_WORK_1}`,
+        defaultBranch: "main",
+        label: LABEL_WORK,
+        worktrees: [{ branch: "main", path: `/tmp/fake/${PROJECT_WORK_1}` }],
+      },
+      {
+        name: PROJECT_WORK_2,
+        path: `/tmp/fake/${PROJECT_WORK_2}`,
+        defaultBranch: "main",
+        label: LABEL_WORK,
+        worktrees: [{ branch: "main", path: `/tmp/fake/${PROJECT_WORK_2}` }],
+      },
+    ],
+  });
+  seedSettings(tmpHome, {
+    tokenSecret: TOKEN,
+    labels: [
+      { id: LABEL_PERSONAL, name: "Personal", color: "#8b5cf6" },
+      { id: LABEL_WORK, name: "Work", color: "#3b82f6" },
+    ],
+  });
+  server = await startServer({ tmpHome });
+});
+
+test.afterAll(async () => {
+  await server.close();
+  cleanupTmpHome(tmpHome);
+});
+
+// Clear the per-test state we care about — the label filter and the
+// "last workspace" map both live in localStorage. The page hasn't
+// navigated yet, so land on a workspace first (any will do) to get
+// access to localStorage in the right origin.
+test.beforeEach(async ({ page }) => {
+  await page.goto(`${server.url}/workspace/${encodeURIComponent(WS_PERSONAL_1)}?token=${TOKEN}`);
+  await page.evaluate(() => {
+    localStorage.removeItem("band.projects-list.label-filter");
+    localStorage.removeItem("band.projects-list.label-last-workspace");
+  });
+});
+
+test.describe("Label switch restores last-used workspace (issue #505)", () => {
+  test("switching to a specific label restores the workspace last viewed under it", async ({
+    page,
+  }) => {
+    const workspacePage = new WorkspacePage(page, server.url, TOKEN);
+
+    // Step 1 — Land on a Personal workspace and pick Personal in the
+    // dropdown. The label switch from ALL → Personal has no history yet,
+    // so the active workspace shouldn't change.
+    await workspacePage.goto(WS_PERSONAL_1);
+    await expect(page).toHaveURL(new RegExp(encodeURIComponent(WS_PERSONAL_1)));
+    await workspacePage.selectLabelFilter(LABEL_PERSONAL);
+    await expect(page).toHaveURL(new RegExp(encodeURIComponent(WS_PERSONAL_1)));
+
+    // Step 2 — Pick the second Personal workspace. The active workspace
+    // is now WS_PERSONAL_2, label filter still Personal.
+    await workspacePage.switchWorkspace(WS_PERSONAL_2);
+    await expect(page).toHaveURL(new RegExp(encodeURIComponent(WS_PERSONAL_2)));
+
+    // Step 3 — Switch to Work via the dropdown. This should:
+    //   - persist Personal → WS_PERSONAL_2 (the active ws was a Personal
+    //     workspace, so it's saved),
+    //   - find no history under Work and leave the active ws alone.
+    await workspacePage.selectLabelFilter(LABEL_WORK);
+    await expect(page).toHaveURL(new RegExp(encodeURIComponent(WS_PERSONAL_2)));
+    await expect
+      .poll(() => workspacePage.readLabelLastWorkspaces())
+      .toEqual({
+        [LABEL_PERSONAL]: WS_PERSONAL_2,
+      });
+
+    // Step 4 — Pick a Work workspace; activeWorkspaceId becomes
+    // WS_WORK_1 while filter is Work.
+    await workspacePage.switchWorkspace(WS_WORK_1);
+    await expect(page).toHaveURL(new RegExp(encodeURIComponent(WS_WORK_1)));
+
+    // Step 5 — Switch back to Personal. This is the headline behaviour:
+    // Work gets persisted as WS_WORK_1, and the saved Personal →
+    // WS_PERSONAL_2 entry restores the workspace.
+    await workspacePage.selectLabelFilter(LABEL_PERSONAL);
+    await expect(page).toHaveURL(new RegExp(encodeURIComponent(WS_PERSONAL_2)));
+    await expect
+      .poll(() => workspacePage.readLabelLastWorkspaces())
+      .toEqual({
+        [LABEL_PERSONAL]: WS_PERSONAL_2,
+        [LABEL_WORK]: WS_WORK_1,
+      });
+
+    // Step 6 — Round-trip: switch back to Work; the restore should land
+    // on WS_WORK_1, not on whatever was active before (WS_PERSONAL_2).
+    await workspacePage.selectLabelFilter(LABEL_WORK);
+    await expect(page).toHaveURL(new RegExp(encodeURIComponent(WS_WORK_1)));
+  });
+
+  test("ALL keeps the current workspace and does not record a per-label entry", async ({
+    page,
+  }) => {
+    const workspacePage = new WorkspacePage(page, server.url, TOKEN);
+
+    // Land on a Personal workspace with the filter starting at ALL
+    // (the beforeEach hook cleared the filter). Pick a different
+    // workspace so we know which one to assert on.
+    await workspacePage.goto(WS_PERSONAL_1);
+    await workspacePage.switchWorkspace(WS_WORK_2);
+    await expect(page).toHaveURL(new RegExp(encodeURIComponent(WS_WORK_2)));
+
+    // Sanity check: no per-label entry has been recorded yet — selecting
+    // a workspace while on ALL must not write to the map.
+    expect(await workspacePage.readLabelLastWorkspaces()).toEqual({});
+
+    // Switch to Personal — no history yet, so the workspace shouldn't
+    // change. (We assert this so the next step's "ALL keeps current
+    // selection" claim has something to push back against.)
+    await workspacePage.selectLabelFilter(LABEL_PERSONAL);
+    await expect(page).toHaveURL(new RegExp(encodeURIComponent(WS_WORK_2)));
+
+    // Switch back to ALL. Per the issue, ALL must NOT navigate — the
+    // current selection persists. WS_WORK_2 was set while on ALL, so
+    // even though we cycled through Personal, the user's last explicit
+    // pick should still be the active workspace.
+    await workspacePage.selectLabelFilter(null);
+    await expect(page).toHaveURL(new RegExp(encodeURIComponent(WS_WORK_2)));
+
+    // ALL also doesn't write a `null` key into the per-label map. The
+    // only entry we should see is the side-effect of leaving Personal
+    // → ALL, which records Personal's outgoing activeWorkspaceId — but
+    // WS_WORK_2's project is labelled Work, not Personal, so the
+    // "only save when project matches outgoing label" guard skips the
+    // write entirely. The map stays empty.
+    expect(await workspacePage.readLabelLastWorkspaces()).toEqual({});
+  });
+
+  test("keyboard shortcut path shares the same restore logic as the dropdown", async ({ page }) => {
+    // Per the issue: "Keyboard shortcut path AND click path should both
+    // use the same restore logic — don't fix only one." This test
+    // verifies that ⌘N (Cmd+N / Ctrl+N) drives the same `setLabelFilter`
+    // orchestration as the dropdown by exercising a round-trip via the
+    // accelerator registered in `DashboardShell`'s keydown listener.
+    //
+    // The handler explicitly skips when focus is inside an editable
+    // element (so users can type "⌘1" into a chat without hijacking it),
+    // so the test focuses the project-list root before each press. That
+    // element is the keyboard nav target the app already uses for arrow
+    // navigation, and it's confirmed not editable. Sending the shortcut
+    // via `locator.press` routes the keystroke to that element directly,
+    // bypassing the chat textarea autofocus on the workspace route.
+
+    const workspacePage = new WorkspacePage(page, server.url, TOKEN);
+    await workspacePage.goto(WS_PERSONAL_1);
+
+    // The project list container has `tabindex="-1"` and isn't editable;
+    // pressing keys against it lets the bubble-phase handler in
+    // DashboardShell see `e.target.tagName === "DIV"` and not skip. We
+    // target it by testid rather than `[tabindex="-1"]` because the
+    // dockview's file tab bar also exposes a tabindex=-1 element and a
+    // generic selector would pick the wrong one (project list lives in
+    // the sidebar; the file tab bar lives in the main area).
+    const projectListRoot = page.getByTestId("project-list__root");
+    await projectListRoot.waitFor({ state: "visible" });
+
+    // Build up: Ctrl+1 → Personal, then click a Personal workspace.
+    await projectListRoot.press("Control+1");
+    await workspacePage.switchWorkspace(WS_PERSONAL_1);
+    await expect(page).toHaveURL(new RegExp(encodeURIComponent(WS_PERSONAL_1)));
+
+    // Ctrl+2 → Work, click a Work workspace.
+    await projectListRoot.press("Control+2");
+    await workspacePage.switchWorkspace(WS_WORK_2);
+    await expect(page).toHaveURL(new RegExp(encodeURIComponent(WS_WORK_2)));
+
+    // Round-trip: Ctrl+1 should restore Personal → WS_PERSONAL_1.
+    await projectListRoot.press("Control+1");
+    await expect(page).toHaveURL(new RegExp(encodeURIComponent(WS_PERSONAL_1)));
+
+    // Ctrl+2 should restore Work → WS_WORK_2.
+    await projectListRoot.press("Control+2");
+    await expect(page).toHaveURL(new RegExp(encodeURIComponent(WS_WORK_2)));
+
+    // Final state of the map mirrors what the click-path test produces.
+    await expect
+      .poll(() => workspacePage.readLabelLastWorkspaces())
+      .toEqual({
+        [LABEL_PERSONAL]: WS_PERSONAL_1,
+        [LABEL_WORK]: WS_WORK_2,
+      });
+  });
+
+  test("per-label memory survives a full page reload", async ({ page }) => {
+    const workspacePage = new WorkspacePage(page, server.url, TOKEN);
+
+    // Build up: Personal → WS_PERSONAL_2, Work → WS_WORK_1.
+    await workspacePage.goto(WS_PERSONAL_2);
+    await workspacePage.selectLabelFilter(LABEL_PERSONAL);
+    await workspacePage.selectLabelFilter(LABEL_WORK);
+    await workspacePage.switchWorkspace(WS_WORK_1);
+
+    // Verify the map has both entries before reload.
+    await expect
+      .poll(() => workspacePage.readLabelLastWorkspaces())
+      .toEqual({
+        [LABEL_PERSONAL]: WS_PERSONAL_2,
+        [LABEL_WORK]: WS_WORK_1,
+      });
+
+    // Hard-reload — the route serializes the current workspace
+    // (WS_WORK_1) in the URL, so we come back on Work. The persisted
+    // label-last-workspace entries should still be there in
+    // localStorage, and restoring to Personal should still land us on
+    // WS_PERSONAL_2.
+    await workspacePage.reload();
+    expect(await workspacePage.readLabelLastWorkspaces()).toEqual({
+      [LABEL_PERSONAL]: WS_PERSONAL_2,
+      [LABEL_WORK]: WS_WORK_1,
+    });
+
+    await workspacePage.selectLabelFilter(LABEL_PERSONAL);
+    await expect(page).toHaveURL(new RegExp(encodeURIComponent(WS_PERSONAL_2)));
+  });
+});

--- a/apps/web/e2e/label-restore-last-workspace.spec.ts
+++ b/apps/web/e2e/label-restore-last-workspace.spec.ts
@@ -213,9 +213,10 @@ test.describe("Label switch restores last-used workspace (issue #505)", () => {
   test("keyboard shortcut path shares the same restore logic as the dropdown", async ({ page }) => {
     // Per the issue: "Keyboard shortcut path AND click path should both
     // use the same restore logic — don't fix only one." This test
-    // verifies that ⌘N (Cmd+N / Ctrl+N) drives the same `setLabelFilter`
-    // orchestration as the dropdown by exercising a round-trip via the
-    // accelerator registered in `DashboardShell`'s keydown listener.
+    // verifies that the ⌘1..9 (Cmd+1..9 / Ctrl+1..9) digit accelerators
+    // drive the same `setLabelFilter` orchestration as the dropdown by
+    // exercising a round-trip via the listener registered in
+    // `DashboardShell`'s `useEffect`.
     //
     // `WorkspacePage.pressLabelShortcut` handles the focus-and-press
     // dance (the chat textarea autofocuses on the workspace route, and
@@ -275,10 +276,12 @@ test.describe("Label switch restores last-used workspace (issue #505)", () => {
     // localStorage, and restoring to Personal should still land us on
     // WS_PERSONAL_2.
     await workspacePage.reload();
-    expect(await workspacePage.readLabelLastWorkspaces()).toEqual({
-      [LABEL_PERSONAL]: WS_PERSONAL_2,
-      [LABEL_WORK]: WS_WORK_1,
-    });
+    await expect
+      .poll(() => workspacePage.readLabelLastWorkspaces())
+      .toEqual({
+        [LABEL_PERSONAL]: WS_PERSONAL_2,
+        [LABEL_WORK]: WS_WORK_1,
+      });
 
     await workspacePage.selectLabelFilter(LABEL_PERSONAL);
     await expect(page).toHaveURL(new RegExp(encodeURIComponent(WS_PERSONAL_2)));

--- a/apps/web/e2e/label-restore-last-workspace.spec.ts
+++ b/apps/web/e2e/label-restore-last-workspace.spec.ts
@@ -20,6 +20,8 @@
 
 import { expect, test } from "@playwright/test";
 import { toWorkspaceId } from "@/dashboard";
+import { LABEL_FILTER_KEY } from "../src/dashboard/hooks/use-label-filter";
+import { LABEL_LAST_WORKSPACE_KEY } from "../src/dashboard/hooks/use-label-last-workspace";
 import {
   cleanupTmpHome,
   createTmpHome,
@@ -111,10 +113,13 @@ test.afterAll(async () => {
 // access to localStorage in the right origin.
 test.beforeEach(async ({ page }) => {
   await page.goto(`${server.url}/workspace/${encodeURIComponent(WS_PERSONAL_1)}?token=${TOKEN}`);
-  await page.evaluate(() => {
-    localStorage.removeItem("band.projects-list.label-filter");
-    localStorage.removeItem("band.projects-list.label-last-workspace");
-  });
+  await page.evaluate(
+    ([filterKey, mapKey]) => {
+      localStorage.removeItem(filterKey);
+      localStorage.removeItem(mapKey);
+    },
+    [LABEL_FILTER_KEY, LABEL_LAST_WORKSPACE_KEY] as const,
+  );
 });
 
 test.describe("Label switch restores last-used workspace (issue #505)", () => {
@@ -216,43 +221,30 @@ test.describe("Label switch restores last-used workspace (issue #505)", () => {
     // orchestration as the dropdown by exercising a round-trip via the
     // accelerator registered in `DashboardShell`'s keydown listener.
     //
-    // The handler explicitly skips when focus is inside an editable
-    // element (so users can type "⌘1" into a chat without hijacking it),
-    // so the test focuses the project-list root before each press. That
-    // element is the keyboard nav target the app already uses for arrow
-    // navigation, and it's confirmed not editable. Sending the shortcut
-    // via `locator.press` routes the keystroke to that element directly,
-    // bypassing the chat textarea autofocus on the workspace route.
+    // `WorkspacePage.pressLabelShortcut` handles the focus-and-press
+    // dance (the chat textarea autofocuses on the workspace route, and
+    // the keydown handler in DashboardShell skips when focus is on an
+    // editable element); see the page-object method for the rationale.
 
     const workspacePage = new WorkspacePage(page, server.url, TOKEN);
     await workspacePage.goto(WS_PERSONAL_1);
 
-    // The project list container has `tabindex="-1"` and isn't editable;
-    // pressing keys against it lets the bubble-phase handler in
-    // DashboardShell see `e.target.tagName === "DIV"` and not skip. We
-    // target it by testid rather than `[tabindex="-1"]` because the
-    // dockview's file tab bar also exposes a tabindex=-1 element and a
-    // generic selector would pick the wrong one (project list lives in
-    // the sidebar; the file tab bar lives in the main area).
-    const projectListRoot = page.getByTestId("project-list__root");
-    await projectListRoot.waitFor({ state: "visible" });
-
     // Build up: Ctrl+1 → Personal, then click a Personal workspace.
-    await projectListRoot.press("Control+1");
+    await workspacePage.pressLabelShortcut(1);
     await workspacePage.switchWorkspace(WS_PERSONAL_1);
     await expect(page).toHaveURL(new RegExp(encodeURIComponent(WS_PERSONAL_1)));
 
     // Ctrl+2 → Work, click a Work workspace.
-    await projectListRoot.press("Control+2");
+    await workspacePage.pressLabelShortcut(2);
     await workspacePage.switchWorkspace(WS_WORK_2);
     await expect(page).toHaveURL(new RegExp(encodeURIComponent(WS_WORK_2)));
 
     // Round-trip: Ctrl+1 should restore Personal → WS_PERSONAL_1.
-    await projectListRoot.press("Control+1");
+    await workspacePage.pressLabelShortcut(1);
     await expect(page).toHaveURL(new RegExp(encodeURIComponent(WS_PERSONAL_1)));
 
     // Ctrl+2 should restore Work → WS_WORK_2.
-    await projectListRoot.press("Control+2");
+    await workspacePage.pressLabelShortcut(2);
     await expect(page).toHaveURL(new RegExp(encodeURIComponent(WS_WORK_2)));
 
     // Final state of the map mirrors what the click-path test produces.

--- a/apps/web/e2e/label-restore-last-workspace.spec.ts
+++ b/apps/web/e2e/label-restore-last-workspace.spec.ts
@@ -19,7 +19,7 @@
  */
 
 import { expect, test } from "@playwright/test";
-import { LABEL_FILTER_KEY, LABEL_LAST_WORKSPACE_KEY, toWorkspaceId } from "@/dashboard";
+import { toWorkspaceId } from "@/dashboard";
 import {
   cleanupTmpHome,
   createTmpHome,
@@ -106,21 +106,12 @@ test.afterAll(async () => {
 });
 
 // Clear the per-test state we care about — the label filter and the
-// "last workspace" map both live in localStorage. The page hasn't
-// navigated yet, so land on a workspace first (any will do) to get
-// access to localStorage in the right origin. Routed through
-// `WorkspacePage.goto` so URL construction stays inside the page
-// object per the integration-test doctrine.
+// "last workspace" map both live in localStorage. Encapsulated in the
+// page object so the test body never touches raw `page.evaluate` /
+// localStorage keys, per the integration-test doctrine.
 test.beforeEach(async ({ page }) => {
   const workspacePage = new WorkspacePage(page, server.url, TOKEN);
-  await workspacePage.goto(WS_PERSONAL_1);
-  await page.evaluate(
-    ([filterKey, mapKey]) => {
-      localStorage.removeItem(filterKey);
-      localStorage.removeItem(mapKey);
-    },
-    [LABEL_FILTER_KEY, LABEL_LAST_WORKSPACE_KEY] as const,
-  );
+  await workspacePage.resetLabelStateAndGoto(WS_PERSONAL_1);
 });
 
 test.describe("Label switch restores last-used workspace (issue #505)", () => {

--- a/apps/web/e2e/pages/WorkspacePage.ts
+++ b/apps/web/e2e/pages/WorkspacePage.ts
@@ -137,17 +137,15 @@ export class WorkspacePage {
   async selectLabelFilter(labelId: string | null): Promise<void> {
     const label = labelId ?? "all";
     await test.step(`Select label filter "${label}" via dropdown`, async () => {
-      // Wait until the previous portal (if any) has finished its fade-out
-      // before opening a new one. The trigger is always in the DOM, so
-      // we anchor on the item we expect to disappear after a previous
-      // selection.
-      await this.labelFilterItem(labelId).waitFor({ state: "hidden" });
       await this.labelFilterTrigger().click();
       const item = this.labelFilterItem(labelId);
       await item.waitFor({ state: "visible" });
       await item.click();
-      // Wait for the menu to close so the next call can detect its
-      // own "previous portal gone" state cleanly.
+      // Wait for the menu to close before returning so a back-to-back
+      // call doesn't try to interact with the previous portal as it
+      // animates out (Radix DropdownMenu keeps the portal mounted
+      // during the fade-out, which Playwright would detect as
+      // "element was detached from the DOM" mid-click).
       await item.waitFor({ state: "hidden" });
     });
   }

--- a/apps/web/e2e/pages/WorkspacePage.ts
+++ b/apps/web/e2e/pages/WorkspacePage.ts
@@ -13,7 +13,7 @@
  */
 
 import { type Locator, type Page, test } from "@playwright/test";
-import { LABEL_LAST_WORKSPACE_KEY } from "@/dashboard";
+import { LABEL_FILTER_KEY, LABEL_LAST_WORKSPACE_KEY } from "@/dashboard";
 
 /** localStorage key prefix used by `SharedDockviewLayout` for per-workspace
  *  state (matches `ACTIVE_STATE_KEY_PREFIX` in the source). */
@@ -147,6 +147,26 @@ export class WorkspacePage {
       // during the fade-out, which Playwright would detect as
       // "element was detached from the DOM" mid-click).
       await item.waitFor({ state: "hidden" });
+    });
+  }
+
+  /** Reset both label-related localStorage entries (active filter +
+   *  per-label "last workspace" map) and navigate to `workspaceId`, so
+   *  tests start from a known-clean slate. Two-step: navigate first to
+   *  land on the origin (localStorage isn't accessible until a same-
+   *  origin page is loaded), then evaluate the clear. Keeps the raw
+   *  `page.evaluate` out of test bodies and centralises the
+   *  storage-key constants in this page object. */
+  async resetLabelStateAndGoto(workspaceId: string): Promise<void> {
+    await test.step(`Reset label state, navigate to ${workspaceId}`, async () => {
+      await this.goto(workspaceId);
+      await this.page.evaluate(
+        ([filterKey, mapKey]) => {
+          localStorage.removeItem(filterKey);
+          localStorage.removeItem(mapKey);
+        },
+        [LABEL_FILTER_KEY, LABEL_LAST_WORKSPACE_KEY] as const,
+      );
     });
   }
 

--- a/apps/web/e2e/pages/WorkspacePage.ts
+++ b/apps/web/e2e/pages/WorkspacePage.ts
@@ -13,7 +13,7 @@
  */
 
 import { type Locator, type Page, test } from "@playwright/test";
-import { LABEL_LAST_WORKSPACE_KEY } from "../../src/dashboard/hooks/use-label-last-workspace";
+import { LABEL_LAST_WORKSPACE_KEY } from "@/dashboard";
 
 /** localStorage key prefix used by `SharedDockviewLayout` for per-workspace
  *  state (matches `ACTIVE_STATE_KEY_PREFIX` in the source). */

--- a/apps/web/e2e/pages/WorkspacePage.ts
+++ b/apps/web/e2e/pages/WorkspacePage.ts
@@ -13,6 +13,7 @@
  */
 
 import { type Locator, type Page, test } from "@playwright/test";
+import { LABEL_LAST_WORKSPACE_KEY } from "../../src/dashboard/hooks/use-label-last-workspace";
 
 /** localStorage key prefix used by `SharedDockviewLayout` for per-workspace
  *  state (matches `ACTIVE_STATE_KEY_PREFIX` in the source). */
@@ -155,8 +156,8 @@ export class WorkspacePage {
    *  localStorage. Returns an empty object when nothing has been
    *  recorded yet. */
   async readLabelLastWorkspaces(): Promise<Record<string, string>> {
-    return await this.page.evaluate(() => {
-      const raw = localStorage.getItem("band.projects-list.label-last-workspace");
+    return await this.page.evaluate((key) => {
+      const raw = localStorage.getItem(key);
       if (!raw) return {};
       try {
         const parsed = JSON.parse(raw);
@@ -167,6 +168,35 @@ export class WorkspacePage {
         // Corrupted entry — treat as empty.
       }
       return {};
+    }, LABEL_LAST_WORKSPACE_KEY);
+  }
+
+  /** Sidebar project-list root — the keyboard nav anchor in
+   *  `ProjectList.tsx` (a `tabindex=-1` div). `DashboardShell`'s
+   *  keydown handler skips the Cmd+1..9 / Ctrl+1..9 label shortcuts
+   *  when `e.target.tagName` is `INPUT` / `TEXTAREA` / `SELECT` /
+   *  `contentEditable`, so tests that fire the shortcut must route the
+   *  keystroke through a non-editable target. The project list root
+   *  fits the bill — it's both keyboard-focusable and intentionally
+   *  not editable. */
+  projectListRoot(): Locator {
+    return this.page.getByTestId("project-list__root");
+  }
+
+  /** Drive the ⌘1..9 / Ctrl+1..9 label shortcut as a real user keypress.
+   *  Uses `projectListRoot.press(...)` so Playwright moves focus there
+   *  before dispatching the key, bypassing the chat textarea autofocus
+   *  on the workspace route. The keydown bubbles to the window listener
+   *  in `DashboardShell` where the shortcut is wired up. `index` is
+   *  0-based; 0 picks "All" (⌘0), 1..9 pick the Nth label (⌘1..9). */
+  async pressLabelShortcut(index: number): Promise<void> {
+    if (index < 0 || index > 9) {
+      throw new Error(`pressLabelShortcut: index must be 0..9, got ${index}`);
+    }
+    await test.step(`Press Control+${index} (label shortcut)`, async () => {
+      const root = this.projectListRoot();
+      await root.waitFor({ state: "visible" });
+      await root.press(`Control+${index}`);
     });
   }
 

--- a/apps/web/e2e/pages/WorkspacePage.ts
+++ b/apps/web/e2e/pages/WorkspacePage.ts
@@ -156,7 +156,16 @@ export class WorkspacePage {
    *  land on the origin (localStorage isn't accessible until a same-
    *  origin page is loaded), then evaluate the clear. Keeps the raw
    *  `page.evaluate` out of test bodies and centralises the
-   *  storage-key constants in this page object. */
+   *  storage-key constants in this page object.
+   *
+   *  IMPORTANT: the clear runs AFTER the page mounts, so the React
+   *  tree's in-memory copies of those values (e.g. `useLabelFilter`'s
+   *  state, `lastSeenActiveRef`) still reflect what was in storage at
+   *  mount time. Tests that call this helper should follow up with
+   *  another `goto(...)` (or `reload()`) before exercising label-state
+   *  behaviour, so the React tree re-reads the now-clean storage on
+   *  remount. All in-tree callers already do — every test body opens
+   *  with its own `goto(...)`. */
   async resetLabelStateAndGoto(workspaceId: string): Promise<void> {
     await test.step(`Reset label state, navigate to ${workspaceId}`, async () => {
       await this.goto(workspaceId);

--- a/apps/web/e2e/pages/WorkspacePage.ts
+++ b/apps/web/e2e/pages/WorkspacePage.ts
@@ -103,6 +103,73 @@ export class WorkspacePage {
     });
   }
 
+  /** Trigger button for the label filter dropdown in the dashboard
+   *  sidebar toolbar (issue #505). Only rendered when at least one label
+   *  is defined in settings. */
+  labelFilterTrigger(): Locator {
+    return this.page.getByTestId("dashboard__label-filter-trigger");
+  }
+
+  /** Menu item inside the label-filter dropdown. Pass `null` for the
+   *  "All" (no-filter) item, or a label id for a specific label. */
+  labelFilterItem(labelId: string | null): Locator {
+    const key = labelId ?? "all";
+    return this.page.getByTestId(`dashboard__label-filter-item--${key}`);
+  }
+
+  /** Open the label-filter dropdown and click the item for `labelId`.
+   *  `null` selects the "All" item. Mirrors what `setLabelFilter` would
+   *  produce — including the per-label "last workspace" restore added in
+   *  issue #505 — so this is the right path for tests that need the
+   *  full click→restore behaviour.
+   *
+   *  Only the SharedDockviewLayout's DashboardShell is mounted on
+   *  desktop (see `apps/web/src/routes/index.tsx` and the comment in
+   *  `SharedDockviewLayout` § ProjectsPanelComponent), so a single
+   *  trigger / item pair is in the DOM at any time. The Radix
+   *  DropdownMenu portals its content to `document.body` with a fade
+   *  animation on close, so a back-to-back reopen can briefly see the
+   *  previous portal animating out while the new one mounts. Waiting
+   *  for the new portal to be both visible AND stable before clicking
+   *  (via Locator's auto-waits + `state: "visible"`) avoids the
+   *  `element was detached from the DOM` flake. */
+  async selectLabelFilter(labelId: string | null): Promise<void> {
+    const label = labelId ?? "all";
+    await test.step(`Select label filter "${label}" via dropdown`, async () => {
+      // Wait until the previous portal (if any) has finished its fade-out
+      // before opening a new one. The trigger is always in the DOM, so
+      // we anchor on the item we expect to disappear after a previous
+      // selection.
+      await this.labelFilterItem(labelId).waitFor({ state: "hidden" });
+      await this.labelFilterTrigger().click();
+      const item = this.labelFilterItem(labelId);
+      await item.waitFor({ state: "visible" });
+      await item.click();
+      // Wait for the menu to close so the next call can detect its
+      // own "previous portal gone" state cleanly.
+      await item.waitFor({ state: "hidden" });
+    });
+  }
+
+  /** Read the persisted per-label "last workspace" map from
+   *  localStorage. Returns an empty object when nothing has been
+   *  recorded yet. */
+  async readLabelLastWorkspaces(): Promise<Record<string, string>> {
+    return await this.page.evaluate(() => {
+      const raw = localStorage.getItem("band.projects-list.label-last-workspace");
+      if (!raw) return {};
+      try {
+        const parsed = JSON.parse(raw);
+        if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+          return parsed as Record<string, string>;
+        }
+      } catch {
+        // Corrupted entry — treat as empty.
+      }
+      return {};
+    });
+  }
+
   /** Locate a tab in the OUTER shared-dockview tab strip by its panel
    *  component id ("chat" | "changes" | "files" | "terminal" |
    *  "browser"). `data-testid` is set by `DefaultTab` / `BadgeTab` in

--- a/apps/web/src/dashboard/components/DashboardShell.tsx
+++ b/apps/web/src/dashboard/components/DashboardShell.tsx
@@ -19,6 +19,7 @@ import {
 } from "@band-app/ui";
 import { Check, ChevronsDownUp, FolderPlus, Menu, Plus, Settings, Tag, X } from "lucide-react";
 import { type ReactNode, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCapabilities } from "../context";
 import { useAppUpdate } from "../hooks/use-app-update";
 import { useCliSetup } from "../hooks/use-cli-setup";
 import {
@@ -31,6 +32,7 @@ import {
 } from "../hooks/use-collapse-state";
 import { useHooksSetup } from "../hooks/use-hooks-setup";
 import { useLabelFilter } from "../hooks/use-label-filter";
+import { useLabelLastWorkspace } from "../hooks/use-label-last-workspace";
 import { useProjects } from "../hooks/use-projects";
 import { useSettingsQuery } from "../hooks/use-settings-query";
 import {
@@ -38,7 +40,9 @@ import {
   useSetupStatusWatcher,
   useStatusWatcher,
 } from "../hooks/use-status";
+import { toWorkspaceId } from "../lib/workspace-id";
 import { useDashboardStore } from "../stores/index";
+import type { ProjectInfo } from "../types";
 import { AddProjectDialog } from "./AddProjectDialog";
 import { ProjectList } from "./ProjectList";
 import { SettingsPage } from "./SettingsPage";
@@ -85,7 +89,10 @@ export function DashboardShell({ toolbarMenuItems, hideTitleBar, hideMenu }: Das
   const [showAddDialog, setShowAddDialog] = useState(false);
   const [showErrorDialog, setShowErrorDialog] = useState(false);
   const [showSettingsDialog, setShowSettingsDialog] = useState(false);
-  const [labelFilter, setLabelFilter] = useLabelFilter();
+  const [labelFilter, persistLabelFilter] = useLabelFilter();
+  const { getLastWorkspace, setLastWorkspace } = useLabelLastWorkspace();
+  const capabilities = useCapabilities();
+  const activeWorkspaceId = useDashboardStore((s) => s.activeWorkspaceId);
   const { state: hooksState, install: installHooks } = useHooksSetup();
   const { state: cliState, install: installCli } = useCliSetup();
   const { state: updateState, install: installUpdate } = useAppUpdate();
@@ -124,6 +131,121 @@ export function DashboardShell({ toolbarMenuItems, hideTitleBar, hideMenu }: Das
   const activeLabel = useMemo(
     () => (labelFilter ? labels.find((l) => l.id === labelFilter) : null),
     [labelFilter, labels],
+  );
+
+  // Find the project that owns `workspaceId` in the current project list, or
+  // `undefined` when the workspace no longer exists (deleted / renamed). Kept
+  // as a helper rather than a Map<workspaceId, ProjectInfo> because the
+  // project list churns rarely and the per-call O(projects × worktrees) walk
+  // is dominated by render cost anyway.
+  const findProjectForWorkspace = useCallback(
+    (workspaceId: string): ProjectInfo | undefined =>
+      projects.find((p) =>
+        p.worktrees.some((wt) => toWorkspaceId(p.name, wt.branch) === workspaceId),
+      ),
+    [projects],
+  );
+
+  // Per-label "last workspace" tracking for issue #505. Two write sites
+  // cooperate so the user's selection is captured whether they click a
+  // workspace card (effect below) or switch label without clicking
+  // anything (`setLabelFilter` further down):
+  //
+  //   - The effect records each fresh `activeWorkspaceId` under the
+  //     currently-active label. The `lastSeenActiveRef` guard skips
+  //     reruns triggered by `labelFilter` changing without
+  //     `activeWorkspaceId` changing — i.e. immediately after a label
+  //     switch, before the restore-driven navigation has propagated. If
+  //     we didn't skip, the effect would briefly stamp the *incoming*
+  //     label with the *outgoing* label's workspace and undo the
+  //     restoration we just initiated.
+  //
+  //   - `setLabelFilter` does an imperative save of the outgoing label
+  //     so the user's most recent selection is captured even when they
+  //     never explicitly clicked the workspace card after navigating to
+  //     it (e.g. direct URL / Cmd+R picker / page reload).
+  const lastSeenActiveRef = useRef<string | null>(activeWorkspaceId);
+  useEffect(() => {
+    if (!activeWorkspaceId) {
+      lastSeenActiveRef.current = null;
+      return;
+    }
+    if (!labelFilter) {
+      // ALL has no per-label memory, but we still update the ref so a
+      // subsequent label switch correctly recognises the workspace as
+      // unchanged (and skips the cross-label stamp).
+      lastSeenActiveRef.current = activeWorkspaceId;
+      return;
+    }
+    if (lastSeenActiveRef.current === activeWorkspaceId) return;
+    lastSeenActiveRef.current = activeWorkspaceId;
+    // Only save when the active workspace's project is actually labelled
+    // with the current filter — see the comment block on the
+    // `setLabelFilter` invariants below for the rationale.
+    const project = findProjectForWorkspace(activeWorkspaceId);
+    if (!project || project.label !== labelFilter) return;
+    setLastWorkspace(labelFilter, activeWorkspaceId);
+  }, [labelFilter, activeWorkspaceId, setLastWorkspace, findProjectForWorkspace]);
+
+  // Per-label "last workspace" plumbing for issue #505. The orchestration
+  // lives in `setLabelFilter` below; the helper here keeps the bookkeeping
+  // out of the keyboard / dropdown handlers.
+  //
+  // Invariants enforced by the caller:
+  //   1. Saves only happen when the outgoing label is non-null (ALL has no
+  //      per-label memory) AND the active workspace's project is actually
+  //      labelled with the outgoing label. If the user navigated to a
+  //      workspace under a different label via the Cmd+R picker, we don't
+  //      want to record that workspace as Personal's "last" just because
+  //      the filter happened to be Personal at the time.
+  //   2. Restores only happen when the saved workspace still exists AND its
+  //      project is still labelled with the target label (labels can be
+  //      reassigned at any time). If validation fails we fall through to
+  //      the "no history" branch — current behaviour, i.e. keep the
+  //      previous active workspace, leaving the user to pick one.
+  const setLabelFilter = useCallback(
+    (newLabel: string | null) => {
+      if (newLabel === labelFilter) return;
+
+      // Save the outgoing label's active workspace before mutating state.
+      // Doing this synchronously (rather than via an effect on
+      // labelFilter/activeWorkspaceId) avoids a race where the effect would
+      // fire after the label changed but before the restore-driven
+      // navigation propagated activeWorkspaceId, briefly re-stamping the
+      // incoming label with the outgoing label's workspace.
+      if (labelFilter && activeWorkspaceId) {
+        const project = findProjectForWorkspace(activeWorkspaceId);
+        if (project && project.label === labelFilter) {
+          setLastWorkspace(labelFilter, activeWorkspaceId);
+        }
+      }
+
+      persistLabelFilter(newLabel);
+
+      // ALL is the explicit no-op case (per the issue): keep the user on
+      // whatever workspace they were last viewing. Restoration only applies
+      // when switching to a *specific* label.
+      if (!newLabel) return;
+
+      const target = getLastWorkspace(newLabel);
+      if (!target || target === activeWorkspaceId) return;
+      const targetProject = findProjectForWorkspace(target);
+      if (!targetProject || targetProject.label !== newLabel) return;
+
+      const href = capabilities.getWorkspaceHref?.(target);
+      if (href && capabilities.navigate) {
+        capabilities.navigate(href);
+      }
+    },
+    [
+      labelFilter,
+      activeWorkspaceId,
+      persistLabelFilter,
+      setLastWorkspace,
+      getLastWorkspace,
+      findProjectForWorkspace,
+      capabilities,
+    ],
   );
 
   // The desktop shell's native menu (Cmd+,) and the in-app DesktopTitleBar
@@ -281,6 +403,7 @@ export function DashboardShell({ toolbarMenuItems, hideTitleBar, hideMenu }: Das
                   <Button
                     size="sm"
                     variant="ghost"
+                    data-testid="dashboard__label-filter-trigger"
                     className={`min-w-0 text-sm h-7 px-2 gap-1.5 ${labelFilter ? "bg-accent text-accent-foreground" : "text-muted-foreground"}`}
                   >
                     {activeLabel ? (
@@ -300,7 +423,10 @@ export function DashboardShell({ toolbarMenuItems, hideTitleBar, hideMenu }: Das
                   </Button>
                 </DropdownMenuTrigger>
                 <DropdownMenuContent align="start">
-                  <DropdownMenuItem onClick={() => setLabelFilter(null)}>
+                  <DropdownMenuItem
+                    data-testid="dashboard__label-filter-item--all"
+                    onClick={() => setLabelFilter(null)}
+                  >
                     <Tag className="size-3.5 shrink-0 mr-2 text-muted-foreground" />
                     <span className="truncate">All</span>
                     {!labelFilter && <Check className="size-3 ml-2 shrink-0" />}
@@ -309,7 +435,11 @@ export function DashboardShell({ toolbarMenuItems, hideTitleBar, hideMenu }: Das
                     </span>
                   </DropdownMenuItem>
                   {labels.map((lbl, idx) => (
-                    <DropdownMenuItem key={lbl.id} onClick={() => setLabelFilter(lbl.id)}>
+                    <DropdownMenuItem
+                      key={lbl.id}
+                      data-testid={`dashboard__label-filter-item--${lbl.id}`}
+                      onClick={() => setLabelFilter(lbl.id)}
+                    >
                       <span
                         className="size-2.5 rounded-full shrink-0 mr-2"
                         style={{ backgroundColor: lbl.color }}

--- a/apps/web/src/dashboard/components/ProjectList.tsx
+++ b/apps/web/src/dashboard/components/ProjectList.tsx
@@ -838,6 +838,7 @@ export function ProjectList({ labelFilter }: ProjectListProps) {
       <div
         ref={containerRef}
         tabIndex={-1}
+        data-testid="project-list__root"
         onKeyDown={handleKeyDown}
         onPointerDown={() => {
           keyboardNavRef.current = false;

--- a/apps/web/src/dashboard/hooks/use-label-last-workspace.ts
+++ b/apps/web/src/dashboard/hooks/use-label-last-workspace.ts
@@ -44,10 +44,16 @@ function write(value: Record<string, string>): void {
   if (typeof window === "undefined") return;
   try {
     window.localStorage.setItem(LABEL_LAST_WORKSPACE_KEY, JSON.stringify(value));
+    // Only dispatch on a successful write. If `setItem` throws (quota
+    // exceeded, private-mode storage disabled, etc.) the on-disk value
+    // is unchanged, so notifying other consumers would make them
+    // `read()` the stale value and overwrite their in-memory map —
+    // a split-brain between this caller's React state and everyone
+    // else's read of localStorage.
+    window.dispatchEvent(new CustomEvent(SYNC_EVENT));
   } catch {
-    // localStorage full or unavailable — ignore.
+    // localStorage full or unavailable — ignore, and skip the dispatch.
   }
-  window.dispatchEvent(new CustomEvent(SYNC_EVENT));
 }
 
 export interface UseLabelLastWorkspaceReturn {

--- a/apps/web/src/dashboard/hooks/use-label-last-workspace.ts
+++ b/apps/web/src/dashboard/hooks/use-label-last-workspace.ts
@@ -1,0 +1,94 @@
+import { useCallback, useEffect, useState } from "react";
+
+/**
+ * Per-label "last selected workspace" memory.
+ *
+ * Lets the dashboard restore the workspace the user was last viewing under
+ * a particular label when they switch back to that label (issue #505). The
+ * map is stored as JSON in localStorage with a custom event for same-tab
+ * synchronisation — mirroring `useLabelFilter` so multiple DashboardShell
+ * instances (one per cached workspace) all agree on what's remembered.
+ *
+ * The dashboard's `setLabelFilter` orchestration layer is responsible for
+ * deciding *when* to call `setLastWorkspace` — see `DashboardShell` — so
+ * this hook is a passive store. In particular, ALL (label === null) has
+ * no per-label memory: callers must not write the null key here.
+ */
+
+/** localStorage key for the per-label "last workspace" map. */
+export const LABEL_LAST_WORKSPACE_KEY = "band.projects-list.label-last-workspace";
+
+/** Custom event broadcast on every write so other consumers re-read. */
+const SYNC_EVENT = "band:label-last-workspace-change";
+
+function read(): Record<string, string> {
+  if (typeof window === "undefined") return {};
+  try {
+    const raw = window.localStorage.getItem(LABEL_LAST_WORKSPACE_KEY);
+    if (!raw) return {};
+    const parsed = JSON.parse(raw);
+    if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+      const out: Record<string, string> = {};
+      for (const [k, v] of Object.entries(parsed)) {
+        if (typeof k === "string" && typeof v === "string") out[k] = v;
+      }
+      return out;
+    }
+  } catch {
+    // Corrupted entry — start fresh.
+  }
+  return {};
+}
+
+function write(value: Record<string, string>): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(LABEL_LAST_WORKSPACE_KEY, JSON.stringify(value));
+  } catch {
+    // localStorage full or unavailable — ignore.
+  }
+  window.dispatchEvent(new CustomEvent(SYNC_EVENT));
+}
+
+export interface UseLabelLastWorkspaceReturn {
+  /** Look up the last workspaceId selected while `labelId` was active.
+   *  Returns `undefined` when no history exists yet. */
+  getLastWorkspace: (labelId: string) => string | undefined;
+  /** Record `workspaceId` as the last workspace selected while `labelId`
+   *  was active. Safe to call repeatedly with the same value (no-op when
+   *  unchanged). */
+  setLastWorkspace: (labelId: string, workspaceId: string) => void;
+}
+
+export function useLabelLastWorkspace(): UseLabelLastWorkspaceReturn {
+  const [map, setMap] = useState<Record<string, string>>(() => read());
+
+  // Sync across tabs (native StorageEvent) and across same-tab consumers
+  // (custom SYNC_EVENT, fired by `write` since the StorageEvent is
+  // cross-tab-only). Same pattern as `useLabelFilter` for consistency.
+  useEffect(() => {
+    const sync = (e: Event) => {
+      if (e instanceof StorageEvent && e.key !== LABEL_LAST_WORKSPACE_KEY) return;
+      setMap(read());
+    };
+    window.addEventListener("storage", sync);
+    window.addEventListener(SYNC_EVENT, sync);
+    return () => {
+      window.removeEventListener("storage", sync);
+      window.removeEventListener(SYNC_EVENT, sync);
+    };
+  }, []);
+
+  const getLastWorkspace = useCallback((labelId: string) => map[labelId], [map]);
+
+  const setLastWorkspace = useCallback((labelId: string, workspaceId: string) => {
+    setMap((prev) => {
+      if (prev[labelId] === workspaceId) return prev;
+      const next = { ...prev, [labelId]: workspaceId };
+      write(next);
+      return next;
+    });
+  }, []);
+
+  return { getLastWorkspace, setLastWorkspace };
+}

--- a/apps/web/src/dashboard/hooks/use-label-last-workspace.ts
+++ b/apps/web/src/dashboard/hooks/use-label-last-workspace.ts
@@ -81,13 +81,21 @@ export function useLabelLastWorkspace(): UseLabelLastWorkspaceReturn {
 
   const getLastWorkspace = useCallback((labelId: string) => map[labelId], [map]);
 
+  // Two-step write: persist + dispatch FIRST, then update local React state.
+  // Calling `write()` inside the functional updater would dispatch
+  // SYNC_EVENT during the setter, which queues `setMap(read())` from the
+  // sync handler — a state setter invoked from inside another setter's
+  // updater is unsupported by React (the nested call can be silently
+  // dropped). `useLabelFilter` uses the same two-step pattern; mirror it
+  // here. Reading the current map via `read()` (rather than the closed-
+  // over `map`) keeps the no-op short-circuit correct across rapid
+  // back-to-back calls where `map` hasn't yet committed.
   const setLastWorkspace = useCallback((labelId: string, workspaceId: string) => {
-    setMap((prev) => {
-      if (prev[labelId] === workspaceId) return prev;
-      const next = { ...prev, [labelId]: workspaceId };
-      write(next);
-      return next;
-    });
+    const current = read();
+    if (current[labelId] === workspaceId) return;
+    const next = { ...current, [labelId]: workspaceId };
+    write(next);
+    setMap(next);
   }, []);
 
   return { getLastWorkspace, setLastWorkspace };

--- a/apps/web/src/dashboard/hooks/use-label-last-workspace.ts
+++ b/apps/web/src/dashboard/hooks/use-label-last-workspace.ts
@@ -1,13 +1,14 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback } from "react";
 
 /**
  * Per-label "last selected workspace" memory.
  *
  * Lets the dashboard restore the workspace the user was last viewing under
  * a particular label when they switch back to that label (issue #505). The
- * map is stored as JSON in localStorage with a custom event for same-tab
- * synchronisation — mirroring `useLabelFilter` so multiple DashboardShell
- * instances (one per cached workspace) all agree on what's remembered.
+ * map is stored as JSON in localStorage; both `getLastWorkspace` and
+ * `setLastWorkspace` go through `read()` / `write()` at call time, so the
+ * hook needs no React state of its own — values are always fresh, and
+ * callers that need reactivity should subscribe to the SYNC_EVENT directly.
  *
  * The dashboard's `setLabelFilter` orchestration layer is responsible for
  * deciding *when* to call `setLastWorkspace` — see `DashboardShell` — so
@@ -18,7 +19,11 @@ import { useCallback, useEffect, useState } from "react";
 /** localStorage key for the per-label "last workspace" map. */
 export const LABEL_LAST_WORKSPACE_KEY = "band.projects-list.label-last-workspace";
 
-/** Custom event broadcast on every write so other consumers re-read. */
+/** Custom event broadcast on every successful write. Cross-tab updates
+ *  also reach consumers via the native `storage` event. No same-file
+ *  consumer subscribes today; the event is exposed for future
+ *  reactive use cases that might want to refresh when another tab
+ *  mutates the map. */
 const SYNC_EVENT = "band:label-last-workspace-change";
 
 function read(): Record<string, string> {
@@ -42,14 +47,17 @@ function read(): Record<string, string> {
 
 function write(value: Record<string, string>): void {
   if (typeof window === "undefined") return;
+  // NB: dispatch lives INSIDE the try block — intentional deviation
+  // from `useLabelFilter.write`, which dispatches unconditionally. The
+  // map carries cross-consumer state that subscribers re-read via
+  // `read()` on every SYNC_EVENT, so a failed `setItem` paired with
+  // an unconditional dispatch would make every consumer pick up the
+  // stale on-disk value and silently lose the caller's intended
+  // update. `useLabelFilter`'s value is consumed locally per shell
+  // rather than read back from storage on each event, so the
+  // trade-off there doesn't apply.
   try {
     window.localStorage.setItem(LABEL_LAST_WORKSPACE_KEY, JSON.stringify(value));
-    // Only dispatch on a successful write. If `setItem` throws (quota
-    // exceeded, private-mode storage disabled, etc.) the on-disk value
-    // is unchanged, so notifying other consumers would make them
-    // `read()` the stale value and overwrite their in-memory map —
-    // a split-brain between this caller's React state and everyone
-    // else's read of localStorage.
     window.dispatchEvent(new CustomEvent(SYNC_EVENT));
   } catch {
     // localStorage full or unavailable — ignore, and skip the dispatch.
@@ -67,41 +75,22 @@ export interface UseLabelLastWorkspaceReturn {
 }
 
 export function useLabelLastWorkspace(): UseLabelLastWorkspaceReturn {
-  const [map, setMap] = useState<Record<string, string>>(() => read());
-
-  // Sync across tabs (native StorageEvent) and across same-tab consumers
-  // (custom SYNC_EVENT, fired by `write` since the StorageEvent is
-  // cross-tab-only). Same pattern as `useLabelFilter` for consistency.
-  useEffect(() => {
-    const sync = (e: Event) => {
-      if (e instanceof StorageEvent && e.key !== LABEL_LAST_WORKSPACE_KEY) return;
-      setMap(read());
-    };
-    window.addEventListener("storage", sync);
-    window.addEventListener(SYNC_EVENT, sync);
-    return () => {
-      window.removeEventListener("storage", sync);
-      window.removeEventListener(SYNC_EVENT, sync);
-    };
-  }, []);
-
-  const getLastWorkspace = useCallback((labelId: string) => map[labelId], [map]);
-
-  // Two-step write: persist + dispatch FIRST, then update local React state.
-  // Calling `write()` inside the functional updater would dispatch
-  // SYNC_EVENT during the setter, which queues `setMap(read())` from the
-  // sync handler — a state setter invoked from inside another setter's
-  // updater is unsupported by React (the nested call can be silently
-  // dropped). `useLabelFilter` uses the same two-step pattern; mirror it
-  // here. Reading the current map via `read()` (rather than the closed-
-  // over `map`) keeps the no-op short-circuit correct across rapid
-  // back-to-back calls where `map` hasn't yet committed.
+  // Both methods go through `read()` / `write()` at call time. No React
+  // state is needed because nothing about the map is rendered today —
+  // `getLastWorkspace` is only invoked imperatively from
+  // `DashboardShell.setLabelFilter` on a user action, where reading
+  // localStorage directly gives an always-fresh value and frees the
+  // callback closure from any React state, keeping
+  // `getLastWorkspace`'s identity stable across navigations so
+  // downstream `useCallback`s don't rebuild and the keyboard shortcut
+  // listener doesn't re-attach. If a future reactive consumer is
+  // added, subscribe to SYNC_EVENT + the native `storage` event in
+  // that consumer rather than re-introducing global state here.
+  const getLastWorkspace = useCallback((labelId: string) => read()[labelId], []);
   const setLastWorkspace = useCallback((labelId: string, workspaceId: string) => {
     const current = read();
     if (current[labelId] === workspaceId) return;
-    const next = { ...current, [labelId]: workspaceId };
-    write(next);
-    setMap(next);
+    write({ ...current, [labelId]: workspaceId });
   }, []);
 
   return { getLastWorkspace, setLastWorkspace };

--- a/apps/web/src/dashboard/index.ts
+++ b/apps/web/src/dashboard/index.ts
@@ -48,6 +48,11 @@ export {
 } from "./hooks/use-editor-history";
 export { type HooksSetupState, useHooksSetup } from "./hooks/use-hooks-setup";
 export { useIsDark } from "./hooks/use-is-dark";
+export { LABEL_FILTER_KEY, useLabelFilter } from "./hooks/use-label-filter";
+export {
+  LABEL_LAST_WORKSPACE_KEY,
+  useLabelLastWorkspace,
+} from "./hooks/use-label-last-workspace";
 export { useProjectKindForWorkspace, useProjectKindMap } from "./hooks/use-project-kind";
 export {
   useAddProject,


### PR DESCRIPTION
## Summary

Closes #505.

Switching to a specific label (Personal / Work / …) now restores the workspace the user was last viewing under that label. Switching to ALL keeps the current selection, matching the issue's acceptance criteria.

- Per-label "last workspace" memory persisted to localStorage alongside the existing label filter (`band.projects-list.label-last-workspace`), surviving full page reloads.
- Both the keyboard shortcut path (⌘1..9 / Ctrl+1..9) and the dropdown click path go through the same `setLabelFilter` orchestration in DashboardShell, so the two surfaces share the restore logic by construction.
- Save / restore are guarded by an "active workspace's project actually has this label" check so cross-label navigation (e.g. Cmd+R picker landing on a Work workspace while filter is Personal) doesn't corrupt the per-label map.
- ALL is the explicit no-op case: switching to or from ALL never changes the active workspace, and never writes a per-label entry.

## Implementation notes

- New `useLabelLastWorkspace` hook mirrors `useLabelFilter`'s localStorage + custom-event sync pattern.
- `setLabelFilter` in `DashboardShell` saves the outgoing label's workspace synchronously before mutating state (avoids the race the issue called out where an effect-based save would re-stamp the incoming label with the outgoing label's workspace before restore-driven navigation propagated).
- An effect on `activeWorkspaceId` also records workspace clicks under the current label, so per-label memory stays fresh between label switches. A ref-based guard skips reruns triggered by label changes alone, preserving the race fix above.

## Test plan

- [x] `pnpm --filter @band-app/server test:e2e` — 39 / 39 passing, including 4 new tests in `apps/web/e2e/label-restore-last-workspace.spec.ts` covering:
  - Headline restore behaviour (Personal ↔ Work round-trip).
  - ALL is a no-op (current workspace persists, no per-label entry written).
  - Keyboard shortcut path (Ctrl+1 / Ctrl+2) drives the same restore.
  - Per-label memory survives a full page reload.
- [x] No tRPC mocks; real production binary boot via `startServer` + Express seeding pattern per the `write-integration-test` skill.
- [x] Page Object Model — new `selectLabelFilter`, `labelFilterTrigger`, `labelFilterItem`, `readLabelLastWorkspaces` methods on `WorkspacePage`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)