### PR TITLE
test(web): await server exit before rmSync in build-output cleanup

### DIFF
--- a/apps/web/tests/build-output.test.ts
+++ b/apps/web/tests/build-output.test.ts
@@ -210,14 +210,35 @@ describe("published @band-app/server runs via the bin shim", () => {
     }
   }, 120_000);
 
-  afterAll((ctx) => {
+  afterAll(async (ctx) => {
     if (ctx.tasks.some((t) => t.result?.state === "fail")) {
       process.stderr.write(
         `\n--- @band-app/server output ---\n${serverOutput.join("")}\n--- exit code: ${exitCode} ---\n`,
       );
     }
+    // Wait for the spawned server to actually exit before removing workDir.
+    // Without this await, `rmSync(workDir, { recursive: true })` races the
+    // server's writes to `BAND_HOME` (SQLite WAL checkpoints, pino log lines,
+    // settings.json updates) — on macOS APFS that surfaces as ENOTEMPTY when
+    // the recursive walk has emptied a child directory but the server writes
+    // back into it between the child removal and the parent rmdir. Observed
+    // on Release run 26726110047 / job 78761522277 with all 1052 tests
+    // otherwise passing.
     if (server && server.exitCode === null && !server.killed) {
+      const exited = new Promise<void>((resolve) => {
+        server!.once("exit", () => resolve());
+      });
       server.kill("SIGTERM");
+      // Escalate to SIGKILL if SIGTERM doesn't take within a few seconds, so
+      // a wedged child can never deadlock cleanup.
+      const escalate = setTimeout(() => {
+        if (server && server.exitCode === null) server.kill("SIGKILL");
+      }, 5_000);
+      try {
+        await exited;
+      } finally {
+        clearTimeout(escalate);
+      }
     }
     if (workDir) {
       rmSync(workDir, { recursive: true, force: true });


### PR DESCRIPTION
## Summary

- Fixes the intermittent `ENOTEMPTY` failure in `apps/web/tests/build-output.test.ts` `afterAll`.
- The spawned bin-shim subprocess was sent `SIGTERM` but the cleanup never awaited its `exit`; on macOS APFS the recursive `rmSync` races the server's writes to `BAND_HOME` (SQLite WAL, pino log lines, `settings.json`) and trips `ENOTEMPTY` on the parent `rmdir`.
- The cleanup now awaits `exit` (with a 5 s SIGKILL escalation guard) before removing `workDir`.

Surfaced on Release run [26726110047 / job 78761522277](https://github.com/band-app/band/actions/runs/26726110047) with all 1052 tests otherwise passing.

## Test plan
- [x] `pnpm --filter @band-app/server exec vitest run tests/build-output.test.ts` passes locally (13/13).
- [x] Biome lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)