### PR TITLE
fix(search): include dot-directories in find-in-files (#536)

### DIFF
--- a/apps/web/src/server/infra/search/ripgrep-client.ts
+++ b/apps/web/src/server/infra/search/ripgrep-client.ts
@@ -16,6 +16,15 @@
  *     ripgrep reads from stdin and hangs for the same reason.
  *   - Non-UTF-8 paths/lines come back as `bytes` (base64) instead of
  *     `text`; we skip those because the UI can't render them.
+ *   - `--hidden` is passed so files inside dot-directories like
+ *     `.github/`, `.husky/`, `.claude/`, `.vscode/` are searched. By
+ *     default ripgrep skips any path whose name starts with `.`, which
+ *     caused find-in-files to silently miss content the user could see
+ *     in the file picker (`git ls-files` already returns those tracked
+ *     dot-paths). `--glob !.git` keeps the repo's internal git database
+ *     out of results — `.gitignore` is still honoured for everything
+ *     else, so `node_modules/`, build output, etc. stay excluded. See
+ *     issue #536.
  */
 
 import { spawn } from "node:child_process";
@@ -65,6 +74,10 @@ function createIterator(options: RipgrepOptions): AsyncIterator<RipgrepMatch> {
   if (!options.caseSensitive) args.push("--ignore-case");
   if (options.wholeWord) args.push("--word-regexp");
   if (!options.regex) args.push("--fixed-strings");
+  // Surface tracked content inside dot-directories (.github, .husky,
+  // .claude, .vscode, ...) — see file header. .git/ stays excluded so
+  // we don't dump the repo's internal git database into results.
+  args.push("--hidden", "--glob", "!.git");
   args.push("--json");
   args.push("--", options.query, "./");
 

--- a/apps/web/tests/search-content.test.ts
+++ b/apps/web/tests/search-content.test.ts
@@ -1,5 +1,5 @@
 import { execFileSync, spawn } from "node:child_process";
-import { mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSync } from "node:fs";
 import { createServer } from "node:net";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -168,6 +168,18 @@ describe("tRPC — workspace.searchContent (ripgrep)", () => {
     writeFileSync(join(repoPath, ".gitignore"), "ignored.txt\n");
     writeFileSync(join(repoPath, "ignored.txt"), "ignored BAND_RG_MARKER skip\n");
 
+    // Tracked file inside a dot-directory — ripgrep skips these by default
+    // (any path starting with `.`), so without `--hidden` find-in-files
+    // silently misses content the user can see in the file picker. See
+    // issue #536.
+    mkdirSync(join(repoPath, ".github", "workflows"), { recursive: true });
+    writeFileSync(
+      join(repoPath, ".github", "workflows", "ci.yml"),
+      "name: ci\nrun: BAND_RG_MARKER dot-dir content\n",
+    );
+    git(repoPath, ["add", ".github/workflows/ci.yml"]);
+    git(repoPath, ["commit", "-m", "ci workflow"]);
+
     seedState(tmpHome, {
       projects: [
         {
@@ -209,6 +221,39 @@ describe("tRPC — workspace.searchContent (ripgrep)", () => {
       expect(r.content).toContain("BAND_RG_MARKER");
       expect(r.line).toBeGreaterThan(0);
     }
+  });
+
+  it("returns matches from tracked files inside dot-directories (#536)", async () => {
+    const res = await trpcQuery(server.url, "workspace.searchContent", {
+      workspaceId: "repo-main",
+      query: "BAND_RG_MARKER",
+    });
+    expect(res.status).toBe(200);
+
+    const { results } = await trpcData<{ results: SearchResult[] }>(res);
+    expect(results.some((r) => r.file === ".github/workflows/ci.yml")).toBe(true);
+  });
+
+  it("does not surface the .git/ internal database", async () => {
+    // Positive anchor: confirm that .git/HEAD actually contains "ref:" on
+    // the seeded repo. If this ever stops being true (e.g. someone packs
+    // refs and HEAD becomes a SHA), the assertion below becomes vacuous,
+    // so fail loudly here instead of silently passing the negative check.
+    const headContent = readFileSync(join(repoPath, ".git", "HEAD"), "utf-8");
+    expect(headContent).toContain("ref:");
+
+    // With `--hidden` enabled the only thing keeping the .git/ contents
+    // out of results is the explicit `--glob !.git` exclusion — verify
+    // it sticks. The query "ref:" is chosen because none of the seeded
+    // fixture files contain it, so any match would have to come from
+    // .git/ itself.
+    const res = await trpcQuery(server.url, "workspace.searchContent", {
+      workspaceId: "repo-main",
+      query: "ref:",
+    });
+    expect(res.status).toBe(200);
+    const { results } = await trpcData<{ results: SearchResult[] }>(res);
+    expect(results.some((r) => r.file.startsWith(".git/"))).toBe(false);
   });
 
   it("respects .gitignore and excludes ignored files", async () => {


### PR DESCRIPTION
## Summary

- Pass `--hidden` to ripgrep in `searchContent` so find-in-files reaches tracked content inside dot-directories (`.github/`, `.husky/`, `.claude/`, `.vscode/`, …). The file-name picker already showed those files via `git ls-files`, so the previous behavior was inconsistent.
- Add `--glob !.git` to keep the repo's internal git database out of results. `.gitignore` is still honoured for everything else, so `node_modules/` and build output stay excluded.

The change lands in `apps/web/src/server/infra/search/ripgrep-client.ts` (the shell-out was extracted out of the router in a prior refactor — the issue's referenced `router.ts:1276` line is stale).

Closes #536

## Test plan

- [x] New test: `returns matches from tracked files inside dot-directories (#536)` — seeds `.github/workflows/ci.yml` with a marker and asserts the marker is returned.
- [x] New test: `does not surface the .git/ internal database` — reads `.git/HEAD` as a positive anchor (proves the query "ref:" has something to find inside `.git/`), then asserts no result starts with `.git/`.
- [x] Existing `respects .gitignore` test still passes — `--hidden` doesn't break the gitignore filter.
- [x] `pnpm --filter @band-app/server test` — 985/985 passing.
- [x] `npx biome check .` — 0 errors across 476 files.
- [x] Pre-push hook (biome + clippy + knip + jscpd) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)