### PR TITLE
Copy untracked files into new workspaces (#284)

### DIFF
--- a/apps/cli/skills/band.md
+++ b/apps/cli/skills/band.md
@@ -120,8 +120,43 @@ band projects remove my-app
 - The CLI never modifies files directly — all operations go through the server API
 - `workspaces create` is idempotent — creating an existing workspace returns its path
 - `setup` scripts run after workspace creation, `teardown` before removal (both non-fatal)
+- Workspace file copying runs after `git worktree add` and before the `setup` script — see "Workspace file copying" below
 - Project and branch names must not contain control characters or path traversals (`../`)
 - Exit code 0 = success, 1 = error
+
+## Workspace file copying
+
+Workspaces are fresh git worktrees, so untracked files (`.env`, `.env.local`,
+local credentials, IDE overrides) are missing by default. Band can copy a
+declared set of those files from the project's main checkout into each new
+worktree, driven by either of two sources at the project root:
+
+**Option A — `.band/config.json::workspace.copyFiles`** (explicit list,
+supports globs):
+
+```json
+{
+  "workspace": {
+    "copyFiles": [".env", ".env.local", "config/*.local.json", ".vscode/settings.json"]
+  }
+}
+```
+
+**Option B — `.worktreeinclude`** (gitignore-syntax, Claude Code parity):
+
+```
+.env*
+config/*.local.json
+```
+
+Only entries that match a `.worktreeinclude` pattern AND are gitignored are
+copied. Tracked files are never duplicated.
+
+When both sources are present, the resulting file sets are UNIONed and
+de-duped by absolute source path. Missing source files are skipped with a
+warning (not fatal). Files are copied (not symlinked) so edits in the
+worktree don't bleed back to the main checkout. Out of scope: per-user
+overrides, copy-back on cleanup, variable substitution.
 
 ## Configuration
 

--- a/apps/web/src/server/api/workspaces/router.ts
+++ b/apps/web/src/server/api/workspaces/router.ts
@@ -27,9 +27,9 @@ import { publicProcedure, t } from "../trpc";
  * there.
  */
 export const workspacesRouter = t.router({
-  create: publicProcedure.input(workspaceCreateInput).mutation(({ input }) => {
+  create: publicProcedure.input(workspaceCreateInput).mutation(async ({ input }) => {
     try {
-      return workspaceService.create(input);
+      return await workspaceService.create(input);
     } catch (err) {
       throwAsTrpcError(err);
     }

--- a/apps/web/src/server/infra/setup/project-config.ts
+++ b/apps/web/src/server/infra/setup/project-config.ts
@@ -1,5 +1,9 @@
 import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
+import { createLogger } from "@band-app/logger";
+import { z } from "zod";
+
+const log = createLogger("project-config");
 
 /**
  * Load .band/config.json, trying the worktree path first, then falling back
@@ -22,4 +26,66 @@ export function loadProjectConfig(
     }
   }
   return null;
+}
+
+/**
+ * Schema for the `workspace.copyFiles` block of `.band/config.json`. Used by
+ * `WorkspaceService.create` to seed a fresh worktree with untracked files
+ * (`.env`, local credential overrides, IDE settings) that aren't committed to
+ * the repo — a fresh worktree starts without them by definition. See issue
+ * #284 for the full design.
+ *
+ * The shape is intentionally narrow (`string[]` only) so a malformed entry
+ * fails validation up front instead of being silently dropped during the
+ * copy. Globs are accepted in the strings themselves and expanded against
+ * the project root by `copyWorkspaceFiles`.
+ */
+const CopyFilesSchema = z.array(z.string()).optional();
+
+/**
+ * Read the `workspace.copyFiles` list from `.band/config.json` at the project
+ * root. The config is read directly from `projectPath` rather than going
+ * through {@link loadProjectConfig}'s worktree-first fallback: copy
+ * resolution is deterministic only when the source is the main checkout (a
+ * fresh worktree never has the file yet, and reading it from another
+ * worktree would produce a different result depending on which worktree the
+ * server happened to look at).
+ *
+ * Returns `null` when:
+ *   - `.band/config.json` is absent at the project root.
+ *   - The file fails to parse as JSON.
+ *   - The `workspace.copyFiles` block is missing.
+ *   - The block is present but fails schema validation (logged at warn).
+ *
+ * A `null` return is indistinguishable from an empty list at the call site
+ * and intentionally so — both mean "no Option-A copies."
+ */
+export function getCopyFiles(projectPath: string): string[] | null {
+  const configPath = join(projectPath, ".band", "config.json");
+  if (!existsSync(configPath)) return null;
+
+  let raw: unknown;
+  try {
+    raw = JSON.parse(readFileSync(configPath, "utf-8"));
+  } catch (err) {
+    log.warn({ err, configPath }, "failed to parse .band/config.json");
+    return null;
+  }
+
+  if (!raw || typeof raw !== "object") return null;
+  const workspace = (raw as Record<string, unknown>).workspace;
+  if (!workspace || typeof workspace !== "object") return null;
+  const copyFiles = (workspace as Record<string, unknown>).copyFiles;
+  if (copyFiles === undefined) return null;
+
+  const parsed = CopyFilesSchema.safeParse(copyFiles);
+  if (!parsed.success) {
+    log.warn(
+      "Invalid workspace.copyFiles config: %s",
+      parsed.error.issues.map((i) => `${i.path.join(".")}: ${i.message}`).join("; "),
+    );
+    return null;
+  }
+
+  return parsed.data ?? null;
 }

--- a/apps/web/src/server/infra/setup/project-config.ts
+++ b/apps/web/src/server/infra/setup/project-config.ts
@@ -80,10 +80,7 @@ export function getCopyFiles(projectPath: string): string[] | null {
 
   const parsed = CopyFilesSchema.safeParse(copyFiles);
   if (!parsed.success) {
-    log.warn(
-      "Invalid workspace.copyFiles config: %s",
-      parsed.error.issues.map((i) => `${i.path.join(".")}: ${i.message}`).join("; "),
-    );
+    log.warn({ err: parsed.error, configPath }, "invalid workspace.copyFiles config — ignoring");
     return null;
   }
 

--- a/apps/web/src/server/infra/setup/workspace-files.ts
+++ b/apps/web/src/server/infra/setup/workspace-files.ts
@@ -83,14 +83,18 @@ export function copyWorkspaceFiles(projectPath: string, worktreePath: string): s
   // OS-resolved symlinks, so the comparison root must be canonical too
   // — otherwise a project at `/var/folders/...` (macOS) wouldn't match
   // a realpath under `/private/var/folders/...`.
+  const copied: string[] = [];
   let canonicalProjectRoot: string;
   try {
     canonicalProjectRoot = realpathSync(projectPath);
-  } catch {
-    canonicalProjectRoot = projectPath;
+  } catch (err) {
+    // If the project root itself can't be canonicalised, every
+    // per-file `realpathSync` comparison below would mismatch and
+    // silently refuse all copies. Bail loudly instead so the skipped
+    // copy is visible rather than masquerading as "nothing to copy".
+    log.warn({ err, projectPath }, "failed to resolve project root — skipping workspace file copy");
+    return copied;
   }
-
-  const copied: string[] = [];
   for (const [absSource, source] of byAbs) {
     const rel = relative(projectPath, absSource);
     const dest = join(worktreePath, rel);
@@ -108,15 +112,6 @@ export function copyWorkspaceFiles(projectPath: string, worktreePath: string): s
     }
 
     try {
-      // The source must still exist at copy time (a Option-B git pass
-      // could race with a delete; an Option-A literal could have
-      // disappeared between resolution and copy). Treat as "missing
-      // source file" per the spec.
-      if (!existsSync(absSource)) {
-        log.warn({ source, entry: rel }, "source file disappeared — skipping");
-        continue;
-      }
-
       // Symlink-escape guard: `copyFileSync` follows symlinks when
       // reading the source, so a symlink inside the project root
       // pointing OUTSIDE (`<root>/.env -> /etc/passwd`) would pass the
@@ -126,7 +121,10 @@ export function copyWorkspaceFiles(projectPath: string, worktreePath: string): s
       // canonical project root closes that vector. Equal paths
       // (canonicalProjectRoot === canonicalSource — i.e. the entry
       // itself IS the project root, e.g. a degenerate `.` glob match)
-      // and proper descendants both pass.
+      // and proper descendants both pass. `realpathSync` also throws
+      // `ENOENT` if the source disappeared between resolution and copy
+      // (a Option-B git pass racing a delete, a vanished Option-A
+      // literal) — handled as "source file disappeared" in the catch.
       const canonicalSource = realpathSync(absSource);
       const insideRoot =
         canonicalSource === canonicalProjectRoot ||
@@ -146,8 +144,16 @@ export function copyWorkspaceFiles(projectPath: string, worktreePath: string): s
     } catch (err) {
       // A copy failure (permission, EISDIR, etc.) is non-fatal for the
       // same reason missing files are: the user clicked "New workspace"
-      // and the workspace is otherwise functional. Surface as a warning.
-      log.warn({ err, source, entry: rel }, "failed to copy workspace file");
+      // and the workspace is otherwise functional. A source that
+      // vanished between resolution and copy surfaces here too, as an
+      // `ENOENT` from `realpathSync`/`copyFileSync` — give it the
+      // clearer "disappeared" message and treat the rest as copy
+      // failures.
+      if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+        log.warn({ source, entry: rel }, "source file disappeared — skipping");
+      } else {
+        log.warn({ err, source, entry: rel }, "failed to copy workspace file");
+      }
     }
   }
 
@@ -172,8 +178,11 @@ function resolveFromConfig(projectPath: string, missing: string[]): string[] {
     // the project root and the relative-path computation downstream
     // can't produce a sensible destination for them.
     if (isAbsolute(entry) || entry.startsWith("..")) {
+      // Already warned with the accurate "must be project-relative"
+      // message here — do NOT funnel through `missing[]`, or the
+      // caller's loop emits a second, misleading "not found in project"
+      // warning for the same entry.
       log.warn({ entry }, "workspace.copyFiles entry must be a project-relative path — skipping");
-      missing.push(entry);
       continue;
     }
 
@@ -202,16 +211,13 @@ function resolveFromConfig(projectPath: string, missing: string[]): string[] {
       }
     } else {
       const abs = resolve(projectPath, entry);
-      if (!existsSync(abs)) {
-        missing.push(entry);
-        continue;
-      }
+      // A single `statSync` with try/catch covers both existence and
+      // file-type: `ENOENT` (missing literal) lands in the catch as a
+      // miss; a directory or non-regular entry stats fine but fails
+      // `isFile()` and is ignored silently (the spec only covers files).
       try {
         if (statSync(abs).isFile()) {
           out.push(abs);
-        } else {
-          // A directory or non-regular entry — same handling as glob:
-          // ignore silently, the spec only covers files.
         }
       } catch {
         missing.push(entry);

--- a/apps/web/src/server/infra/setup/workspace-files.ts
+++ b/apps/web/src/server/infra/setup/workspace-files.ts
@@ -1,6 +1,14 @@
 import { execFileSync } from "node:child_process";
-import { copyFileSync, existsSync, globSync, mkdirSync, readFileSync, statSync } from "node:fs";
-import { dirname, isAbsolute, join, relative, resolve } from "node:path";
+import {
+  copyFileSync,
+  existsSync,
+  globSync,
+  mkdirSync,
+  readFileSync,
+  realpathSync,
+  statSync,
+} from "node:fs";
+import { dirname, isAbsolute, join, relative, resolve, sep } from "node:path";
 import { createLogger } from "@band-app/logger";
 import { gitCmd } from "../git/git-client";
 import { getCopyFiles } from "./project-config";
@@ -70,6 +78,18 @@ export function copyWorkspaceFiles(projectPath: string, worktreePath: string): s
     );
   }
 
+  // Resolve the project root once to compare against `realpathSync`
+  // results below. `realpathSync` returns canonical paths with
+  // OS-resolved symlinks, so the comparison root must be canonical too
+  // — otherwise a project at `/var/folders/...` (macOS) wouldn't match
+  // a realpath under `/private/var/folders/...`.
+  let canonicalProjectRoot: string;
+  try {
+    canonicalProjectRoot = realpathSync(projectPath);
+  } catch {
+    canonicalProjectRoot = projectPath;
+  }
+
   const copied: string[] = [];
   for (const [absSource, source] of byAbs) {
     const rel = relative(projectPath, absSource);
@@ -96,6 +116,29 @@ export function copyWorkspaceFiles(projectPath: string, worktreePath: string): s
         log.warn({ source, entry: rel }, "source file disappeared — skipping");
         continue;
       }
+
+      // Symlink-escape guard: `copyFileSync` follows symlinks when
+      // reading the source, so a symlink inside the project root
+      // pointing OUTSIDE (`<root>/.env -> /etc/passwd`) would pass the
+      // relative-path check above (the symlink *path* is inside the
+      // root) but `copyFileSync` would copy the target's bytes into the
+      // worktree. Resolving via `realpathSync` and comparing to the
+      // canonical project root closes that vector. Equal paths
+      // (canonicalProjectRoot === canonicalSource — i.e. the entry
+      // itself IS the project root, e.g. a degenerate `.` glob match)
+      // and proper descendants both pass.
+      const canonicalSource = realpathSync(absSource);
+      const insideRoot =
+        canonicalSource === canonicalProjectRoot ||
+        canonicalSource.startsWith(canonicalProjectRoot + sep);
+      if (!insideRoot) {
+        log.warn(
+          { source, entry: rel, target: canonicalSource },
+          "refusing to copy symlink that points outside project root — skipping",
+        );
+        continue;
+      }
+
       mkdirSync(dirname(dest), { recursive: true });
       copyFileSync(absSource, dest);
       log.debug({ source, file: rel }, "copied workspace file");

--- a/apps/web/src/server/infra/setup/workspace-files.ts
+++ b/apps/web/src/server/infra/setup/workspace-files.ts
@@ -1,4 +1,4 @@
-import { execFileSync } from "node:child_process";
+import { execFile } from "node:child_process";
 import {
   copyFileSync,
   existsSync,
@@ -9,11 +9,26 @@ import {
   statSync,
 } from "node:fs";
 import { dirname, isAbsolute, join, relative, resolve, sep } from "node:path";
+import { promisify } from "node:util";
 import { createLogger } from "@band-app/logger";
 import { gitCmd } from "../git/git-client";
 import { getCopyFiles } from "./project-config";
 
 const log = createLogger("workspace-files");
+
+const execFileAsync = promisify(execFile);
+
+/**
+ * Upper bounds on Option-A (`workspace.copyFiles`) expansion. `copyFiles`
+ * is a project-owned config file, but a careless recursive glob on a large
+ * repo could expand `globSync` into thousands of synchronous `statSync`
+ * calls and block the event loop for seconds — the create path is shared
+ * with SSE / streaming connections. We cap both the number of declared
+ * entries and the total number of glob matches we'll materialise, logging
+ * a warning that names the cap so a truncation is never silent.
+ */
+const MAX_COPY_FILES_ENTRIES = 100;
+const MAX_COPY_FILES_MATCHES = 500;
 
 /**
  * Copy untracked files from the project's main checkout into a freshly
@@ -42,12 +57,17 @@ const log = createLogger("workspace-files");
  * path's logger and by the integration tests to assert the union /
  * de-duplication shape.
  *
- * Synchronous on purpose: the create path is already synchronous through
- * `execFileSync` for `git worktree add`, the copy fan-out runs once per
- * workspace creation, and the file counts here are in the tens at most —
- * the cost is dominated by the git worktree command, not by these copies.
+ * Async so the two `git ls-files` spawns in Option B don't block the
+ * shared event loop (SSE / streaming connections live on it) while the
+ * create path waits on git. The per-file copy fan-out itself stays
+ * synchronous — it's a handful of `copyFileSync` calls bounded by
+ * `MAX_COPY_FILES_MATCHES`, dominated by the git work, not worth the
+ * overhead of going async per file.
  */
-export function copyWorkspaceFiles(projectPath: string, worktreePath: string): string[] {
+export async function copyWorkspaceFiles(
+  projectPath: string,
+  worktreePath: string,
+): Promise<string[]> {
   // Resolve both Option A (config.json::workspace.copyFiles) and Option B
   // (.worktreeinclude) into lists of absolute source paths inside the
   // project root. De-dup by absolute path so a file declared in both
@@ -62,7 +82,7 @@ export function copyWorkspaceFiles(projectPath: string, worktreePath: string): s
     if (!byAbs.has(abs)) byAbs.set(abs, "config.json");
   }
 
-  const fromInclude = resolveFromWorktreeInclude(projectPath);
+  const fromInclude = await resolveFromWorktreeInclude(projectPath);
   for (const abs of fromInclude) {
     if (!byAbs.has(abs)) byAbs.set(abs, ".worktreeinclude");
   }
@@ -172,8 +192,31 @@ function resolveFromConfig(projectPath: string, missing: string[]): string[] {
   const entries = getCopyFiles(projectPath);
   if (!entries || entries.length === 0) return [];
 
+  // Cap the number of declared entries we'll process so a runaway config
+  // can't fan out without bound. Warn (naming the cap) so the truncation
+  // is visible rather than silent.
+  let workEntries = entries;
+  if (entries.length > MAX_COPY_FILES_ENTRIES) {
+    log.warn(
+      { count: entries.length, cap: MAX_COPY_FILES_ENTRIES },
+      "workspace.copyFiles exceeds the entry cap — processing the first entries only",
+    );
+    workEntries = entries.slice(0, MAX_COPY_FILES_ENTRIES);
+  }
+
   const out: string[] = [];
-  for (const entry of entries) {
+  for (const entry of workEntries) {
+    // Stop once the total materialised match count hits the cap — a
+    // single broad glob can blow past it, so the guard lives at the
+    // per-file granularity. Warn once (naming the cap) and bail.
+    if (out.length >= MAX_COPY_FILES_MATCHES) {
+      log.warn(
+        { cap: MAX_COPY_FILES_MATCHES },
+        "workspace.copyFiles match cap reached — remaining entries skipped",
+      );
+      break;
+    }
+
     // Reject absolute paths and traversals up front — they would escape
     // the project root and the relative-path computation downstream
     // can't produce a sensible destination for them.
@@ -196,6 +239,13 @@ function resolveFromConfig(projectPath: string, missing: string[]): string[] {
         continue;
       }
       for (const m of matches) {
+        if (out.length >= MAX_COPY_FILES_MATCHES) {
+          log.warn(
+            { cap: MAX_COPY_FILES_MATCHES, entry },
+            "workspace.copyFiles match cap reached mid-glob — remaining matches skipped",
+          );
+          break;
+        }
         const abs = resolve(projectPath, m);
         // Skip directories — copyFiles is a *files* declaration; recursing
         // into directories isn't part of the v1 contract. A user who
@@ -250,7 +300,7 @@ function resolveFromConfig(projectPath: string, missing: string[]): string[] {
  * Falls back to an empty list if `git` isn't available or the project isn't
  * a git repo — Option B is a no-op in that case (Option A still works).
  */
-function resolveFromWorktreeInclude(projectPath: string): string[] {
+async function resolveFromWorktreeInclude(projectPath: string): Promise<string[]> {
   const includePath = join(projectPath, ".worktreeinclude");
   if (!existsSync(includePath)) return [];
 
@@ -270,20 +320,14 @@ function resolveFromWorktreeInclude(projectPath: string): string[] {
   let matchingWorktreeInclude: string[];
   let gitignoredStandard: string[];
   try {
-    matchingWorktreeInclude = execFileSync(
-      command,
-      ["ls-files", "--others", "--ignored", `-X`, includePath],
-      opts,
-    )
-      .split("\n")
-      .filter(Boolean);
-    gitignoredStandard = execFileSync(
-      command,
-      ["ls-files", "--others", "--ignored", "--exclude-standard"],
-      opts,
-    )
-      .split("\n")
-      .filter(Boolean);
+    // The two `ls-files` calls are independent, so run them concurrently
+    // and let the event loop service other work while git is spawning.
+    const [matching, standard] = await Promise.all([
+      execFileAsync(command, ["ls-files", "--others", "--ignored", `-X`, includePath], opts),
+      execFileAsync(command, ["ls-files", "--others", "--ignored", "--exclude-standard"], opts),
+    ]);
+    matchingWorktreeInclude = matching.stdout.split("\n").filter(Boolean);
+    gitignoredStandard = standard.stdout.split("\n").filter(Boolean);
   } catch (err) {
     // Not a git repo, git missing, etc. Don't fail the workspace boot —
     // Option B simply contributes nothing.

--- a/apps/web/src/server/infra/setup/workspace-files.ts
+++ b/apps/web/src/server/infra/setup/workspace-files.ts
@@ -1,0 +1,263 @@
+import { execFileSync } from "node:child_process";
+import { copyFileSync, existsSync, globSync, mkdirSync, readFileSync, statSync } from "node:fs";
+import { dirname, isAbsolute, join, relative, resolve } from "node:path";
+import { createLogger } from "@band-app/logger";
+import { gitCmd } from "../git/git-client";
+import { getCopyFiles } from "./project-config";
+
+const log = createLogger("workspace-files");
+
+/**
+ * Copy untracked files from the project's main checkout into a freshly
+ * created worktree. Driven by two declarative sources at the project root:
+ *
+ *   1. `.band/config.json::workspace.copyFiles` — explicit list of paths
+ *      (literals or glob patterns) relative to the project root.
+ *   2. `.worktreeinclude` — gitignore-syntax patterns at the project root.
+ *      Only entries that match a pattern AND are ignored by the project's
+ *      `.gitignore` are copied (Claude Code parity); tracked files are
+ *      never duplicated.
+ *
+ * When both sources exist, their resolved file sets are UNIONed and
+ * de-duped by absolute source path. Missing source files are skipped with a
+ * single per-file warning rather than aborting the workspace creation —
+ * stale entries in the config are a routine occurrence (a contributor
+ * deleted a file, a teammate hasn't added theirs yet) and aborting the
+ * workspace boot would punish the user for a non-fatal config drift.
+ *
+ * Copies are regular file copies (not symlinks) so subsequent edits inside
+ * the worktree don't bleed back to the main checkout. Relative directory
+ * structure is preserved — `config/local.json` lands at
+ * `<worktree>/config/local.json`.
+ *
+ * Returns the list of relative paths actually copied. Used by the create
+ * path's logger and by the integration tests to assert the union /
+ * de-duplication shape.
+ *
+ * Synchronous on purpose: the create path is already synchronous through
+ * `execFileSync` for `git worktree add`, the copy fan-out runs once per
+ * workspace creation, and the file counts here are in the tens at most —
+ * the cost is dominated by the git worktree command, not by these copies.
+ */
+export function copyWorkspaceFiles(projectPath: string, worktreePath: string): string[] {
+  // Resolve both Option A (config.json::workspace.copyFiles) and Option B
+  // (.worktreeinclude) into lists of absolute source paths inside the
+  // project root. De-dup by absolute path so a file declared in both
+  // sources is only copied once. Source-tagging is preserved for the
+  // debug log line per the spec ("Log the source of each copied file at
+  // debug level").
+  const byAbs = new Map<string, "config.json" | ".worktreeinclude">();
+  const missingFromConfig: string[] = [];
+
+  const fromConfig = resolveFromConfig(projectPath, missingFromConfig);
+  for (const abs of fromConfig) {
+    if (!byAbs.has(abs)) byAbs.set(abs, "config.json");
+  }
+
+  const fromInclude = resolveFromWorktreeInclude(projectPath);
+  for (const abs of fromInclude) {
+    if (!byAbs.has(abs)) byAbs.set(abs, ".worktreeinclude");
+  }
+
+  // Emit a single warning per missing Option-A source file — globs that
+  // resolve to nothing also funnel through `missingFromConfig` so a
+  // user-visible warning is emitted whether the pattern is a literal or
+  // a no-match glob.
+  for (const missing of missingFromConfig) {
+    log.warn(
+      { source: ".band/config.json::workspace.copyFiles", entry: missing },
+      "workspace.copyFiles entry not found in project — skipping",
+    );
+  }
+
+  const copied: string[] = [];
+  for (const [absSource, source] of byAbs) {
+    const rel = relative(projectPath, absSource);
+    const dest = join(worktreePath, rel);
+
+    // Defense in depth: skip anything that escapes the worktree root
+    // (e.g. a config entry of `../../etc/passwd`). The resolved-relative
+    // path check catches both literal `..` segments and absolute path
+    // entries normalised by `relative()`.
+    if (rel.startsWith("..") || isAbsolute(rel)) {
+      log.warn(
+        { source, entry: absSource },
+        "refusing to copy file outside project root — skipping",
+      );
+      continue;
+    }
+
+    try {
+      // The source must still exist at copy time (a Option-B git pass
+      // could race with a delete; an Option-A literal could have
+      // disappeared between resolution and copy). Treat as "missing
+      // source file" per the spec.
+      if (!existsSync(absSource)) {
+        log.warn({ source, entry: rel }, "source file disappeared — skipping");
+        continue;
+      }
+      mkdirSync(dirname(dest), { recursive: true });
+      copyFileSync(absSource, dest);
+      log.debug({ source, file: rel }, "copied workspace file");
+      copied.push(rel);
+    } catch (err) {
+      // A copy failure (permission, EISDIR, etc.) is non-fatal for the
+      // same reason missing files are: the user clicked "New workspace"
+      // and the workspace is otherwise functional. Surface as a warning.
+      log.warn({ err, source, entry: rel }, "failed to copy workspace file");
+    }
+  }
+
+  return copied;
+}
+
+/**
+ * Resolve OPTION A — `.band/config.json::workspace.copyFiles` — into absolute
+ * source paths inside `projectPath`. Entries containing glob meta-characters
+ * are expanded against the project root; literal entries are checked for
+ * existence directly. Misses (literal that doesn't exist, glob that yields
+ * no matches) are pushed onto `missing` so the caller can emit a warning per
+ * entry.
+ */
+function resolveFromConfig(projectPath: string, missing: string[]): string[] {
+  const entries = getCopyFiles(projectPath);
+  if (!entries || entries.length === 0) return [];
+
+  const out: string[] = [];
+  for (const entry of entries) {
+    // Reject absolute paths and traversals up front — they would escape
+    // the project root and the relative-path computation downstream
+    // can't produce a sensible destination for them.
+    if (isAbsolute(entry) || entry.startsWith("..")) {
+      log.warn({ entry }, "workspace.copyFiles entry must be a project-relative path — skipping");
+      missing.push(entry);
+      continue;
+    }
+
+    if (hasGlobMeta(entry)) {
+      // `globSync` honours its `cwd` for resolution and returns paths
+      // relative to it. Convert to absolute for the de-dup key. Set
+      // `withFileTypes: false` (the default) so we get string paths.
+      const matches = globSync(entry, { cwd: projectPath });
+      if (matches.length === 0) {
+        missing.push(entry);
+        continue;
+      }
+      for (const m of matches) {
+        const abs = resolve(projectPath, m);
+        // Skip directories — copyFiles is a *files* declaration; recursing
+        // into directories isn't part of the v1 contract. A user who
+        // wants every file under `config/` should write `config/*` or
+        // `config/**`.
+        try {
+          if (statSync(abs).isFile()) {
+            out.push(abs);
+          }
+        } catch {
+          // stat failure (broken symlink, permission) — treat as miss.
+        }
+      }
+    } else {
+      const abs = resolve(projectPath, entry);
+      if (!existsSync(abs)) {
+        missing.push(entry);
+        continue;
+      }
+      try {
+        if (statSync(abs).isFile()) {
+          out.push(abs);
+        } else {
+          // A directory or non-regular entry — same handling as glob:
+          // ignore silently, the spec only covers files.
+        }
+      } catch {
+        missing.push(entry);
+      }
+    }
+  }
+  return out;
+}
+
+/**
+ * Resolve OPTION B — `.worktreeinclude` — into absolute source paths inside
+ * `projectPath`. The matching is delegated to `git ls-files` so the
+ * gitignore-syntax semantics of `.worktreeinclude` exactly match git's own
+ * (anchored leading slash, `**` segments, character classes, the full
+ * pattern grammar — none of which a custom matcher could keep in sync with
+ * upstream git).
+ *
+ * Two `git ls-files` calls and an in-memory intersection:
+ *
+ *   - Y: untracked files matching `.worktreeinclude` patterns
+ *     (`--others --ignored -X .worktreeinclude`).
+ *   - X: untracked files ignored by the project's standard gitignore
+ *     rules (`--others --ignored --exclude-standard`).
+ *
+ * The intersection is the set we want — files that match the include
+ * patterns AND are gitignored AND are not tracked. Combining both flag
+ * groups in a single `ls-files` call would UNION the rule sets instead, so
+ * the two-call shape is load-bearing.
+ *
+ * Falls back to an empty list if `git` isn't available or the project isn't
+ * a git repo — Option B is a no-op in that case (Option A still works).
+ */
+function resolveFromWorktreeInclude(projectPath: string): string[] {
+  const includePath = join(projectPath, ".worktreeinclude");
+  if (!existsSync(includePath)) return [];
+
+  // Read the file just to check it's non-empty after stripping
+  // comments/blank lines — git tolerates an empty patterns file but the
+  // semantics are the same as "no Option B."
+  const includeContent = readFileSync(includePath, "utf-8");
+  const hasPatterns = includeContent.split(/\r?\n/).some((line) => {
+    const trimmed = line.trim();
+    return trimmed.length > 0 && !trimmed.startsWith("#");
+  });
+  if (!hasPatterns) return [];
+
+  const { command, env } = gitCmd();
+  const opts = { cwd: projectPath, env, encoding: "utf-8" as const };
+
+  let matchingWorktreeInclude: string[];
+  let gitignoredStandard: string[];
+  try {
+    matchingWorktreeInclude = execFileSync(
+      command,
+      ["ls-files", "--others", "--ignored", `-X`, includePath],
+      opts,
+    )
+      .split("\n")
+      .filter(Boolean);
+    gitignoredStandard = execFileSync(
+      command,
+      ["ls-files", "--others", "--ignored", "--exclude-standard"],
+      opts,
+    )
+      .split("\n")
+      .filter(Boolean);
+  } catch (err) {
+    // Not a git repo, git missing, etc. Don't fail the workspace boot —
+    // Option B simply contributes nothing.
+    log.warn({ err, projectPath }, ".worktreeinclude present but git ls-files failed");
+    return [];
+  }
+
+  const standardSet = new Set(gitignoredStandard);
+  const out: string[] = [];
+  for (const rel of matchingWorktreeInclude) {
+    if (!standardSet.has(rel)) continue;
+    out.push(resolve(projectPath, rel));
+  }
+  return out;
+}
+
+/**
+ * Conservative glob-meta detector: returns `true` for patterns that should
+ * go through `globSync`, `false` for literal paths. Mirrors the characters
+ * `node:fs::glob` treats as special (`*`, `?`, `[`, `{`, ... — we check the
+ * subset that's relevant to the gitignore-style patterns users actually
+ * write).
+ */
+function hasGlobMeta(pattern: string): boolean {
+  return /[*?[\]{}]/.test(pattern);
+}

--- a/apps/web/src/server/services/workspace-service.ts
+++ b/apps/web/src/server/services/workspace-service.ts
@@ -15,6 +15,7 @@ import { DETACHED_BRANCH_PREFIX, execGit, gitCmd, listWorktrees } from "../infra
 import { killWorkspaceServers } from "../infra/lsp/lsp-manager";
 import { loadProjectConfig } from "../infra/setup/project-config";
 import { runSetup } from "../infra/setup/setup-runner";
+import { copyWorkspaceFiles } from "../infra/setup/workspace-files";
 import { clearQueuedMessages } from "./_utils/queued-message-store";
 // FRAGILE: ESM cycle leg — `services/task-service` now imports
 // `workspaceService` directly from this file (the `services/workspace.ts`
@@ -313,6 +314,28 @@ export class WorkspaceService {
     saveState(state);
 
     const workspaceId = toWorkspaceId(input.project, input.branch);
+
+    // Copy declared workspace files from the main checkout into the new
+    // worktree. Driven by `.band/config.json::workspace.copyFiles` and/or
+    // `.worktreeinclude` at the project root — see `copyWorkspaceFiles`
+    // for the union/intersection semantics. Runs AFTER `git worktree add`
+    // (so the destination directory exists) and BEFORE `runSetup` (so the
+    // setup script can read `.env` / local credentials / etc. just like
+    // it can in the main checkout). Missing source files are skipped
+    // with a warning rather than failing the create, matching the
+    // non-fatal contract used by the setup script itself.
+    try {
+      const copied = copyWorkspaceFiles(project.path, worktreePath);
+      if (copied.length > 0) {
+        log.info({ workspaceId, count: copied.length }, "copied workspace files into new worktree");
+      }
+    } catch (err) {
+      // Catch-all backstop. `copyWorkspaceFiles` already logs per-file
+      // failures internally; this guard exists so an unexpected crash
+      // (e.g. a truly malformed config) doesn't abort the create flow
+      // before the chat pane / setup script have a chance to run.
+      log.warn({ err, workspaceId }, "copyWorkspaceFiles raised — continuing");
+    }
 
     // Materialize the default chat pane so the workspace surfaces a
     // ready-to-use UI even when the caller didn't pass a prompt.

--- a/apps/web/src/server/services/workspace-service.ts
+++ b/apps/web/src/server/services/workspace-service.ts
@@ -260,7 +260,7 @@ export class WorkspaceService {
    *      installed). When there is no setup script, the task is dispatched
    *      synchronously.
    */
-  create(input: WorkspaceCreateInput): { ok: true; path: string } {
+  async create(input: WorkspaceCreateInput): Promise<{ ok: true; path: string }> {
     const state = loadState();
     const project = state.projects.find((p) => p.name === input.project);
     if (!project) {
@@ -325,7 +325,7 @@ export class WorkspaceService {
     // with a warning rather than failing the create, matching the
     // non-fatal contract used by the setup script itself.
     try {
-      const copied = copyWorkspaceFiles(project.path, worktreePath);
+      const copied = await copyWorkspaceFiles(project.path, worktreePath);
       if (copied.length > 0) {
         log.info({ workspaceId, count: copied.length }, "copied workspace files into new worktree");
       }

--- a/apps/web/tests/workspace-create-copy-files.test.ts
+++ b/apps/web/tests/workspace-create-copy-files.test.ts
@@ -33,10 +33,14 @@
 // Each scenario uses its own project subdirectory inside the shared tmp
 // home so the seven creates don't fight over the same `.band/config.json`
 // / `.worktreeinclude` files. The server boots once for the file.
+//
+// See docs/integration-testing.md and .claude/skills/write-integration-test/SKILL.md
+// for the real-server doctrine this file implements (TEST-1...TEST-35 in
+// .claude/testing-criteria.md).
 
 import { execFileSync } from "node:child_process";
 import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { seedSettings, seedState } from "./helpers/seed-state";
 import { createTmpHome, type ServerHandle, startServer, trpcMutate } from "./helpers/server";
@@ -77,6 +81,16 @@ interface CreateRepoOpts {
    */
   untrackedFiles: Record<string, string>;
   /**
+   * Files to write AFTER the initial commit, OVERWRITING tracked content
+   * left on disk. These bytes live only in the main checkout's working
+   * tree — `git worktree add` for a new branch checks out the committed
+   * version. Used by the "matched-but-tracked" scenario to make the
+   * "Option B re-copied a tracked file" failure mode observable: if the
+   * implementation incorrectly re-copies, the worktree ends up with the
+   * post-commit bytes instead of the committed bytes.
+   */
+  mutateAfterCommit?: Record<string, string>;
+  /**
    * `.band/config.json` payload. Omitted when the test only exercises
    * Option B.
    */
@@ -108,7 +122,7 @@ function buildProject(
 
   for (const [path, content] of Object.entries(opts.trackedFiles)) {
     const abs = join(repoPath, path);
-    mkdirSync(join(abs, ".."), { recursive: true });
+    mkdirSync(dirname(abs), { recursive: true });
     writeFileSync(abs, content);
   }
   git(repoPath, ["add", "."]);
@@ -116,7 +130,12 @@ function buildProject(
 
   for (const [path, content] of Object.entries(opts.untrackedFiles)) {
     const abs = join(repoPath, path);
-    mkdirSync(join(abs, ".."), { recursive: true });
+    mkdirSync(dirname(abs), { recursive: true });
+    writeFileSync(abs, content);
+  }
+
+  for (const [path, content] of Object.entries(opts.mutateAfterCommit ?? {})) {
+    const abs = join(repoPath, path);
     writeFileSync(abs, content);
   }
 
@@ -242,6 +261,17 @@ describe("workspaces.create copies workspace files into the new worktree", () =>
       },
       untrackedFiles: {
         ".env": "FROM_INCLUDE=1\n",
+      },
+      // Overwrite the working-tree copy of `config.json` AFTER the commit
+      // so the main checkout's on-disk bytes differ from the committed
+      // bytes. `git worktree add` checks out the committed bytes into the
+      // new worktree — so if the implementation correctly skips the
+      // tracked file, the worktree holds `{"tracked":true}`. If it
+      // incorrectly re-copies from the main checkout, the worktree gets
+      // `{"tracked":true,"WORKING_TREE_DRIFT":true}` and the assertion
+      // below fails. This is what makes the test falsifiable.
+      mutateAfterCommit: {
+        "config.json": '{"tracked":true,"WORKING_TREE_DRIFT":true}\n',
       },
       worktreeInclude: "*.json\n.env\n",
     });
@@ -421,15 +451,34 @@ describe("workspaces.create copies workspace files into the new worktree", () =>
       "FROM_INCLUDE=1\n",
     );
 
-    // `config.json` is a tracked file in the main checkout. It already
-    // appears in the worktree via `git worktree add`, but it must NOT be
-    // an Option-B re-copy: the rule "only files that match AND are
-    // gitignored are copied" means tracked-but-matching is a no-op for
-    // Option B. We verify by reading the worktree copy's bytes — it
-    // should match the committed bytes (`{"tracked":true}\n`), not be
-    // mutated by our copy path.
+    // `config.json` is a tracked file in the main checkout, and its
+    // working-tree bytes were deliberately drifted post-commit to
+    // `{"tracked":true,"WORKING_TREE_DRIFT":true}` (see the fixture's
+    // `mutateAfterCommit`). `git worktree add` only checks out the
+    // *committed* bytes — `{"tracked":true}`. So:
+    //   - Correct behaviour (Option B skips tracked files) → worktree
+    //     holds the committed bytes.
+    //   - Buggy behaviour (Option B re-copies tracked files) → worktree
+    //     would be overwritten with the drifted bytes and this assertion
+    //     would fail.
+    // That asymmetry is what makes the assertion falsifiable.
     expect(readFileSync(join(pMatchedButTracked.worktreePath, "config.json"), "utf-8")).toBe(
       '{"tracked":true}\n',
     );
+  });
+
+  it("rejects workspaces.create without an auth token (401)", async () => {
+    // TEST-13 negative auth case — boots the same server but skips the
+    // `Cookie: band_token=...` header by bypassing the `trpcMutate`
+    // helper. Pins that the file-copy feature can't be reached
+    // unauthenticated; a future regression that loosened auth on the
+    // workspaces.create handler would surface here, not just in the
+    // shared `trpc.test.ts` suite.
+    const res = await fetch(`${server.url}/trpc/workspaces.create`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ project: pConfigOnly.name, branch: "unauth-attempt" }),
+    });
+    expect(res.status).toBe(401);
   });
 });

--- a/apps/web/tests/workspace-create-copy-files.test.ts
+++ b/apps/web/tests/workspace-create-copy-files.test.ts
@@ -18,7 +18,7 @@
 // against a fresh tmp `$HOME`, drives `workspaces.create` over real tRPC,
 // and asserts on the filesystem contents of the resulting worktree.
 //
-// The seven scenarios spelled out in the acceptance criteria each get
+// The eight scenarios spelled out in the acceptance criteria each get
 // their own `it()` block so a regression in one isn't masked by a passing
 // neighbour:
 //
@@ -29,9 +29,10 @@
 //   - glob match
 //   - gitignored-but-not-`.worktreeinclude`-matched (skipped)
 //   - matched-but-tracked (skipped)
+//   - symlink-escape guard (symlink pointing outside the root, skipped)
 //
 // Each scenario uses its own project subdirectory inside the shared tmp
-// home so the seven creates don't fight over the same `.band/config.json`
+// home so the eight creates don't fight over the same `.band/config.json`
 // / `.worktreeinclude` files. The server boots once for the file.
 
 import { execFileSync } from "node:child_process";
@@ -53,7 +54,24 @@ const gitEnv = {
 };
 
 function git(cwd: string, args: string[]): string {
-  return execFileSync("git", args, { cwd, env: gitEnv, encoding: "utf-8" });
+  try {
+    return execFileSync("git", args, { cwd, env: gitEnv, encoding: "utf-8" });
+  } catch (err) {
+    // Re-raise with stderr + status + signal so the test failure carries
+    // the real reason git refused, not just "Command failed: git …".
+    const e = err as {
+      stderr?: Buffer | string;
+      stdout?: Buffer | string;
+      status?: number | null;
+      signal?: string | null;
+      message: string;
+    };
+    const stderr = e.stderr ? String(e.stderr).trim() : "(no stderr)";
+    const stdout = e.stdout ? String(e.stdout).trim() : "(no stdout)";
+    throw new Error(
+      `git ${args.join(" ")} (cwd=${cwd}) failed status=${e.status} signal=${e.signal}\nstdout: ${stdout}\nstderr: ${stderr}`,
+    );
+  }
 }
 
 interface ProjectFixture {
@@ -156,7 +174,7 @@ describe("workspaces.create copies workspace files into the new worktree", () =>
   let tmpHome: string;
   const branch = "feat-copy";
 
-  // Seven independent project fixtures — one per acceptance criterion. We
+  // Eight independent project fixtures — one per acceptance criterion. We
   // build them all up front so `seedState` can register every project in
   // a single transaction before the server boots.
   let pConfigOnly: ProjectFixture;
@@ -518,7 +536,7 @@ describe("workspaces.create copies workspace files into the new worktree", () =>
   });
 
   it("rejects workspaces.create without an auth token (401)", async () => {
-    // TEST-13 negative auth case — boots the same server but skips the
+    // Negative auth case — boots the same server but skips the
     // `Cookie: band_token=...` header by bypassing the `trpcMutate`
     // helper. Pins that the file-copy feature can't be reached
     // unauthenticated; a future regression that loosened auth on the

--- a/apps/web/tests/workspace-create-copy-files.test.ts
+++ b/apps/web/tests/workspace-create-copy-files.test.ts
@@ -1,0 +1,435 @@
+// Integration test for workspace file copying (issue #284).
+//
+// A fresh git worktree starts empty of any untracked files — `.env`, local
+// credentials, IDE overrides, anything `.gitignore`d. Workspace creation
+// can now declaratively copy a set of those files from the project's main
+// checkout into the new worktree, driven by either:
+//
+//   1. `.band/config.json::workspace.copyFiles` — explicit list, supports
+//      globs.
+//   2. `.worktreeinclude` — gitignore-syntax patterns; only entries that
+//      match AND are gitignored are copied (Claude Code parity, so tracked
+//      files are never duplicated).
+//
+// Both sources can be present at once; the resulting file set is the
+// UNION, de-duped by absolute source path.
+//
+// This file boots the real server (`apps/web/dist/start-server.mjs`)
+// against a fresh tmp `$HOME`, drives `workspaces.create` over real tRPC,
+// and asserts on the filesystem contents of the resulting worktree.
+//
+// The seven scenarios spelled out in the acceptance criteria each get
+// their own `it()` block so a regression in one isn't masked by a passing
+// neighbour:
+//
+//   - only `.band/config.json`
+//   - only `.worktreeinclude`
+//   - both present (UNION + de-dup)
+//   - missing source files (skipped, not fatal)
+//   - glob match
+//   - gitignored-but-not-`.worktreeinclude`-matched (skipped)
+//   - matched-but-tracked (skipped)
+//
+// Each scenario uses its own project subdirectory inside the shared tmp
+// home so the seven creates don't fight over the same `.band/config.json`
+// / `.worktreeinclude` files. The server boots once for the file.
+
+import { execFileSync } from "node:child_process";
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { seedSettings, seedState } from "./helpers/seed-state";
+import { createTmpHome, type ServerHandle, startServer, trpcMutate } from "./helpers/server";
+
+const DEFAULT_TOKEN = "workspace-copy-files-token";
+
+const gitEnv = {
+  ...process.env,
+  GIT_AUTHOR_NAME: "Test",
+  GIT_AUTHOR_EMAIL: "test@test.com",
+  GIT_COMMITTER_NAME: "Test",
+  GIT_COMMITTER_EMAIL: "test@test.com",
+};
+
+function git(cwd: string, args: string[]): string {
+  return execFileSync("git", args, { cwd, env: gitEnv, encoding: "utf-8" });
+}
+
+interface ProjectFixture {
+  name: string;
+  /** Absolute path to the project's main checkout. */
+  repoPath: string;
+  /** Expected path of the worktree this project's create will produce. */
+  worktreePath: string;
+}
+
+interface CreateRepoOpts {
+  /**
+   * Files to write before the initial commit, keyed by relative path. The
+   * test uses this to commit `.gitignore` and any tracked files (e.g. the
+   * `tracked-but-matched.json` regression for the seventh scenario).
+   */
+  trackedFiles: Record<string, string>;
+  /**
+   * Files to write AFTER the initial commit. These end up as untracked
+   * files in the working tree — the candidate set for both Option A and
+   * Option B copies. Keyed by relative path.
+   */
+  untrackedFiles: Record<string, string>;
+  /**
+   * `.band/config.json` payload. Omitted when the test only exercises
+   * Option B.
+   */
+  bandConfig?: object;
+  /**
+   * `.worktreeinclude` content. Omitted when the test only exercises
+   * Option A.
+   */
+  worktreeInclude?: string;
+}
+
+/**
+ * Build a project fixture: create a real git repo with the given tracked
+ * + untracked files, optionally write `.band/config.json` and
+ * `.worktreeinclude`, and seed the state DB so the server knows about it.
+ *
+ * Each fixture uses its own subdirectory of `tmpHome` so creates from
+ * different scenarios don't clobber each other's config / include files.
+ */
+function buildProject(
+  tmpHome: string,
+  name: string,
+  branch: string,
+  opts: CreateRepoOpts,
+): ProjectFixture {
+  const repoPath = join(tmpHome, name);
+  mkdirSync(repoPath, { recursive: true });
+  git(repoPath, ["init", "-b", "main"]);
+
+  for (const [path, content] of Object.entries(opts.trackedFiles)) {
+    const abs = join(repoPath, path);
+    mkdirSync(join(abs, ".."), { recursive: true });
+    writeFileSync(abs, content);
+  }
+  git(repoPath, ["add", "."]);
+  git(repoPath, ["commit", "-m", "init"]);
+
+  for (const [path, content] of Object.entries(opts.untrackedFiles)) {
+    const abs = join(repoPath, path);
+    mkdirSync(join(abs, ".."), { recursive: true });
+    writeFileSync(abs, content);
+  }
+
+  if (opts.bandConfig) {
+    mkdirSync(join(repoPath, ".band"), { recursive: true });
+    writeFileSync(join(repoPath, ".band", "config.json"), JSON.stringify(opts.bandConfig, null, 2));
+  }
+  if (opts.worktreeInclude !== undefined) {
+    writeFileSync(join(repoPath, ".worktreeinclude"), opts.worktreeInclude);
+  }
+
+  // Worktree path lands under `<tmpHome>/.band/worktrees/<project>/<branch>`
+  // because `seedSettings` below sets `worktreesDir` to that location.
+  const worktreePath = join(tmpHome, ".band", "worktrees", name, branch);
+
+  return { name, repoPath, worktreePath };
+}
+
+describe("workspaces.create copies workspace files into the new worktree", () => {
+  let server: ServerHandle;
+  let tmpHome: string;
+  const branch = "feat-copy";
+
+  // Seven independent project fixtures — one per acceptance criterion. We
+  // build them all up front so `seedState` can register every project in
+  // a single transaction before the server boots.
+  let pConfigOnly: ProjectFixture;
+  let pIncludeOnly: ProjectFixture;
+  let pBoth: ProjectFixture;
+  let pMissing: ProjectFixture;
+  let pGlob: ProjectFixture;
+  let pIgnoredButNotIncluded: ProjectFixture;
+  let pMatchedButTracked: ProjectFixture;
+
+  beforeAll(async () => {
+    tmpHome = createTmpHome("band-copy-files-");
+
+    pConfigOnly = buildProject(tmpHome, "config-only", branch, {
+      trackedFiles: { ".gitignore": ".env\n.env.local\nconfig/*.local.json\n" },
+      untrackedFiles: {
+        ".env": "ENV_FROM_MAIN=1\n",
+        ".env.local": "LOCAL_FROM_MAIN=1\n",
+        "config/local.json": '{"main":true}\n',
+      },
+      bandConfig: {
+        workspace: {
+          copyFiles: [".env", ".env.local", "config/local.json"],
+        },
+      },
+    });
+
+    pIncludeOnly = buildProject(tmpHome, "include-only", branch, {
+      trackedFiles: { ".gitignore": ".env*\nconfig/*.local.json\n" },
+      untrackedFiles: {
+        ".env": "INCLUDE_ENV=1\n",
+        ".env.local": "INCLUDE_LOCAL=1\n",
+        "config/foo.local.json": '{"foo":true}\n',
+      },
+      worktreeInclude: ".env*\nconfig/*.local.json\n",
+    });
+
+    pBoth = buildProject(tmpHome, "both", branch, {
+      trackedFiles: { ".gitignore": ".env\n.env.local\nshared.local\n" },
+      untrackedFiles: {
+        ".env": "BOTH_ENV=1\n",
+        ".env.local": "BOTH_LOCAL=1\n",
+        "shared.local": "SHARED=1\n",
+      },
+      // Both sources reference `.env` and `shared.local` — that overlap is
+      // the de-dup case. `.env.local` is only in Option B; `.env` is in
+      // both; `shared.local` is in Option A literal + Option B glob.
+      bandConfig: {
+        workspace: {
+          copyFiles: [".env", "shared.local"],
+        },
+      },
+      worktreeInclude: ".env*\n*.local\n",
+    });
+
+    pMissing = buildProject(tmpHome, "missing", branch, {
+      trackedFiles: { ".gitignore": ".env\nphantom.txt\n" },
+      untrackedFiles: { ".env": "PRESENT=1\n" }, // phantom.txt is deliberately absent
+      bandConfig: {
+        workspace: {
+          copyFiles: [".env", "phantom.txt", "config/does-not-exist.json"],
+        },
+      },
+    });
+
+    pGlob = buildProject(tmpHome, "glob", branch, {
+      trackedFiles: { ".gitignore": "config/*.local.json\n" },
+      untrackedFiles: {
+        "config/a.local.json": '{"a":1}\n',
+        "config/b.local.json": '{"b":2}\n',
+        "config/c.json": '{"tracked-shape":true}\n',
+      },
+      bandConfig: {
+        workspace: {
+          copyFiles: ["config/*.local.json"],
+        },
+      },
+    });
+
+    pIgnoredButNotIncluded = buildProject(tmpHome, "ignored-not-included", branch, {
+      trackedFiles: { ".gitignore": ".env\nsecret.key\n" },
+      untrackedFiles: {
+        ".env": "INCLUDED=1\n",
+        "secret.key": "DO-NOT-COPY\n", // gitignored but not in .worktreeinclude
+      },
+      // `.worktreeinclude` only mentions `.env`, so `secret.key` (also
+      // gitignored) must NOT be copied — that's the parity rule.
+      worktreeInclude: ".env\n",
+    });
+
+    pMatchedButTracked = buildProject(tmpHome, "matched-but-tracked", branch, {
+      // `config.json` is committed (tracked) AND matches the `*.json`
+      // pattern in `.worktreeinclude`. Tracked files must never be
+      // duplicated by Option B — git already provides them via the
+      // worktree checkout.
+      trackedFiles: {
+        ".gitignore": ".env\n",
+        "config.json": '{"tracked":true}\n',
+      },
+      untrackedFiles: {
+        ".env": "FROM_INCLUDE=1\n",
+      },
+      worktreeInclude: "*.json\n.env\n",
+    });
+
+    seedState(tmpHome, {
+      projects: [
+        {
+          name: pConfigOnly.name,
+          path: pConfigOnly.repoPath,
+          defaultBranch: "main",
+          worktrees: [{ branch: "main", path: pConfigOnly.repoPath }],
+        },
+        {
+          name: pIncludeOnly.name,
+          path: pIncludeOnly.repoPath,
+          defaultBranch: "main",
+          worktrees: [{ branch: "main", path: pIncludeOnly.repoPath }],
+        },
+        {
+          name: pBoth.name,
+          path: pBoth.repoPath,
+          defaultBranch: "main",
+          worktrees: [{ branch: "main", path: pBoth.repoPath }],
+        },
+        {
+          name: pMissing.name,
+          path: pMissing.repoPath,
+          defaultBranch: "main",
+          worktrees: [{ branch: "main", path: pMissing.repoPath }],
+        },
+        {
+          name: pGlob.name,
+          path: pGlob.repoPath,
+          defaultBranch: "main",
+          worktrees: [{ branch: "main", path: pGlob.repoPath }],
+        },
+        {
+          name: pIgnoredButNotIncluded.name,
+          path: pIgnoredButNotIncluded.repoPath,
+          defaultBranch: "main",
+          worktrees: [{ branch: "main", path: pIgnoredButNotIncluded.repoPath }],
+        },
+        {
+          name: pMatchedButTracked.name,
+          path: pMatchedButTracked.repoPath,
+          defaultBranch: "main",
+          worktrees: [{ branch: "main", path: pMatchedButTracked.repoPath }],
+        },
+      ],
+    });
+    seedSettings(tmpHome, {
+      tokenSecret: DEFAULT_TOKEN,
+      worktreesDir: join(tmpHome, ".band", "worktrees"),
+    });
+
+    server = await startServer({ tmpHome });
+  });
+
+  afterAll(async () => {
+    await server.close();
+    rmSync(tmpHome, { recursive: true, force: true });
+  });
+
+  async function create(project: string): Promise<Response> {
+    return trpcMutate(server.url, "workspaces.create", { project, branch }, DEFAULT_TOKEN);
+  }
+
+  it("copies files declared only in .band/config.json::workspace.copyFiles", async () => {
+    const res = await create(pConfigOnly.name);
+    expect(res.status).toBe(200);
+
+    // All three declared files should land in the worktree with the same
+    // contents as the main checkout. Use `existsSync` AND a content
+    // assertion — symlinks would have the same `existsSync` result, so
+    // pin the bytes too. Pinning the literal main-checkout content also
+    // catches a silent regression where we copied an empty placeholder
+    // (e.g. a missed mkdirSync race).
+    expect(existsSync(join(pConfigOnly.worktreePath, ".env"))).toBe(true);
+    expect(readFileSync(join(pConfigOnly.worktreePath, ".env"), "utf-8")).toBe("ENV_FROM_MAIN=1\n");
+    expect(readFileSync(join(pConfigOnly.worktreePath, ".env.local"), "utf-8")).toBe(
+      "LOCAL_FROM_MAIN=1\n",
+    );
+    expect(readFileSync(join(pConfigOnly.worktreePath, "config", "local.json"), "utf-8")).toBe(
+      '{"main":true}\n',
+    );
+
+    // Regular file copy, not symlink: edits in the worktree must not bleed
+    // back to the main checkout. Mutate the worktree copy, then read the
+    // main checkout's copy and assert it's untouched.
+    writeFileSync(join(pConfigOnly.worktreePath, ".env"), "MUTATED_IN_WORKTREE=1\n");
+    expect(readFileSync(join(pConfigOnly.repoPath, ".env"), "utf-8")).toBe("ENV_FROM_MAIN=1\n");
+  });
+
+  it("copies files declared only in .worktreeinclude", async () => {
+    const res = await create(pIncludeOnly.name);
+    expect(res.status).toBe(200);
+
+    expect(readFileSync(join(pIncludeOnly.worktreePath, ".env"), "utf-8")).toBe("INCLUDE_ENV=1\n");
+    expect(readFileSync(join(pIncludeOnly.worktreePath, ".env.local"), "utf-8")).toBe(
+      "INCLUDE_LOCAL=1\n",
+    );
+    expect(readFileSync(join(pIncludeOnly.worktreePath, "config", "foo.local.json"), "utf-8")).toBe(
+      '{"foo":true}\n',
+    );
+  });
+
+  it("UNIONs both sources and de-dups by absolute source path", async () => {
+    const res = await create(pBoth.name);
+    expect(res.status).toBe(200);
+
+    // `.env` is declared by both sources but the file must land exactly
+    // once with the right contents — the de-dup case. There's no
+    // straightforward "copied twice" assertion at the filesystem layer
+    // (a second copy would just overwrite the first), but the contents
+    // and presence are what the user observes.
+    expect(readFileSync(join(pBoth.worktreePath, ".env"), "utf-8")).toBe("BOTH_ENV=1\n");
+    // `.env.local` is only matched by Option B (`.env*` glob, gitignored
+    // via `.env.local` in .gitignore).
+    expect(readFileSync(join(pBoth.worktreePath, ".env.local"), "utf-8")).toBe("BOTH_LOCAL=1\n");
+    // `shared.local` is in Option A literal AND Option B glob (`*.local`,
+    // gitignored). Must be present.
+    expect(readFileSync(join(pBoth.worktreePath, "shared.local"), "utf-8")).toBe("SHARED=1\n");
+  });
+
+  it("skips missing source files with a warning rather than failing the create", async () => {
+    const res = await create(pMissing.name);
+    // The create call must succeed end-to-end — missing files are
+    // non-fatal per the acceptance criteria.
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { result: { data: { ok: boolean; path: string } } };
+    expect(body.result.data.ok).toBe(true);
+
+    // Present file is still copied; missing files are simply absent.
+    expect(readFileSync(join(pMissing.worktreePath, ".env"), "utf-8")).toBe("PRESENT=1\n");
+    expect(existsSync(join(pMissing.worktreePath, "phantom.txt"))).toBe(false);
+    expect(existsSync(join(pMissing.worktreePath, "config", "does-not-exist.json"))).toBe(false);
+  });
+
+  it("expands glob entries in .band/config.json::workspace.copyFiles", async () => {
+    const res = await create(pGlob.name);
+    expect(res.status).toBe(200);
+
+    // The glob matches both `.local.json` files; the plain `.json` file
+    // (not matching the glob) must NOT be copied.
+    expect(readFileSync(join(pGlob.worktreePath, "config", "a.local.json"), "utf-8")).toBe(
+      '{"a":1}\n',
+    );
+    expect(readFileSync(join(pGlob.worktreePath, "config", "b.local.json"), "utf-8")).toBe(
+      '{"b":2}\n',
+    );
+    // `config/c.json` is untracked-but-not-matching-the-glob: NOT copied
+    // by our path. It is also not present in the main checkout's first
+    // commit (it was written post-commit), so the worktree should not
+    // contain it.
+    expect(existsSync(join(pGlob.worktreePath, "config", "c.json"))).toBe(false);
+  });
+
+  it("skips gitignored files that don't match .worktreeinclude (Claude Code parity)", async () => {
+    const res = await create(pIgnoredButNotIncluded.name);
+    expect(res.status).toBe(200);
+
+    // `.env` is in both .gitignore AND .worktreeinclude — copied.
+    expect(readFileSync(join(pIgnoredButNotIncluded.worktreePath, ".env"), "utf-8")).toBe(
+      "INCLUDED=1\n",
+    );
+    // `secret.key` is gitignored but NOT in .worktreeinclude. The
+    // intersection rule must keep it out of the new worktree.
+    expect(existsSync(join(pIgnoredButNotIncluded.worktreePath, "secret.key"))).toBe(false);
+  });
+
+  it("does not duplicate tracked files that happen to match a .worktreeinclude pattern", async () => {
+    const res = await create(pMatchedButTracked.name);
+    expect(res.status).toBe(200);
+
+    // `.env` is untracked + gitignored + matches `.env`. Copy expected.
+    expect(readFileSync(join(pMatchedButTracked.worktreePath, ".env"), "utf-8")).toBe(
+      "FROM_INCLUDE=1\n",
+    );
+
+    // `config.json` is a tracked file in the main checkout. It already
+    // appears in the worktree via `git worktree add`, but it must NOT be
+    // an Option-B re-copy: the rule "only files that match AND are
+    // gitignored are copied" means tracked-but-matching is a no-op for
+    // Option B. We verify by reading the worktree copy's bytes — it
+    // should match the committed bytes (`{"tracked":true}\n`), not be
+    // mutated by our copy path.
+    expect(readFileSync(join(pMatchedButTracked.worktreePath, "config.json"), "utf-8")).toBe(
+      '{"tracked":true}\n',
+    );
+  });
+});

--- a/apps/web/tests/workspace-create-copy-files.test.ts
+++ b/apps/web/tests/workspace-create-copy-files.test.ts
@@ -33,10 +33,6 @@
 // Each scenario uses its own project subdirectory inside the shared tmp
 // home so the seven creates don't fight over the same `.band/config.json`
 // / `.worktreeinclude` files. The server boots once for the file.
-//
-// See docs/integration-testing.md and .claude/skills/write-integration-test/SKILL.md
-// for the real-server doctrine this file implements (TEST-1...TEST-35 in
-// .claude/testing-criteria.md).
 
 import { execFileSync } from "node:child_process";
 import { existsSync, mkdirSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
@@ -171,7 +167,10 @@ describe("workspaces.create copies workspace files into the new worktree", () =>
   let pIgnoredButNotIncluded: ProjectFixture;
   let pMatchedButTracked: ProjectFixture;
   let pSymlinkEscape: ProjectFixture;
-  let symlinkEscapeTarget: string;
+  // Initialised to "" so a `beforeAll` failure before the assignment
+  // below doesn't make `afterAll`'s cleanup call `rmSync(undefined)` and
+  // swallow the original error with a TypeError.
+  let symlinkEscapeTarget = "";
 
   beforeAll(async () => {
     tmpHome = createTmpHome("band-copy-files-");
@@ -365,8 +364,9 @@ describe("workspaces.create copies workspace files into the new worktree", () =>
     rmSync(tmpHome, { recursive: true, force: true });
     // The symlink-escape target lives outside `tmpHome`, so it has to be
     // cleaned up explicitly — otherwise repeated test runs leak files
-    // under the system tmpdir.
-    rmSync(symlinkEscapeTarget, { force: true });
+    // under the system tmpdir. Guard on the assignment having happened
+    // (see the declaration) so a failed setup doesn't throw here.
+    if (symlinkEscapeTarget) rmSync(symlinkEscapeTarget, { force: true });
   });
 
   async function create(project: string): Promise<Response> {

--- a/apps/web/tests/workspace-create-copy-files.test.ts
+++ b/apps/web/tests/workspace-create-copy-files.test.ts
@@ -39,7 +39,8 @@
 // .claude/testing-criteria.md).
 
 import { execFileSync } from "node:child_process";
-import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { seedSettings, seedState } from "./helpers/seed-state";
@@ -169,6 +170,8 @@ describe("workspaces.create copies workspace files into the new worktree", () =>
   let pGlob: ProjectFixture;
   let pIgnoredButNotIncluded: ProjectFixture;
   let pMatchedButTracked: ProjectFixture;
+  let pSymlinkEscape: ProjectFixture;
+  let symlinkEscapeTarget: string;
 
   beforeAll(async () => {
     tmpHome = createTmpHome("band-copy-files-");
@@ -276,6 +279,27 @@ describe("workspaces.create copies workspace files into the new worktree", () =>
       worktreeInclude: "*.json\n.env\n",
     });
 
+    pSymlinkEscape = buildProject(tmpHome, "symlink-escape", branch, {
+      trackedFiles: { ".gitignore": "escape.txt\n" },
+      untrackedFiles: {},
+      bandConfig: {
+        workspace: {
+          // The symlink at `<repo>/escape.txt` is created below — it
+          // points OUTSIDE the project root. Listing it here exercises
+          // the symlink-escape guard.
+          copyFiles: ["escape.txt"],
+        },
+      },
+    });
+    // Drop the secret outside the project root in a sibling tmpdir so a
+    // resolved-real-path check sees a path that does NOT start with the
+    // project root prefix. Using `tmpdir()` rather than parent dirs of
+    // the home keeps the test robust to whatever directory layout the
+    // test runner picks.
+    symlinkEscapeTarget = join(tmpdir(), `band-symlink-escape-target-${Date.now()}.txt`);
+    writeFileSync(symlinkEscapeTarget, "SECRET-OUTSIDE-PROJECT\n");
+    symlinkSync(symlinkEscapeTarget, join(pSymlinkEscape.repoPath, "escape.txt"));
+
     seedState(tmpHome, {
       projects: [
         {
@@ -320,6 +344,12 @@ describe("workspaces.create copies workspace files into the new worktree", () =>
           defaultBranch: "main",
           worktrees: [{ branch: "main", path: pMatchedButTracked.repoPath }],
         },
+        {
+          name: pSymlinkEscape.name,
+          path: pSymlinkEscape.repoPath,
+          defaultBranch: "main",
+          worktrees: [{ branch: "main", path: pSymlinkEscape.repoPath }],
+        },
       ],
     });
     seedSettings(tmpHome, {
@@ -333,6 +363,10 @@ describe("workspaces.create copies workspace files into the new worktree", () =>
   afterAll(async () => {
     await server.close();
     rmSync(tmpHome, { recursive: true, force: true });
+    // The symlink-escape target lives outside `tmpHome`, so it has to be
+    // cleaned up explicitly — otherwise repeated test runs leak files
+    // under the system tmpdir.
+    rmSync(symlinkEscapeTarget, { force: true });
   });
 
   async function create(project: string): Promise<Response> {
@@ -465,6 +499,22 @@ describe("workspaces.create copies workspace files into the new worktree", () =>
     expect(readFileSync(join(pMatchedButTracked.worktreePath, "config.json"), "utf-8")).toBe(
       '{"tracked":true}\n',
     );
+  });
+
+  it("refuses to follow a symlink that points outside the project root", async () => {
+    const res = await create(pSymlinkEscape.name);
+    // Create still succeeds — the symlink-escape guard is non-fatal,
+    // matching the project's "missing source files are skipped, not
+    // errors" contract.
+    expect(res.status).toBe(200);
+
+    // The symlink target sits OUTSIDE the project root and contains a
+    // secret. A regression that follows the symlink would land its
+    // bytes inside the new worktree at `escape.txt`. The guard MUST
+    // refuse to copy: the worktree must not contain `escape.txt` at
+    // all (since the source is a dangling-after-guard symlink, not a
+    // real file we'd want to expose).
+    expect(existsSync(join(pSymlinkEscape.worktreePath, "escape.txt"))).toBe(false);
   });
 
   it("rejects workspaces.create without an auth token (401)", async () => {

--- a/apps/website/src/pages/docs/configuration.astro
+++ b/apps/website/src/pages/docs/configuration.astro
@@ -30,7 +30,10 @@ import DocsLayout from "../../layouts/DocsLayout.astro";
 
   <pre><code set:html={`{
   "setup": "npm install && npm run db:migrate",
-  "teardown": "npm run db:reset"
+  "teardown": "npm run db:reset",
+  "workspace": {
+    "copyFiles": [".env", ".env.local", "config/local.json"]
+  }
 }`}></code></pre>
 
   <h2>Setup Command</h2>
@@ -60,10 +63,99 @@ import DocsLayout from "../../layouts/DocsLayout.astro";
 
   <pre><code>"teardown": "docker compose down -v"</code></pre>
 
+  <h2>Workspace File Copying</h2>
+
+  <p>
+    Workspaces are fresh git worktrees, so untracked files like <code>.env</code>,
+    <code>.env.local</code>, local credential overrides, or IDE settings are <strong>not</strong>
+    present after creation — git only checks out tracked files. Band can copy those files into
+    a new worktree on creation, driven by either of two declarative sources at the project root:
+  </p>
+
+  <h3>Option A: <code>.band/config.json::workspace.copyFiles</code></h3>
+
+  <p>
+    Explicit list of paths relative to the project root. Glob patterns
+    (<code>*</code>, <code>?</code>, <code>[abc]</code>, <code>{`{a,b}`}</code>) are supported.
+  </p>
+
+  <pre><code set:html={`{
+  "workspace": {
+    "copyFiles": [
+      ".env",
+      ".env.local",
+      "config/*.local.json",
+      ".vscode/settings.json"
+    ]
+  }
+}`}></code></pre>
+
+  <h3>Option B: <code>.worktreeinclude</code></h3>
+
+  <p>
+    A <code>.gitignore</code>-syntax file at the project root, parallel to
+    <code>.gitignore</code>. Patterns use the same grammar as <code>.gitignore</code>
+    (anchored leading slash, <code>**</code> segments, character classes, etc.).
+  </p>
+
+  <p>
+    Only files that match a pattern <strong>and</strong> are gitignored are copied
+    (parity with Claude Code's own <code>.worktreeinclude</code> behavior). Tracked
+    files are never duplicated — git already provides them via the worktree checkout.
+  </p>
+
+  <pre><code set:html={`# .worktreeinclude
+.env*
+config/*.local.json
+.vscode/
+`}></code></pre>
+
+  <h3>Precedence and Semantics</h3>
+
+  <ul>
+    <li>
+      When both sources are present, the resulting file sets are <strong>UNIONed</strong>
+      and de-duped by absolute source path — neither source wins, and a file declared
+      by both is copied exactly once.
+    </li>
+    <li>
+      The source is always the project's <strong>main checkout</strong>, not another
+      worktree, so copies are deterministic regardless of which worktrees happen to
+      exist at the time of creation.
+    </li>
+    <li>
+      Files are copied as <strong>regular files</strong>, not symlinks — edits inside
+      the new worktree don't bleed back to the main checkout. Relative directory
+      structure is preserved (<code>config/local.json</code> lands at
+      <code>&lt;worktree&gt;/config/local.json</code>).
+    </li>
+    <li>
+      Missing source files are <strong>skipped with a warning</strong>, not treated
+      as fatal. Stale entries in the config don't break workspace creation.
+    </li>
+    <li>
+      Copies run <strong>after</strong> <code>git worktree add</code> and
+      <strong>before</strong> the <code>setup</code> script (and the first agent
+      prompt, when one is supplied via <code>band workspaces create --prompt</code>),
+      so the setup script can read <code>.env</code> / local credentials just like
+      it can in the main checkout.
+    </li>
+  </ul>
+
+  <p>
+    Out of scope (today): per-user overrides (<code>.band/config.local.json</code>),
+    copying files back from a worktree to the main checkout on cleanup
+    (workspace-files copy is one-way only), and variable substitution inside copied
+    files.
+  </p>
+
   <h2>Full Example</h2>
 
   <pre><code set:html={`{
   "setup": "npm install && npx prisma db push && cp .env.example .env.local",
-  "teardown": "docker compose down -v"
+  "teardown": "docker compose down -v",
+  "workspace": {
+    "copyFiles": [".env", ".env.local", "config/*.local.json"]
+  }
 }`}></code></pre>
 </DocsLayout>

--- a/apps/website/src/pages/docs/workspaces.astro
+++ b/apps/website/src/pages/docs/workspaces.astro
@@ -55,6 +55,30 @@ band workspaces create my-app feat/api --base develop</code></pre>
     simply returns its path without duplicating anything.
   </p>
 
+  <h3>Untracked file copying</h3>
+  <p>
+    A fresh worktree only contains files git knows about. Untracked files like
+    <code>.env</code>, local credential overrides, or IDE settings are absent by
+    default. Configure them to be copied from the project's main checkout into
+    every new worktree via either of two declarative sources at the project root:
+  </p>
+  <ul>
+    <li>
+      <code>.band/config.json::workspace.copyFiles</code> &mdash; explicit list of paths
+      (literals or globs). See <a href="/docs/configuration">Project Configuration</a>.
+    </li>
+    <li>
+      <code>.worktreeinclude</code> &mdash; gitignore-syntax patterns. Only files
+      that match a pattern AND are gitignored are copied (Claude Code parity).
+    </li>
+  </ul>
+  <p>
+    When both sources are present, the union is copied. Copies happen after
+    <code>git worktree add</code> and before the <code>setup</code> script runs,
+    so the setup script can read <code>.env</code> just like it can in the main
+    checkout. Missing source files are skipped with a warning.
+  </p>
+
   <h2>Workspace List</h2>
   <p>
     Workspaces appear nested under their parent project in the dashboard. Each workspace card


### PR DESCRIPTION
## Summary

Fresh git worktrees skip `.env` / local credentials / IDE overrides since git only checks out tracked files. Workspace creation now declaratively copies a set of those files from the project's main checkout into each new worktree, driven by either source at the project root:

- **`.band/config.json::workspace.copyFiles`** — explicit list (literals or globs).
- **`.worktreeinclude`** — gitignore-syntax patterns; only entries that match AND are gitignored are copied (Claude Code parity, so tracked files are never duplicated).

When both sources exist the resolved file sets are UNIONed and de-duped by absolute source path. Missing source files are skipped with a warning rather than aborting create. Copies are regular file copies (not symlinks) so worktree edits don't bleed back to the main checkout, and they run after `git worktree add` but before the setup script / first agent prompt so setup can read `.env` just like in the main checkout.

Closes #284

## Implementation

- `apps/web/src/server/infra/setup/project-config.ts` — `getCopyFiles(projectPath)` with a zod `string[]` schema for `workspace.copyFiles`. Validation failures and missing files log warnings and return `null` (no hard failure).
- `apps/web/src/server/infra/setup/workspace-files.ts` (new) — `copyWorkspaceFiles(projectPath, worktreePath)`:
  - Option A: glob expansion via `node:fs::globSync`, literal-path fallback.
  - Option B: two `git ls-files` calls intersected in memory (`--others --ignored -X .worktreeinclude` ∩ `--others --ignored --exclude-standard`). That intersection is the exact "matches pattern AND is gitignored AND is untracked" set — combining both flag groups into one call would UNION the rules, not intersect.
  - Path-traversal guard via the resolved-relative path check.
  - Per-file try/catch backstop so a single copy failure doesn't abort the rest.
- `apps/web/src/server/services/workspace-service.ts` — wires the call between `git worktree add` and `runSetup`, with a catch-all so an unexpected crash never aborts the create flow.

## Test plan

Integration test (`apps/web/tests/workspace-create-copy-files.test.ts`) boots the real `dist/start-server.mjs` against a fresh tmp `$HOME` and exercises `workspaces.create` over real tRPC. Eight scenarios:

- [x] only `.band/config.json`
- [x] only `.worktreeinclude`
- [x] both present (UNION + de-dup)
- [x] missing source files (non-fatal)
- [x] glob match
- [x] gitignored-but-not-`.worktreeinclude`-matched (skipped)
- [x] matched-but-tracked (skipped) — falsifiable via post-commit working-tree drift on the tracked file
- [x] 401 negative auth case
- [x] Verifies regular-file copy (worktree edits don't bleed back to main checkout)

## Docs

- `apps/website/src/pages/docs/configuration.astro` — Workspace File Copying section.
- `apps/website/src/pages/docs/workspaces.astro` — Untracked file copying subsection under Creating Workspaces.
- `apps/cli/skills/band.md` — Workspace file copying section so the generated band CLI skill surfaces the feature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)