### PR TITLE
fix(web): slugify workspace branch name to prevent invalid git worktree names

### DIFF
--- a/apps/web/src/dashboard/components/NewWorkspaceForm.tsx
+++ b/apps/web/src/dashboard/components/NewWorkspaceForm.tsx
@@ -11,7 +11,9 @@ import {
   Textarea,
 } from "@band-app/ui";
 import { useState } from "react";
+import { slugifyBranchName } from "../../lib/branch-name";
 import { useCreateWorkspace } from "../hooks/use-project-mutations";
+import { useProjects } from "../hooks/use-projects";
 
 interface Props {
   projectName: string;
@@ -24,13 +26,27 @@ export function NewWorkspaceDialog({ projectName, open, onOpenChange }: Props) {
   const [base, setBase] = useState("");
   const [prompt, setPrompt] = useState("");
   const createWorkspaceMutation = useCreateWorkspace();
+  const { projects } = useProjects();
+
+  const slug = slugifyBranchName(branch);
+
+  const slugError: string | null = (() => {
+    if (branch && !slug) return "Branch name contains no valid characters.";
+    if (slug) {
+      const project = projects.find((p) => p.name === projectName);
+      if (project?.worktrees.some((wt) => wt.branch === slug)) {
+        return `A workspace named "${slug}" already exists.`;
+      }
+    }
+    return null;
+  })();
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    if (!branch.trim()) return;
+    if (!slug || slugError) return;
     await createWorkspaceMutation.mutateAsync({
       project: projectName,
-      branch: branch.trim(),
+      branch: slug,
       base: base.trim() || undefined,
       prompt: prompt.trim() || undefined,
     });
@@ -60,6 +76,12 @@ export function NewWorkspaceDialog({ projectName, open, onOpenChange }: Props) {
               spellCheck={false}
               autoFocus
             />
+            {branch && slug !== branch && !slugError && (
+              <p className="text-xs text-muted-foreground">
+                Will be created as: <code>{slug}</code>
+              </p>
+            )}
+            {slugError && <p className="text-xs text-destructive">{slugError}</p>}
             <Label htmlFor="base-branch">Base branch (optional)</Label>
             <Input
               id="base-branch"
@@ -83,7 +105,12 @@ export function NewWorkspaceDialog({ projectName, open, onOpenChange }: Props) {
             <Button type="button" variant="ghost" onClick={() => onOpenChange(false)}>
               Cancel
             </Button>
-            <Button type="submit">Create</Button>
+            <Button
+              type="submit"
+              disabled={!slug || !!slugError || createWorkspaceMutation.isPending}
+            >
+              Create
+            </Button>
           </DialogFooter>
         </form>
       </DialogContent>

--- a/apps/web/src/lib/branch-name.ts
+++ b/apps/web/src/lib/branch-name.ts
@@ -1,0 +1,13 @@
+/**
+ * Converts arbitrary text to a valid git branch name slug.
+ * Preserves "/" for namespace prefixes (e.g. feature/my-branch).
+ */
+export function slugifyBranchName(input: string): string {
+  return input
+    .toLowerCase()
+    .replace(/\s+/g, "-") // spaces → hyphens
+    .replace(/[^a-z0-9\-/]/g, "") // strip anything not alphanumeric, hyphen, or slash
+    .replace(/-{2,}/g, "-") // collapse runs of hyphens
+    .replace(/\/+/g, "/") // collapse duplicate slashes
+    .replace(/^[-/]+|[-/]+$/g, ""); // trim leading/trailing hyphens and slashes
+}

--- a/apps/web/src/server/services/workspace-service.ts
+++ b/apps/web/src/server/services/workspace-service.ts
@@ -7,6 +7,7 @@ import { promisify } from "node:util";
 import { createLogger } from "@band-app/logger";
 import { z } from "zod";
 import { toWorkspaceId } from "@/dashboard";
+import { slugifyBranchName } from "@/lib/branch-name";
 import { WorkspaceNotFoundError } from "../errors";
 import { TaskQueries } from "../infra/db/queries/tasks";
 import { UsageEventQueries } from "../infra/db/queries/usage-events";
@@ -336,6 +337,14 @@ export class WorkspaceService {
     via?: WorkspaceVia;
     terminalId?: string;
   }> {
+    const sanitizedBranch = slugifyBranchName(input.branch);
+    if (!sanitizedBranch) {
+      throw new Error(
+        `Branch name "${input.branch}" is invalid — it contains no valid characters after sanitization.`,
+      );
+    }
+    input = { ...input, branch: sanitizedBranch };
+
     const state = loadState();
     const project = state.projects.find((p) => p.name === input.project);
     if (!project) {


### PR DESCRIPTION
hey good people @amirilovic & @marsicdev 

was trying out the `Version 0.19.1 (0.19.1)` today.

here were my repro steps which led me to an error
1. added my personal project "freightbound"
2. wanted to work on my feature "consolitate loads ui", i typed branch name with spaces (expecting a slug)  but it threw a tRPC error similar to following:

```
TRPCClientError: Command failed: git worktree add -b this will cause the error /Users/nebojsavojvodic/.band/worktrees/freightbound/this will cause the error master
Preparing worktree (new branch 'this will cause the error')
fatal: 'this will cause the error' is not a valid branch name
```

<img width="505" height="505" alt="image" src="https://github.com/user-attachments/assets/00e0bc0c-71a2-4469-84b8-485e1a3403e8" />
<img width="603" height="421" alt="image" src="https://github.com/user-attachments/assets/80743d79-8805-4f21-9971-220c69edc940" />



## Summary

- didnt run locally
- was having issues with pnpm 11 locally (your ci uses 10)
```
pnpm 11 made allowBuilds in pnpm-workspace.yaml strictly required with real booleans.
```

- Typing branch names with spaces (e.g. `consolidate loads ui`) caused `git worktree add` to fail with `fatal: 'consolidate loads ui' is not a valid branch name`
- Add `slugifyBranchName()` utility (lowercase, spaces→hyphens, strip non-`[a-z0-9-/]`, collapse runs, trim edges) in `src/lib/branch-name.ts`
- Show a live preview below the input when the slug differs from what was typed (e.g. `Will be created as: consolidate-loads-ui`)
- Block submission with an inline error if the slug is empty (all invalid chars) or a workspace with that name already exists (checked against cached `useProjects()` data)
- Server-side safety net: `WorkspaceService.create()` now slugifies the branch name before hitting git, with a clear error if the result is empty

## Test plan

- [ ] Type `consolidate loads ui` → preview shows `Will be created as: consolidate-loads-ui`, Create enabled, worktree created successfully
- [ ] Type `!!!` → error `"Branch name contains no valid characters."`, Create disabled
- [ ] Type the name of an existing workspace → error `"A workspace named '...' already exists."`, Create disabled
- [ ] Type `feature/my-branch` → no preview (slug equals input), no error, creates normally
- [ ] Type a clean name like `my-feature` → no preview, no error, creates normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Made with [Cursor](https://cursor.com)