### PR TITLE
fix(web): stable per-worktree workspace identity so branch switches don't drop the card

### DIFF
--- a/apps/cli/tests/integration.rs
+++ b/apps/cli/tests/integration.rs
@@ -31,6 +31,15 @@ impl TestEnv {
         // Create .band dirs
         fs::create_dir_all(band_dir.join("status")).unwrap();
         fs::create_dir_all(band_dir.join("worktrees")).unwrap();
+        // Canonicalize the worktrees dir for the same reason repo_path is
+        // canonicalized below: `git worktree add` records git's canonical
+        // form (`/private/var/...` on macOS), and `projects.list` now
+        // intersects git's live worktrees against tracked rows by PATH
+        // (string equality). A worktreesDir that still carries the
+        // `/var/...` symlink form would never match git's report, so every
+        // created worktree would be filtered out of the list.
+        let worktrees_dir =
+            fs::canonicalize(band_dir.join("worktrees")).expect("canonicalize worktrees dir");
 
         // Create a real git repo. Canonicalize the path immediately so it
         // matches what `git worktree list --porcelain` reports — on
@@ -56,7 +65,7 @@ impl TestEnv {
         let settings = serde_json::json!({
             "tokenSecret": token,
             "webServerPort": port,
-            "worktreesDir": band_dir.join("worktrees").to_string_lossy(),
+            "worktreesDir": worktrees_dir.to_string_lossy(),
         });
 
         // Seed SQLite database with migrations, project data, and settings

--- a/apps/cli/tests/seed-db.mjs
+++ b/apps/cli/tests/seed-db.mjs
@@ -88,9 +88,14 @@ db.prepare(
   "INSERT INTO projects (name, path, default_branch, sort_order) VALUES (?, ?, ?, 0)"
 ).run(projectName, projectPath, defaultBranch);
 
+// `workspace_id` is the worktree's stable, frozen identity (minted once at
+// creation in production). Seed it with the historical derived value
+// (`name-branch`, slashes → dashes) so resolve/findIdentity return the id the
+// tests expect (e.g. `my-project-main`).
+const workspaceId = `${projectName}-${defaultBranch.replace(/\//g, "-")}`;
 db.prepare(
-  "INSERT INTO worktrees (project_name, branch, path) VALUES (?, ?, ?)"
-).run(projectName, defaultBranch, projectPath);
+  "INSERT INTO worktrees (project_name, branch, path, workspace_id) VALUES (?, ?, ?, ?)"
+).run(projectName, defaultBranch, projectPath, workspaceId);
 
 db.close();
 

--- a/apps/web/e2e/helpers/server.ts
+++ b/apps/web/e2e/helpers/server.ts
@@ -6,6 +6,7 @@ import { join } from "node:path";
 import { DatabaseSync } from "node:sqlite";
 import { drizzle } from "drizzle-orm/node-sqlite";
 import { migrate } from "drizzle-orm/node-sqlite/migrator";
+import { toWorkspaceId } from "../../src/dashboard";
 
 const PROJECT_ROOT = join(import.meta.dirname, "../..");
 const MIGRATIONS_FOLDER = join(PROJECT_ROOT, "src/server/infra/db/migrations");
@@ -48,7 +49,7 @@ interface SeedProject {
   path: string;
   defaultBranch: string;
   label?: string;
-  worktrees: { branch: string; path: string }[];
+  worktrees: { branch: string; path: string; workspaceId?: string }[];
 }
 
 export function seedState(tmpHome: string, state: { projects: SeedProject[] }): void {
@@ -74,10 +75,15 @@ export function seedState(tmpHome: string, state: { projects: SeedProject[] }): 
     for (const wt of project.worktrees) {
       sqlite
         .prepare(
-          `INSERT INTO worktrees (project_name, branch, path)
-           VALUES (?, ?, ?)`,
+          `INSERT INTO worktrees (project_name, workspace_id, branch, path)
+           VALUES (?, ?, ?, ?)`,
         )
-        .run(project.name, wt.branch, wt.path);
+        .run(
+          project.name,
+          wt.workspaceId ?? toWorkspaceId(project.name, wt.branch),
+          wt.branch,
+          wt.path,
+        );
     }
   }
   sqlite.close();

--- a/apps/web/e2e/projects-branch-switch.spec.ts
+++ b/apps/web/e2e/projects-branch-switch.spec.ts
@@ -1,0 +1,142 @@
+/**
+ * Frontend regression for the "branch disappears from project branches"
+ * bug. When the branch checked out inside a worktree is switched (by an
+ * agent, a person, or a terminal `git switch`), the worktree's card used to
+ * vanish from the project-list sidebar until a restart — because
+ * `projects.list` intersected git's live view against tracked worktrees by
+ * BRANCH NAME, and `WorkspaceCard` keyed its DOM identity off a branch-derived
+ * workspace id. The fix keys both on the worktree's stable, frozen
+ * `workspaceId`, so the card survives the rename.
+ *
+ * Test architecture (matches the doctrine in CLAUDE.md § Testing Strategy and
+ * the `write-integration-test` skill):
+ *
+ *   - The same production binary the user ships runs against a fresh tmp
+ *     `~/.band/`; migrations apply to the throwaway SQLite DB on boot.
+ *   - A REAL git repo + secondary worktree on disk — required because
+ *     `projects.list` enriches each project with `git worktree list`, and the
+ *     branch switch must be a real `git switch` for the list to see it.
+ *   - The branch is switched out from under the running server, then a fresh
+ *     navigation re-runs `projects.list` against the switched git state. The
+ *     card, keyed by the frozen `workspaceId`, must still be rendered.
+ *   - No tRPC mocking, no `page.route()` on our own routes, no MSW.
+ */
+
+import { execFileSync } from "node:child_process";
+import { mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { expect, test } from "@playwright/test";
+import { toWorkspaceId } from "@/dashboard";
+import {
+  cleanupTmpHome,
+  createTmpHome,
+  type ServerHandle,
+  seedSettings,
+  seedState,
+  startServer,
+} from "./helpers/server";
+import { WorkspacePage } from "./pages/WorkspacePage";
+
+const TOKEN = "e2e-projects-branch-switch-token";
+
+const PROJECT = "branch-switch-repo";
+const DEFAULT_BRANCH = "main";
+const FEATURE_BRANCH = "feature";
+
+const WORKSPACE_MAIN = toWorkspaceId(PROJECT, DEFAULT_BRANCH);
+// The card's identity is frozen at creation on `feature`, so this id stays
+// stable across the later `git switch` to `feature-renamed`.
+const WORKSPACE_FEATURE = toWorkspaceId(PROJECT, FEATURE_BRANCH);
+
+// Wide viewport so `useIsDesktop()` reports true and the shared dockview —
+// and therefore the project-list sidebar with its workspace cards — renders.
+test.use({ viewport: { width: 1280, height: 800 } });
+
+// Hermetic git environment — explicit allowlist, host config pinned to
+// /dev/null so a contributor's global git settings can't leak in. Mirrors
+// the canonical pattern in `workspace-cache-eviction.spec.ts`.
+function makeGitEnv(home: string): NodeJS.ProcessEnv {
+  return {
+    PATH: process.env.PATH,
+    HOME: home,
+    GIT_AUTHOR_NAME: "Test",
+    GIT_AUTHOR_EMAIL: "test@test.com",
+    GIT_COMMITTER_NAME: "Test",
+    GIT_COMMITTER_EMAIL: "test@test.com",
+    GIT_CONFIG_GLOBAL: "/dev/null",
+    GIT_CONFIG_SYSTEM: "/dev/null",
+  };
+}
+
+function git(cwd: string, args: string[], home: string): string {
+  return execFileSync("git", args, { cwd, env: makeGitEnv(home), encoding: "utf-8" });
+}
+
+let server!: ServerHandle;
+let tmpHome: string;
+let repoPath: string;
+let featureWorktreePath: string;
+
+test.beforeAll(async () => {
+  tmpHome = createTmpHome();
+
+  repoPath = join(tmpHome, PROJECT);
+  mkdirSync(repoPath, { recursive: true });
+  git(repoPath, ["init", "-b", DEFAULT_BRANCH], tmpHome);
+  writeFileSync(join(repoPath, "README.md"), "# Branch switch test\n");
+  git(repoPath, ["add", "."], tmpHome);
+  git(repoPath, ["commit", "-m", "initial commit"], tmpHome);
+
+  // Worktree lives inside `tmpHome` so the recursive cleanup reaps it.
+  featureWorktreePath = join(tmpHome, `${PROJECT}-${FEATURE_BRANCH}`);
+  git(repoPath, ["worktree", "add", "-b", FEATURE_BRANCH, featureWorktreePath], tmpHome);
+
+  seedState(tmpHome, {
+    projects: [
+      {
+        name: PROJECT,
+        path: repoPath,
+        defaultBranch: DEFAULT_BRANCH,
+        worktrees: [
+          { branch: DEFAULT_BRANCH, path: repoPath },
+          { branch: FEATURE_BRANCH, path: featureWorktreePath },
+        ],
+      },
+    ],
+  });
+  seedSettings(tmpHome, { tokenSecret: TOKEN });
+  server = await startServer({ tmpHome });
+});
+
+test.afterAll(async () => {
+  if (server) await server.close();
+  cleanupTmpHome(tmpHome);
+});
+
+test.describe("Project branch list across a worktree branch switch", () => {
+  test("the workspace card stays visible after the worktree's branch is switched", async ({
+    page,
+  }) => {
+    const workspacePage = new WorkspacePage(page, server.url, TOKEN);
+
+    await workspacePage.goto(WORKSPACE_MAIN);
+    await workspacePage.waitForReady();
+
+    // Positive anchor: the feature worktree's card is rendered in the sidebar
+    // before any switch, keyed by its frozen workspaceId.
+    await expect(workspacePage.workspaceCard(WORKSPACE_FEATURE)).toBeVisible();
+
+    // Switch the branch checked out inside the worktree, out from under the
+    // running server — exactly what an agent / terminal `git switch` does.
+    git(featureWorktreePath, ["switch", "-c", "feature-renamed"], tmpHome);
+
+    // Re-navigate so the dashboard re-runs `projects.list` against the
+    // switched git state (rather than waiting on the 30s background poll).
+    await workspacePage.goto(WORKSPACE_MAIN);
+    await workspacePage.waitForReady();
+
+    // The card must still be present — its identity is the frozen workspaceId,
+    // not the now-changed branch. Before the fix it vanished here.
+    await expect(workspacePage.workspaceCard(WORKSPACE_FEATURE)).toBeVisible();
+  });
+});

--- a/apps/web/e2e/workspace-switch-changes.spec.ts
+++ b/apps/web/e2e/workspace-switch-changes.spec.ts
@@ -81,14 +81,28 @@ async function setupMocks(page: Page): Promise<MockHandles> {
         path: `/tmp/fake/${PROJECT_A}`,
         defaultBranch: "main",
         kind: "git",
-        worktrees: [{ branch: "main", path: `/tmp/fake/${PROJECT_A}`, pinned: false }],
+        worktrees: [
+          {
+            branch: "main",
+            path: `/tmp/fake/${PROJECT_A}`,
+            pinned: false,
+            workspaceId: WORKSPACE_A,
+          },
+        ],
       },
       {
         name: PROJECT_B,
         path: `/tmp/fake/${PROJECT_B}`,
         defaultBranch: "main",
         kind: "git",
-        worktrees: [{ branch: "main", path: `/tmp/fake/${PROJECT_B}`, pinned: false }],
+        worktrees: [
+          {
+            branch: "main",
+            path: `/tmp/fake/${PROJECT_B}`,
+            pinned: false,
+            workspaceId: WORKSPACE_B,
+          },
+        ],
       },
     ],
   });

