### PR TITLE
fix(cli): quote argument-hint in band.md so it parses as valid YAML

### DIFF
--- a/apps/cli/Cargo.lock
+++ b/apps/cli/Cargo.lock
@@ -72,7 +72,7 @@ dependencies = [
  "dirs",
  "serde",
  "serde_json",
- "serde_yaml",
+ "serde_yml",
  "tempfile",
  "ureq",
 ]
@@ -513,6 +513,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "libyml"
+version = "0.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3302702afa434ffa30847a83305f0a69d6abd74293b6554c18ec85c7ef30c980"
+dependencies = [
+ "anyhow",
+ "version_check",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -760,16 +770,18 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_yaml"
-version = "0.9.34+deprecated"
+name = "serde_yml"
+version = "0.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+checksum = "59e2dd588bf1597a252c3b920e0143eb99b0f76e4e082f4c92ce34fbc9e71ddd"
 dependencies = [
  "indexmap",
  "itoa",
+ "libyml",
+ "memchr",
  "ryu",
  "serde",
- "unsafe-libyaml",
+ "version_check",
 ]
 
 [[package]]
@@ -915,12 +927,6 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
-
-[[package]]
-name = "unsafe-libyaml"
-version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "untrusted"

--- a/apps/cli/Cargo.lock
+++ b/apps/cli/Cargo.lock
@@ -72,6 +72,7 @@ dependencies = [
  "dirs",
  "serde",
  "serde_json",
+ "serde_yaml",
  "tempfile",
  "ureq",
 ]
@@ -704,6 +705,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
 name = "semver"
 version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -750,6 +757,19 @@ dependencies = [
  "serde",
  "serde_core",
  "zmij",
+]
+
+[[package]]
+name = "serde_yaml"
+version = "0.9.34+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
 ]
 
 [[package]]
@@ -895,6 +915,12 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "untrusted"

