### PR TITLE
refactor(web): unify chat/terminal/browser visibility contexts (#469)

### DIFF
--- a/apps/web/e2e/pages/WorkspacePage.ts
+++ b/apps/web/e2e/pages/WorkspacePage.ts
@@ -79,6 +79,32 @@ export class WorkspacePage {
     return this.page.getByTestId(`workspace-panel-host__cached-entry--${workspaceId}`);
   }
 
+  /** Locator for the chat tab panel's visibility marker inside a specific
+   *  workspace's cached panel host (issue #469). The marker testid is set
+   *  by `ChatTabContent` in `DockviewChatContainer.tsx` and encodes the
+   *  visibility signal the shared `PanelVisibilityContext` propagated
+   *  into the tab — so the test can observe context plumbing directly,
+   *  independent of dockview's outer detach behaviour.
+   *
+   *  Scoping the locator to the workspace's cached entry lets a test
+   *  query workspace A's marker and workspace B's marker independently
+   *  even when both are mounted (active + cached) at once. */
+  chatTabVisibilityMarker(workspaceId: string, visible: boolean): Locator {
+    return this.cachedPanelEntries(workspaceId).getByTestId(
+      `dockview-chat-tab__visible-${visible ? "true" : "false"}`,
+    );
+  }
+
+  /** Locator for the terminal tab panel's visibility marker inside a
+   *  specific workspace's cached panel host (issue #469). Counterpart of
+   *  `chatTabVisibilityMarker` for the terminal container — see that
+   *  method's doc comment for the rationale. */
+  terminalTabVisibilityMarker(workspaceId: string, visible: boolean): Locator {
+    return this.cachedPanelEntries(workspaceId).getByTestId(
+      `dockview-terminal-tab__visible-${visible ? "true" : "false"}`,
+    );
+  }
+
   /** Right-click the workspace card to open its context menu, then click
    *  "Delete workspace". The deletion goes through the real
    *  `useRemoveWorkspace` mutation — same path the user takes — so the

--- a/apps/web/e2e/panel-visibility-context.spec.ts
+++ b/apps/web/e2e/panel-visibility-context.spec.ts
@@ -147,7 +147,7 @@ test.describe("Panel visibility context (issue #469)", () => {
 
     // Anchor on B's visible-true marker first — proves the new
     // workspace actually rendered before we assert on A's now-hidden
-    // state (TEST-25: negative assertions need a positive companion).
+    // state.
     await expect(workspacePage.chatTabVisibilityMarker(WORKSPACE_B, true)).toBeVisible();
 
     // A is cached → `wsActive=false` → context value becomes

--- a/apps/web/e2e/panel-visibility-context.spec.ts
+++ b/apps/web/e2e/panel-visibility-context.spec.ts
@@ -1,0 +1,205 @@
+/**
+ * Regression coverage for issue #469 — the three Dockview inner
+ * containers (Chat / Terminal / Browser) share a single
+ * `PanelVisibilityContext` instead of each declaring their own.
+ *
+ * Background
+ * ----------
+ * Before #469, `DockviewChatContainer`, `DockviewTerminalContainer` and
+ * `DockviewBrowserContainer` each declared their own React Context with
+ * an identical `{ visible, wsActive }` shape and wrapped their inner
+ * `DockviewReact` in a per-container Provider. The refactor moved the
+ * context out into `panel-visibility-context.tsx` and pointed all three
+ * containers at the shared `PanelVisibilityContext` + `usePanelVisibility`.
+ *
+ * What this spec asserts
+ * ----------------------
+ * The visibility signal still reaches the tab panels — i.e. each
+ * container's `<PanelVisibilityContext.Provider value={…}>` is correctly
+ * wired AND the leaf tab panel still calls `usePanelVisibility()`
+ * inside the Provider's subtree. We assert this directly by reading a
+ * `data-testid` on the tab panel's wrapper div that encodes the
+ * `visible` value the context plumbed in.
+ *
+ * If a future change removed the Provider on any one container (or
+ * pointed the hook at the wrong context), the leaf would fall back to
+ * the context's default value (`{ visible: true, wsActive: true }`) and
+ * the marker for a workspace cached behind another active one would
+ * report `visible-true` instead of `visible-false`. The test below
+ * checks exactly that case for both the chat and terminal containers.
+ *
+ * Why we use the LRU-cached entry as the regression lever
+ * --------------------------------------------------------
+ * The outer Shared Dockview's default `onlyWhenVisible` mode detaches a
+ * panel's content from the DOM when its outer tab is inactive — so a
+ * test that just clicks outer tabs back and forth couldn't distinguish
+ * "context propagated visible=false" from "container unmounted". The
+ * `MultiWorkspacePanelHost` LRU cache keeps the inactive workspace's
+ * subtree MOUNTED but passes `wsActive=false` into its
+ * `DockviewChatContainer` / `DockviewTerminalContainer`. The shared
+ * context is the only channel that propagates that `wsActive=false`
+ * down to the leaf — making it the exact regression lever this refactor
+ * could break.
+ *
+ * Out of scope
+ * ------------
+ * The Browser container is only mounted in the Electron desktop build
+ * (see `SharedDockviewLayout`'s `BrowserPanelComponent` web fallback).
+ * The same `data-testid` marker is set on it for parity, but verifying
+ * it requires desktop e2e coverage that this web-build spec can't
+ * provide. The TypeScript + biome + lint pipeline catches the symbol-
+ * level half of the refactor on that container; the structural half
+ * (Provider wiring + hook usage) mirrors chat and terminal exactly, so
+ * coverage on those two is a reasonable proxy.
+ */
+
+import { expect, test } from "@playwright/test";
+import { toWorkspaceId } from "@/dashboard";
+import {
+  cleanupTmpHome,
+  createTmpHome,
+  type ServerHandle,
+  seedSettings,
+  seedState,
+  startServer,
+} from "./helpers/server";
+import { WorkspacePage } from "./pages/WorkspacePage";
+
+const TOKEN = "e2e-panel-visibility-context-token";
+
+const PROJECT_A = "alpha-visibility";
+const PROJECT_B = "bravo-visibility";
+const WORKSPACE_A = toWorkspaceId(PROJECT_A, "main");
+const WORKSPACE_B = toWorkspaceId(PROJECT_B, "main");
+
+// Wide viewport so `useIsDesktop()` reports true and the shared dockview
+// renders (>= 1024px in `apps/web/src/hooks/useIsDesktop.ts`). The chat
+// / terminal containers under test only mount in the desktop layout.
+test.use({ viewport: { width: 1280, height: 800 } });
+
+let server: ServerHandle;
+let tmpHome: string;
+
+test.beforeAll(async () => {
+  tmpHome = createTmpHome();
+  seedState(tmpHome, {
+    projects: [
+      {
+        name: PROJECT_A,
+        path: `/tmp/fake/${PROJECT_A}`,
+        defaultBranch: "main",
+        worktrees: [{ branch: "main", path: `/tmp/fake/${PROJECT_A}` }],
+      },
+      {
+        name: PROJECT_B,
+        path: `/tmp/fake/${PROJECT_B}`,
+        defaultBranch: "main",
+        worktrees: [{ branch: "main", path: `/tmp/fake/${PROJECT_B}` }],
+      },
+    ],
+  });
+  seedSettings(tmpHome, { tokenSecret: TOKEN });
+  server = await startServer({ tmpHome });
+});
+
+test.afterAll(async () => {
+  await server.close();
+  cleanupTmpHome(tmpHome);
+});
+
+test.beforeEach(async ({ page }) => {
+  // Land on the workspace URL first so localStorage is accessible
+  // (origin-scoped), clear the per-workspace dockview state for both
+  // workspaces, and start tests from a default layout.
+  await page.goto(`${server.url}/workspace/${encodeURIComponent(WORKSPACE_A)}?token=${TOKEN}`);
+  await page.evaluate(
+    ([keys]) => {
+      for (const key of keys) localStorage.removeItem(key);
+    },
+    [[`band:dockview-active:${WORKSPACE_A}`, `band:dockview-active:${WORKSPACE_B}`]],
+  );
+});
+
+test.describe("Panel visibility context (issue #469)", () => {
+  test("Chat tab panel observes visible=true for the active workspace and visible=false for the cached one", async ({
+    page,
+  }) => {
+    const workspacePage = new WorkspacePage(page, server.url, TOKEN);
+
+    // Navigate to A. The default layout puts the Chat panel in its own
+    // group on the left so it's mounted and visible immediately —
+    // `parentVisible` from context is `true` AND the inner default chat
+    // tab is the active inner tab, so the leaf gets `visible=true`.
+    await workspacePage.goto(WORKSPACE_A);
+    await workspacePage.waitForReady();
+
+    // Positive anchor: A's active chat tab has the visible-true marker.
+    // The marker is set on the inner ChatTabContent wrapper div whose
+    // `visible` value is `parentVisible(true) && tabActive(true)`.
+    await expect(workspacePage.chatTabVisibilityMarker(WORKSPACE_A, true)).toBeVisible();
+
+    // Switch to B via the sidebar card. This uses TanStack Router's
+    // in-app navigation, which keeps A's panels mounted in the LRU
+    // cache while flipping `wsActive` from true→false for A and
+    // false→true for B. The full-page `goto()` would tear down the
+    // React tree and defeat the regression lever.
+    await workspacePage.switchWorkspace(WORKSPACE_B);
+
+    // Anchor on B's visible-true marker first — proves the new
+    // workspace actually rendered before we assert on A's now-hidden
+    // state (TEST-25: negative assertions need a positive companion).
+    await expect(workspacePage.chatTabVisibilityMarker(WORKSPACE_B, true)).toBeVisible();
+
+    // A is cached → `wsActive=false` → context value becomes
+    // `{ visible: false, wsActive: false }` → leaf marker flips to
+    // `visible-false`. If the shared-context refactor regressed (e.g.
+    // the Provider was removed from `DockviewChatContainer`), the
+    // leaf would default to `{ visible: true, wsActive: true }` and
+    // A's marker would still report `visible-true` even while cached.
+    await expect(workspacePage.chatTabVisibilityMarker(WORKSPACE_A, false)).toBeAttached();
+    await expect(workspacePage.chatTabVisibilityMarker(WORKSPACE_A, true)).toHaveCount(0);
+  });
+
+  test("Terminal tab panel observes visible=true for the active workspace and visible=false for the cached one", async ({
+    page,
+  }) => {
+    const workspacePage = new WorkspacePage(page, server.url, TOKEN);
+
+    await workspacePage.goto(WORKSPACE_A);
+    await workspacePage.waitForReady();
+
+    // Activate the outer Terminal tab. The default layout starts with
+    // Changes as the active tab in the right group; clicking Terminal
+    // promotes its panel to active and mounts the
+    // `DockviewTerminalContainer`. The Chat panel is in a separate
+    // group on the left and stays mounted regardless.
+    await workspacePage.tab("terminal").click();
+
+    // Sanity-check A's terminal tab observed visible=true via the
+    // shared context.
+    await expect(workspacePage.terminalTabVisibilityMarker(WORKSPACE_A, true)).toBeVisible();
+
+    // Switch to B — A becomes cached, B is now active. The outer
+    // Terminal tab stays selected (the outer dockview is shared across
+    // workspaces), so both A's and B's terminal containers stay
+    // mounted simultaneously.
+    await workspacePage.switchWorkspace(WORKSPACE_B);
+
+    // Positive anchor on B before asserting A is hidden.
+    await expect(workspacePage.terminalTabVisibilityMarker(WORKSPACE_B, true)).toBeVisible();
+
+    // A's cached terminal tab must now report visible=false. The same
+    // regression-lever logic as the chat test above: the only way for
+    // `wsActive=false` to reach the leaf is via the shared context.
+    await expect(workspacePage.terminalTabVisibilityMarker(WORKSPACE_A, false)).toBeAttached();
+    await expect(workspacePage.terminalTabVisibilityMarker(WORKSPACE_A, true)).toHaveCount(0);
+
+    // Round-trip back to A — A becomes active, B becomes cached. The
+    // direction of the visibility flip reverses, proving the context
+    // tracks `wsActive` symmetrically.
+    await workspacePage.switchWorkspace(WORKSPACE_A);
+    await expect(workspacePage.terminalTabVisibilityMarker(WORKSPACE_A, true)).toBeVisible();
+    await expect(workspacePage.terminalTabVisibilityMarker(WORKSPACE_B, false)).toBeAttached();
+    await expect(workspacePage.terminalTabVisibilityMarker(WORKSPACE_B, true)).toHaveCount(0);
+  });
+});

--- a/apps/web/src/components/DockviewBrowserContainer.tsx
+++ b/apps/web/src/components/DockviewBrowserContainer.tsx
@@ -9,16 +9,7 @@ import {
   type IDockviewPanelProps,
 } from "dockview";
 import { Columns2, Globe, Plus, Rows2, X } from "lucide-react";
-import React, {
-  createContext,
-  useCallback,
-  useContext,
-  useEffect,
-  useLayoutEffect,
-  useMemo,
-  useRef,
-  useState,
-} from "react";
+import React, { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { useAdapter } from "@/dashboard";
 import { injectInitialUrls } from "../lib/browser-layout";
 import { invoke as desktopInvoke, listen as desktopListen } from "../lib/desktop-ipc";
@@ -35,6 +26,7 @@ import {
 import { isDesktop } from "../lib/is-desktop";
 import { trpc } from "../lib/trpc-client";
 import { BrowserPaneComponent, type BrowserPaneParams, useFavicon } from "./BrowserPanel";
+import { PanelVisibilityContext, usePanelVisibility } from "./panel-visibility-context";
 
 // ---------------------------------------------------------------------------
 // Track browser IDs that were just created by an "add tab" action.
@@ -172,9 +164,9 @@ const browserTabTheme: DockviewTheme = {
 // Browser tab panel component (renders inside each dockview tab)
 // ---------------------------------------------------------------------------
 
-// Visibility context — propagated from DockviewBrowserContainer via React
-// context instead of dockview's updateParameters (which clobbers params).
-const BrowserVisibilityContext = createContext({ visible: true, wsActive: true });
+// Visibility is propagated from DockviewBrowserContainer via the shared
+// PanelVisibilityContext instead of dockview's updateParameters (which
+// clobbers params).
 
 interface BrowserTabParams {
   workspaceId: string;
@@ -183,7 +175,7 @@ interface BrowserTabParams {
 }
 
 function BrowserTabPanel({ params, api }: IDockviewPanelProps<BrowserTabParams>) {
-  const { visible } = useContext(BrowserVisibilityContext);
+  const { visible } = usePanelVisibility();
 
   if (!params.workspaceId || !params.browserId) return null;
 
@@ -199,7 +191,19 @@ function BrowserTabPanel({ params, api }: IDockviewPanelProps<BrowserTabParams>)
   };
 
   return (
-    <div className="flex h-full w-full flex-col overflow-hidden">
+    // `data-testid` encodes the visibility signal the SHARED
+    // `PanelVisibilityContext` propagated into this tab panel
+    // (see `panel-visibility-context.tsx`), so an integration test can
+    // assert the context plumbing reaches the leaf. Note: the browser
+    // path is only mounted in the Electron desktop build (see
+    // `SharedDockviewLayout`'s `BrowserPanelComponent` web-fallback
+    // branch), so the marker is only observable from desktop e2e
+    // coverage — but the assignment is part of the same shared-context
+    // contract, so we mark it here for parity.
+    <div
+      className="flex h-full w-full flex-col overflow-hidden"
+      data-testid={`dockview-browser-tab__visible-${visible ? "true" : "false"}`}
+    >
       <BrowserPaneComponent
         params={paneParams}
         api={api}
@@ -1016,7 +1020,7 @@ export function DockviewBrowserContainer({
     });
   }, [adapter, workspaceId]);
 
-  // Visibility is now propagated via BrowserVisibilityContext (React context)
+  // Visibility is now propagated via PanelVisibilityContext (React context)
   // instead of updateParameters — see the Provider wrapping DockviewReact.
 
   // Keep module-level refs in sync for stable Dockview components
@@ -1168,7 +1172,7 @@ export function DockviewBrowserContainer({
 
   return (
     <div ref={containerRef} className="flex h-full w-full flex-col overflow-hidden">
-      <BrowserVisibilityContext.Provider value={visibilityValue}>
+      <PanelVisibilityContext.Provider value={visibilityValue}>
         <DockviewReact
           theme={browserTabTheme}
           className="h-full"
@@ -1178,7 +1182,7 @@ export function DockviewBrowserContainer({
           onReady={onReady}
           rightHeaderActionsComponent={RightHeaderActions}
         />
-      </BrowserVisibilityContext.Provider>
+      </PanelVisibilityContext.Provider>
     </div>
   );
 }

--- a/apps/web/src/components/DockviewChatContainer.tsx
+++ b/apps/web/src/components/DockviewChatContainer.tsx
@@ -9,15 +9,7 @@ import {
   type IDockviewPanelProps,
 } from "dockview";
 import { Columns2, Plus, Rows2, X } from "lucide-react";
-import React, {
-  createContext,
-  useCallback,
-  useContext,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-} from "react";
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { AgentIcon, useAdapter } from "@/dashboard";
 import {
   attachEdgeGroupDragVisibility,
@@ -31,6 +23,7 @@ import {
 } from "../lib/dockview-section-actions";
 import { trpc } from "../lib/trpc-client";
 import { ChatPane, type CodingAgentDef, useChatPaneState } from "./ChatPane";
+import { PanelVisibilityContext, usePanelVisibility } from "./panel-visibility-context";
 
 // ---------------------------------------------------------------------------
 // Track chat IDs that were just created by an "add tab" action.
@@ -142,9 +135,9 @@ const chatTabTheme: DockviewTheme = {
 // Chat tab panel component (renders inside each dockview tab)
 // ---------------------------------------------------------------------------
 
-// Visibility context — propagated from DockviewChatContainer via React
-// context instead of dockview's updateParameters (which clobbers params).
-const ChatVisibilityContext = createContext({ visible: true, wsActive: true });
+// Visibility is propagated from DockviewChatContainer via the shared
+// PanelVisibilityContext instead of dockview's updateParameters (which
+// clobbers params).
 
 interface ChatTabParams {
   workspaceId: string;
@@ -154,7 +147,7 @@ interface ChatTabParams {
 function ChatTabPanel({ params, api }: IDockviewPanelProps<ChatTabParams>) {
   // Track visibility: combine parent visibility context with dockview's own active state
   const [tabActive, setTabActive] = useState(api.isActive);
-  const { visible: parentVisible, wsActive } = useContext(ChatVisibilityContext);
+  const { visible: parentVisible, wsActive } = usePanelVisibility();
 
   useEffect(() => {
     const d = api.onDidActiveChange((e) => setTabActive(e.isActive));
@@ -207,7 +200,16 @@ function ChatTabContent({
   }, [state.sessionQueryDone, state.activeSessionSummary, state.agentLabel, state.codingAgentId]);
 
   return (
-    <div className="flex h-full w-full flex-col overflow-hidden">
+    // `data-testid` encodes the visibility signal the SHARED
+    // `PanelVisibilityContext` propagated into this tab panel
+    // (see `panel-visibility-context.tsx`), so an integration test can
+    // assert that the context plumbing — not just dockview's outer
+    // detach behaviour — actually reaches the leaf. Pinned to the wrapper
+    // div so the BEM convention matches the rest of the codebase.
+    <div
+      className="flex h-full w-full flex-col overflow-hidden"
+      data-testid={`dockview-chat-tab__visible-${visible ? "true" : "false"}`}
+    >
       <ChatPane
         workspaceId={workspaceId}
         chatId={chatId}
@@ -750,7 +752,7 @@ export function DockviewChatContainer({
     });
   }, [adapter, workspaceId]);
 
-  // Visibility is now propagated via ChatVisibilityContext (React context)
+  // Visibility is now propagated via PanelVisibilityContext (React context)
   // instead of updateParameters — see the Provider wrapping DockviewReact.
 
   // Keep module-level refs in sync for stable Dockview components
@@ -791,7 +793,7 @@ export function DockviewChatContainer({
           createDefaultPanel(event.api, workspaceId);
         }
 
-        // Visibility is propagated via ChatVisibilityContext — no param update needed.
+        // Visibility is propagated via PanelVisibilityContext — no param update needed.
 
         // Prune panels whose chat records no longer exist on the server —
         // e.g. the user removed them via `band chats remove` while the
@@ -885,7 +887,7 @@ export function DockviewChatContainer({
 
   return (
     <div ref={containerRef} className="flex h-full w-full flex-col overflow-hidden">
-      <ChatVisibilityContext.Provider value={visibilityValue}>
+      <PanelVisibilityContext.Provider value={visibilityValue}>
         <DockviewReact
           theme={chatTabTheme}
           className="h-full"
@@ -895,7 +897,7 @@ export function DockviewChatContainer({
           onReady={onReady}
           rightHeaderActionsComponent={RightHeaderActions}
         />
-      </ChatVisibilityContext.Provider>
+      </PanelVisibilityContext.Provider>
     </div>
   );
 }

--- a/apps/web/src/components/DockviewTerminalContainer.tsx
+++ b/apps/web/src/components/DockviewTerminalContainer.tsx
@@ -10,11 +10,9 @@ import {
 } from "dockview";
 import { Columns2, Plus, Rows2, TerminalSquare, X } from "lucide-react";
 import React, {
-  createContext,
   lazy,
   Suspense,
   useCallback,
-  useContext,
   useEffect,
   useLayoutEffect,
   useMemo,
@@ -33,6 +31,7 @@ import {
   selectNeighbourBeforeRemove,
 } from "../lib/dockview-section-actions";
 import { trpc } from "../lib/trpc-client";
+import { PanelVisibilityContext, usePanelVisibility } from "./panel-visibility-context";
 
 // Lazy-load TerminalPanel to avoid importing @xterm CJS during SSR
 const TerminalPanel = lazy(() =>
@@ -142,8 +141,6 @@ const terminalTabTheme: DockviewTheme = {
 // Terminal tab panel component (renders inside each dockview tab)
 // ---------------------------------------------------------------------------
 
-const TerminalVisibilityContext = createContext({ visible: true, wsActive: true });
-
 interface TerminalTabParams {
   workspaceId: string;
   terminalId: string;
@@ -154,7 +151,7 @@ interface TerminalTabParams {
 }
 
 function TerminalTabPanel({ params, api }: IDockviewPanelProps<TerminalTabParams>) {
-  const { visible } = useContext(TerminalVisibilityContext);
+  const { visible } = usePanelVisibility();
 
   // Stable callback to update the dockview tab title when the shell emits a title change
   const onTitleChange = useCallback(
@@ -177,7 +174,14 @@ function TerminalTabPanel({ params, api }: IDockviewPanelProps<TerminalTabParams
       : undefined;
 
   return (
-    <div className="flex h-full w-full flex-col overflow-hidden">
+    // `data-testid` encodes the visibility signal the SHARED
+    // `PanelVisibilityContext` propagated into this tab panel
+    // (see `panel-visibility-context.tsx`), so an integration test can
+    // assert the context plumbing reaches the leaf.
+    <div
+      className="flex h-full w-full flex-col overflow-hidden"
+      data-testid={`dockview-terminal-tab__visible-${visible ? "true" : "false"}`}
+    >
       <Suspense fallback={null}>
         <TerminalPanel
           workspaceId={params.workspaceId}
@@ -860,7 +864,7 @@ export function DockviewTerminalContainer({
 
   return (
     <div ref={containerRef} className="flex h-full w-full flex-col overflow-hidden">
-      <TerminalVisibilityContext.Provider value={visibilityValue}>
+      <PanelVisibilityContext.Provider value={visibilityValue}>
         <DockviewReact
           theme={terminalTabTheme}
           className="h-full"
@@ -870,7 +874,7 @@ export function DockviewTerminalContainer({
           onReady={onReady}
           rightHeaderActionsComponent={RightHeaderActions}
         />
-      </TerminalVisibilityContext.Provider>
+      </PanelVisibilityContext.Provider>
     </div>
   );
 }

--- a/apps/web/src/components/panel-visibility-context.tsx
+++ b/apps/web/src/components/panel-visibility-context.tsx
@@ -1,0 +1,33 @@
+import { createContext, useContext } from "react";
+
+/**
+ * Shape of the visibility signal each Dockview inner container
+ * (Chat / Terminal / Browser) propagates down to its tab panels.
+ *
+ * - `visible`  — combined "this container's outer panel is visible
+ *                AND the workspace is active". Tab panels combine it
+ *                with dockview's per-tab active state to decide
+ *                whether the leaf content (chat / terminal / browser)
+ *                should actually render or stay suspended.
+ * - `wsActive` — workspace-level activity flag on its own. Some leaves
+ *                (e.g. `BrowserPaneComponent`) use this to hide the
+ *                native webview for reasons external to the inner
+ *                dockview.
+ *
+ * Both default to `true` so leaf components that mount outside a
+ * Provider (e.g. in tests, or Storybook) behave like they're fully
+ * visible.
+ */
+export interface PanelVisibility {
+  visible: boolean;
+  wsActive: boolean;
+}
+
+export const PanelVisibilityContext = createContext<PanelVisibility>({
+  visible: true,
+  wsActive: true,
+});
+
+export function usePanelVisibility(): PanelVisibility {
+  return useContext(PanelVisibilityContext);
+}


### PR DESCRIPTION
## Summary

Issue: #469

- Moves the visibility context out of `DockviewChatContainer`, `DockviewTerminalContainer`, and `DockviewBrowserContainer` into a shared `panel-visibility-context.tsx` (exports `PanelVisibility`, `PanelVisibilityContext`, and `usePanelVisibility`).
- All three containers now wrap their `DockviewReact` in the shared `PanelVisibilityContext.Provider`; the per-container `ChatVisibilityContext` / `TerminalVisibilityContext` / `BrowserVisibilityContext` symbols are deleted.
- Adds a Playwright integration test (`apps/web/e2e/panel-visibility-context.spec.ts`) that boots the real production binary, parks workspace A in the `MultiWorkspacePanelHost` LRU cache, switches to workspace B via sidebar click, and asserts the cached A's chat/terminal tab panels observe `visible=false` while B's report `visible=true`.

## Why this is the right regression lever

The outer Shared Dockview's default `onlyWhenVisible` mode detaches inactive outer panels from the DOM, so toggling outer tabs can't distinguish *"context propagated `visible=false`"* from *"container unmounted"*. The `MultiWorkspacePanelHost` LRU cache keeps the inactive workspace's React tree MOUNTED but flips `wsActive` from `true` → `false` on its container — and the only channel that propagates `wsActive=false` down to the leaf is the shared context. If a future change removes the Provider on any of the three containers, the leaf falls back to the default `{ visible: true, wsActive: true }` and the cached marker reports `visible-true` instead of `visible-false`.

## Production-code changes

Only `data-testid` attributes per `TEST-1`:

- `DockviewChatContainer.tsx` — `data-testid=\"dockview-chat-tab__visible-\${true|false}\"` on the chat tab wrapper.
- `DockviewTerminalContainer.tsx` — same shape for terminal.
- `DockviewBrowserContainer.tsx` — same shape for parity (browser is desktop-only, so the marker is observable only in desktop e2e).

## Test plan

- [x] `pnpm exec tsc --noEmit` clean.
- [x] `pnpm exec biome check` clean across all touched files.
- [x] `pnpm --filter @band-app/server test:e2e panel-visibility-context.spec.ts` — 2/2 pass in ~5s.
- [x] Sanity check: removed Provider from `DockviewChatContainer` only → chat test fails, terminal test still passes. Then from `DockviewTerminalContainer` only → terminal test fails, chat test still passes. Both restored → both pass. Each spec is independently load-bearing.
- [ ] Manual desktop QA on the Browser container (out of web build's scope, same exclusion as `workspace-tab-switch-stability.spec.ts`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)