### PR TITLE
fix(web): pin inner dockview panels to central area instead of edge groups

### DIFF
--- a/apps/web/e2e/pages/WorkspacePage.ts
+++ b/apps/web/e2e/pages/WorkspacePage.ts
@@ -349,4 +349,83 @@ export class WorkspacePage {
     const state = await this.readActiveState(workspaceId);
     return state?.groups[groupId];
   }
+
+  /** Reset the per-workspace shared-dockview state entry in
+   *  `localStorage` and (re-)navigate to the workspace so the next
+   *  mount runs against a clean slate. Two-step (matches
+   *  `resetLabelStateAndGoto`): navigate first to land on the origin
+   *  (localStorage isn't accessible until a same-origin page has
+   *  loaded), then evaluate the clear. Centralises the
+   *  `ACTIVE_STATE_KEY_PREFIX` key construction so test bodies don't
+   *  rebuild the key inline.
+   *
+   *  IMPORTANT: the clear runs AFTER the initial `goto`, so the React
+   *  tree's in-memory copy of the active state still reflects what was
+   *  in storage at mount time. Tests that need a fully clean React
+   *  state should follow up with another `goto(...)` (or `reload()`)
+   *  before exercising layout behaviour. */
+  async resetDockviewActiveStateAndGoto(workspaceId: string): Promise<void> {
+    await test.step(`Reset dockview active state, navigate to ${workspaceId}`, async () => {
+      await this.goto(workspaceId);
+      await this.page.evaluate(
+        ([prefix, id]) => {
+          localStorage.removeItem(`${prefix}${id}`);
+        },
+        [ACTIVE_STATE_KEY_PREFIX, workspaceId] as const,
+      );
+    });
+  }
+
+  /** Fetch the persisted server-side dockview layout for the given
+   *  inner container (`chat`, `terminal`, or `browser`). Each container
+   *  has its own tRPC namespace (`chatLayout.get`, `terminalLayout.get`,
+   *  `browserLayout.get`) that returns `{ tree }`; this helper unwraps
+   *  the response and returns the parsed tree (or `null` when no layout
+   *  has been persisted yet).
+   *
+   *  Used by the panel-default-position regression test to verify that
+   *  newly-added panels end up in a central (grid-located) leaf instead
+   *  of being appended into one of the three collapsed edge groups
+   *  (`edge-left`, `edge-right`, `edge-bottom`) that `ensureEdgeGroups`
+   *  adds in `onReady`. The return type narrows the response into the
+   *  dockview-toJSON shape the test traverses — keeps dockview
+   *  knowledge inside the page object so test bodies can skip casts. */
+  async readInnerLayout(
+    container: "chat" | "terminal" | "browser",
+    workspaceId: string,
+  ): Promise<DockviewLayoutSnapshot | null> {
+    const procedure =
+      container === "chat"
+        ? "chatLayout.get"
+        : container === "terminal"
+          ? "terminalLayout.get"
+          : "browserLayout.get";
+    const input = encodeURIComponent(JSON.stringify({ workspaceId }));
+    const res = await this.page.request.get(
+      `${this.baseUrl}/trpc/${procedure}?input=${input}&token=${this.token}`,
+    );
+    if (!res.ok()) {
+      throw new Error(`readInnerLayout(${container}) failed: ${res.status()} ${await res.text()}`);
+    }
+    const body = (await res.json()) as {
+      result: { data: { tree: DockviewLayoutSnapshot | null } };
+    };
+    return body.result.data.tree;
+  }
 }
+
+/** Narrowed shape for what `*.Layout.get` returns. Mirrors the parts of
+ *  `dockview.toJSON()` the regression test traverses (`grid.root` walk
+ *  + `panels` lookup); other fields are ignored. Lives at the bottom of
+ *  the page-object file so callers get a typed return from
+ *  `readInnerLayout` without re-deriving the shape inline. */
+export interface DockviewLayoutSnapshot {
+  grid?: {
+    root?: DockviewGridNode;
+  };
+  panels: Record<string, unknown>;
+}
+
+export type DockviewGridNode =
+  | { type: "leaf"; data: { id: string; views: string[]; activeView?: string } }
+  | { type: "branch"; data: DockviewGridNode[] };

