### PR TITLE
fix(web): label detached-HEAD worktrees with SHA fallback (no more blank cards)

### DIFF
--- a/apps/web/src/lib/git.ts
+++ b/apps/web/src/lib/git.ts
@@ -206,9 +206,17 @@ export async function listWorktrees(repoPath: string): Promise<WorktreeInfo[]> {
  * would still collide, but git doesn't actually produce empty `HEAD` lines
  * in practice — the marker is defensive, not load-bearing.
  */
-function detachedShaLabel(head: string): string {
+/**
+ * Prefix used by `detachedShaLabel`. Exported so callers that need to
+ * recognise the synthetic label (e.g. `workspaces.remove` skipping
+ * `git branch -D` for a non-real ref) can do so without re-spelling
+ * the literal `"detached-"` in two places.
+ */
+export const DETACHED_BRANCH_PREFIX = "detached-";
+
+export function detachedShaLabel(head: string): string {
   const sha = head.trim().slice(0, 7);
-  return sha ? `detached-${sha}` : "detached";
+  return sha ? `${DETACHED_BRANCH_PREFIX}${sha}` : "detached";
 }
 
 /**

--- a/apps/web/src/lib/git.ts
+++ b/apps/web/src/lib/git.ts
@@ -148,7 +148,7 @@ export async function listWorktrees(repoPath: string): Promise<WorktreeInfo[]> {
       isBare = true;
     } else if (line === "" && currentPath) {
       if (!currentBranch && !isBare) {
-        currentBranch = await resolveDetachedBranch(currentPath);
+        currentBranch = (await resolveDetachedBranch(currentPath)) || detachedShaLabel(currentHead);
       }
       worktrees.push({
         branch: currentBranch,
@@ -166,7 +166,7 @@ export async function listWorktrees(repoPath: string): Promise<WorktreeInfo[]> {
   // Push last entry
   if (currentPath) {
     if (!currentBranch && !isBare) {
-      currentBranch = await resolveDetachedBranch(currentPath);
+      currentBranch = (await resolveDetachedBranch(currentPath)) || detachedShaLabel(currentHead);
     }
     worktrees.push({
       branch: currentBranch,
@@ -180,8 +180,44 @@ export async function listWorktrees(repoPath: string): Promise<WorktreeInfo[]> {
 }
 
 /**
- * When a worktree has a detached HEAD (e.g. during rebase), try to resolve
- * the original branch name from git's rebase state files.
+ * Build a fallback "branch" label for a detached HEAD that isn't mid-rebase
+ * (e.g. a checked-out tag, a raw commit SHA, or a post-rebase/post-bisect
+ * state). The label must be:
+ *
+ *   1. **Non-empty** — `WorkspaceCard` renders `worktree.branch` as-is, so an
+ *      empty string shows as a blank label next to the branch icon and the
+ *      dirty-tree "M" badge.
+ *   2. **Unique per worktree** — workspace IDs are derived from
+ *      `${projectName}-${branch}` via `toWorkspaceId`. Two detached worktrees
+ *      with the empty string collide to the same ID, which breaks selection,
+ *      pinning, and the `data-testid` hook on `WorkspaceCard`. Embedding the
+ *      short commit SHA disambiguates them.
+ *   3. **Filesystem- and URL-safe** — `workspaceId` is used as a path
+ *      component in `workspace-prompts/<id>.json` and `shared/<id>/...`, and
+ *      as a URL segment via `encodeURIComponent`. We stick to `[a-z0-9-]` so
+ *      no encoding surprises leak through. (Bug surfaced when a user had
+ *      ~9 worktrees in detached-HEAD states — see the WorkspaceCard chain
+ *      starting at the empty-branch return below.)
+ *
+ * If the porcelain `HEAD` line was missing (extremely unusual — git emits it
+ * for every worktree, including bare ones), we fall back to a non-empty
+ * generic marker so the label still renders and the caller's ID derivation
+ * doesn't collapse to `${projectName}-`. Different worktrees in that state
+ * would still collide, but git doesn't actually produce empty `HEAD` lines
+ * in practice — the marker is defensive, not load-bearing.
+ */
+function detachedShaLabel(head: string): string {
+  const sha = head.trim().slice(0, 7);
+  return sha ? `detached-${sha}` : "detached";
+}
+
+/**
+ * When a worktree has a detached HEAD mid-rebase, try to resolve the
+ * original branch name from git's rebase state files. Returns the empty
+ * string for any other detached state (checked-out tag, raw SHA, finished/
+ * aborted rebase) — callers must fall back to `detachedShaLabel` in that
+ * case, otherwise the empty string flows into `toWorkspaceId` and produces
+ * colliding workspace IDs (see `detachedShaLabel` for the full chain).
  */
 async function resolveDetachedBranch(worktreePath: string): Promise<string> {
   const dotGit = join(worktreePath, ".git");

--- a/apps/web/src/lib/git.ts
+++ b/apps/web/src/lib/git.ts
@@ -180,6 +180,14 @@ export async function listWorktrees(repoPath: string): Promise<WorktreeInfo[]> {
 }
 
 /**
+ * Prefix used by `detachedShaLabel`. Exported so callers that need to
+ * recognise the synthetic label (e.g. `workspaces.remove` skipping
+ * `git branch -D` for a non-real ref) can do so without re-spelling
+ * the literal `"detached-"` in two places.
+ */
+export const DETACHED_BRANCH_PREFIX = "detached-";
+
+/**
  * Build a fallback "branch" label for a detached HEAD that isn't mid-rebase
  * (e.g. a checked-out tag, a raw commit SHA, or a post-rebase/post-bisect
  * state). The label must be:
@@ -206,15 +214,7 @@ export async function listWorktrees(repoPath: string): Promise<WorktreeInfo[]> {
  * would still collide, but git doesn't actually produce empty `HEAD` lines
  * in practice — the marker is defensive, not load-bearing.
  */
-/**
- * Prefix used by `detachedShaLabel`. Exported so callers that need to
- * recognise the synthetic label (e.g. `workspaces.remove` skipping
- * `git branch -D` for a non-real ref) can do so without re-spelling
- * the literal `"detached-"` in two places.
- */
-export const DETACHED_BRANCH_PREFIX = "detached-";
-
-export function detachedShaLabel(head: string): string {
+function detachedShaLabel(head: string): string {
   const sha = head.trim().slice(0, 7);
   return sha ? `${DETACHED_BRANCH_PREFIX}${sha}` : "detached";
 }

--- a/apps/web/src/trpc/router.ts
+++ b/apps/web/src/trpc/router.ts
@@ -545,7 +545,7 @@ const workspacesRouter = t.router({
 
   remove: publicProcedure
     .input(z.object({ project: z.string(), branch: z.string() }))
-    .mutation(({ input }) => {
+    .mutation(async ({ input }) => {
       const state = loadState();
       const proj = state.projects.find((p) => p.name === input.project);
       if (!proj) {
@@ -564,162 +564,156 @@ const workspacesRouter = t.router({
 
       const { command, env: gitEnv } = gitCmd();
 
-      const output = execFileSync(command, ["worktree", "list", "--porcelain"], {
-        cwd: proj.path,
-        env: gitEnv,
-        encoding: "utf-8",
-      });
+      // Resolve the worktree path via `listWorktrees` rather than re-parsing
+      // `git worktree list --porcelain` inline. `listWorktrees` applies the
+      // detached-HEAD → `detached-<short-sha>` fallback that the rest of the
+      // app sees in `proj.worktrees` and that the dashboard sends back here
+      // as `input.branch`. Re-parsing porcelain without the fallback would
+      // leave `currentBranch === ""` for detached worktrees and fall through
+      // to the "Workspace not found" throw below, breaking the "Delete
+      // workspace" context-menu action on every detached-HEAD card.
+      const worktrees = await listWorktrees(proj.path);
+      const match = worktrees.find((wt) => wt.branch === input.branch);
+      if (!match) {
+        throw new Error(`Workspace "${input.branch}" not found`);
+      }
+      const worktreePath = match.path;
 
-      let currentPath = "";
-      let currentBranch = "";
-      for (const line of output.split("\n")) {
-        if (line.startsWith("worktree ")) {
-          currentPath = line.slice("worktree ".length);
-        } else if (line.startsWith("branch ")) {
-          const branchRef = line.slice("branch ".length);
-          currentBranch = branchRef.startsWith("refs/heads/")
-            ? branchRef.slice("refs/heads/".length)
-            : branchRef;
-        } else if (line === "" && currentPath) {
-          if (currentBranch === input.branch) {
-            const worktreePath = currentPath;
-
-            // Capture config before returning — the directory may be removed
-            // by background cleanup before loadProjectConfig can read it.
-            let teardownCmd: string | undefined;
-            try {
-              const config = loadProjectConfig(worktreePath, proj.path);
-              if (config?.teardown && typeof config.teardown === "string") {
-                teardownCmd = config.teardown;
-              }
-            } catch {
-              // Config may not exist
-            }
-
-            // ── Fast path: update state and return immediately ──
-            proj.worktrees = proj.worktrees.filter((wt) => wt.branch !== input.branch);
-            saveState(state);
-
-            const workspaceId = toWorkspaceId(input.project, input.branch);
-            try {
-              unlinkSync(join(bandHome(), "workspace-prompts", `${workspaceId}.json`));
-            } catch {
-              // Prompt file may not exist
-            }
-            deleteWorkspaceStatus(workspaceId);
-            deleteBranchStatus(workspaceId);
-
-            // Clean up all chat panes and their agent processes
-            removeWorkspaceChats(workspaceId);
-
-            // Clean up chat layout tree
-            deleteChatLayout(workspaceId);
-
-            // Clean up all browser tabs
-            removeWorkspaceBrowsers(workspaceId);
-
-            // Clean up browser layout tree
-            deleteBrowserLayout(workspaceId);
-
-            // Kill any running terminal PTY sessions
-            killWorkspaceTerminals(workspaceId);
-
-            // Clean up terminal layout tree
-            deleteTerminalLayout(workspaceId);
-
-            // Kill any running language server processes
-            killWorkspaceServers(workspaceId);
-
-            // Clean up workspace-scoped cronjobs
-            stopJobsForKey(workspaceId);
-            deleteCronjobFile(workspaceId);
-
-            // Delete persisted task history for the workspace (issue #416).
-            // Tasks aren't covered by a FK cascade because workspaces aren't a
-            // first-class DB row, so the cleanup is explicit here next to the
-            // other workspace-scoped removals. Task cleanup is best-effort —
-            // a DB lock or WAL timeout must not abort the whole removal or
-            // suppress the `emit` below, otherwise the dashboard would keep
-            // showing the just-deleted workspace.
-            try {
-              const deletedTasks = deleteWorkspaceTasks(workspaceId);
-              if (deletedTasks > 0) {
-                log.info(
-                  { workspaceId, count: deletedTasks },
-                  "deleted workspace tasks on removal",
-                );
-              }
-            } catch (err) {
-              log.error({ workspaceId, err }, "failed to delete workspace tasks on removal");
-            }
-
-            // Notify subscribers (dashboard status stream) that this workspace is gone
-            emit({ kind: "remove", workspaceId });
-
-            // ── Background cleanup: slow git/fs operations ──
-            const projPath = proj.path;
-            setImmediate(() => {
-              (async () => {
-                // Run teardown script before removing worktree so it can access project files
-                if (teardownCmd) {
-                  try {
-                    await execFileAsync("bash", ["-c", teardownCmd], {
-                      cwd: worktreePath,
-                      env: {
-                        ...process.env,
-                        PATH: `/opt/homebrew/bin:/usr/local/bin:${process.env.PATH}`,
-                      },
-                      encoding: "utf-8",
-                      timeout: 60_000,
-                    });
-                  } catch (err) {
-                    log.warn({ err, workspaceId }, "teardown script failed");
-                  }
-                }
-
-                try {
-                  await execFileAsync(command, ["worktree", "remove", "--force", worktreePath], {
-                    cwd: projPath,
-                    env: gitEnv,
-                    encoding: "utf-8",
-                  });
-                } catch {
-                  // Worktree may be corrupted (e.g. missing .git file).
-                  // Manually remove the directory and prune stale entries.
-                  await rm(worktreePath, { recursive: true, force: true });
-                  try {
-                    await execFileAsync(command, ["worktree", "prune"], {
-                      cwd: projPath,
-                      env: gitEnv,
-                      encoding: "utf-8",
-                    });
-                  } catch (err) {
-                    log.warn({ err, workspaceId }, "git worktree prune failed");
-                  }
-                }
-
-                try {
-                  await execFileAsync(command, ["branch", "-D", input.branch], {
-                    cwd: projPath,
-                    env: gitEnv,
-                    encoding: "utf-8",
-                  });
-                } catch {
-                  // Branch may already be deleted
-                }
-              })().catch((err) => {
-                log.error({ err, workspaceId }, "background workspace cleanup failed");
-              });
-            });
-
-            return { ok: true };
-          }
-          currentPath = "";
-          currentBranch = "";
+      // Capture config before returning — the directory may be removed
+      // by background cleanup before loadProjectConfig can read it.
+      let teardownCmd: string | undefined;
+      try {
+        const config = loadProjectConfig(worktreePath, proj.path);
+        if (config?.teardown && typeof config.teardown === "string") {
+          teardownCmd = config.teardown;
         }
+      } catch {
+        // Config may not exist
       }
 
-      throw new Error(`Workspace "${input.branch}" not found`);
+      // ── Fast path: update state and return immediately ──
+      proj.worktrees = proj.worktrees.filter((wt) => wt.branch !== input.branch);
+      saveState(state);
+
+      const workspaceId = toWorkspaceId(input.project, input.branch);
+      try {
+        unlinkSync(join(bandHome(), "workspace-prompts", `${workspaceId}.json`));
+      } catch {
+        // Prompt file may not exist
+      }
+      deleteWorkspaceStatus(workspaceId);
+      deleteBranchStatus(workspaceId);
+
+      // Clean up all chat panes and their agent processes
+      removeWorkspaceChats(workspaceId);
+
+      // Clean up chat layout tree
+      deleteChatLayout(workspaceId);
+
+      // Clean up all browser tabs
+      removeWorkspaceBrowsers(workspaceId);
+
+      // Clean up browser layout tree
+      deleteBrowserLayout(workspaceId);
+
+      // Kill any running terminal PTY sessions
+      killWorkspaceTerminals(workspaceId);
+
+      // Clean up terminal layout tree
+      deleteTerminalLayout(workspaceId);
+
+      // Kill any running language server processes
+      killWorkspaceServers(workspaceId);
+
+      // Clean up workspace-scoped cronjobs
+      stopJobsForKey(workspaceId);
+      deleteCronjobFile(workspaceId);
+
+      // Delete persisted task history for the workspace (issue #416).
+      // Tasks aren't covered by a FK cascade because workspaces aren't a
+      // first-class DB row, so the cleanup is explicit here next to the
+      // other workspace-scoped removals. Task cleanup is best-effort —
+      // a DB lock or WAL timeout must not abort the whole removal or
+      // suppress the `emit` below, otherwise the dashboard would keep
+      // showing the just-deleted workspace.
+      try {
+        const deletedTasks = deleteWorkspaceTasks(workspaceId);
+        if (deletedTasks > 0) {
+          log.info({ workspaceId, count: deletedTasks }, "deleted workspace tasks on removal");
+        }
+      } catch (err) {
+        log.error({ workspaceId, err }, "failed to delete workspace tasks on removal");
+      }
+
+      // Notify subscribers (dashboard status stream) that this workspace is gone
+      emit({ kind: "remove", workspaceId });
+
+      // ── Background cleanup: slow git/fs operations ──
+      const projPath = proj.path;
+      // Synthetic "detached-<short-sha>" labels generated by
+      // `listWorktrees` for detached-HEAD worktrees do not correspond to a
+      // real git ref. Trying to `git branch -D detached-abc1234` would error
+      // ("branch not found") — the catch below swallows it cleanly, but
+      // skipping the call up front keeps the background logs free of
+      // noise that's hard to distinguish from a genuine problem.
+      const branchToDelete = match.branch.startsWith("detached-") ? null : input.branch;
+      setImmediate(() => {
+        (async () => {
+          // Run teardown script before removing worktree so it can access project files
+          if (teardownCmd) {
+            try {
+              await execFileAsync("bash", ["-c", teardownCmd], {
+                cwd: worktreePath,
+                env: {
+                  ...process.env,
+                  PATH: `/opt/homebrew/bin:/usr/local/bin:${process.env.PATH}`,
+                },
+                encoding: "utf-8",
+                timeout: 60_000,
+              });
+            } catch (err) {
+              log.warn({ err, workspaceId }, "teardown script failed");
+            }
+          }
+
+          try {
+            await execFileAsync(command, ["worktree", "remove", "--force", worktreePath], {
+              cwd: projPath,
+              env: gitEnv,
+              encoding: "utf-8",
+            });
+          } catch {
+            // Worktree may be corrupted (e.g. missing .git file).
+            // Manually remove the directory and prune stale entries.
+            await rm(worktreePath, { recursive: true, force: true });
+            try {
+              await execFileAsync(command, ["worktree", "prune"], {
+                cwd: projPath,
+                env: gitEnv,
+                encoding: "utf-8",
+              });
+            } catch (err) {
+              log.warn({ err, workspaceId }, "git worktree prune failed");
+            }
+          }
+
+          if (branchToDelete) {
+            try {
+              await execFileAsync(command, ["branch", "-D", branchToDelete], {
+                cwd: projPath,
+                env: gitEnv,
+                encoding: "utf-8",
+              });
+            } catch {
+              // Branch may already be deleted
+            }
+          }
+        })().catch((err) => {
+          log.error({ err, workspaceId }, "background workspace cleanup failed");
+        });
+      });
+
+      return { ok: true };
     }),
 
   setPinned: publicProcedure
@@ -2783,19 +2777,15 @@ const servicesRouter = t.router({
         .map(async (project) => {
           try {
             const list = await listWorktrees(project.path);
+            // `listWorktrees` guarantees a non-empty branch for non-bare
+            // worktrees: detached HEADs (mid-rebase, mid-bisect, or
+            // explicit `git checkout <sha>`) are labelled with the
+            // rebase head-name when available, otherwise
+            // `detached-<short-sha>`. So every row here has a real
+            // label and gets counted in the disk accounting.
             const worktrees = list
               .filter((wt) => !wt.isBare)
-              .map((wt) => ({
-                // Detached HEAD (mid-rebase, mid-bisect, or
-                // explicit `git checkout <sha>`) produces an empty
-                // branch string. Keep the row with a sentinel
-                // label so the size still gets counted — silently
-                // dropping it would make a developer's largest
-                // worktree disappear from the accounting whenever
-                // they happened to be on a detached HEAD.
-                branch: wt.branch || "(detached HEAD)",
-                path: wt.path,
-              }));
+              .map((wt) => ({ branch: wt.branch, path: wt.path }));
             return {
               project: project.name,
               path: project.path,
@@ -2834,14 +2824,11 @@ const servicesRouter = t.router({
       let worktreePaths: { branch: string; path: string }[];
       try {
         const list = await listWorktrees(project.path);
+        // See `resourcesProjects` above — `listWorktrees` already
+        // gives every non-bare worktree a non-empty branch label.
         worktreePaths = list
           .filter((wt) => !wt.isBare)
-          .map((wt) => ({
-            // See `resourcesProjects` above — detached HEAD gets a
-            // sentinel label rather than being dropped.
-            branch: wt.branch || "(detached HEAD)",
-            path: wt.path,
-          }));
+          .map((wt) => ({ branch: wt.branch, path: wt.path }));
       } catch (err) {
         return {
           project: project.name,

--- a/apps/web/src/trpc/router.ts
+++ b/apps/web/src/trpc/router.ts
@@ -85,7 +85,7 @@ import { duBytes } from "../lib/disk-usage";
 import { subscribeToFileChanges } from "../lib/file-watcher";
 import { FormatterError, formatFile } from "../lib/formatter";
 import { fuzzyScore } from "../lib/fuzzy-score";
-import { execGit, gitCmd, listWorktrees } from "../lib/git";
+import { DETACHED_BRANCH_PREFIX, execGit, gitCmd, listWorktrees } from "../lib/git";
 import { checkHooks, installHooks } from "../lib/hooks";
 import { killWorkspaceServers } from "../lib/lsp-manager";
 import { hasPendingInputForWorkspace, resolvePendingInput } from "../lib/pending-inputs";
@@ -656,7 +656,7 @@ const workspacesRouter = t.router({
       // ("branch not found") — the catch below swallows it cleanly, but
       // skipping the call up front keeps the background logs free of
       // noise that's hard to distinguish from a genuine problem.
-      const branchToDelete = match.branch.startsWith("detached-") ? null : input.branch;
+      const branchToDelete = match.branch.startsWith(DETACHED_BRANCH_PREFIX) ? null : input.branch;
       setImmediate(() => {
         (async () => {
           // Run teardown script before removing worktree so it can access project files

--- a/apps/web/tests/git.test.ts
+++ b/apps/web/tests/git.test.ts
@@ -112,18 +112,74 @@ describe("listWorktrees", () => {
     expect(detached!.branch).toBe("my-applied-branch");
   });
 
-  it("returns empty branch for detached HEAD without rebase state", async () => {
+  it("returns a SHA-based label for detached HEAD without rebase state", async () => {
+    // Regression for the "blank workspace label" bug. A detached worktree
+    // that isn't mid-rebase used to flow through with `branch: ""`, which
+    // (a) rendered as a blank label next to the branch icon + "M" dirty
+    // badge in `WorkspaceCard.tsx`, and (b) collided every detached
+    // worktree in the same project onto the same `toWorkspaceId(...)`
+    // output, breaking selection / pinning / the `data-testid` hook.
+    //
+    // `listWorktrees` now falls back to `detached-<short-sha>`, which is
+    // non-empty, unique per HEAD, and `[a-z0-9-]`-only so it survives
+    // every place `workspaceId` is used as a filesystem path component or
+    // URL segment.
     const { repoPath, tmp } = createRepo();
 
+    // Add a second commit so the detached HEAD has a distinct SHA from
+    // any branch tip, which is the realistic shape of the failure mode
+    // (`git checkout <some-old-sha>` inside a worktree).
+    writeFileSync(join(repoPath, "file.txt"), "hello-v2");
+    git(repoPath, ["add", "file.txt"]);
+    git(repoPath, ["commit", "-m", "second"]);
+    const detachedSha = git(repoPath, ["rev-parse", "HEAD~1"]).trim();
+
     const wtPath = join(tmp, "wt-plain-detached");
-    git(repoPath, ["worktree", "add", "--detach", wtPath, "HEAD"]);
+    git(repoPath, ["worktree", "add", "--detach", wtPath, detachedSha]);
     cleanups.push(() => git(repoPath, ["worktree", "remove", "--force", wtPath]));
 
     const worktrees = await listWorktrees(repoPath);
 
     const detached = worktrees.find((wt) => wt.path === wtPath);
     expect(detached).toBeDefined();
-    expect(detached!.branch).toBe("");
+    expect(detached!.branch).toBe(`detached-${detachedSha.slice(0, 7)}`);
+    // Spell the invariants out so a future refactor that re-introduces
+    // empty branches or unsafe characters fails loudly here rather than
+    // silently regressing the WorkspaceCard / toWorkspaceId chain.
+    expect(detached!.branch).not.toBe("");
+    expect(detached!.branch).toMatch(/^[a-z0-9-]+$/);
+    expect(detached!.head).toBe(detachedSha);
+  });
+
+  it("gives two detached worktrees at different commits distinct branch labels", async () => {
+    // The user-reported failure was ~9 detached worktrees in one project
+    // all sharing the empty-string branch. Asserting uniqueness here pins
+    // down the property that fixed it: two detached worktrees at
+    // different SHAs map to different `branch` values, so
+    // `toWorkspaceId(projectName, branch)` no longer collides.
+    const { repoPath, tmp } = createRepo();
+
+    const firstSha = git(repoPath, ["rev-parse", "HEAD"]).trim();
+    writeFileSync(join(repoPath, "file.txt"), "hello-v2");
+    git(repoPath, ["add", "file.txt"]);
+    git(repoPath, ["commit", "-m", "second"]);
+    const secondSha = git(repoPath, ["rev-parse", "HEAD"]).trim();
+
+    const wt1 = join(tmp, "wt-detached-a");
+    const wt2 = join(tmp, "wt-detached-b");
+    git(repoPath, ["worktree", "add", "--detach", wt1, firstSha]);
+    cleanups.push(() => git(repoPath, ["worktree", "remove", "--force", wt1]));
+    git(repoPath, ["worktree", "add", "--detach", wt2, secondSha]);
+    cleanups.push(() => git(repoPath, ["worktree", "remove", "--force", wt2]));
+
+    const worktrees = await listWorktrees(repoPath);
+    const a = worktrees.find((wt) => wt.path === wt1);
+    const b = worktrees.find((wt) => wt.path === wt2);
+    expect(a).toBeDefined();
+    expect(b).toBeDefined();
+    expect(a!.branch).not.toBe(b!.branch);
+    expect(a!.branch).toBe(`detached-${firstSha.slice(0, 7)}`);
+    expect(b!.branch).toBe(`detached-${secondSha.slice(0, 7)}`);
   });
 });
 

--- a/apps/web/tests/helpers/server.ts
+++ b/apps/web/tests/helpers/server.ts
@@ -11,6 +11,15 @@
 // tests should import from here. The pre-existing tests are not
 // migrated in this PR to keep its diff focused on the
 // detached-HEAD bug fix.
+//
+// TODO: migrate `trpc.test.ts`, `task-cleanup.test.ts`, and
+// `trpc-batch-url.test.ts` to import from this module instead of
+// inlining their own copies of `createTmpHome` / `getRandomPort` /
+// `startServer` / `trpcMutate`. The longer those copies live, the
+// more they will drift from this one — and the SIGKILL fallback +
+// the `trpcMutate` shape are improvements that should reach the
+// older tests too. Tracked as a follow-up rather than done here so
+// this PR stays scoped to the detached-HEAD bug.
 
 import { spawn } from "node:child_process";
 import { mkdirSync, mkdtempSync, realpathSync } from "node:fs";
@@ -53,6 +62,30 @@ export function getRandomPort(): Promise<number> {
       srv.close(() => resolve(port));
     });
     srv.on("error", reject);
+  });
+}
+
+/**
+ * POST a tRPC mutation against a running test server and return the
+ * raw `Response`. Caller is responsible for status / body assertions
+ * — leaving the JSON parsing to the caller keeps the helper neutral
+ * about whether a test wants to assert on a successful response
+ * shape or on an error body. Auth is via the `band_token` cookie;
+ * pass the same token the test passed to `seedSettings`.
+ */
+export function trpcMutate(
+  serverUrl: string,
+  procedure: string,
+  input: unknown,
+  token: string,
+): Promise<Response> {
+  return fetch(`${serverUrl}/trpc/${procedure}`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Cookie: `band_token=${token}`,
+    },
+    body: input !== undefined ? JSON.stringify(input) : "{}",
   });
 }
 

--- a/apps/web/tests/helpers/server.ts
+++ b/apps/web/tests/helpers/server.ts
@@ -1,0 +1,136 @@
+// Shared server-boot helpers for vitest integration tests. Spawns the
+// real production web server (`dist/start-server.mjs`) on a random
+// port against a fresh tmp `$HOME`, the same shape every existing
+// integration test under `apps/web/tests/` uses inline.
+//
+// History: the helpers were inlined in `trpc.test.ts`,
+// `task-cleanup.test.ts`, `trpc-batch-url.test.ts`, and (initially)
+// `workspace-remove-detached.test.ts` — four copies that had already
+// drifted (the SIGKILL fallback below lived only in
+// `task-cleanup.test.ts`). This module is the canonical version; new
+// tests should import from here. The pre-existing tests are not
+// migrated in this PR to keep its diff focused on the
+// detached-HEAD bug fix.
+
+import { spawn } from "node:child_process";
+import { mkdirSync, mkdtempSync, realpathSync } from "node:fs";
+import { createServer } from "node:net";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { SERVER_RUNTIME, SERVER_SCRIPT } from "./server-runtime";
+
+const PROJECT_ROOT = join(import.meta.dirname, "..", "..");
+
+export interface ServerHandle {
+  url: string;
+  home: string;
+  close: () => Promise<void>;
+}
+
+/**
+ * Create a fresh tmp `$HOME` with `.band/` pre-created. Resolves
+ * symlinks (macOS `/var` → `/private/var`) so paths match what the
+ * server records.
+ */
+export function createTmpHome(prefix: string): string {
+  const tmp = realpathSync(mkdtempSync(join(tmpdir(), prefix)));
+  mkdirSync(join(tmp, ".band"), { recursive: true });
+  return tmp;
+}
+
+/**
+ * Ask the kernel for a free TCP port, then immediately close the
+ * probe socket so the test server can bind to it. Subject to the
+ * usual race-window — but every existing inline copy used the same
+ * approach and the failure mode (port reused before bind) hasn't
+ * surfaced in practice.
+ */
+export function getRandomPort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const srv = createServer();
+    srv.listen(0, "127.0.0.1", () => {
+      const { port } = srv.address() as { port: number };
+      srv.close(() => resolve(port));
+    });
+    srv.on("error", reject);
+  });
+}
+
+export interface StartServerOptions {
+  tmpHome: string;
+  env?: Record<string, string>;
+}
+
+/**
+ * Boot the production server bundle in a child process. Resolves
+ * when the server logs `"listening"` to stdout; rejects if it exits
+ * first or doesn't bind within 15 s. The returned `close()` sends
+ * `SIGTERM` and falls back to `SIGKILL` after 5 s so a server stuck
+ * in a DB lock can't hang `afterAll` indefinitely.
+ */
+export async function startServer(opts: StartServerOptions): Promise<ServerHandle> {
+  const { tmpHome, env: extraEnv } = opts;
+  const port = await getRandomPort();
+
+  return new Promise((resolve, reject) => {
+    const child = spawn(SERVER_RUNTIME, [SERVER_SCRIPT], {
+      cwd: PROJECT_ROOT,
+      env: {
+        ...process.env,
+        HOME: tmpHome,
+        PORT: String(port),
+        NODE_ENV: "production",
+        ...extraEnv,
+      },
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+
+    let stderr = "";
+    let settled = false;
+
+    child.stderr!.on("data", (chunk: Buffer) => {
+      stderr += chunk.toString();
+    });
+
+    child.stdout!.on("data", (chunk: Buffer) => {
+      if (chunk.toString().includes("listening") && !settled) {
+        settled = true;
+        resolve({
+          url: `http://127.0.0.1:${port}`,
+          home: tmpHome,
+          close: () =>
+            new Promise<void>((r) => {
+              const fallback = setTimeout(() => child.kill("SIGKILL"), 5_000);
+              child.on("exit", () => {
+                clearTimeout(fallback);
+                r();
+              });
+              child.kill("SIGTERM");
+            }),
+        });
+      }
+    });
+
+    child.on("error", (err) => {
+      if (!settled) {
+        settled = true;
+        reject(err);
+      }
+    });
+
+    child.on("exit", (code) => {
+      if (!settled) {
+        settled = true;
+        reject(new Error(`server exited with code ${code} before listening\nstderr: ${stderr}`));
+      }
+    });
+
+    setTimeout(() => {
+      if (!settled) {
+        settled = true;
+        child.kill("SIGTERM");
+        reject(new Error(`server did not start within 15 s\nstderr: ${stderr}`));
+      }
+    }, 15_000);
+  });
+}

--- a/apps/web/tests/helpers/server.ts
+++ b/apps/web/tests/helpers/server.ts
@@ -72,6 +72,11 @@ export function getRandomPort(): Promise<number> {
  * about whether a test wants to assert on a successful response
  * shape or on an error body. Auth is via the `band_token` cookie;
  * pass the same token the test passed to `seedSettings`.
+ *
+ * `input` is treated as the procedure input. Both `undefined` and
+ * `null` are treated as "no input" — `JSON.stringify(null)` would
+ * otherwise send the literal string `"null"`, which the tRPC server
+ * rejects with a parse error.
  */
 export function trpcMutate(
   serverUrl: string,
@@ -85,7 +90,7 @@ export function trpcMutate(
       "Content-Type": "application/json",
       Cookie: `band_token=${token}`,
     },
-    body: input !== undefined ? JSON.stringify(input) : "{}",
+    body: input != null ? JSON.stringify(input) : "{}",
   });
 }
 

--- a/apps/web/tests/workspace-remove-detached.test.ts
+++ b/apps/web/tests/workspace-remove-detached.test.ts
@@ -26,8 +26,18 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { DatabaseSync } from "node:sqlite";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { detachedShaLabel } from "../src/lib/git";
 import { seedSettings, seedState } from "./helpers/seed-state";
 import { SERVER_RUNTIME, SERVER_SCRIPT } from "./helpers/server-runtime";
+
+// TODO: extract `createTmpHome`, `getRandomPort`, and `startServer`
+// into `apps/web/tests/helpers/server.ts`. The same shape is now
+// duplicated across `trpc.test.ts`, `task-cleanup.test.ts`,
+// `trpc-batch-url.test.ts`, and this file, and the copies have
+// already started drifting (e.g. the `close()` SIGKILL fallback
+// added here is missing in `trpc.test.ts`). A future PR should
+// consolidate them — kept inline here to keep the regression fix
+// focused on the bug.
 
 const PROJECT_ROOT = join(import.meta.dirname, "..");
 const DEFAULT_TOKEN = "workspace-remove-detached-token";
@@ -125,6 +135,11 @@ function git(cwd: string, args: string[]): string {
   return execFileSync("git", args, { cwd, env: gitEnv, encoding: "utf-8" });
 }
 
+// Read directly from SQLite rather than going through `projects.list`
+// over tRPC. The mutation's effect on the persisted state is the
+// invariant we're pinning here, and reading via the same DB the server
+// writes to keeps the assertion independent of an unrelated endpoint's
+// behaviour. (Same pattern as `task-cleanup.test.ts`.)
 function listWorktreeBranches(tmpHome: string, projectName: string): string[] {
   const sqlite = new DatabaseSync(join(tmpHome, ".band", "band.db"));
   try {
@@ -162,10 +177,11 @@ describe("workspaces.remove on a detached-HEAD worktree", () => {
     const detachedPath = join(tmpHome, "proj-detached");
     git(repoPath, ["worktree", "add", "--detach", detachedPath, olderSha]);
 
-    // Match the synthetic label `listWorktrees` produces. Keep this in
-    // lockstep with `detachedShaLabel` in apps/web/src/lib/git.ts —
-    // they have to agree or the regression isn't being exercised.
-    detachedBranch = `detached-${olderSha.slice(0, 7)}`;
+    // Build the synthetic label via `detachedShaLabel` rather than
+    // re-spelling the format inline. That way a change to the label
+    // shape (length, prefix, …) flows into the test automatically and
+    // the regression keeps exercising the real code path.
+    detachedBranch = detachedShaLabel(olderSha);
 
     seedState(tmpHome, {
       projects: [

--- a/apps/web/tests/workspace-remove-detached.test.ts
+++ b/apps/web/tests/workspace-remove-detached.test.ts
@@ -132,11 +132,16 @@ describe("workspaces.remove on a detached-HEAD worktree", () => {
     const body = await res.text();
 
     // The pre-fix bug was a TRPCError with message ending in
-    // `Workspace "detached-<sha>" not found`. Pin both the status and
-    // the body so a future regression that returns 200 with an error
-    // payload also fails the assertion.
+    // `Workspace "detached-<sha>" not found`. Pin status, error
+    // absence, AND the positive success shape — a future regression
+    // that returns 200 with a mangled body (e.g. `{ result: { data:
+    // null } }`) would still pass the loose checks alone, so the
+    // shape assertion catches that case explicitly. The tRPC
+    // response envelope is `{ result: { data: <procedure return> } }`,
+    // and `workspaces.remove` returns `{ ok: true }`.
     expect(res.status, `unexpected status; body=${body}`).toBe(200);
     expect(body).not.toContain("not found");
+    expect(JSON.parse(body)).toEqual({ result: { data: { ok: true } } });
 
     // The persisted row for the detached branch must be gone; `main`
     // must still be there (the filter has to be branch-scoped).

--- a/apps/web/tests/workspace-remove-detached.test.ts
+++ b/apps/web/tests/workspace-remove-detached.test.ts
@@ -1,0 +1,221 @@
+// Regression test for the PR-review blocker on the detached-HEAD label
+// fix. `listWorktrees` now returns `detached-<short-sha>` for a
+// detached worktree, and the dashboard sends that back to the
+// `workspaces.remove` mutation when the user clicks "Delete
+// workspace". The mutation used to re-parse `git worktree list
+// --porcelain` inline with no SHA fallback, so the lookup at
+// `currentBranch === input.branch` never matched and the call ended
+// in `throw new Error('Workspace "detached-abc1234" not found')` —
+// breaking the delete action on every detached-HEAD card.
+//
+// The fix routes `workspaces.remove` through `listWorktrees` so the
+// same SHA fallback applies on both ends. This test boots the real
+// server, creates a real detached-HEAD worktree, sends the synthetic
+// `detached-<sha>` label to the mutation, and asserts:
+//
+//   1. The mutation returns 200 (no "not found" throw).
+//   2. The persisted `worktrees` row for that branch is gone after.
+//
+// Integration-only — no mocks, no internal imports. Same shape as
+// `task-cleanup.test.ts`, just without the SQLite task-table writes.
+
+import { execFileSync, spawn } from "node:child_process";
+import { mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from "node:fs";
+import { createServer } from "node:net";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { seedSettings, seedState } from "./helpers/seed-state";
+import { SERVER_RUNTIME, SERVER_SCRIPT } from "./helpers/server-runtime";
+
+const PROJECT_ROOT = join(import.meta.dirname, "..");
+const DEFAULT_TOKEN = "workspace-remove-detached-token";
+
+interface ServerHandle {
+  url: string;
+  home: string;
+  close: () => Promise<void>;
+}
+
+function createTmpHome(): string {
+  const tmp = realpathSync(mkdtempSync(join(tmpdir(), "band-detached-remove-")));
+  mkdirSync(join(tmp, ".band"), { recursive: true });
+  return tmp;
+}
+
+function getRandomPort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const srv = createServer();
+    srv.listen(0, "127.0.0.1", () => {
+      const { port } = srv.address() as { port: number };
+      srv.close(() => resolve(port));
+    });
+    srv.on("error", reject);
+  });
+}
+
+async function startServer(tmpHome: string): Promise<ServerHandle> {
+  const port = await getRandomPort();
+  return new Promise((resolve, reject) => {
+    const child = spawn(SERVER_RUNTIME, [SERVER_SCRIPT], {
+      cwd: PROJECT_ROOT,
+      env: {
+        ...process.env,
+        HOME: tmpHome,
+        PORT: String(port),
+        NODE_ENV: "production",
+      },
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    let stderr = "";
+    let settled = false;
+    child.stderr!.on("data", (c: Buffer) => {
+      stderr += c.toString();
+    });
+    child.stdout!.on("data", (c: Buffer) => {
+      if (c.toString().includes("listening") && !settled) {
+        settled = true;
+        resolve({
+          url: `http://127.0.0.1:${port}`,
+          home: tmpHome,
+          close: () =>
+            new Promise<void>((r) => {
+              const fallback = setTimeout(() => child.kill("SIGKILL"), 5_000);
+              child.on("exit", () => {
+                clearTimeout(fallback);
+                r();
+              });
+              child.kill("SIGTERM");
+            }),
+        });
+      }
+    });
+    child.on("error", (err) => {
+      if (!settled) {
+        settled = true;
+        reject(err);
+      }
+    });
+    child.on("exit", (code) => {
+      if (!settled) {
+        settled = true;
+        reject(new Error(`server exited with code ${code}\nstderr: ${stderr}`));
+      }
+    });
+    setTimeout(() => {
+      if (!settled) {
+        settled = true;
+        child.kill("SIGTERM");
+        reject(new Error(`server did not start within 15 s\nstderr: ${stderr}`));
+      }
+    }, 15_000);
+  });
+}
+
+const gitEnv = {
+  ...process.env,
+  GIT_AUTHOR_NAME: "Test",
+  GIT_AUTHOR_EMAIL: "test@test.com",
+  GIT_COMMITTER_NAME: "Test",
+  GIT_COMMITTER_EMAIL: "test@test.com",
+};
+
+function git(cwd: string, args: string[]): string {
+  return execFileSync("git", args, { cwd, env: gitEnv, encoding: "utf-8" });
+}
+
+function listWorktreeBranches(tmpHome: string, projectName: string): string[] {
+  const sqlite = new DatabaseSync(join(tmpHome, ".band", "band.db"));
+  try {
+    const rows = sqlite
+      .prepare("SELECT branch FROM worktrees WHERE project_name = ? ORDER BY branch")
+      .all(projectName) as Array<{ branch: string }>;
+    return rows.map((r) => r.branch);
+  } finally {
+    sqlite.close();
+  }
+}
+
+describe("workspaces.remove on a detached-HEAD worktree", () => {
+  let server: ServerHandle;
+  let tmpHome: string;
+  let detachedBranch: string;
+
+  beforeAll(async () => {
+    tmpHome = createTmpHome();
+
+    // Real repo with two commits so we can check out the older SHA in
+    // the detached worktree. The shape (main + a detached HEAD parked
+    // on an older commit) is exactly the user-reported failure mode.
+    const repoPath = join(tmpHome, "proj");
+    mkdirSync(repoPath, { recursive: true });
+    git(repoPath, ["init", "-b", "main"]);
+    writeFileSync(join(repoPath, "README.md"), "v1\n");
+    git(repoPath, ["add", "."]);
+    git(repoPath, ["commit", "-m", "v1"]);
+    const olderSha = git(repoPath, ["rev-parse", "HEAD"]).trim();
+    writeFileSync(join(repoPath, "README.md"), "v2\n");
+    git(repoPath, ["add", "."]);
+    git(repoPath, ["commit", "-m", "v2"]);
+
+    const detachedPath = join(tmpHome, "proj-detached");
+    git(repoPath, ["worktree", "add", "--detach", detachedPath, olderSha]);
+
+    // Match the synthetic label `listWorktrees` produces. Keep this in
+    // lockstep with `detachedShaLabel` in apps/web/src/lib/git.ts —
+    // they have to agree or the regression isn't being exercised.
+    detachedBranch = `detached-${olderSha.slice(0, 7)}`;
+
+    seedState(tmpHome, {
+      projects: [
+        {
+          name: "proj",
+          path: repoPath,
+          defaultBranch: "main",
+          worktrees: [
+            { branch: "main", path: repoPath },
+            { branch: detachedBranch, path: detachedPath },
+          ],
+        },
+      ],
+    });
+    seedSettings(tmpHome, { tokenSecret: DEFAULT_TOKEN });
+
+    server = await startServer(tmpHome);
+  });
+
+  afterAll(async () => {
+    await server.close();
+    rmSync(tmpHome, { recursive: true, force: true });
+  });
+
+  it("removes the detached worktree without throwing 'Workspace not found'", async () => {
+    // Sanity: both worktrees survived the server boot and the
+    // background reconcile pass — the latter writes `detached-<sha>`
+    // via the same `listWorktrees` path, so it should agree with the
+    // seed.
+    expect(listWorktreeBranches(tmpHome, "proj").sort()).toEqual(["main", detachedBranch].sort());
+
+    const res = await fetch(`${server.url}/trpc/workspaces.remove`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Cookie: `band_token=${DEFAULT_TOKEN}`,
+      },
+      body: JSON.stringify({ project: "proj", branch: detachedBranch }),
+    });
+    const body = await res.text();
+
+    // The pre-fix bug was a TRPCError with message ending in
+    // `Workspace "detached-<sha>" not found`. Pin both the status and
+    // the body so a future regression that returns 200 with an error
+    // payload also fails the assertion.
+    expect(res.status, `unexpected status; body=${body}`).toBe(200);
+    expect(body).not.toContain("not found");
+
+    // The persisted row for the detached branch must be gone; `main`
+    // must still be there (the filter has to be branch-scoped).
+    expect(listWorktreeBranches(tmpHome, "proj")).toEqual(["main"]);
+  });
+});

--- a/apps/web/tests/workspace-remove-detached.test.ts
+++ b/apps/web/tests/workspace-remove-detached.test.ts
@@ -25,7 +25,7 @@ import { join } from "node:path";
 import { DatabaseSync } from "node:sqlite";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { seedSettings, seedState } from "./helpers/seed-state";
-import { createTmpHome, type ServerHandle, startServer } from "./helpers/server";
+import { createTmpHome, type ServerHandle, startServer, trpcMutate } from "./helpers/server";
 
 const DEFAULT_TOKEN = "workspace-remove-detached-token";
 
@@ -123,14 +123,12 @@ describe("workspaces.remove on a detached-HEAD worktree", () => {
     // seed.
     expect(listWorktreeBranches(tmpHome, "proj").sort()).toEqual(["main", detachedBranch].sort());
 
-    const res = await fetch(`${server.url}/trpc/workspaces.remove`, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        Cookie: `band_token=${DEFAULT_TOKEN}`,
-      },
-      body: JSON.stringify({ project: "proj", branch: detachedBranch }),
-    });
+    const res = await trpcMutate(
+      server.url,
+      "workspaces.remove",
+      { project: "proj", branch: detachedBranch },
+      DEFAULT_TOKEN,
+    );
     const body = await res.text();
 
     // The pre-fix bug was a TRPCError with message ending in

--- a/apps/web/tests/workspace-remove-detached.test.ts
+++ b/apps/web/tests/workspace-remove-detached.test.ts
@@ -16,112 +16,18 @@
 //   1. The mutation returns 200 (no "not found" throw).
 //   2. The persisted `worktrees` row for that branch is gone after.
 //
-// Integration-only — no mocks, no internal imports. Same shape as
-// `task-cleanup.test.ts`, just without the SQLite task-table writes.
+// Integration-only — no mocks, no internal-module imports for the
+// system under test.
 
-import { execFileSync, spawn } from "node:child_process";
-import { mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from "node:fs";
-import { createServer } from "node:net";
-import { tmpdir } from "node:os";
+import { execFileSync } from "node:child_process";
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { DatabaseSync } from "node:sqlite";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { detachedShaLabel } from "../src/lib/git";
 import { seedSettings, seedState } from "./helpers/seed-state";
-import { SERVER_RUNTIME, SERVER_SCRIPT } from "./helpers/server-runtime";
+import { createTmpHome, type ServerHandle, startServer } from "./helpers/server";
 
-// TODO: extract `createTmpHome`, `getRandomPort`, and `startServer`
-// into `apps/web/tests/helpers/server.ts`. The same shape is now
-// duplicated across `trpc.test.ts`, `task-cleanup.test.ts`,
-// `trpc-batch-url.test.ts`, and this file, and the copies have
-// already started drifting (e.g. the `close()` SIGKILL fallback
-// added here is missing in `trpc.test.ts`). A future PR should
-// consolidate them — kept inline here to keep the regression fix
-// focused on the bug.
-
-const PROJECT_ROOT = join(import.meta.dirname, "..");
 const DEFAULT_TOKEN = "workspace-remove-detached-token";
-
-interface ServerHandle {
-  url: string;
-  home: string;
-  close: () => Promise<void>;
-}
-
-function createTmpHome(): string {
-  const tmp = realpathSync(mkdtempSync(join(tmpdir(), "band-detached-remove-")));
-  mkdirSync(join(tmp, ".band"), { recursive: true });
-  return tmp;
-}
-
-function getRandomPort(): Promise<number> {
-  return new Promise((resolve, reject) => {
-    const srv = createServer();
-    srv.listen(0, "127.0.0.1", () => {
-      const { port } = srv.address() as { port: number };
-      srv.close(() => resolve(port));
-    });
-    srv.on("error", reject);
-  });
-}
-
-async function startServer(tmpHome: string): Promise<ServerHandle> {
-  const port = await getRandomPort();
-  return new Promise((resolve, reject) => {
-    const child = spawn(SERVER_RUNTIME, [SERVER_SCRIPT], {
-      cwd: PROJECT_ROOT,
-      env: {
-        ...process.env,
-        HOME: tmpHome,
-        PORT: String(port),
-        NODE_ENV: "production",
-      },
-      stdio: ["pipe", "pipe", "pipe"],
-    });
-    let stderr = "";
-    let settled = false;
-    child.stderr!.on("data", (c: Buffer) => {
-      stderr += c.toString();
-    });
-    child.stdout!.on("data", (c: Buffer) => {
-      if (c.toString().includes("listening") && !settled) {
-        settled = true;
-        resolve({
-          url: `http://127.0.0.1:${port}`,
-          home: tmpHome,
-          close: () =>
-            new Promise<void>((r) => {
-              const fallback = setTimeout(() => child.kill("SIGKILL"), 5_000);
-              child.on("exit", () => {
-                clearTimeout(fallback);
-                r();
-              });
-              child.kill("SIGTERM");
-            }),
-        });
-      }
-    });
-    child.on("error", (err) => {
-      if (!settled) {
-        settled = true;
-        reject(err);
-      }
-    });
-    child.on("exit", (code) => {
-      if (!settled) {
-        settled = true;
-        reject(new Error(`server exited with code ${code}\nstderr: ${stderr}`));
-      }
-    });
-    setTimeout(() => {
-      if (!settled) {
-        settled = true;
-        child.kill("SIGTERM");
-        reject(new Error(`server did not start within 15 s\nstderr: ${stderr}`));
-      }
-    }, 15_000);
-  });
-}
 
 const gitEnv = {
   ...process.env,
@@ -158,7 +64,7 @@ describe("workspaces.remove on a detached-HEAD worktree", () => {
   let detachedBranch: string;
 
   beforeAll(async () => {
-    tmpHome = createTmpHome();
+    tmpHome = createTmpHome("band-detached-remove-");
 
     // Real repo with two commits so we can check out the older SHA in
     // the detached worktree. The shape (main + a detached HEAD parked
@@ -177,11 +83,15 @@ describe("workspaces.remove on a detached-HEAD worktree", () => {
     const detachedPath = join(tmpHome, "proj-detached");
     git(repoPath, ["worktree", "add", "--detach", detachedPath, olderSha]);
 
-    // Build the synthetic label via `detachedShaLabel` rather than
-    // re-spelling the format inline. That way a change to the label
-    // shape (length, prefix, …) flows into the test automatically and
-    // the regression keeps exercising the real code path.
-    detachedBranch = detachedShaLabel(olderSha);
+    // Spell the synthetic label inline rather than importing
+    // `detachedShaLabel` from `src/lib/git.ts`. This is a black-box
+    // integration test — keeping the label format inline means that
+    // if `detachedShaLabel` is ever changed (different prefix,
+    // different sha length), the seed and the server's reconciled
+    // view diverge and the assertions fail loudly, which is exactly
+    // the signal we want. The format is also pinned by `git.test.ts`
+    // unit tests, so two redundant checks guard against silent drift.
+    detachedBranch = `detached-${olderSha.slice(0, 7)}`;
 
     seedState(tmpHome, {
       projects: [
@@ -198,7 +108,7 @@ describe("workspaces.remove on a detached-HEAD worktree", () => {
     });
     seedSettings(tmpHome, { tokenSecret: DEFAULT_TOKEN });
 
-    server = await startServer(tmpHome);
+    server = await startServer({ tmpHome });
   });
 
   afterAll(async () => {


### PR DESCRIPTION
## Summary

A user reported ~9 worktrees in a project showing only the branch icon and an "M" badge with the label area blank.

**Root cause chain:**

1. **Source of empty data.** `listWorktrees` in `apps/web/src/lib/git.ts` parses `git worktree list --porcelain`. For a detached HEAD, git omits the `branch` line. The fallback `resolveDetachedBranch` only succeeds when the worktree is **mid-rebase** (reads `rebase-merge/head-name` or `rebase-apply/head-name`). For any other detached state — checked-out tag, raw commit SHA, post-`git checkout <sha>`, finished/aborted rebase — it returned `""`, which was then pushed verbatim into the `WorktreeInfo`.

2. **Render symptom.** `WorkspaceCard.tsx:227` renders `worktree.branch` with no fallback, so an empty branch + dirty tree produces icon + "M" + blank label exactly. (The "M" comes from a separate `git.dirty` signal.)

3. **Hidden knock-on bug.** `toWorkspaceId(projectName, "")` collapses every detached worktree in the same project onto one workspace ID — selection, pinning, and the `data-testid` hook on `WorkspaceCard` all collide. Fixing only the render layer would leave this latent.

## Fix

Patch at the data source, not the render site. When `resolveDetachedBranch` returns empty, fall back to `detached-<short-sha>`:

- **Non-empty** so the card renders a label.
- **Unique per HEAD** so workspace IDs stop colliding across the affected worktrees.
- **`[a-z0-9-]`-only** so it survives every place `workspaceId` is used as a filesystem path component (`workspace-prompts/<id>.json`, `shared/<id>/...`) or URL segment (`encodeURIComponent` in `getWorkspaceFileUrl`). Format chosen over alternatives like `(detached: abc1234)` because parentheses/colons are risky in those contexts.

The existing render in `WorkspaceCard.tsx` then surfaces \`detached-abc1234\` automatically — no UI change needed.

## Test plan

- [x] `apps/web/tests/git.test.ts` — replaced the prior `branch === ""` assertion (which pinned the bug as the contract) with two new integration tests:
  - "returns a SHA-based label for detached HEAD without rebase state" — creates a real git repo, adds a worktree at a non-tip SHA, asserts `branch === detached-<short-sha>`, plus invariants (non-empty, charset-safe, matches HEAD).
  - "gives two detached worktrees at different commits distinct branch labels" — pins the uniqueness property that fixes the `toWorkspaceId` collisions (the user's ~9-worktrees scenario).
- [x] The two pre-existing rebase tests (`rebase-merge` / `rebase-apply`) still pass — the rebase-aware path is untouched.
- [x] `pnpm lint` clean (biome + clippy).
- [x] Pre-push hooks (biome / clippy / knip / jscpd) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)