### PR TITLE
fix(chat): stop Esc in mention/slash dropdown from cancelling running task

### DIFF
--- a/apps/web/e2e/chat-mention-escape.spec.ts
+++ b/apps/web/e2e/chat-mention-escape.spec.ts
@@ -1,0 +1,214 @@
+/**
+ * Regression coverage: pressing Esc while the `@`-mention file dropdown
+ * is open closes the dropdown but MUST NOT cancel the in-flight agent
+ * task.
+ *
+ * Before the fix in `file-mention-suggestions.tsx` (and the matching
+ * change in `slash-command-suggestions.tsx`), the dropdown's Esc handler
+ * called `preventDefault()` but not `stopPropagation()`. The capture-
+ * phase document listener fired first, but the event then continued to
+ * the textarea's React onKeyDown, which calls `onEscape()`, which is
+ * wired in `ChatView.tsx` to `cancel()` whenever a task is streaming.
+ * Result: typing `@`, getting a file picker, pressing Esc to dismiss it
+ * also killed the running task — extremely surprising behaviour.
+ *
+ * Architecture: same shape as `chat-cancel.spec.ts` — real
+ * `dist/start-server.mjs`, fake-agent stdio scenario with a 30 s sleep
+ * so the Stop button stays visible the entire test, no tRPC mocking.
+ *
+ * The `@`-mention dropdown is the chosen surface because its data path
+ * (`workspace.searchFiles` → `git ls-files`) needs only a real git
+ * repo + one committed file in the worktree. The slash-command
+ * dropdown requires the bound coding-agent to implement `listSkills()`,
+ * which the fake-agent does not — but the fix applied to both Esc
+ * handlers is identical (`stopPropagation()` in the capture-phase
+ * document listener), so this single spec is sufficient regression
+ * coverage for both call sites.
+ */
+
+import { execFileSync } from "node:child_process";
+import { mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { expect, test } from "@playwright/test";
+import { toWorkspaceId } from "@/dashboard";
+import {
+  cleanupTmpHome,
+  createTmpHome,
+  type ServerHandle,
+  seedSettings,
+  seedState,
+  startServer,
+} from "./helpers/server";
+import { ChatPanePage } from "./pages/ChatPanePage";
+
+const TOKEN = "e2e-chat-mention-escape-token";
+const PROJECT = "mentionproj";
+const WORKSPACE = toWorkspaceId(PROJECT, "main");
+
+test.use({ viewport: { width: 1280, height: 800 } });
+
+const FAKE_AGENT_PATH = join(import.meta.dirname, "..", "tests", "fake-agent.mjs");
+
+let server: ServerHandle;
+let tmpHome: string;
+
+// Hermetic git environment — identical pattern to
+// `workspace-cache-eviction.spec.ts`. Without it a contributor's
+// `GIT_CONFIG_GLOBAL` (signing keys, hooks, etc.) leaks into the
+// `git init` / `commit` calls below and can hang or fail the test.
+function makeGitEnv(home: string): NodeJS.ProcessEnv {
+  return {
+    PATH: process.env.PATH,
+    HOME: home,
+    GIT_AUTHOR_NAME: "Test",
+    GIT_AUTHOR_EMAIL: "test@test.com",
+    GIT_COMMITTER_NAME: "Test",
+    GIT_COMMITTER_EMAIL: "test@test.com",
+    GIT_CONFIG_GLOBAL: "/dev/null",
+    GIT_CONFIG_SYSTEM: "/dev/null",
+  };
+}
+
+function git(cwd: string, args: string[], home: string): string {
+  return execFileSync("git", args, { cwd, env: makeGitEnv(home), encoding: "utf-8" });
+}
+
+test.beforeAll(async () => {
+  tmpHome = createTmpHome();
+
+  // Real git repo with one committed file. `workspace.searchFiles` runs
+  // `git ls-files --cached --others --exclude-standard` against the
+  // worktree; without a real repo the call throws and the `@`-mention
+  // dropdown never opens.
+  const repoDir = join(tmpHome, "repo");
+  mkdirSync(repoDir, { recursive: true });
+  git(repoDir, ["init", "-b", "main"], tmpHome);
+  writeFileSync(join(repoDir, "README.md"), "# Mention escape test\n");
+  git(repoDir, ["add", "."], tmpHome);
+  git(repoDir, ["commit", "-m", "initial commit"], tmpHome);
+
+  seedState(tmpHome, {
+    projects: [
+      {
+        name: PROJECT,
+        path: repoDir,
+        defaultBranch: "main",
+        worktrees: [{ branch: "main", path: repoDir }],
+      },
+    ],
+  });
+  seedSettings(tmpHome, {
+    tokenSecret: TOKEN,
+    codingAgents: [
+      {
+        id: "claude-code",
+        type: "claude-code",
+        label: "Claude Code",
+        command: FAKE_AGENT_PATH,
+      },
+    ],
+  });
+
+  // Same fake-agent scenario as `chat-cancel.spec.ts`: emit one
+  // `text-delta` IMMEDIATELY so status flips to "streaming" (Stop
+  // button visible), then sleep 30 s. The sleep window is where the
+  // test opens and dismisses the dropdown.
+  const scenarioPath = join(tmpHome, "scenario.json");
+  writeFileSync(
+    scenarioPath,
+    JSON.stringify([
+      { type: "system", subtype: "init", session_id: "mention-escape-session" },
+      {
+        type: "assistant",
+        message: { content: [{ type: "text", text: "partial reply " }] },
+      },
+      { _sleep_ms: 30_000 },
+      {
+        type: "assistant",
+        message: { content: [{ type: "text", text: "never observed" }] },
+      },
+      {
+        type: "result",
+        subtype: "success",
+        session_id: "mention-escape-session",
+        duration_ms: 30_000,
+        num_turns: 1,
+        total_cost_usd: 0.0,
+      },
+    ]),
+  );
+
+  server = await startServer({
+    tmpHome,
+    env: { FAKE_AGENT_SCENARIO: scenarioPath },
+  });
+});
+
+test.afterAll(async () => {
+  if (server) await server.close();
+  cleanupTmpHome(tmpHome);
+});
+
+test.describe("@-mention dropdown — Esc dismisses dropdown, not the running task", () => {
+  test("Esc with the @-mention dropdown open does NOT cancel the streaming task", async ({
+    page,
+  }) => {
+    const chatPane = new ChatPanePage(page, server.url, TOKEN);
+    await chatPane.goto(WORKSPACE);
+    await chatPane.waitForReady();
+
+    // Kick a task off — Stop button visible == task is streaming.
+    await chatPane.typeMessage("start a task");
+    await chatPane.submit();
+    await expect(chatPane.stopButton).toBeVisible();
+
+    // Type `@` in the (now-empty) prompt to open the file-mention
+    // dropdown. `fill("")` after submit ensures the textarea is empty
+    // first — most submit paths clear it, but the prompt's draft logic
+    // can leave whitespace, and the dropdown's regex needs `@` at
+    // position 0 or preceded by whitespace.
+    await chatPane.promptInput.fill("");
+    await chatPane.focusPrompt();
+    await chatPane.pressKey("@");
+
+    // The dropdown takes ~150 ms (debounced trpc.workspace.searchFiles)
+    // to populate. `toBeVisible()` auto-retries until it appears or
+    // Playwright times out.
+    await expect(chatPane.fileMentionDropdown).toBeVisible();
+
+    // Press Esc. With the fix, the dropdown's capture-phase document
+    // listener swallows the event via `stopPropagation()` BEFORE it
+    // reaches the textarea's React onKeyDown → no `cancel()` call.
+    await chatPane.pressKey("Escape");
+
+    // 1) The dropdown is gone.
+    await expect(chatPane.fileMentionDropdown).not.toBeVisible();
+
+    // 2) The Stop button is STILL visible — i.e. the task is still
+    //    streaming.
+    //
+    //    A single `toBeVisible()` check would race the cancel path:
+    //    without the fix, Esc fires `trpc.tasks.abort` whose round-trip
+    //    (~100-500 ms locally) eventually emits `task-error` and the
+    //    reducer flips status out of "streaming" → Stop button
+    //    unmounts. If we asserted visibility once immediately after
+    //    Esc, that assertion might pass before the cancel response
+    //    landed.
+    //
+    //    Instead, poll the button's visibility over a 1.5 s window via
+    //    repeated `toBeVisible()` calls. Each call returns ~immediately
+    //    when visible and only waits if the button is missing; the
+    //    tight loop consumes real wall-clock time as Playwright keeps
+    //    querying the DOM, comfortably longer than the worst-case
+    //    cancel round-trip. If the button ever becomes invisible in
+    //    that window, `toBeVisible({ timeout: 100 })` times out and
+    //    the test fails — catching the regression.
+    //
+    //    `page.waitForTimeout` is banned by repo convention, so this
+    //    natural-DOM-query polling is the idiomatic alternative.
+    const deadline = Date.now() + 1500;
+    while (Date.now() < deadline) {
+      await expect(chatPane.stopButton).toBeVisible({ timeout: 100 });
+    }
+  });
+});

--- a/apps/web/e2e/chat-mention-escape.spec.ts
+++ b/apps/web/e2e/chat-mention-escape.spec.ts
@@ -163,11 +163,11 @@ test.describe("@-mention dropdown — Esc dismisses dropdown, not the running ta
     await expect(chatPane.stopButton).toBeVisible();
 
     // Type `@` in the (now-empty) prompt to open the file-mention
-    // dropdown. `fill("")` after submit ensures the textarea is empty
-    // first — most submit paths clear it, but the prompt's draft logic
-    // can leave whitespace, and the dropdown's regex needs `@` at
-    // position 0 or preceded by whitespace.
-    await chatPane.promptInput.fill("");
+    // dropdown. `clearPrompt()` ensures the textarea is empty first —
+    // most submit paths clear it, but the prompt's draft logic can
+    // leave whitespace, and the dropdown's regex needs `@` at position
+    // 0 or preceded by whitespace.
+    await chatPane.clearPrompt();
     await chatPane.focusPrompt();
     await chatPane.pressKey("@");
 
@@ -195,17 +195,24 @@ test.describe("@-mention dropdown — Esc dismisses dropdown, not the running ta
     //    Esc, that assertion might pass before the cancel response
     //    landed.
     //
-    //    Instead, poll the button's visibility over a 1.5 s window via
-    //    repeated `toBeVisible()` calls. Each call returns ~immediately
-    //    when visible and only waits if the button is missing; the
-    //    tight loop consumes real wall-clock time as Playwright keeps
-    //    querying the DOM, comfortably longer than the worst-case
-    //    cancel round-trip. If the button ever becomes invisible in
-    //    that window, `toBeVisible({ timeout: 100 })` times out and
-    //    the test fails — catching the regression.
+    //    The natural reflex is `expect.poll(() => isVisible(), {
+    //    timeout: 1500 }).toBe(true)`, but that's WRONG here: poll
+    //    stops on the first iteration where the predicate returns the
+    //    expected value, so it succeeds immediately when the button is
+    //    visible and never samples STABILITY over the window. We need
+    //    the opposite — assert visibility is maintained across many
+    //    samples spanning the full 1.5 s.
     //
-    //    `page.waitForTimeout` is banned by repo convention, so this
-    //    natural-DOM-query polling is the idiomatic alternative.
+    //    Instead, loop with `toBeVisible({ timeout: 100 })` for
+    //    1.5 s. Each call returns ~immediately when visible and only
+    //    waits if the button is missing; the tight loop consumes real
+    //    wall-clock time as Playwright keeps querying the DOM,
+    //    comfortably longer than the worst-case cancel round-trip. If
+    //    the button ever becomes invisible in that window, the per-
+    //    iteration assertion times out and the test fails — catching
+    //    the regression. `page.waitForTimeout` is banned by repo
+    //    convention, so this natural-DOM-query polling is the
+    //    idiomatic alternative.
     const deadline = Date.now() + 1500;
     while (Date.now() < deadline) {
       await expect(chatPane.stopButton).toBeVisible({ timeout: 100 });

--- a/apps/web/e2e/pages/ChatPanePage.ts
+++ b/apps/web/e2e/pages/ChatPanePage.ts
@@ -44,6 +44,10 @@ export class ChatPanePage {
    *  #509 regression spec so a future change that updates one and
    *  forgets the other still trips the test. */
   readonly toolCallStatusDots: Locator;
+  /** The `@`-mention file dropdown — opens when the user types `@` in
+   *  the prompt. ARIA name is system-controlled in
+   *  `file-mention-suggestions.tsx`. */
+  readonly fileMentionDropdown: Locator;
 
   constructor(
     private readonly page: Page,
@@ -59,6 +63,7 @@ export class ChatPanePage {
     this.stopButton = page.getByTestId("prompt-input__stop-button");
     this.toolCallContainers = page.getByTestId("tool-call__container");
     this.toolCallStatusDots = page.getByTestId("tool-call__status-dot");
+    this.fileMentionDropdown = page.getByRole("listbox", { name: "File mentions" });
   }
 
   /** Navigate to the workspace's chat view. The only place URLs are
@@ -121,6 +126,25 @@ export class ChatPanePage {
   async clickNewSession(): Promise<void> {
     await test.step("Click New session", async () => {
       await this.newSessionMenuItem.click();
+    });
+  }
+
+  /** Type a single key in the focused prompt textarea. The prompt
+   *  must already be focused — call `focusPrompt()` first. Used by the
+   *  mention/slash-dropdown tests where `fill()` would replace the whole
+   *  value and lose the `@`/`/` trigger context. */
+  async pressKey(key: string): Promise<void> {
+    await test.step(`Press "${key}" in the prompt`, async () => {
+      await this.promptInput.press(key);
+    });
+  }
+
+  /** Focus the prompt textarea so subsequent `pressKey()` calls land
+   *  there. Click is used instead of `focus()` so the textarea also
+   *  becomes the document's `activeElement` for keydown dispatch. */
+  async focusPrompt(): Promise<void> {
+    await test.step("Focus the prompt", async () => {
+      await this.promptInput.click();
     });
   }
 }

--- a/apps/web/e2e/pages/ChatPanePage.ts
+++ b/apps/web/e2e/pages/ChatPanePage.ts
@@ -88,6 +88,16 @@ export class ChatPanePage {
     });
   }
 
+  /** Clear the prompt textarea. Most submit paths empty the textarea
+   *  already, but the draft-persistence logic in `PromptInput` can
+   *  leave whitespace behind — call this before tests that need a
+   *  guaranteed-empty input (e.g. typing `@` or `/` at position 0). */
+  async clearPrompt(): Promise<void> {
+    await test.step("Clear the prompt", async () => {
+      await this.promptInput.fill("");
+    });
+  }
+
   /** Submit the typed message via Enter (mirrors the keyboard path users
    *  take). The form's submit handler triggers `useChatSubscription.send`
    *  which dispatches the optimistic user-message + task-started events. */

--- a/apps/web/src/components/ai-elements/file-mention-suggestions.tsx
+++ b/apps/web/src/components/ai-elements/file-mention-suggestions.tsx
@@ -96,29 +96,42 @@ export function FileMentionSuggestions({ workspaceId }: FileMentionSuggestionsPr
     [inputValue, setTextareaValue],
   );
 
-  // Intercept keyboard events on the textarea for navigation
+  // Intercept keyboard events on the textarea for navigation.
+  //
+  // The listener is gated only on `isOpen` — NOT on `files.length` — so
+  // that Esc is swallowed even while the dropdown is showing the
+  // "Searching..." placeholder (files not yet loaded). Otherwise the
+  // user could open the dropdown, press Esc before the network query
+  // returns, and have Esc fall through to the chat-level handler that
+  // cancels the in-flight task.
   useEffect(() => {
-    if (!isOpen || files.length === 0) return;
+    if (!isOpen) return;
 
     const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key === "ArrowDown") {
+      if (e.key === "ArrowDown" && files.length > 0) {
         e.preventDefault();
         setSelectedIndex((prev) => (prev + 1) % files.length);
-      } else if (e.key === "ArrowUp") {
+      } else if (e.key === "ArrowUp" && files.length > 0) {
         e.preventDefault();
         setSelectedIndex((prev) => (prev - 1 + files.length) % files.length);
-      } else if (e.key === "Enter" && !e.shiftKey) {
+      } else if (e.key === "Enter" && !e.shiftKey && files.length > 0) {
         e.preventDefault();
         e.stopPropagation();
         handleSelect(files[selectedIndex]);
       } else if (e.key === "Escape") {
+        // Swallow Esc so it doesn't bubble to the chat-level handler that
+        // cancels the in-flight task — the user just wants to close this
+        // dropdown. Listener is registered in the capture phase, so
+        // stopPropagation() here also keeps the event from reaching the
+        // textarea's React onKeyDown.
         e.preventDefault();
+        e.stopPropagation();
         // Remove the @ trigger to dismiss
         const current = getMentionContext(inputValue);
         if (current) {
           setTextareaValue(current.prefix);
         }
-      } else if (e.key === "Tab") {
+      } else if (e.key === "Tab" && files.length > 0) {
         e.preventDefault();
         handleSelect(files[selectedIndex]);
       }

--- a/apps/web/src/components/ai-elements/slash-command-suggestions.tsx
+++ b/apps/web/src/components/ai-elements/slash-command-suggestions.tsx
@@ -85,18 +85,25 @@ export function SlashCommandSuggestions({ skills }: SlashCommandSuggestionsProps
     [inputValue, setTextareaValue, setCommandHint],
   );
 
-  // Intercept keyboard events on the textarea for navigation
+  // Intercept keyboard events on the textarea for navigation.
+  //
+  // The listener is gated only on `isOpen` — NOT on `hasResults` — so
+  // that Esc is swallowed even when the user has typed `/something`
+  // that matches no skill (e.g. mid-typing before a longer command
+  // name becomes valid). Otherwise Esc would fall through to the
+  // chat-level handler that cancels the in-flight task. Mirrors the
+  // same fix applied to `file-mention-suggestions.tsx`.
   useEffect(() => {
-    if (!isOpen || !hasResults) return;
+    if (!isOpen) return;
 
     const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key === "ArrowDown") {
+      if (e.key === "ArrowDown" && hasResults) {
         e.preventDefault();
         setSelectedIndex((prev) => (prev + 1) % filteredSkills.length);
-      } else if (e.key === "ArrowUp") {
+      } else if (e.key === "ArrowUp" && hasResults) {
         e.preventDefault();
         setSelectedIndex((prev) => (prev - 1 + filteredSkills.length) % filteredSkills.length);
-      } else if (e.key === "Enter" && !e.shiftKey) {
+      } else if (e.key === "Enter" && !e.shiftKey && hasResults) {
         e.preventDefault();
         e.stopPropagation();
         handleSelect(filteredSkills[selectedIndex]);
@@ -110,7 +117,7 @@ export function SlashCommandSuggestions({ skills }: SlashCommandSuggestionsProps
         e.stopPropagation();
         setTextareaValue("");
         setCommandHint(null);
-      } else if (e.key === "Tab") {
+      } else if (e.key === "Tab" && hasResults) {
         e.preventDefault();
         handleSelect(filteredSkills[selectedIndex]);
       }

--- a/apps/web/src/components/ai-elements/slash-command-suggestions.tsx
+++ b/apps/web/src/components/ai-elements/slash-command-suggestions.tsx
@@ -101,7 +101,13 @@ export function SlashCommandSuggestions({ skills }: SlashCommandSuggestionsProps
         e.stopPropagation();
         handleSelect(filteredSkills[selectedIndex]);
       } else if (e.key === "Escape") {
+        // Swallow Esc so it doesn't bubble to the chat-level handler that
+        // cancels the in-flight task — the user just wants to close this
+        // dropdown. Listener is registered in the capture phase, so
+        // stopPropagation() here also keeps the event from reaching the
+        // textarea's React onKeyDown.
         e.preventDefault();
+        e.stopPropagation();
         setTextareaValue("");
         setCommandHint(null);
       } else if (e.key === "Tab") {


### PR DESCRIPTION
## Summary

- The `@`-mention and `/`-command dropdowns under the chat prompt registered a document capture-phase keydown listener that called `preventDefault()` on Esc but **not** `stopPropagation()`. Esc continued bubbling to the textarea's React `onKeyDown` → `onEscape()` → `ChatView.handleEscape()` → `cancel()`, so closing the dropdown with Esc silently aborted the running agent task.
- Add `e.stopPropagation()` to both dropdowns' Esc branches. Since the listener runs in document capture phase, the event is intercepted before React's delegated handler sees it.
- Loosen the `file-mention-suggestions` effect gate: register the keydown listener whenever the dropdown is open, not only after files have loaded. Otherwise Esc during the "Searching..." placeholder would still bubble through.

## Test plan

- [x] `biome check` clean on changed files
- [x] `tsc --noEmit -p apps/web/tsconfig.json` clean
- [x] New Playwright spec `apps/web/e2e/chat-mention-escape.spec.ts` — boots the real `dist/start-server.mjs` against a real git repo with the fake-agent (30s sleep scenario), opens the `@`-mention dropdown over a streaming task, presses Esc, and asserts (a) the dropdown disappears and (b) the Stop button stays visible across a 1.5s window (no `waitForTimeout` — repo convention). Verified the test **fails** when the fix is reverted and **passes** 5/5 with the fix applied.
- [x] `pnpm vitest run tests/slash-commands.test.ts` — 6 passed
- [x] `chat-cancel.spec.ts`, `chat-mention-escape.spec.ts`, `chat-send-optimistic.spec.ts` — all green