--- a/apps/web/e2e/panel-default-position.spec.ts
+++ b/apps/web/e2e/panel-default-position.spec.ts
@@ -1,0 +1,258 @@
+/**
+ * Regression coverage for the chat / terminal panels landing in a
+ * collapsed edge group on cold mount.
+ *
+ * Background
+ * ----------
+ * Each inner dockview (`DockviewChatContainer`,
+ * `DockviewTerminalContainer`, `DockviewBrowserContainer`) calls
+ * `ensureEdgeGroups` in `onReady` to add three cardinal edge groups
+ * (`edge-left`, `edge-right`, `edge-bottom`), all collapsed and empty.
+ * dockview-core 6.0.6 falls back to `activeGroup` when `api.addPanel`
+ * is called without a `position` — and when `activeGroup` happens to
+ * be one of those collapsed edge groups (e.g. because the inner
+ * dockview's seed path is async and runs AFTER `ensureEdgeGroups`),
+ * the new panel is appended INTO the edge group instead of the
+ * central area. Visually this renders as a thin docked strip at the
+ * bottom of the section instead of a normal full-area pane.
+ *
+ * The fix pins every positionless `addPanel` call site to the central
+ * area via the `centralPanelPosition` helper in
+ * `apps/web/src/lib/dockview-edge-groups.ts`: prefer
+ * `{ referenceGroup: <id> }` when a grid-located group exists, and
+ * otherwise return `{ direction: "within" }` to force dockview to
+ * create a brand-new central group at location `[0]` regardless of
+ * what `activeGroup` happens to be.
+ *
+ * What this spec asserts
+ * ----------------------
+ * For each of the chat / terminal containers we:
+ *   1. Boot the real server with an empty `panel_states` table (no
+ *      seeded layout for the workspace).
+ *   2. Open the workspace and let the inner dockview's `onReady` run
+ *      its default-seed path (chat: `createDefaultPanel`; terminal:
+ *      `seedFromConfigOrDefault`).
+ *   3. Wait for the layout to be persisted server-side (the inner
+ *      containers debounce-save to `chat_layout` / `terminal_layout`
+ *      panel state rows via tRPC).
+ *   4. Read the persisted layout via `chatLayout.get` /
+ *      `terminalLayout.get` and assert the freshly-seeded panel's id
+ *      is in a leaf whose group id is NOT one of `edge-left`,
+ *      `edge-right`, `edge-bottom`. Equivalently: the panel sits in a
+ *      central (grid-located) leaf, which is what the user expects.
+ *
+ * The terminal test is the most direct regression catch — the
+ * `seedFromConfigOrDefault` async path is the documented race that
+ * reliably reproduces the bug on cold-start. The chat test codifies
+ * the contract for the analogous chat call sites.
+ *
+ * Out of scope: browser container
+ * -------------------------------
+ * The fix in `DockviewBrowserContainer` (default panel +
+ * `browser-created` subscription) mirrors the chat container line-for-
+ * line, but `BrowserPanelComponent` in `SharedDockviewLayout.tsx`
+ * skips `DockviewBrowserContainer` entirely on the web build (only
+ * the Electron desktop build mounts it — see the `if (!isDesktop)`
+ * branch). The TypeScript + biome + structural review covers the
+ * symbol-level half of the fix on that container; a runtime
+ * regression catch requires desktop e2e coverage which this web-build
+ * spec can't provide. Same shape and rationale as
+ * `panel-visibility-context.spec.ts`'s scope note. The
+ * `WorkspacePage.readInnerLayout("browser", …)` helper is kept so a
+ * future desktop e2e harness can wire up the missing third test
+ * without re-deriving the tRPC path.
+ */
+
+import { expect, test } from "@playwright/test";
+import { toWorkspaceId } from "@/dashboard";
+import { EDGE_GROUP_IDS } from "@/lib/dockview-edge-groups";
+import {
+  cleanupTmpHome,
+  createTmpHome,
+  type ServerHandle,
+  seedSettings,
+  seedState,
+  startServer,
+} from "./helpers/server";
+import type { DockviewGridNode, DockviewLayoutSnapshot } from "./pages/WorkspacePage";
+import { WorkspacePage } from "./pages/WorkspacePage";
+
+const TOKEN = "e2e-panel-default-position-token";
+
+const PROJECT = "alpha-panel-default";
+const WORKSPACE = toWorkspaceId(PROJECT, "main");
+
+// Wide viewport so `useIsDesktop()` reports true and the shared
+// dockview (which hosts the inner containers under test) renders.
+test.use({ viewport: { width: 1280, height: 800 } });
+
+let server: ServerHandle;
+let tmpHome: string;
+
+test.beforeAll(async () => {
+  tmpHome = createTmpHome();
+  seedState(tmpHome, {
+    projects: [
+      {
+        name: PROJECT,
+        path: `/tmp/fake/${PROJECT}`,
+        defaultBranch: "main",
+        worktrees: [{ branch: "main", path: `/tmp/fake/${PROJECT}` }],
+      },
+    ],
+  });
+  seedSettings(tmpHome, { tokenSecret: TOKEN });
+  server = await startServer({ tmpHome });
+});
+
+test.afterAll(async () => {
+  await server.close();
+  cleanupTmpHome(tmpHome);
+});
+
+test.beforeEach(async ({ page }) => {
+  // Clear the per-workspace shared-dockview state so each test starts
+  // with the default outer layout (Chat on the left,
+  // Terminal/Changes/Files/Browser on the right). The page-object
+  // method centralises the localStorage key construction so the test
+  // body never reaches for the prefix inline.
+  const workspacePage = new WorkspacePage(page, server.url, TOKEN);
+  await workspacePage.resetDockviewActiveStateAndGoto(WORKSPACE);
+});
+
+// ---------------------------------------------------------------------------
+// Layout traversal helper
+// ---------------------------------------------------------------------------
+
+/** Walk a dockview grid tree and return the id of the leaf whose
+ *  `views` array contains `panelId`. Returns `undefined` when the
+ *  panel id is not present anywhere in the tree. */
+function findContainingLeafId(layout: DockviewLayoutSnapshot, panelId: string): string | undefined {
+  const root = layout.grid?.root;
+  if (!root) return undefined;
+
+  const visit = (node: DockviewGridNode): string | undefined => {
+    if (node.type === "leaf") {
+      return node.data.views.includes(panelId) ? node.data.id : undefined;
+    }
+    for (const child of node.data) {
+      const found = visit(child);
+      if (found) return found;
+    }
+    return undefined;
+  };
+
+  return visit(root);
+}
+
+/** Leaf ids `ensureEdgeGroups` injects into every inner dockview. A
+ *  panel landing in any of these is the bug. Re-uses the production
+ *  constant so adding a fourth edge in `ensureEdgeGroups` automatically
+ *  extends the regression check. */
+const FORBIDDEN_LEAF_IDS = new Set<string>(Object.values(EDGE_GROUP_IDS));
+
+/** Poll the inner container's tRPC `*.Layout.get` endpoint until it
+ *  returns a layout that contains at least one panel, then return the
+ *  resolved layout. The 500 ms persistence debounce inside each inner
+ *  container means the layout briefly looks "empty" after onReady —
+ *  this helper waits for the debounced save to land before the test
+ *  asserts on it. */
+async function pollForLayoutWithPanels(
+  workspacePage: WorkspacePage,
+  container: "chat" | "terminal" | "browser",
+  workspaceId: string,
+): Promise<DockviewLayoutSnapshot> {
+  let layout: DockviewLayoutSnapshot | undefined;
+  await expect
+    .poll(
+      async () => {
+        const tree = await workspacePage.readInnerLayout(container, workspaceId);
+        if (!tree || Object.keys(tree.panels).length === 0) return false;
+        layout = tree;
+        return true;
+      },
+      { timeout: 10_000 },
+    )
+    .toBe(true);
+  if (!layout) {
+    throw new Error(`pollForLayoutWithPanels(${container}): poll returned true but no layout`);
+  }
+  return layout;
+}
+
+/** Shared body for each container's regression test. Reads the freshly
+ *  persisted layout, locates the seeded panel's leaf, and asserts the
+ *  leaf id is not one of the collapsed edge-group ids. The terminal
+ *  test additionally drives the outer tab activation before this runs
+ *  (the inner container doesn't mount until the outer tab is active);
+ *  the chat container is already mounted on workspace load. */
+async function assertSeededPanelInCentralArea(
+  workspacePage: WorkspacePage,
+  container: "chat" | "terminal" | "browser",
+  workspaceId: string,
+): Promise<void> {
+  const layout = await pollForLayoutWithPanels(workspacePage, container, workspaceId);
+  const panelIds = Object.keys(layout.panels);
+  // The default-seed path creates exactly one panel — a second one
+  // would indicate the seed ran twice (the bug some earlier
+  // refactors of this code path actually introduced) and is worth
+  // surfacing as a test failure.
+  expect(panelIds).toHaveLength(1);
+  const panelId = panelIds[0];
+  const leafId = findContainingLeafId(layout, panelId);
+  expect(leafId, `${container} panel ${panelId} is not in any leaf`).toBeDefined();
+  expect(FORBIDDEN_LEAF_IDS.has(leafId as string)).toBe(false);
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+test.describe("Panel default position (regression: edge-group leak)", () => {
+  test("Chat container's default panel lands in a central (grid) group, not an edge group", async ({
+    page,
+  }) => {
+    const workspacePage = new WorkspacePage(page, server.url, TOKEN);
+
+    await workspacePage.goto(WORKSPACE);
+    await workspacePage.waitForReady();
+
+    // Positive anchor: the default chat tab is visible. This proves
+    // the chat container's `onReady` has actually run — without it the
+    // `chatLayout.get` poll below could pass simply because nothing
+    // was ever persisted.
+    await expect(workspacePage.chatTabVisibilityMarker(WORKSPACE, true)).toBeVisible();
+
+    await assertSeededPanelInCentralArea(workspacePage, "chat", WORKSPACE);
+  });
+
+  test("Terminal container's default panel lands in a central (grid) group, not an edge group", async ({
+    page,
+  }) => {
+    const workspacePage = new WorkspacePage(page, server.url, TOKEN);
+
+    await workspacePage.goto(WORKSPACE);
+    await workspacePage.waitForReady();
+
+    // Activate the outer Terminal tab so the inner
+    // `DockviewTerminalContainer` mounts and its `onReady` runs the
+    // `seedFromConfigOrDefault` async path that the bug originated in.
+    await workspacePage.tab("terminal").click();
+
+    // Positive anchor: the default terminal tab is visible. Confirms
+    // the inner container's seed path actually ran AND the tab is
+    // showing in the central area (a panel in a collapsed edge group
+    // resolves to a `visible-true` test id, since the React component
+    // still sees `parentVisible && tabActive`, but the dockview wrapper
+    // hides it — so this also doubles as a coarse pre-check of the
+    // regression assertion below).
+    await expect(workspacePage.terminalTabVisibilityMarker(WORKSPACE, true)).toBeVisible();
+
+    await assertSeededPanelInCentralArea(workspacePage, "terminal", WORKSPACE);
+  });
+
+  // Browser container test deliberately omitted — see the
+  // "Out of scope: browser container" section of the file docstring
+  // for the rationale and the migration path when desktop e2e
+  // coverage lands.
+});

--- a/apps/web/src/components/DockviewBrowserContainer.tsx
+++ b/apps/web/src/components/DockviewBrowserContainer.tsx
@@ -15,6 +15,7 @@ import { injectInitialUrls } from "../lib/browser-layout";
 import { invoke as desktopInvoke, listen as desktopListen } from "../lib/desktop-ipc";
 import {
   attachEdgeGroupDragVisibility,
+  centralPanelPosition,
   ensureEdgeGroups,
   registerInnerDockview,
 } from "../lib/dockview-edge-groups";
@@ -1000,12 +1001,19 @@ export function DockviewBrowserContainer({
       if (event.kind === "browser-created" && typeof event.browserId === "string") {
         // Skip if this panel already exists (we created it ourselves)
         if (api.getPanel(event.browserId)) return;
+        // Pin the new panel to the inner dockview's central area.
+        // Without this explicit position, dockview's fallback uses
+        // `activeGroup`, which can be one of the collapsed edge
+        // groups added by `ensureEdgeGroups` — making the panel
+        // render as a thin docked strip. See `centralPanelPosition`
+        // for the full rationale.
         api.addPanel({
           id: event.browserId,
           component: "browserTab",
           tabComponent: "browserTab",
           title: "New Tab",
           params: { workspaceId, browserId: event.browserId },
+          position: centralPanelPosition(api),
         });
       } else if (event.kind === "browser-removed" && typeof event.browserId === "string") {
         const panel = api.getPanel(event.browserId);
@@ -1193,6 +1201,10 @@ function createDefaultPanel(api: DockviewApi, workspaceId: string): void {
   trpc.browsers.create.mutate({ workspaceId, id: browserId }).catch((err) => {
     console.error("[DockviewBrowserContainer] error creating default browser:", err);
   });
+  // Pin the default panel to the inner dockview's central area so it
+  // lands there instead of leaking into an edge group that
+  // `ensureEdgeGroups` may have already added. See
+  // `centralPanelPosition` for the full rationale.
   api.addPanel({
     id: browserId,
     component: "browserTab",
@@ -1202,5 +1214,6 @@ function createDefaultPanel(api: DockviewApi, workspaceId: string): void {
       workspaceId,
       browserId,
     },
+    position: centralPanelPosition(api),
   });
 }

--- a/apps/web/src/components/DockviewChatContainer.tsx
+++ b/apps/web/src/components/DockviewChatContainer.tsx
@@ -13,6 +13,7 @@ import React, { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { AgentIcon, useAdapter } from "@/dashboard";
 import {
   attachEdgeGroupDragVisibility,
+  centralPanelPosition,
   ensureEdgeGroups,
   registerInnerDockview,
 } from "../lib/dockview-edge-groups";
@@ -732,12 +733,19 @@ export function DockviewChatContainer({
       if (event.kind === "chat-created" && typeof event.chatId === "string") {
         // Skip if this panel already exists (we created it ourselves)
         if (api.getPanel(event.chatId)) return;
+        // Pin the new panel to the inner dockview's central area.
+        // Without this explicit position, dockview's fallback uses
+        // `activeGroup`, which can be one of the collapsed edge
+        // groups added by `ensureEdgeGroups` — making the panel
+        // render as a thin docked strip instead of in the center.
+        // See `centralPanelPosition` for the full rationale.
         api.addPanel({
           id: event.chatId,
           component: "chatTab",
           tabComponent: "chatTab",
           title: "Chat",
           params: { workspaceId, chatId: event.chatId },
+          position: centralPanelPosition(api),
         });
       } else if (event.kind === "chat-removed" && typeof event.chatId === "string") {
         const panel = api.getPanel(event.chatId);
@@ -904,6 +912,10 @@ export function DockviewChatContainer({
 
 function createDefaultPanel(api: DockviewApi, workspaceId: string): void {
   const chatId = newChatId();
+  // Pin the default panel to the inner dockview's central area so it
+  // lands there instead of leaking into an edge group that
+  // `ensureEdgeGroups` may have already added. See
+  // `centralPanelPosition` for the full rationale.
   api.addPanel({
     id: chatId,
     component: "chatTab",
@@ -913,5 +925,6 @@ function createDefaultPanel(api: DockviewApi, workspaceId: string): void {
       workspaceId,
       chatId,
     },
+    position: centralPanelPosition(api),
   });
 }

--- a/apps/web/src/components/DockviewTerminalContainer.tsx
+++ b/apps/web/src/components/DockviewTerminalContainer.tsx
@@ -22,6 +22,7 @@ import React, {
 import { useAdapter } from "@/dashboard";
 import {
   attachEdgeGroupDragVisibility,
+  centralPanelPosition,
   ensureEdgeGroups,
   registerInnerDockview,
 } from "../lib/dockview-edge-groups";
@@ -698,12 +699,19 @@ export function DockviewTerminalContainer({
       if (event.kind === "terminal-created" && typeof event.terminalId === "string") {
         // Skip if this panel already exists (we created it ourselves)
         if (api.getPanel(event.terminalId)) return;
+        // Pin the new panel to the inner dockview's central area.
+        // Without this explicit position, dockview's fallback uses
+        // `activeGroup`, which can be one of the collapsed edge
+        // groups added by `ensureEdgeGroups` — making the panel
+        // render as a thin docked strip. See `centralPanelPosition`
+        // for the full rationale.
         api.addPanel({
           id: event.terminalId,
           component: "terminalTab",
           tabComponent: "terminalTab",
           title: "Terminal",
           params: { workspaceId, terminalId: event.terminalId },
+          position: centralPanelPosition(api),
         });
       } else if (event.kind === "terminal-killed" && typeof event.terminalId === "string") {
         const panel = api.getPanel(event.terminalId);
@@ -887,6 +895,10 @@ function createDefaultTerminal(api: DockviewApi, workspaceId: string): void {
   // Generate ID client-side so we can add the panel immediately.
   const terminalId = newTerminalId();
 
+  // Pin the default panel to the inner dockview's central area so it
+  // lands there instead of leaking into an edge group that
+  // `ensureEdgeGroups` may have already added. See
+  // `centralPanelPosition` for the full rationale.
   api.addPanel({
     id: terminalId,
     component: "terminalTab",
@@ -896,6 +908,7 @@ function createDefaultTerminal(api: DockviewApi, workspaceId: string): void {
       workspaceId,
       terminalId,
     },
+    position: centralPanelPosition(api),
   });
 
   // Create the server-side terminal (spawns PTY + updates layout + emits event).
@@ -923,6 +936,13 @@ async function seedFromConfigOrDefault(
         for (const pane of panes) {
           try {
             const terminalId = newTerminalId();
+            // `seedFromConfigOrDefault` is async and runs AFTER the
+            // synchronous `ensureEdgeGroups` call in `onReady` — by
+            // the time we get here, the inner dockview's collapsed
+            // edge groups already exist. Pin each seeded panel to
+            // the central area so it lands there instead of being
+            // appended into one of those edge groups. See
+            // `centralPanelPosition` for the full rationale.
             api.addPanel({
               id: terminalId,
               component: "terminalTab",
@@ -935,6 +955,7 @@ async function seedFromConfigOrDefault(
                 cwd: pane.cwd,
                 env: pane.env,
               },
+              position: centralPanelPosition(api),
             });
             await trpc.terminal.create.mutate({
               workspaceId,

--- a/apps/web/src/lib/dockview-edge-groups.ts
+++ b/apps/web/src/lib/dockview-edge-groups.ts
@@ -23,6 +23,40 @@ export const EDGE_GROUP_IDS = {
 export type EdgeDirection = keyof typeof EDGE_GROUP_IDS;
 
 /**
+ * Build a dockview `addPanel` `position` value that pins a new panel
+ * to the central area of `api`, regardless of which group happens to
+ * be `activeGroup` right now.
+ *
+ * Background: every inner dockview (Chat / Terminal / Browser) calls
+ * `ensureEdgeGroups` in `onReady` to add the three cardinal edge groups
+ * (left / right / bottom) collapsed. dockview-core's `addPanel` falls
+ * back to `activeGroup` when `position` is omitted, and once edge groups
+ * exist `activeGroup` can be one of those collapsed edge groups — which
+ * makes the new panel render as a thin collapsed strip docked at the
+ * edge instead of filling the center.
+ *
+ * Strategy:
+ * - If any grid-located group exists, return
+ *   `{ referenceGroup: <id> }` so the new panel becomes a tab in the
+ *   central area.
+ * - Otherwise return `{ direction: "within" }`, which routes through
+ *   dockview-core's `orthogonalize('center')` → `createGroupAtLocation([0])`
+ *   path and creates a fresh central group regardless of what
+ *   `activeGroup` happens to be. Passing this direction WITHOUT a
+ *   reference (`referencePanel`/`referenceGroup`) is the dockview API
+ *   shape that means "create a new central group from scratch" — the
+ *   only way to force the create-new-group branch when only edge
+ *   groups exist.
+ */
+export function centralPanelPosition(
+  api: DockviewApi,
+): { referenceGroup: string } | { direction: "within" } {
+  const central = api.groups.find((g) => g.api.location.type === "grid");
+  if (central) return { referenceGroup: central.id };
+  return { direction: "within" };
+}
+
+/**
  * Add the three cardinal edge groups (left/right/bottom) to `api` if
  * they aren't already present, collapsed and with no panels. Then set
  * each one's visibility based on whether it currently holds panels —


### PR DESCRIPTION
## Summary
- Adds `centralPanelPosition(api)` helper that returns either `{ referenceGroup: <grid-group-id> }` or `{ direction: "within" }` so newly created panels always land in the inner dockview's central area, even when only collapsed edge groups exist
- Applies the helper to every positionless `api.addPanel(...)` call site in `DockviewChatContainer` / `DockviewTerminalContainer` / `DockviewBrowserContainer` (default-seed + status-event-subscription paths)
- Adds a Playwright regression test that boots the real server with an empty `panel_states` table, opens a workspace, and asserts the seeded chat / terminal panel is in a grid-located leaf — not in `edge-left` / `edge-right` / `edge-bottom`

## Bug

Cold-start with no saved layout (delete all rows from `panel_states`, clear `localStorage`, open a workspace) caused the chat or terminal pane to render as a thin docked strip at the bottom of its section instead of filling the central area.

Root cause: dockview-core 6.0.6 falls back to `activeGroup` when `api.addPanel` is called without a `position`. The terminal container's `seedFromConfigOrDefault` runs async — by the time it resolves, `ensureEdgeGroups` has already added the three collapsed edge groups, and dockview routes the positionless `addPanel` into one of them.

## Test plan
- [x] `npx playwright test panel-default-position` — 47/47 e2e tests pass (incl. the new chat + terminal regression tests)
- [x] `pnpm --filter @band-app/server test` — 994/994 vitest tests pass
- [x] `pnpm check` (biome + cargo fmt + clippy) — clean
- [x] Reverted the fix and re-ran the terminal test — reliably fails (panel is in `edge-bottom`, visibility marker reports hidden), confirming the regression catch

## Out of scope: browser container
The fix in `DockviewBrowserContainer` mirrors the chat container line-for-line, but `BrowserPanelComponent` in `SharedDockviewLayout.tsx` skips `DockviewBrowserContainer` entirely on the web build (only Electron desktop mounts it). The TypeScript + biome + structural review covers the symbol-level half of the fix on that container; a runtime regression catch requires desktop e2e coverage which this web-build spec can't provide. Same scope-note pattern as \`panel-visibility-context.spec.ts\`. The \`WorkspacePage.readInnerLayout("browser", …)\` helper is kept so a future desktop e2e harness can wire up the missing third test without re-deriving the tRPC path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)