--- a/apps/web/e2e/workspace-switch-scroll.spec.ts
+++ b/apps/web/e2e/workspace-switch-scroll.spec.ts
@@ -55,15 +55,25 @@ function makeProjects(): {
   path: string;
   defaultBranch: string;
   kind: "git";
-  worktrees: { branch: string; path: string; pinned: boolean }[];
+  worktrees: { branch: string; path: string; pinned: boolean; workspaceId: string }[];
 }[] {
-  return Array.from({ length: PROJECT_COUNT }, (_, i) => ({
-    name: `project-${String(i).padStart(2, "0")}`,
-    path: `/tmp/fake/project-${i}`,
-    defaultBranch: "main",
-    kind: "git",
-    worktrees: [{ branch: "main", path: `/tmp/fake/project-${i}`, pinned: false }],
-  }));
+  return Array.from({ length: PROJECT_COUNT }, (_, i) => {
+    const name = `project-${String(i).padStart(2, "0")}`;
+    return {
+      name,
+      path: `/tmp/fake/project-${i}`,
+      defaultBranch: "main",
+      kind: "git" as const,
+      worktrees: [
+        {
+          branch: "main",
+          path: `/tmp/fake/project-${i}`,
+          pinned: false,
+          workspaceId: toWorkspaceId(name, "main"),
+        },
+      ],
+    };
+  });
 }
 
 const FIRST_WORKSPACE = toWorkspaceId("project-00", "main");

