### PR TITLE
Virtualize chat list + cached-workspace reconnect/UX fixes

### DIFF
--- a/apps/web/e2e/chat-cancel.spec.ts
+++ b/apps/web/e2e/chat-cancel.spec.ts
@@ -30,6 +30,7 @@ import { mkdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { expect, test } from "@playwright/test";
 import { toWorkspaceId } from "@/dashboard";
+import { fakeAgentPath } from "./helpers/fake-agent";
 import {
   cleanupTmpHome,
   createTmpHome,
@@ -46,7 +47,7 @@ const WORKSPACE = toWorkspaceId(PROJECT, "main");
 
 test.use({ viewport: { width: 1280, height: 800 } });
 
-const FAKE_AGENT_PATH = join(import.meta.dirname, "..", "tests", "fake-agent.mjs");
+const FAKE_AGENT_PATH = fakeAgentPath();
 
 let server: ServerHandle;
 let tmpHome: string;

--- a/apps/web/e2e/chat-cancel.spec.ts
+++ b/apps/web/e2e/chat-cancel.spec.ts
@@ -135,7 +135,11 @@ test.describe("Chat cancel — Stop button aborts the task", () => {
     // a second; the subsequent 30 s sleep keeps the Stop button on
     // screen until we click it.
     await expect(chatPane.stopButton).toBeVisible();
-    await expect(chatPane.userMessage("partial reply")).toBeVisible();
+    // "partial reply" is the agent's streamed text (fake-agent
+    // text-delta), so scope to the assistant role — the page object's
+    // locators distinguish user vs assistant after #562's role-scoping
+    // change.
+    await expect(chatPane.assistantMessage("partial reply")).toBeVisible();
     // While streaming, the inline thinking indicator IS rendered (the
     // trailing-assistant indicator's condition + the inline
     // `showThinking` branch both fire). We don't assert its absence
@@ -152,6 +156,6 @@ test.describe("Chat cancel — Stop button aborts the task", () => {
     // The partial text the agent had already streamed remains in the
     // conversation — cancelling preserves what was rendered, doesn't
     // wipe it.
-    await expect(chatPane.userMessage("partial reply")).toBeVisible();
+    await expect(chatPane.assistantMessage("partial reply")).toBeVisible();
   });
 });

--- a/apps/web/e2e/chat-cancel.spec.ts
+++ b/apps/web/e2e/chat-cancel.spec.ts
@@ -137,9 +137,12 @@ test.describe("Chat cancel — Stop button aborts the task", () => {
     // screen until we click it.
     await expect(chatPane.stopButton).toBeVisible();
     // "partial reply" is the agent's streamed text (fake-agent
-    // text-delta), so scope to the assistant role — the page object's
-    // locators distinguish user vs assistant after #562's role-scoping
-    // change.
+    // text-delta), so scope to the assistant role. The page object's
+    // `assistantMessage`/`userMessage` locators are role-scoped on
+    // `chat-pane__assistant-message` / `chat-pane__user-message` —
+    // a future rendering change that places user text inside an
+    // assistant bubble (or vice versa) trips this locator instead
+    // of silently passing.
     await expect(chatPane.assistantMessage("partial reply")).toBeVisible();
     // While streaming, the inline thinking indicator IS rendered (the
     // trailing-assistant indicator's condition + the inline

--- a/apps/web/e2e/chat-cancel.spec.ts
+++ b/apps/web/e2e/chat-cancel.spec.ts
@@ -152,6 +152,12 @@ test.describe("Chat cancel — Stop button aborts the task", () => {
     // unmounts and the thinking indicator unmounts.
     await chatPane.clickStop();
 
+    // Positive anchor: the prompt becomes interactive again once
+    // status leaves "streaming". Asserting this BEFORE the two
+    // not-toBeVisible() calls below proves the cancel reached
+    // a settled state — without the anchor the negatives could
+    // pass vacuously against a still-mid-transition UI.
+    await expect(chatPane.promptInput).toBeEnabled();
     await expect(chatPane.stopButton).not.toBeVisible();
     await expect(chatPane.thinkingIndicator).not.toBeVisible();
     // The partial text the agent had already streamed remains in the

--- a/apps/web/e2e/chat-virtualization.spec.ts
+++ b/apps/web/e2e/chat-virtualization.spec.ts
@@ -1,0 +1,304 @@
+/**
+ * Frontend integration test for chat message-list virtualization (issue
+ * tracking renderer memory: live profiling found ~88% of the desktop
+ * renderer's DOM was un-virtualized chat history; a 600-turn
+ * conversation produced ~30k DOM nodes and held the renderer at ~1 GB
+ * resident). The fix mounts only messages near the viewport via
+ * `@tanstack/react-virtual` inside `<StickToBottom.Content>`.
+ *
+ * Doctrine references:
+ *   - `docs/integration-testing.md` — the why behind real-server +
+ *     Express-stub testing.
+ *   - `.claude/skills/write-integration-test/SKILL.md` — the operational
+ *     playbook this spec follows.
+ *   - `.claude/testing-criteria.md` (TEST-1...TEST-35) — the
+ *     reviewer-enforced rules.
+ *
+ * What this test proves:
+ *
+ *   1. **Windowing works.** A chat seeded with a 500-turn
+ *      (1000-message) session renders only a handful of message rows
+ *      in the DOM at any one time — well below the total.
+ *
+ *   2. **Stick-to-bottom still works.** On cold load with a long
+ *      conversation, the last (most recent) message is the one visible
+ *      in the viewport, not the first.
+ *
+ *   3. **Scrolling reveals earlier messages.** Scrolling the chat
+ *      container to the top brings the first seeded message into the
+ *      DOM (the virtualizer mounts it on demand).
+ *
+ * Architecture:
+ *
+ *   - REAL production `dist/start-server.mjs` against a fresh
+ *     `mkdtempSync()` home. Migrations run on boot.
+ *   - NO tRPC mocking; the chat-events SSE stream replays our
+ *     seeded JSONL through the real Claude Code adapter
+ *     (`getSessionMessages` reads the file from disk).
+ *   - The chat row + chat dockview layout are seeded through real
+ *     tRPC calls (`chats.create` + `chats.setActiveSession`) BEFORE
+ *     the user navigates — that way the dashboard's saved layout
+ *     reflects our chosen `chatId` and we don't fight with the
+ *     `createDefaultPanel` fallback.
+ *   - The fake-agent path is configured so the claude-code adapter
+ *     resolves cleanly; the binary is never spawned (we don't submit
+ *     a message in this test — replay is all we need).
+ *   - UI driven through `ChatPanePage` (page-object pattern); no
+ *     `page.getByTestId` / `page.getByText` / `page.evaluate`
+ *     querySelector lookups in the test body.
+ */
+
+import { mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { expect, test } from "@playwright/test";
+import { toWorkspaceId } from "@/dashboard";
+import {
+  cleanupTmpHome,
+  createTmpHome,
+  type ServerHandle,
+  seedSettings,
+  seedState,
+  startServer,
+} from "./helpers/server";
+import { ChatPanePage } from "./pages/ChatPanePage";
+
+const TOKEN = "e2e-chat-virtualization-token";
+const PROJECT = "virtproj";
+const WORKSPACE = toWorkspaceId(PROJECT, "main");
+const CHAT_ID = "virt-chat-deterministic-id";
+const SESSION_ID = "11111111-2222-3333-4444-555555555555";
+
+// Total seeded turns. Each turn writes one user + one assistant message,
+// so the rendered conversation is 2 × TURNS messages. 500 is large
+// enough to make windowing measurable (renderer should ideally cap at
+// a few dozen rows mounted) without ballooning test cost.
+const TURNS = 500;
+
+// Wide viewport so useIsDesktop() reports true and the shared dockview
+// renders the chat pane in its desktop layout (mobile layout has a
+// different DOM structure).
+test.use({ viewport: { width: 1280, height: 800 } });
+
+const FAKE_AGENT_PATH = join(import.meta.dirname, "..", "tests", "fake-agent.mjs");
+
+let server: ServerHandle;
+let tmpHome: string;
+let repoDir: string;
+
+test.beforeAll(async () => {
+  tmpHome = createTmpHome();
+
+  repoDir = join(tmpHome, "repo");
+  mkdirSync(repoDir, { recursive: true });
+
+  seedState(tmpHome, {
+    projects: [
+      {
+        name: PROJECT,
+        path: repoDir,
+        defaultBranch: "main",
+        worktrees: [{ branch: "main", path: repoDir }],
+      },
+    ],
+  });
+  seedSettings(tmpHome, {
+    tokenSecret: TOKEN,
+    defaultCodingAgent: "claude-code",
+    codingAgents: [
+      {
+        id: "claude-code",
+        type: "claude-code",
+        label: "Claude Code",
+        // The binary path only matters if we spawn a task — we don't
+        // here. Still required so the agent config validates.
+        command: FAKE_AGENT_PATH,
+      },
+    ],
+  });
+
+  // Seed the session JSONL on disk in the Claude Code SDK's expected
+  // layout: `<HOME>/.claude/projects/<encoded-cwd>/<sessionId>.jsonl`.
+  // The encoded path replaces every non-alphanumeric char with `-` —
+  // matches the SDK's hashing in `getSessionMessages`.
+  const encodedRepoDir = repoDir.replace(/[^a-zA-Z0-9]/g, "-");
+  const projectDir = join(tmpHome, ".claude", "projects", encodedRepoDir);
+  mkdirSync(projectDir, { recursive: true });
+  writeFileSync(join(projectDir, `${SESSION_ID}.jsonl`), buildLongSessionJsonl(SESSION_ID, TURNS));
+
+  server = await startServer({
+    tmpHome,
+    env: {
+      // Empty scenario — the agent binary isn't spawned in this test,
+      // but the env var is still read on boot.
+      FAKE_AGENT_SCENARIO: "",
+    },
+  });
+
+  // Pre-create the chat with a deterministic id (so the dashboard's
+  // saved-layout lookup finds it) and point it at our seeded session.
+  // Hitting the real tRPC surface keeps the layout/active-session
+  // bookkeeping consistent with the production code paths.
+  await trpcMutate("chats.create", {
+    workspaceId: WORKSPACE,
+    id: CHAT_ID,
+    agent: "claude-code",
+  });
+  // `chats.update` doesn't take sessionId — `setActiveSession` does, and
+  // it also synchronously resolves the on-disk summary via the agent so
+  // the chat row carries a valid `activeSessionSummary` before the
+  // chat-events subscription opens.
+  await trpcMutate("chats.setActiveSession", {
+    workspaceId: WORKSPACE,
+    chatId: CHAT_ID,
+    sessionId: SESSION_ID,
+  });
+});
+
+test.afterAll(async () => {
+  await server.close();
+  cleanupTmpHome(tmpHome);
+});
+
+test.describe("Chat message-list virtualization", () => {
+  test("long conversation renders only a windowed slice of messages and stays scrolled to bottom", async ({
+    page,
+  }) => {
+    const chatPane = new ChatPanePage(page, server.url, TOKEN);
+    await chatPane.goto(WORKSPACE);
+    await chatPane.waitForReady();
+
+    // Wait for the virtualized list container to mount. Its appearance
+    // means the chat-events subscription has resolved the seeded
+    // session and the reducer has at least one message to render.
+    await expect(chatPane.virtualList).toBeVisible({ timeout: 15_000 });
+
+    // Wait for the LAST seeded message text to be present. That's how
+    // we know JSONL replay completed AND stick-to-bottom did its
+    // initial scroll — the bottom row mounts only when the viewport
+    // is at the end of the list.
+    const lastAssistantTag = assistantText(TURNS - 1);
+    await expect(chatPane.assistantMessage(lastAssistantTag)).toBeVisible({
+      timeout: 30_000,
+    });
+
+    // Windowing assertion — the number of mounted message rows must be
+    // a small fraction of the total. A non-virtualized list would
+    // mount all 1000 rows. The exact cap depends on viewport height
+    // and overscan; well below 100 leaves plenty of headroom for
+    // safe variation across CI runners and rules out the
+    // un-virtualized regression cleanly. `expect.poll` lets the bound
+    // itself auto-retry — the visibility wait above already proves at
+    // least one row mounted, so we don't need a separate "> 0" check.
+    await expect.poll(() => chatPane.messageRowCount()).toBeLessThan(100);
+
+    // The very first seeded message must NOT be in the DOM right now —
+    // the user is parked at the bottom of a 1000-message conversation,
+    // there's no way the row at position 0 is mounted. This is the
+    // dual of the bounded-row assertion: it pins *which* rows are
+    // mounted, not just how many.
+    const firstUserTag = userText(0);
+    await expect(chatPane.userMessage(firstUserTag)).toHaveCount(0);
+
+    // Scroll to the top of the chat container via the page-object
+    // helper — drives the virtualizer's on-demand mount path so the
+    // earliest rows enter the DOM.
+    await chatPane.scrollToTop();
+    await expect(chatPane.userMessage(firstUserTag)).toBeVisible({
+      timeout: 10_000,
+    });
+
+    // After scrolling up, the bottom row is no longer mounted — the
+    // window moved. This proves the renderer is genuinely swapping
+    // rows in and out (not just rendering everything and scrolling).
+    await expect(chatPane.assistantMessage(lastAssistantTag)).toHaveCount(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Real tRPC mutation hitting the server's HTTP surface. Same shape as
+ * the queue-ui spec — keeps the test's setup path identical to a real
+ * client's so the chat row + layout end up in the same on-disk state
+ * as a production user clicking the same buttons.
+ */
+async function trpcMutate(procedure: string, input: unknown): Promise<void> {
+  const res = await fetch(`${server.url}/trpc/${procedure}`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Cookie: `band_token=${TOKEN}`,
+    },
+    body: JSON.stringify(input),
+  });
+  if (!res.ok) {
+    const text = await res.text().catch(() => "");
+    throw new Error(`trpcMutate(${procedure}) failed: ${res.status} ${text}`);
+  }
+}
+
+/** Build a Claude Code session JSONL with `turns` user→assistant
+ *  message pairs. Each prompt and reply carries a unique tag so the
+ *  test can `page.getByText(tag)` against a specific message without
+ *  matching the wrong row. */
+function buildLongSessionJsonl(sessionId: string, turns: number): string {
+  const lines: string[] = [];
+  let parentUuid: string | null = null;
+  for (let i = 0; i < turns; i++) {
+    const userUuid = uuid(i * 2 + 1);
+    const assistantUuid = uuid(i * 2 + 2);
+    const ts = new Date(Date.UTC(2026, 0, 1, 0, 0, i * 2)).toISOString();
+    lines.push(
+      JSON.stringify({
+        type: "user",
+        uuid: userUuid,
+        parentUuid,
+        sessionId,
+        isSidechain: false,
+        userType: "external",
+        message: { role: "user", content: [{ type: "text", text: userText(i) }] },
+        timestamp: ts,
+      }),
+    );
+    lines.push(
+      JSON.stringify({
+        type: "assistant",
+        uuid: assistantUuid,
+        parentUuid: userUuid,
+        sessionId,
+        isSidechain: false,
+        message: { role: "assistant", content: [{ type: "text", text: assistantText(i) }] },
+        timestamp: new Date(Date.UTC(2026, 0, 1, 0, 0, i * 2 + 1)).toISOString(),
+      }),
+    );
+    parentUuid = assistantUuid;
+  }
+  // last-prompt record — surfaced as the session summary.
+  lines.push(
+    JSON.stringify({
+      type: "last-prompt",
+      sessionId,
+      lastPrompt: userText(turns - 1),
+      timestamp: new Date(Date.UTC(2026, 0, 1, 0, 0, turns * 2)).toISOString(),
+      uuid: uuid(turns * 2 + 1),
+      parentUuid: null,
+    }),
+  );
+  return `${lines.join("\n")}\n`;
+}
+
+function uuid(n: number): string {
+  return `00000000-0000-0000-0000-${String(n).padStart(12, "0")}`;
+}
+
+/** Distinct, easily-matchable text per turn — index-bearing so we can
+ *  query for a specific message without ambiguity. */
+function userText(turn: number): string {
+  return `virt-prompt-${turn}-marker`;
+}
+
+function assistantText(turn: number): string {
+  return `virt-reply-${turn}-marker`;
+}

--- a/apps/web/e2e/chat-virtualization.spec.ts
+++ b/apps/web/e2e/chat-virtualization.spec.ts
@@ -6,9 +6,10 @@
  * resident). The fix mounts only messages near the viewport via
  * `@tanstack/react-virtual` inside `<StickToBottom.Content>`.
  *
- * See `docs/integration-testing.md` for the doctrine this spec follows
- * (real-server boot, Express stubs at the network boundary, page-object
- * driving, no tRPC mocking).
+ * Boots the real production server, drives through Playwright + a page
+ * object, no tRPC mocking. The spec body never touches `page.goto` /
+ * `page.getByTestId` / `page.getByText` directly — all locators live on
+ * `ChatPanePage`.
  *
  * What this test proves:
  *

--- a/apps/web/e2e/chat-virtualization.spec.ts
+++ b/apps/web/e2e/chat-virtualization.spec.ts
@@ -154,7 +154,10 @@ test.beforeAll(async () => {
 });
 
 test.afterAll(async () => {
-  await server.close();
+  // Null-guard: if `startServer` threw in beforeAll, `server` is
+  // unassigned. Letting that bubble would mask the original
+  // setup failure with a `TypeError`.
+  if (server) await server.close();
   cleanupTmpHome(tmpHome);
 });
 

--- a/apps/web/e2e/chat-virtualization.spec.ts
+++ b/apps/web/e2e/chat-virtualization.spec.ts
@@ -189,7 +189,10 @@ test.describe("Chat message-list virtualization", () => {
     // un-virtualized regression cleanly. `expect.poll` lets the bound
     // itself auto-retry — the visibility wait above already proves at
     // least one row mounted, so we don't need a separate "> 0" check.
-    await expect.poll(() => chatPane.messageRowCount()).toBeLessThan(100);
+    // Explicit `timeout: 15_000` so a slow CI runner replaying a
+    // 500-turn JSONL has time to settle (Playwright's default poll
+    // timeout is ~5 s).
+    await expect.poll(() => chatPane.messageRowCount(), { timeout: 15_000 }).toBeLessThan(100);
 
     // The very first seeded message must NOT be in the DOM right now —
     // the user is parked at the bottom of a 1000-message conversation,
@@ -213,7 +216,12 @@ test.describe("Chat message-list virtualization", () => {
     // After scrolling up, the bottom row is no longer mounted — the
     // window moved. This proves the renderer is genuinely swapping
     // rows in and out (not just rendering everything and scrolling).
-    await expect(chatPane.assistantMessage(lastAssistantTag)).toHaveCount(0);
+    // `expect.poll` so Playwright retries while the virtualizer
+    // catches up to the scroll-position change; a single synchronous
+    // sample could race the React commit on slow CI runners.
+    await expect
+      .poll(() => chatPane.assistantMessage(lastAssistantTag).count(), { timeout: 10_000 })
+      .toBe(0);
   });
 });
 

--- a/apps/web/e2e/chat-virtualization.spec.ts
+++ b/apps/web/e2e/chat-virtualization.spec.ts
@@ -58,6 +58,7 @@ import {
   seedState,
   startServer,
 } from "./helpers/server";
+import { trpcMutate } from "./helpers/trpc";
 import { ChatPanePage } from "./pages/ChatPanePage";
 
 const TOKEN = "e2e-chat-virtualization-token";
@@ -136,7 +137,7 @@ test.beforeAll(async () => {
   // saved-layout lookup finds it) and point it at our seeded session.
   // Hitting the real tRPC surface keeps the layout/active-session
   // bookkeeping consistent with the production code paths.
-  await trpcMutate("chats.create", {
+  await trpcMutate(server.url, TOKEN, "chats.create", {
     workspaceId: WORKSPACE,
     id: CHAT_ID,
     agent: "claude-code",
@@ -145,7 +146,7 @@ test.beforeAll(async () => {
   // it also synchronously resolves the on-disk summary via the agent so
   // the chat row carries a valid `activeSessionSummary` before the
   // chat-events subscription opens.
-  await trpcMutate("chats.setActiveSession", {
+  await trpcMutate(server.url, TOKEN, "chats.setActiveSession", {
     workspaceId: WORKSPACE,
     chatId: CHAT_ID,
     sessionId: SESSION_ID,
@@ -229,30 +230,11 @@ test.describe("Chat message-list virtualization", () => {
 // Helpers
 // ---------------------------------------------------------------------------
 
-/**
- * Real tRPC mutation hitting the server's HTTP surface. Same shape as
- * the queue-ui spec — keeps the test's setup path identical to a real
- * client's so the chat row + layout end up in the same on-disk state
- * as a production user clicking the same buttons.
- */
-async function trpcMutate(procedure: string, input: unknown): Promise<void> {
-  // Query-string auth mirrors the established pattern in
-  // `apps/web/e2e/queue-ui.spec.ts` — keeps the test-helper auth idiom
-  // consistent across the suite.
-  const res = await fetch(`${server.url}/trpc/${procedure}?token=${TOKEN}`, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify(input),
-  });
-  if (!res.ok) {
-    const text = await res.text().catch(() => "");
-    throw new Error(`trpcMutate(${procedure}) failed: ${res.status} ${text}`);
-  }
-}
-
 /** Build a Claude Code session JSONL with `turns` user→assistant
  *  message pairs. Each prompt and reply carries a unique tag so the
- *  test can `page.getByText(tag)` against a specific message without
+ *  test can address a specific message via
+ *  `chatPane.userMessage(tag)` / `chatPane.assistantMessage(tag)`
+ *  (role-scoped `getByTestId(...).filter({ hasText })`) without
  *  matching the wrong row. */
 function buildLongSessionJsonl(sessionId: string, turns: number): string {
   const lines: string[] = [];

--- a/apps/web/e2e/chat-virtualization.spec.ts
+++ b/apps/web/e2e/chat-virtualization.spec.ts
@@ -192,8 +192,13 @@ test.describe("Chat message-list virtualization", () => {
     // least one row mounted, so we don't need a separate "> 0" check.
     // Explicit `timeout: 15_000` so a slow CI runner replaying a
     // 500-turn JSONL has time to settle (Playwright's default poll
-    // timeout is ~5 s).
-    await expect.poll(() => chatPane.messageRowCount(), { timeout: 15_000 }).toBeLessThan(100);
+    // timeout is ~5 s). `interval: 500` because the actual signal we
+    // care about (row count stabilising under the bound) flips
+    // exactly once, so polling 10× per second during the long
+    // loading phase wastes CPU compared to ~2× per second.
+    await expect
+      .poll(() => chatPane.messageRowCount(), { timeout: 15_000, interval: 500 })
+      .toBeLessThan(100);
 
     // The very first seeded message must NOT be in the DOM right now —
     // the user is parked at the bottom of a 1000-message conversation,

--- a/apps/web/e2e/chat-virtualization.spec.ts
+++ b/apps/web/e2e/chat-virtualization.spec.ts
@@ -6,13 +6,9 @@
  * resident). The fix mounts only messages near the viewport via
  * `@tanstack/react-virtual` inside `<StickToBottom.Content>`.
  *
- * Doctrine references:
- *   - `docs/integration-testing.md` — the why behind real-server +
- *     Express-stub testing.
- *   - `.claude/skills/write-integration-test/SKILL.md` — the operational
- *     playbook this spec follows.
- *   - `.claude/testing-criteria.md` (TEST-1...TEST-35) — the
- *     reviewer-enforced rules.
+ * See `docs/integration-testing.md` for the doctrine this spec follows
+ * (real-server boot, Express stubs at the network boundary, page-object
+ * driving, no tRPC mocking).
  *
  * What this test proves:
  *
@@ -225,12 +221,12 @@ test.describe("Chat message-list virtualization", () => {
  * as a production user clicking the same buttons.
  */
 async function trpcMutate(procedure: string, input: unknown): Promise<void> {
-  const res = await fetch(`${server.url}/trpc/${procedure}`, {
+  // Query-string auth mirrors the established pattern in
+  // `apps/web/e2e/queue-ui.spec.ts` — keeps the test-helper auth idiom
+  // consistent across the suite.
+  const res = await fetch(`${server.url}/trpc/${procedure}?token=${TOKEN}`, {
     method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      Cookie: `band_token=${TOKEN}`,
-    },
+    headers: { "Content-Type": "application/json" },
     body: JSON.stringify(input),
   });
   if (!res.ok) {

--- a/apps/web/e2e/chat-virtualization.spec.ts
+++ b/apps/web/e2e/chat-virtualization.spec.ts
@@ -49,6 +49,7 @@ import { mkdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { expect, test } from "@playwright/test";
 import { toWorkspaceId } from "@/dashboard";
+import { fakeAgentPath } from "./helpers/fake-agent";
 import {
   cleanupTmpHome,
   createTmpHome,
@@ -76,7 +77,7 @@ const TURNS = 500;
 // different DOM structure).
 test.use({ viewport: { width: 1280, height: 800 } });
 
-const FAKE_AGENT_PATH = join(import.meta.dirname, "..", "tests", "fake-agent.mjs");
+const FAKE_AGENT_PATH = fakeAgentPath();
 
 let server: ServerHandle;
 let tmpHome: string;
@@ -167,7 +168,9 @@ test.describe("Chat message-list virtualization", () => {
     // Wait for the virtualized list container to mount. Its appearance
     // means the chat-events subscription has resolved the seeded
     // session and the reducer has at least one message to render.
-    await expect(chatPane.virtualList).toBeVisible({ timeout: 15_000 });
+    // Driven through a page-object method so the test body never
+    // touches the raw `virtualList` locator.
+    await chatPane.waitForVirtualList(15_000);
 
     // Wait for the LAST seeded message text to be present. That's how
     // we know JSONL replay completed AND stick-to-bottom did its
@@ -190,9 +193,12 @@ test.describe("Chat message-list virtualization", () => {
 
     // The very first seeded message must NOT be in the DOM right now —
     // the user is parked at the bottom of a 1000-message conversation,
-    // there's no way the row at position 0 is mounted. This is the
-    // dual of the bounded-row assertion: it pins *which* rows are
-    // mounted, not just how many.
+    // there's no way the row at position 0 is mounted. The positive
+    // anchor proving the virtualizer has settled is the
+    // `assistantMessage(lastAssistantTag).toBeVisible()` assertion
+    // above plus the bounded-row poll — once those two hold the
+    // viewport has stabilised at the end of the list, so this
+    // negative assertion is safe (the alternate state has rendered).
     const firstUserTag = userText(0);
     await expect(chatPane.userMessage(firstUserTag)).toHaveCount(0);
 

--- a/apps/web/e2e/helpers/fake-agent.ts
+++ b/apps/web/e2e/helpers/fake-agent.ts
@@ -1,0 +1,25 @@
+/**
+ * Shared resolver for the path to the fake-agent stub binary used by
+ * chat-related e2e specs.
+ *
+ * The fake-agent lives at `apps/web/tests/fake-agent.mjs` — it speaks
+ * the Claude Agent SDK stdio protocol but replays a deterministic
+ * scenario file instead of contacting a real LLM. Specs that
+ * configure a `claude-code` agent (`chat-cancel`, `chat-send-optimistic`,
+ * `chat-tool-output-routing`, `chat-virtualization`, …) all point the
+ * `command` setting at the same file; resolving that path in one
+ * place avoids the "if the file moves, two specs break" trap a
+ * reviewer flagged on PR #562.
+ */
+
+import { join } from "node:path";
+
+/** Absolute path to `apps/web/tests/fake-agent.mjs`. The caller's
+ *  module typically passes `import.meta.dirname` to keep the
+ *  computation co-located with its own file, but every caller agrees
+ *  on the same target. */
+export function fakeAgentPath(): string {
+  // This helper itself lives at `apps/web/e2e/helpers/fake-agent.ts`.
+  // `../../tests/fake-agent.mjs` is `apps/web/tests/fake-agent.mjs`.
+  return join(import.meta.dirname, "..", "..", "tests", "fake-agent.mjs");
+}

--- a/apps/web/e2e/helpers/trpc.ts
+++ b/apps/web/e2e/helpers/trpc.ts
@@ -1,11 +1,12 @@
 /**
  * Shared tRPC helper for e2e specs that drive the real server.
  *
- * Centralises the "POST /trpc/<procedure>?token=…" idiom so multiple
- * specs (`queue-ui`, `chat-virtualization`, …) share one
- * implementation instead of each copying it inline. The auth shape
- * (`?token=…` query param) matches the established pattern across
- * existing specs.
+ * Centralises the "POST /trpc/<procedure>" idiom so multiple specs
+ * share one implementation instead of each copying it inline. Auth
+ * is carried via the `band_token` Cookie (matching the
+ * `defaultHeaders` pattern in `apps/web/tests/chat-events.test.ts`)
+ * rather than a `?token=` query param — keeps secrets out of the
+ * server access logs and proxy logs.
  */
 
 /**
@@ -21,9 +22,12 @@ export async function trpcMutate(
   procedure: string,
   input: unknown,
 ): Promise<void> {
-  const res = await fetch(`${serverUrl}/trpc/${procedure}?token=${token}`, {
+  const res = await fetch(`${serverUrl}/trpc/${procedure}`, {
     method: "POST",
-    headers: { "Content-Type": "application/json" },
+    headers: {
+      "Content-Type": "application/json",
+      Cookie: `band_token=${token}`,
+    },
     body: JSON.stringify(input),
   });
   if (!res.ok) {

--- a/apps/web/e2e/helpers/trpc.ts
+++ b/apps/web/e2e/helpers/trpc.ts
@@ -32,6 +32,11 @@ export async function trpcMutate(
   });
   if (!res.ok) {
     const text = await res.text().catch(() => "");
-    throw new Error(`trpcMutate(${procedure}) failed: ${res.status} ${text}`);
+    // Truncate so a chatty validation error that echoes request
+    // input back doesn't bloat test logs or accidentally surface
+    // sensitive fields. 200 chars is enough to identify which
+    // procedure failed and what kind of error it was.
+    const snippet = text.length > 200 ? `${text.slice(0, 200)}…` : text;
+    throw new Error(`trpcMutate(${procedure}) failed: ${res.status} ${snippet}`);
   }
 }

--- a/apps/web/e2e/helpers/trpc.ts
+++ b/apps/web/e2e/helpers/trpc.ts
@@ -1,0 +1,33 @@
+/**
+ * Shared tRPC helper for e2e specs that drive the real server.
+ *
+ * Centralises the "POST /trpc/<procedure>?token=…" idiom so multiple
+ * specs (`queue-ui`, `chat-virtualization`, …) share one
+ * implementation instead of each copying it inline. The auth shape
+ * (`?token=…` query param) matches the established pattern across
+ * existing specs.
+ */
+
+/**
+ * Call a tRPC mutation against the real server's HTTP surface.
+ *
+ * Throws on non-2xx so callers don't need to handle response
+ * inspection themselves — the integration tests want a fast
+ * "something is broken" signal, not silent error swallowing.
+ */
+export async function trpcMutate(
+  serverUrl: string,
+  token: string,
+  procedure: string,
+  input: unknown,
+): Promise<void> {
+  const res = await fetch(`${serverUrl}/trpc/${procedure}?token=${token}`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(input),
+  });
+  if (!res.ok) {
+    const text = await res.text().catch(() => "");
+    throw new Error(`trpcMutate(${procedure}) failed: ${res.status} ${text}`);
+  }
+}

--- a/apps/web/e2e/pages/ChatPanePage.ts
+++ b/apps/web/e2e/pages/ChatPanePage.ts
@@ -48,6 +48,21 @@ export class ChatPanePage {
    *  the prompt. ARIA name is system-controlled in
    *  `file-mention-suggestions.tsx`. */
   readonly fileMentionDropdown: Locator;
+  /** The StickToBottom scroll container — the element whose `scrollTop`
+   *  drives the chat virtualizer. The testid is attached in
+   *  `ChatView.tsx` via the `stickyContextRef.scrollRef.current` since
+   *  `use-stick-to-bottom` doesn't expose a prop for scroller
+   *  attributes. Used for programmatic scrolling in virtualization
+   *  tests. */
+  readonly scroller: Locator;
+  /** Sized wrapper rendered by `VirtualizedMessageList` whose explicit
+   *  height equals the virtualizer's `totalSize`. Tests assert on its
+   *  visibility as a proxy for "messages are mounted". */
+  readonly virtualList: Locator;
+  /** Each currently-mounted message row inside the virtualizer. Use
+   *  `messageRowCount()` to get the windowed count without inlining
+   *  `await this.messageRows.count()` in the test body. */
+  readonly messageRows: Locator;
 
   constructor(
     private readonly page: Page,
@@ -64,6 +79,9 @@ export class ChatPanePage {
     this.toolCallContainers = page.getByTestId("tool-call__container");
     this.toolCallStatusDots = page.getByTestId("tool-call__status-dot");
     this.fileMentionDropdown = page.getByRole("listbox", { name: "File mentions" });
+    this.scroller = page.getByTestId("chat-pane__scroller");
+    this.virtualList = page.getByTestId("chat-pane__virtual-list");
+    this.messageRows = page.getByTestId("chat-pane__message-row");
   }
 
   /** Navigate to the workspace's chat view. The only place URLs are
@@ -114,6 +132,32 @@ export class ChatPanePage {
     // `MessageResponse` element. We anchor on the text the test seeded
     // — explicitly allowed by the doctrine for runtime-test-data. */
     return this.page.getByText(text, { exact: false });
+  }
+
+  /** Locator for an assistant-role message bubble carrying the given
+   *  text. Same shape as `userMessage` — both anchor on the test's
+   *  seeded runtime data, the doctrine-approved use of `getByText`. */
+  assistantMessage(text: string): Locator {
+    return this.page.getByText(text, { exact: false });
+  }
+
+  /** Count of currently-mounted message rows in the virtualized list.
+   *  Used by the windowing test to assert the row count is bounded. */
+  async messageRowCount(): Promise<number> {
+    return await this.messageRows.count();
+  }
+
+  /** Scroll the chat container to the top — drives the virtualizer's
+   *  on-demand mount path so earlier-message rows appear in the DOM.
+   *  Uses the scroller locator (same pattern as
+   *  `ChangesPanelPage.scrollTo`) so a missing scroller surfaces as a
+   *  Playwright locator timeout rather than a silent no-op. */
+  async scrollToTop(): Promise<void> {
+    await test.step("Scroll chat to top", async () => {
+      await this.scroller.evaluate((el) => {
+        (el as HTMLDivElement).scrollTop = 0;
+      });
+    });
   }
 
   /** Click the Stop button to cancel the in-flight task. The button is

--- a/apps/web/e2e/pages/ChatPanePage.ts
+++ b/apps/web/e2e/pages/ChatPanePage.ts
@@ -16,7 +16,7 @@
  *      supplied (the user-message text we just typed).
  */
 
-import { type Locator, type Page, test } from "@playwright/test";
+import { expect, type Locator, type Page, test } from "@playwright/test";
 
 export class ChatPanePage {
   /** The prompt textarea — placeholder is stable, hard-coded in
@@ -143,6 +143,17 @@ export class ChatPanePage {
    *  Used by the windowing test to assert the row count is bounded. */
   async messageRowCount(): Promise<number> {
     return await this.messageRows.count();
+  }
+
+  /** Wait for the virtualized list container to mount — this is the
+   *  signal that the chat-events subscription has resolved the session
+   *  and the reducer has at least one message to render. Encapsulates
+   *  the raw locator behind a page-object action so the test body
+   *  never touches the locator field directly. */
+  async waitForVirtualList(timeout = 15_000): Promise<void> {
+    await test.step("Wait for chat virtualized list", async () => {
+      await expect(this.virtualList).toBeVisible({ timeout });
+    });
   }
 
   /** Scroll the chat container to the top — drives the virtualizer's

--- a/apps/web/e2e/pages/ChatPanePage.ts
+++ b/apps/web/e2e/pages/ChatPanePage.ts
@@ -11,9 +11,16 @@
  *      (a constant prop in `ChatView.tsx`, not localised user copy).
  *   2. `getByTestId("page__element")` — used for the thinking indicator,
  *      where role alone is ambiguous (lots of decorative loaders in
- *      ai-elements).
- *   3. `getByText(value)` — used for assertions on values the TEST itself
- *      supplied (the user-message text we just typed).
+ *      ai-elements). Also used to ROLE-SCOPE the user/assistant message
+ *      bubble containers via
+ *      `getByTestId("chat-pane__user-message").filter({ hasText })` /
+ *      `getByTestId("chat-pane__assistant-message").filter({ hasText })`,
+ *      so a future change rendering user text inside an assistant
+ *      bubble (or vice versa) fails the locator instead of silently
+ *      passing.
+ *   3. `getByText(value)` — only when the value is genuinely
+ *      role-agnostic test data (rarely needed since the role-scoped
+ *      `.filter({ hasText: ... })` form above is preferred).
  */
 
 import { expect, type Locator, type Page, test } from "@playwright/test";

--- a/apps/web/e2e/pages/ChatPanePage.ts
+++ b/apps/web/e2e/pages/ChatPanePage.ts
@@ -126,19 +126,17 @@ export class ChatPanePage {
   }
 
   /** Locator for a user-role message bubble carrying the given text.
-   *  Asserts use this directly with `await expect(locator).toBeVisible()`. */
+   *  Scoped to the `chat-pane__user-message` data-testid container so a
+   *  future change that renders user text inside an assistant bubble
+   *  (or vice versa) trips this locator instead of silently passing. */
   userMessage(text: string): Locator {
-    // The conversation's `MessageContent` renders user text inside a
-    // `MessageResponse` element. We anchor on the text the test seeded
-    // — explicitly allowed by the doctrine for runtime-test-data. */
-    return this.page.getByText(text, { exact: false });
+    return this.page.getByTestId("chat-pane__user-message").filter({ hasText: text });
   }
 
   /** Locator for an assistant-role message bubble carrying the given
-   *  text. Same shape as `userMessage` — both anchor on the test's
-   *  seeded runtime data, the doctrine-approved use of `getByText`. */
+   *  text. Same role-scoping rationale as `userMessage`. */
   assistantMessage(text: string): Locator {
-    return this.page.getByText(text, { exact: false });
+    return this.page.getByTestId("chat-pane__assistant-message").filter({ hasText: text });
   }
 
   /** Count of currently-mounted message rows in the virtualized list.

--- a/apps/web/e2e/queue-ui.spec.ts
+++ b/apps/web/e2e/queue-ui.spec.ts
@@ -7,7 +7,6 @@ import {
   seedState,
   startServer,
 } from "./helpers/server";
-import { trpcMutate } from "./helpers/trpc";
 
 const TOKEN = "e2e-queue-test-token";
 
@@ -30,12 +29,24 @@ test.afterAll(async () => {
 // Helpers — call the real server's queue store via tRPC HTTP API
 // ---------------------------------------------------------------------------
 
+async function trpcMutate(procedure: string, input: unknown): Promise<void> {
+  const res = await fetch(`${server.url}/trpc/${procedure}?token=${TOKEN}`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(input),
+  });
+  if (!res.ok) {
+    const text = await res.text().catch(() => "");
+    throw new Error(`trpcMutate(${procedure}) failed: ${res.status} ${text}`);
+  }
+}
+
 async function pushQueue(workspaceId: string, text: string, chatId?: string): Promise<void> {
-  await trpcMutate(server.url, TOKEN, "queue.push", { workspaceId, text, chatId });
+  await trpcMutate("queue.push", { workspaceId, text, chatId });
 }
 
 async function clearQueue(workspaceId: string, chatId?: string): Promise<void> {
-  await trpcMutate(server.url, TOKEN, "queue.clear", { workspaceId, chatId });
+  await trpcMutate("queue.clear", { workspaceId, chatId });
 }
 
 /**

--- a/apps/web/e2e/queue-ui.spec.ts
+++ b/apps/web/e2e/queue-ui.spec.ts
@@ -7,6 +7,7 @@ import {
   seedState,
   startServer,
 } from "./helpers/server";
+import { trpcMutate } from "./helpers/trpc";
 
 const TOKEN = "e2e-queue-test-token";
 
@@ -29,24 +30,12 @@ test.afterAll(async () => {
 // Helpers — call the real server's queue store via tRPC HTTP API
 // ---------------------------------------------------------------------------
 
-async function trpcMutate(procedure: string, input: unknown): Promise<void> {
-  const res = await fetch(`${server.url}/trpc/${procedure}?token=${TOKEN}`, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify(input),
-  });
-  if (!res.ok) {
-    const text = await res.text().catch(() => "");
-    throw new Error(`trpcMutate(${procedure}) failed: ${res.status} ${text}`);
-  }
-}
-
 async function pushQueue(workspaceId: string, text: string, chatId?: string): Promise<void> {
-  await trpcMutate("queue.push", { workspaceId, text, chatId });
+  await trpcMutate(server.url, TOKEN, "queue.push", { workspaceId, text, chatId });
 }
 
 async function clearQueue(workspaceId: string, chatId?: string): Promise<void> {
-  await trpcMutate("queue.clear", { workspaceId, chatId });
+  await trpcMutate(server.url, TOKEN, "queue.clear", { workspaceId, chatId });
 }
 
 /**

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -85,6 +85,7 @@
     "@tanstack/react-query": "^5.90.21",
     "@tanstack/react-router": "^1.154.0",
     "@tanstack/react-start": "^1.154.0",
+    "@tanstack/react-virtual": "^3.13.12",
     "@tanstack/router-plugin": "^1.154.0",
     "@trpc/client": "^11.12.0",
     "@trpc/openapi": "11.16.0-alpha",

--- a/apps/web/src/api/chat-events.ts
+++ b/apps/web/src/api/chat-events.ts
@@ -425,8 +425,16 @@ async function replayPast(opts: {
   //   • `buf.events.length > 0 && cursor + 1 < buf.events[0].eventId` —
   //     buffer rotated past the cursor (MAX_BUFFER_SIZE eviction).
   //     Backfill the missing range from JSONL.
+  // `?? Number.POSITIVE_INFINITY` (not `?? 0`) for the missing-eventId
+  // fallback — matches the cold-path rationale above. A malformed
+  // buffer entry with no eventId must NOT collapse `bufferFirstId` to
+  // 0, which would silently skip the gap-fill JSONL fetch
+  // (`afterEventId + 1 < 0` is impossible for any non-negative
+  // cursor).
   const bufferFirstId =
-    buf && buf.events.length > 0 ? (buf.events[0].eventId ?? 0) : Number.POSITIVE_INFINITY;
+    buf && buf.events.length > 0
+      ? (buf.events[0].eventId ?? Number.POSITIVE_INFINITY)
+      : Number.POSITIVE_INFINITY;
   const needJsonl = !!buf && buf.events.length > 0 && afterEventId + 1 < bufferFirstId;
 
   if (needJsonl && chatWorkspaceId) {

--- a/apps/web/src/api/chat-events.ts
+++ b/apps/web/src/api/chat-events.ts
@@ -305,7 +305,43 @@ async function replayPast(opts: {
   //     only the last turn visible after a page refresh — the buffer
   //     had the new turn and the older JSONL history was elided.
   if (afterEventId === undefined) {
-    // Cold subscribe — JSONL is the full history.
+    // Cold subscribe — replay full session history.
+    //
+    // PREFERENCE ORDER:
+    //   1. In-memory buffer when it covers the session from event 1.
+    //      Buffer events carry their real `eventId`s, so after this
+    //      cold subscribe the client's `state.lastEventId` lines up
+    //      with the buffer's natural numbering. Any reconnect then
+    //      arrives with a cursor at the buffer's tail, and the
+    //      `evt.eventId <= afterEventId` filter on the buffer-replay
+    //      path naturally drops every event the client already has —
+    //      no duplication on workspace switch.
+    //
+    //      Compare this to the JSONL path below: JSONL events carry
+    //      *synthetic* negative ids (so they sort below live buffer
+    //      ids on this single subscription), but those negative ids
+    //      never move the client's `Math.max(state.lastEventId ?? 0,
+    //      eventId)` cursor above 0. The next reconnect then sends
+    //      `lastEventId=0`, and the server's buffer replay re-emits
+    //      every event from id 1 onward — producing the
+    //      "switch-back-doubles-the-conversation" bug.
+    //   2. JSONL backfill for sessions whose buffer is missing or
+    //      partial (server restart, rotation past the start).
+    //   3. Buffer-as-fallback for the rare case JSONL fails *and* the
+    //      buffer is partial — emits what we can.
+    const bufferFirstId =
+      buf && buf.events.length > 0 ? (buf.events[0].eventId ?? 0) : Number.POSITIVE_INFINITY;
+    const bufferCoversStart = buf !== undefined && bufferFirstId <= 1;
+
+    if (bufferCoversStart && buf) {
+      for (const c of buf.events) {
+        const payload = chunkToChatEvent(c as StreamChunk, sessionId);
+        if (!payload) continue;
+        writer.write({ ...payload, eventId: c.eventId ?? 0 } as ChatEvent);
+      }
+      return;
+    }
+
     let jsonlEmittedAny = false;
     if (chatWorkspaceId) {
       try {
@@ -321,7 +357,12 @@ async function replayPast(opts: {
             const messages = result.messages;
             // Synthetic ids sort below any live buffer ids (-1000-N..-1000),
             // so subsequent live events the client receives keep their
-            // monotonic order.
+            // monotonic order. They DO leave `state.lastEventId` at 0 on
+            // the client — that's why the buffer-covers-start branch
+            // above prefers the buffer when it can; this path is reached
+            // only when no buffer exists at all (server restart, fresh
+            // process) and a 0 cursor is harmless because the matching
+            // buffer-replay branch is empty.
             let syntheticId = -1000 - messages.length;
             for (const msg of messages) {
               const events = jsonlMessageToEvents(msg, syntheticId);
@@ -351,12 +392,24 @@ async function replayPast(opts: {
   }
 
   // Hot reconnect path — gap-fill from buffer past the cursor. JSONL is
-  // only re-fetched when the buffer DOESN'T cover the cursor:
+  // only re-fetched when the in-memory buffer EXISTS but doesn't cover
+  // the cursor:
   //
-  //   • `buf === undefined` — the in-memory buffer is GONE (server
-  //     restart, eviction). The client carries a cursor from before the
-  //     restart; without JSONL it would see a blank chat until the next
-  //     agent turn produces fresh events. Treat as a gap, backfill.
+  //   • `buf === undefined` — the in-memory buffer is GONE (no task has
+  //     ever run for this session in this server process, the buffer
+  //     was evicted, or the server was restarted). The client carries
+  //     a cursor it set during an earlier subscription, which means it
+  //     already has the JSONL history in its reducer — DO NOT backfill.
+  //     The previous behaviour was to re-emit the entire transcript
+  //     here, and that's what made every workspace switch re-render
+  //     every cached chat: the JSONL-backfill path generates fresh
+  //     synthetic eventIds, which the client's reducer treats as new
+  //     events, rebuilds the `messages` array, and busts every memo
+  //     downstream — Streamdown re-tokenises every code block on the
+  //     switch back to a cached workspace. The cold-subscribe branch
+  //     above (afterEventId === undefined) still backfills JSONL on a
+  //     fresh page load, which is the only scenario where the client
+  //     doesn't already have history.
   //   • `buf.events.length === 0` — buffer exists but has no events
   //     since the cursor. Client is fully caught up; no JSONL needed.
   //     (Avoids re-pushing the conversation on every workspace switch
@@ -366,7 +419,7 @@ async function replayPast(opts: {
   //     Backfill the missing range from JSONL.
   const bufferFirstId =
     buf && buf.events.length > 0 ? (buf.events[0].eventId ?? 0) : Number.POSITIVE_INFINITY;
-  const needJsonl = !buf || (buf.events.length > 0 && afterEventId + 1 < bufferFirstId);
+  const needJsonl = !!buf && buf.events.length > 0 && afterEventId + 1 < bufferFirstId;
 
   if (needJsonl && chatWorkspaceId) {
     try {

--- a/apps/web/src/api/chat-events.ts
+++ b/apps/web/src/api/chat-events.ts
@@ -329,9 +329,17 @@ async function replayPast(opts: {
     //      partial (server restart, rotation past the start).
     //   3. Buffer-as-fallback for the rare case JSONL fails *and* the
     //      buffer is partial — emits what we can.
+    // Use `?? Number.POSITIVE_INFINITY` (not `?? 0`) for the
+    // missing-eventId fallback so a malformed buffer entry with no
+    // eventId does NOT spoof `bufferCoversStart`. If we let it
+    // become 0 the buffer path would emit events with `eventId: 0`
+    // and the client's cursor would land at 0 — re-introducing the
+    // exact bug this branch was added to fix.
     const bufferFirstId =
-      buf && buf.events.length > 0 ? (buf.events[0].eventId ?? 0) : Number.POSITIVE_INFINITY;
-    const bufferCoversStart = buf !== undefined && bufferFirstId <= 1;
+      buf && buf.events.length > 0
+        ? (buf.events[0].eventId ?? Number.POSITIVE_INFINITY)
+        : Number.POSITIVE_INFINITY;
+    const bufferCoversStart = buf !== undefined && bufferFirstId > 0 && bufferFirstId <= 1;
 
     if (bufferCoversStart && buf) {
       for (const c of buf.events) {

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -298,17 +298,17 @@ export function ChatView({
   // Attach a stable `data-testid` to the StickToBottom scroll element so
   // integration tests can locate the scroller without walking up the DOM
   // from a child (which would couple the test to the use-stick-to-bottom
-  // library's internal markup). `use-stick-to-bottom` doesn't expose a
-  // prop for arbitrary attributes on the scroller — the JSX-prop path
-  // that TEST-1 normally requires for `data-testid` is unreachable here
-  // — so we set it once via the same `contextRef` we use for
-  // programmatic scrolling. The imperative attach is intentional and
-  // documented because the JSX path doesn't exist on this third-party
-  // component; if `use-stick-to-bottom` adds a `scrollerProps` (or
-  // similar) prop in a future release, switch back to the JSX form.
-  // Empty deps because the attribute write is idempotent and only
-  // needs to happen when the underlying DOM element is created — re-
-  // firing on every render during streaming was needlessly busy.
+  // library's internal markup). The JSX-prop path normally used to
+  // attach `data-testid` to owned elements is unreachable here —
+  // `use-stick-to-bottom` renders the scroll container internally and
+  // exposes no attribute-forwarding prop — so we set it once via the
+  // same `contextRef` we use for programmatic scrolling. The imperative
+  // attach is intentional; if `use-stick-to-bottom` adds a
+  // `scrollerProps` (or similar) prop in a future release, switch back
+  // to the JSX form. Empty deps because the attribute write is
+  // idempotent and only needs to happen when the underlying DOM element
+  // is created — re-firing on every render during streaming was
+  // needlessly busy.
   useEffect(() => {
     const el = stickyContextRef.current?.scrollRef?.current;
     if (el && !el.dataset.testid) {
@@ -718,11 +718,103 @@ export function ChatView({
   // `getMeasurements()` to re-walk the full message count per render.
   // At a fast-streaming agent (~30 text-delta events/s × N messages
   // each), the saved per-second work scales linearly with conversation
-  // length. The `renderItem` closure below captures `messages` and
-  // `isStreaming` so its identity necessarily changes per delta — that
-  // path can't be memoised the same way without recomputing on every
-  // change anyway, so we leave it inline.
+  // length.
   const getMessageKey = useCallback((message: UIMessage) => message.id, []);
+
+  // Stabilise the `renderItem` closure too. Its deps (`messages`,
+  // `isStreaming`) DO change during streaming, so this only helps for
+  // the renders where they don't — chatQuery refetches, settings
+  // refetches, parent context refreshes etc. — but for those it cuts
+  // the per-render closure allocation entirely.
+  const renderMessageItem = useCallback(
+    (message: UIMessage, messageIndex: number) => {
+      const isLastMessage = messageIndex === messages.length - 1;
+      const isLastAssistant = message.role === "assistant" && isLastMessage;
+      const hasPendingInteractiveTool =
+        isLastAssistant &&
+        message.parts.some(
+          (p) =>
+            isToolUIPart(p) &&
+            IN_PROGRESS_STATES.has(p.state) &&
+            (getToolName(p) === "AskUserQuestion" || getToolName(p) === "ExitPlanMode"),
+        );
+      const showThinking = isLastAssistant && isStreaming && !hasPendingInteractiveTool;
+
+      if (message.role !== "assistant") {
+        // User messages render normally
+        const userParts = groupMessageParts(message.parts);
+        if (userParts.length === 0) return null;
+        return (
+          <Message from="user">
+            <MessageContent>
+              {userParts.map((segment) => {
+                if (
+                  segment.type === "text" &&
+                  segment.part.type === "text" &&
+                  segment.part.text.trim()
+                ) {
+                  return (
+                    <MessageResponse key={`${message.id}-text-${segment.partIndex}`}>
+                      {segment.part.text}
+                    </MessageResponse>
+                  );
+                }
+                if (segment.type === "file") {
+                  return (
+                    <MessageFilePart
+                      key={`${message.id}-file-${segment.partIndex}`}
+                      part={segment.part}
+                    />
+                  );
+                }
+                return null;
+              })}
+            </MessageContent>
+          </Message>
+        );
+      }
+
+      // Assistant message — under the chat-events model every queued
+      // turn becomes its own user-role message, so we never need to
+      // split an assistant message at `data-prompt` boundaries.
+      const visibleParts = message.parts.filter(
+        (p) => (p.type === "text" && p.text.trim()) || p.type === "file" || isToolUIPart(p),
+      );
+      if (visibleParts.length === 0 && !showThinking) return null;
+      return (
+        <Message from="assistant">
+          <MessageContent>
+            {groupMessageParts(message.parts).map((segment) => {
+              if (segment.type === "text") {
+                const { part, partIndex } = segment;
+                if (part.type === "text" && part.text.trim()) {
+                  return (
+                    <MessageResponse key={`${message.id}-text-${partIndex}`}>
+                      {part.text}
+                    </MessageResponse>
+                  );
+                }
+                return null;
+              }
+              if (segment.type === "file") {
+                return (
+                  <MessageFilePart
+                    key={`${message.id}-file-${segment.partIndex}`}
+                    part={segment.part}
+                  />
+                );
+              }
+              const item = toolPartToItem(segment.part);
+              if (isTaskTool(item.toolName)) return null;
+              return <ToolCall key={`${message.id}-tool-${segment.partIndex}`} item={item} />;
+            })}
+            {showThinking && <ThinkingIndicator />}
+          </MessageContent>
+        </Message>
+      );
+    },
+    [messages, isStreaming],
+  );
 
   const getLastUserMessage = useCallback((): string | undefined => {
     // Under the chat-events model, queued/drained user messages emit their
@@ -812,95 +904,7 @@ export function ChatView({
               <VirtualizedMessageList
                 items={messages}
                 getKey={getMessageKey}
-                renderItem={(message, messageIndex) => {
-                  const isLastMessage = messageIndex === messages.length - 1;
-                  const isLastAssistant = message.role === "assistant" && isLastMessage;
-                  const hasPendingInteractiveTool =
-                    isLastAssistant &&
-                    message.parts.some(
-                      (p) =>
-                        isToolUIPart(p) &&
-                        IN_PROGRESS_STATES.has(p.state) &&
-                        (getToolName(p) === "AskUserQuestion" || getToolName(p) === "ExitPlanMode"),
-                    );
-                  const showThinking = isLastAssistant && isStreaming && !hasPendingInteractiveTool;
-
-                  if (message.role !== "assistant") {
-                    // User messages render normally
-                    const userParts = groupMessageParts(message.parts);
-                    if (userParts.length === 0) return null;
-                    return (
-                      <Message from="user">
-                        <MessageContent>
-                          {userParts.map((segment) => {
-                            if (
-                              segment.type === "text" &&
-                              segment.part.type === "text" &&
-                              segment.part.text.trim()
-                            ) {
-                              return (
-                                <MessageResponse key={`${message.id}-text-${segment.partIndex}`}>
-                                  {segment.part.text}
-                                </MessageResponse>
-                              );
-                            }
-                            if (segment.type === "file") {
-                              return (
-                                <MessageFilePart
-                                  key={`${message.id}-file-${segment.partIndex}`}
-                                  part={segment.part}
-                                />
-                              );
-                            }
-                            return null;
-                          })}
-                        </MessageContent>
-                      </Message>
-                    );
-                  }
-
-                  // Assistant message — under the chat-events model every queued
-                  // turn becomes its own user-role message, so we never need to
-                  // split an assistant message at `data-prompt` boundaries.
-                  const visibleParts = message.parts.filter(
-                    (p) =>
-                      (p.type === "text" && p.text.trim()) || p.type === "file" || isToolUIPart(p),
-                  );
-                  if (visibleParts.length === 0 && !showThinking) return null;
-                  return (
-                    <Message from="assistant">
-                      <MessageContent>
-                        {groupMessageParts(message.parts).map((segment) => {
-                          if (segment.type === "text") {
-                            const { part, partIndex } = segment;
-                            if (part.type === "text" && part.text.trim()) {
-                              return (
-                                <MessageResponse key={`${message.id}-text-${partIndex}`}>
-                                  {part.text}
-                                </MessageResponse>
-                              );
-                            }
-                            return null;
-                          }
-                          if (segment.type === "file") {
-                            return (
-                              <MessageFilePart
-                                key={`${message.id}-file-${segment.partIndex}`}
-                                part={segment.part}
-                              />
-                            );
-                          }
-                          const item = toolPartToItem(segment.part);
-                          if (isTaskTool(item.toolName)) return null;
-                          return (
-                            <ToolCall key={`${message.id}-tool-${segment.partIndex}`} item={item} />
-                          );
-                        })}
-                        {showThinking && <ThinkingIndicator />}
-                      </MessageContent>
-                    </Message>
-                  );
-                }}
+                renderItem={renderMessageItem}
               />
             )}
             {isStreaming && (!messages.length || messages[messages.length - 1].role === "user") && (

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -140,6 +140,10 @@ function SkeletonBar({ widthClass, className }: { widthClass: string; className?
 }
 
 function ConversationSkeleton() {
+  // Skeleton bubbles override the role-scoped `data-testid` that
+  // `Message` stamps by default — locators like
+  // `chatPane.userMessage(text)` should target REAL message bubbles
+  // only, never the loading-state placeholders.
   return (
     <output
       className="flex animate-pulse flex-col gap-6"
@@ -147,7 +151,7 @@ function ConversationSkeleton() {
       aria-label="Loading messages"
     >
       {/* User bubble — right-aligned, narrower */}
-      <Message from="user">
+      <Message from="user" data-testid={undefined}>
         <MessageContent>
           <div className="flex flex-col gap-2 py-1">
             <SkeletonBar widthClass="w-48" className="bg-foreground/10" />
@@ -157,7 +161,7 @@ function ConversationSkeleton() {
       </Message>
 
       {/* Assistant bubble — full width, several lines */}
-      <Message from="assistant">
+      <Message from="assistant" data-testid={undefined}>
         <MessageContent>
           <div className="flex flex-col gap-2 pt-1">
             <SkeletonBar widthClass="w-3/4" />
@@ -169,7 +173,7 @@ function ConversationSkeleton() {
       </Message>
 
       {/* A second user/assistant pair for longer-feeling conversations */}
-      <Message from="user">
+      <Message from="user" data-testid={undefined}>
         <MessageContent>
           <div className="flex flex-col gap-2 py-1">
             <SkeletonBar widthClass="w-40" className="bg-foreground/10" />
@@ -177,7 +181,7 @@ function ConversationSkeleton() {
         </MessageContent>
       </Message>
 
-      <Message from="assistant">
+      <Message from="assistant" data-testid={undefined}>
         <MessageContent>
           <div className="flex flex-col gap-2 pt-1">
             <SkeletonBar widthClass="w-2/3" />
@@ -305,15 +309,26 @@ export function ChatView({
   // same `contextRef` we use for programmatic scrolling. The imperative
   // attach is intentional; if `use-stick-to-bottom` adds a
   // `scrollerProps` (or similar) prop in a future release, switch back
-  // to the JSX form. Empty deps because the attribute write is
-  // idempotent and only needs to happen when the underlying DOM element
-  // is created — re-firing on every render during streaming was
-  // needlessly busy.
+  // to the JSX form.
+  //
+  // `use-stick-to-bottom`'s `useImperativeHandle` populates the
+  // context AFTER the first commit, so the very first effect firing
+  // sees `scrollRef.current === null`. We retry on the next animation
+  // frame; the idempotent guard keeps subsequent re-renders cheap.
   useEffect(() => {
-    const el = stickyContextRef.current?.scrollRef?.current;
-    if (el && !el.dataset.testid) {
-      el.dataset.testid = "chat-pane__scroller";
-    }
+    let raf = 0;
+    const attach = () => {
+      const el = stickyContextRef.current?.scrollRef?.current;
+      if (!el) {
+        raf = requestAnimationFrame(attach);
+        return;
+      }
+      if (!el.dataset.testid) el.dataset.testid = "chat-pane__scroller";
+    };
+    attach();
+    return () => {
+      if (raf) cancelAnimationFrame(raf);
+    };
   }, []);
 
   // Scroll to bottom when the panel becomes visible (e.g. switching tabs in dockview).
@@ -737,12 +752,14 @@ export function ChatView({
     const isLastAssistant = message.role === "assistant" && isLastMessage;
     const hasPendingInteractiveTool =
       isLastAssistant &&
-      message.parts.some(
-        (p) =>
-          isToolUIPart(p) &&
-          IN_PROGRESS_STATES.has(p.state) &&
-          (getToolName(p) === "AskUserQuestion" || getToolName(p) === "ExitPlanMode"),
-      );
+      message.parts.some((p) => {
+        if (!isToolUIPart(p) || !IN_PROGRESS_STATES.has(p.state)) return false;
+        // Hoist `getToolName(p)` so the second check doesn't re-invoke
+        // it for every tool part on every render (~30 renders/sec
+        // during streaming).
+        const name = getToolName(p);
+        return name === "AskUserQuestion" || name === "ExitPlanMode";
+      });
     const showThinking = isLastAssistant && currentIsStreaming && !hasPendingInteractiveTool;
 
     // Compute the grouped segments ONCE per render — `groupMessageParts`
@@ -826,9 +843,14 @@ export function ChatView({
     // Under the chat-events model, queued/drained user messages emit their
     // own user-role messages — no need to scan assistant parts for
     // `data-prompt` markers (that legacy AI-SDK chunk type is gone).
-    for (let i = messages.length - 1; i >= 0; i--) {
-      if (messages[i].role !== "user") continue;
-      const text = messages[i].parts
+    // Read through `messagesRef` (kept in sync above) so the callback
+    // identity is stable across re-renders — `getLastUserMessage` is
+    // a cold-path keyboard-shortcut handler, and re-creating it on
+    // every streaming delta was wasted work.
+    const currentMessages = messagesRef.current;
+    for (let i = currentMessages.length - 1; i >= 0; i--) {
+      if (currentMessages[i].role !== "user") continue;
+      const text = currentMessages[i].parts
         .filter((p): p is { type: "text"; text: string } => p.type === "text")
         .map((p) => p.text)
         .join("\n")
@@ -836,7 +858,7 @@ export function ChatView({
       if (text) return text;
     }
     return undefined;
-  }, [messages]);
+  }, []);
 
   return (
     // Scope every `band-file:` link clicked inside this chat to *this*

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -1232,13 +1232,20 @@ const MODEL_CONTEXT_WINDOWS: Record<string, number> = {
   "gemini-2.5-flash": 1_000_000,
 };
 
+// Pre-sorted entries by descending key length so the prefix-match
+// branch in `getContextWindow` doesn't re-sort on every call. The
+// `MODEL_CONTEXT_WINDOWS` map is module-level and immutable so the
+// sort is correct at module init time.
+const SORTED_MODEL_CONTEXT_ENTRIES: ReadonlyArray<[string, number]> = Object.entries(
+  MODEL_CONTEXT_WINDOWS,
+).sort(([a], [b]) => b.length - a.length);
+
 function getContextWindow(model: string | undefined): number {
   if (!model) return 200_000;
   if (MODEL_CONTEXT_WINDOWS[model]) return MODEL_CONTEXT_WINDOWS[model];
   // Prefix match — sort by descending key length so longer/more specific
   // keys win (e.g. "claude-opus-4-7[1m]" before "claude-opus-4-7").
-  const entries = Object.entries(MODEL_CONTEXT_WINDOWS).sort(([a], [b]) => b.length - a.length);
-  for (const [key, value] of entries) {
+  for (const [key, value] of SORTED_MODEL_CONTEXT_ENTRIES) {
     if (model.startsWith(key)) return value;
   }
   return 200_000;

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -41,7 +41,7 @@ import {
   verticalListSortingStrategy,
 } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
-import { getToolName, isToolUIPart } from "ai";
+import { getToolName, isToolUIPart, type UIMessage } from "ai";
 import {
   Bot,
   ChevronDown,
@@ -83,6 +83,7 @@ import type { ToolPart } from "./ai-elements/tool";
 import type { ToolCallItem } from "./ai-elements/tool-call";
 import { ToolCall } from "./ai-elements/tool-call";
 import { useChatSubscription } from "./chat/use-chat-subscription";
+import { VirtualizedMessageList } from "./chat/VirtualizedMessageList";
 
 const IN_PROGRESS_STATES = new Set<ToolPart["state"]>([
   "input-available",
@@ -293,6 +294,21 @@ export function ChatView({
   const sentinelRef = useRef<HTMLDivElement>(null);
   const stickyContextRef = useRef<StickToBottomContext>(null);
   const prevVisibleRef = useRef(visible);
+
+  // Attach a stable `data-testid` to the StickToBottom scroll element so
+  // integration tests can locate the scroller without walking up the DOM
+  // from a child (which would couple the test to the use-stick-to-bottom
+  // library's internal markup). `use-stick-to-bottom` doesn't expose a
+  // prop for arbitrary attributes on the scroller, so we set it once via
+  // the same `contextRef` we use for programmatic scrolling. No
+  // dependency array — the ref is populated on first paint and the
+  // attribute survives subsequent renders.
+  useEffect(() => {
+    const el = stickyContextRef.current?.scrollRef?.current;
+    if (el && !el.dataset.testid) {
+      el.dataset.testid = "chat-pane__scroller";
+    }
+  });
 
   // Scroll to bottom when the panel becomes visible (e.g. switching tabs in dockview).
   // The scroll container may have had zero height while hidden, so StickToBottom
@@ -690,6 +706,18 @@ export function ChatView({
     return map;
   }, [messages]);
 
+  // Stable identity for the virtualizer's `getItemKey` — without this,
+  // every `ChatView` render creates a fresh arrow function whose
+  // identity flips the `useVirtualizer` memoization keys, causing
+  // `getMeasurements()` to re-walk the full message count per render.
+  // At a fast-streaming agent (~30 text-delta events/s × N messages
+  // each), the saved per-second work scales linearly with conversation
+  // length. The `renderItem` closure below captures `messages` and
+  // `isStreaming` so its identity necessarily changes per delta — that
+  // path can't be memoised the same way without recomputing on every
+  // change anyway, so we leave it inline.
+  const getMessageKey = useCallback((message: UIMessage) => message.id, []);
+
   const getLastUserMessage = useCallback((): string | undefined => {
     // Under the chat-events model, queued/drained user messages emit their
     // own user-role messages — no need to scan assistant parts for
@@ -774,38 +802,79 @@ export function ChatView({
               />
             )}
 
-            {(() => {
-              return messages.map((message, messageIndex) => {
-                const isLastMessage = messageIndex === messages.length - 1;
-                const isLastAssistant = message.role === "assistant" && isLastMessage;
-                const hasPendingInteractiveTool =
-                  isLastAssistant &&
-                  message.parts.some(
-                    (p) =>
-                      isToolUIPart(p) &&
-                      IN_PROGRESS_STATES.has(p.state) &&
-                      (getToolName(p) === "AskUserQuestion" || getToolName(p) === "ExitPlanMode"),
-                  );
-                const showThinking = isLastAssistant && isStreaming && !hasPendingInteractiveTool;
+            {messages.length > 0 && (
+              <VirtualizedMessageList
+                items={messages}
+                getKey={getMessageKey}
+                renderItem={(message, messageIndex) => {
+                  const isLastMessage = messageIndex === messages.length - 1;
+                  const isLastAssistant = message.role === "assistant" && isLastMessage;
+                  const hasPendingInteractiveTool =
+                    isLastAssistant &&
+                    message.parts.some(
+                      (p) =>
+                        isToolUIPart(p) &&
+                        IN_PROGRESS_STATES.has(p.state) &&
+                        (getToolName(p) === "AskUserQuestion" || getToolName(p) === "ExitPlanMode"),
+                    );
+                  const showThinking = isLastAssistant && isStreaming && !hasPendingInteractiveTool;
 
-                if (message.role !== "assistant") {
-                  // User messages render normally
-                  const userParts = groupMessageParts(message.parts);
-                  if (userParts.length === 0) return null;
+                  if (message.role !== "assistant") {
+                    // User messages render normally
+                    const userParts = groupMessageParts(message.parts);
+                    if (userParts.length === 0) return null;
+                    return (
+                      <Message from="user">
+                        <MessageContent>
+                          {userParts.map((segment) => {
+                            if (
+                              segment.type === "text" &&
+                              segment.part.type === "text" &&
+                              segment.part.text.trim()
+                            ) {
+                              return (
+                                <MessageResponse key={`${message.id}-text-${segment.partIndex}`}>
+                                  {segment.part.text}
+                                </MessageResponse>
+                              );
+                            }
+                            if (segment.type === "file") {
+                              return (
+                                <MessageFilePart
+                                  key={`${message.id}-file-${segment.partIndex}`}
+                                  part={segment.part}
+                                />
+                              );
+                            }
+                            return null;
+                          })}
+                        </MessageContent>
+                      </Message>
+                    );
+                  }
+
+                  // Assistant message — under the chat-events model every queued
+                  // turn becomes its own user-role message, so we never need to
+                  // split an assistant message at `data-prompt` boundaries.
+                  const visibleParts = message.parts.filter(
+                    (p) =>
+                      (p.type === "text" && p.text.trim()) || p.type === "file" || isToolUIPart(p),
+                  );
+                  if (visibleParts.length === 0 && !showThinking) return null;
                   return (
-                    <Message key={message.id} from="user">
+                    <Message from="assistant">
                       <MessageContent>
-                        {userParts.map((segment) => {
-                          if (
-                            segment.type === "text" &&
-                            segment.part.type === "text" &&
-                            segment.part.text.trim()
-                          ) {
-                            return (
-                              <MessageResponse key={`${message.id}-text-${segment.partIndex}`}>
-                                {segment.part.text}
-                              </MessageResponse>
-                            );
+                        {groupMessageParts(message.parts).map((segment) => {
+                          if (segment.type === "text") {
+                            const { part, partIndex } = segment;
+                            if (part.type === "text" && part.text.trim()) {
+                              return (
+                                <MessageResponse key={`${message.id}-text-${partIndex}`}>
+                                  {part.text}
+                                </MessageResponse>
+                              );
+                            }
+                            return null;
                           }
                           if (segment.type === "file") {
                             return (
@@ -815,56 +884,19 @@ export function ChatView({
                               />
                             );
                           }
-                          return null;
+                          const item = toolPartToItem(segment.part);
+                          if (isTaskTool(item.toolName)) return null;
+                          return (
+                            <ToolCall key={`${message.id}-tool-${segment.partIndex}`} item={item} />
+                          );
                         })}
+                        {showThinking && <ThinkingIndicator />}
                       </MessageContent>
                     </Message>
                   );
-                }
-
-                // Assistant message — under the chat-events model every queued
-                // turn becomes its own user-role message, so we never need to
-                // split an assistant message at `data-prompt` boundaries.
-                const visibleParts = message.parts.filter(
-                  (p) =>
-                    (p.type === "text" && p.text.trim()) || p.type === "file" || isToolUIPart(p),
-                );
-                if (visibleParts.length === 0 && !showThinking) return null;
-                return (
-                  <Message key={message.id} from="assistant">
-                    <MessageContent>
-                      {groupMessageParts(message.parts).map((segment) => {
-                        if (segment.type === "text") {
-                          const { part, partIndex } = segment;
-                          if (part.type === "text" && part.text.trim()) {
-                            return (
-                              <MessageResponse key={`${message.id}-text-${partIndex}`}>
-                                {part.text}
-                              </MessageResponse>
-                            );
-                          }
-                          return null;
-                        }
-                        if (segment.type === "file") {
-                          return (
-                            <MessageFilePart
-                              key={`${message.id}-file-${segment.partIndex}`}
-                              part={segment.part}
-                            />
-                          );
-                        }
-                        const item = toolPartToItem(segment.part);
-                        if (isTaskTool(item.toolName)) return null;
-                        return (
-                          <ToolCall key={`${message.id}-tool-${segment.partIndex}`} item={item} />
-                        );
-                      })}
-                      {showThinking && <ThinkingIndicator />}
-                    </MessageContent>
-                  </Message>
-                );
-              });
-            })()}
+                }}
+              />
+            )}
             {isStreaming && (!messages.length || messages[messages.length - 1].role === "user") && (
               <Message from="assistant">
                 <MessageContent>

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -316,14 +316,26 @@ export function ChatView({
   // sees `scrollRef.current === null`. We retry on the next animation
   // frame; the idempotent guard keeps subsequent re-renders cheap.
   useEffect(() => {
+    // Cap the retry loop at 10 frames (~167 ms at 60 Hz) so a
+    // bug that prevents the scroll ref from ever resolving doesn't
+    // leave us scheduling a spinning rAF until unmount. In practice
+    // the ref is populated on the first or second frame.
     let raf = 0;
+    let attempts = 0;
     const attach = () => {
+      attempts += 1;
       const el = stickyContextRef.current?.scrollRef?.current;
-      if (!el) {
-        raf = requestAnimationFrame(attach);
+      if (el) {
+        if (!el.dataset.testid) el.dataset.testid = "chat-pane__scroller";
         return;
       }
-      if (!el.dataset.testid) el.dataset.testid = "chat-pane__scroller";
+      if (attempts >= 10) {
+        console.warn(
+          "[ChatView] StickToBottom scrollRef did not resolve within 10 frames; chat-pane__scroller testid not attached",
+        );
+        return;
+      }
+      raf = requestAnimationFrame(attach);
     };
     attach();
     return () => {
@@ -936,7 +948,13 @@ export function ChatView({
               />
             )}
             {isStreaming && (!messages.length || messages[messages.length - 1].role === "user") && (
-              <Message from="assistant">
+              // No `chat-pane__assistant-message` testid on the
+              // standalone thinking bubble — locators that target
+              // assistant message bubbles should never pick up the
+              // intermediate "agent is thinking" placeholder. The
+              // dedicated `chat-pane__thinking-indicator` testid on
+              // `ThinkingIndicator` is what tests use for this state.
+              <Message from="assistant" data-testid={undefined}>
                 <MessageContent>
                   <ThinkingIndicator />
                 </MessageContent>

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -299,11 +299,16 @@ export function ChatView({
   // integration tests can locate the scroller without walking up the DOM
   // from a child (which would couple the test to the use-stick-to-bottom
   // library's internal markup). `use-stick-to-bottom` doesn't expose a
-  // prop for arbitrary attributes on the scroller, so we set it once via
-  // the same `contextRef` we use for programmatic scrolling. Empty deps
-  // because the attribute write is idempotent and only needs to happen
-  // when the underlying DOM element is created — re-firing on every
-  // render during streaming was needlessly busy.
+  // prop for arbitrary attributes on the scroller — the JSX-prop path
+  // that TEST-1 normally requires for `data-testid` is unreachable here
+  // — so we set it once via the same `contextRef` we use for
+  // programmatic scrolling. The imperative attach is intentional and
+  // documented because the JSX path doesn't exist on this third-party
+  // component; if `use-stick-to-bottom` adds a `scrollerProps` (or
+  // similar) prop in a future release, switch back to the JSX form.
+  // Empty deps because the attribute write is idempotent and only
+  // needs to happen when the underlying DOM element is created — re-
+  // firing on every render during streaming was needlessly busy.
   useEffect(() => {
     const el = stickyContextRef.current?.scrollRef?.current;
     if (el && !el.dataset.testid) {

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -721,80 +721,54 @@ export function ChatView({
   // length.
   const getMessageKey = useCallback((message: UIMessage) => message.id, []);
 
-  // Stabilise the `renderItem` closure too. Its deps (`messages`,
-  // `isStreaming`) DO change during streaming, so this only helps for
-  // the renders where they don't — chatQuery refetches, settings
-  // refetches, parent context refreshes etc. — but for those it cuts
-  // the per-render closure allocation entirely.
-  const renderMessageItem = useCallback(
-    (message: UIMessage, messageIndex: number) => {
-      const isLastMessage = messageIndex === messages.length - 1;
-      const isLastAssistant = message.role === "assistant" && isLastMessage;
-      const hasPendingInteractiveTool =
-        isLastAssistant &&
-        message.parts.some(
-          (p) =>
-            isToolUIPart(p) &&
-            IN_PROGRESS_STATES.has(p.state) &&
-            (getToolName(p) === "AskUserQuestion" || getToolName(p) === "ExitPlanMode"),
-        );
-      const showThinking = isLastAssistant && isStreaming && !hasPendingInteractiveTool;
-
-      if (message.role !== "assistant") {
-        // User messages render normally
-        const userParts = groupMessageParts(message.parts);
-        if (userParts.length === 0) return null;
-        return (
-          <Message from="user">
-            <MessageContent>
-              {userParts.map((segment) => {
-                if (
-                  segment.type === "text" &&
-                  segment.part.type === "text" &&
-                  segment.part.text.trim()
-                ) {
-                  return (
-                    <MessageResponse key={`${message.id}-text-${segment.partIndex}`}>
-                      {segment.part.text}
-                    </MessageResponse>
-                  );
-                }
-                if (segment.type === "file") {
-                  return (
-                    <MessageFilePart
-                      key={`${message.id}-file-${segment.partIndex}`}
-                      part={segment.part}
-                    />
-                  );
-                }
-                return null;
-              })}
-            </MessageContent>
-          </Message>
-        );
-      }
-
-      // Assistant message — under the chat-events model every queued
-      // turn becomes its own user-role message, so we never need to
-      // split an assistant message at `data-prompt` boundaries.
-      const visibleParts = message.parts.filter(
-        (p) => (p.type === "text" && p.text.trim()) || p.type === "file" || isToolUIPart(p),
+  // Stabilise the `renderItem` closure too. Read the variable deps
+  // (`messages`, `isStreaming`) through refs so the callback identity
+  // stays stable across ALL renders, including the streaming hot path
+  // (~30 text-delta events/sec where `messages` is a fresh array each
+  // time). Same pattern as `itemsRef` in `VirtualizedMessageList`.
+  const messagesRef = useRef(messages);
+  messagesRef.current = messages;
+  const isStreamingRef = useRef(isStreaming);
+  isStreamingRef.current = isStreaming;
+  const renderMessageItem = useCallback((message: UIMessage, messageIndex: number) => {
+    const currentMessages = messagesRef.current;
+    const currentIsStreaming = isStreamingRef.current;
+    const isLastMessage = messageIndex === currentMessages.length - 1;
+    const isLastAssistant = message.role === "assistant" && isLastMessage;
+    const hasPendingInteractiveTool =
+      isLastAssistant &&
+      message.parts.some(
+        (p) =>
+          isToolUIPart(p) &&
+          IN_PROGRESS_STATES.has(p.state) &&
+          (getToolName(p) === "AskUserQuestion" || getToolName(p) === "ExitPlanMode"),
       );
-      if (visibleParts.length === 0 && !showThinking) return null;
+    const showThinking = isLastAssistant && currentIsStreaming && !hasPendingInteractiveTool;
+
+    // Compute the grouped segments ONCE per render — `groupMessageParts`
+    // allocates a fresh array, and the previous version called it twice
+    // per assistant render (once for the emptiness guard, once for the
+    // map). With N assistant messages and ~30 deltas/sec that's 60N
+    // redundant allocations/sec; one call cuts it in half.
+    const segments = groupMessageParts(message.parts);
+
+    if (message.role !== "assistant") {
+      // User messages render normally
+      if (segments.length === 0) return null;
       return (
-        <Message from="assistant">
+        <Message from="user">
           <MessageContent>
-            {groupMessageParts(message.parts).map((segment) => {
-              if (segment.type === "text") {
-                const { part, partIndex } = segment;
-                if (part.type === "text" && part.text.trim()) {
-                  return (
-                    <MessageResponse key={`${message.id}-text-${partIndex}`}>
-                      {part.text}
-                    </MessageResponse>
-                  );
-                }
-                return null;
+            {segments.map((segment) => {
+              if (
+                segment.type === "text" &&
+                segment.part.type === "text" &&
+                segment.part.text.trim()
+              ) {
+                return (
+                  <MessageResponse key={`${message.id}-text-${segment.partIndex}`}>
+                    {segment.part.text}
+                  </MessageResponse>
+                );
               }
               if (segment.type === "file") {
                 return (
@@ -804,17 +778,49 @@ export function ChatView({
                   />
                 );
               }
-              const item = toolPartToItem(segment.part);
-              if (isTaskTool(item.toolName)) return null;
-              return <ToolCall key={`${message.id}-tool-${segment.partIndex}`} item={item} />;
+              return null;
             })}
-            {showThinking && <ThinkingIndicator />}
           </MessageContent>
         </Message>
       );
-    },
-    [messages, isStreaming],
-  );
+    }
+
+    // Assistant message — under the chat-events model every queued
+    // turn becomes its own user-role message, so we never need to
+    // split an assistant message at `data-prompt` boundaries.
+    if (segments.length === 0 && !showThinking) return null;
+    return (
+      <Message from="assistant">
+        <MessageContent>
+          {segments.map((segment) => {
+            if (segment.type === "text") {
+              const { part, partIndex } = segment;
+              if (part.type === "text" && part.text.trim()) {
+                return (
+                  <MessageResponse key={`${message.id}-text-${partIndex}`}>
+                    {part.text}
+                  </MessageResponse>
+                );
+              }
+              return null;
+            }
+            if (segment.type === "file") {
+              return (
+                <MessageFilePart
+                  key={`${message.id}-file-${segment.partIndex}`}
+                  part={segment.part}
+                />
+              );
+            }
+            const item = toolPartToItem(segment.part);
+            if (isTaskTool(item.toolName)) return null;
+            return <ToolCall key={`${message.id}-tool-${segment.partIndex}`} item={item} />;
+          })}
+          {showThinking && <ThinkingIndicator />}
+        </MessageContent>
+      </Message>
+    );
+  }, []);
 
   const getLastUserMessage = useCallback((): string | undefined => {
     // Under the chat-events model, queued/drained user messages emit their

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -300,15 +300,16 @@ export function ChatView({
   // from a child (which would couple the test to the use-stick-to-bottom
   // library's internal markup). `use-stick-to-bottom` doesn't expose a
   // prop for arbitrary attributes on the scroller, so we set it once via
-  // the same `contextRef` we use for programmatic scrolling. No
-  // dependency array — the ref is populated on first paint and the
-  // attribute survives subsequent renders.
+  // the same `contextRef` we use for programmatic scrolling. Empty deps
+  // because the attribute write is idempotent and only needs to happen
+  // when the underlying DOM element is created — re-firing on every
+  // render during streaming was needlessly busy.
   useEffect(() => {
     const el = stickyContextRef.current?.scrollRef?.current;
     if (el && !el.dataset.testid) {
       el.dataset.testid = "chat-pane__scroller";
     }
-  });
+  }, []);
 
   // Scroll to bottom when the panel becomes visible (e.g. switching tabs in dockview).
   // The scroll container may have had zero height while hidden, so StickToBottom

--- a/apps/web/src/components/MultiWorkspacePanelHost.tsx
+++ b/apps/web/src/components/MultiWorkspacePanelHost.tsx
@@ -21,6 +21,20 @@ interface CachedEntry {
 const DEFAULT_MAX_CACHED_WORKSPACES = 3;
 const MIN_MAX_CACHED_WORKSPACES = 1;
 
+// Hoisted style objects so the cached-entry divs receive
+// reference-equal `style` props across renders — React's
+// reconciler short-circuits on `===` before walking individual
+// CSS properties.
+const ACTIVE_ENTRY_STYLE: React.CSSProperties = {
+  visibility: "visible",
+  contentVisibility: "visible",
+};
+const HIDDEN_ENTRY_STYLE: React.CSSProperties = {
+  visibility: "hidden",
+  contentVisibility: "hidden",
+  pointerEvents: "none",
+};
+
 interface MultiWorkspacePanelHostProps {
   /**
    * Rendered when no workspace is selected (index route). Each panel gets a
@@ -264,11 +278,7 @@ export function MultiWorkspacePanelHost({ emptyState, children }: MultiWorkspace
             // case a future style override re-asserts visibility on a
             // descendant.
             className="absolute inset-0"
-            style={{
-              visibility: isActive ? "visible" : "hidden",
-              contentVisibility: isActive ? "visible" : "hidden",
-              pointerEvents: isActive ? undefined : "none",
-            }}
+            style={isActive ? ACTIVE_ENTRY_STYLE : HIDDEN_ENTRY_STYLE}
           >
             {children(workspaceId, isActive)}
           </div>

--- a/apps/web/src/components/MultiWorkspacePanelHost.tsx
+++ b/apps/web/src/components/MultiWorkspacePanelHost.tsx
@@ -237,9 +237,24 @@ export function MultiWorkspacePanelHost({ emptyState, children }: MultiWorkspace
             // cached entry divs would multiply-match the existing
             // `locator('[data-active="true"]')` queries other specs use.
             data-testid={`workspace-panel-host__cached-entry--${workspaceId}`}
-            className="absolute inset-0 transition-opacity duration-150 ease-out"
+            // `content-visibility: hidden` instead of `opacity: 0` for the
+            // inactive entries. opacity-0 still pays the layout + paint
+            // cost for every cached chat on every frame (and Streamdown's
+            // syntax highlighting in particular keeps re-running its
+            // intersection observers); content-visibility:hidden lets the
+            // browser SKIP rendering work on the subtree entirely while
+            // preserving the React tree + DOM state. The element keeps
+            // its 100%×100% box from `absolute inset-0`, so when it
+            // flips back to `visible` the layout settles in one frame
+            // without re-mounting any of its content.
+            //
+            // We also keep `pointer-events: none` as belt-and-suspenders
+            // — content-visibility:hidden already blocks hit-testing,
+            // but the explicit prop guarantees the same on legacy
+            // browsers that haven't shipped the spec.
+            className="absolute inset-0"
             style={{
-              opacity: isActive ? 1 : 0,
+              contentVisibility: isActive ? "visible" : "hidden",
               pointerEvents: isActive ? undefined : "none",
             }}
           >

--- a/apps/web/src/components/MultiWorkspacePanelHost.tsx
+++ b/apps/web/src/components/MultiWorkspacePanelHost.tsx
@@ -237,23 +237,35 @@ export function MultiWorkspacePanelHost({ emptyState, children }: MultiWorkspace
             // cached entry divs would multiply-match the existing
             // `locator('[data-active="true"]')` queries other specs use.
             data-testid={`workspace-panel-host__cached-entry--${workspaceId}`}
-            // `content-visibility: hidden` instead of `opacity: 0` for the
-            // inactive entries. opacity-0 still pays the layout + paint
-            // cost for every cached chat on every frame (and Streamdown's
-            // syntax highlighting in particular keeps re-running its
-            // intersection observers); content-visibility:hidden lets the
-            // browser SKIP rendering work on the subtree entirely while
-            // preserving the React tree + DOM state. The element keeps
-            // its 100%×100% box from `absolute inset-0`, so when it
-            // flips back to `visible` the layout settles in one frame
-            // without re-mounting any of its content.
+            // Hide inactive entries with `visibility: hidden` (universal
+            // browser support) for the visual effect, AND
+            // `content-visibility: hidden` on top as a progressive perf
+            // enhancement on browsers that ship it. Safari hadn't yet
+            // shipped `content-visibility` as of 18.4, so using it
+            // alone would leave every cached panel visible on Safari
+            // and stack them on top of each other — flagged as a
+            // blocker on PR #562.
             //
-            // We also keep `pointer-events: none` as belt-and-suspenders
-            // — content-visibility:hidden already blocks hit-testing,
-            // but the explicit prop guarantees the same on legacy
-            // browsers that haven't shipped the spec.
+            // Why both:
+            //   • `visibility: hidden` is the cross-browser way to
+            //     hide a subtree while keeping it laid out and its
+            //     React state alive. Pointer events are also blocked
+            //     on the subtree automatically.
+            //   • `content-visibility: hidden` additionally tells the
+            //     browser to skip layout + paint work for the subtree
+            //     entirely. Where it's supported it's the per-frame
+            //     CPU win we originally chased (opacity-0 still paid
+            //     the full layout + paint cost). Where it isn't, it's
+            //     a harmless no-op.
+            //
+            // We also keep `pointer-events: none` as belt-and-suspenders.
+            // `visibility: hidden` already blocks hit-testing on every
+            // browser, but the explicit prop guarantees the same in
+            // case a future style override re-asserts visibility on a
+            // descendant.
             className="absolute inset-0"
             style={{
+              visibility: isActive ? "visible" : "hidden",
               contentVisibility: isActive ? "visible" : "hidden",
               pointerEvents: isActive ? undefined : "none",
             }}

--- a/apps/web/src/components/ai-elements/message.tsx
+++ b/apps/web/src/components/ai-elements/message.tsx
@@ -22,6 +22,12 @@ export type MessageProps = HTMLAttributes<HTMLDivElement> & {
 
 export const Message = ({ className, from, ...props }: MessageProps) => (
   <div
+    // Default role-scoped testid lets integration tests target real
+    // message bubbles. Callers that wrap `Message` in a skeleton
+    // placeholder (see `ConversationSkeleton`) override it with
+    // `data-testid={undefined}` so locators don't pick up loading
+    // states. Spread-after-default means an explicit `data-testid` in
+    // `props` always wins.
     data-testid={from === "user" ? "chat-pane__user-message" : "chat-pane__assistant-message"}
     className={cn(
       "group flex w-full min-w-0 flex-col gap-2",

--- a/apps/web/src/components/ai-elements/message.tsx
+++ b/apps/web/src/components/ai-elements/message.tsx
@@ -22,6 +22,7 @@ export type MessageProps = HTMLAttributes<HTMLDivElement> & {
 
 export const Message = ({ className, from, ...props }: MessageProps) => (
   <div
+    data-testid={from === "user" ? "chat-pane__user-message" : "chat-pane__assistant-message"}
     className={cn(
       "group flex w-full min-w-0 flex-col gap-2",
       from === "user" ? "is-user ml-auto max-w-[90%] justify-end" : "is-assistant",

--- a/apps/web/src/components/chat/VirtualizedMessageList.tsx
+++ b/apps/web/src/components/chat/VirtualizedMessageList.tsx
@@ -1,0 +1,132 @@
+/**
+ * Virtualized (windowed) renderer for the chat message list.
+ *
+ * Why this exists — issue #586. Live profiling of the Band desktop
+ * renderer found ~88% of the DOM is agent chat history; a 600-turn
+ * conversation produced ~30k DOM nodes and ~5.5k streamdown-highlighted
+ * code blocks, holding the renderer at ~1 GB resident (peak 2.2 GB).
+ * Two forced GC passes reclaimed <1% of nodes — the memory was live,
+ * reachable, fully-rendered chat, NOT a detached-node leak. The fix is
+ * to mount only the messages near the viewport.
+ *
+ * Why it lives inside `<StickToBottom.Content>` — TanStack Virtual needs
+ * a scroll container ref; `use-stick-to-bottom` already owns the scroll
+ * container. We grab the same `scrollRef` from the StickToBottom context
+ * so both libraries read/write the same `scrollTop`. The virtualizer
+ * exposes its measured `totalSize` as the height of an inner sized div,
+ * which the StickToBottom ResizeObserver picks up and treats as "content
+ * grew" — so its stick-to-bottom behaviour keeps working on new
+ * messages and during streaming.
+ *
+ * Variable-height rows. Messages contain anything from a one-line user
+ * prompt to multiple highlighted code blocks. We use `measureElement`
+ * for dynamic measurement (each rendered row's ResizeObserver feeds the
+ * virtualizer); the estimate is only used for not-yet-mounted rows.
+ *
+ * Spacing. The previous flow layout used `[&>*+*]:mt-4` on the parent
+ * to space messages; with absolute positioning that descendant selector
+ * no longer applies. The inter-message gap is baked into each row's
+ * `pb-4` instead, so the measured `size` already includes it.
+ */
+
+import { useVirtualizer } from "@tanstack/react-virtual";
+import { useStickToBottomContext } from "use-stick-to-bottom";
+
+export interface VirtualizedMessageListProps<T> {
+  /** Items to virtualize. Stable identity per item via `getKey`. */
+  items: T[];
+  /** Stable React key for an item — used by the virtualizer's row map. */
+  getKey: (item: T, index: number) => string;
+  /** Render a single item. Receives the item and its index in `items`.
+   *  Returning `null` is allowed (e.g. for messages with no visible
+   *  parts), and the wrapper row collapses to zero height so a skipped
+   *  item doesn't contribute a visible gap. */
+  renderItem: (item: T, index: number) => React.ReactNode;
+  /**
+   * Rough average row height. Used only for not-yet-measured rows so
+   * the scrollbar position is plausible on first paint. 220 px is a
+   * sensible default for a mixed user/assistant conversation — short
+   * user bubbles balance long assistant turns. Measurement converges
+   * to the real value within one frame per row.
+   */
+  estimateSize?: number;
+  /**
+   * Number of rows to render outside the viewport on each side.
+   * Bigger overscan = smoother fast-scroll but more DOM in flight; 5
+   * is the TanStack-recommended starting point.
+   */
+  overscan?: number;
+}
+
+export function VirtualizedMessageList<T>({
+  items,
+  getKey,
+  renderItem,
+  estimateSize = 220,
+  overscan = 5,
+}: VirtualizedMessageListProps<T>) {
+  const { scrollRef } = useStickToBottomContext();
+
+  const virtualizer = useVirtualizer({
+    count: items.length,
+    getScrollElement: () => scrollRef.current,
+    estimateSize: () => estimateSize,
+    overscan,
+    // Stable key per item — important so React reuses the same DOM row
+    // when items shift (e.g. a new message pushes earlier ones up).
+    getItemKey: (index) => getKey(items[index], index),
+  });
+
+  const virtualItems = virtualizer.getVirtualItems();
+  const totalSize = virtualizer.getTotalSize();
+
+  return (
+    <div
+      data-testid="chat-pane__virtual-list"
+      style={{
+        // Explicit total height so the parent flex container's
+        // ResizeObserver (use-stick-to-bottom) sees growth and the
+        // scrollbar shows the correct extent.
+        height: `${totalSize}px`,
+        width: "100%",
+        position: "relative",
+      }}
+    >
+      {virtualItems.map((virtualRow) => {
+        const item = items[virtualRow.index];
+        const content = renderItem(item, virtualRow.index);
+        // Trailing row has no following sibling — drop the inter-row
+        // gap so the conversation doesn't end with an extra 16px of
+        // dead space before the queued-messages / thinking sibling
+        // outside the virtualized region. Skipped rows (renderItem →
+        // null) also drop `pb-4` so an empty assistant turn collapses
+        // to zero height instead of leaving a visible gap (matches
+        // the pre-virtualization `.map() → null` behaviour).
+        const isLast = virtualRow.index === items.length - 1;
+        const padding = content == null || isLast ? "" : "pb-4";
+        return (
+          <div
+            key={virtualRow.key}
+            data-index={virtualRow.index}
+            data-testid="chat-pane__message-row"
+            ref={virtualizer.measureElement}
+            style={{
+              position: "absolute",
+              top: 0,
+              left: 0,
+              width: "100%",
+              transform: `translateY(${virtualRow.start}px)`,
+            }}
+            // `pb-4` bakes the inter-row gap into the measured size so
+            // visual spacing matches the old `[&>*+*]:mt-4` layout
+            // without depending on a descendant selector that absolute
+            // positioning would defeat.
+            className={padding}
+          >
+            {content}
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/web/src/components/chat/VirtualizedMessageList.tsx
+++ b/apps/web/src/components/chat/VirtualizedMessageList.tsx
@@ -30,6 +30,7 @@
  */
 
 import { useVirtualizer } from "@tanstack/react-virtual";
+import { type ReactNode, useCallback } from "react";
 import { useStickToBottomContext } from "use-stick-to-bottom";
 
 export interface VirtualizedMessageListProps<T> {
@@ -41,7 +42,7 @@ export interface VirtualizedMessageListProps<T> {
    *  Returning `null` is allowed (e.g. for messages with no visible
    *  parts), and the wrapper row collapses to zero height so a skipped
    *  item doesn't contribute a visible gap. */
-  renderItem: (item: T, index: number) => React.ReactNode;
+  renderItem: (item: T, index: number) => ReactNode;
   /**
    * Rough average row height. Used only for not-yet-measured rows so
    * the scrollbar position is plausible on first paint. 220 px is a
@@ -67,10 +68,17 @@ export function VirtualizedMessageList<T>({
 }: VirtualizedMessageListProps<T>) {
   const { scrollRef } = useStickToBottomContext();
 
+  // Hoist the estimateSize callback so its identity is stable across
+  // re-renders — during streaming `ChatView` re-renders ~30×/sec and an
+  // inline arrow would allocate a fresh closure each time. The
+  // `useVirtualizer` options memoise on identity, so stable callbacks
+  // also keep the internal `getMeasurementOptions` memo valid.
+  const estimateSizeFn = useCallback(() => estimateSize, [estimateSize]);
+
   const virtualizer = useVirtualizer({
     count: items.length,
     getScrollElement: () => scrollRef.current,
-    estimateSize: () => estimateSize,
+    estimateSize: estimateSizeFn,
     overscan,
     // Stable key per item — important so React reuses the same DOM row
     // when items shift (e.g. a new message pushes earlier ones up).

--- a/apps/web/src/components/chat/VirtualizedMessageList.tsx
+++ b/apps/web/src/components/chat/VirtualizedMessageList.tsx
@@ -29,8 +29,8 @@
  * `pb-4` instead, so the measured `size` already includes it.
  */
 
-import { useVirtualizer } from "@tanstack/react-virtual";
-import { type ReactNode, useCallback, useRef } from "react";
+import { useVirtualizer, type Virtualizer } from "@tanstack/react-virtual";
+import { memo, type ReactNode, useCallback, useRef } from "react";
 import { useStickToBottomContext } from "use-stick-to-bottom";
 
 export interface VirtualizedMessageListProps<T> {
@@ -121,44 +121,92 @@ export function VirtualizedMessageList<T>({
     >
       {virtualItems.map((virtualRow) => {
         const item = items[virtualRow.index];
-        const content = renderItem(item, virtualRow.index);
-        // Trailing row has no following sibling — drop the inter-row
-        // gap so the conversation doesn't end with an extra 16px of
-        // dead space before the queued-messages / thinking sibling
-        // outside the virtualized region. Skipped rows (renderItem →
-        // null) also drop `pb-4` so an empty assistant turn collapses
-        // to zero height instead of leaving a visible gap (matches
-        // the pre-virtualization `.map() → null` behaviour).
         const isLast = virtualRow.index === items.length - 1;
-        const padding = content == null || isLast ? "" : "pb-4";
         return (
-          <div
+          <VirtualRow
             key={virtualRow.key}
-            data-index={virtualRow.index}
-            // Skip the testid for null-content rows so
-            // `messageRowCount()` only includes rows that actually
-            // contain a message — without this the windowing bound
-            // would inflate by the count of skipped (renderItem ===
-            // null) entries.
-            data-testid={content == null ? undefined : "chat-pane__message-row"}
-            ref={virtualizer.measureElement}
-            style={{
-              position: "absolute",
-              top: 0,
-              left: 0,
-              width: "100%",
-              transform: `translateY(${virtualRow.start}px)`,
-            }}
-            // `pb-4` bakes the inter-row gap into the measured size so
-            // visual spacing matches the old `[&>*+*]:mt-4` layout
-            // without depending on a descendant selector that absolute
-            // positioning would defeat.
-            className={padding}
-          >
-            {content}
-          </div>
+            item={item}
+            index={virtualRow.index}
+            start={virtualRow.start}
+            isLast={isLast}
+            renderItem={renderItem}
+            measureRef={virtualizer.measureElement}
+          />
         );
       })}
     </div>
   );
 }
+
+interface VirtualRowProps<T> {
+  item: T;
+  index: number;
+  start: number;
+  isLast: boolean;
+  renderItem: (item: T, index: number) => ReactNode;
+  measureRef: Virtualizer<HTMLElement, Element>["measureElement"];
+}
+
+/**
+ * Memoized row wrapper — short-circuits the React reconciler for rows
+ * whose `(item, index, start, isLast, renderItem, measureRef)` tuple
+ * is reference-equal to the previous render. During streaming
+ * `ChatView` re-renders ~30×/sec and only the trailing (streaming)
+ * message's `item` reference mutates; every other windowed row gets
+ * the same `item` reference from the reducer state, so memoizing the
+ * row skips the `renderItem` call and the inner Streamdown/Shiki
+ * highlight pass for those rows.
+ *
+ * `renderItem` and `measureRef` are stable across renders (the
+ * caller wraps `renderItem` in `useCallback`, and TanStack's
+ * `measureElement` is a stable function on the virtualizer
+ * instance), so React.memo's default shallow comparison is correct.
+ */
+function VirtualRowImpl<T>({
+  item,
+  index,
+  start,
+  isLast,
+  renderItem,
+  measureRef,
+}: VirtualRowProps<T>) {
+  const content = renderItem(item, index);
+  // Trailing row has no following sibling — drop the inter-row gap so
+  // the conversation doesn't end with an extra 16px of dead space
+  // before the queued-messages / thinking sibling outside the
+  // virtualized region. Skipped rows (renderItem → null) also drop
+  // `pb-4` so an empty assistant turn collapses to zero height
+  // instead of leaving a visible gap (matches the pre-virtualization
+  // `.map() → null` behaviour).
+  const padding = content == null || isLast ? "" : "pb-4";
+  return (
+    <div
+      data-index={index}
+      // Skip the testid for null-content rows so `messageRowCount()`
+      // only includes rows that actually contain a message — without
+      // this the windowing bound would inflate by the count of
+      // skipped (renderItem === null) entries.
+      data-testid={content == null ? undefined : "chat-pane__message-row"}
+      ref={measureRef}
+      style={{
+        position: "absolute",
+        top: 0,
+        left: 0,
+        width: "100%",
+        transform: `translateY(${start}px)`,
+      }}
+      // `pb-4` bakes the inter-row gap into the measured size so
+      // visual spacing matches the old `[&>*+*]:mt-4` layout without
+      // depending on a descendant selector that absolute positioning
+      // would defeat.
+      className={padding}
+    >
+      {content}
+    </div>
+  );
+}
+
+// `React.memo` strips the generic parameter from the wrapped
+// component's type. Re-cast through `typeof VirtualRowImpl` so
+// callers retain inference on the element type `T`.
+const VirtualRow = memo(VirtualRowImpl) as typeof VirtualRowImpl;

--- a/apps/web/src/components/chat/VirtualizedMessageList.tsx
+++ b/apps/web/src/components/chat/VirtualizedMessageList.tsx
@@ -68,12 +68,16 @@ export function VirtualizedMessageList<T>({
 }: VirtualizedMessageListProps<T>) {
   const { scrollRef } = useStickToBottomContext();
 
-  // Hoist the estimateSize callback so its identity is stable across
-  // re-renders — during streaming `ChatView` re-renders ~30×/sec and an
-  // inline arrow would allocate a fresh closure each time. The
+  // Hoist the virtualizer callbacks so their identity is stable across
+  // re-renders — during streaming `ChatView` re-renders ~30×/sec and
+  // inline arrows would allocate fresh closures each time. The
   // `useVirtualizer` options memoise on identity, so stable callbacks
-  // also keep the internal `getMeasurementOptions` memo valid.
+  // also keep the internal `getMeasurementOptions` memo valid (which
+  // gates whether `getMeasurements()` re-walks the full count). For
+  // `getItemKey` the cost grows linearly with conversation length, so
+  // it's the highest-leverage one to stabilise.
   const estimateSizeFn = useCallback(() => estimateSize, [estimateSize]);
+  const getItemKeyFn = useCallback((index: number) => getKey(items[index], index), [items, getKey]);
 
   const virtualizer = useVirtualizer({
     count: items.length,
@@ -82,7 +86,7 @@ export function VirtualizedMessageList<T>({
     overscan,
     // Stable key per item — important so React reuses the same DOM row
     // when items shift (e.g. a new message pushes earlier ones up).
-    getItemKey: (index) => getKey(items[index], index),
+    getItemKey: getItemKeyFn,
   });
 
   const virtualItems = virtualizer.getVirtualItems();

--- a/apps/web/src/components/chat/VirtualizedMessageList.tsx
+++ b/apps/web/src/components/chat/VirtualizedMessageList.tsx
@@ -78,10 +78,14 @@ export function VirtualizedMessageList<T>({
   // it's the highest-leverage one to stabilise.
   const estimateSizeFn = useCallback(() => estimateSize, [estimateSize]);
   const getItemKeyFn = useCallback((index: number) => getKey(items[index], index), [items, getKey]);
+  // `scrollRef` is a stable ref object from the StickToBottom context
+  // — its `.current` may change but the ref identity does not — so
+  // this callback never invalidates after mount.
+  const getScrollElement = useCallback(() => scrollRef.current, [scrollRef]);
 
   const virtualizer = useVirtualizer({
     count: items.length,
-    getScrollElement: () => scrollRef.current,
+    getScrollElement,
     estimateSize: estimateSizeFn,
     overscan,
     // Stable key per item — important so React reuses the same DOM row

--- a/apps/web/src/components/chat/VirtualizedMessageList.tsx
+++ b/apps/web/src/components/chat/VirtualizedMessageList.tsx
@@ -135,7 +135,12 @@ export function VirtualizedMessageList<T>({
           <div
             key={virtualRow.key}
             data-index={virtualRow.index}
-            data-testid="chat-pane__message-row"
+            // Skip the testid for null-content rows so
+            // `messageRowCount()` only includes rows that actually
+            // contain a message — without this the windowing bound
+            // would inflate by the count of skipped (renderItem ===
+            // null) entries.
+            data-testid={content == null ? undefined : "chat-pane__message-row"}
             ref={virtualizer.measureElement}
             style={{
               position: "absolute",

--- a/apps/web/src/components/chat/VirtualizedMessageList.tsx
+++ b/apps/web/src/components/chat/VirtualizedMessageList.tsx
@@ -30,7 +30,7 @@
  */
 
 import { useVirtualizer } from "@tanstack/react-virtual";
-import { type ReactNode, useCallback } from "react";
+import { type ReactNode, useCallback, useRef } from "react";
 import { useStickToBottomContext } from "use-stick-to-bottom";
 
 export interface VirtualizedMessageListProps<T> {
@@ -77,7 +77,18 @@ export function VirtualizedMessageList<T>({
   // `getItemKey` the cost grows linearly with conversation length, so
   // it's the highest-leverage one to stabilise.
   const estimateSizeFn = useCallback(() => estimateSize, [estimateSize]);
-  const getItemKeyFn = useCallback((index: number) => getKey(items[index], index), [items, getKey]);
+  // Ref-backed `items` reference so `getItemKeyFn`'s closure is
+  // stable across re-renders even though `items` itself is a fresh
+  // array on every text-delta. The ref stays attached to the latest
+  // value via the `.current = items` assignment-on-render; the
+  // closure reads through the ref so the virtualizer's internal
+  // `getMeasurementOptions` memo holds.
+  const itemsRef = useRef(items);
+  itemsRef.current = items;
+  const getItemKeyFn = useCallback(
+    (index: number) => getKey(itemsRef.current[index], index),
+    [getKey],
+  );
   // `scrollRef` is a stable ref object from the StickToBottom context
   // — its `.current` may change but the ref identity does not — so
   // this callback never invalidates after mount.

--- a/apps/web/src/dashboard/components/ProjectList.tsx
+++ b/apps/web/src/dashboard/components/ProjectList.tsx
@@ -284,7 +284,10 @@ function SortableProject({
                     {project.name}
                   </h2>
                 </TooltipTrigger>
-                <TooltipContent side="top">{project.name}</TooltipContent>
+                {/* Anchored to the right so a long project name doesn't
+                    cover the row above — matches the `side="right"`
+                    treatment on `WorkspaceCard`'s label tooltip. */}
+                <TooltipContent side="right">{project.name}</TooltipContent>
               </Tooltip>
             </div>
             <div className="flex items-center gap-1">

--- a/apps/web/src/dashboard/components/WorkspaceCard.tsx
+++ b/apps/web/src/dashboard/components/WorkspaceCard.tsx
@@ -221,7 +221,12 @@ export const WorkspaceCard = memo(function WorkspaceCard({
     <ContextMenu>
       <ContextMenuTrigger asChild>
         <div {...containerProps}>
-          <Tooltip>
+          {/* `delayDuration` overrides the provider's default 500 ms so
+              the tooltip waits long enough that a short mouse pass while
+              scanning the sidebar doesn't fire one — but still snappy
+              enough to feel responsive when the user actually pauses on
+              a card to read the truncated label. */}
+          <Tooltip delayDuration={800}>
             <TooltipTrigger asChild>
               <div className="flex items-center gap-2 min-w-0 overflow-hidden">
                 <AgentStatusIndicator agent={status?.agent} isActive={isActive} />
@@ -232,14 +237,18 @@ export const WorkspaceCard = memo(function WorkspaceCard({
                 </span>
               </div>
             </TooltipTrigger>
-            {/* When showProjectName is true the visible label already
-                spells out `project/branch`, so re-displaying it in the
-                tooltip is noise. Show the worktree's absolute path
-                instead — that's genuinely supplementary information the
-                card body never surfaces. */}
-            <TooltipContent side="top">
-              {showProjectName ? worktree.path : worktree.branch}
-            </TooltipContent>
+            {/* Always show the full `project/branch` name in the
+                tooltip. The visible label is `truncate`-ellipsised when
+                the sidebar is narrow, so spelling out the full thing on
+                hover is the one thing a tooltip is actually useful for
+                — the worktree's absolute path was clutter (and it
+                exposed `$HOME` paths that the user doesn't typically
+                care about while scanning the list).
+                Anchored to the right of the card (was top) so a long
+                project/branch string doesn't cover the next card down
+                — fans out into open viewport space instead of
+                overlapping siblings. */}
+            <TooltipContent side="right">{`${projectName}/${worktree.branch}`}</TooltipContent>
           </Tooltip>
           <div className="hidden @[10rem]:flex group-hover:flex items-center gap-2 shrink-0 ml-auto pl-2">
             <SetupStatusIndicator setup={setupStatus} />

--- a/apps/web/tests/chat-events.test.ts
+++ b/apps/web/tests/chat-events.test.ts
@@ -1744,18 +1744,18 @@ describe("chat-events — cold subscribe + reconnect: no duplication on the work
     });
     // No content event with id > 0 should appear at all on the
     // reconnect — the previous run already covered every buffered
-    // event up to `cursor`.
-    for (const evt of reconnect) {
-      if (contentEventTypes.has(evt.type as ChatEventType) && evt.id > 0) {
-        // Either the buffer-replay filter (evt.id <= cursor) is broken
-        // or someone removed the buffer-replay path entirely — both
-        // are regressions.
-        throw new Error(
-          `Unexpected re-emission of content event after reconnect: type=${evt.type} id=${evt.id} cursor=${cursor}`,
-        );
-      }
-    }
-    // Sanity: the stream did open and emit its initial bookkeeping.
+    // event up to `cursor`. Explicit `expect(...).toBe(0)` so a silent
+    // timeout (zero events collected within the window) is asserted
+    // as success against the SAME predicate rather than implicitly
+    // passing because the for-loop body never executed.
+    const reEmittedContent = reconnect.filter(
+      (e) => contentEventTypes.has(e.type as ChatEventType) && e.id > 0,
+    );
+    expect(reEmittedContent.length).toBe(0);
+    // Sanity: the stream did open and emit its initial bookkeeping —
+    // this is the positive anchor that proves the timeout is "no
+    // re-emission proven" rather than "the connection never
+    // established".
     expect(reconnect[0]?.type).toBe("subscription-opened");
   }, 25_000);
 });

--- a/apps/web/tests/chat-events.test.ts
+++ b/apps/web/tests/chat-events.test.ts
@@ -1635,3 +1635,154 @@ describe("chat-events — auth + input-validation contracts", () => {
     expect(body).toEqual({ error: "Invalid JSON body" });
   });
 });
+
+// ---------------------------------------------------------------------------
+// Regression coverage for the workspace-switch duplication fix in
+// `apps/web/src/api/chat-events.ts` (the two code paths reviewed under
+// PR #562's Testing [1] blocker).
+// ---------------------------------------------------------------------------
+
+describe("chat-events — cold subscribe + reconnect: no duplication on the workspace-switch path", () => {
+  let server: ServerHandle;
+  let tmpHome: string;
+
+  beforeAll(async () => {
+    tmpHome = createTmpHome();
+    seedState(tmpHome, createDefaultState(tmpHome));
+    seedSettings(tmpHome, defaultSettings());
+    const scenario = writeScenario(tmpHome, quickScenario("noreplay-session"));
+    server = await startServer({ tmpHome, scenarioPath: scenario });
+  }, 30_000);
+
+  afterAll(async () => {
+    if (server) await server.close();
+    rmSync(tmpHome, { recursive: true, force: true });
+  });
+
+  /**
+   * Covers the `bufferCoversStart` branch of cold subscribe: when an
+   * in-memory buffer exists from event id 1, the server emits the
+   * BUFFER (real positive eventIds), not JSONL synthetic negative ids.
+   * Then verifies cursor preservation: a reconnect with the highest
+   * buffer eventId emits no further content events.
+   *
+   * Together these two assertions cover the workspace-switch
+   * duplication regression on the buffer-populated path — the exact
+   * scenario reproduced live in PR #562 where typing "hey", switching
+   * away, and switching back duplicated the conversation. The
+   * complementary `buf === undefined` + JSONL-on-disk hot-reconnect
+   * branch is exercised end-to-end by
+   * `apps/web/e2e/chat-virtualization.spec.ts`, which seeds the JSONL
+   * directly and drives the full switch-back through Playwright.
+   */
+  it("cold subscribe uses buffer (real positive ids), and reconnect with that cursor sees no re-emission", async () => {
+    const chatId = newChatId("noreplay");
+
+    // Phase 1: run a real task so the in-memory buffer for the session
+    // is populated with events starting at eventId 1. Subscribe BEFORE
+    // submit so the task's full lifecycle (user-message → task-started
+    // → text-* → task-completed) is captured.
+    const turn1Promise = collectEvents(server.url, chatId, {
+      until: (e) => e.type === "task-completed",
+      timeoutMs: 15_000,
+    });
+    const submitRes = await submitMessage(server.url, chatId, {
+      workspaceId: "testproject-main",
+      text: "hello",
+    });
+    expect(submitRes.status).toBe(200);
+    const turn1 = await turn1Promise;
+
+    expect(turn1.some((e) => e.type === "task-completed")).toBe(true);
+    expect(turn1.some((e) => e.type === "user-message" && e.id > 0)).toBe(true);
+
+    // Phase 2: cold-subscribe to the same chat AGAIN (no Last-Event-ID).
+    // This is the path a fresh tab / cached-workspace cold subscribe
+    // takes — the buffer for the session is now populated with real
+    // events 1..N. The fix's `bufferCoversStart` branch emits the
+    // buffer (positive ids); the previous JSONL-preferred path
+    // emitted synthetic negative ids and stranded the client's cursor
+    // at 0.
+    const cold = await collectEvents(server.url, chatId, {
+      until: (e) => e.type === "task-completed",
+      timeoutMs: 5_000,
+    });
+
+    const contentEventTypes = new Set<ChatEventType>([
+      "user-message",
+      "text-start",
+      "text-delta",
+      "text-end",
+      "tool-input-available",
+      "tool-output-available",
+      "task-started",
+      "task-completed",
+    ]);
+    const contentEvents = cold.filter((e) => contentEventTypes.has(e.type as ChatEventType));
+    expect(contentEvents.length).toBeGreaterThan(0);
+    for (const evt of contentEvents) {
+      // Buffer-emitted events carry their real, positive task-service
+      // eventId. JSONL-backfill events would be negative synthetics.
+      expect(evt.id).toBeGreaterThan(0);
+    }
+    // The client's cursor after dispatching these would be max(ids).
+    const cursor = Math.max(...contentEvents.map((e) => e.id));
+    expect(cursor).toBeGreaterThan(0);
+
+    // Phase 3: reconnect with the cursor from phase 2 — the exact
+    // value the client's `lastEventId` would hold after a buffer-
+    // backed cold subscribe. The server must NOT re-emit any of the
+    // events the client already has; the `evt.eventId <= afterEventId`
+    // filter in the buffer-replay branch drops everything in range.
+    const reconnect = await collectEvents(server.url, chatId, {
+      lastEventId: cursor,
+      // Stop the moment a forbidden content event arrives so a
+      // regression fails fast instead of timing out.
+      until: (evt) => contentEventTypes.has(evt.type as ChatEventType) && evt.id > 0,
+      maxEvents: 20,
+      timeoutMs: 2_500,
+    });
+    // No content event with id > 0 should appear at all on the
+    // reconnect — the previous run already covered every buffered
+    // event up to `cursor`.
+    for (const evt of reconnect) {
+      if (contentEventTypes.has(evt.type as ChatEventType) && evt.id > 0) {
+        // Either the buffer-replay filter (evt.id <= cursor) is broken
+        // or someone removed the buffer-replay path entirely — both
+        // are regressions.
+        throw new Error(
+          `Unexpected re-emission of content event after reconnect: type=${evt.type} id=${evt.id} cursor=${cursor}`,
+        );
+      }
+    }
+    // Sanity: the stream did open and emit its initial bookkeeping.
+    expect(reconnect[0]?.type).toBe("subscription-opened");
+  }, 25_000);
+});
+
+/* Note on the second case the PR #562 review requested — the
+ * `buf === undefined` + JSONL-on-disk hot-reconnect scenario — that we
+ * intentionally do NOT add here:
+ *
+ *   The vitest harness uses the `fake-agent.mjs` stub binary which
+ *   speaks the Claude Agent SDK stdio protocol but does NOT write a
+ *   transcript to `~/.claude/projects/<encoded>/<sessionId>.jsonl`.
+ *   And every attempt to seed that JSONL directly (matching the format
+ *   the working `apps/web/e2e/chat-virtualization.spec.ts` uses) ends
+ *   with the SDK's `getSessionMessages` returning an empty array in
+ *   this harness, even though the identical seed works under
+ *   Playwright. That difference appears to come from the Playwright
+ *   harness booting a real production bundle while vitest boots tsx
+ *   source — but the SDK is closed-source and minified, so confirming
+ *   that is beyond the bounds of this PR.
+ *
+ *   The user-observable scenario the second case would cover (typing
+ *   into a chat, switching away and back, never seeing the
+ *   conversation double) is exercised end-to-end by the live-app
+ *   reproduction documented in PR #562's description: switching
+ *   between two real workspaces 5× while observing both reducer state
+ *   and SSE traffic, before and after the fix. That reproduction is
+ *   the proof the fix works; the test above pins the buffer/cursor
+ *   half of the implementation as the part we can guard
+ *   deterministically in the vitest harness today.
+ */

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -220,6 +220,9 @@ importers:
       '@tanstack/react-start':
         specifier: ^1.154.0
         version: 1.166.2(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vite@7.3.1(@types/node@22.19.13)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+      '@tanstack/react-virtual':
+        specifier: ^3.13.12
+        version: 3.14.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@tanstack/router-plugin':
         specifier: ^1.154.0
         version: 1.166.2(@tanstack/react-router@1.166.2(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@7.3.1(@types/node@22.19.13)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
@@ -2919,6 +2922,12 @@ packages:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
+  '@tanstack/react-virtual@3.14.3':
+    resolution: {integrity: sha512-k/cnHPVaOfn46hSbiY6n4Dzf4QjCGWSF40zR5QIIYUqPAjpA6TN7InfYmcMiDVQGP2iUn9xsRbAl8u1v3UmeVQ==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
   '@tanstack/router-core@1.166.2':
     resolution: {integrity: sha512-zn3NhENOAX9ToQiX077UV2OH3aJKOvV2ZMNZZxZ3gDG3i3WqL8NfWfEgetEAfMN37/Mnt90PpotYgf7IyuoKqQ==}
     engines: {node: '>=20.19'}
@@ -2976,6 +2985,9 @@ packages:
 
   '@tanstack/store@0.9.1':
     resolution: {integrity: sha512-+qcNkOy0N1qSGsP7omVCW0SDrXtaDcycPqBDE726yryiA5eTDFpjBReaYjghVJwNf1pcPMyzIwTGlYjCSQR0Fg==}
+
+  '@tanstack/virtual-core@3.17.1':
+    resolution: {integrity: sha512-VZyW2Uiml5tmBZwPGrSD3Sz73OxzljQMCmzYHsUTPEuTsERf5xwa+uWb01xEzkz3ZSYTjj8NEb/mKHvgKxyZdA==}
 
   '@tanstack/virtual-file-routes@1.161.4':
     resolution: {integrity: sha512-42WoRePf8v690qG8yGRe/YOh+oHni9vUaUUfoqlS91U2scd3a5rkLtVsc6b7z60w3RogH0I00vdrC5AaeiZ18w==}
@@ -9982,6 +9994,12 @@ snapshots:
       react-dom: 19.2.4(react@19.2.4)
       use-sync-external-store: 1.6.0(react@19.2.4)
 
+  '@tanstack/react-virtual@3.14.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@tanstack/virtual-core': 3.17.1
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+
   '@tanstack/router-core@1.166.2':
     dependencies:
       '@tanstack/history': 1.161.4
@@ -10100,6 +10118,8 @@ snapshots:
       '@tanstack/router-core': 1.166.2
 
   '@tanstack/store@0.9.1': {}
+
+  '@tanstack/virtual-core@3.17.1': {}
 
   '@tanstack/virtual-file-routes@1.161.4': {}
 


### PR DESCRIPTION
## Summary

- **Virtualize the chat message list** with `@tanstack/react-virtual` so long conversations cap DOM nodes near viewport. Live profiling found ~88% of the renderer's DOM was un-virtualized chat history (~30k nodes on a 600-turn conversation); now ~9 rows mount regardless of conversation length.
- **Fix the "switch back to a cached workspace duplicates the conversation" bug.** Two server-side changes in `chat-events.ts`:
  - Hot reconnect with `buf === undefined` no longer backfills JSONL — the client already has the history.
  - Cold subscribe prefers the in-memory buffer (real `eventId`s) over JSONL (negative synthetic ids) so `state.lastEventId` tracks correctly and reconnects naturally drop duplicates via the existing filter.
- **Switch inactive cached workspace entries to `content-visibility: hidden`** (no opacity transition). The browser skips layout + paint on cached chats; switches feel instant.
- **Workspace-card tooltip polish**: 800 ms delay (was 500), anchored `side="right"`, always shows `project/branch` instead of the absolute path on pinned cards. Project-header tooltip also moved to `side="right"`.

## Test plan

- [x] `pnpm vitest run tests/chat-events.test.ts` — 22/22 passing
- [x] `pnpm test:e2e -- chat-virtualization` — windowing test passes (9 rows / 1000 messages)
- [x] `pnpm test:e2e -- chat-send-optimistic chat-cancel chat-file-link-dispatch chat-mention-escape session-history chat-tool-output-routing chat-file-link-mobile chat-file-link-workspace queue-ui` — 16/16 passing
- [x] Live reproduction: open `kbhq-main` → type "hey" → page reload → switch to `webmcp-playground-main` → switch back. Without fix: 2→4 rows ("hey duplicated"). With fix: stays at 2 across 5 round-trip switches; SSE traffic = 5 events per switch (open/close + bookkeeping), 0 message events.
- [x] `pnpm lint` clean (the one pre-existing `_home` unused-param warning is from `model-refresh-router.test.ts` on `main`, not this branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)