### PR TITLE
Fix band-start dispatch: chat-hosted agents → chat, robust terminal auto-run

### DIFF
--- a/apps/web/src/server/api/terminals/router.ts
+++ b/apps/web/src/server/api/terminals/router.ts
@@ -31,7 +31,11 @@ const terminalRouter = t.router({
     .input(
       z.object({
         workspaceId: z.string(),
-        id: z.string().optional(),
+        // Constrain to a UUID: every caller (the dashboard's
+        // `newTerminalId()` and the server's `randomUUID()` fallback)
+        // already sends one, and it stops a hostile id from being used
+        // anywhere the pool derives a filesystem path from it.
+        id: z.string().uuid().optional(),
         command: z.string().optional(),
         cwd: z.string().optional(),
         env: z.record(z.string()).optional(),

--- a/apps/web/src/server/infra/terminals/terminal-pool.ts
+++ b/apps/web/src/server/infra/terminals/terminal-pool.ts
@@ -116,15 +116,6 @@ export class TerminalPool {
     // Hint foreground/background colors so CLI tools (vim, bat, etc.) don't send
     // OSC 11 queries whose responses leak as visible garbage in the terminal.
     env.COLORFGBG = "15;0";
-    // Pin the dispatch target for any nested `band` CLI call typed into
-    // this pane to `terminal`, matching where it runs. The server's own
-    // process.env carries no `BAND_DISPATCH` today, so the Rust CLI would
-    // already fall through to its `terminal` default — but setting it
-    // explicitly keeps the terminal path correct even if a future change
-    // ever sets `BAND_DISPATCH` server-wide, and mirrors the
-    // `BAND_DISPATCH=chat` the coding-agent subprocesses inject (see
-    // packages/coding-agent/src/adapter-env.ts).
-    env.BAND_DISPATCH = "terminal";
     // Remove PORT so workspace dev servers don't inherit the Band server's port
     delete env.PORT;
 
@@ -132,6 +123,19 @@ export class TerminalPool {
     if (options?.env) {
       Object.assign(env, options.env);
     }
+
+    // Pin the dispatch target for any nested `band` CLI call typed into
+    // this pane to `terminal`, matching where it runs. The server's own
+    // process.env carries no `BAND_DISPATCH` today, so the Rust CLI would
+    // already fall through to its `terminal` default — but setting it
+    // explicitly keeps the terminal path correct even if a future change
+    // ever sets `BAND_DISPATCH` server-wide, and mirrors the
+    // `BAND_DISPATCH=chat` the coding-agent subprocesses inject (see
+    // packages/coding-agent/src/adapter-env.ts). Set AFTER the
+    // `options.env` merge so the pool-mandated value always wins — a
+    // caller can't accidentally (or deliberately) downgrade a terminal
+    // pane to `chat` dispatch.
+    env.BAND_DISPATCH = "terminal";
 
     // Resolve cwd: options.cwd is relative to workspace root
     let cwd = workspaceRoot;
@@ -307,26 +311,42 @@ export class TerminalPool {
       return;
     }
 
-    // Single-quote the path (our own temp path under tmpdir — no quotes
-    // to escape) so a tmpdir with spaces still resolves.
-    const sourceLine = `source '${cmdFile}'\n`;
+    // Single-quote the path for the shell. The path is our own
+    // `tmpdir()`-rooted temp file, but escape any embedded single-quote
+    // (POSIX `'\''`) anyway so a `TMPDIR` containing a `'` can't break the
+    // quoting and inject into the interactive shell.
+    const quotedPath = cmdFile.replace(/'/g, `'\\''`);
+    const sourceLine = `source '${quotedPath}'\n`;
 
-    let injected = false;
+    let done = false;
     const inject = () => {
-      if (injected) return;
-      injected = true;
-      pty.write(sourceLine);
+      if (done) return;
+      done = true;
+      try {
+        pty.write(sourceLine);
+      } catch (err) {
+        // The PTY exited before we got to inject (e.g. the user closed the
+        // pane during the cold-start window). Nothing left to run.
+        log.warn("autoRunCommand: failed to inject source line (%s)", err);
+      }
     };
 
     // The shell's first output (its prompt) is our readiness signal that
-    // the tty is past its cold-start window. Inject then. A fallback
-    // timer covers a shell that prints nothing, so the command still
-    // runs. The timer is unref'd so it never keeps the process alive.
-    const disposable = pty.onData(() => {
-      disposable.dispose();
+    // the tty is past its cold-start window. Inject then. A fallback timer
+    // covers a shell that prints nothing, so the command still runs; it's
+    // unref'd so it never keeps the process alive. An `onExit` listener
+    // cancels both signals so a late timer can never write to a dead PTY.
+    const dataDisposable = pty.onData(() => {
+      dataDisposable.dispose();
       inject();
     });
-    setTimeout(inject, 750).unref();
+    const timer = setTimeout(inject, 750);
+    timer.unref();
+    pty.onExit(() => {
+      done = true;
+      clearTimeout(timer);
+      dataDisposable.dispose();
+    });
   }
 
   /**

--- a/apps/web/src/server/infra/terminals/terminal-pool.ts
+++ b/apps/web/src/server/infra/terminals/terminal-pool.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 import { existsSync, unlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, sep } from "node:path";
@@ -207,7 +208,7 @@ export class TerminalPool {
     // race — see autoRunCommand for why a naive `pty.write` truncates and
     // mangles long prompt-as-argv command lines.
     if (options?.command) {
-      this.autoRunCommand(session, terminalId, options.command);
+      this.autoRunCommand(session, options.command);
     }
 
     // Register in reverse index
@@ -287,11 +288,18 @@ export class TerminalPool {
    * survives. `source` runs the command in the current interactive shell,
    * so the user keeps their session afterwards.
    */
-  private autoRunCommand(session: TerminalSession, terminalId: string, command: string): void {
+  private autoRunCommand(session: TerminalSession, command: string): void {
     const pty = session.pty;
     let cmdFile: string;
     try {
-      cmdFile = join(tmpdir(), `band-autorun-${terminalId}.sh`);
+      // Derive the temp filename from a FRESH server-side `randomUUID()`,
+      // NOT from the caller-supplied `terminalId`: that id reaches the
+      // pool unvalidated from both the tRPC `terminal.create` input and
+      // the `/terminal` WebSocket query string, and `path.join` collapses
+      // `../` segments — so keying the path on it would let a caller
+      // (`id: "../../etc/cron.d/evil"`) steer this write anywhere. A fresh
+      // UUID keeps the path unconditionally inside `tmpdir()`.
+      cmdFile = join(tmpdir(), `band-autorun-${randomUUID()}.sh`);
       // Trailing newline so the final command in the file is a complete
       // line for the shell parser. UTF-8 bytes are preserved verbatim —
       // the shell reads them from the file, not through the tty.
@@ -299,17 +307,21 @@ export class TerminalPool {
       // `flag: "wx"` opens with O_CREAT|O_EXCL so the write REFUSES to
       // follow a pre-existing file or symlink planted at this path —
       // closing the classic predictable-temp-file symlink/TOCTOU hole on
-      // a multi-user host. `terminalId` is a random UUID so a collision is
-      // only realistic on a layout-restore re-spawn after an unclean
-      // shutdown left a stale file; in that case the EEXIST throw drops us
-      // to the catch's direct-write fallback, which is safe.
+      // a multi-user host. With a fresh UUID a collision is effectively
+      // impossible; if one ever occurs the EEXIST throw drops us to the
+      // catch's direct-write fallback, which is safe.
       writeFileSync(cmdFile, `${command}\n`, { encoding: "utf-8", mode: 0o600, flag: "wx" });
       session.autoRunFile = cmdFile;
     } catch (err) {
       // If we can't stage a temp file, fall back to the naive write —
       // better to risk the cold-PTY race than to silently not run the
       // command at all.
-      log.warn("autoRunCommand: temp-file staging failed (%s); writing command directly", err);
+      // Log only the message, not the raw error — its serialisation can
+      // include the attempted filesystem path.
+      log.warn(
+        "autoRunCommand: temp-file staging failed (%s); writing command directly",
+        err instanceof Error ? err.message : String(err),
+      );
       pty.write(`${command}\n`);
       return;
     }
@@ -464,6 +476,9 @@ export class TerminalPool {
   kill(terminalId: string): void {
     const session = this.terminals.get(terminalId);
     if (session) {
+      // `pty.kill()` triggers the `onExit` handler registered in `spawn`,
+      // which is what unlinks `session.autoRunFile` — cleanup is delegated
+      // there rather than duplicated in every kill path.
       session.pty.kill();
       this.terminals.delete(terminalId);
       const set = this.workspaceTerminals.get(session.workspaceId);

--- a/apps/web/src/server/infra/terminals/terminal-pool.ts
+++ b/apps/web/src/server/infra/terminals/terminal-pool.ts
@@ -357,10 +357,13 @@ export class TerminalPool {
     });
     const timer = setTimeout(inject, 750);
     timer.unref();
-    pty.onExit(() => {
+    const exitDisposable = pty.onExit(() => {
       done = true;
       clearTimeout(timer);
       disposeData();
+      // Self-remove so this listener doesn't outlive the one PTY exit it
+      // exists to catch.
+      exitDisposable.dispose();
     });
   }
 

--- a/apps/web/src/server/infra/terminals/terminal-pool.ts
+++ b/apps/web/src/server/infra/terminals/terminal-pool.ts
@@ -293,12 +293,14 @@ export class TerminalPool {
     let cmdFile: string;
     try {
       // Derive the temp filename from a FRESH server-side `randomUUID()`,
-      // NOT from the caller-supplied `terminalId`: that id reaches the
-      // pool unvalidated from both the tRPC `terminal.create` input and
-      // the `/terminal` WebSocket query string, and `path.join` collapses
-      // `../` segments — so keying the path on it would let a caller
-      // (`id: "../../etc/cron.d/evil"`) steer this write anywhere. A fresh
-      // UUID keeps the path unconditionally inside `tmpdir()`.
+      // NOT from the caller-supplied `terminalId`: the `/terminal`
+      // WebSocket spawn path takes that id straight from the query string
+      // without validation (the tRPC `terminal.create` input IS
+      // UUID-constrained, but the WS path is not), and `path.join`
+      // collapses `../` segments — so keying the path on it would let a
+      // caller (`terminalId=../../etc/cron.d/evil`) steer this write
+      // anywhere. A fresh UUID keeps the path unconditionally inside
+      // `tmpdir()`, which is why the unvalidated WS id is harmless here.
       cmdFile = join(tmpdir(), `band-autorun-${randomUUID()}.sh`);
       // Trailing newline so the final command in the file is a complete
       // line for the shell parser. UTF-8 bytes are preserved verbatim —
@@ -369,12 +371,16 @@ export class TerminalPool {
     });
     const timer = setTimeout(inject, 750);
     timer.unref();
+    let exitDisposed = false;
     const exitDisposable = pty.onExit(() => {
       done = true;
       clearTimeout(timer);
       disposeData();
-      // Self-remove so this listener doesn't outlive the one PTY exit it
-      // exists to catch.
+      // Self-remove (once) so this listener doesn't outlive the single PTY
+      // exit it exists to catch. Guarded like `disposeData` because
+      // node-pty's IDisposable doesn't promise idempotency.
+      if (exitDisposed) return;
+      exitDisposed = true;
       exitDisposable.dispose();
     });
   }

--- a/apps/web/src/server/infra/terminals/terminal-pool.ts
+++ b/apps/web/src/server/infra/terminals/terminal-pool.ts
@@ -1,6 +1,6 @@
 import { existsSync, unlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { join, sep } from "node:path";
 import { createLogger } from "@band-app/logger";
 import type { IPty } from "node-pty";
 import { shellPath } from "../process/path";
@@ -141,8 +141,11 @@ export class TerminalPool {
     let cwd = workspaceRoot;
     if (options?.cwd) {
       const resolved = join(workspaceRoot, options.cwd);
-      // Security: ensure the resolved path stays within the workspace
-      if (!resolved.startsWith(workspaceRoot)) {
+      // Security: ensure the resolved path stays within the workspace.
+      // Append `sep` (with an equality carve-out for cwd === root) so a
+      // sibling like `<root>-evil` can't pass the prefix check — same
+      // shape as `serveWorkspaceFile` in start-server.ts.
+      if (resolved !== workspaceRoot && !resolved.startsWith(workspaceRoot + sep)) {
         log.warn(
           "Ignoring cwd %s — resolves outside workspace root %s",
           options.cwd,
@@ -311,12 +314,15 @@ export class TerminalPool {
       return;
     }
 
-    // Single-quote the path for the shell. The path is our own
-    // `tmpdir()`-rooted temp file, but escape any embedded single-quote
-    // (POSIX `'\''`) anyway so a `TMPDIR` containing a `'` can't break the
-    // quoting and inject into the interactive shell.
+    // Use the POSIX dot builtin (`. '<file>'`), NOT `source`: `source` is
+    // a bash/zsh-ism that dash (`/bin/sh` on most Linux hosts) doesn't
+    // recognise, so the injected line would silently fail there. `.` runs
+    // the file in the current interactive shell across sh/dash/bash/zsh.
+    // Single-quote the path and escape any embedded single-quote (POSIX
+    // `'\''`) so a `TMPDIR` containing a `'` can't break the quoting and
+    // inject into the shell.
     const quotedPath = cmdFile.replace(/'/g, `'\\''`);
-    const sourceLine = `source '${quotedPath}'\n`;
+    const sourceLine = `. '${quotedPath}'\n`;
 
     let done = false;
     const inject = () => {
@@ -327,8 +333,17 @@ export class TerminalPool {
       } catch (err) {
         // The PTY exited before we got to inject (e.g. the user closed the
         // pane during the cold-start window). Nothing left to run.
-        log.warn("autoRunCommand: failed to inject source line (%s)", err);
+        log.warn("autoRunCommand: failed to inject command line (%s)", err);
       }
+    };
+
+    // Dispose the readiness listener at most once — node-pty's IDisposable
+    // doesn't promise idempotency, so a double-dispose could throw.
+    let dataDisposed = false;
+    const disposeData = () => {
+      if (dataDisposed) return;
+      dataDisposed = true;
+      dataDisposable.dispose();
     };
 
     // The shell's first output (its prompt) is our readiness signal that
@@ -337,7 +352,7 @@ export class TerminalPool {
     // unref'd so it never keeps the process alive. An `onExit` listener
     // cancels both signals so a late timer can never write to a dead PTY.
     const dataDisposable = pty.onData(() => {
-      dataDisposable.dispose();
+      disposeData();
       inject();
     });
     const timer = setTimeout(inject, 750);
@@ -345,7 +360,7 @@ export class TerminalPool {
     pty.onExit(() => {
       done = true;
       clearTimeout(timer);
-      dataDisposable.dispose();
+      disposeData();
     });
   }
 

--- a/apps/web/src/server/infra/terminals/terminal-pool.ts
+++ b/apps/web/src/server/infra/terminals/terminal-pool.ts
@@ -1,4 +1,5 @@
-import { existsSync } from "node:fs";
+import { existsSync, unlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { createLogger } from "@band-app/logger";
 import type { IPty } from "node-pty";
@@ -37,6 +38,12 @@ export interface TerminalSession {
   pty: IPty;
   scrollback: string;
   workspaceId: string;
+  /**
+   * Path of the temp file staging an auto-run command, if any. Removed
+   * when the PTY exits (see {@link TerminalPool.autoRunCommand}). Kept on
+   * the session so cleanup doesn't depend on the command ever running.
+   */
+  autoRunFile?: string;
 }
 
 /**
@@ -109,6 +116,15 @@ export class TerminalPool {
     // Hint foreground/background colors so CLI tools (vim, bat, etc.) don't send
     // OSC 11 queries whose responses leak as visible garbage in the terminal.
     env.COLORFGBG = "15;0";
+    // Pin the dispatch target for any nested `band` CLI call typed into
+    // this pane to `terminal`, matching where it runs. The server's own
+    // process.env carries no `BAND_DISPATCH` today, so the Rust CLI would
+    // already fall through to its `terminal` default — but setting it
+    // explicitly keeps the terminal path correct even if a future change
+    // ever sets `BAND_DISPATCH` server-wide, and mirrors the
+    // `BAND_DISPATCH=chat` the coding-agent subprocesses inject (see
+    // packages/coding-agent/src/adapter-env.ts).
+    env.BAND_DISPATCH = "terminal";
     // Remove PORT so workspace dev servers don't inherit the Band server's port
     delete env.PORT;
 
@@ -180,9 +196,11 @@ export class TerminalPool {
     const session: TerminalSession = { pty: ptyProcess, scrollback: "", workspaceId };
     this.terminals.set(terminalId, session);
 
-    // Auto-run initial command if provided
+    // Auto-run initial command if provided. Robust against the cold-PTY
+    // race — see autoRunCommand for why a naive `pty.write` truncates and
+    // mangles long prompt-as-argv command lines.
     if (options?.command) {
-      ptyProcess.write(`${options.command}\n`);
+      this.autoRunCommand(session, terminalId, options.command);
     }
 
     // Register in reverse index
@@ -222,9 +240,93 @@ export class TerminalPool {
           this.workspaceTerminals.delete(workspaceId);
         }
       }
+      // Remove the staged auto-run command file, if any.
+      if (session.autoRunFile) {
+        try {
+          unlinkSync(session.autoRunFile);
+        } catch {
+          // Already gone / never written — nothing to clean up.
+        }
+      }
     });
 
     return session;
+  }
+
+  /**
+   * Auto-run the workspace's initial command inside a freshly spawned PTY,
+   * robustly.
+   *
+   * Writing a long command line straight into a cold PTY is racy on three
+   * fronts, all of which surfaced in production with `via=terminal`
+   * prompt-as-argv launches (`'<agent-binary>' '<entire-prompt>'`):
+   *
+   *   1. **Dropped newline.** The shell may not have finished sourcing its
+   *      rc files, and the tty can still be in its startup canonical-mode
+   *      window. A trailing `\n` written then is swallowed — the command
+   *      is typed at the prompt but never executed.
+   *   2. **Truncation.** A single input line longer than the tty's
+   *      canonical buffer (`MAX_CANON`, ~4 KB) is clipped. Long prompts
+   *      blow past that easily.
+   *   3. **UTF-8 corruption.** A multi-byte sequence split across a tty
+   *      buffer boundary is mangled (the classic em-dash → mojibake).
+   *
+   * Fix both layers: (1) stage the command's bytes in a temp file so they
+   * never traverse the tty's canonical input buffer — sidestepping the
+   * truncation and UTF-8-split failures entirely — and (2) wait for the
+   * shell to emit its first output (its prompt) before writing the
+   * *short* `source <file>` line. The short line is well under the
+   * canonical limit and lands after the cold-start window, so its newline
+   * survives. `source` runs the command in the current interactive shell,
+   * so the user keeps their session afterwards.
+   */
+  private autoRunCommand(session: TerminalSession, terminalId: string, command: string): void {
+    const pty = session.pty;
+    let cmdFile: string;
+    try {
+      cmdFile = join(tmpdir(), `band-autorun-${terminalId}.sh`);
+      // Trailing newline so the final command in the file is a complete
+      // line for the shell parser. UTF-8 bytes are preserved verbatim —
+      // the shell reads them from the file, not through the tty.
+      //
+      // `flag: "wx"` opens with O_CREAT|O_EXCL so the write REFUSES to
+      // follow a pre-existing file or symlink planted at this path —
+      // closing the classic predictable-temp-file symlink/TOCTOU hole on
+      // a multi-user host. `terminalId` is a random UUID so a collision is
+      // only realistic on a layout-restore re-spawn after an unclean
+      // shutdown left a stale file; in that case the EEXIST throw drops us
+      // to the catch's direct-write fallback, which is safe.
+      writeFileSync(cmdFile, `${command}\n`, { encoding: "utf-8", mode: 0o600, flag: "wx" });
+      session.autoRunFile = cmdFile;
+    } catch (err) {
+      // If we can't stage a temp file, fall back to the naive write —
+      // better to risk the cold-PTY race than to silently not run the
+      // command at all.
+      log.warn("autoRunCommand: temp-file staging failed (%s); writing command directly", err);
+      pty.write(`${command}\n`);
+      return;
+    }
+
+    // Single-quote the path (our own temp path under tmpdir — no quotes
+    // to escape) so a tmpdir with spaces still resolves.
+    const sourceLine = `source '${cmdFile}'\n`;
+
+    let injected = false;
+    const inject = () => {
+      if (injected) return;
+      injected = true;
+      pty.write(sourceLine);
+    };
+
+    // The shell's first output (its prompt) is our readiness signal that
+    // the tty is past its cold-start window. Inject then. A fallback
+    // timer covers a shell that prints nothing, so the command still
+    // runs. The timer is unref'd so it never keeps the process alive.
+    const disposable = pty.onData(() => {
+      disposable.dispose();
+      inject();
+    });
+    setTimeout(inject, 750).unref();
   }
 
   /**

--- a/apps/web/start-server.ts
+++ b/apps/web/start-server.ts
@@ -995,10 +995,12 @@ async function main() {
   // children must still reach THIS server (and authenticate with the
   // token in THIS home's settings), not the grandparent's.
   //
-  // Plain `http://` is intentional and safe: the URL is pinned to the
-  // `127.0.0.1` loopback (`listenWithFallback` always binds locally), so
-  // the band_token a child CLI sends never leaves the host — there is no
-  // network hop to encrypt.
+  // Pin the host to the `127.0.0.1` loopback rather than the bound
+  // interface: the server listens on `0.0.0.0`, but child processes are
+  // always co-located on this host, so loopback is the correct (and
+  // narrowest) target. Plain `http://` is intentional and safe — a
+  // loopback request never leaves the machine, so the band_token a child
+  // CLI sends has no network hop to encrypt.
   process.env.BAND_SERVER_URL = `http://127.0.0.1:${boundPort}`;
 
   console.log(`Web server listening on http://0.0.0.0:${boundPort}`);

--- a/apps/web/start-server.ts
+++ b/apps/web/start-server.ts
@@ -994,6 +994,11 @@ async function main() {
   // if a grandparent Band process exported its own `BAND_SERVER_URL`, our
   // children must still reach THIS server (and authenticate with the
   // token in THIS home's settings), not the grandparent's.
+  //
+  // Plain `http://` is intentional and safe: the URL is pinned to the
+  // `127.0.0.1` loopback (`listenWithFallback` always binds locally), so
+  // the band_token a child CLI sends never leaves the host — there is no
+  // network hop to encrypt.
   process.env.BAND_SERVER_URL = `http://127.0.0.1:${boundPort}`;
 
   console.log(`Web server listening on http://0.0.0.0:${boundPort}`);

--- a/apps/web/start-server.ts
+++ b/apps/web/start-server.ts
@@ -979,6 +979,23 @@ async function main() {
   // then was just a hint, not a guarantee.
   process.env.BAND_PORT = String(boundPort);
 
+  // Advertise this server's own URL to every child process we fork
+  // (coding-agent subprocesses, terminal PTYs, setup scripts). A nested
+  // `band` CLI invocation — e.g. the `band-start` skill running `band
+  // workspaces create --prompt …` from inside a chat-hosted agent, or a
+  // user typing `band …` in a terminal pane — reads `BAND_SERVER_URL`
+  // (see `apps/cli/src/api.rs`) to decide which server to call. Without
+  // it the CLI falls back to its hardcoded `127.0.0.1:3456`, which is
+  // wrong whenever this server bound a different port (dev runs on
+  // 3457/3458 when the desktop app owns 3456; integration tests bind a
+  // random port).
+  //
+  // Overwrite unconditionally rather than honouring an inherited value:
+  // if a grandparent Band process exported its own `BAND_SERVER_URL`, our
+  // children must still reach THIS server (and authenticate with the
+  // token in THIS home's settings), not the grandparent's.
+  process.env.BAND_SERVER_URL = `http://127.0.0.1:${boundPort}`;
+
   console.log(`Web server listening on http://0.0.0.0:${boundPort}`);
   if (boundPort !== initialPort) {
     console.log(

--- a/apps/web/tests/fake-agent.mjs
+++ b/apps/web/tests/fake-agent.mjs
@@ -44,6 +44,35 @@ const exitCode = parseInt(process.env.FAKE_AGENT_EXIT_CODE || "0", 10);
 // after the task completes. Without it the prompt is black-box.
 const stdinLogPath = process.env.FAKE_AGENT_STDIN_LOG;
 
+// Optional: when FAKE_AGENT_ENV_LOG is set, append (one JSON object per
+// line) the subset of this process's environment that controls how a
+// NESTED `band` CLI call would dispatch — `BAND_DISPATCH` (chat vs
+// terminal) and `BAND_SERVER_URL` (which server to reach). Tests that
+// assert a chat-hosted agent's nested `band workspaces create --prompt`
+// would resolve to `via: chat` read this back: the Rust CLI's
+// `resolve_dispatch_target` consults exactly these env vars, so recording
+// what the spawned agent received proves the server injected them
+// correctly. Append (not overwrite) because the server may spawn this
+// stub more than once per boot — e.g. the model-refresh probe runs with
+// the SDK's default env (no BAND_DISPATCH) alongside the task spawn that
+// carries BAND_DISPATCH=chat — and the test looks for the task spawn's
+// record rather than racing the two writers. Best-effort, at startup.
+const envLogPath = process.env.FAKE_AGENT_ENV_LOG;
+if (envLogPath) {
+	try {
+		mkdirSync(dirname(envLogPath), { recursive: true });
+		appendFileSync(
+			envLogPath,
+			JSON.stringify({
+				BAND_DISPATCH: process.env.BAND_DISPATCH ?? null,
+				BAND_SERVER_URL: process.env.BAND_SERVER_URL ?? null,
+			}) + "\n",
+		);
+	} catch {
+		// best effort
+	}
+}
+
 if (stdinLogPath) {
 	try {
 		mkdirSync(dirname(stdinLogPath), { recursive: true });

--- a/apps/web/tests/workspace-create-via.test.ts
+++ b/apps/web/tests/workspace-create-via.test.ts
@@ -37,7 +37,7 @@
 //     emits a success scenario and exits cleanly.
 
 import { execFileSync } from "node:child_process";
-import { chmodSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { chmodSync, existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { toWorkspaceId } from "@/dashboard";
@@ -520,5 +520,211 @@ describe("workspaces.create via=terminal — adapter fallback", () => {
     // bookkeeping for the cases where a PTY *should* exist.
     expect(data.via).toBe("chat");
     expect(data.terminalId).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Bug 1 — band-start run from the webchat must dispatch the new
+// workspace's task to the CHAT, not a terminal.
+//
+// The mechanism: a chat-hosted coding agent is spawned with
+// `BAND_DISPATCH=chat` in its environment, so a NESTED `band workspaces
+// create --prompt …` it fires (the band-start skill) resolves to
+// `via: chat` — matching where the agent itself runs — instead of the
+// Rust CLI's built-in `terminal` default. `BAND_SERVER_URL` is injected
+// too so the nested CLI reaches THIS server rather than the hardcoded
+// `127.0.0.1:3456`.
+//
+// We can't drive the real Rust `band` binary through the Claude-Agent-SDK
+// stub (the stub speaks the SDK's stdin/stdout protocol; it can't also be
+// a shell that shells out to a CLI), so we assert the precondition the
+// nested CLI reads: the environment the server handed the spawned agent.
+// The CLI's `resolve_dispatch_target` (apps/cli/src/main.rs) consults
+// exactly `BAND_DISPATCH` then `BAND_SERVER_URL`, so pinning what the
+// agent received is what proves a nested create would resolve to chat.
+// ---------------------------------------------------------------------------
+
+interface AgentEnvRecord {
+  BAND_DISPATCH: string | null;
+  BAND_SERVER_URL: string | null;
+}
+
+describe("chat-hosted agent dispatch env (band-start nested create)", () => {
+  const TOKEN = "wc-dispatch-env-token";
+  let server: ServerHandle;
+  let tmpHome: string;
+  let scenarioPath: string;
+  let envLogPath: string;
+
+  beforeAll(async () => {
+    tmpHome = createTmpHome("band-dispatch-env-");
+    const repoPath = createGitRepo(tmpHome, "dispproj");
+    scenarioPath = writeChatScenario(tmpHome, "dispatch-scenario.json");
+    envLogPath = join(tmpHome, "agent-env.jsonl");
+    seedState(tmpHome, {
+      projects: [
+        {
+          name: "dispproj",
+          path: repoPath,
+          defaultBranch: "main",
+          worktrees: [{ branch: "main", path: repoPath }],
+        },
+      ],
+    });
+    seedSettings(tmpHome, {
+      tokenSecret: TOKEN,
+      codingAgents: [
+        {
+          id: "claude-code",
+          type: "claude-code",
+          label: "Claude Code",
+          command: FAKE_AGENT_PATH,
+        },
+      ],
+    });
+    server = await startServer({
+      tmpHome,
+      env: { FAKE_AGENT_SCENARIO: scenarioPath, FAKE_AGENT_ENV_LOG: envLogPath },
+    });
+  });
+
+  afterAll(async () => {
+    await server.close();
+    rmSync(tmpHome, { recursive: true, force: true });
+  });
+
+  it("spawns the chat agent with BAND_DISPATCH=chat and BAND_SERVER_URL pointing at this server", async () => {
+    const createRes = await trpcMutate(
+      server.url,
+      "workspaces.create",
+      {
+        project: "dispproj",
+        branch: "feat/nested",
+        prompt: "kick off nested work",
+        via: "chat",
+      },
+      TOKEN,
+    );
+    const createBody = await createRes.text();
+    expect(createRes.status, createBody).toBe(200);
+
+    // Poll the env log until the TASK spawn's record appears (the one
+    // carrying BAND_DISPATCH=chat). The boot-time model-refresh probe may
+    // also spawn the stub and append a record with BAND_DISPATCH=null
+    // (refreshModels runs with the SDK's default env) — we look past that
+    // for the runSession spawn that dispatches the prompt.
+    const record = await waitFor<AgentEnvRecord>(
+      async () => {
+        if (!existsSync(envLogPath)) return undefined;
+        const records = readFileSync(envLogPath, "utf-8")
+          .split("\n")
+          .filter((l) => l.trim().length > 0)
+          .map((l) => JSON.parse(l) as AgentEnvRecord);
+        return records.find((r) => r.BAND_DISPATCH === "chat");
+      },
+      { label: "agent spawned with BAND_DISPATCH=chat" },
+    );
+
+    expect(record.BAND_DISPATCH).toBe("chat");
+    // The server advertises its own bound URL to every child process so a
+    // nested CLI call reaches it regardless of which port it claimed.
+    expect(record.BAND_SERVER_URL).toBe(server.url);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Bug 2 — terminal dispatch must execute long, UTF-8-containing prompts
+// without truncation or corruption.
+//
+// Previously the server wrote the whole `'<agent-binary>' '<prompt>'`
+// line straight into a freshly spawned PTY. That raced the shell startup:
+// the trailing newline could be dropped (command typed but never run), a
+// line longer than the tty canonical buffer (~4 KB) could be truncated,
+// and a multi-byte UTF-8 sequence (em-dash U+2014) split across a buffer
+// boundary could be mangled. The fix stages the command in a temp file
+// and injects a short `source <file>` line after the shell is ready.
+//
+// This pins the end-to-end contract: a ~6 KB prompt peppered with
+// em-dashes is echoed back by the stub vendor CLI as a single argv token,
+// intact — proving it both EXECUTED and survived byte-for-byte.
+// ---------------------------------------------------------------------------
+
+describe("workspaces.create via=terminal — long UTF-8 prompt", () => {
+  const TOKEN = "wc-via-longprompt-token";
+  let server: ServerHandle;
+  let tmpHome: string;
+  let stubBin: string;
+
+  beforeAll(async () => {
+    tmpHome = createTmpHome("band-via-longprompt-");
+    const repoPath = createGitRepo(tmpHome, "longproj");
+    stubBin = writeStubVendorCli(tmpHome, "stub-claude.sh");
+    seedState(tmpHome, {
+      projects: [
+        {
+          name: "longproj",
+          path: repoPath,
+          defaultBranch: "main",
+          worktrees: [{ branch: "main", path: repoPath }],
+        },
+      ],
+    });
+    seedSettings(tmpHome, {
+      tokenSecret: TOKEN,
+      codingAgents: [
+        { id: "claude-code", type: "claude-code", label: "Claude Code", command: stubBin },
+      ],
+    });
+    server = await startServer({ tmpHome });
+  });
+
+  afterAll(async () => {
+    await server.close();
+    rmSync(tmpHome, { recursive: true, force: true });
+  });
+
+  it("executes the full prompt with em-dashes intact (no truncation/corruption)", async () => {
+    // ~6 KB — well past the tty canonical buffer (~4 KB) — with em-dashes
+    // (U+2014) scattered throughout, the exact character that came back
+    // mangled in the production report.
+    const segment = "implement the feature — carefully — and thoroughly ";
+    const longPrompt = `BEGIN—${segment.repeat(120)}—END`;
+    expect(longPrompt.length).toBeGreaterThan(5000);
+
+    const createRes = await trpcMutate(
+      server.url,
+      "workspaces.create",
+      {
+        project: "longproj",
+        branch: "feat/long",
+        prompt: longPrompt,
+        via: "terminal",
+      },
+      TOKEN,
+    );
+    const createBody = await createRes.text();
+    expect(createRes.status, createBody).toBe(200);
+    const data = (JSON.parse(createBody) as { result: { data: CreateResponse } }).result.data;
+
+    expect(data.via).toBe("terminal");
+    expect(typeof data.terminalId).toBe("string");
+
+    // The stub prints `ARGV:<arg0>|<arg1>|...`. Assert the FULL prompt
+    // came back as a single argv token terminated by the `|` the stub
+    // writes after each arg — proving nothing was clipped mid-line and
+    // the em-dashes round-tripped byte-for-byte. If the cold-PTY race had
+    // dropped the newline the command would never run and `ARGV:` would
+    // never appear; if it had truncated, the `${longPrompt}|` needle
+    // wouldn't match.
+    const output = await waitFor(
+      async () => {
+        const out = await readTerminalOutput(server.url, data.terminalId!, TOKEN);
+        return out?.includes(`${longPrompt}|`) ? out : undefined;
+      },
+      { label: "full long prompt echoed by stub", timeoutMs: 15_000 },
+    );
+    expect(output).toContain(`${longPrompt}|`);
+    // Belt-and-suspenders: the em-dash survived as U+2014, not mojibake.
+    expect(output).toContain("—");
   });
 });

--- a/apps/web/tests/workspace-create-via.test.ts
+++ b/apps/web/tests/workspace-create-via.test.ts
@@ -97,18 +97,20 @@ function writeStubVendorCli(tmpHome: string, name: string): string {
 }
 
 /**
- * Stub vendor CLI that echoes the `BAND_DISPATCH` it was spawned with as
- * `ENV_BAND_DISPATCH:<value>|`. Used to prove that a process spawned
- * inside a terminal PTY inherits `BAND_DISPATCH=terminal` (the value
- * `terminal-pool` pins on the PTY env) — the terminal-side mirror of the
- * chat-side `FAKE_AGENT_ENV_LOG` assertion. Terminates immediately; the
- * pool drains stdout into its scrollback.
+ * Stub vendor CLI that echoes the dispatch-relevant env vars it was
+ * spawned with as `ENV_BAND_DISPATCH:<value>|` and
+ * `ENV_BAND_SERVER_URL:<value>|`. Used to prove that a process spawned
+ * inside a terminal PTY inherits `BAND_DISPATCH=terminal` (pinned by
+ * `terminal-pool`) and `BAND_SERVER_URL` (advertised by start-server) —
+ * the terminal-side mirror of the chat-side `FAKE_AGENT_ENV_LOG`
+ * assertion. Terminates immediately; the pool drains stdout into its
+ * scrollback.
  */
 function writeEnvEchoVendorCli(tmpHome: string, name: string): string {
   const binPath = join(tmpHome, name);
   writeFileSync(
     binPath,
-    `#!/bin/sh\nprintf 'ENV_BAND_DISPATCH:%s|\\n' "$BAND_DISPATCH"\n`,
+    `#!/bin/sh\nprintf 'ENV_BAND_DISPATCH:%s|\\n' "$BAND_DISPATCH"\nprintf 'ENV_BAND_SERVER_URL:%s|\\n' "$BAND_SERVER_URL"\n`,
     "utf-8",
   );
   chmodSync(binPath, 0o755);
@@ -646,12 +648,12 @@ describe("chat-hosted agent dispatch env (band-start nested create)", () => {
       { label: "agent spawned with BAND_DISPATCH=chat" },
     );
 
-    // `waitFor` already gates on BAND_DISPATCH === "chat", so this line
-    // documents the contract rather than independently catching a
-    // regression — the substantive assertion is BAND_SERVER_URL below.
-    expect(record.BAND_DISPATCH).toBe("chat");
-    // The server advertises its own bound URL to every child process so a
-    // nested CLI call reaches it regardless of which port it claimed.
+    // The `waitFor` predicate above only resolves once a spawn recorded
+    // BAND_DISPATCH === "chat", so reaching here already proves the chat
+    // agent was spawned with the chat dispatch target. The remaining
+    // assertion pins the other half: the server advertised its own bound
+    // URL so a nested CLI call reaches it regardless of which port it
+    // claimed.
     expect(record.BAND_SERVER_URL).toBe(server.url);
   });
 });
@@ -816,18 +818,21 @@ describe("terminal PTY env — BAND_DISPATCH=terminal", () => {
     expect(data.via).toBe("terminal");
     expect(typeof data.terminalId).toBe("string");
 
-    // The stub printed the BAND_DISPATCH it inherited from the PTY env.
-    // `terminal` (not `chat`, not empty) proves the terminal pane pins the
-    // dispatch target for any nested `band` CLI call typed into it.
+    // The stub printed the env it inherited from the PTY. `terminal` (not
+    // `chat`, not empty) proves the terminal pane pins the dispatch target
+    // for any nested `band` CLI call typed into it.
     const output = await waitFor(
       async () => {
         const out = await readTerminalOutput(server.url, data.terminalId!, TOKEN);
-        return out?.includes("ENV_BAND_DISPATCH:terminal|") ? out : undefined;
+        return out?.includes("ENV_BAND_SERVER_URL:") ? out : undefined;
       },
-      { label: "stub echoed BAND_DISPATCH=terminal" },
+      { label: "stub echoed dispatch env" },
     );
     expect(output).toContain("ENV_BAND_DISPATCH:terminal|");
     // Negative guard: it must not have leaked the chat value.
     expect(output).not.toContain("ENV_BAND_DISPATCH:chat|");
+    // Symmetric with the chat-path assertion: the PTY child also reaches
+    // THIS server, so a nested `band` CLI call resolves to the right port.
+    expect(output).toContain(`ENV_BAND_SERVER_URL:${server.url}|`);
   });
 });

--- a/apps/web/tests/workspace-create-via.test.ts
+++ b/apps/web/tests/workspace-create-via.test.ts
@@ -767,6 +767,27 @@ describe("workspaces.create via=terminal — long UTF-8 prompt", () => {
     // Belt-and-suspenders: the em-dash survived as U+2014, not mojibake.
     expect(output).toContain("—");
   });
+
+  it("rejects terminal.create with a path-traversal id", async () => {
+    // The auto-run staging file is keyed on a server-side randomUUID, but
+    // the `terminal.create` schema also constrains `id` to a UUID so a
+    // hostile value can never reach the pool in the first place. Pin that
+    // boundary: a `../`-laden id is rejected at the tRPC layer, so no PTY
+    // is spawned and `command` never runs.
+    const res = await trpcMutate(
+      server.url,
+      "terminal.create",
+      {
+        workspaceId: toWorkspaceId("longproj", "main"),
+        id: "../../../../tmp/band-evil",
+        command: "echo pwned",
+      },
+      TOKEN,
+    );
+    expect(res.status).toBe(400);
+    const body = await res.text();
+    expect(body).toMatch(/uuid/i);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/apps/web/tests/workspace-create-via.test.ts
+++ b/apps/web/tests/workspace-create-via.test.ts
@@ -77,6 +77,19 @@ function createGitRepo(parentDir: string, name: string): string {
 }
 
 /**
+ * Write an executable `/bin/sh` stub at `tmpHome/name` with the given
+ * body and return its path. Shared scaffold for the per-purpose stub
+ * vendor CLIs below — the only thing that varies between them is the
+ * script body.
+ */
+function writeVendorCliScript(tmpHome: string, name: string, body: string): string {
+  const binPath = join(tmpHome, name);
+  writeFileSync(binPath, `#!/bin/sh\n${body}`, "utf-8");
+  chmodSync(binPath, 0o755);
+  return binPath;
+}
+
+/**
  * Stub vendor CLI for the `via=terminal` path. Prints
  * `ARGV:<arg0>|<arg1>|...` so the test can pin both the binary path the
  * adapter picked AND the prompt that was threaded through as positional
@@ -86,14 +99,11 @@ function createGitRepo(parentDir: string, name: string): string {
  * buffer; the test reads it back via `terminal.output`.
  */
 function writeStubVendorCli(tmpHome: string, name: string): string {
-  const binPath = join(tmpHome, name);
-  writeFileSync(
-    binPath,
-    `#!/bin/sh\nprintf 'ARGV:'\nfor arg in "$@"; do printf '%s|' "$arg"; done\nprintf '\\n'\n`,
-    "utf-8",
+  return writeVendorCliScript(
+    tmpHome,
+    name,
+    `printf 'ARGV:'\nfor arg in "$@"; do printf '%s|' "$arg"; done\nprintf '\\n'\n`,
   );
-  chmodSync(binPath, 0o755);
-  return binPath;
 }
 
 /**
@@ -107,14 +117,11 @@ function writeStubVendorCli(tmpHome: string, name: string): string {
  * scrollback.
  */
 function writeEnvEchoVendorCli(tmpHome: string, name: string): string {
-  const binPath = join(tmpHome, name);
-  writeFileSync(
-    binPath,
-    `#!/bin/sh\nprintf 'ENV_BAND_DISPATCH:%s|\\n' "$BAND_DISPATCH"\nprintf 'ENV_BAND_SERVER_URL:%s|\\n' "$BAND_SERVER_URL"\n`,
-    "utf-8",
+  return writeVendorCliScript(
+    tmpHome,
+    name,
+    `printf 'ENV_BAND_DISPATCH:%s|\\n' "$BAND_DISPATCH"\nprintf 'ENV_BAND_SERVER_URL:%s|\\n' "$BAND_SERVER_URL"\n`,
   );
-  chmodSync(binPath, 0o755);
-  return binPath;
 }
 
 /**
@@ -563,6 +570,13 @@ describe("workspaces.create via=terminal — adapter fallback", () => {
 // The CLI's `resolve_dispatch_target` (apps/cli/src/main.rs) consults
 // exactly `BAND_DISPATCH` then `BAND_SERVER_URL`, so pinning what the
 // agent received is what proves a nested create would resolve to chat.
+//
+// We exercise the claude-code adapter as the representative case rather
+// than all four: every adapter merges the SAME `AGENT_DISPATCH_ENV`
+// constant into its subprocess env (claude-code/codex/gemini-cli/opencode
+// in packages/coding-agent/src/adapters/), so one integration test plus
+// the shared constant covers the mechanism. The codex/gemini/opencode
+// stubs would each need a different protocol shim for no added signal.
 // ---------------------------------------------------------------------------
 
 describe("chat-hosted agent dispatch env (band-start nested create)", () => {

--- a/apps/web/tests/workspace-create-via.test.ts
+++ b/apps/web/tests/workspace-create-via.test.ts
@@ -563,12 +563,14 @@ describe("workspaces.create via=terminal — adapter fallback", () => {
 // agent received is what proves a nested create would resolve to chat.
 // ---------------------------------------------------------------------------
 
-interface AgentEnvRecord {
-  BAND_DISPATCH: string | null;
-  BAND_SERVER_URL: string | null;
-}
-
 describe("chat-hosted agent dispatch env (band-start nested create)", () => {
+  // One JSONL record per fake-agent spawn (see fake-agent.mjs
+  // FAKE_AGENT_ENV_LOG). Scoped to this block — it's the only consumer.
+  interface AgentEnvRecord {
+    BAND_DISPATCH: string | null;
+    BAND_SERVER_URL: string | null;
+  }
+
   const TOKEN = "wc-dispatch-env-token";
   let server: ServerHandle;
   let tmpHome: string;
@@ -770,7 +772,7 @@ describe("terminal PTY env — BAND_DISPATCH=terminal", () => {
   beforeAll(async () => {
     tmpHome = createTmpHome("band-via-termenv-");
     const repoPath = createGitRepo(tmpHome, "termenvproj");
-    stubBin = writeEnvEchoVendorCli(tmpHome, "stub-claude.sh");
+    stubBin = writeEnvEchoVendorCli(tmpHome, "stub-env-echo.sh");
     seedState(tmpHome, {
       projects: [
         {

--- a/apps/web/tests/workspace-create-via.test.ts
+++ b/apps/web/tests/workspace-create-via.test.ts
@@ -97,6 +97,25 @@ function writeStubVendorCli(tmpHome: string, name: string): string {
 }
 
 /**
+ * Stub vendor CLI that echoes the `BAND_DISPATCH` it was spawned with as
+ * `ENV_BAND_DISPATCH:<value>|`. Used to prove that a process spawned
+ * inside a terminal PTY inherits `BAND_DISPATCH=terminal` (the value
+ * `terminal-pool` pins on the PTY env) — the terminal-side mirror of the
+ * chat-side `FAKE_AGENT_ENV_LOG` assertion. Terminates immediately; the
+ * pool drains stdout into its scrollback.
+ */
+function writeEnvEchoVendorCli(tmpHome: string, name: string): string {
+  const binPath = join(tmpHome, name);
+  writeFileSync(
+    binPath,
+    `#!/bin/sh\nprintf 'ENV_BAND_DISPATCH:%s|\\n' "$BAND_DISPATCH"\n`,
+    "utf-8",
+  );
+  chmodSync(binPath, 0o755);
+  return binPath;
+}
+
+/**
  * Minimal fake-agent scenario: emit `system.init`, then a terminal
  * `result` event so `taskService.submitTask` records a completed task
  * and tears down the agent cleanly. Used by every test whose dispatch
@@ -625,6 +644,9 @@ describe("chat-hosted agent dispatch env (band-start nested create)", () => {
       { label: "agent spawned with BAND_DISPATCH=chat" },
     );
 
+    // `waitFor` already gates on BAND_DISPATCH === "chat", so this line
+    // documents the contract rather than independently catching a
+    // regression — the substantive assertion is BAND_SERVER_URL below.
     expect(record.BAND_DISPATCH).toBe("chat");
     // The server advertises its own bound URL to every child process so a
     // nested CLI call reaches it regardless of which port it claimed.
@@ -726,5 +748,84 @@ describe("workspaces.create via=terminal — long UTF-8 prompt", () => {
     expect(output).toContain(`${longPrompt}|`);
     // Belt-and-suspenders: the em-dash survived as U+2014, not mojibake.
     expect(output).toContain("—");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Bug 1 (terminal mirror) — a process spawned inside a terminal PTY must
+// inherit `BAND_DISPATCH=terminal`, so a nested `band` CLI call typed into
+// that pane keeps resolving to `terminal` (the symmetric counterpart to
+// the chat agent inheriting `BAND_DISPATCH=chat`). `terminal-pool` pins
+// the var on the PTY env; this proves the spawned vendor CLI actually sees
+// it. The stub echoes `ENV_BAND_DISPATCH:<value>|` — the terminal-side
+// equivalent of the chat path's `FAKE_AGENT_ENV_LOG`.
+// ---------------------------------------------------------------------------
+
+describe("terminal PTY env — BAND_DISPATCH=terminal", () => {
+  const TOKEN = "wc-via-termenv-token";
+  let server: ServerHandle;
+  let tmpHome: string;
+  let stubBin: string;
+
+  beforeAll(async () => {
+    tmpHome = createTmpHome("band-via-termenv-");
+    const repoPath = createGitRepo(tmpHome, "termenvproj");
+    stubBin = writeEnvEchoVendorCli(tmpHome, "stub-claude.sh");
+    seedState(tmpHome, {
+      projects: [
+        {
+          name: "termenvproj",
+          path: repoPath,
+          defaultBranch: "main",
+          worktrees: [{ branch: "main", path: repoPath }],
+        },
+      ],
+    });
+    seedSettings(tmpHome, {
+      tokenSecret: TOKEN,
+      codingAgents: [
+        { id: "claude-code", type: "claude-code", label: "Claude Code", command: stubBin },
+      ],
+    });
+    server = await startServer({ tmpHome });
+  });
+
+  afterAll(async () => {
+    await server.close();
+    rmSync(tmpHome, { recursive: true, force: true });
+  });
+
+  it("spawns the PTY vendor CLI with BAND_DISPATCH=terminal", async () => {
+    const createRes = await trpcMutate(
+      server.url,
+      "workspaces.create",
+      {
+        project: "termenvproj",
+        branch: "feat/termenv",
+        prompt: "run in terminal",
+        via: "terminal",
+      },
+      TOKEN,
+    );
+    const createBody = await createRes.text();
+    expect(createRes.status, createBody).toBe(200);
+    const data = (JSON.parse(createBody) as { result: { data: CreateResponse } }).result.data;
+
+    expect(data.via).toBe("terminal");
+    expect(typeof data.terminalId).toBe("string");
+
+    // The stub printed the BAND_DISPATCH it inherited from the PTY env.
+    // `terminal` (not `chat`, not empty) proves the terminal pane pins the
+    // dispatch target for any nested `band` CLI call typed into it.
+    const output = await waitFor(
+      async () => {
+        const out = await readTerminalOutput(server.url, data.terminalId!, TOKEN);
+        return out?.includes("ENV_BAND_DISPATCH:terminal|") ? out : undefined;
+      },
+      { label: "stub echoed BAND_DISPATCH=terminal" },
+    );
+    expect(output).toContain("ENV_BAND_DISPATCH:terminal|");
+    // Negative guard: it must not have leaked the chat value.
+    expect(output).not.toContain("ENV_BAND_DISPATCH:chat|");
   });
 });

--- a/apps/web/tests/workspace-create-via.test.ts
+++ b/apps/web/tests/workspace-create-via.test.ts
@@ -859,7 +859,11 @@ describe("terminal PTY env — BAND_DISPATCH=terminal", () => {
     const output = await waitFor(
       async () => {
         const out = await readTerminalOutput(server.url, data.terminalId!, TOKEN);
-        return out?.includes("ENV_BAND_SERVER_URL:") ? out : undefined;
+        // Require BOTH echoed lines so a split PTY flush can't resolve the
+        // poll before the second line is captured.
+        return out?.includes("ENV_BAND_DISPATCH:terminal|") && out.includes("ENV_BAND_SERVER_URL:")
+          ? out
+          : undefined;
       },
       { label: "stub echoed dispatch env" },
     );

--- a/packages/coding-agent/src/adapter-env.ts
+++ b/packages/coding-agent/src/adapter-env.ts
@@ -1,0 +1,19 @@
+/**
+ * Environment overrides merged into every coding-agent subprocess.
+ *
+ * `BAND_DISPATCH=chat` makes a nested `band` CLI call that originates
+ * from a chat-hosted agent — e.g. the `band-start` skill running `band
+ * workspaces create --prompt …` — dispatch the new workspace's task back
+ * into a chat pane, matching where the agent itself runs. Without it the
+ * Rust CLI's dispatch-precedence chain (`apps/cli/src/main.rs`
+ * `resolve_dispatch_target`) falls through to its built-in `terminal`
+ * default, so band-start launched from the web UI would land the task in
+ * a terminal instead of the chat.
+ *
+ * The terminal-pane path deliberately sets `BAND_DISPATCH=terminal`
+ * instead (see `terminal-pool.ts`), so a nested CLI call typed into a
+ * terminal keeps resolving to `terminal`.
+ */
+export const AGENT_DISPATCH_ENV: Readonly<Record<string, string>> = {
+  BAND_DISPATCH: "chat",
+};

--- a/packages/coding-agent/src/adapter-env.ts
+++ b/packages/coding-agent/src/adapter-env.ts
@@ -13,6 +13,12 @@
  * The terminal-pane path deliberately sets `BAND_DISPATCH=terminal`
  * instead (see `terminal-pool.ts`), so a nested CLI call typed into a
  * terminal keeps resolving to `terminal`.
+ *
+ * `BAND_SERVER_URL` is intentionally NOT listed here: it is set on
+ * `process.env` by the web server only after it binds a port, and flows
+ * to agent subprocesses via normal `process.env` inheritance at spawn
+ * time. Capturing it as a constant at module load would freeze a stale
+ * (or undefined) value.
  */
 export const AGENT_DISPATCH_ENV: Readonly<Record<string, string>> = {
   BAND_DISPATCH: "chat",

--- a/packages/coding-agent/src/adapters/claude-code.ts
+++ b/packages/coding-agent/src/adapters/claude-code.ts
@@ -15,6 +15,7 @@ import {
   getSessionInfo as sdkGetSessionInfo,
 } from "@anthropic-ai/claude-agent-sdk";
 import { createLogger } from "@band-app/logger";
+import { AGENT_DISPATCH_ENV } from "../adapter-env.js";
 import type { ClaudeCodeConfig } from "../config.js";
 import type { AgentEvent } from "../events.js";
 import { computeCost } from "../pricing.js";
@@ -232,7 +233,12 @@ export class ClaudeCodeAdapter implements CodingAgent {
     sessionId?: string,
     options?: RunSessionOptions,
   ): AsyncGenerator<AgentEvent> {
-    const env = { ...process.env };
+    // Spread `AGENT_DISPATCH_ENV` (BAND_DISPATCH=chat) so a nested `band`
+    // CLI call from this agent dispatches back into a chat pane — see
+    // adapter-env.ts. `BAND_SERVER_URL` is already on `process.env`
+    // (advertised by start-server.ts at boot), so the nested CLI reaches
+    // this server even when it bound a non-default port.
+    const env = { ...process.env, ...AGENT_DISPATCH_ENV };
     env.CLAUDECODE = undefined;
     env.CLAUDE_CODE_ENTRYPOINT = undefined;
     env.ANTHROPIC_CUSTOM_HEADERS = undefined;

--- a/packages/coding-agent/src/adapters/codex.ts
+++ b/packages/coding-agent/src/adapters/codex.ts
@@ -8,6 +8,7 @@ import { createLogger } from "@band-app/logger";
 import type { ThreadEvent, ThreadItem, TodoListItem } from "@openai/codex-sdk";
 import { Codex } from "@openai/codex-sdk";
 import { z } from "zod";
+import { AGENT_DISPATCH_ENV } from "../adapter-env.js";
 import type { CodexConfig } from "../config.js";
 import type { AgentEvent } from "../events.js";
 import { computeCost } from "../pricing.js";
@@ -149,6 +150,9 @@ export class CodexAdapter implements CodingAgent {
       }
       cleanEnv[key] = value;
     }
+    // BAND_DISPATCH=chat so a nested `band` CLI call from this agent
+    // dispatches back into a chat pane (see adapter-env.ts).
+    Object.assign(cleanEnv, AGENT_DISPATCH_ENV);
 
     const codex = new Codex({
       ...(this.executablePath ? { codexPathOverride: this.executablePath } : {}),

--- a/packages/coding-agent/src/adapters/gemini-cli.ts
+++ b/packages/coding-agent/src/adapters/gemini-cli.ts
@@ -4,6 +4,7 @@ import { homedir } from "node:os";
 import { join } from "node:path";
 import { createInterface } from "node:readline";
 import { createLogger } from "@band-app/logger";
+import { AGENT_DISPATCH_ENV } from "../adapter-env.js";
 import type { GeminiCliConfig } from "../config.js";
 import type { AgentEvent } from "../events.js";
 import { readSkillsFromDir } from "../skills.js";
@@ -73,7 +74,9 @@ export class GeminiCliAdapter implements CodingAgent {
     const child = spawn(this.executablePath, args, {
       cwd: this.workspaceDir,
       stdio: ["ignore", "pipe", "pipe"],
-      env: { ...process.env },
+      // BAND_DISPATCH=chat so a nested `band` CLI call from this agent
+      // dispatches back into a chat pane (see adapter-env.ts).
+      env: { ...process.env, ...AGENT_DISPATCH_ENV },
     });
     this.activeChild = child;
 

--- a/packages/coding-agent/src/adapters/opencode.ts
+++ b/packages/coding-agent/src/adapters/opencode.ts
@@ -4,6 +4,7 @@ import { homedir } from "node:os";
 import { join } from "node:path";
 import { createInterface } from "node:readline";
 import { createLogger } from "@band-app/logger";
+import { AGENT_DISPATCH_ENV } from "../adapter-env.js";
 import type { OpenCodeConfig } from "../config.js";
 import type { AgentEvent } from "../events.js";
 import { readSkillsFromDir } from "../skills.js";
@@ -108,7 +109,9 @@ export class OpenCodeAdapter implements CodingAgent {
       const child = spawn(this.executablePath, args, {
         cwd: this.workspaceDir,
         stdio: ["ignore", "pipe", "pipe"],
-        env: { ...process.env },
+        // BAND_DISPATCH=chat so a nested `band` CLI call from this agent
+        // dispatches back into a chat pane (see adapter-env.ts).
+        env: { ...process.env, ...AGENT_DISPATCH_ENV },
       });
       this.activeChild = child;
 


### PR DESCRIPTION
## Summary

Fixes two bugs in the `band-start` / `workspaces create --prompt` dispatch flow.

### Bug 1 — band-start run from the webchat dispatched the new workspace's agent to a **terminal** instead of the chat

The Rust CLI's `resolve_dispatch_target` (`apps/cli/src/main.rs`) walks `--via` → `BAND_DISPATCH` → repo/user config → built-in `terminal` default, but the server never injected `BAND_DISPATCH` (nor `BAND_SERVER_URL`) into the coding-agent's environment. So a nested `band workspaces create --prompt …` fired by a chat-hosted agent fell through to `terminal`.

Fixed at the agent-spawn boundary:
- **`apps/web/start-server.ts`** — advertises `process.env.BAND_SERVER_URL` = this server's bound URL at boot (overwriting any inherited value) so a nested CLI call reaches *this* server regardless of port (dev 3457/3458, tests' random port).
- **`packages/coding-agent/src/adapter-env.ts`** (new) — shared `AGENT_DISPATCH_ENV = { BAND_DISPATCH: "chat" }`, merged into the subprocess env of the claude-code, codex, gemini-cli, and opencode adapters.
- **`terminal-pool.ts`** — explicitly sets `BAND_DISPATCH=terminal` so a nested CLI call typed in a terminal pane keeps resolving to `terminal`.

### Bug 2 — terminal dispatch corrupted / never executed long UTF-8 prompts

The whole `'<binary>' '<prompt>'` line was written into a cold PTY, racing shell startup → dropped trailing newline (command never ran), >4 KB canonical-buffer truncation, and split-multibyte em-dash (U+2014) mojibake.

- **`terminal-pool.ts`** now stages the command in a temp file (`flag: "wx"`, mode `0o600`) so its bytes never traverse the tty's canonical input buffer, then writes a short `source '<file>'` line *after the shell's first output* (readiness signal), with a 750 ms unref'd fallback. The temp file is unlinked on PTY exit.

## Tests

`apps/web/tests/workspace-create-via.test.ts` (+ `fake-agent.mjs` env-log helper):
- **(a)** A chat-hosted agent is spawned with `BAND_DISPATCH=chat` and `BAND_SERVER_URL` = the server's URL — the precondition the nested CLI reads to resolve `via: chat`.
- **(b)** A ~6 KB em-dash-laden prompt dispatched `via=terminal` is echoed back by the stub vendor CLI as one intact argv token — proving it executed without truncation or corruption.

Real production server, real PTY, real SQLite; no tRPC mocking, no MSW — per the repo's integration-test doctrine.

## Verification

- `apps/web` tests: `workspace-create-via` (7), `terminal-config` (9), `terminal-ws` (2) — 18 passed.
- `packages/coding-agent` unit tests — 61 passed.
- `biome check` on changed files — clean. No Rust touched.
- Ran the local CI-style review (`/review-and-apply`): approved 👍, 0 blockers; applied the one hardening suggestion (`O_EXCL` on the temp-file write).

🤖 Generated with [Claude Code](https://claude.com/claude-code)