### PR TITLE
feat(web): mobile accessibility & workspace switching improvements

### DIFF
--- a/apps/web/e2e/pages/WorkspacePage.ts
+++ b/apps/web/e2e/pages/WorkspacePage.ts
@@ -350,7 +350,14 @@ export class WorkspacePage {
   /** The active workspace card, identified by the `data-active` attribute
    *  `WorkspaceCard` sets when its workspaceId matches the store's
    *  `activeWorkspaceId`. Scoped to a specific workspaceId so the test can
-   *  assert the right card carries the active marker. */
+   *  assert the right card carries the active marker.
+   *
+   *  The `[data-active]` presence filter is intentional rather than a CSS
+   *  selector smell: `data-active` is a binary *state* marker (present ⇔
+   *  active), so the card's identity still comes from its `getByTestId`-based
+   *  `workspaceCard(...)` locator — this only narrows it to the active state.
+   *  A separate testid per state would duplicate the marker the component
+   *  already owns. */
   activeWorkspaceCard(workspaceId: string): Locator {
     return this.workspaceCard(workspaceId).and(this.page.locator("[data-active]"));
   }

--- a/apps/web/e2e/pages/WorkspacePage.ts
+++ b/apps/web/e2e/pages/WorkspacePage.ts
@@ -301,6 +301,103 @@ export class WorkspacePage {
       .waitFor({ state: "visible", timeout: 15_000 });
   }
 
+  /** Activate the outer Terminal tab so the inner
+   *  `DockviewTerminalContainer` mounts and (on cold start) seeds a
+   *  default terminal panel, which boots a real PTY server-side. */
+  async openTerminalTab(): Promise<void> {
+    await test.step("Activate the Terminal tab", async () => {
+      await this.tab("terminal").click();
+    });
+  }
+
+  /** Wait for the terminal's xterm input to be attached — the DOM-level
+   *  signal that the xterm instance mounted. xterm keeps its input as an
+   *  offscreen "helper" textarea (Playwright reports it as hidden, never
+   *  "visible"), so we wait for `attached`, not `visible`. */
+  async waitForTerminalReady(): Promise<void> {
+    await this.terminalInput.first().waitFor({ state: "attached", timeout: 15_000 });
+  }
+
+  /** Type a line into the focused terminal and submit it with Enter.
+   *  Routes the keystrokes through the real xterm input (which calls
+   *  `terminal.onData` → `ws.send`), exactly as a user typing would.
+   *  `focus()` (not `click()`) because xterm's helper textarea is
+   *  offscreen and not click-targetable. A leading Enter clears any
+   *  partial line left by keystrokes dropped while the socket was
+   *  mid-reconnect, so a retried command never concatenates onto a
+   *  half-typed previous attempt. */
+  async runInTerminal(line: string): Promise<void> {
+    await test.step(`Run in terminal: ${line}`, async () => {
+      await this.terminalInput.first().focus();
+      await this.page.keyboard.press("Enter");
+      await this.page.keyboard.type(line);
+      await this.page.keyboard.press("Enter");
+    });
+  }
+
+  /** Start counting terminal WebSocket connections the page opens.
+   *  Returns a getter for the running count. Call this BEFORE `goto` so
+   *  the listener is attached before the first socket opens. A test
+   *  asserts the count climbs past 1 after a network drop — protocol-
+   *  level proof the client auto-reconnected, without depending on the
+   *  (WebGL-canvas) rendered terminal text. */
+  trackTerminalSocketOpens(): () => number {
+    let count = 0;
+    this.page.on("websocket", (ws) => {
+      if (ws.url().includes("/terminal?")) count += 1;
+    });
+    return () => count;
+  }
+
+  /** Install a browser-side wrapper around `window.WebSocket` that records
+   *  every terminal socket the page opens in `window.__terminalSockets`.
+   *  Must run BEFORE `goto` (uses `addInitScript`). Test-only
+   *  instrumentation — it touches no production code — that lets a test
+   *  force-close the live socket to simulate the TCP death a machine sleep
+   *  causes (Chromium's `context.setOffline` does NOT drop an established
+   *  loopback WebSocket, so it can't reproduce the disconnect). */
+  async installTerminalSocketInstrumentation(): Promise<void> {
+    await this.page.addInitScript(() => {
+      const w = window as unknown as {
+        WebSocket: typeof WebSocket;
+        __terminalSockets?: WebSocket[];
+      };
+      const Orig = w.WebSocket;
+      w.__terminalSockets = [];
+      // A function *declaration*, not an arrow — arrows aren't constructors
+      // and `new WebSocket(...)` in the app would throw "not a constructor".
+      function TrackedWebSocket(url: string | URL, protocols?: string | string[]) {
+        const ws = new Orig(url, protocols);
+        if (String(url).includes("/terminal?")) {
+          w.__terminalSockets?.push(ws);
+        }
+        return ws;
+      }
+      const Wrapped = TrackedWebSocket as unknown as typeof WebSocket;
+      Wrapped.prototype = Orig.prototype;
+      const statics = Wrapped as unknown as Record<string, number>;
+      statics.CONNECTING = Orig.CONNECTING;
+      statics.OPEN = Orig.OPEN;
+      statics.CLOSING = Orig.CLOSING;
+      statics.CLOSED = Orig.CLOSED;
+      w.WebSocket = Wrapped;
+    });
+  }
+
+  /** Force-close the most recently opened terminal WebSocket from inside
+   *  the page — the deterministic stand-in for a socket dying on machine
+   *  wake. Fires the client's `onclose`, which drives the auto-reconnect
+   *  path under test. Requires `installTerminalSocketInstrumentation`. */
+  async dropLatestTerminalSocket(): Promise<void> {
+    await test.step("Force-close the live terminal WebSocket (simulate sleep)", async () => {
+      await this.page.evaluate(() => {
+        const w = window as unknown as { __terminalSockets?: WebSocket[] };
+        const list = w.__terminalSockets ?? [];
+        list[list.length - 1]?.close();
+      });
+    });
+  }
+
   /** Click the Nth Maximize button (0-indexed). Useful when the layout
    *  has multiple groups and the test wants to target a specific one. */
   async maximizePanel(index = 0): Promise<void> {

--- a/apps/web/e2e/pages/WorkspacePage.ts
+++ b/apps/web/e2e/pages/WorkspacePage.ts
@@ -301,6 +301,60 @@ export class WorkspacePage {
       .waitFor({ state: "visible", timeout: 15_000 });
   }
 
+  /** The mobile workspace header's title button. Its aria-label
+   *  ("Switch workspace") is system-controlled (set in
+   *  `workspace.$workspaceId.tsx` MobileWorkspaceLayout), so
+   *  `getByRole({ name })` is the preferred locator. Tapping it opens the
+   *  WorkspacePickerDialog. */
+  get switchWorkspaceButton(): Locator {
+    return this.page.getByRole("button", { name: "Switch workspace" });
+  }
+
+  /** The mobile header's back button — navigates (in-app) to the project
+   *  list at `/`. aria-label set in MobileWorkspaceLayout. */
+  get backToProjectListButton(): Locator {
+    return this.page.getByRole("button", { name: "Back to project list" });
+  }
+
+  /** Open the workspace switcher from the mobile header title. */
+  async openSwitcherFromHeader(): Promise<void> {
+    await test.step("Tap the mobile header title to open the workspace switcher", async () => {
+      await this.switchWorkspaceButton.click();
+    });
+  }
+
+  /** Tap the mobile header back button to return to the project list via
+   *  client-side navigation (not a full reload — so the in-memory
+   *  `activeWorkspaceId` store survives, which is the behaviour the
+   *  active-persistence test asserts). */
+  async goBackToProjectList(): Promise<void> {
+    await test.step("Tap back to project list", async () => {
+      await this.backToProjectListButton.click();
+    });
+  }
+
+  /** Open the workspace picker on desktop via its Ctrl+R shortcut. The
+   *  handler lives on a window keydown listener in
+   *  `SharedDockviewLayout.tsx`; it ignores the shortcut while the
+   *  terminal is focused, so we route the keypress through the project
+   *  list root (focusable, non-editable) — the same anchor the label
+   *  shortcut test uses. */
+  async openWorkspacePickerViaShortcut(): Promise<void> {
+    await test.step("Open workspace picker (Ctrl+R)", async () => {
+      const root = this.projectListRoot();
+      await root.waitFor({ state: "visible" });
+      await root.press("Control+r");
+    });
+  }
+
+  /** The active workspace card, identified by the `data-active` attribute
+   *  `WorkspaceCard` sets when its workspaceId matches the store's
+   *  `activeWorkspaceId`. Scoped to a specific workspaceId so the test can
+   *  assert the right card carries the active marker. */
+  activeWorkspaceCard(workspaceId: string): Locator {
+    return this.workspaceCard(workspaceId).and(this.page.locator("[data-active]"));
+  }
+
   /** Activate the outer Terminal tab so the inner
    *  `DockviewTerminalContainer` mounts and (on cold start) seeds a
    *  default terminal panel, which boots a real PTY server-side. */

--- a/apps/web/e2e/pages/WorkspacePicker.ts
+++ b/apps/web/e2e/pages/WorkspacePicker.ts
@@ -1,0 +1,66 @@
+/**
+ * Component object for the WorkspacePickerDialog
+ * (`apps/web/src/dashboard/components/WorkspacePickerDialog.tsx`) — the
+ * command-palette-style "Switch Workspace" dialog reachable on desktop via
+ * Ctrl+R and on mobile by tapping the workspace header title.
+ *
+ * Locators key off `data-testid` hooks the component sets:
+ *   - `workspace-picker`                       — the dialog content
+ *   - `workspace-picker__item--<workspaceId>`  — a workspace row
+ *   - `workspace-picker__pin--<workspaceId>`   — that row's pin/unpin button
+ *
+ * The pin button additionally carries a system-controlled aria-label that
+ * flips between "Pin workspace" and "Unpin workspace" — the observable signal
+ * the pin/select-separation regression test asserts on.
+ */
+
+import { type Locator, type Page, test } from "@playwright/test";
+
+export class WorkspacePicker {
+  readonly dialog: Locator;
+
+  constructor(private readonly page: Page) {
+    this.dialog = page.getByTestId("workspace-picker");
+  }
+
+  item(workspaceId: string): Locator {
+    return this.page.getByTestId(`workspace-picker__item--${workspaceId}`);
+  }
+
+  pinButton(workspaceId: string): Locator {
+    return this.page.getByTestId(`workspace-picker__pin--${workspaceId}`);
+  }
+
+  async waitVisible(): Promise<void> {
+    await test.step("Wait for the workspace picker to open", async () => {
+      await this.dialog.waitFor({ state: "visible", timeout: 15_000 });
+    });
+  }
+
+  /** Tap a row's pin/unpin button. This must NOT select the workspace —
+   *  the dialog stays open and no navigation happens. */
+  async togglePin(workspaceId: string): Promise<void> {
+    await test.step(`Toggle pin for ${workspaceId}`, async () => {
+      await this.pinButton(workspaceId).click();
+    });
+  }
+
+  /** Select a workspace by clicking its row body (not the pin button). This
+   *  navigates to the workspace and closes the dialog. */
+  async select(workspaceId: string): Promise<void> {
+    await test.step(`Select workspace ${workspaceId}`, async () => {
+      // Click the row near its left edge (the label), away from the trailing
+      // pin button on the right, so the click lands on the cmdk item body and
+      // fires its onSelect.
+      await this.item(workspaceId).click({ position: { x: 12, y: 12 } });
+    });
+  }
+
+  /** Dismiss the dialog without selecting — Escape, the same affordance a
+   *  user has to back out. */
+  async dismiss(): Promise<void> {
+    await test.step("Dismiss the workspace picker", async () => {
+      await this.page.keyboard.press("Escape");
+    });
+  }
+}

--- a/apps/web/e2e/pages/WorkspacePicker.ts
+++ b/apps/web/e2e/pages/WorkspacePicker.ts
@@ -12,6 +12,12 @@
  * The pin button additionally carries a system-controlled aria-label that
  * flips between "Pin workspace" and "Unpin workspace" — the observable signal
  * the pin/select-separation regression test asserts on.
+ *
+ * This is a *component* object, not a route page object: the dialog has no URL
+ * of its own (it's opened by a gesture on whatever page already rendered), so
+ * it deliberately omits the `(page, baseUrl)` constructor + `goto()` that route
+ * page objects (e.g. WorkspacePage) carry. Component objects take only `page`
+ * and expose interaction methods.
  */
 
 import { type Locator, type Page, test } from "@playwright/test";

--- a/apps/web/e2e/reports-dialog.spec.ts
+++ b/apps/web/e2e/reports-dialog.spec.ts
@@ -41,22 +41,26 @@ test.use({ viewport: { width: 1280, height: 800 } });
 let server!: ServerHandle;
 let tmpHome: string;
 
-// Anchor to start-of-day on the test host so the byBucket day buckets are
-// stable across timezones and don't depend on wall-clock at run time.
+// Seed "today" data relative to the real clock so the "Today" period filter
+// (server-side: captured_at in [start-of-today, now)) always includes it.
 //
-// Using `dayStart` directly means seeded "today" data lives at
-// dayStart + 9h — which is in the FUTURE if the test runs before
-// local 9am, and `reports.summary`'s `captured_at < toMs (now)`
-// filter excludes it (caused flake when tests ran in the early
-// morning). Anchor to `now - 3h` instead so "today" data is always
-// in the past relative to wall-clock when the test runs.
+// Earlier anchors were brittle around clock edges:
+//   - dayStart + 9h put "today" in the FUTURE before 9am, so the
+//     `captured_at < now` filter dropped it.
+//   - now - 3h fixed the morning case but pushed "today" into the PREVIOUS
+//     calendar day when the suite ran between midnight and 3am, so the
+//     "Today" filter (which keys off the real start-of-today) dropped it
+//     instead — a deterministic failure every night, not a flake.
+//
+// Anchor today's row to one minute ago, clamped so it can't fall before
+// midnight: that's guaranteed to sit in [start-of-today, now) at any hour.
 const nowMs = Date.now();
-const TODAY_ANCHOR = nowMs - 3 * 60 * 60 * 1000;
 const dayStart = (() => {
-  const d = new Date(TODAY_ANCHOR);
+  const d = new Date(nowMs);
   d.setHours(0, 0, 0, 0);
   return d.getTime();
 })();
+const TODAY_ANCHOR = Math.max(dayStart, nowMs - 60 * 1000);
 
 function openDb(home: string): DatabaseSync {
   const dbPath = join(home, ".band", "band.db");

--- a/apps/web/e2e/terminal-reconnect.spec.ts
+++ b/apps/web/e2e/terminal-reconnect.spec.ts
@@ -1,0 +1,159 @@
+/**
+ * Regression coverage: a terminal must never be permanently disconnected
+ * by a transient network drop / machine sleep.
+ *
+ * Background
+ * ----------
+ * When the machine sleeps (or the network drops), the terminal WebSocket
+ * dies. The server has always kept the PTY alive across a socket close and
+ * reuses it by `terminalId` on reconnect (see
+ * `apps/web/src/server/api/terminals/ws.ts`). The missing half was the
+ * client: `TerminalPanel` only printed "[Terminal disconnected]" and never
+ * reconnected, so after a wake the pane was dead until the user manually
+ * closed and reopened the tab. The fix adds client auto-reconnect (with an
+ * application-level heartbeat + `online`/`visibilitychange` triggers) so the
+ * pane re-attaches to the same PTY on its own.
+ *
+ * What this spec asserts (all black-box, renderer-independent)
+ * ------------------------------------------------------------
+ *   1. A shell variable is set in the PTY and confirmed live by echoing it
+ *      to a file the test reads back.
+ *   2. The live WebSocket is force-closed from inside the page (the
+ *      deterministic stand-in for the TCP death a machine sleep causes —
+ *      Chromium's `context.setOffline` does NOT drop an established
+ *      loopback socket).
+ *   3. The page opens a *second* terminal WebSocket (tracked at the
+ *      protocol level via `page.on("websocket")`) — proof the client
+ *      auto-reconnected rather than sitting dead, which is exactly what the
+ *      old `onclose` handler did.
+ *   4. Echoing the variable set BEFORE the drop writes the original marker
+ *      to a new file — proof the reconnected client is driving the SAME
+ *      shell, not a freshly-spawned one (a new PTY would have an empty
+ *      `$MARKER`). This single assertion proves both halves: a reconnect
+ *      happened AND the PTY session survived the disconnect.
+ *
+ * This exercises the close→reconnect path (the primary fix). The
+ * application-level heartbeat and `online`/`visibilitychange` triggers are
+ * additional defenses for the case where the socket goes "zombie" (stuck
+ * OPEN, no `onclose`) after sleep.
+ */
+
+import { existsSync, mkdtempSync, readFileSync, realpathSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { expect, test } from "@playwright/test";
+import { toWorkspaceId } from "@/dashboard";
+import {
+  cleanupTmpHome,
+  createTmpHome,
+  type ServerHandle,
+  seedSettings,
+  seedState,
+  startServer,
+} from "./helpers/server";
+import { WorkspacePage } from "./pages/WorkspacePage";
+
+const TOKEN = "e2e-terminal-reconnect-token";
+const PROJECT = "alpha-terminal-reconnect";
+const WORKSPACE = toWorkspaceId(PROJECT, "main");
+const MARKER = "band-reconnect-marker-7f3c";
+
+// Wide viewport so `useIsDesktop()` reports true and the shared dockview
+// (which hosts the terminal container) renders.
+test.use({ viewport: { width: 1280, height: 800 } });
+
+let server: ServerHandle;
+let tmpHome: string;
+/** A real directory used as the project path — the PTY spawns with cwd =
+ *  the project path and `terminal-pool` throws if it doesn't exist, so a
+ *  fake `/tmp/...` path (fine for layout-only tests) won't work here. */
+let workdir: string;
+
+test.beforeAll(async () => {
+  tmpHome = createTmpHome();
+  workdir = realpathSync(mkdtempSync(join(tmpdir(), "band-term-workdir-")));
+  seedState(tmpHome, {
+    projects: [
+      {
+        name: PROJECT,
+        path: workdir,
+        defaultBranch: "main",
+        worktrees: [{ branch: "main", path: workdir }],
+      },
+    ],
+  });
+  seedSettings(tmpHome, { tokenSecret: TOKEN });
+  server = await startServer({ tmpHome });
+});
+
+test.afterAll(async () => {
+  await server.close();
+  cleanupTmpHome(tmpHome);
+  rmSync(workdir, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 });
+});
+
+/** Read a marker file written by the shell, or `null` if it doesn't exist
+ *  yet. Trimmed because `echo` appends a trailing newline. */
+function readMarker(file: string): string | null {
+  if (!existsSync(file)) return null;
+  return readFileSync(file, "utf-8").trim();
+}
+
+test.describe("Terminal reconnect across a network drop (machine sleep)", () => {
+  test("the shell session survives a disconnect and the client reconnects to it", async ({
+    page,
+  }) => {
+    const workspacePage = new WorkspacePage(page, server.url, TOKEN);
+    const terminalSocketOpens = workspacePage.trackTerminalSocketOpens();
+    await workspacePage.installTerminalSocketInstrumentation();
+    const beforeFile = join(workdir, "before.txt");
+    const afterFile = join(workdir, "after.txt");
+
+    await workspacePage.goto(WORKSPACE);
+    await workspacePage.waitForReady();
+    await workspacePage.openTerminalTab();
+    await workspacePage.waitForTerminalReady();
+
+    // The first socket is open.
+    await expect.poll(() => terminalSocketOpens(), { timeout: 10_000 }).toBeGreaterThanOrEqual(1);
+
+    // Establish session state that only survives as long as THIS shell
+    // process does: a variable unique to this PTY. No quotes / spaces around
+    // the redirect so a keystroke dropped mid-reconnect can't wedge the
+    // shell at a continuation prompt.
+    await workspacePage.runInTerminal(`MARKER=${MARKER}`);
+
+    // Positive anchor: the variable is set and input is routed to a live PTY.
+    await expect
+      .poll(
+        async () => {
+          await workspacePage.runInTerminal(`echo $MARKER>${beforeFile}`);
+          return readMarker(beforeFile);
+        },
+        { timeout: 15_000 },
+      )
+      .toBe(MARKER);
+
+    // Drop the connection mid-session, simulating the socket dying on sleep.
+    await workspacePage.dropLatestTerminalSocket();
+
+    // Protocol-level proof of reconnect: a second terminal WebSocket opens.
+    await expect.poll(() => terminalSocketOpens(), { timeout: 20_000 }).toBeGreaterThanOrEqual(2);
+
+    // Prove the reconnected client drives the ORIGINAL shell: echo the
+    // variable set BEFORE the drop. A freshly-spawned PTY would have an
+    // empty `$MARKER`, so `afterFile` would never equal MARKER. Retried via
+    // poll because keystrokes typed before the reconnect fully settles are
+    // dropped (the leading Enter in `runInTerminal` keeps a partial attempt
+    // from wedging the next one).
+    await expect
+      .poll(
+        async () => {
+          await workspacePage.runInTerminal(`echo $MARKER>${afterFile}`);
+          return readMarker(afterFile);
+        },
+        { timeout: 20_000 },
+      )
+      .toBe(MARKER);
+  });
+});

--- a/apps/web/e2e/workspace-picker.spec.ts
+++ b/apps/web/e2e/workspace-picker.spec.ts
@@ -1,0 +1,115 @@
+/**
+ * Regression coverage for the WorkspacePickerDialog pin/select separation
+ * (PR #553). Tapping a row's pin button must toggle the pinned state WITHOUT
+ * selecting the workspace — the dialog stays open and the URL doesn't change.
+ * Clicking the row body, by contrast, selects the workspace: it navigates and
+ * closes the dialog.
+ *
+ * The bug this guards: cmdk fires a row's `onSelect` from the item's bubbled
+ * `onClick`, so an earlier version of the pin button (which only stopped
+ * propagation on `mousedown`) let a real click bubble to the item and navigate
+ * away. The fix stops propagation on pointerdown/mousedown/click and toggles
+ * once on click.
+ *
+ * Architecture: real production binary against a fresh tmp `~/.band/`, no tRPC
+ * mocks. Two projects are seeded into the SQLite DB; the picker lists their
+ * worktrees from the real `projects.list` response. Pinning goes through the
+ * real `pinnedWorkspaces` mutation. All interaction is via page objects.
+ */
+
+import { expect, test } from "@playwright/test";
+import { toWorkspaceId } from "@/dashboard";
+import {
+  cleanupTmpHome,
+  createTmpHome,
+  type ServerHandle,
+  seedSettings,
+  seedState,
+  startServer,
+} from "./helpers/server";
+import { WorkspacePage } from "./pages/WorkspacePage";
+import { WorkspacePicker } from "./pages/WorkspacePicker";
+
+const TOKEN = "e2e-workspace-picker-token";
+
+const PROJECT_ALPHA = "alpha-picker";
+const PROJECT_BETA = "beta-picker";
+
+const WS_ALPHA = toWorkspaceId(PROJECT_ALPHA, "main");
+const WS_BETA = toWorkspaceId(PROJECT_BETA, "main");
+
+// Wide viewport so `useIsDesktop()` reports true and the shared dockview (which
+// owns the Ctrl+R picker shortcut and the project-list sidebar) mounts.
+test.use({ viewport: { width: 1280, height: 800 } });
+
+let server: ServerHandle;
+let tmpHome: string;
+
+test.beforeAll(async () => {
+  tmpHome = createTmpHome();
+  seedState(tmpHome, {
+    projects: [
+      {
+        name: PROJECT_ALPHA,
+        path: `/tmp/fake/${PROJECT_ALPHA}`,
+        defaultBranch: "main",
+        worktrees: [{ branch: "main", path: `/tmp/fake/${PROJECT_ALPHA}` }],
+      },
+      {
+        name: PROJECT_BETA,
+        path: `/tmp/fake/${PROJECT_BETA}`,
+        defaultBranch: "main",
+        worktrees: [{ branch: "main", path: `/tmp/fake/${PROJECT_BETA}` }],
+      },
+    ],
+  });
+  seedSettings(tmpHome, { tokenSecret: TOKEN });
+  server = await startServer({ tmpHome });
+});
+
+test.afterAll(async () => {
+  await server.close();
+  cleanupTmpHome(tmpHome);
+});
+
+test.describe("Workspace picker — pin is separate from select", () => {
+  test("tapping pin toggles the pinned state without selecting the workspace", async ({ page }) => {
+    const workspacePage = new WorkspacePage(page, server.url, TOKEN);
+    const picker = new WorkspacePicker(page);
+
+    await workspacePage.goto(WS_ALPHA);
+    await workspacePage.waitForReady();
+
+    await workspacePage.openWorkspacePickerViaShortcut();
+    await picker.waitVisible();
+
+    // Pre-condition: beta is not pinned yet.
+    await expect(picker.pinButton(WS_BETA)).toHaveAttribute("aria-label", "Pin workspace");
+
+    await picker.togglePin(WS_BETA);
+
+    // The pin flipped...
+    await expect(picker.pinButton(WS_BETA)).toHaveAttribute("aria-label", "Unpin workspace");
+    // ...and the pin tap did NOT select beta: dialog still open, still on alpha.
+    await expect(picker.dialog).toBeVisible();
+    await expect(page).toHaveURL(new RegExp(WS_ALPHA));
+  });
+
+  test("clicking a row body selects the workspace and closes the dialog", async ({ page }) => {
+    const workspacePage = new WorkspacePage(page, server.url, TOKEN);
+    const picker = new WorkspacePicker(page);
+
+    await workspacePage.goto(WS_ALPHA);
+    await workspacePage.waitForReady();
+
+    await workspacePage.openWorkspacePickerViaShortcut();
+    await picker.waitVisible();
+
+    await picker.select(WS_BETA);
+
+    // Positive anchor: we navigated to beta...
+    await expect(page).toHaveURL(new RegExp(WS_BETA));
+    // ...and the dialog closed.
+    await expect(picker.dialog).toBeHidden();
+  });
+});

--- a/apps/web/e2e/workspace-switcher-mobile.spec.ts
+++ b/apps/web/e2e/workspace-switcher-mobile.spec.ts
@@ -1,0 +1,136 @@
+/**
+ * Mobile workspace switcher coverage (PR #553).
+ *
+ * Two behaviours, both mobile-only:
+ *
+ *  1. The workspace header title is a button ("Switch workspace") that opens
+ *     the WorkspacePickerDialog, and the dialog can be dismissed (Escape) to
+ *     stay on the current workspace — the user is never forced to make a
+ *     selection to get out of it.
+ *
+ *  2. The active workspace stays marked active after navigating back to the
+ *     project-list menu route (`/`). This guards the removal of the
+ *     `setActiveWorkspace(null)` unmount-clear effect in
+ *     `workspace.$workspaceId.tsx`: on mobile the menu lives on a separate
+ *     route from the workspace, so clearing the store on unmount would leave
+ *     the menu unable to highlight the workspace the user just came from.
+ *
+ * A real git repo backs the project so it reconciles to kind "git" and its
+ * branch renders as a WorkspaceCard (whose `data-active` attribute is the
+ * observable active marker) — fake paths reconcile to "plain" and render only
+ * a flat header. Real production binary, no tRPC mocks, page objects only.
+ */
+
+import { execFileSync } from "node:child_process";
+import { mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { expect, test } from "@playwright/test";
+import { toWorkspaceId } from "@/dashboard";
+import {
+  cleanupTmpHome,
+  createTmpHome,
+  type ServerHandle,
+  seedSettings,
+  seedState,
+  startServer,
+} from "./helpers/server";
+import { WorkspacePage } from "./pages/WorkspacePage";
+import { WorkspacePicker } from "./pages/WorkspacePicker";
+
+const TOKEN = "e2e-workspace-switcher-mobile-token";
+const PROJECT = "switcher-mobile-repo";
+const DEFAULT_BRANCH = "main";
+
+const WORKSPACE = toWorkspaceId(PROJECT, DEFAULT_BRANCH);
+
+// Narrow viewport — `useIsDesktop()` reports false (threshold 1024 px), so the
+// mobile branch of `workspace.$workspaceId.tsx` mounts (header title button +
+// back button) and the `/` route renders the full-screen DashboardShell menu.
+test.use({ viewport: { width: 800, height: 900 } });
+
+function makeGitEnv(home: string): NodeJS.ProcessEnv {
+  return {
+    PATH: process.env.PATH,
+    HOME: home,
+    GIT_AUTHOR_NAME: "Test",
+    GIT_AUTHOR_EMAIL: "test@test.com",
+    GIT_COMMITTER_NAME: "Test",
+    GIT_COMMITTER_EMAIL: "test@test.com",
+    GIT_CONFIG_GLOBAL: "/dev/null",
+    GIT_CONFIG_SYSTEM: "/dev/null",
+  };
+}
+
+function git(cwd: string, args: string[], home: string): void {
+  execFileSync("git", args, { cwd, env: makeGitEnv(home) });
+}
+
+let server: ServerHandle;
+let tmpHome: string;
+
+test.beforeAll(async () => {
+  tmpHome = createTmpHome();
+
+  const repoPath = join(tmpHome, PROJECT);
+  mkdirSync(repoPath, { recursive: true });
+  git(repoPath, ["init", "-b", DEFAULT_BRANCH], tmpHome);
+  writeFileSync(join(repoPath, "README.md"), "# Switcher mobile test\n");
+  git(repoPath, ["add", "."], tmpHome);
+  git(repoPath, ["commit", "-m", "init"], tmpHome);
+
+  seedState(tmpHome, {
+    projects: [
+      {
+        name: PROJECT,
+        path: repoPath,
+        defaultBranch: DEFAULT_BRANCH,
+        worktrees: [{ branch: DEFAULT_BRANCH, path: repoPath }],
+      },
+    ],
+  });
+  seedSettings(tmpHome, { tokenSecret: TOKEN });
+  server = await startServer({ tmpHome });
+});
+
+test.afterAll(async () => {
+  await server.close();
+  cleanupTmpHome(tmpHome);
+});
+
+test.describe("Mobile workspace switcher", () => {
+  test("the header title opens the picker, which can be dismissed without selecting", async ({
+    page,
+  }) => {
+    const workspacePage = new WorkspacePage(page, server.url, TOKEN);
+    const picker = new WorkspacePicker(page);
+
+    await workspacePage.goto(WORKSPACE);
+    await workspacePage.waitForMobileReady();
+
+    await workspacePage.openSwitcherFromHeader();
+    await picker.waitVisible();
+
+    await picker.dismiss();
+
+    // Positive anchor: dialog gone, and we're still on the same workspace
+    // (the mobile layout is interactive again) — dismissing did not navigate.
+    await expect(picker.dialog).toBeHidden();
+    await workspacePage.waitForMobileReady();
+    await expect(page).toHaveURL(new RegExp(WORKSPACE));
+  });
+
+  test("the workspace stays active after returning to the project-list menu", async ({ page }) => {
+    const workspacePage = new WorkspacePage(page, server.url, TOKEN);
+
+    await workspacePage.goto(WORKSPACE);
+    await workspacePage.waitForMobileReady();
+
+    await workspacePage.goBackToProjectList();
+
+    // On the menu route, the workspace we came from is still marked active
+    // (data-active) — the store retained `activeWorkspaceId` across the
+    // route change. Asserting on the active-scoped locator proves both that
+    // the card rendered and that it carries the active marker.
+    await expect(workspacePage.activeWorkspaceCard(WORKSPACE)).toBeVisible();
+  });
+});

--- a/apps/web/e2e/workspace-switcher-mobile.spec.ts
+++ b/apps/web/e2e/workspace-switcher-mobile.spec.ts
@@ -112,11 +112,13 @@ test.describe("Mobile workspace switcher", () => {
 
     await picker.dismiss();
 
-    // Positive anchor: dialog gone, and we're still on the same workspace
-    // (the mobile layout is interactive again) — dismissing did not navigate.
-    await expect(picker.dialog).toBeHidden();
+    // Establish the positive anchor first: the mobile layout is interactive
+    // again and we're still on the same workspace (dismissing did not
+    // navigate). Only then assert the dialog is gone, so the negative
+    // assertion has live state to anchor against.
     await workspacePage.waitForMobileReady();
     await expect(page).toHaveURL(new RegExp(WORKSPACE));
+    await expect(picker.dialog).toBeHidden();
   });
 
   test("the workspace stays active after returning to the project-list menu", async ({ page }) => {

--- a/apps/web/src/components/TerminalPanel.tsx
+++ b/apps/web/src/components/TerminalPanel.tsx
@@ -686,7 +686,10 @@ export function TerminalPanel({
       const scheduleReconnect = () => {
         if (intentionalClose || reconnectTimer !== null) return;
         const delay = Math.min(RECONNECT_BASE_MS * 2 ** reconnectAttempts, RECONNECT_MAX_MS);
-        reconnectAttempts += 1;
+        // Stop growing the exponent once the backoff is pinned at the ceiling —
+        // otherwise 2 ** reconnectAttempts overflows to Infinity after ~1023
+        // consecutive drops.
+        if (delay < RECONNECT_MAX_MS) reconnectAttempts += 1;
         reconnectTimer = setTimeout(() => {
           reconnectTimer = null;
           connect();
@@ -758,6 +761,11 @@ export function TerminalPanel({
         };
 
         ws.onclose = () => {
+          // Discard events from a socket that's already been replaced —
+          // `handleResume` can call `connect()` while a previous socket is
+          // still CONNECTING, and that orphan's late `onclose` would otherwise
+          // schedule a second, overlapping reconnect.
+          if (wsRef.current !== ws) return;
           stopHeartbeat();
           if (intentionalClose) return;
           // Transient drop — tell the user we're retrying. The message is

--- a/apps/web/src/components/TerminalPanel.tsx
+++ b/apps/web/src/components/TerminalPanel.tsx
@@ -623,66 +623,176 @@ export function TerminalPanel({
       containerEl.addEventListener("touchend", onTapEnd, { passive: true });
       containerEl.addEventListener("touchcancel", onTapCancel, { passive: true });
 
-      // Connect WebSocket
+      // Connect WebSocket — with auto-reconnect + heartbeat so the terminal
+      // survives machine sleep, network drops, and tab-backgrounding. The
+      // server keeps the PTY alive across socket drops and replays scrollback
+      // on reconnect (see apps/web/src/server/api/terminals/ws.ts), so the
+      // client only has to notice the drop and re-open the socket.
       const proto = location.protocol === "https:" ? "wss:" : "ws:";
-      const ws = new WebSocket(
-        `${proto}//${location.host}/terminal?workspaceId=${encodeURIComponent(workspaceId)}&terminalId=${encodeURIComponent(terminalId)}`,
-      );
-      wsRef.current = ws;
+      const wsUrl = `${proto}//${location.host}/terminal?workspaceId=${encodeURIComponent(workspaceId)}&terminalId=${encodeURIComponent(terminalId)}`;
 
-      // Binary frames = PTY data, text frames = JSON control messages (e.g. title updates)
-      ws.binaryType = "arraybuffer";
+      // Heartbeat: the browser WebSocket API can neither send protocol-level
+      // pings nor observe protocol-level pongs, so after sleep a dead socket
+      // can sit in `readyState === OPEN` indefinitely without ever firing
+      // `onclose`. We run an application-level ping/pong instead: ping every
+      // HEARTBEAT_INTERVAL_MS, and if no pong arrives within
+      // HEARTBEAT_TIMEOUT_MS treat the socket as dead and force it closed
+      // (which triggers the reconnect path). On wake the suspended interval
+      // fires immediately and sees a stale `lastPongAt`, so the zombie socket
+      // is caught at once rather than only when the user next types.
+      const HEARTBEAT_INTERVAL_MS = 10_000;
+      const HEARTBEAT_TIMEOUT_MS = 20_000;
+      const RECONNECT_BASE_MS = 500;
+      const RECONNECT_MAX_MS = 10_000;
 
-      ws.onopen = () => {
-        // Send init message with pane metadata (command, cwd, env) if available.
-        // The server uses this to configure the PTY on first spawn.
-        if (paneMetadata && (paneMetadata.command || paneMetadata.cwd || paneMetadata.env)) {
-          const initMsg: Record<string, unknown> = { type: "init" };
-          if (paneMetadata.command) initMsg.command = paneMetadata.command;
-          if (paneMetadata.cwd) initMsg.cwd = paneMetadata.cwd;
-          if (paneMetadata.env) initMsg.env = paneMetadata.env;
-          ws.send(JSON.stringify(initMsg));
+      let intentionalClose = false;
+      let didConnectOnce = false;
+      let reconnectAttempts = 0;
+      let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+      let heartbeatTimer: ReturnType<typeof setInterval> | null = null;
+      let lastPongAt = 0;
+
+      const clearReconnectTimer = () => {
+        if (reconnectTimer !== null) {
+          clearTimeout(reconnectTimer);
+          reconnectTimer = null;
         }
-
-        fitAddon.fit();
-        ws.send(
-          JSON.stringify({
-            type: "resize",
-            cols: terminal.cols,
-            rows: terminal.rows,
-          }),
-        );
-
-        // Auto-focus this terminal if requested
-        if (autoFocus) {
-          terminal.focus();
+      };
+      const stopHeartbeat = () => {
+        if (heartbeatTimer !== null) {
+          clearInterval(heartbeatTimer);
+          heartbeatTimer = null;
         }
       };
 
-      ws.onmessage = (event) => {
-        if (event.data instanceof ArrayBuffer) {
-          // Binary frame = raw PTY output
-          terminal.write(new Uint8Array(event.data));
-        } else {
-          // Text frame = JSON control message
-          try {
-            const msg = JSON.parse(event.data as string);
-            if (msg.type === "title" && typeof msg.title === "string") {
-              onTitleChangeRef.current?.(msg.title);
-            }
-          } catch {
-            // Not valid JSON — write as-is (shouldn't happen)
-            terminal.write(event.data);
+      // Probe the live socket: drop it if a pong is overdue, otherwise ping.
+      // Shared by the heartbeat interval and the resume handler.
+      const probeConnection = () => {
+        const ws = wsRef.current;
+        if (!ws || ws.readyState !== WebSocket.OPEN) return;
+        if (Date.now() - lastPongAt > HEARTBEAT_TIMEOUT_MS) {
+          // No pong within the timeout window — the socket is a zombie.
+          // Closing it fires `onclose`, which schedules a reconnect.
+          ws.close();
+          return;
+        }
+        try {
+          ws.send(JSON.stringify({ type: "ping" }));
+        } catch {
+          ws.close();
+        }
+      };
+
+      const scheduleReconnect = () => {
+        if (intentionalClose || reconnectTimer !== null) return;
+        const delay = Math.min(RECONNECT_BASE_MS * 2 ** reconnectAttempts, RECONNECT_MAX_MS);
+        reconnectAttempts += 1;
+        reconnectTimer = setTimeout(() => {
+          reconnectTimer = null;
+          connect();
+        }, delay);
+      };
+
+      function connect() {
+        if (intentionalClose) return;
+        clearReconnectTimer();
+        const isReconnect = didConnectOnce;
+        const ws = new WebSocket(wsUrl);
+        wsRef.current = ws;
+        // Binary frames = PTY data, text frames = JSON control messages.
+        ws.binaryType = "arraybuffer";
+
+        ws.onopen = () => {
+          reconnectAttempts = 0;
+          lastPongAt = Date.now();
+
+          // On reconnect the server replays the full buffered scrollback, so
+          // wipe the local buffer first to avoid duplicating everything the
+          // user already sees. (On the first connect there's nothing to clear.)
+          if (isReconnect) terminal.reset();
+
+          // Send the init message only on the very first connect — the server
+          // spawns the PTY once and ignores `init` for an existing session.
+          if (
+            !didConnectOnce &&
+            paneMetadata &&
+            (paneMetadata.command || paneMetadata.cwd || paneMetadata.env)
+          ) {
+            const initMsg: Record<string, unknown> = { type: "init" };
+            if (paneMetadata.command) initMsg.command = paneMetadata.command;
+            if (paneMetadata.cwd) initMsg.cwd = paneMetadata.cwd;
+            if (paneMetadata.env) initMsg.env = paneMetadata.env;
+            ws.send(JSON.stringify(initMsg));
           }
+          didConnectOnce = true;
+
+          fitAddon.fit();
+          ws.send(JSON.stringify({ type: "resize", cols: terminal.cols, rows: terminal.rows }));
+
+          // Auto-focus only on the initial open — stealing focus on every
+          // background reconnect would be hostile.
+          if (autoFocus && !isReconnect) terminal.focus();
+
+          stopHeartbeat();
+          heartbeatTimer = setInterval(probeConnection, HEARTBEAT_INTERVAL_MS);
+        };
+
+        ws.onmessage = (event) => {
+          if (event.data instanceof ArrayBuffer) {
+            // Binary frame = raw PTY output
+            terminal.write(new Uint8Array(event.data));
+          } else {
+            // Text frame = JSON control message
+            try {
+              const msg = JSON.parse(event.data as string);
+              if (msg.type === "pong") {
+                lastPongAt = Date.now();
+              } else if (msg.type === "title" && typeof msg.title === "string") {
+                onTitleChangeRef.current?.(msg.title);
+              }
+            } catch {
+              // Not valid JSON — write as-is (shouldn't happen)
+              terminal.write(event.data);
+            }
+          }
+        };
+
+        ws.onclose = () => {
+          stopHeartbeat();
+          if (intentionalClose) return;
+          // Transient drop — tell the user we're retrying. The message is
+          // wiped by `terminal.reset()` once the reconnect lands.
+          terminal.write("\r\n\x1b[90m[Reconnecting…]\x1b[0m\r\n");
+          scheduleReconnect();
+        };
+      }
+
+      // Re-establish the connection immediately when the machine wakes, the
+      // network returns, or the tab is refocused, rather than waiting for the
+      // next heartbeat tick. If the socket is already gone we reconnect now;
+      // if it merely looks alive we probe it so a zombie is caught fast.
+      const handleResume = () => {
+        if (intentionalClose) return;
+        const ws = wsRef.current;
+        if (!ws || ws.readyState === WebSocket.CLOSED || ws.readyState === WebSocket.CLOSING) {
+          reconnectAttempts = 0;
+          clearReconnectTimer();
+          connect();
+        } else if (ws.readyState === WebSocket.OPEN) {
+          probeConnection();
         }
       };
-
-      ws.onclose = () => {
-        terminal.write("\r\n\x1b[90m[Terminal disconnected]\x1b[0m\r\n");
+      const handleVisibility = () => {
+        if (!document.hidden) handleResume();
       };
+      window.addEventListener("online", handleResume);
+      document.addEventListener("visibilitychange", handleVisibility);
+
+      connect();
 
       terminal.onData((data) => {
-        if (ws.readyState === WebSocket.OPEN) {
+        const ws = wsRef.current;
+        if (ws && ws.readyState === WebSocket.OPEN) {
           ws.send(data);
         }
       });
@@ -741,7 +851,8 @@ export function TerminalPanel({
       // defers that work, this assumption would need to move to a
       // post-fit `onResize` listener instead.
       const sendPtyResize = () => {
-        if (ws.readyState !== WebSocket.OPEN) return;
+        const ws = wsRef.current;
+        if (!ws || ws.readyState !== WebSocket.OPEN) return;
         if (terminal.cols <= 0 || terminal.rows <= 0) return;
         ws.send(
           JSON.stringify({
@@ -874,6 +985,13 @@ export function TerminalPanel({
       bindDprListener();
 
       cleanup = () => {
+        // Mark the close intentional so neither the heartbeat nor `onclose`
+        // tries to reconnect during teardown.
+        intentionalClose = true;
+        clearReconnectTimer();
+        stopHeartbeat();
+        window.removeEventListener("online", handleResume);
+        document.removeEventListener("visibilitychange", handleVisibility);
         themeObserver.disconnect();
         resizeObserver.disconnect();
         searchResultsDisposable.dispose();
@@ -894,7 +1012,7 @@ export function TerminalPanel({
         containerEl.removeEventListener("touchstart", onTapStart);
         containerEl.removeEventListener("touchend", onTapEnd);
         containerEl.removeEventListener("touchcancel", onTapCancel);
-        ws.close();
+        wsRef.current?.close();
         // `terminal.dispose()` cascades to all loaded addons (including the
         // WebGL addon if present), so we don't need to dispose it manually.
         terminal.dispose();

--- a/apps/web/src/components/TerminalToolbar.tsx
+++ b/apps/web/src/components/TerminalToolbar.tsx
@@ -27,7 +27,7 @@ import type { ArrowDirection } from "../lib/terminal-selection";
  *   (long-press, or Select All which delegates to the parent's
  *   `onSelectAll` callback to flip into selection mode immediately).
  *
- * - **Selecting** (`selectionMode === true`): Copy · Done · ← → ↑ ↓ (arrows
+ * - **Selecting** (`selectionMode === true`): Copy · Done · ← ↑ ↓ → (arrows
  *   extend the highlighted selection one cell at a time; the parent owns the
  *   anchor/head state and updates xterm via `terminal.select()`).
  *

--- a/apps/web/src/components/TerminalToolbar.tsx
+++ b/apps/web/src/components/TerminalToolbar.tsx
@@ -6,6 +6,7 @@ import {
   ArrowUp,
   ClipboardCopy,
   ClipboardPaste,
+  CornerDownLeft,
   TextCursorInput,
   X,
 } from "lucide-react";
@@ -73,6 +74,7 @@ export interface TerminalToolbarProps {
 // keys on a desktop browser — sending them as raw input mirrors that path.
 const SEQ_ESC = "\x1b";
 const SEQ_TAB = "\t";
+const SEQ_ENTER = "\r";
 const SEQ_ARROW_UP = "\x1b[A";
 const SEQ_ARROW_DOWN = "\x1b[B";
 const SEQ_ARROW_RIGHT = "\x1b[C";
@@ -178,110 +180,131 @@ export function TerminalToolbar({
       style={{ bottom: bottomOffset }}
       className="fixed inset-x-0 z-50 flex justify-center border-t border-border bg-background/95 shadow-lg backdrop-blur-md"
     >
-      <div className="flex w-full max-w-3xl items-center gap-1 overflow-x-auto px-2 py-1.5">
-        {selectionMode ? (
-          <>
-            <ToolbarButton
-              ariaLabel="Copy selection and exit"
-              title="Copy"
-              onPointerDown={tap(handleCopyAndExit)}
-              variant="primary"
-            >
-              <ClipboardCopy className="size-4" />
-              <span className="text-xs">Copy</span>
-            </ToolbarButton>
-            <ToolbarButton
-              ariaLabel="Exit selection mode"
-              title="Done"
-              onPointerDown={tap(onExitSelection)}
-            >
-              <X className="size-4" />
-              <span className="text-xs">Done</span>
-            </ToolbarButton>
-
-            <div className="mx-1 h-6 w-px shrink-0 bg-border" aria-hidden="true" />
-
-            <span
-              className="mr-1 shrink-0 select-none text-xs font-medium uppercase tracking-wide text-muted-foreground"
-              aria-hidden="true"
-            >
-              Extend
-            </span>
-
-            {selectionArrows.map(({ Icon, dir, ariaLabel }) => (
+      <div className="flex w-full max-w-3xl items-center gap-1 px-2 py-1.5">
+        {/* Scrolling key row. Enter is pulled out of this container (below) so
+         *  it stays pinned to the right edge while the rest of the keys scroll
+         *  horizontally behind it — Enter is the highest-frequency key and must
+         *  never be scrolled off-screen on a narrow phone. */}
+        <div className="flex min-w-0 flex-1 items-center gap-1 overflow-x-auto">
+          {selectionMode ? (
+            <>
               <ToolbarButton
-                key={dir}
-                ariaLabel={ariaLabel}
-                title={ariaLabel}
-                onPointerDown={tap(() => onExtendSelection(dir))}
+                ariaLabel="Copy selection and exit"
+                title="Copy"
+                onPointerDown={tap(handleCopyAndExit)}
+                variant="primary"
               >
-                <Icon className="size-4" />
+                <ClipboardCopy className="size-4" />
+                <span className="text-xs">Copy</span>
               </ToolbarButton>
-            ))}
-          </>
-        ) : (
-          <>
-            {/* No idle-mode Copy: there's no way to make a selection without
-             *  entering selection mode (long-press or Select All), so an
-             *  idle Copy button is always either disabled or stale (the
-             *  toolbar doesn't re-render on xterm selection changes). Copy
-             *  lives in the selection-mode layout where it's reachable
-             *  immediately after creating a selection. */}
-            <ToolbarButton
-              ariaLabel="Paste from clipboard"
-              title="Paste"
-              onPointerDown={tap(handlePaste)}
-            >
-              <ClipboardPaste className="size-4" />
-              <span className="text-xs">Paste</span>
-            </ToolbarButton>
-            <ToolbarButton
-              ariaLabel="Select all"
-              title="Select all"
-              // Delegates to the parent so the highlight is paired with a
-              // mode flip into selection-mode — otherwise the user would
-              // see a selection but have no UI to copy it.
-              onPointerDown={tap(onSelectAll)}
-            >
-              <TextCursorInput className="size-4" />
-              <span className="text-xs">All</span>
-            </ToolbarButton>
-
-            <div className="mx-1 h-6 w-px shrink-0 bg-border" aria-hidden="true" />
-
-            {idleKeyButtons.map(({ label, seq, ariaLabel }) => (
               <ToolbarButton
-                key={label}
-                ariaLabel={ariaLabel}
-                title={label}
-                onPointerDown={tap(() => sendInput(seq))}
+                ariaLabel="Exit selection mode"
+                title="Done"
+                onPointerDown={tap(onExitSelection)}
               >
-                <span className="text-xs font-medium">{label}</span>
+                <X className="size-4" />
+                <span className="text-xs">Done</span>
               </ToolbarButton>
-            ))}
-            <ToolbarButton
-              ariaLabel={pendingCtrl ? "Cancel pending Ctrl" : "Arm Ctrl modifier"}
-              title="Ctrl (sticky — taps the next key as Ctrl+key)"
-              onPointerDown={tap(onToggleCtrl)}
-              active={pendingCtrl}
-            >
-              <span className="text-xs font-medium">Ctrl</span>
-            </ToolbarButton>
 
-            <div className="mx-1 h-6 w-px shrink-0 bg-border" aria-hidden="true" />
+              <div className="mx-1 h-6 w-px shrink-0 bg-border" aria-hidden="true" />
 
-            {idleArrows.map(({ Icon, seq, ariaLabel }) => (
+              <span
+                className="mr-1 shrink-0 select-none text-xs font-medium uppercase tracking-wide text-muted-foreground"
+                aria-hidden="true"
+              >
+                Extend
+              </span>
+
+              {selectionArrows.map(({ Icon, dir, ariaLabel }) => (
+                <ToolbarButton
+                  key={dir}
+                  ariaLabel={ariaLabel}
+                  title={ariaLabel}
+                  onPointerDown={tap(() => onExtendSelection(dir))}
+                >
+                  <Icon className="size-4" />
+                </ToolbarButton>
+              ))}
+            </>
+          ) : (
+            <>
+              {/* No idle-mode Copy: there's no way to make a selection without
+               *  entering selection mode (long-press or Select All), so an
+               *  idle Copy button is always either disabled or stale (the
+               *  toolbar doesn't re-render on xterm selection changes). Copy
+               *  lives in the selection-mode layout where it's reachable
+               *  immediately after creating a selection. */}
               <ToolbarButton
-                key={ariaLabel}
-                ariaLabel={ariaLabel}
-                title={ariaLabel}
-                onPointerDown={tap(() => sendInput(seq))}
+                ariaLabel="Paste from clipboard"
+                title="Paste"
+                onPointerDown={tap(handlePaste)}
               >
-                <Icon className="size-4" />
+                <ClipboardPaste className="size-4" />
+                <span className="text-xs">Paste</span>
               </ToolbarButton>
-            ))}
-          </>
-        )}
+              <ToolbarButton
+                ariaLabel="Select all"
+                title="Select all"
+                // Delegates to the parent so the highlight is paired with a
+                // mode flip into selection-mode — otherwise the user would
+                // see a selection but have no UI to copy it.
+                onPointerDown={tap(onSelectAll)}
+              >
+                <TextCursorInput className="size-4" />
+                <span className="text-xs">All</span>
+              </ToolbarButton>
+
+              <div className="mx-1 h-6 w-px shrink-0 bg-border" aria-hidden="true" />
+
+              {idleKeyButtons.map(({ label, seq, ariaLabel }) => (
+                <ToolbarButton
+                  key={label}
+                  ariaLabel={ariaLabel}
+                  title={label}
+                  onPointerDown={tap(() => sendInput(seq))}
+                >
+                  <span className="text-xs font-medium">{label}</span>
+                </ToolbarButton>
+              ))}
+              <ToolbarButton
+                ariaLabel={pendingCtrl ? "Cancel pending Ctrl" : "Arm Ctrl modifier"}
+                title="Ctrl (sticky — taps the next key as Ctrl+key)"
+                onPointerDown={tap(onToggleCtrl)}
+                active={pendingCtrl}
+              >
+                <span className="text-xs font-medium">Ctrl</span>
+              </ToolbarButton>
+
+              <div className="mx-1 h-6 w-px shrink-0 bg-border" aria-hidden="true" />
+
+              {idleArrows.map(({ Icon, seq, ariaLabel }) => (
+                <ToolbarButton
+                  key={ariaLabel}
+                  ariaLabel={ariaLabel}
+                  title={ariaLabel}
+                  onPointerDown={tap(() => sendInput(seq))}
+                >
+                  <Icon className="size-4" />
+                </ToolbarButton>
+              ))}
+            </>
+          )}
+        </div>
+
+        {/* Enter — pinned to the right edge, outside the scroll container, so
+         *  it's always reachable. Tinted like a CTA since it's the primary
+         *  action. Sends a carriage return (\r), the same byte a hardware
+         *  Return key produces. */}
+        <div className="h-6 w-px shrink-0 bg-border" aria-hidden="true" />
+        <ToolbarButton
+          ariaLabel="Send Enter"
+          title="Enter"
+          onPointerDown={tap(() => sendInput(SEQ_ENTER))}
+          variant="primary"
+        >
+          <CornerDownLeft className="size-4" />
+          <span className="text-xs">Enter</span>
+        </ToolbarButton>
       </div>
     </div>
   );

--- a/apps/web/src/components/TerminalToolbar.tsx
+++ b/apps/web/src/components/TerminalToolbar.tsx
@@ -7,6 +7,7 @@ import {
   ClipboardCopy,
   ClipboardPaste,
   CornerDownLeft,
+  Slash,
   TextCursorInput,
   X,
 } from "lucide-react";
@@ -20,7 +21,7 @@ import type { ArrowDirection } from "../lib/terminal-selection";
  * terminal panel. Has two layouts that swap based on `selectionMode`:
  *
  * - **Idle** (`selectionMode === false`): Paste · Select All · Esc · Tab ·
- *   Ctrl · ← → ↑ ↓ (arrows send ANSI escape sequences to the PTY,
+ *   Slash · Ctrl · ← ↑ ↓ → (arrows send ANSI escape sequences to the PTY,
  *   identical to a hardware arrow press). No Copy in idle mode — there's
  *   no way to make a selection from idle without entering selection mode
  *   (long-press, or Select All which delegates to the parent's
@@ -75,6 +76,10 @@ export interface TerminalToolbarProps {
 const SEQ_ESC = "\x1b";
 const SEQ_TAB = "\t";
 const SEQ_ENTER = "\r";
+// Plain "/" — a literal keystroke, not an escape. Lives on the toolbar so the
+// agent slash-command menu is one tap away on a phone (the iOS soft keyboard
+// buries "/" behind the number/symbol layer).
+const SEQ_SLASH = "/";
 const SEQ_ARROW_UP = "\x1b[A";
 const SEQ_ARROW_DOWN = "\x1b[B";
 const SEQ_ARROW_RIGHT = "\x1b[C";
@@ -141,16 +146,15 @@ export function TerminalToolbar({
     [],
   );
 
-  // Arrow order matches the PR description and the visual convention on
-  // physical iOS keyboards: horizontal pair first (← →), then vertical
-  // pair (↑ ↓). Earlier the order was ← ↓ ↑ → which contradicted the
-  // documented layout (PR #413 review).
+  // Arrow order: ← ↑ ↓ →. Horizontal extremes bookend the vertical pair so a
+  // thumb can rock left/right at the edges and nudge up/down in the middle —
+  // the layout requested for the mobile toolbar.
   const idleArrows = useMemo(
     () => [
       { Icon: ArrowLeft, seq: SEQ_ARROW_LEFT, ariaLabel: "Arrow Left" },
-      { Icon: ArrowRight, seq: SEQ_ARROW_RIGHT, ariaLabel: "Arrow Right" },
       { Icon: ArrowUp, seq: SEQ_ARROW_UP, ariaLabel: "Arrow Up" },
       { Icon: ArrowDown, seq: SEQ_ARROW_DOWN, ariaLabel: "Arrow Down" },
+      { Icon: ArrowRight, seq: SEQ_ARROW_RIGHT, ariaLabel: "Arrow Right" },
     ],
     [],
   );
@@ -159,9 +163,9 @@ export function TerminalToolbar({
     () =>
       [
         { Icon: ArrowLeft, dir: "left", ariaLabel: "Extend selection left" },
-        { Icon: ArrowRight, dir: "right", ariaLabel: "Extend selection right" },
         { Icon: ArrowUp, dir: "up", ariaLabel: "Extend selection up" },
         { Icon: ArrowDown, dir: "down", ariaLabel: "Extend selection down" },
+        { Icon: ArrowRight, dir: "right", ariaLabel: "Extend selection right" },
       ] as const,
     [],
   );
@@ -266,6 +270,14 @@ export function TerminalToolbar({
                   <span className="text-xs font-medium">{label}</span>
                 </ToolbarButton>
               ))}
+              {/* Slash — one-tap entry into an agent's slash-command menu. */}
+              <ToolbarButton
+                ariaLabel="Send slash"
+                title="Slash command"
+                onPointerDown={tap(() => sendInput(SEQ_SLASH))}
+              >
+                <Slash className="size-4" />
+              </ToolbarButton>
               <ToolbarButton
                 ariaLabel={pendingCtrl ? "Cancel pending Ctrl" : "Arm Ctrl modifier"}
                 title="Ctrl (sticky — taps the next key as Ctrl+key)"
@@ -303,7 +315,6 @@ export function TerminalToolbar({
           variant="primary"
         >
           <CornerDownLeft className="size-4" />
-          <span className="text-xs">Enter</span>
         </ToolbarButton>
       </div>
     </div>

--- a/apps/web/src/dashboard/components/ProjectList.tsx
+++ b/apps/web/src/dashboard/components/ProjectList.tsx
@@ -176,9 +176,14 @@ function SortableProject({
   // the open workspace belonged to once scrolled away from its card — this
   // tints the header (and its folder icon) to close that gap.
   const activeWorkspaceId = useDashboardStore((s) => s.activeWorkspaceId);
-  const gitHeaderIsActive =
-    !isPlain &&
-    project.worktrees.some((wt) => toWorkspaceId(project.name, wt.branch) === activeWorkspaceId);
+  // Memoized: every Zustand update re-renders this row, and the `.some(...)`
+  // walk is O(worktrees) — recompute only when the inputs actually change.
+  const gitHeaderIsActive = useMemo(
+    () =>
+      !isPlain &&
+      project.worktrees.some((wt) => toWorkspaceId(project.name, wt.branch) === activeWorkspaceId),
+    [isPlain, project.worktrees, project.name, activeWorkspaceId],
+  );
 
   // Single onClick / onKeyDown for the plain-project header (mirrors the
   // navigate-or-open dance WorkspaceCard does). For git projects the

--- a/apps/web/src/dashboard/components/ProjectList.tsx
+++ b/apps/web/src/dashboard/components/ProjectList.tsx
@@ -170,6 +170,16 @@ function SortableProject({
   const plainAgent = isPlain ? statuses.get(plainWorkspaceId)?.agent : undefined;
   const plainIsFocused = isPlain && workspaceIndexStart === focusedIndex;
 
+  // For git projects: is the currently-active workspace one of this project's
+  // branches? Plain projects already surface this via `plainIsActive`. Git
+  // headers had no active treatment, so the user couldn't tell which project
+  // the open workspace belonged to once scrolled away from its card — this
+  // tints the header (and its folder icon) to close that gap.
+  const activeWorkspaceId = useDashboardStore((s) => s.activeWorkspaceId);
+  const gitHeaderIsActive =
+    !isPlain &&
+    project.worktrees.some((wt) => toWorkspaceId(project.name, wt.branch) === activeWorkspaceId);
+
   // Single onClick / onKeyDown for the plain-project header (mirrors the
   // navigate-or-open dance WorkspaceCard does). For git projects the
   // header onClick toggles collapse — branched at the call site.
@@ -192,11 +202,17 @@ function SortableProject({
   // (see the `<h2>` block below). `py-1.5` gives a taller hit target
   // than a workspace card (`py-1`) so the row reads as a project, not
   // a nested workspace.
+  // On touch devices (`pointer: coarse`) the row grows to a 44px-tall hit
+  // target (iOS HIG minimum) so projects are easy to tap in the list; with a
+  // mouse the row stays compact. `touch-pan-y` (not `touch-manipulation`) is
+  // kept because dnd-kit needs vertical panning to scroll the list mid-drag.
   const headerClassName = isPlain
-    ? `group flex items-center justify-between mb-0.5 pl-1 pr-1 py-1.5 min-w-0 overflow-hidden cursor-pointer select-none touch-pan-y transition-colors hover:bg-accent/50 ${
-        plainIsActive ? "bg-accent/50 border-l-2 border-l-primary" : ""
+    ? `group flex items-center justify-between mb-0.5 pl-1 pr-1 py-1.5 min-w-0 overflow-hidden cursor-pointer select-none touch-pan-y transition-colors hover:bg-accent/50 [@media(pointer:coarse)]:min-h-11 [@media(pointer:coarse)]:py-2.5 ${
+        plainIsActive ? "bg-primary/15 hover:bg-primary/15 border-l-2 border-l-primary" : ""
       } ${plainIsFocused ? "ring-2 ring-inset ring-ring" : ""}`
-    : "group flex items-center justify-between mb-0.5 pl-1 pr-0 select-none touch-pan-y";
+    : `group flex items-center justify-between mb-0.5 pl-1 pr-0 rounded select-none touch-pan-y transition-colors hover:bg-accent/50 [@media(pointer:coarse)]:min-h-11 ${
+        gitHeaderIsActive ? "bg-primary/15 hover:bg-primary/15 border-l-2 border-l-primary" : ""
+      }`;
 
   return (
     <div ref={setNodeRef} style={style} className="min-w-0 px-2">
@@ -237,9 +253,13 @@ function SortableProject({
                   <Folder className="size-4 shrink-0 text-muted-foreground" />
                 )
               ) : collapsed ? (
-                <Folder className="size-4 shrink-0 text-muted-foreground" />
+                <Folder
+                  className={`size-4 shrink-0 ${gitHeaderIsActive ? "text-primary" : "text-muted-foreground"}`}
+                />
               ) : (
-                <FolderOpen className="size-4 shrink-0 text-muted-foreground" />
+                <FolderOpen
+                  className={`size-4 shrink-0 ${gitHeaderIsActive ? "text-primary" : "text-muted-foreground"}`}
+                />
               )}
               <Tooltip>
                 <TooltipTrigger asChild>
@@ -249,8 +269,10 @@ function SortableProject({
                       bump to full-foreground for the same emphasis a
                       WorkspaceCard would get. */}
                   <h2
-                    className={`text-sm font-semibold truncate ${
-                      isPlain && plainIsActive ? "text-foreground" : "text-foreground/80"
+                    className={`text-sm truncate ${
+                      (isPlain && plainIsActive) || gitHeaderIsActive
+                        ? "font-bold text-foreground"
+                        : "font-semibold text-foreground/80"
                     }`}
                   >
                     {project.name}
@@ -358,7 +380,11 @@ function SortableProject({
       {/* Nested workspaces section — only meaningful for git projects.
           Plain projects are flat: the header above IS the workspace. */}
       {!isPlain && !collapsed && (
-        <div className="flex flex-col gap-0.5 overflow-hidden">
+        // `ml-3 border-l` draws a thin tree rail down the left of the branch
+        // list so the workspaces read as children of the project header above,
+        // not as sibling rows. The header sits at `pl-1`; the rail lands just
+        // under its folder icon so the hierarchy is obvious at a glance.
+        <div className="flex flex-col gap-0.5 overflow-hidden ml-3 border-l border-border/50">
           {project.worktrees.length === 0 ? (
             hasPinnedSiblings ? null : (
               <p className="text-sm text-muted-foreground px-4 py-2">No workspaces yet</p>
@@ -921,7 +947,14 @@ export function ProjectList({ labelFilter }: ProjectListProps) {
                     ))}
                   {!groupCollapsed &&
                     group.projects.map((project) => (
-                      <div key={project.name}>
+                      // Thin divider between consecutive projects in a label
+                      // group (skipped on the first row, which sits flush under
+                      // the label header) so project blocks are visually
+                      // separated without a heavy border.
+                      <div
+                        key={project.name}
+                        className="border-border/40 pt-1 first:pt-0 not-first:border-t"
+                      >
                         <SortableProject
                           project={project}
                           statuses={statuses}

--- a/apps/web/src/dashboard/components/WorkspaceCard.tsx
+++ b/apps/web/src/dashboard/components/WorkspaceCard.tsx
@@ -165,7 +165,11 @@ export const WorkspaceCard = memo(function WorkspaceCard({
     }
   };
 
-  const className = `@container group flex flex-row items-center justify-between pl-3 pr-2 py-1 min-w-0 overflow-hidden cursor-pointer select-none transition-colors hover:bg-accent/50 ${isActive ? "bg-accent/50 border-l-2 border-l-primary" : ""} ${isFocused ? "ring-2 ring-inset ring-ring" : ""} ${href ? "no-underline text-inherit" : ""}`;
+  // `py-1` keeps the row compact with a mouse; on touch devices the
+  // `(pointer: coarse)` variant bumps it to a 44px-tall hit target (iOS HIG
+  // minimum) so the branch row is easy to tap in the list. `touch-manipulation`
+  // drops the 300ms double-tap delay so taps register immediately.
+  const className = `@container group flex flex-row items-center justify-between pl-3 pr-2 py-1 min-h-9 min-w-0 overflow-hidden cursor-pointer select-none touch-manipulation transition-colors hover:bg-accent/50 [@media(pointer:coarse)]:min-h-11 [@media(pointer:coarse)]:py-2 ${isActive ? "border-l-2 border-l-primary" : ""} ${isFocused ? "ring-2 ring-inset ring-ring" : ""} ${href ? "no-underline text-inherit" : ""}`;
 
   const containerProps = {
     ref: cardRef,
@@ -222,7 +226,7 @@ export const WorkspaceCard = memo(function WorkspaceCard({
               <div className="flex items-center gap-2 min-w-0 overflow-hidden">
                 <AgentStatusIndicator agent={status?.agent} isActive={isActive} />
                 <span
-                  className={`text-sm truncate ${isActive ? "font-semibold text-foreground" : "font-medium text-muted-foreground"}`}
+                  className={`text-sm truncate ${isActive ? "font-bold text-foreground" : "font-medium text-muted-foreground"}`}
                 >
                   {showProjectName ? `${projectName}/${worktree.branch}` : worktree.branch}
                 </span>

--- a/apps/web/src/dashboard/components/WorkspacePickerDialog.tsx
+++ b/apps/web/src/dashboard/components/WorkspacePickerDialog.tsx
@@ -116,6 +116,7 @@ export function WorkspacePickerDialog({ open, onOpenChange }: WorkspacePickerDia
         className="overflow-hidden border-0 bg-popover p-0 shadow-2xl sm:max-w-[520px]"
         overlayClassName="backdrop-blur-sm"
         showCloseButton={false}
+        data-testid="workspace-picker"
         // On touch devices, don't auto-focus the search input on open — that
         // would pop the soft keyboard over the list the user wants to tap. They
         // can tap the input to search. On desktop (fine pointer) keep the
@@ -140,6 +141,7 @@ export function WorkspacePickerDialog({ open, onOpenChange }: WorkspacePickerDia
                   key={entry.workspaceId}
                   value={`${entry.projectName} ${entry.branch}`}
                   onSelect={() => handleSelect(entry.workspaceId)}
+                  data-testid={`workspace-picker__item--${entry.workspaceId}`}
                   // Coarse pointers (touch) get a 44px-tall row (iOS HIG hit
                   // target) and `touch-manipulation` to drop the tap delay, so
                   // workspaces are easy to select by tap — mirroring the
@@ -160,6 +162,7 @@ export function WorkspacePickerDialog({ open, onOpenChange }: WorkspacePickerDia
                     <button
                       type="button"
                       aria-label={pinnedNow ? "Unpin workspace" : "Pin workspace"}
+                      data-testid={`workspace-picker__pin--${entry.workspaceId}`}
                       // Hover-reveal on fine pointers (mouse); always visible on
                       // coarse pointers (touch has no hover) and sized to a 36px
                       // tap target so it can be pinned/unpinned by tap.

--- a/apps/web/src/dashboard/components/WorkspacePickerDialog.tsx
+++ b/apps/web/src/dashboard/components/WorkspacePickerDialog.tsx
@@ -108,7 +108,22 @@ export function WorkspacePickerDialog({ open, onOpenChange }: WorkspacePickerDia
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="overflow-hidden p-0 sm:max-w-[520px]" showCloseButton={false}>
+      <DialogContent
+        // No border ("white frame") and the app's floating-surface colour
+        // (`bg-popover`, same as dropdowns / context menus) so the picker reads
+        // as part of the app rather than a stock modal. `shadow-2xl` + the
+        // blurred overlay give it depth without a hard edge.
+        className="overflow-hidden border-0 bg-popover p-0 shadow-2xl sm:max-w-[520px]"
+        overlayClassName="backdrop-blur-sm"
+        showCloseButton={false}
+        // On touch devices, don't auto-focus the search input on open — that
+        // would pop the soft keyboard over the list the user wants to tap. They
+        // can tap the input to search. On desktop (fine pointer) keep the
+        // default focus so type-to-filter works immediately.
+        onOpenAutoFocus={(e) => {
+          if (window.matchMedia("(pointer: coarse)").matches) e.preventDefault();
+        }}
+      >
         <DialogHeader className="sr-only">
           <DialogTitle>Switch Workspace</DialogTitle>
           <DialogDescription>Search workspaces by name, project, or branch</DialogDescription>
@@ -125,7 +140,11 @@ export function WorkspacePickerDialog({ open, onOpenChange }: WorkspacePickerDia
                   key={entry.workspaceId}
                   value={`${entry.projectName} ${entry.branch}`}
                   onSelect={() => handleSelect(entry.workspaceId)}
-                  className="group"
+                  // Coarse pointers (touch) get a 44px-tall row (iOS HIG hit
+                  // target) and `touch-manipulation` to drop the tap delay, so
+                  // workspaces are easy to select by tap — mirroring the
+                  // project-list rows.
+                  className="group touch-manipulation [@media(pointer:coarse)]:min-h-11 [@media(pointer:coarse)]:gap-3"
                 >
                   <AgentStatusIndicator agent={entry.agent} />
                   <span className="text-sm font-medium">
@@ -141,22 +160,20 @@ export function WorkspacePickerDialog({ open, onOpenChange }: WorkspacePickerDia
                     <button
                       type="button"
                       aria-label={pinnedNow ? "Unpin workspace" : "Pin workspace"}
-                      className="opacity-0 group-hover:opacity-100 focus:opacity-100 transition-opacity text-muted-foreground hover:text-foreground"
-                      // onMouseDown + preventDefault + stopPropagation keeps
-                      // cmdk's onSelect from firing on pointer activation
-                      // (which would navigate and close the dialog). Keyboard
-                      // activation (Tab to the button + Enter/Space) goes
-                      // through `click`, not `mousedown`, so we mirror the
-                      // toggle here and stop propagation so the focused
-                      // CommandItem doesn't also fire onSelect.
-                      onMouseDown={(e) => {
-                        e.preventDefault();
-                        e.stopPropagation();
-                        togglePinned(entry.projectName, entry.branch, pinnedNow);
-                      }}
+                      // Hover-reveal on fine pointers (mouse); always visible on
+                      // coarse pointers (touch has no hover) and sized to a 36px
+                      // tap target so it can be pinned/unpinned by tap.
+                      className="inline-flex size-7 shrink-0 items-center justify-center rounded-md opacity-0 transition-opacity text-muted-foreground hover:text-foreground group-hover:opacity-100 focus:opacity-100 [@media(pointer:coarse)]:size-9 [@media(pointer:coarse)]:opacity-100"
+                      // Pin/unpin is a distinct action — it must never select
+                      // the workspace. cmdk fires the row's onSelect from the
+                      // item's bubbled `onClick`, so we stopPropagation on every
+                      // event that could reach it: pointerdown/mousedown (touch
+                      // + mouse activation) and click (the actual select trigger
+                      // + keyboard Enter/Space). We toggle once, on click, so a
+                      // tap and a keyboard press behave identically.
+                      onPointerDown={(e) => e.stopPropagation()}
+                      onMouseDown={(e) => e.stopPropagation()}
                       onClick={(e) => {
-                        // Skip when the mousedown handler already toggled.
-                        if (e.detail !== 0) return;
                         e.preventDefault();
                         e.stopPropagation();
                         togglePinned(entry.projectName, entry.branch, pinnedNow);

--- a/apps/web/src/dashboard/lib/codemirror-setup.ts
+++ b/apps/web/src/dashboard/lib/codemirror-setup.ts
@@ -129,6 +129,10 @@ export async function loadLanguage(lang: string): Promise<LanguageSupport | null
         return import("@codemirror/legacy-modes/mode/clojure").then(
           ({ clojure }) => new LanguageSupport(StreamLanguage.define(clojure)),
         );
+      case "dart":
+        return import("@codemirror/legacy-modes/mode/clike").then(
+          ({ dart }) => new LanguageSupport(StreamLanguage.define(dart)),
+        );
       case "erlang":
         return import("@codemirror/legacy-modes/mode/erlang").then(
           ({ erlang }) => new LanguageSupport(StreamLanguage.define(erlang)),

--- a/apps/web/src/routes/workspace.$workspaceId.tsx
+++ b/apps/web/src/routes/workspace.$workspaceId.tsx
@@ -347,6 +347,7 @@ function MobileWorkspaceLayout({ workspaceId }: { workspaceId: string }) {
             <button
               type="button"
               onClick={handleBack}
+              aria-label="Back to project list"
               className="inline-flex size-7 shrink-0 items-center justify-center rounded-md hover:bg-accent"
             >
               <ArrowLeft className="size-4" />

--- a/apps/web/src/routes/workspace.$workspaceId.tsx
+++ b/apps/web/src/routes/workspace.$workspaceId.tsx
@@ -1,5 +1,5 @@
 import { createFileRoute, Navigate, useNavigate } from "@tanstack/react-router";
-import { ArrowLeft } from "lucide-react";
+import { ArrowLeft, ChevronsUpDown } from "lucide-react";
 import { lazy, Suspense, useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
 import {
   DiffView,
@@ -8,6 +8,7 @@ import {
   useDashboardStore,
   useDiffTarget,
   useSettingsQuery,
+  WorkspacePickerDialog,
   type WorkspaceTab,
   WorkspaceTabNav,
 } from "@/dashboard";
@@ -126,17 +127,18 @@ function WorkspaceLayout() {
     setHydrated(true);
   }, []);
 
-  // Sync zustand active workspace from URL.
-  // Two effects: one updates on param change, the other clears only on unmount.
-  // Combining them caused a brief null-then-set toggle on every workspace
-  // switch, which made sidebar cards flash inactive for one frame.
+  // Sync zustand active workspace from URL. We set on param change but never
+  // clear on unmount: on mobile the project-list "menu" lives on a *separate*
+  // route (`/`) from the workspace (`/workspace/$id`), so unmounting this route
+  // to show the menu would wipe `activeWorkspaceId` and leave the menu unable
+  // to bold the workspace the user just came from. Keeping the last-opened id
+  // lets the menu mark it active on every viewport. The title bar reads the
+  // active id from the pathname (`parseWorkspaceFromPath` in __root), not this
+  // store, so it still clears correctly when no workspace route is mounted.
   const setActiveWorkspace = useDashboardStore((s) => s.setActiveWorkspace);
   useEffect(() => {
     setActiveWorkspace(decoded);
   }, [decoded, setActiveWorkspace]);
-  useEffect(() => {
-    return () => setActiveWorkspace(null);
-  }, [setActiveWorkspace]);
 
   // Clear needs_attention status when viewing this workspace
   const clearNeedsAttention = useDashboardStore((s) => s.clearNeedsAttention);
@@ -235,6 +237,12 @@ function MobileWorkspaceLayout({ workspaceId }: { workspaceId: string }) {
       cancelled = true;
     };
   }, [workspaceId, chatKey]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Workspace switcher (recent / previous workspaces). Tapping the header
+  // title opens it so the user can jump to another worktree without first
+  // navigating back to the full project list — and can dismiss it (backdrop /
+  // Esc) to stay on the current workspace if they change their mind.
+  const [pickerOpen, setPickerOpen] = useState(false);
 
   // Quick Open state for file link clicks from chat
   const [quickOpenOpen, setQuickOpenOpen] = useState(false);
@@ -343,9 +351,19 @@ function MobileWorkspaceLayout({ workspaceId }: { workspaceId: string }) {
             >
               <ArrowLeft className="size-4" />
             </button>
-            <div className="min-w-0 flex-1">
-              <h1 className="truncate text-center text-sm font-semibold">{workspaceId}</h1>
-            </div>
+            {/* Tapping the title opens the workspace switcher — the fast path
+                to jump to a recent/previous worktree without going back to the
+                full project list. The chevron signals it's interactive. */}
+            <button
+              type="button"
+              onClick={() => setPickerOpen(true)}
+              aria-haspopup="dialog"
+              aria-label="Switch workspace"
+              className="inline-flex min-w-0 flex-1 items-center justify-center gap-1.5 rounded-md px-2 py-1 hover:bg-accent active:bg-accent"
+            >
+              <h1 className="truncate text-sm font-semibold">{workspaceId}</h1>
+              <ChevronsUpDown className="size-3.5 shrink-0 text-muted-foreground" />
+            </button>
             <div aria-hidden="true" className="size-7 shrink-0" />
           </header>
           <WorkspaceTabNav
@@ -391,6 +409,7 @@ function MobileWorkspaceLayout({ workspaceId }: { workspaceId: string }) {
             onOpenChange={setSearchFilesOpen}
             onOpenFile={handleOpenFile}
           />
+          <WorkspacePickerDialog open={pickerOpen} onOpenChange={setPickerOpen} />
         </div>
       </AgentSwitcherContext.Provider>
     </SessionListContext.Provider>

--- a/apps/web/src/server/api/terminals/ws.ts
+++ b/apps/web/src/server/api/terminals/ws.ts
@@ -63,7 +63,11 @@ function safeClose(ws: WebSocket, code: number, reason: string): void {
 }
 
 export async function handleTerminalConnection(ws: WebSocket, req: IncomingMessage): Promise<void> {
-  const url = new URL(req.url!, `http://${req.headers.host}`);
+  if (!req.url) {
+    safeClose(ws, 4000, "Missing request URL");
+    return;
+  }
+  const url = new URL(req.url, `http://${req.headers.host}`);
   const workspaceId = url.searchParams.get("workspaceId");
   const terminalId = url.searchParams.get("terminalId");
 
@@ -96,7 +100,13 @@ export async function handleTerminalConnection(ws: WebSocket, req: IncomingMessa
             command: typeof parsed.command === "string" ? parsed.command : undefined,
             cwd: typeof parsed.cwd === "string" ? parsed.cwd : undefined,
             env:
-              parsed.env && typeof parsed.env === "object" && !Array.isArray(parsed.env)
+              parsed.env &&
+              typeof parsed.env === "object" &&
+              !Array.isArray(parsed.env) &&
+              // A client could send non-string values (e.g. a number); the PTY
+              // spawn expects a string map, so reject the whole env field
+              // rather than silently passing a non-string through.
+              Object.values(parsed.env).every((v) => typeof v === "string")
                 ? (parsed.env as Record<string, string>)
                 : undefined,
           };

--- a/apps/web/src/server/api/terminals/ws.ts
+++ b/apps/web/src/server/api/terminals/ws.ts
@@ -20,6 +20,14 @@ const log = createLogger("terminal-ws");
 // rather than the truncated tail.
 const MAX_CLOSE_REASON_BYTES = 123;
 
+// Server-side protocol-ping cadence. Every interval we ping the client and
+// terminate the socket if the previous ping went unanswered — so a client
+// that slept or dropped off the network is reaped within one interval instead
+// of lingering with live listeners. The PTY is kept alive regardless (see the
+// close handler) so the client can reconnect. 30s is lenient enough not to
+// race a briefly-backgrounded tab whose timers are throttled.
+const HEARTBEAT_INTERVAL_MS = 30_000;
+
 function clampCloseReason(reason: string): string {
   const enc = new TextEncoder();
   const bytes = enc.encode(reason);
@@ -189,6 +197,28 @@ function attachSession(
     }
   });
 
+  // Protocol-level heartbeat: reap server sockets whose client vanished
+  // (machine slept, network dropped) so their listeners don't leak. The PTY
+  // is intentionally left alive — `ws.on("close")` keeps it — so the client
+  // can reconnect and resume. `ws.ping()` triggers a TCP-level pong from any
+  // live peer; if the previous ping went unanswered we terminate.
+  let isAlive = true;
+  ws.on("pong", () => {
+    isAlive = true;
+  });
+  const pingInterval = setInterval(() => {
+    if (!isAlive) {
+      ws.terminate();
+      return;
+    }
+    isAlive = false;
+    try {
+      ws.ping();
+    } catch {
+      // socket already closing — the close handler will clean up
+    }
+  }, HEARTBEAT_INTERVAL_MS);
+
   // WebSocket input -> PTY
   ws.on("message", (data: Buffer | string) => {
     handleMessage(ws, terminalId, session, data.toString());
@@ -197,6 +227,7 @@ function attachSession(
   // WebSocket close -> detach listeners but keep PTY alive
   ws.on("close", () => {
     clearInterval(processInterval);
+    clearInterval(pingInterval);
     dataDisposable.dispose();
     exitDisposable.dispose();
     log.debug("Terminal disconnected: %s (PTY kept alive)", terminalId);
@@ -216,6 +247,16 @@ function handleMessage(
   if (message.startsWith("{")) {
     try {
       const parsed = JSON.parse(message);
+      if (parsed.type === "ping") {
+        // Application-level heartbeat. The browser WebSocket API can't send
+        // or observe protocol-level ping/pong, so the client pings over the
+        // data channel and relies on this pong to detect a dead socket after
+        // sleep / network loss.
+        if (ws.readyState === ws.OPEN) {
+          ws.send(JSON.stringify({ type: "pong" }));
+        }
+        return;
+      }
       if (parsed.type === "resize" && parsed.cols && parsed.rows) {
         terminalService.resize(terminalId, parsed.cols, parsed.rows);
         return;

--- a/apps/web/tests/terminal-toolbar.test.ts
+++ b/apps/web/tests/terminal-toolbar.test.ts
@@ -458,6 +458,21 @@ describe("TerminalToolbar – special keys", () => {
     unmount(root, container);
   });
 
+  it("Enter button sends a carriage return (icon-only, always pinned right)", () => {
+    const sent: string[] = [];
+    const term = makeFakeTerminal();
+    const { container, root } = mount({ terminal: term, sendInput: (d) => sent.push(d) });
+    const enterBtn = container.querySelector(
+      "button[aria-label='Send Enter']",
+    ) as HTMLButtonElement;
+    expect(enterBtn).not.toBeNull();
+    act(() => {
+      dispatchPointerDown(enterBtn);
+    });
+    expect(sent).toEqual(["\r"]);
+    unmount(root, container);
+  });
+
   it("Ctrl button toggles a pending state via onToggleCtrl", () => {
     const onToggleCtrl = vi.fn();
     const term = makeFakeTerminal();

--- a/apps/web/tests/terminal-toolbar.test.ts
+++ b/apps/web/tests/terminal-toolbar.test.ts
@@ -532,6 +532,7 @@ describe("TerminalToolbar – selection mode", () => {
     expect(container.querySelector("button[aria-label='Arm Ctrl modifier']")).toBeNull();
     expect(container.querySelector("button[aria-label='Send Escape']")).toBeNull();
     expect(container.querySelector("button[aria-label='Send Tab']")).toBeNull();
+    expect(container.querySelector("button[aria-label='Send slash']")).toBeNull();
     // The four extend buttons + Copy + Done should be present.
     expect(container.querySelector("button[aria-label='Copy selection and exit']")).not.toBeNull();
     expect(container.querySelector("button[aria-label='Exit selection mode']")).not.toBeNull();

--- a/apps/web/tests/terminal-toolbar.test.ts
+++ b/apps/web/tests/terminal-toolbar.test.ts
@@ -443,6 +443,21 @@ describe("TerminalToolbar – special keys", () => {
     unmount(root, container);
   });
 
+  it("Slash button sends a literal '/' (one-tap agent slash-command entry)", () => {
+    const sent: string[] = [];
+    const term = makeFakeTerminal();
+    const { container, root } = mount({ terminal: term, sendInput: (d) => sent.push(d) });
+    const slashBtn = container.querySelector(
+      "button[aria-label='Send slash']",
+    ) as HTMLButtonElement;
+    expect(slashBtn).not.toBeNull();
+    act(() => {
+      dispatchPointerDown(slashBtn);
+    });
+    expect(sent).toEqual(["/"]);
+    unmount(root, container);
+  });
+
   it("Ctrl button toggles a pending state via onToggleCtrl", () => {
     const onToggleCtrl = vi.fn();
     const term = makeFakeTerminal();

--- a/apps/web/tests/terminal-ws.test.ts
+++ b/apps/web/tests/terminal-ws.test.ts
@@ -255,3 +255,84 @@ describe("terminal WebSocket — close-reason byte cap", () => {
     expect(healthRes.status).toBeLessThan(500);
   });
 });
+
+describe("terminal WebSocket — application-level ping/pong heartbeat", () => {
+  let server: ServerHandle;
+  let tmpHome: string;
+
+  beforeAll(async () => {
+    tmpHome = createTmpHome();
+    // A real, existing worktree directory so the PTY actually spawns — the
+    // ping/pong path only runs once a session is attached.
+    const projectPath = join(tmpHome, "workspace");
+    mkdirSync(projectPath, { recursive: true });
+    seedState(tmpHome, {
+      projects: [
+        {
+          name: "workspace",
+          path: projectPath,
+          defaultBranch: "main",
+          worktrees: [{ branch: "main", path: projectPath }],
+        },
+      ],
+    });
+    seedSettings(tmpHome, {
+      tokenSecret: DEFAULT_TOKEN,
+      worktreesDir: join(tmpHome, ".band", "worktrees"),
+    });
+    server = await startServer(tmpHome);
+  });
+
+  afterAll(async () => {
+    if (server) await server.close();
+    if (tmpHome) rmSync(tmpHome, { recursive: true, force: true });
+  });
+
+  it("responds with a {type:'pong'} frame to a client {type:'ping'}", async () => {
+    const workspaceId = "workspace-main";
+    const terminalId = "ping-pong-terminal";
+    const wsUrl = `ws://127.0.0.1:${server.port}/terminal?workspaceId=${workspaceId}&terminalId=${terminalId}`;
+
+    const ws = new WebSocket(wsUrl, {
+      headers: { Cookie: `band_token=${DEFAULT_TOKEN}` },
+    });
+
+    let gotPong = false;
+    let pinged = false;
+
+    await new Promise<void>((resolve, reject) => {
+      // Spawn the PTY. The `init` message is consumed by the handler's
+      // one-shot listener; the persistent `message` listener (which serves
+      // ping/pong) is only attached after the async spawn resolves, so we
+      // must wait for the first server frame before pinging — otherwise the
+      // ping races ahead of the listener and is dropped.
+      ws.on("open", () => {
+        ws.send(JSON.stringify({ type: "init" }));
+      });
+      ws.on("message", (data: Buffer, isBinary: boolean) => {
+        if (!pinged) {
+          // First frame (PTY scrollback / shell prompt) proves the session is
+          // attached and the message listener is live — now ping.
+          pinged = true;
+          ws.send(JSON.stringify({ type: "ping" }));
+          return;
+        }
+        if (isBinary) return; // further PTY output frames
+        try {
+          const parsed = JSON.parse(data.toString());
+          if (parsed.type === "pong") {
+            gotPong = true;
+            resolve();
+          }
+        } catch {
+          // ignore non-JSON frames
+        }
+      });
+      ws.on("error", reject);
+      setTimeout(() => reject(new Error("No pong received within 10 s")), 10_000);
+    });
+
+    expect(gotPong).toBe(true);
+    ws.close();
+  });
+});

--- a/packages/ui/src/components/dialog.tsx
+++ b/packages/ui/src/components/dialog.tsx
@@ -39,15 +39,18 @@ function DialogOverlay({
 
 function DialogContent({
   className,
+  overlayClassName,
   children,
   showCloseButton = true,
   ...props
 }: React.ComponentProps<typeof DialogPrimitive.Content> & {
   showCloseButton?: boolean;
+  /** Extra classes for the backdrop overlay (e.g. `backdrop-blur-sm`). */
+  overlayClassName?: string;
 }) {
   return (
     <DialogPortal data-slot="dialog-portal">
-      <DialogOverlay />
+      <DialogOverlay className={overlayClassName} />
       <DialogPrimitive.Content
         data-slot="dialog-content"
         className={cn(


### PR DESCRIPTION
## PO Summary

Band's mobile experience gets a round of accessibility and usability fixes for working from a phone:

- **Terminal Enter key** — the on-screen terminal key bar now has a dedicated **Enter** button pinned to the right so it's always reachable; the other keys scroll behind it.
- **Easier-to-tap project list** — projects and branches now have larger, finger-friendly tap areas on touch screens, a clearer parent/child layout (a guide line under each project), and thin separators between projects. The workspace you currently have open is shown in **bold** with a coloured accent, and its project is highlighted too — so you can always see where you are.
- **Quick workspace switching** — tap the workspace name at the top of a workspace on mobile to open a **switcher** listing your current, pinned, and recent workspaces. Jump straight to another one, or dismiss it to stay put — no more dead-ending in the full project list with no way back.
- **Switcher polish** — bigger tap targets, a pin button you can actually hit (and that no longer accidentally opens the workspace), no keyboard popping up the moment it opens, and a cleaner look that matches the rest of the app with a softly blurred background.

These changes are mobile-first but degrade cleanly to desktop, which keeps its existing compact look and behaviour.

## Testing

New Playwright integration tests (real server boot, page objects, no tRPC mocks) cover the two behaviours a reviewer flagged as user-observable but untested:

- **`workspace-picker.spec.ts`** — tapping a row's pin button toggles the pinned state **without** selecting the workspace (dialog stays open, URL unchanged); clicking the row body selects, navigates, and closes. Guards the regression where a pin tap bubbled through cmdk and navigated away.
- **`workspace-switcher-mobile.spec.ts`** — the mobile header title opens the switcher and dismisses without navigating; the workspace stays marked active after returning to the project-list menu route (guards the removed `activeWorkspaceId` unmount-clear).

Both were confirmed to fail on the pre-fix code and pass on the fix. Support added: a `WorkspacePicker` page-object, `data-testid` hooks on the picker rows/pin buttons, and an `aria-label` on the mobile back button.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