--- a/apps/cli/Cargo.toml
+++ b/apps/cli/Cargo.toml
@@ -12,6 +12,9 @@ path = "src/main.rs"
 clap = { version = "4", features = ["derive", "env"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+# Pre-1.0 crate; the `0.0.x` semver range is `>=0.0.12, <0.0.13`,
+# so patch bumps need a manual `cargo update -p serde_yml`. Intentional
+# while the API is still settling — revisit once it ships a 0.1.x line.
 serde_yml = "0.0.12"
 dirs = "6"
 ureq = { version = "3", features = ["json"] }

--- a/apps/cli/Cargo.toml
+++ b/apps/cli/Cargo.toml
@@ -12,14 +12,13 @@ path = "src/main.rs"
 clap = { version = "4", features = ["derive", "env"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-serde_yaml = "0.9"
+serde_yml = "0.0.12"
 dirs = "6"
 ureq = { version = "3", features = ["json"] }
 
 [dev-dependencies]
 tempfile = "3"
 serde_json = "1"
-serde_yaml = "0.9"
 
 [lints.clippy]
 all = { level = "warn", priority = -1 }

--- a/apps/cli/Cargo.toml
+++ b/apps/cli/Cargo.toml
@@ -12,12 +12,14 @@ path = "src/main.rs"
 clap = { version = "4", features = ["derive", "env"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+serde_yaml = "0.9"
 dirs = "6"
 ureq = { version = "3", features = ["json"] }
 
 [dev-dependencies]
 tempfile = "3"
 serde_json = "1"
+serde_yaml = "0.9"
 
 [lints.clippy]
 all = { level = "warn", priority = -1 }

--- a/apps/cli/skills/band.md
+++ b/apps/cli/skills/band.md
@@ -3,7 +3,7 @@ name: band
 version: 0.1.0
 description: Programmatic workspace management for Band. Use when the user wants to create, list, or remove Band workspaces or projects, manage tunnels, manage cronjobs, or check settings via the Band CLI. Triggers include "create workspace", "list projects", "band workspace", "band project", "schedule a job". For sending chat messages to coding agents, see the `band-chat` skill.
 allowed-tools: Bash
-argument-hint: [command] [args...]
+argument-hint: "[command] [args...]"
 commands: projects, workspaces, cronjobs, tunnel, settings, open, notify, schema, generate-skills, skills
 ---
 

--- a/apps/cli/src/skills.rs
+++ b/apps/cli/src/skills.rs
@@ -64,17 +64,21 @@ fn render_skills(filter: Option<&str>) -> Result<Vec<RenderedSkill>, String> {
         let prefixes = parse_command_prefixes(template);
         let has_placeholder = template.contains(COMMANDS_PLACEHOLDER);
 
-        if !matches_filter(&name, filter) {
-            continue;
-        }
-
         // Defense in depth: parse the YAML frontmatter with a strict parser
         // before we ship the rendered file. A bad template (e.g. an
         // unquoted `argument-hint: [foo] [bar]` that YAML reads as a
         // malformed flow sequence) would otherwise serialise to disk and
         // only surface at agent-load time as "Skipped loading N skill(s)
         // due to invalid SKILL.md files". Fail the build instead.
+        //
+        // Runs *before* the filter check so `band skills install
+        // --filter chat` still fast-fails if any other template has
+        // regressed, even though it isn't being rendered this run.
         validate_frontmatter(&name, template)?;
+
+        if !matches_filter(&name, filter) {
+            continue;
+        }
 
         // `commands:` frontmatter and the `<!-- COMMANDS -->` placeholder are
         // a pair: reference-shaped skills need both, workflow-shaped skills

--- a/apps/cli/src/skills.rs
+++ b/apps/cli/src/skills.rs
@@ -68,6 +68,14 @@ fn render_skills(filter: Option<&str>) -> Result<Vec<RenderedSkill>, String> {
             continue;
         }
 
+        // Defense in depth: parse the YAML frontmatter with a strict parser
+        // before we ship the rendered file. A bad template (e.g. an
+        // unquoted `argument-hint: [foo] [bar]` that YAML reads as a
+        // malformed flow sequence) would otherwise serialise to disk and
+        // only surface at agent-load time as "Skipped loading N skill(s)
+        // due to invalid SKILL.md files". Fail the build instead.
+        validate_frontmatter(&name, template)?;
+
         // `commands:` frontmatter and the `<!-- COMMANDS -->` placeholder are
         // a pair: reference-shaped skills need both, workflow-shaped skills
         // need neither. Reject mismatches so a template can't silently lose
@@ -554,6 +562,42 @@ fn parse_command_prefixes(content: &str) -> Vec<String> {
         .unwrap_or_default()
 }
 
+/// Extract the YAML frontmatter block (without the `---` delimiters) from a
+/// skill template. Returns `None` if the template doesn't open with `---`
+/// or doesn't have a closing `---` line — those templates are also invalid,
+/// but the caller's job is to validate what's present rather than impose
+/// the delimiter convention here.
+fn extract_frontmatter_block(content: &str) -> Option<&str> {
+    let rest = content
+        .strip_prefix("---\n")
+        .or_else(|| content.strip_prefix("---\r\n"))?;
+    let end = rest.find("\n---\n").or_else(|| rest.find("\n---\r\n"))?;
+    Some(&rest[..end])
+}
+
+/// Parse the skill template's YAML frontmatter with a strict parser to
+/// catch malformed values before we write the rendered file. Returns
+/// an error string of the form
+/// `skill '<name>': invalid YAML frontmatter at line N: <msg>`.
+fn validate_frontmatter(name: &str, template: &str) -> Result<(), String> {
+    let block = extract_frontmatter_block(template).ok_or_else(|| {
+        format!("skill '{name}': template is missing YAML frontmatter delimited by `---`")
+    })?;
+    serde_yaml::from_str::<serde_yaml::Value>(block).map_err(|err| {
+        // serde_yaml's Display format already includes the line/column,
+        // but the block we hand it starts at the line *after* the opening
+        // `---`, so adjust the reported line back to the source file's
+        // numbering by adding 1.
+        let location = err.location();
+        let line = location.map(|l| l.line() + 1);
+        match line {
+            Some(n) => format!("skill '{name}': invalid YAML frontmatter at line {n}: {err}"),
+            None => format!("skill '{name}': invalid YAML frontmatter: {err}"),
+        }
+    })?;
+    Ok(())
+}
+
 /// Parse a single field from YAML frontmatter delimited by `---`.
 fn parse_frontmatter_field(content: &str, key: &str) -> Option<String> {
     let mut in_frontmatter = false;
@@ -667,6 +711,70 @@ mod tests {
             "Rust SUPPORTED_AGENTS drifted from the canonical list; update both this slice and \
              packages/coding-agent/src/install-skills.ts::SUPPORTED_AGENT_TYPES (plus the \
              matching test on each side) when adding/removing an agent"
+        );
+    }
+
+    /// Every checked-in skill template under `apps/cli/skills/` must have
+    /// strictly-parseable YAML frontmatter. Catches the regression that
+    /// shipped `argument-hint: [command] [args...]` (parsed as a malformed
+    /// flow sequence) at `cargo test` time, before the build ever
+    /// generates files for a user's coding agent.
+    #[test]
+    fn checked_in_templates_have_valid_yaml_frontmatter() {
+        for (name, template) in SKILL_TEMPLATES {
+            validate_frontmatter(name, template)
+                .unwrap_or_else(|e| panic!("template `{name}` is invalid: {e}"));
+        }
+    }
+
+    /// Regression: the exact failure mode that caused Codex to skip the
+    /// `band` skill. An unquoted `argument-hint: [command] [args...]` is
+    /// parsed as a one-element flow sequence followed by garbage and must
+    /// be rejected by the validator.
+    #[test]
+    fn validate_frontmatter_rejects_unquoted_flow_sequence_then_text() {
+        let bad = "---\nname: bad\nargument-hint: [command] [args...]\n---\n\nbody\n";
+        let err = validate_frontmatter("bad", bad)
+            .expect_err("must reject unquoted flow-sequence-then-text value");
+        assert!(
+            err.starts_with("skill 'bad': invalid YAML frontmatter"),
+            "error should name the skill and signal a YAML parse failure: {err}"
+        );
+    }
+
+    /// The validator's error message must include a line number so a
+    /// future template author can find the offending line without
+    /// guessing — and the number must be in the source file's
+    /// frame, not the post-strip block's.
+    #[test]
+    fn validate_frontmatter_error_reports_source_line_number() {
+        // Line 1: `---`
+        // Line 2: `name: bad`
+        // Line 3: `argument-hint: [command] [args...]`  <-- error
+        let bad = "---\nname: bad\nargument-hint: [command] [args...]\n---\n";
+        let err = validate_frontmatter("bad", bad).expect_err("must reject");
+        assert!(
+            err.contains("line 3"),
+            "expected 'line 3' (source-frame line of the broken value), got: {err}"
+        );
+    }
+
+    /// Sanity: well-formed templates with bracketed-but-quoted values pass.
+    #[test]
+    fn validate_frontmatter_accepts_quoted_bracket_value() {
+        let ok = "---\nname: ok\nargument-hint: \"[command] [args...]\"\n---\n\nbody\n";
+        validate_frontmatter("ok", ok).expect("quoted bracketed value should parse");
+    }
+
+    /// A template with no frontmatter at all is invalid — surface a clear
+    /// message instead of silently rendering a file with no header.
+    #[test]
+    fn validate_frontmatter_rejects_missing_block() {
+        let no_fm = "# just a markdown body, no frontmatter at all\n";
+        let err = validate_frontmatter("no-fm", no_fm).expect_err("must reject");
+        assert!(
+            err.contains("missing YAML frontmatter"),
+            "expected missing-frontmatter error, got: {err}"
         );
     }
 }

--- a/apps/cli/src/skills.rs
+++ b/apps/cli/src/skills.rs
@@ -567,6 +567,13 @@ fn parse_command_prefixes(content: &str) -> Vec<String> {
 /// or doesn't have a closing `---` line — those templates are also invalid,
 /// but the caller's job is to validate what's present rather than impose
 /// the delimiter convention here.
+///
+/// **Required shape:** the closing `---` must be followed by a newline
+/// (`\n` or `\r\n`). A file ending with `---` at EOF without a trailing
+/// newline is treated as missing the closing delimiter and surfaces as
+/// "missing YAML frontmatter". Every checked-in template ends with a body
+/// paragraph and trailing newline, so this is documentation of the
+/// invariant rather than a runtime concern.
 fn extract_frontmatter_block(content: &str) -> Option<&str> {
     let rest = content
         .strip_prefix("---\n")

--- a/apps/cli/src/skills.rs
+++ b/apps/cli/src/skills.rs
@@ -583,11 +583,11 @@ fn validate_frontmatter(name: &str, template: &str) -> Result<(), String> {
     let block = extract_frontmatter_block(template).ok_or_else(|| {
         format!("skill '{name}': template is missing YAML frontmatter delimited by `---`")
     })?;
-    serde_yaml::from_str::<serde_yaml::Value>(block).map_err(|err| {
-        // serde_yaml's Display format already includes the line/column,
+    serde_yml::from_str::<serde_yml::Value>(block).map_err(|err| {
+        // serde_yml's Display format already includes the line/column,
         // but the block we hand it starts at the line *after* the opening
-        // `---`, so adjust the reported line back to the source file's
-        // numbering by adding 1.
+        // `---` (whether `\n` or `\r\n`), so adjust the reported line
+        // back to the source file's numbering by adding 1.
         let location = err.location();
         let line = location.map(|l| l.line() + 1);
         match line {

--- a/apps/cli/tests/integration.rs
+++ b/apps/cli/tests/integration.rs
@@ -3142,7 +3142,14 @@ fn skills_install_filter_limits_to_matching_skills_only() {
 fn skills_install_emits_yaml_frontmatter_that_parses_strictly() {
     let tmp = skills_sandbox(&[]);
     let home = tmp.path();
-    let _ = run_install_json(home);
+    // Assert the install itself succeeded so a failure here surfaces as an
+    // install error rather than a confusing "file not found" downstream.
+    let result = run_install_json(home);
+    assert_eq!(
+        result["shared"]["written"].as_array().map(Vec::len),
+        Some(6),
+        "install did not write 6 shared skills: {result}"
+    );
 
     let shared_dir = home.join(".agents").join("skills");
     for name in [
@@ -3170,7 +3177,11 @@ fn skills_install_emits_yaml_frontmatter_that_parses_strictly() {
 
         // Sanity-check that the fields the agent reads are present and the
         // right shape (not an accidental flow sequence). Catches the exact
-        // regression that prompted this test.
+        // regression that prompted this test. All 6 Band skills are
+        // expected to declare `argument-hint` — the hard unwrap below is
+        // intentional, not an oversight. A future skill without
+        // `argument-hint` should add the field rather than soften the
+        // assertion here.
         let mapping = value
             .as_mapping()
             .unwrap_or_else(|| panic!("{name}: frontmatter is not a YAML mapping"));

--- a/apps/cli/tests/integration.rs
+++ b/apps/cli/tests/integration.rs
@@ -3128,6 +3128,92 @@ fn skills_install_filter_limits_to_matching_skills_only() {
     assert_eq!(result["symlinks"]["linked"].as_array().unwrap().len(), 1);
 }
 
+/// Regression test for the "Skipped loading N skill(s) due to invalid SKILL.md
+/// files" error that Codex emitted on startup (issue: `argument-hint:
+/// [command] [args...]` in `apps/cli/skills/band.md` was parsed by strict
+/// YAML as a malformed flow sequence).
+///
+/// Install all 6 templates via the public CLI surface, then parse each
+/// installed file's YAML frontmatter with a strict parser. Any template that
+/// regresses to invalid YAML (unquoted flow-sequence-looking values, stray
+/// colons, bad indentation) will fail here before it reaches a user's
+/// coding agent.
+#[test]
+fn skills_install_emits_yaml_frontmatter_that_parses_strictly() {
+    let tmp = skills_sandbox(&[]);
+    let home = tmp.path();
+    let _ = run_install_json(home);
+
+    let shared_dir = home.join(".agents").join("skills");
+    for name in [
+        "band",
+        "band-chat",
+        "band-terminal",
+        "band-browser",
+        "band-start",
+        "band-loop",
+    ] {
+        let path = shared_dir.join(name).join("SKILL.md");
+        let content =
+            fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {}: {e}", path.display()));
+
+        // Frontmatter block lives between the first two `---` lines.
+        let mut parts = content.splitn(3, "---\n");
+        let _leading_empty = parts.next().expect("split prefix");
+        let block = parts
+            .next()
+            .unwrap_or_else(|| panic!("{name}: missing opening `---`"));
+
+        let value: serde_yaml::Value = serde_yaml::from_str(block).unwrap_or_else(|e| {
+            panic!("{name}: SKILL.md frontmatter does not parse as YAML: {e}\nblock:\n{block}")
+        });
+
+        // Sanity-check that the fields the agent reads are present and the
+        // right shape (not an accidental flow sequence). Catches the exact
+        // regression that prompted this test.
+        let mapping = value
+            .as_mapping()
+            .unwrap_or_else(|| panic!("{name}: frontmatter is not a YAML mapping"));
+        let arg_hint = mapping
+            .get(serde_yaml::Value::String("argument-hint".to_string()))
+            .unwrap_or_else(|| panic!("{name}: missing argument-hint"));
+        assert!(
+            arg_hint.is_string(),
+            "{name}: argument-hint must be a string, got {arg_hint:?} (looks like an unquoted \
+             flow sequence — quote the value in the template)"
+        );
+    }
+}
+
+/// Defense-in-depth: when a template's YAML frontmatter is malformed, the
+/// renderer must fail loudly with a message that names the skill and
+/// surfaces the YAML parser's error.
+///
+/// The renderer reads `SKILL_TEMPLATES` baked in via `include_str!`, so we
+/// can't inject a bad template at runtime through the public CLI. The
+/// validator itself is exercised by a unit test in
+/// `src/skills.rs::tests::validate_frontmatter_*` — both call sites
+/// (`generate-skills`, `skills install`) share the same `render_skills`
+/// entry point, so locking down the validator there covers both routes
+/// without spawning a process.
+///
+/// What this integration test asserts at the CLI boundary is the
+/// happy-path inverse: with the canonical templates checked into the
+/// repo, the renderer succeeds. Combined with the unit test on the
+/// validator, future bad templates fail at `cargo test` before ever
+/// reaching a release build.
+#[test]
+fn generate_skills_succeeds_with_canonical_templates() {
+    let tmp = tempfile::tempdir().expect("create tempdir");
+    let out = tmp.path();
+    let output = band_offline(&["generate-skills", "--output-dir", out.to_str().unwrap()]);
+    assert!(
+        output.status.success(),
+        "generate-skills failed: stderr: {}",
+        stderr(&output)
+    );
+}
+
 // --- Open command tests ---
 
 /// Call the test helper that posts to `editor.setActiveWorkspace` on the

--- a/apps/cli/tests/integration.rs
+++ b/apps/cli/tests/integration.rs
@@ -3164,7 +3164,7 @@ fn skills_install_emits_yaml_frontmatter_that_parses_strictly() {
             .next()
             .unwrap_or_else(|| panic!("{name}: missing opening `---`"));
 
-        let value: serde_yaml::Value = serde_yaml::from_str(block).unwrap_or_else(|e| {
+        let value: serde_yml::Value = serde_yml::from_str(block).unwrap_or_else(|e| {
             panic!("{name}: SKILL.md frontmatter does not parse as YAML: {e}\nblock:\n{block}")
         });
 
@@ -3175,7 +3175,7 @@ fn skills_install_emits_yaml_frontmatter_that_parses_strictly() {
             .as_mapping()
             .unwrap_or_else(|| panic!("{name}: frontmatter is not a YAML mapping"));
         let arg_hint = mapping
-            .get(serde_yaml::Value::String("argument-hint".to_string()))
+            .get(serde_yml::Value::String("argument-hint".to_string()))
             .unwrap_or_else(|| panic!("{name}: missing argument-hint"));
         assert!(
             arg_hint.is_string(),


### PR DESCRIPTION
## Symptom

Codex CLI reported `Skipped loading 3 skill(s) due to invalid SKILL.md files` on startup. Claude Code didn't surface the error because its YAML parser is more lenient and silently accepts the broken file.

## Root cause

`apps/cli/skills/band.md` line 6:

```yaml
argument-hint: [command] [args...]
```

YAML parses a value starting with `[` as a flow sequence. `[command]` is read as a one-element list and the trailing ` [args...]` becomes a syntax error. Strict parsers (including the one Codex uses) reject the file.

The "3 skills" count is the same broken file reported once per discovery path (symlink duplication across user-scoped skill dirs). Only one source template — `band.md` — was actually broken.

## Why only `band.md`

The other 5 templates (`band-chat`, `band-terminal`, `band-browser`, `band-start`, `band-loop`) all have `argument-hint` values that start with a plain word (`browsers`, `chats`, `terminals`) or `<`, so YAML treats the brackets inside as literal plain-scalar text and they parse fine. No change needed there — kept this diff focused on the one broken file.

## Fix

Quote the value so YAML reads it as a plain string:

```diff
-argument-hint: [command] [args...]
+argument-hint: "[command] [args...]"
```

## Defense in depth

The renderer in `apps/cli/src/skills.rs::render_skills` (which both `band generate-skills` and `band skills install` flow through) now parses every template's frontmatter with `serde_yaml` before writing the rendered SKILL.md. A future broken template now fails the build with a clear message naming the skill and the parse-error line:

```
skill 'band': invalid YAML frontmatter at line 6: did not find expected node content
```

This prevents this class of bug from ever shipping again — `cargo test` catches it instead of users discovering it at agent-load time.

## Test plan

- [x] `cargo test --bin band` — 6 unit tests pass (4 new validator tests + the lockdown test that exercises every checked-in template against the validator)
- [x] `cargo test --test integration -- skills generate_skills` — 19 tests pass (including the new `skills_install_emits_yaml_frontmatter_that_parses_strictly` end-to-end regression test that installs all 6 skills via the public CLI surface and parses each generated frontmatter with `serde_yaml`)
- [x] `pnpm check` (biome + cargo fmt + cargo clippy `-D warnings`) — clean
- [x] Manual smoke test: `band skills install --home /tmp/band-test-home` then `python3 -c "import yaml; yaml.safe_load(open('/tmp/band-test-home/.agents/skills/band/SKILL.md').read().split('---')[1])"` — exits 0
- [x] Idempotency: `band generate-skills --output-dir apps/cli/skills` produces only the rendered outputs (in per-skill subdirs); the checked-in source templates are unchanged apart from the one-character `band.md` fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)