--- a/apps/web/src/components/CodeBrowserView.tsx
+++ b/apps/web/src/components/CodeBrowserView.tsx
@@ -51,7 +51,6 @@ import {
   serializeEditorState,
   toFileUri,
   toLspServerLang,
-  toWorkspaceId,
   useCapabilities,
   useEditorHistory,
   useProjects,
@@ -448,7 +447,7 @@ export function CodeBrowserView({
   const workspacePath = (() => {
     for (const proj of projects) {
       for (const wt of proj.worktrees) {
-        if (toWorkspaceId(proj.name, wt.branch) === workspaceId) {
+        if (wt.workspaceId === workspaceId) {
           return wt.path;
         }
       }

--- a/apps/web/src/components/CronjobsPageContent.tsx
+++ b/apps/web/src/components/CronjobsPageContent.tsx
@@ -39,7 +39,7 @@ interface CronjobRecord {
 interface ProjectInfo {
   name: string;
   defaultBranch: string;
-  worktrees: { branch: string; workspaceId?: string }[];
+  worktrees: { branch: string; workspaceId: string }[];
 }
 
 function relativeTime(iso: string): string {
@@ -63,6 +63,12 @@ export function CronjobsPageContent() {
   const [projectFilter, setProjectFilter] = useState<string>("all");
   const [showDialog, setShowDialog] = useState(false);
   const [editingJob, setEditingJob] = useState<CronjobRecord | null>(null);
+  // Maps each workspace's stable `workspaceId` to its owning project name.
+  // Built from `projects.list` so a workspace-scoped cronjob can be attributed
+  // to its project WITHOUT parsing the workspaceId string (the id no longer
+  // reliably encodes the project, since it's frozen at worktree creation and
+  // survives branch switches).
+  const [workspaceProject, setWorkspaceProject] = useState<Map<string, string>>(new Map());
 
   const fetchData = useCallback(async () => {
     setLoading(true);
@@ -83,25 +89,54 @@ export function CronjobsPageContent() {
     return () => clearInterval(interval);
   }, [fetchData]);
 
+  // The workspaceId → project map only changes when a worktree is
+  // added/removed/renamed — far less often than the 5s cronjob poll, and
+  // `projects.list` spawns a `git worktree list` subprocess per project
+  // server-side. Fetch it once on mount instead of on every tick so the page
+  // doesn't fork git every 5s (and so the Map identity stays stable, keeping
+  // the `filteredCronjobs` / `projectNames` memos from recomputing each poll).
+  useEffect(() => {
+    let cancelled = false;
+    trpc.projects.list
+      .query()
+      .then((projectsData) => {
+        if (cancelled) return;
+        const map = new Map<string, string>();
+        for (const project of projectsData.projects as ProjectInfo[]) {
+          for (const wt of project.worktrees) {
+            map.set(wt.workspaceId, project.name);
+          }
+        }
+        setWorkspaceProject(map);
+      })
+      .catch(() => {
+        // Leave the existing map in place; a project-attribution miss only
+        // affects the filter dropdown, and the cronjob list still renders.
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
   const filteredCronjobs = useMemo(() => {
     if (projectFilter === "all") return cronjobs;
     return cronjobs.filter((job) => {
       if (job.scope === "project") return job.fileKey === projectFilter;
-      return job.workspaceId?.startsWith(`${projectFilter}-`);
+      return job.workspaceId ? workspaceProject.get(job.workspaceId) === projectFilter : false;
     });
-  }, [cronjobs, projectFilter]);
+  }, [cronjobs, projectFilter, workspaceProject]);
 
   const projectNames = useMemo(() => {
     const names = new Set<string>();
     for (const job of cronjobs) {
       if (job.scope === "project") names.add(job.fileKey);
       else if (job.workspaceId) {
-        const dash = job.workspaceId.indexOf("-");
-        if (dash > 0) names.add(job.workspaceId.slice(0, dash));
+        const projectName = workspaceProject.get(job.workspaceId);
+        if (projectName) names.add(projectName);
       }
     }
     return Array.from(names).sort();
-  }, [cronjobs]);
+  }, [cronjobs, workspaceProject]);
 
   const handleEdit = useCallback((job: CronjobRecord) => {
     setEditingJob(job);
@@ -421,7 +456,7 @@ function CronjobDialog({
     return (
       project?.worktrees.map((w) => ({
         branch: w.branch,
-        workspaceId: w.workspaceId ?? `${selectedProject}-${w.branch.replaceAll("/", "-")}`,
+        workspaceId: w.workspaceId,
       })) ?? []
     );
   }, [projects, selectedProject]);

--- a/apps/web/src/components/MultiWorkspacePanelHost.tsx
+++ b/apps/web/src/components/MultiWorkspacePanelHost.tsx
@@ -1,6 +1,6 @@
 import { useRouterState } from "@tanstack/react-router";
 import { useEffect, useRef, useState } from "react";
-import { toWorkspaceId, useProjects, useSettingsQuery } from "@/dashboard";
+import { useProjects, useSettingsQuery } from "@/dashboard";
 import { parseWorkspaceFromPath } from "../lib/parse-workspace";
 import { clearPerWorkspaceState } from "./per-workspace-state-store";
 
@@ -169,7 +169,7 @@ export function MultiWorkspacePanelHost({ emptyState, children }: MultiWorkspace
     const validIds = new Set<string>();
     for (const project of projects) {
       for (const worktree of project.worktrees) {
-        validIds.add(toWorkspaceId(project.name, worktree.branch));
+        validIds.add(worktree.workspaceId);
       }
     }
     setCache((prev) => {

--- a/apps/web/src/dashboard/components/DashboardShell.tsx
+++ b/apps/web/src/dashboard/components/DashboardShell.tsx
@@ -40,7 +40,6 @@ import {
   useSetupStatusWatcher,
   useStatusWatcher,
 } from "../hooks/use-status";
-import { toWorkspaceId } from "../lib/workspace-id";
 import { useDashboardStore } from "../stores/index";
 import type { ProjectInfo } from "../types";
 import { AddProjectDialog } from "./AddProjectDialog";
@@ -140,9 +139,7 @@ export function DashboardShell({ toolbarMenuItems, hideTitleBar, hideMenu }: Das
   // is dominated by render cost anyway.
   const findProjectForWorkspace = useCallback(
     (workspaceId: string): ProjectInfo | undefined =>
-      projects.find((p) =>
-        p.worktrees.some((wt) => toWorkspaceId(p.name, wt.branch) === workspaceId),
-      ),
+      projects.find((p) => p.worktrees.some((wt) => wt.workspaceId === workspaceId)),
     [projects],
   );
 

--- a/apps/web/src/dashboard/components/ProjectList.tsx
+++ b/apps/web/src/dashboard/components/ProjectList.tsx
@@ -64,7 +64,6 @@ import {
 } from "../hooks/use-project-mutations";
 import { useProjects } from "../hooks/use-projects";
 import { useSettingsQuery } from "../hooks/use-settings-query";
-import { toWorkspaceId } from "../lib/workspace-id";
 import { useDashboardStore } from "../stores/index";
 import type {
   DeleteDialogInfo,
@@ -159,10 +158,9 @@ function SortableProject({
   // Plain projects are guaranteed to have exactly one worktree (the
   // implicit `main` synthesized by projects.add and re-synthesized by
   // `reconcileKindForProject` on any git → plain flip). Read
-  // `worktrees[0].branch` directly rather than `?.branch ?? "main"`;
-  // the optional chain would mask a real state-corruption bug.
-  const plainBranch = isPlain ? project.worktrees[0].branch : "";
-  const plainWorkspaceId = isPlain ? toWorkspaceId(project.name, plainBranch) : "";
+  // `worktrees[0]` directly rather than `?.` chaining; the optional chain
+  // would mask a real state-corruption bug.
+  const plainWorkspaceId = isPlain ? project.worktrees[0].workspaceId : "";
   const plainIsActive = useDashboardStore(
     (s) => isPlain && s.activeWorkspaceId === plainWorkspaceId,
   );
@@ -179,10 +177,8 @@ function SortableProject({
   // Memoized: every Zustand update re-renders this row, and the `.some(...)`
   // walk is O(worktrees) — recompute only when the inputs actually change.
   const gitHeaderIsActive = useMemo(
-    () =>
-      !isPlain &&
-      project.worktrees.some((wt) => toWorkspaceId(project.name, wt.branch) === activeWorkspaceId),
-    [isPlain, project.worktrees, project.name, activeWorkspaceId],
+    () => !isPlain && project.worktrees.some((wt) => wt.workspaceId === activeWorkspaceId),
+    [isPlain, project.worktrees, activeWorkspaceId],
   );
 
   // Single onClick / onKeyDown for the plain-project header (mirrors the
@@ -400,7 +396,7 @@ function SortableProject({
             )
           ) : (
             project.worktrees.map((wt) => {
-              const wsId = toWorkspaceId(project.name, wt.branch);
+              const wsId = wt.workspaceId;
               const currentIndex = workspaceIndex++;
               return (
                 <WorkspaceCard
@@ -614,7 +610,7 @@ export function ProjectList({ labelFilter }: ProjectListProps) {
       if (headerVisible && labelCollapse.isCollapsed(groupKey)) return [];
       return g.projects.flatMap((p) => {
         if (projectCollapse.isCollapsed(p.name)) return [];
-        return p.worktrees.map((wt) => toWorkspaceId(p.name, wt.branch));
+        return p.worktrees.map((wt) => wt.workspaceId);
       });
     });
     return [...pinnedPart, ...rest];
@@ -718,9 +714,7 @@ export function ProjectList({ labelFilter }: ProjectListProps) {
     }
     for (const group of groups) {
       for (const project of group.projects) {
-        const containsActive = project.worktrees.some(
-          (wt) => toWorkspaceId(project.name, wt.branch) === activeWorkspaceId,
-        );
+        const containsActive = project.worktrees.some((wt) => wt.workspaceId === activeWorkspaceId);
         if (!containsActive) continue;
         if (labelFilter && group.labelId !== labelFilter) return;
         const headerVisible = labels.length > 0 && !labelFilter;

--- a/apps/web/src/dashboard/components/WorkspaceCard.tsx
+++ b/apps/web/src/dashboard/components/WorkspaceCard.tsx
@@ -22,7 +22,6 @@ import {
 import { memo, useEffect, useRef } from "react";
 import { useCapabilities } from "../context";
 import { useRemoveWorkspace } from "../hooks/use-project-mutations";
-import { toWorkspaceId } from "../lib/workspace-id";
 import { useDashboardStore } from "../stores/index";
 import type {
   DeleteDialogInfo,
@@ -135,7 +134,7 @@ export const WorkspaceCard = memo(function WorkspaceCard({
   const removeWorkspaceMutation = useRemoveWorkspace();
   const isPinned = worktree.pinned;
 
-  const workspaceId = toWorkspaceId(projectName, worktree.branch);
+  const workspaceId = worktree.workspaceId;
   const isActive = useDashboardStore((s) => s.activeWorkspaceId === workspaceId);
   const href = capabilities.getWorkspaceHref?.(workspaceId);
 
@@ -182,9 +181,9 @@ export const WorkspaceCard = memo(function WorkspaceCard({
     "data-active": isActive || undefined,
     "aria-current": isActive ? ("page" as const) : undefined,
     // Stable test hook keyed by workspaceId so integration tests can right-
-    // click the specific card (issue #508). Branches with `/` in them are
-    // collapsed to `-` by `toWorkspaceId` so the attribute value matches
-    // the canonical workspace id used everywhere else in the UI.
+    // click the specific card (issue #508). The id is the server-provided
+    // stable `worktree.workspaceId`, matching the canonical workspace id used
+    // everywhere else in the UI.
     "data-testid": `project-list__workspace-card--${workspaceId}`,
     onClick: (e: React.MouseEvent) => {
       e.stopPropagation();

--- a/apps/web/src/dashboard/components/WorkspacePickerDialog.tsx
+++ b/apps/web/src/dashboard/components/WorkspacePickerDialog.tsx
@@ -16,7 +16,6 @@ import { useCapabilities } from "../context";
 import { usePinnedWorkspaces } from "../hooks/use-pinned-workspaces";
 import { useProjects } from "../hooks/use-projects";
 import { getRecentWorkspaceOrder, recordWorkspaceAccess } from "../lib/recent-workspaces";
-import { toWorkspaceId } from "../lib/workspace-id";
 import { useDashboardStore } from "../stores/index";
 import type { AgentInfo } from "../types";
 import { AgentStatusIndicator } from "./AgentStatusIndicator";
@@ -64,7 +63,7 @@ export function WorkspacePickerDialog({ open, onOpenChange }: WorkspacePickerDia
     const entries: WorkspaceEntry[] = [];
     for (const project of projects) {
       for (const worktree of project.worktrees) {
-        const workspaceId = toWorkspaceId(project.name, worktree.branch);
+        const workspaceId = worktree.workspaceId;
         entries.push({
           workspaceId,
           projectName: project.name,

--- a/apps/web/src/dashboard/hooks/use-pinned-workspaces.ts
+++ b/apps/web/src/dashboard/hooks/use-pinned-workspaces.ts
@@ -1,7 +1,6 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useCallback, useMemo } from "react";
 import { useAdapter } from "../context";
-import { toWorkspaceId } from "../lib/workspace-id";
 import { queryKeys } from "../query-client";
 import { useDashboardStore } from "../stores/index";
 import type { ProjectInfo, WorktreeInfo } from "../types";
@@ -36,7 +35,7 @@ export function usePinnedWorkspaces() {
           list.push({
             project,
             worktree: wt,
-            workspaceId: toWorkspaceId(project.name, wt.branch),
+            workspaceId: wt.workspaceId,
           });
         }
       }

--- a/apps/web/src/dashboard/hooks/use-project-kind.ts
+++ b/apps/web/src/dashboard/hooks/use-project-kind.ts
@@ -1,5 +1,4 @@
 import { useMemo } from "react";
-import { toWorkspaceId } from "../lib/workspace-id";
 import type { ProjectKind } from "../types";
 import { useProjects } from "./use-projects";
 
@@ -22,7 +21,7 @@ export function useProjectKindMap(): Map<string, ProjectKind> {
     const map = new Map<string, ProjectKind>();
     for (const p of projects) {
       for (const wt of p.worktrees) {
-        map.set(toWorkspaceId(p.name, wt.branch), p.kind);
+        map.set(wt.workspaceId, p.kind);
       }
     }
     return map;

--- a/apps/web/src/dashboard/hooks/use-project-mutations.ts
+++ b/apps/web/src/dashboard/hooks/use-project-mutations.ts
@@ -140,6 +140,10 @@ export function useCreateWorkspace() {
     }) => adapter.createWorkspace(project, branch, base, prompt),
     onSuccess: (_data, vars) => {
       queryClient.invalidateQueries({ queryKey: queryKeys.projects });
+      // The workspace was just created, so its frozen server id equals the id
+      // derived from the branch it was created on (the freeze happens AT
+      // creation). The new worktree isn't in the just-invalidated projects
+      // cache yet, so deriving it here is both correct and the only option.
       const workspaceId = toWorkspaceId(vars.project, vars.branch);
       openWorkspace(workspaceId);
     },
@@ -160,14 +164,23 @@ export function useRemoveWorkspace() {
     mutationFn: ({ project, branch }: { project: string; branch: string }) =>
       adapter.removeWorkspace(project, branch),
     onSuccess: (_data, { project, branch }) => {
+      // Read the still-cached (pre-invalidation) projects list to resolve the
+      // server's stable workspace ids. `invalidateQueries` only marks the
+      // query stale and schedules a refetch, so `getQueryData` still returns
+      // the snapshot that includes the worktree we just removed.
+      const projects = queryClient.getQueryData<ProjectInfo[]>(queryKeys.projects);
       queryClient.invalidateQueries({ queryKey: queryKeys.projects });
 
-      const deletedWorkspaceId = toWorkspaceId(project, branch);
-      if (store.getState().activeWorkspaceId === deletedWorkspaceId) {
-        const projects = queryClient.getQueryData<ProjectInfo[]>(queryKeys.projects);
-        const projectInfo = projects?.find((p) => p.name === project);
-        if (projectInfo) {
-          openWorkspace(toWorkspaceId(project, projectInfo.defaultBranch));
+      const projectInfo = projects?.find((p) => p.name === project);
+      const deletedWorkspaceId = projectInfo?.worktrees.find(
+        (wt) => wt.branch === branch,
+      )?.workspaceId;
+      if (deletedWorkspaceId && store.getState().activeWorkspaceId === deletedWorkspaceId) {
+        const fallback = projectInfo?.worktrees.find(
+          (wt) => wt.branch === projectInfo.defaultBranch,
+        )?.workspaceId;
+        if (fallback) {
+          openWorkspace(fallback);
         }
       }
     },

--- a/apps/web/src/dashboard/types.ts
+++ b/apps/web/src/dashboard/types.ts
@@ -42,6 +42,12 @@ export interface ProjectInfo {
 export interface WorktreeInfo {
   branch: string;
   path: string;
+  /**
+   * Stable workspace identity from the server. Frozen at worktree creation —
+   * does NOT change when the branch inside the worktree is switched. Always
+   * use this to identify a workspace; never recompute it from the branch.
+   */
+  workspaceId: string;
   head?: string;
   hasSetup?: boolean;
   hasTeardown?: boolean;

--- a/apps/web/src/server/api/statuses/router.ts
+++ b/apps/web/src/server/api/statuses/router.ts
@@ -1,5 +1,4 @@
 import { z } from "zod";
-import { toWorkspaceId } from "@/dashboard";
 import { getWorkspaceStatus, loadState, upsertWorkspaceStatus } from "../../services/state";
 import { taskService } from "../../services/task-service";
 import { emit, type WatcherService, watcherService } from "../../services/watcher-service";
@@ -80,7 +79,7 @@ export const statusesRouter = t.router({
     for (const proj of state.projects) {
       for (const wt of proj.worktrees) {
         if (input.cwd === wt.path || input.cwd.startsWith(`${wt.path}/`)) {
-          return { workspaceId: toWorkspaceId(proj.name, wt.branch) };
+          return { workspaceId: wt.id };
         }
       }
     }

--- a/apps/web/src/server/api/tasks/router.ts
+++ b/apps/web/src/server/api/tasks/router.ts
@@ -1,7 +1,6 @@
 import { createLogger } from "@band-app/logger";
 import { TRPCError } from "@trpc/server";
 import { z } from "zod";
-import { toWorkspaceId } from "@/dashboard";
 import { WorkspaceNotFoundError } from "../../errors";
 import { saveUploadedFilesDetailed } from "../../services/_utils/upload-utils";
 import { chatService } from "../../services/chat-service";
@@ -64,7 +63,7 @@ export const tasksRouter = t.router({
       const workspaceIds = new Set<string>();
       for (const p of state.projects) {
         for (const wt of p.worktrees) {
-          workspaceIds.add(toWorkspaceId(p.name, wt.branch));
+          workspaceIds.add(wt.id);
         }
       }
       return {

--- a/apps/web/src/server/infra/db/migrations/20260616153353_colossal_night_thrasher/migration.sql
+++ b/apps/web/src/server/infra/db/migrations/20260616153353_colossal_night_thrasher/migration.sql
@@ -1,0 +1,12 @@
+ALTER TABLE `worktrees` ADD `workspace_id` text DEFAULT '' NOT NULL;--> statement-breakpoint
+UPDATE `worktrees` SET `workspace_id` = `project_name` || '-' || REPLACE(`branch`, '/', '-');--> statement-breakpoint
+-- The derived id encoding is non-injective: project `foo-bar`+branch `main`
+-- and project `foo`+branch `bar/main` both backfill to `foo-bar-main`. A
+-- pre-existing DB holding such a colliding pair would make the UNIQUE INDEX
+-- below fail and abort the migration on boot. Disambiguate every duplicate
+-- (all rows in a colliding group except the lowest-`id` keeper) by appending
+-- the row's unique `id`, so the keeper retains the historical derived value
+-- (existing chats/tasks keyed on it stay valid) and the index can't throw.
+UPDATE `worktrees` SET `workspace_id` = `workspace_id` || '-' || `id`
+  WHERE `id` NOT IN (SELECT MIN(`id`) FROM `worktrees` GROUP BY `workspace_id`);--> statement-breakpoint
+CREATE UNIQUE INDEX `worktrees_workspace_id_unique` ON `worktrees` (`workspace_id`);

--- a/apps/web/src/server/infra/db/migrations/20260616153353_colossal_night_thrasher/snapshot.json
+++ b/apps/web/src/server/infra/db/migrations/20260616153353_colossal_night_thrasher/snapshot.json
@@ -1,0 +1,1191 @@
+{
+  "version": "7",
+  "dialect": "sqlite",
+  "id": "4b2cd35b-bd8c-43c4-988b-c47edc1b5b96",
+  "prevIds": [
+    "17560156-8432-46fd-905b-5a963619f8a8"
+  ],
+  "ddl": [
+    {
+      "name": "branch_statuses",
+      "entityType": "tables"
+    },
+    {
+      "name": "browser_history",
+      "entityType": "tables"
+    },
+    {
+      "name": "cronjobs",
+      "entityType": "tables"
+    },
+    {
+      "name": "panel_states",
+      "entityType": "tables"
+    },
+    {
+      "name": "projects",
+      "entityType": "tables"
+    },
+    {
+      "name": "tasks",
+      "entityType": "tables"
+    },
+    {
+      "name": "usage_events",
+      "entityType": "tables"
+    },
+    {
+      "name": "usage_scan_state",
+      "entityType": "tables"
+    },
+    {
+      "name": "workspace_statuses",
+      "entityType": "tables"
+    },
+    {
+      "name": "worktrees",
+      "entityType": "tables"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "workspace_id",
+      "entityType": "columns",
+      "table": "branch_statuses"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "git_dirty",
+      "entityType": "columns",
+      "table": "branch_statuses"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "git_conflict",
+      "entityType": "columns",
+      "table": "branch_statuses"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "git_ahead",
+      "entityType": "columns",
+      "table": "branch_statuses"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "git_behind",
+      "entityType": "columns",
+      "table": "branch_statuses"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "git_sync_state",
+      "entityType": "columns",
+      "table": "branch_statuses"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "ci_state",
+      "entityType": "columns",
+      "table": "branch_statuses"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "ci_url",
+      "entityType": "columns",
+      "table": "branch_statuses"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "branch_statuses"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": true,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "browser_history"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "workspace_id",
+      "entityType": "columns",
+      "table": "browser_history"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "url",
+      "entityType": "columns",
+      "table": "browser_history"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "title",
+      "entityType": "columns",
+      "table": "browser_history"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "favicon_url",
+      "entityType": "columns",
+      "table": "browser_history"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "last_visited_at",
+      "entityType": "columns",
+      "table": "browser_history"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "1",
+      "generated": null,
+      "name": "visit_count",
+      "entityType": "columns",
+      "table": "browser_history"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "cronjobs"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "file_key",
+      "entityType": "columns",
+      "table": "cronjobs"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "name",
+      "entityType": "columns",
+      "table": "cronjobs"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "prompt",
+      "entityType": "columns",
+      "table": "cronjobs"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "cron_expression",
+      "entityType": "columns",
+      "table": "cronjobs"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "scope",
+      "entityType": "columns",
+      "table": "cronjobs"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "workspace_id",
+      "entityType": "columns",
+      "table": "cronjobs"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "true",
+      "generated": null,
+      "name": "enabled",
+      "entityType": "columns",
+      "table": "cronjobs"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "cronjobs"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "last_run_at",
+      "entityType": "columns",
+      "table": "cronjobs"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "last_run_status",
+      "entityType": "columns",
+      "table": "cronjobs"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "panel_states"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "workspace_id",
+      "entityType": "columns",
+      "table": "panel_states"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "panel_type",
+      "entityType": "columns",
+      "table": "panel_states"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "state",
+      "entityType": "columns",
+      "table": "panel_states"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "labels",
+      "entityType": "columns",
+      "table": "panel_states"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "panel_states"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "panel_states"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "name",
+      "entityType": "columns",
+      "table": "projects"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "path",
+      "entityType": "columns",
+      "table": "projects"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "default_branch",
+      "entityType": "columns",
+      "table": "projects"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "label",
+      "entityType": "columns",
+      "table": "projects"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "sort_order",
+      "entityType": "columns",
+      "table": "projects"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'git'",
+      "generated": null,
+      "name": "kind",
+      "entityType": "columns",
+      "table": "projects"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "true",
+      "generated": null,
+      "name": "has_origin",
+      "entityType": "columns",
+      "table": "projects"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "tasks"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "workspace_id",
+      "entityType": "columns",
+      "table": "tasks"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "project",
+      "entityType": "columns",
+      "table": "tasks"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "branch",
+      "entityType": "columns",
+      "table": "tasks"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "prompt",
+      "entityType": "columns",
+      "table": "tasks"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "status",
+      "entityType": "columns",
+      "table": "tasks"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "session_id",
+      "entityType": "columns",
+      "table": "tasks"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "started_at",
+      "entityType": "columns",
+      "table": "tasks"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "completed_at",
+      "entityType": "columns",
+      "table": "tasks"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "max_turns",
+      "entityType": "columns",
+      "table": "tasks"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "mode",
+      "entityType": "columns",
+      "table": "tasks"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "model",
+      "entityType": "columns",
+      "table": "tasks"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "coding_agent_id",
+      "entityType": "columns",
+      "table": "tasks"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "chat_id",
+      "entityType": "columns",
+      "table": "tasks"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": true,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "usage_events"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "task_id",
+      "entityType": "columns",
+      "table": "usage_events"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "chat_id",
+      "entityType": "columns",
+      "table": "usage_events"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "workspace_id",
+      "entityType": "columns",
+      "table": "usage_events"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "project",
+      "entityType": "columns",
+      "table": "usage_events"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "session_id",
+      "entityType": "columns",
+      "table": "usage_events"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "coding_agent_id",
+      "entityType": "columns",
+      "table": "usage_events"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "provider",
+      "entityType": "columns",
+      "table": "usage_events"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "model",
+      "entityType": "columns",
+      "table": "usage_events"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "0",
+      "generated": null,
+      "name": "input_tokens",
+      "entityType": "columns",
+      "table": "usage_events"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "0",
+      "generated": null,
+      "name": "output_tokens",
+      "entityType": "columns",
+      "table": "usage_events"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "0",
+      "generated": null,
+      "name": "cache_read_tokens",
+      "entityType": "columns",
+      "table": "usage_events"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "0",
+      "generated": null,
+      "name": "cache_creation_tokens",
+      "entityType": "columns",
+      "table": "usage_events"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "0",
+      "generated": null,
+      "name": "reasoning_output_tokens",
+      "entityType": "columns",
+      "table": "usage_events"
+    },
+    {
+      "type": "real",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "0",
+      "generated": null,
+      "name": "cost_usd",
+      "entityType": "columns",
+      "table": "usage_events"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "captured_at",
+      "entityType": "columns",
+      "table": "usage_events"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "external_key",
+      "entityType": "columns",
+      "table": "usage_events"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "workspace_id",
+      "entityType": "columns",
+      "table": "usage_scan_state"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "agent_type",
+      "entityType": "columns",
+      "table": "usage_scan_state"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "last_scanned_updated_at",
+      "entityType": "columns",
+      "table": "usage_scan_state"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "workspace_id",
+      "entityType": "columns",
+      "table": "workspace_statuses"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "project",
+      "entityType": "columns",
+      "table": "workspace_statuses"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "branch",
+      "entityType": "columns",
+      "table": "workspace_statuses"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "worktree_path",
+      "entityType": "columns",
+      "table": "workspace_statuses"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "agent_name",
+      "entityType": "columns",
+      "table": "workspace_statuses"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "agent_status",
+      "entityType": "columns",
+      "table": "workspace_statuses"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "agent_last_activity",
+      "entityType": "columns",
+      "table": "workspace_statuses"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "agent_summary",
+      "entityType": "columns",
+      "table": "workspace_statuses"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "coding_agent_id",
+      "entityType": "columns",
+      "table": "workspace_statuses"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "workspace_statuses"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": true,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "worktrees"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "project_name",
+      "entityType": "columns",
+      "table": "worktrees"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "branch",
+      "entityType": "columns",
+      "table": "worktrees"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "path",
+      "entityType": "columns",
+      "table": "worktrees"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "head",
+      "entityType": "columns",
+      "table": "worktrees"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "false",
+      "generated": null,
+      "name": "pinned",
+      "entityType": "columns",
+      "table": "worktrees"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "''",
+      "generated": null,
+      "name": "workspace_id",
+      "entityType": "columns",
+      "table": "worktrees"
+    },
+    {
+      "columns": [
+        "project_name"
+      ],
+      "tableTo": "projects",
+      "columnsTo": [
+        "name"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "worktrees_project_name_projects_name_fk",
+      "entityType": "fks",
+      "table": "worktrees"
+    },
+    {
+      "columns": [
+        "workspace_id"
+      ],
+      "nameExplicit": false,
+      "name": "branch_statuses_pk",
+      "table": "branch_statuses",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "browser_history_pk",
+      "table": "browser_history",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "cronjobs_pk",
+      "table": "cronjobs",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "panel_states_pk",
+      "table": "panel_states",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "name"
+      ],
+      "nameExplicit": false,
+      "name": "projects_pk",
+      "table": "projects",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "tasks_pk",
+      "table": "tasks",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "usage_events_pk",
+      "table": "usage_events",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "workspace_id"
+      ],
+      "nameExplicit": false,
+      "name": "workspace_statuses_pk",
+      "table": "workspace_statuses",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "worktrees_pk",
+      "table": "worktrees",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        {
+          "value": "workspace_id",
+          "isExpression": false
+        },
+        {
+          "value": "url",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "origin": "manual",
+      "name": "browser_history_workspace_url_uq",
+      "entityType": "indexes",
+      "table": "browser_history"
+    },
+    {
+      "columns": [
+        {
+          "value": "workspace_id",
+          "isExpression": false
+        },
+        {
+          "value": "last_visited_at",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "browser_history_workspace_visited_idx",
+      "entityType": "indexes",
+      "table": "browser_history"
+    },
+    {
+      "columns": [
+        {
+          "value": "captured_at",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "usage_events_captured_at_idx",
+      "entityType": "indexes",
+      "table": "usage_events"
+    },
+    {
+      "columns": [
+        {
+          "value": "task_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "usage_events_task_idx",
+      "entityType": "indexes",
+      "table": "usage_events"
+    },
+    {
+      "columns": [
+        {
+          "value": "workspace_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "usage_events_workspace_idx",
+      "entityType": "indexes",
+      "table": "usage_events"
+    },
+    {
+      "columns": [
+        {
+          "value": "external_key",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "origin": "manual",
+      "name": "usage_events_external_key_uq",
+      "entityType": "indexes",
+      "table": "usage_events"
+    },
+    {
+      "columns": [
+        {
+          "value": "workspace_id",
+          "isExpression": false
+        },
+        {
+          "value": "agent_type",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "origin": "manual",
+      "name": "usage_scan_state_pk",
+      "entityType": "indexes",
+      "table": "usage_scan_state"
+    },
+    {
+      "columns": [
+        {
+          "value": "workspace_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "origin": "manual",
+      "name": "worktrees_workspace_id_unique",
+      "entityType": "indexes",
+      "table": "worktrees"
+    }
+  ],
+  "renames": []
+}

--- a/apps/web/src/server/infra/db/queries/projects.ts
+++ b/apps/web/src/server/infra/db/queries/projects.ts
@@ -65,6 +65,14 @@ export interface ProjectState {
  * worktree at `{branch: "main", path: project.path}`.
  */
 export interface WorktreeState {
+  /**
+   * Stable, opaque workspace identity. Minted once when the worktree is
+   * created (`toWorkspaceId(project, branch)`) and frozen for the worktree's
+   * lifetime — a `git switch` inside the worktree changes `branch` but NOT
+   * `id`, so chats / tasks / cronjobs / panels keyed on it survive the
+   * rename. The worktree PATH is the real identity; `id` is its handle.
+   */
+  id: string;
   branch: string;
   path: string;
   head?: string;
@@ -88,9 +96,12 @@ export interface WorktreeState {
  *
  * Lives in the Infra tier (not the service) because both the
  * sync-state poller and the back-compat `lib/state.ts` re-export need
- * to reach it without pulling in the higher service layer.
+ * to reach it without pulling in the higher service layer. The caller
+ * supplies `plainWorkspaceId` (the id to freeze on the synthesized
+ * `main` worktree on a git → plain flip) rather than the infra tier
+ * computing it from the browser-side `toWorkspaceId` helper.
  */
-export function reconcileKindForProject(project: ProjectState): boolean {
+export function reconcileKindForProject(project: ProjectState, plainWorkspaceId: string): boolean {
   // Skip rows whose path no longer exists — leave kind alone rather
   // than synthesize a workspace under a missing directory.
   if (!existsSync(project.path)) return false;
@@ -113,7 +124,14 @@ export function reconcileKindForProject(project: ProjectState): boolean {
   // with no `.git` to reach back to) and the flattened plain UI would
   // render the wrong branch label.
   if (detectedKind === "plain") {
-    project.worktrees = [{ branch: "main", path: project.path, pinned: false }];
+    project.worktrees = [
+      {
+        id: plainWorkspaceId,
+        branch: "main",
+        path: project.path,
+        pinned: false,
+      },
+    ];
   }
   return true;
 }
@@ -147,6 +165,7 @@ export class ProjectQueries {
     for (const row of worktreeRows) {
       const list = wtByProject.get(row.projectName) ?? [];
       list.push({
+        id: row.workspaceId,
         branch: row.branch,
         path: row.path,
         head: row.head ?? undefined,
@@ -203,6 +222,7 @@ export class ProjectQueries {
           tx.insert(worktreesTable)
             .values({
               projectName: project.name,
+              workspaceId: wt.id,
               branch: wt.branch,
               path: wt.path,
               head: wt.head ?? null,

--- a/apps/web/src/server/infra/db/queries/workspaces.ts
+++ b/apps/web/src/server/infra/db/queries/workspaces.ts
@@ -1,5 +1,4 @@
-import { eq, sql } from "drizzle-orm";
-import { toWorkspaceId } from "@/dashboard";
+import { eq } from "drizzle-orm";
 import { getDb } from "../connection";
 import { branchStatuses as branchStatusesTable, worktrees as worktreesTable } from "../schema";
 
@@ -45,30 +44,15 @@ export interface WorkspaceIdentity {
 export class WorkspaceQueries {
   /**
    * Resolve a workspace ID back to its on-disk identity (project, branch,
-   * worktree path) by scanning the `worktrees` table.
+   * worktree path) with a single indexed lookup on the stored
+   * `worktrees.workspace_id` column.
    *
-   * The match expression mirrors `toWorkspaceId(project, branch)`:
-   *   `${project}-${branch.replaceAll("/", "-")}`
-   * SQLite's `REPLACE(str, "/", "-")` is also a replace-all, so this is
-   * bit-identical to the JS computation. Pushing the match down into SQL
-   * lets us read at most one row instead of fanning out the projects +
-   * worktrees tree just to find a single workspace (the previous
-   * `loadState()`-based implementation walked every project's worktree
-   * list to find the match in JS).
-   *
-   * Called from two places today: the workspace-status upsert path in
-   * `lib/state.ts::upsertWorkspaceStatus` (via the private
-   * `resolveWorkspaceIdentity` helper, which delegates here so the SQL
-   * lives in one place) and any future service caller that needs to map
-   * an opaque `workspaceId` back to its on-disk worktree without
-   * loading the full project tree.
-   *
-   * TODO: `toWorkspaceId`'s encoding is not injective — project `foo-bar` +
-   * branch `main` and project `foo` + branch `bar/main` both serialize to
-   * `foo-bar-main`. `.get()` returns whichever row SQLite finds first, and
-   * the sanity check below cannot disambiguate (both candidates satisfy
-   * it). Fixing this requires changing the workspace-id encoding, which is
-   * a cross-cutting change tracked separately from this refactor.
+   * `workspace_id` is the worktree's frozen identity (minted once at
+   * creation, never re-derived from the mutable branch), so this match is
+   * exact and unambiguous — it replaces the old `project || '-' ||
+   * REPLACE(branch, '/', '-')` expression, which collided whenever a
+   * project name contained a `-` (project `foo-bar` + branch `main` and
+   * project `foo` + branch `bar/main` both serialized to `foo-bar-main`).
    */
   findIdentity(workspaceId: string): WorkspaceIdentity | null {
     const db = getDb();
@@ -79,13 +63,9 @@ export class WorkspaceQueries {
         worktreePath: worktreesTable.path,
       })
       .from(worktreesTable)
-      .where(
-        sql`${worktreesTable.projectName} || '-' || REPLACE(${worktreesTable.branch}, '/', '-') = ${workspaceId}`,
-      )
+      .where(eq(worktreesTable.workspaceId, workspaceId))
       .get();
-    // Use the `toWorkspaceId` helper as a runtime sanity check in case the
-    // helper's encoding ever evolves to disagree with the SQL above.
-    if (row && toWorkspaceId(row.project, row.branch) === workspaceId) {
+    if (row) {
       return { project: row.project, branch: row.branch, worktreePath: row.worktreePath };
     }
     return null;

--- a/apps/web/src/server/infra/db/schema.ts
+++ b/apps/web/src/server/infra/db/schema.ts
@@ -48,16 +48,28 @@ export const projects = sqliteTable("projects", {
   hasOrigin: integer("has_origin", { mode: "boolean" }).notNull().default(true),
 });
 
-export const worktrees = sqliteTable("worktrees", {
-  id: integer("id").primaryKey({ autoIncrement: true }),
-  projectName: text("project_name")
-    .notNull()
-    .references(() => projects.name, { onDelete: "cascade" }),
-  branch: text("branch").notNull(),
-  path: text("path").notNull(),
-  head: text("head"),
-  pinned: integer("pinned", { mode: "boolean" }).notNull().default(false),
-});
+export const worktrees = sqliteTable(
+  "worktrees",
+  {
+    id: integer("id").primaryKey({ autoIncrement: true }),
+    projectName: text("project_name")
+      .notNull()
+      .references(() => projects.name, { onDelete: "cascade" }),
+    branch: text("branch").notNull(),
+    path: text("path").notNull(),
+    head: text("head"),
+    pinned: integer("pinned", { mode: "boolean" }).notNull().default(false),
+    // Stable, opaque workspace identity. Minted once at worktree creation
+    // (`toWorkspaceId(project, branch)`) and frozen thereafter — switching
+    // the git branch inside the worktree must NOT re-key the workspace, or
+    // every chat / task / cronjob / panel row bound to this id would orphan.
+    // Existing rows are backfilled to the historical derived value by the
+    // accompanying migration, so persisted references stay valid. Identity
+    // is the worktree PATH; the branch is just a mutable label on top.
+    workspaceId: text("workspace_id").notNull().default(""),
+  },
+  (table) => [uniqueIndex("worktrees_workspace_id_unique").on(table.workspaceId)],
+);
 
 export const tasks = sqliteTable("tasks", {
   id: text("id").primaryKey(),

--- a/apps/web/src/server/infra/usage-scanner/usage-scanner.ts
+++ b/apps/web/src/server/infra/usage-scanner/usage-scanner.ts
@@ -1,6 +1,5 @@
 import type { CodingAgent, SessionUsageSnapshot } from "@band-app/coding-agent";
 import { createLogger } from "@band-app/logger";
-import { toWorkspaceId } from "@/dashboard";
 import { createWorkspaceAgent } from "../agents/agent-pool";
 import { ProjectQueries } from "../db/queries/projects";
 import { SettingsQueries } from "../db/queries/settings";
@@ -485,7 +484,7 @@ function defaultListWorkspaces(): ReturnType<NonNullable<UsageScannerDeps["listW
   for (const project of projects) {
     for (const worktree of project.worktrees) {
       out.push({
-        workspaceId: toWorkspaceId(project.name, worktree.branch),
+        workspaceId: worktree.id,
         project: project.name,
         worktreePath: worktree.path,
       });

--- a/apps/web/src/server/services/branch-status-poller.ts
+++ b/apps/web/src/server/services/branch-status-poller.ts
@@ -1,6 +1,5 @@
 import { createLogger } from "@band-app/logger";
 import { eq } from "drizzle-orm";
-import { toWorkspaceId } from "@/dashboard";
 import { getDb } from "../infra/db/connection";
 import { branchStatuses as branchStatusesTable } from "../infra/db/schema";
 import { execGh, execGit, getRepoInfo, type RepoInfo } from "../infra/git/git-client";
@@ -87,7 +86,7 @@ function getWorkspaces(): WorkspaceInfo[] {
     if (project.kind === "plain") continue;
     for (const wt of project.worktrees) {
       workspaces.push({
-        workspaceId: toWorkspaceId(project.name, wt.branch),
+        workspaceId: wt.id,
         project: project.name,
         branch: wt.branch,
         defaultBranch: project.defaultBranch,

--- a/apps/web/src/server/services/cronjob-service.ts
+++ b/apps/web/src/server/services/cronjob-service.ts
@@ -453,7 +453,10 @@ export class CronjobService {
     const appState = loadState();
     const project = appState.projects.find((p) => p.name === fileKey);
     if (!project) return null;
-    return toWorkspaceId(project.name, project.defaultBranch);
+    // Resolve to the default-branch worktree's frozen id. Fall back to the
+    // derived value only if no worktree currently sits on the default branch.
+    const defaultWorktree = project.worktrees.find((wt) => wt.branch === project.defaultBranch);
+    return defaultWorktree?.id ?? toWorkspaceId(project.name, project.defaultBranch);
   }
 
   // -------------------------------------------------------------------------

--- a/apps/web/src/server/services/project-service.ts
+++ b/apps/web/src/server/services/project-service.ts
@@ -94,7 +94,7 @@ export class ProjectService {
     // just rely on the helper to mutate `project.kind` /
     // `project.worktrees` in place.
     for (const project of projects) {
-      reconcileKindForProject(project);
+      reconcileKindForProject(project, toWorkspaceId(project.name, "main"));
     }
 
     const result = await Promise.all(
@@ -115,20 +115,30 @@ export class ProjectService {
           // worktree. Without this filter, the list reads stale data from
           // `git worktree list` and shows just-deleted workspaces until the
           // background cleanup completes.
-          const trackedBranches = new Set(project.worktrees.map((wt) => wt.branch));
-          // Map by branch so we can preserve metadata (e.g. `pinned`) that git
-          // doesn't know about when merging git's view with our tracked state.
-          const trackedByBranch = new Map(project.worktrees.map((wt) => [wt.branch, wt]));
+          // Match git's view to our tracked rows by PATH, not branch. A
+          // worktree's path is its stable identity; its branch is a mutable
+          // label that a `git switch` (by the user, an agent, or a terminal)
+          // can change at any time. Keying on branch made a just-switched
+          // worktree vanish from the list until the next `syncWorktrees`
+          // rewrote state — see the disappearing-branch bug. Keying on path
+          // keeps the card present and lets us surface git's live branch.
+          const trackedByPath = new Map(project.worktrees.map((wt) => [wt.path, wt]));
           try {
             const gitWorktrees = await this.git.listWorktrees(project.path);
             worktrees = gitWorktrees
-              .filter((wt) => !wt.isBare && trackedBranches.has(wt.branch))
-              .map((wt) => ({
-                branch: wt.branch,
-                path: wt.path,
-                head: wt.head,
-                pinned: trackedByBranch.get(wt.branch)?.pinned ?? false,
-              }));
+              .filter((wt) => !wt.isBare && trackedByPath.has(wt.path))
+              .map((wt) => {
+                const tracked = trackedByPath.get(wt.path)!;
+                return {
+                  // Preserve the frozen workspace id + pin state from our
+                  // tracked row; take the live branch/head from git.
+                  id: tracked.id,
+                  branch: wt.branch,
+                  path: wt.path,
+                  head: wt.head,
+                  pinned: tracked.pinned,
+                };
+              });
           } catch {
             // Fall back to tracked worktrees
           }
@@ -141,7 +151,7 @@ export class ProjectService {
           label: project.label,
           kind: project.kind,
           worktrees: worktrees.map((wt) => {
-            const workspaceId = toWorkspaceId(project.name, wt.branch);
+            const workspaceId = wt.id;
             const status = statusMap.get(workspaceId);
             return {
               ...wt,
@@ -229,7 +239,13 @@ export class ProjectService {
         const gitWorktrees = await this.git.listWorktrees(resolvedPath);
         worktrees = gitWorktrees
           .filter((wt) => !wt.isBare)
-          .map((wt) => ({ branch: wt.branch, path: wt.path, head: wt.head, pinned: false }));
+          .map((wt) => ({
+            id: toWorkspaceId(name, wt.branch),
+            branch: wt.branch,
+            path: wt.path,
+            head: wt.head,
+            pinned: false,
+          }));
       } catch {
         // No worktrees
       }
@@ -245,7 +261,9 @@ export class ProjectService {
       // the stored workspace path consistent with the `.git` probe and
       // with the implicit assumption elsewhere that workspace paths are
       // canonical.
-      worktrees = [{ branch: "main", path: resolvedPath, pinned: false }];
+      worktrees = [
+        { id: toWorkspaceId(name, "main"), branch: "main", path: resolvedPath, pinned: false },
+      ];
     }
 
     const project: ProjectState = {

--- a/apps/web/src/server/services/sync-service.ts
+++ b/apps/web/src/server/services/sync-service.ts
@@ -1,3 +1,4 @@
+import { toWorkspaceId } from "@/dashboard";
 import { execGit, getRepoInfo, listWorktrees } from "../infra/git/git-client";
 import {
   loadState,
@@ -69,7 +70,7 @@ export async function syncWorktrees(): Promise<void> {
   // end of this function — `projects.list` discards the return value
   // since queries shouldn't write to the DB.
   for (const project of state.projects) {
-    if (reconcileKindForProject(project)) {
+    if (reconcileKindForProject(project, toWorkspaceId(project.name, "main"))) {
       changed = true;
     }
   }
@@ -116,19 +117,24 @@ async function reconcileOneProject(project: ProjectState): Promise<boolean> {
   let diskWorktrees: WorktreeState[];
   try {
     const gitWorktrees = await listWorktrees(project.path);
-    // Preserve the `pinned` flag for branches that still exist —
-    // syncWorktrees runs on a timer, and replacing the tracked
-    // worktrees with git's view would otherwise wipe pin state on
-    // every sync that adds/removes a worktree.
-    const pinnedByBranch = new Map(project.worktrees.map((wt) => [wt.branch, wt.pinned]));
+    // Match by PATH (the stable worktree identity), not branch — a worktree
+    // whose branch was switched keeps the same path, so we carry over its
+    // frozen `id` and `pinned` flag instead of treating it as a brand-new
+    // worktree (which would mint a new id and orphan its chats/tasks). A
+    // worktree we've never seen (created outside Band) mints a fresh id.
+    const existingByPath = new Map(project.worktrees.map((wt) => [wt.path, wt]));
     diskWorktrees = gitWorktrees
       .filter((wt) => !wt.isBare)
-      .map((wt) => ({
-        branch: wt.branch,
-        path: wt.path,
-        head: wt.head,
-        pinned: pinnedByBranch.get(wt.branch) ?? false,
-      }));
+      .map((wt) => {
+        const existing = existingByPath.get(wt.path);
+        return {
+          id: existing?.id ?? toWorkspaceId(project.name, wt.branch),
+          branch: wt.branch,
+          path: wt.path,
+          head: wt.head,
+          pinned: existing?.pinned ?? false,
+        };
+      });
   } catch {
     // If git fails for this project (e.g. path was deleted, NFS mount is
     // gone), it has no usable origin — clear `hasOrigin` so the CI poller

--- a/apps/web/src/server/services/workspace-service.ts
+++ b/apps/web/src/server/services/workspace-service.ts
@@ -233,12 +233,30 @@ export class WorkspaceService {
     const state = loadState();
     for (const project of state.projects) {
       for (const worktree of project.worktrees) {
-        if (toWorkspaceId(project.name, worktree.branch) === workspaceId) {
+        // Match the worktree's frozen identity, not a value re-derived from
+        // its branch — a `git switch` inside the worktree changes the branch
+        // but must still resolve to the same workspace.
+        if (worktree.id === workspaceId) {
           return { project, worktree };
         }
       }
     }
     return null;
+  }
+
+  /**
+   * Resolve a workspace by its `(project, branch)` pair. Used by the legacy
+   * `(project, branch)`-keyed git surface (`gitPull`/`gitPush`) — the
+   * workspaceId-keyed callers go through `resolve()` instead. Returns the
+   * first worktree whose current branch matches; the stable id lives on the
+   * returned `worktree.id` when callers need it.
+   */
+  private resolveByBranch(projectName: string, branch: string): ResolvedWorkspace | null {
+    const state = loadState();
+    const project = state.projects.find((p) => p.name === projectName);
+    if (!project) return null;
+    const worktree = project.worktrees.find((w) => w.branch === branch);
+    return worktree ? { project, worktree } : null;
   }
 
   /**
@@ -310,10 +328,17 @@ export class WorkspaceService {
       throw new Error(e instanceof Error ? e.message : String(e));
     }
 
-    project.worktrees.push({ branch: input.branch, path: worktreePath, pinned: false });
-    saveState(state);
-
+    // Mint the workspace identity once, here, and freeze it on the row. From
+    // now on the id travels with the worktree path — switching the branch
+    // inside the worktree won't re-key it.
     const workspaceId = toWorkspaceId(input.project, input.branch);
+    project.worktrees.push({
+      id: workspaceId,
+      branch: input.branch,
+      path: worktreePath,
+      pinned: false,
+    });
+    saveState(state);
 
     // Copy declared workspace files from the main checkout into the new
     // worktree. Driven by `.band/config.json::workspace.copyFiles` and/or
@@ -426,10 +451,14 @@ export class WorkspaceService {
     }
 
     // ── Fast path: update state and emit immediately ──
+    // Capture the worktree's frozen id BEFORE pruning it from state — all the
+    // workspace-scoped cleanup below keys on the stored id, not a value
+    // re-derived from the branch (which may have been switched since create).
+    const tracked = project.worktrees.find((wt) => wt.branch === input.branch);
     project.worktrees = project.worktrees.filter((wt) => wt.branch !== input.branch);
     saveState(state);
 
-    const workspaceId = toWorkspaceId(input.project, input.branch);
+    const workspaceId = tracked?.id ?? toWorkspaceId(input.project, input.branch);
     try {
       unlinkSync(join(bandHome(), "workspace-prompts", `${workspaceId}.json`));
     } catch {
@@ -612,8 +641,7 @@ export class WorkspaceService {
    * case and a thrown error would surface as a red toast.
    */
   async gitPull(input: WorkspaceGitInput): Promise<{ ok: true }> {
-    const workspaceId = toWorkspaceId(input.project, input.branch);
-    const workspace = this.resolve(workspaceId);
+    const workspace = this.resolveByBranch(input.project, input.branch);
     if (!workspace) {
       throw new WorkspaceNotFoundError(input.branch);
     }
@@ -643,8 +671,7 @@ export class WorkspaceService {
    * a second failing push.
    */
   async gitPush(input: WorkspaceGitInput): Promise<{ ok: true }> {
-    const workspaceId = toWorkspaceId(input.project, input.branch);
-    const workspace = this.resolve(workspaceId);
+    const workspace = this.resolveByBranch(input.project, input.branch);
     if (!workspace) {
       throw new WorkspaceNotFoundError(input.branch);
     }

--- a/apps/web/tests/helpers/seed-state.ts
+++ b/apps/web/tests/helpers/seed-state.ts
@@ -3,6 +3,7 @@ import { join } from "node:path";
 import { DatabaseSync } from "node:sqlite";
 import { drizzle } from "drizzle-orm/node-sqlite";
 import { migrate } from "drizzle-orm/node-sqlite/migrator";
+import { toWorkspaceId } from "../../src/dashboard";
 import * as schema from "../../src/server/infra/db/schema";
 
 const migrationsFolder = join(import.meta.dirname, "../../src/server/infra/db/migrations");
@@ -12,6 +13,14 @@ interface WorktreeData {
   path: string;
   head?: string;
   pinned?: boolean;
+  /**
+   * Stable workspace id. Defaults to the canonical `toWorkspaceId(project,
+   * branch)` value the server would mint at creation — matching the
+   * migration backfill — so existing seeds need no change. Set this
+   * explicitly to simulate a worktree whose branch was switched after
+   * creation (id frozen at the original branch, `branch` now different).
+   */
+  workspaceId?: string;
 }
 
 interface ProjectData {
@@ -64,6 +73,7 @@ export function seedState(tmpHome: string, state: StateData): void {
         tx.insert(schema.worktrees)
           .values({
             projectName: project.name,
+            workspaceId: wt.workspaceId ?? toWorkspaceId(project.name, wt.branch),
             branch: wt.branch,
             path: wt.path,
             head: wt.head ?? null,

--- a/apps/web/tests/projects-branch-switch.test.ts
+++ b/apps/web/tests/projects-branch-switch.test.ts
@@ -1,0 +1,145 @@
+// Black-box regression for the "branch disappears from project branches"
+// bug. When the branch checked out inside a worktree is switched (by an
+// agent, a person, or a terminal `git switch`), the worktree used to vanish
+// from `projects.list` until the app was restarted / state was rewritten —
+// because the list intersected git's live view against tracked worktrees by
+// BRANCH NAME, and the switched worktree's new branch wasn't in the tracked
+// set. The fix keys that intersection by the worktree PATH (its stable
+// identity) and carries the frozen `workspaceId` over, so the card stays
+// present and surfaces git's live branch.
+//
+// Boots the real production server against a tmp `$HOME` with a real on-disk
+// git repo + worktree, drives `projects.list` over real HTTP, and asserts on
+// the response — no mocks. Mirrors the setup style of
+// `workspace-git-ops.test.ts`.
+
+import { execFileSync } from "node:child_process";
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { toWorkspaceId } from "../src/dashboard";
+import { seedSettings, seedState } from "./helpers/seed-state";
+import {
+  createTmpHome,
+  type ServerHandle,
+  startServer,
+  trpcData,
+  trpcQuery,
+} from "./helpers/server";
+
+const TOKEN = "projects-branch-switch-token";
+
+const gitEnv = {
+  ...process.env,
+  GIT_AUTHOR_NAME: "Test",
+  GIT_AUTHOR_EMAIL: "test@test.com",
+  GIT_COMMITTER_NAME: "Test",
+  GIT_COMMITTER_EMAIL: "test@test.com",
+};
+
+function git(cwd: string, args: string[]): string {
+  return execFileSync("git", args, { cwd, env: gitEnv, encoding: "utf-8" });
+}
+
+interface ListedWorktree {
+  workspaceId: string;
+  branch: string;
+  path: string;
+}
+interface ListedProject {
+  name: string;
+  worktrees: ListedWorktree[];
+}
+
+describe("tRPC — projects.list across a worktree branch switch", () => {
+  let server: ServerHandle;
+  let tmpHome: string;
+  let repoPath: string;
+  let wtPath: string;
+
+  const featureId = toWorkspaceId("alpha", "feature");
+
+  beforeAll(async () => {
+    tmpHome = createTmpHome("band-projects-branch-switch-");
+
+    // Real git repo with a real secondary worktree on `feature`.
+    repoPath = join(tmpHome, "alpha");
+    mkdirSync(repoPath, { recursive: true });
+    git(repoPath, ["init", "-b", "main"]);
+    writeFileSync(join(repoPath, "file.txt"), "hello");
+    git(repoPath, ["add", "file.txt"]);
+    git(repoPath, ["commit", "-m", "initial"]);
+
+    wtPath = join(tmpHome, "wt-feature");
+    git(repoPath, ["worktree", "add", "-b", "feature", wtPath]);
+
+    seedState(tmpHome, {
+      projects: [
+        {
+          name: "alpha",
+          path: repoPath,
+          defaultBranch: "main",
+          worktrees: [
+            { branch: "main", path: repoPath },
+            { branch: "feature", path: wtPath },
+          ],
+        },
+      ],
+    });
+    seedSettings(tmpHome, { tokenSecret: TOKEN });
+
+    server = await startServer({ tmpHome });
+  });
+
+  afterAll(async () => {
+    await server.close();
+    rmSync(tmpHome, { recursive: true, force: true });
+  });
+
+  async function listAlpha(): Promise<ListedProject> {
+    const res = await trpcQuery(server.url, "projects.list", undefined, TOKEN);
+    expect(res.status).toBe(200);
+    const data = await trpcData<{ projects: ListedProject[] }>(res);
+    const alpha = data.projects.find((p) => p.name === "alpha");
+    expect(alpha).toBeDefined();
+    return alpha!;
+  }
+
+  it("returns 401 without a token", async () => {
+    const res = await fetch(`${server.url}/trpc/projects.list`);
+    expect(res.status).toBe(401);
+  });
+
+  it("lists the feature worktree with its frozen id before any switch", async () => {
+    const alpha = await listAlpha();
+    const feature = alpha.worktrees.find((wt) => wt.path === wtPath);
+    expect(feature).toBeDefined();
+    expect(feature!.workspaceId).toBe(featureId);
+    expect(feature!.branch).toBe("feature");
+  });
+
+  it("keeps the worktree visible (same id, live branch) after its branch is switched", async () => {
+    // The branch checked out inside the worktree changes out from under Band.
+    git(wtPath, ["switch", "-c", "feature-renamed"]);
+
+    const alpha = await listAlpha();
+
+    // The worktree must not have vanished — the whole bug was a missing card.
+    // Assert the count is unchanged so a disappearing worktree fails here even
+    // if no duplicate appears under the old branch.
+    expect(alpha.worktrees).toHaveLength(2);
+
+    // The worktree must still be present — keyed by its stable path, not the
+    // branch that just changed.
+    const feature = alpha.worktrees.find((wt) => wt.path === wtPath);
+    expect(feature).toBeDefined();
+    // Its workspace identity is frozen at the value minted on creation ...
+    expect(feature!.workspaceId).toBe(featureId);
+    // ... and the list now surfaces git's live branch label.
+    expect(feature!.branch).toBe("feature-renamed");
+
+    // And there is no phantom entry under the old branch name.
+    const stillFeature = alpha.worktrees.filter((wt) => wt.branch === "feature");
+    expect(stillFeature).toHaveLength(0);
+  });
+});

--- a/apps/web/tests/sync-service.test.ts
+++ b/apps/web/tests/sync-service.test.ts
@@ -17,6 +17,7 @@ import { mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from "nod
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { toWorkspaceId } from "../src/dashboard";
 import { closeDb } from "../src/server/infra/db/connection";
 import { loadState, saveState } from "../src/server/services/state";
 import { syncWorktrees } from "../src/server/services/sync-service";
@@ -103,8 +104,12 @@ describe("syncWorktrees", () => {
           path: repoPath,
           defaultBranch: "main",
           worktrees: [
-            { branch: "main", path: repoPath },
-            { branch: "gone", path: join(tmp, "nonexistent-wt") },
+            { id: toWorkspaceId("test-project", "main"), branch: "main", path: repoPath },
+            {
+              id: toWorkspaceId("test-project", "gone"),
+              branch: "gone",
+              path: join(tmp, "nonexistent-wt"),
+            },
           ],
         },
       ],
@@ -132,7 +137,9 @@ describe("syncWorktrees", () => {
           name: "test-project",
           path: repoPath,
           defaultBranch: "main",
-          worktrees: [{ branch: "main", path: repoPath, head }],
+          worktrees: [
+            { id: toWorkspaceId("test-project", "main"), branch: "main", path: repoPath, head },
+          ],
           hasOrigin: false,
         },
       ],
@@ -164,7 +171,7 @@ describe("syncWorktrees", () => {
           name: "with-origin",
           path: repoPath,
           defaultBranch: "main",
-          worktrees: [{ branch: "main", path: repoPath }],
+          worktrees: [{ id: toWorkspaceId("with-origin", "main"), branch: "main", path: repoPath }],
           hasOrigin: false, // seeded false so we can prove the sync flips it
         },
       ],
@@ -187,7 +194,7 @@ describe("syncWorktrees", () => {
           name: "no-origin",
           path: repoPath,
           defaultBranch: "main",
-          worktrees: [{ branch: "main", path: repoPath }],
+          worktrees: [{ id: toWorkspaceId("no-origin", "main"), branch: "main", path: repoPath }],
           hasOrigin: true,
         },
       ],
@@ -209,7 +216,13 @@ describe("syncWorktrees", () => {
           name: "broken-project",
           path: join(tmp, "does-not-exist"),
           defaultBranch: "main",
-          worktrees: [{ branch: "stale", path: join(tmp, "does-not-exist", "wt") }],
+          worktrees: [
+            {
+              id: toWorkspaceId("broken-project", "stale"),
+              branch: "stale",
+              path: join(tmp, "does-not-exist", "wt"),
+            },
+          ],
         },
         {
           name: "good-project",
@@ -248,7 +261,15 @@ describe("syncWorktrees", () => {
           name: "pin-test",
           path: repoPath,
           defaultBranch: "main",
-          worktrees: [{ branch: "main", path: repoPath, head, pinned: true }],
+          worktrees: [
+            {
+              id: toWorkspaceId("pin-test", "main"),
+              branch: "main",
+              path: repoPath,
+              head,
+              pinned: true,
+            },
+          ],
           hasOrigin: false,
         },
       ],
@@ -259,5 +280,48 @@ describe("syncWorktrees", () => {
     const state = loadState();
     expect(state.projects[0].worktrees.length).toBe(1);
     expect(state.projects[0].worktrees[0].pinned).toBe(true);
+  });
+
+  // Regression: switching the branch checked out inside a worktree (by an
+  // agent, a person, or a terminal) must NOT re-key the workspace. The
+  // worktree's path is its stable identity, so sync keys by path and carries
+  // the frozen `id` over even though the branch label changed. Before the
+  // path-based identity fix, the branch switch made the worktree look brand
+  // new and it vanished from the project's branch list until the next full
+  // state rewrite.
+  it("preserves the frozen workspace id when the worktree's branch is switched", async () => {
+    const repoPath = createRepo(tmp);
+    const wtPath = join(tmp, "wt-feature");
+    git(repoPath, ["worktree", "add", "-b", "feature", wtPath]);
+
+    const frozenId = toWorkspaceId("switch-test", "feature");
+    saveState({
+      projects: [
+        {
+          name: "switch-test",
+          path: repoPath,
+          defaultBranch: "main",
+          worktrees: [
+            { id: toWorkspaceId("switch-test", "main"), branch: "main", path: repoPath },
+            { id: frozenId, branch: "feature", path: wtPath },
+          ],
+          hasOrigin: false,
+        },
+      ],
+    });
+
+    // The branch the worktree sits on changes out from under Band.
+    git(wtPath, ["switch", "-c", "feature-renamed"]);
+
+    await syncWorktrees();
+
+    const worktrees = loadState().projects[0].worktrees;
+    // The worktree is still tracked (it did not vanish) ...
+    const switched = worktrees.find((wt) => wt.path === wtPath);
+    expect(switched).toBeDefined();
+    // ... its id is unchanged (frozen at creation) ...
+    expect(switched!.id).toBe(frozenId);
+    // ... and the branch label now reflects git's live value.
+    expect(switched!.branch).toBe("feature-renamed");
   });
 });

--- a/apps/web/tests/workspace-queries.test.ts
+++ b/apps/web/tests/workspace-queries.test.ts
@@ -8,20 +8,15 @@ import { WorkspaceQueries } from "../src/server/infra/db/queries/workspaces";
 import { seedState } from "./helpers/seed-state";
 
 // ---------------------------------------------------------------------------
-// WorkspaceQueries.findIdentity — pins the SQL match expression and the
-// non-injective `toWorkspaceId` collision behaviour acknowledged in the
-// TODO on `findIdentity`. The encoding
+// WorkspaceQueries.findIdentity — pins the exact-id lookup contract.
 //
-//   ${project}-${branch.replaceAll("/", "-")}
-//
-// is lossy: project "foo-bar" + branch "main" and project "foo" + branch
-// "bar/main" both serialize to "foo-bar-main". The SQL match expression
-// (`project_name || '-' || REPLACE(branch, '/', '-')`) and the runtime
-// sanity-check guard (`toWorkspaceId(row.project, row.branch) ===
-// workspaceId`) both accept either row, so SQLite's `.get()` returns
-// whichever row it finds first. These tests lock that current contract
-// so a future SQL rewrite (or change to `toWorkspaceId`) can't silently
-// flip the behaviour.
+// `findIdentity` now matches on the stored, unique `worktrees.workspace_id`
+// column (the worktree's frozen identity) rather than re-deriving the id
+// from `project_name || '-' || REPLACE(branch, '/', '-')` at query time.
+// That kills the old non-injective-encoding ambiguity (project "foo-bar" +
+// branch "main" and project "foo" + branch "bar/main" both serialize to
+// "foo-bar-main"): the unique index makes two such rows impossible to store
+// at all, and lookups resolve to one exact row by id.
 // ---------------------------------------------------------------------------
 
 describe("WorkspaceQueries.findIdentity", () => {
@@ -105,50 +100,66 @@ describe("WorkspaceQueries.findIdentity", () => {
     expect(identity).toBeNull();
   });
 
-  it("returns ONE of the colliding rows when the workspace id is ambiguous", () => {
-    // Both ("foo-bar", "main") and ("foo", "bar/main") serialize to
-    // "foo-bar-main" via `toWorkspaceId`. Both SQL rows satisfy the
-    // match expression `project_name || '-' || REPLACE(branch, '/', '-')`
-    // and both satisfy the runtime sanity check
-    // `toWorkspaceId(row.project, row.branch) === workspaceId`, so
-    // SQLite's `.get()` returns whichever row it finds first. We don't
-    // assert which one wins — that's an implementation detail of the
-    // SQL engine — but we DO assert that:
-    //   1. some row is returned (the sanity check doesn't drop both), and
-    //   2. it's one of the two colliding rows verbatim (no field
-    //      mangling), and
-    //   3. it round-trips through `toWorkspaceId` to the same id
-    //      (sanity-check holds).
-    const wtPathA = join(tmp, "worktrees", "foo-bar", "main");
-    const wtPathB = join(tmp, "worktrees", "foo", "bar", "main");
-    const workspaceId = toWorkspaceId("foo-bar", "main");
-    expect(workspaceId).toBe("foo-bar-main");
-    expect(toWorkspaceId("foo", "bar/main")).toBe(workspaceId);
+  it("resolves each workspace by its exact stored id with no cross-talk", () => {
+    // Two worktrees whose ids share a prefix. The old query re-derived the
+    // id from (project, branch) and could mis-resolve; the column lookup is
+    // exact, so each id maps to exactly its own row.
+    const wtPathA = join(tmp, "worktrees", "alpha", "main");
+    const wtPathB = join(tmp, "worktrees", "alpha", "feature");
+    const idA = toWorkspaceId("alpha", "main");
+    const idB = toWorkspaceId("alpha", "feature");
 
     seedState(tmp, {
       projects: [
         {
-          name: "foo-bar",
-          path: join(tmp, "repos", "foo-bar"),
+          name: "alpha",
+          path: join(tmp, "repos", "alpha"),
           defaultBranch: "main",
-          worktrees: [{ branch: "main", path: wtPathA }],
-        },
-        {
-          name: "foo",
-          path: join(tmp, "repos", "foo"),
-          defaultBranch: "main",
-          worktrees: [{ branch: "bar/main", path: wtPathB }],
+          worktrees: [
+            { branch: "main", path: wtPathA },
+            { branch: "feature", path: wtPathB },
+          ],
         },
       ],
     });
 
-    const identity = queries.findIdentity(workspaceId);
-    expect(identity).not.toBeNull();
-    const candidates = [
-      { project: "foo-bar", branch: "main", worktreePath: wtPathA },
-      { project: "foo", branch: "bar/main", worktreePath: wtPathB },
-    ];
-    expect(candidates).toContainEqual(identity);
-    expect(toWorkspaceId(identity!.project, identity!.branch)).toBe(workspaceId);
+    expect(queries.findIdentity(idA)).toEqual({
+      project: "alpha",
+      branch: "main",
+      worktreePath: wtPathA,
+    });
+    expect(queries.findIdentity(idB)).toEqual({
+      project: "alpha",
+      branch: "feature",
+      worktreePath: wtPathB,
+    });
+  });
+
+  it("a switched branch still resolves via its frozen id, not the new branch", () => {
+    // The worktree was created on `feature` (id frozen as alpha-feature) but
+    // its branch was later switched to `feature-renamed`. Resolution must key
+    // on the frozen id; the live branch is just a label carried on the row.
+    const wtPath = join(tmp, "worktrees", "alpha", "feature");
+    const frozenId = toWorkspaceId("alpha", "feature");
+
+    seedState(tmp, {
+      projects: [
+        {
+          name: "alpha",
+          path: join(tmp, "repos", "alpha"),
+          defaultBranch: "main",
+          worktrees: [{ workspaceId: frozenId, branch: "feature-renamed", path: wtPath }],
+        },
+      ],
+    });
+
+    // The id derived from the *new* branch resolves to nothing ...
+    expect(queries.findIdentity(toWorkspaceId("alpha", "feature-renamed"))).toBeNull();
+    // ... while the frozen id resolves to the worktree, reporting its live branch.
+    expect(queries.findIdentity(frozenId)).toEqual({
+      project: "alpha",
+      branch: "feature-renamed",
+      worktreePath: wtPath,
+    });
   });
 });


### PR DESCRIPTION
Closes #558

## PO Summary

When you switched the git branch inside a worktree — whether the agent did it, you did it, or a terminal `git switch` ran — that worktree's card would **disappear** from the project's branch list until the next state rewrite or app restart. This made workspaces feel like they randomly vanished.

This fixes it: each worktree now keeps a **stable identity tied to its folder**, not its branch. Switch branches as much as you like — the card stays put, and the list just shows the new branch name. Existing workspaces, their chats, tasks, cronjobs, and pinned state all carry over cleanly via a one-time migration.

## What changed

A workspace's id was derived on the fly from its git branch. Switching the branch changed the derived id, so `projects.list` — which matched git's live worktrees against tracked state by branch name — filtered the worktree out and dropped its card.

Each worktree now gets a stable, frozen `workspaceId`, stored in a new `worktrees.workspace_id` column and minted once at creation. Identity is the worktree **path**; the branch is a mutable label on top.

- **schema + migration**: add `workspace_id` (unique index); backfill existing rows to the historical derived value (`name-branch`) so all persisted refs (chats / tasks / cronjobs / panels / localStorage) stay valid. Backfill disambiguates rows that would collide under the old non-injective encoding before creating the unique index, so the migration can't abort.
- **project-service.list / sync-service**: reconcile git's view against tracked rows by path, carry the frozen id over, surface git's live branch.
- **findIdentity**: exact indexed lookup on `workspace_id` (also fixes the long-standing non-injective-id ambiguity).
- **resolve / create / remove / routers / pollers / usage-scanner**: use the stored id instead of recomputing from the branch.
- **frontend**: `WorktreeInfo.workspaceId` from the server; all recompute sites use it; `CronjobsPageContent` attributes jobs via a workspaceId→project map and fetches projects once on mount instead of on the 5s poll.

## Tests

- backend black-box `projects-branch-switch` + frontend e2e prove the card survives a real branch switch
- `sync-service` + `workspace-queries` cover the path-keyed reconcile and exact-id resolution

🤖 Generated with [Claude Code](https://claude.com/claude-code)