### PR TITLE
feat(chat): continue chat session in a terminal + copy session ID

### DIFF
--- a/apps/web/e2e/chat-continue-in-terminal.spec.ts
+++ b/apps/web/e2e/chat-continue-in-terminal.spec.ts
@@ -138,6 +138,10 @@ test.describe("Chat tab context menu — continue in terminal / copy session id"
     await expect
       .poll(async () => (await workspace.readCopied()).at(-1), {
         message: "session id copied to clipboard",
+        // The copy follows the on-open chats.get round-trip; give it room
+        // beyond Playwright's 5 s expect.poll default so a slow CI run
+        // doesn't flake.
+        timeout: 15_000,
       })
       .toBe(SESSION_ID);
 

--- a/apps/web/e2e/chat-continue-in-terminal.spec.ts
+++ b/apps/web/e2e/chat-continue-in-terminal.spec.ts
@@ -147,7 +147,7 @@ test.describe("Chat tab context menu — continue in terminal / copy session id"
     await expect(workspace.continueInTerminalItem).toBeEnabled();
     await workspace.continueInTerminalItem.click();
 
-    await expect(workspace.tabContainer("terminal")).toHaveClass(/dv-active-tab/);
+    await expect(workspace.tabContainer("terminal")).toHaveClass(/\bdv-active-tab\b/);
     await workspace.waitForTerminalReady(75_000);
   });
 });

--- a/apps/web/e2e/chat-continue-in-terminal.spec.ts
+++ b/apps/web/e2e/chat-continue-in-terminal.spec.ts
@@ -151,7 +151,11 @@ test.describe("Chat tab context menu — continue in terminal / copy session id"
     await expect(workspace.continueInTerminalItem).toBeEnabled();
     await workspace.continueInTerminalItem.click();
 
-    await expect(workspace.tabContainer("terminal")).toHaveClass(/\bdv-active-tab\b/);
+    // Explicit timeout: the dockview setActive effect can be starved under
+    // parallel-worker CI contention (mirrors workspace-maximize-state.spec.ts).
+    await expect(workspace.tabContainer("terminal")).toHaveClass(/\bdv-active-tab\b/, {
+      timeout: 15_000,
+    });
     await workspace.waitForTerminalReady(75_000);
   });
 });

--- a/apps/web/e2e/chat-continue-in-terminal.spec.ts
+++ b/apps/web/e2e/chat-continue-in-terminal.spec.ts
@@ -1,0 +1,153 @@
+/**
+ * End-to-end coverage for the chat tab's right-click actions: "Copy session
+ * ID" and "Continue in terminal".
+ *
+ * Architecture (mirrors the rest of the e2e suite + the chat specs):
+ *   - REAL production `dist/start-server.mjs` boots against a fresh tmp
+ *     `$HOME`. No tRPC mocking.
+ *   - The only stub is `apps/web/tests/fake-agent.mjs` — the boundary stub
+ *     for the agent subprocess (Claude SDK protocol over stdio). Its
+ *     scenario emits a `system.init` with a known `session_id`, so sending
+ *     one message establishes the chat's `activeSessionId` exactly the way
+ *     a real agent run would. That session id is what both context-menu
+ *     actions operate on.
+ *   - UI driven through page objects: `ChatPanePage` to send the message,
+ *     `WorkspacePage` for the chat-tab context menu, clipboard capture, and
+ *     the outer Terminal panel. The test body never touches raw `page.*`
+ *     locators.
+ *
+ * What's asserted here is the UI wiring: the menu opens with both items,
+ * "Copy session ID" copies the underlying session id, and "Continue in
+ * terminal" spawns a terminal and surfaces the Terminal panel. The exact
+ * resume argv (`claude --resume <id>`) is pinned by the backend integration
+ * test (`apps/web/tests/chat-continue-in-terminal.test.ts`).
+ */
+
+import { mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { expect, test } from "@playwright/test";
+import { toWorkspaceId } from "@/dashboard";
+import {
+  cleanupTmpHome,
+  createTmpHome,
+  type ServerHandle,
+  seedSettings,
+  seedState,
+  startServer,
+} from "./helpers/server";
+import { ChatPanePage } from "./pages/ChatPanePage";
+import { WorkspacePage } from "./pages/WorkspacePage";
+
+const TOKEN = "e2e-chat-continue-terminal-token";
+const PROJECT = "continueproj";
+const WORKSPACE = toWorkspaceId(PROJECT, "main");
+const SESSION_ID = "continue-term-session-xyz";
+
+// Wide viewport so the desktop dockview layout (with the outer Terminal tab)
+// renders.
+test.use({ viewport: { width: 1280, height: 800 } });
+
+const FAKE_AGENT_PATH = join(import.meta.dirname, "..", "tests", "fake-agent.mjs");
+
+let server: ServerHandle;
+let tmpHome: string;
+
+test.beforeAll(async () => {
+  tmpHome = createTmpHome();
+
+  // The worktree directory must exist on disk — the server resolves it and
+  // (for "Continue in terminal") spawns a PTY with it as CWD.
+  const repoDir = join(tmpHome, "repo");
+  mkdirSync(repoDir, { recursive: true });
+
+  seedState(tmpHome, {
+    projects: [
+      {
+        name: PROJECT,
+        path: repoDir,
+        defaultBranch: "main",
+        worktrees: [{ branch: "main", path: repoDir }],
+      },
+    ],
+  });
+  seedSettings(tmpHome, {
+    tokenSecret: TOKEN,
+    codingAgents: [
+      { id: "claude-code", type: "claude-code", label: "Claude Code", command: FAKE_AGENT_PATH },
+    ],
+  });
+
+  // Fast scenario: emit session-start (so the chat persists activeSessionId)
+  // then an assistant message + result so the round-trip completes and we
+  // have a positive UI anchor to wait on before opening the menu.
+  const scenarioPath = join(tmpHome, "scenario.json");
+  writeFileSync(
+    scenarioPath,
+    JSON.stringify([
+      { type: "system", subtype: "init", session_id: SESSION_ID },
+      { type: "assistant", message: { content: [{ type: "text", text: "session ready" }] } },
+      {
+        type: "result",
+        subtype: "success",
+        session_id: SESSION_ID,
+        duration_ms: 1,
+        num_turns: 1,
+        total_cost_usd: 0.0,
+      },
+    ]),
+  );
+
+  server = await startServer({ tmpHome, env: { FAKE_AGENT_SCENARIO: scenarioPath } });
+});
+
+test.afterAll(async () => {
+  await server.close();
+  cleanupTmpHome(tmpHome);
+});
+
+test.describe("Chat tab context menu — continue in terminal / copy session id", () => {
+  test("copies the session id and continues the session in a terminal", async ({ page }) => {
+    const chatPane = new ChatPanePage(page, server.url, TOKEN);
+    const workspace = new WorkspacePage(page, server.url, TOKEN);
+
+    // Record clipboard writes before any navigation.
+    await workspace.installClipboardCapture();
+
+    await chatPane.goto(WORKSPACE);
+    await chatPane.waitForReady();
+
+    // Send one message to establish the agent session. Waiting for the
+    // assistant reply is the positive anchor that session-start was
+    // processed and `activeSessionId` is persisted server-side.
+    await chatPane.typeMessage("kick off a session");
+    await chatPane.submit();
+    await expect(chatPane.assistantMessage("session ready")).toBeVisible();
+
+    // Open the chat tab's right-click menu — both items present.
+    await workspace.openChatTabContextMenu();
+    await expect(workspace.chatTabContextMenu).toBeVisible();
+    await expect(workspace.continueInTerminalItem).toBeVisible();
+    await expect(workspace.copySessionIdItem).toBeVisible();
+
+    // "Copy session ID" copies the chat's underlying agent session id. The
+    // item enables once the on-open `chats.get` resolves the active session;
+    // assert that enabled transition as a positive anchor before clicking so
+    // the click can't race the resolve.
+    await expect(workspace.copySessionIdItem).toBeEnabled();
+    await workspace.copySessionIdItem.click();
+    await expect
+      .poll(async () => (await workspace.readCopied()).at(-1), {
+        message: "session id copied to clipboard",
+      })
+      .toBe(SESSION_ID);
+
+    // "Continue in terminal" spawns the resume terminal and surfaces the
+    // outer Terminal panel so the user lands on it.
+    await workspace.openChatTabContextMenu();
+    await expect(workspace.continueInTerminalItem).toBeEnabled();
+    await workspace.continueInTerminalItem.click();
+
+    await expect(workspace.tabContainer("terminal")).toHaveClass(/dv-active-tab/);
+    await workspace.waitForTerminalReady(75_000);
+  });
+});

--- a/apps/web/e2e/pages/WorkspacePage.ts
+++ b/apps/web/e2e/pages/WorkspacePage.ts
@@ -877,7 +877,11 @@ export class WorkspacePage {
   // single-chat workspaces these tests use resolve to `.first()`.
   // ──────────────────────────────────────────────────────────────────────
 
-  /** The chat tab header (right-click target). */
+  /** The chat tab header (right-click target). The `data-testid` is
+   *  `chat-tab__trigger--<chatId>` where the chatId suffix is generated at
+   *  runtime, so a fixed `getByTestId(...)` can't address it — we match the
+   *  stable testid PREFIX via an attribute selector and take `.first()` (the
+   *  workspaces these tests seed have a single chat tab). */
   chatTabTrigger(): Locator {
     return this.page.locator('[data-testid^="chat-tab__trigger--"]').first();
   }

--- a/apps/web/e2e/pages/WorkspacePage.ts
+++ b/apps/web/e2e/pages/WorkspacePage.ts
@@ -879,11 +879,11 @@ export class WorkspacePage {
 
   /** The chat tab header (right-click target). The `data-testid` is
    *  `chat-tab__trigger--<chatId>` where the chatId suffix is generated at
-   *  runtime, so a fixed `getByTestId(...)` can't address it — we match the
-   *  stable testid PREFIX via an attribute selector and take `.first()` (the
-   *  workspaces these tests seed have a single chat tab). */
+   *  runtime, so we match the stable testid PREFIX with a regex (testid-first
+   *  locator priority) and take `.first()` — the workspaces these tests seed
+   *  have a single chat tab. */
   chatTabTrigger(): Locator {
-    return this.page.locator('[data-testid^="chat-tab__trigger--"]').first();
+    return this.page.getByTestId(/^chat-tab__trigger--/).first();
   }
 
   /** The opened chat-tab context menu content (portalled to body). */

--- a/apps/web/e2e/pages/WorkspacePage.ts
+++ b/apps/web/e2e/pages/WorkspacePage.ts
@@ -868,6 +868,91 @@ export class WorkspacePage {
       }
     }, `band-open-tabs:${workspaceId}`);
   }
+
+  // ──────────────────────────────────────────────────────────────────────
+  // Chat tab context menu ("Continue in terminal" / "Copy session ID").
+  // The tab header is a dockview-rendered `.dv-default-tab`; we tag it with
+  // `chat-tab__trigger--<chatId>` in `DockviewChatContainer.tsx`. chatIds
+  // are client-generated, so the locator matches the testid PREFIX and the
+  // single-chat workspaces these tests use resolve to `.first()`.
+  // ──────────────────────────────────────────────────────────────────────
+
+  /** The chat tab header (right-click target). */
+  chatTabTrigger(): Locator {
+    return this.page.locator('[data-testid^="chat-tab__trigger--"]').first();
+  }
+
+  /** The opened chat-tab context menu content (portalled to body). */
+  get chatTabContextMenu(): Locator {
+    return this.page.getByTestId("chat-tab__context-menu");
+  }
+
+  /** "Continue in terminal" item. */
+  get continueInTerminalItem(): Locator {
+    return this.page.getByTestId("chat-tab__context-menu-item--continue-in-terminal");
+  }
+
+  /** "Copy session ID" item. */
+  get copySessionIdItem(): Locator {
+    return this.page.getByTestId("chat-tab__context-menu-item--copy-session-id");
+  }
+
+  /** Right-click the chat tab header to open its context menu. */
+  async openChatTabContextMenu(): Promise<void> {
+    await test.step("Right-click the chat tab to open its context menu", async () => {
+      await this.chatTabTrigger().click({ button: "right" });
+    });
+  }
+
+  /** Simulate a NON-secure context (`navigator.clipboard === undefined`,
+   *  the LAN-IP / non-HTTPS-tunnel case) and capture the `execCommand("copy")`
+   *  fallback's payload into `window.__copied`. Must run BEFORE `goto` (uses
+   *  `addInitScript`) — same instrumentation pattern as
+   *  `ChatPanePage.installOpenFileCapture`.
+   *
+   *  This deliberately removes `navigator.clipboard` so the test is a real
+   *  regression guard: code that calls `navigator.clipboard.writeText`
+   *  directly (instead of the shared `writeClipboardText` helper) silently
+   *  no-ops here and leaves `__copied` empty, failing the assertion. The
+   *  helper's `document.execCommand("copy")` fallback — the only path that
+   *  works without a secure context — is what we record. */
+  async installClipboardCapture(): Promise<void> {
+    await this.page.addInitScript(() => {
+      const w = window as unknown as { __copied: string[] };
+      w.__copied = [];
+      // No `navigator.clipboard` — forces the execCommand fallback path.
+      Object.defineProperty(navigator, "clipboard", {
+        configurable: true,
+        value: undefined,
+      });
+      // Capture the value the fallback copies. `writeClipboardText`'s legacy
+      // path sets a textarea's value, calls `.select()` on it, then runs
+      // `execCommand("copy")`. We record the selected textarea's value (the
+      // `.select()` receiver, reliable regardless of headless focus quirks)
+      // and push it when the matching `copy` command fires.
+      let lastSelected = "";
+      const originalSelect = HTMLTextAreaElement.prototype.select;
+      HTMLTextAreaElement.prototype.select = function select(this: HTMLTextAreaElement) {
+        lastSelected = this.value;
+        return originalSelect.call(this);
+      };
+      const originalExec = document.execCommand.bind(document);
+      document.execCommand = (commandId: string, ...rest: unknown[]): boolean => {
+        if (commandId === "copy") {
+          w.__copied.push(lastSelected);
+          return true;
+        }
+        return (originalExec as (c: string, ...r: unknown[]) => boolean)(commandId, ...rest);
+      };
+    });
+  }
+
+  /** Read the strings captured by `installClipboardCapture()`. */
+  async readCopied(): Promise<string[]> {
+    return await this.page.evaluate(
+      () => (window as unknown as { __copied?: string[] }).__copied ?? [],
+    );
+  }
 }
 
 /** Narrowed shape for what `*.Layout.get` returns. Mirrors the parts of

--- a/apps/web/src/components/DockviewChatContainer.tsx
+++ b/apps/web/src/components/DockviewChatContainer.tsx
@@ -81,7 +81,7 @@ function chatLayoutKey(workspaceId: string) {
 }
 
 // ---------------------------------------------------------------------------
-// Shared settings fetch (PERF-7)
+// Shared settings fetch
 //
 // `settings.get` is global. When a workspace with several chat tabs loads,
 // each tab's mount would otherwise fire its own `settings.get` (N small

--- a/apps/web/src/components/DockviewChatContainer.tsx
+++ b/apps/web/src/components/DockviewChatContainer.tsx
@@ -1,3 +1,4 @@
+import { ContextMenu, ContextMenuContent, ContextMenuItem, ContextMenuTrigger } from "@band-app/ui";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import {
   type DockviewApi,
@@ -11,6 +12,7 @@ import {
 import { Columns2, Plus, Rows2, X } from "lucide-react";
 import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { AgentIcon, useAdapter } from "@/dashboard";
+import { writeClipboardText } from "../lib/clipboard";
 import {
   attachEdgeGroupDragVisibility,
   centralPanelPosition,
@@ -25,6 +27,13 @@ import {
 import { trpc } from "../lib/trpc-client";
 import { ChatPane, type CodingAgentDef, useChatPaneState } from "./ChatPane";
 import { PanelVisibilityContext, usePanelVisibility } from "./panel-visibility-context";
+// `crossPanelHandlers` is a module-level mutable registry exported from
+// SharedDockviewLayout. Importing it here closes an ESM cycle
+// (SharedDockviewLayout → DockviewChatContainer → SharedDockviewLayout),
+// but we only read it inside a click handler (call time, never module
+// eval), so the live binding is always populated by then — same pattern
+// `__root.tsx` uses to drive the dockview without a dockview API ref.
+import { crossPanelHandlers } from "./SharedDockviewLayout";
 
 // ---------------------------------------------------------------------------
 // Track chat IDs that were just created by an "add tab" action.
@@ -248,11 +257,22 @@ function writeCachedTabMeta(chatId: string, patch: { title?: string; agentType?:
   } catch {}
 }
 
+/**
+ * Coding-agent types whose vendor CLI can resume a session by ID in an
+ * interactive terminal (`resumeCliInvocation`). Used to disable the chat
+ * tab's "Continue in terminal" item for agents that can't (gemini-cli has
+ * no session model; cursor-cli is SDK-only). Kept in sync with the
+ * adapters' `resumeCliInvocation` implementations in
+ * `packages/coding-agent/src/adapters/`.
+ */
+const RESUME_CAPABLE_AGENT_TYPES = new Set(["claude-code", "codex", "opencode"]);
+
 function ChatTab(props: IDockviewPanelHeaderProps<ChatTabParams>) {
   const initialChatId = props.params.chatId;
   const initialCache = readCachedTabMeta(initialChatId);
   const [title, setTitle] = useState(initialCache.title ?? props.api.title ?? "Chat");
   const [agentType, setAgentType] = useState<string | undefined>(initialCache.agentType);
+  const [sessionId, setSessionId] = useState<string | undefined>(undefined);
   const [panelCount, setPanelCount] = useState(props.containerApi.panels.length);
 
   useEffect(() => {
@@ -276,34 +296,101 @@ function ChatTab(props: IDockviewPanelHeaderProps<ChatTabParams>) {
     };
   }, [props.containerApi]);
 
-  // Load agent type once for the icon
+  // Resolve agent type (for the icon) + active session id (for the
+  // context-menu actions). The global `settings` blob (agent id → type
+  // map) is fetched once on mount and cached in a ref; the per-menu-open
+  // refresh re-reads only the chat (for the active session id AND the
+  // agent, which often only resolves after the first message creates the
+  // chat record) and maps the agent through the cached settings — so a
+  // right-click never re-fetches the global settings blob.
   const chatId = props.params.chatId;
   const workspaceId = props.params.workspaceId;
 
+  const mountedRef = useRef(true);
   useEffect(() => {
-    if (!chatId || !workspaceId) return;
-    let cancelled = false;
-    Promise.all([
-      trpc.settings.get.query().catch(() => null),
-      trpc.chats.get.query({ chatId }).catch(() => ({ chat: null })),
-    ]).then(([settings, chatResult]) => {
-      if (cancelled) return;
-      const raw = (settings as Record<string, unknown> | null)?.codingAgents;
-      const codingAgents = Array.isArray(raw) ? (raw as CodingAgentDef[]) : [];
-      const defaultAgentId = (settings as Record<string, unknown> | null)?.defaultCodingAgent as
-        | string
-        | undefined;
-      const agentId = chatResult.chat?.agent ?? defaultAgentId ?? "";
-      const found = codingAgents.find((a) => a.id === agentId);
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
+
+  // Cached settings (populated on mount) so the per-open refresh can map a
+  // chat's agent id to its type without re-fetching the global blob.
+  const codingAgentsRef = useRef<CodingAgentDef[]>([]);
+  const defaultAgentIdRef = useRef<string | undefined>(undefined);
+
+  // Apply a `chats.get` result: update the active session id and (via the
+  // cached settings) the agent type. The chat record is created lazily on
+  // the first message, so the agent type frequently only resolves on a
+  // later refresh — recompute it here rather than only on mount.
+  const applyChatMeta = useCallback(
+    (chat: { agent?: string; activeSessionId?: string } | null | undefined) => {
+      if (!mountedRef.current) return;
+      setSessionId(chat?.activeSessionId ?? undefined);
+      const agentId = chat?.agent ?? defaultAgentIdRef.current ?? "";
+      const found = codingAgentsRef.current.find((a) => a.id === agentId);
       if (found) {
         setAgentType(found.type);
         writeCachedTabMeta(chatId, { agentType: found.type });
       }
+    },
+    [chatId],
+  );
+
+  const refreshTabMeta = useCallback(() => {
+    if (!chatId || !workspaceId) return;
+    Promise.all([
+      trpc.settings.get.query().catch(() => null),
+      trpc.chats.get.query({ chatId }).catch(() => ({ chat: null })),
+    ]).then(([settings, chatResult]) => {
+      if (!mountedRef.current) return;
+      const raw = (settings as Record<string, unknown> | null)?.codingAgents;
+      codingAgentsRef.current = Array.isArray(raw) ? (raw as CodingAgentDef[]) : [];
+      defaultAgentIdRef.current = (settings as Record<string, unknown> | null)
+        ?.defaultCodingAgent as string | undefined;
+      applyChatMeta(chatResult.chat);
     });
-    return () => {
-      cancelled = true;
-    };
+  }, [chatId, workspaceId, applyChatMeta]);
+
+  // Lightweight refresh for the context-menu open path: re-reads only the
+  // chat (session id + agent), mapping the agent through the settings
+  // cached on mount — no redundant global `settings.get`.
+  const refreshChatMeta = useCallback(() => {
+    if (!chatId) return;
+    trpc.chats.get
+      .query({ chatId })
+      .then((res) => applyChatMeta(res.chat))
+      .catch(() => {});
+  }, [chatId, applyChatMeta]);
+
+  useEffect(() => {
+    refreshTabMeta();
+  }, [refreshTabMeta]);
+
+  const canResume = !!sessionId && !!agentType && RESUME_CAPABLE_AGENT_TYPES.has(agentType);
+
+  const handleContinueInTerminal = useCallback(() => {
+    trpc.chats.continueInTerminal
+      .mutate({ chatId })
+      .then(() => {
+        // Surface the Terminal panel so the user lands on the resumed
+        // session. The server already spawned the pane + emitted
+        // `terminal-created`; this just flips the outer panel switcher.
+        crossPanelHandlers.onActivateTerminalPanel(workspaceId);
+      })
+      .catch((err) => {
+        console.error("[ChatTab] continue in terminal failed:", err);
+      });
   }, [chatId, workspaceId]);
+
+  const handleCopySessionId = useCallback(() => {
+    if (!sessionId) return;
+    // Use the shared helper, not `navigator.clipboard` directly:
+    // `navigator.clipboard` is undefined in a non-secure context (Band
+    // served over plain HTTP on a LAN IP / non-HTTPS tunnel), so the raw
+    // API silently no-ops there. `writeClipboardText` falls back to the
+    // legacy execCommand path that works without a secure context.
+    void writeClipboardText(sessionId);
+  }, [sessionId]);
 
   const handleClose = useCallback(
     (e: React.MouseEvent) => {
@@ -316,37 +403,65 @@ function ChatTab(props: IDockviewPanelHeaderProps<ChatTabParams>) {
   const showClose = panelCount > 1;
 
   return (
-    <div className="dv-default-tab">
-      <div className="flex items-center gap-1.5 min-w-0">
-        {/* Reserve icon slot — opacity fades in once agentType resolves so
-            the icon does not pop in. Width is reserved either way. */}
-        <span
-          className="inline-flex size-3.5 shrink-0 items-center justify-center transition-opacity duration-150"
-          style={{ opacity: agentType ? 1 : 0 }}
+    <ContextMenu
+      onOpenChange={(open) => {
+        // Refresh the chat's session id + agent each time the menu opens so
+        // the items' enabled state reflects the latest values (both can
+        // change as the user works — the chat record itself is created
+        // lazily on the first message). Settings stay cached from mount.
+        if (open) refreshChatMeta();
+      }}
+    >
+      <ContextMenuTrigger asChild>
+        <div className="dv-default-tab" data-testid={`chat-tab__trigger--${chatId}`}>
+          <div className="flex items-center gap-1.5 min-w-0">
+            {/* Reserve icon slot — opacity fades in once agentType resolves so
+                the icon does not pop in. Width is reserved either way. */}
+            <span
+              className="inline-flex size-3.5 shrink-0 items-center justify-center transition-opacity duration-150"
+              style={{ opacity: agentType ? 1 : 0 }}
+            >
+              {agentType && <AgentIcon type={agentType} className="size-3.5" />}
+            </span>
+            {/* Bounded width so chat tab does not reflow as title loads/changes. */}
+            <span className="truncate min-w-[6rem] max-w-[14rem]">{title}</span>
+          </div>
+          {/* Always render the close button slot — toggle visibility via opacity
+              instead of mounting/unmounting so panelCount swings (1 ↔ 2) do not
+              shift the tab width. */}
+          <button
+            type="button"
+            aria-hidden={!showClose}
+            tabIndex={showClose ? 0 : -1}
+            className="ml-1 inline-flex size-4 items-center justify-center rounded-sm opacity-60 hover:opacity-100 hover:bg-accent transition-opacity"
+            style={{
+              opacity: showClose ? undefined : 0,
+              pointerEvents: showClose ? undefined : "none",
+            }}
+            onClick={handleClose}
+            title="Close tab"
+          >
+            <X className="size-3" />
+          </button>
+        </div>
+      </ContextMenuTrigger>
+      <ContextMenuContent data-testid="chat-tab__context-menu">
+        <ContextMenuItem
+          disabled={!canResume}
+          onClick={handleContinueInTerminal}
+          data-testid="chat-tab__context-menu-item--continue-in-terminal"
         >
-          {agentType && <AgentIcon type={agentType} className="size-3.5" />}
-        </span>
-        {/* Bounded width so chat tab does not reflow as title loads/changes. */}
-        <span className="truncate min-w-[6rem] max-w-[14rem]">{title}</span>
-      </div>
-      {/* Always render the close button slot — toggle visibility via opacity
-          instead of mounting/unmounting so panelCount swings (1 ↔ 2) do not
-          shift the tab width. */}
-      <button
-        type="button"
-        aria-hidden={!showClose}
-        tabIndex={showClose ? 0 : -1}
-        className="ml-1 inline-flex size-4 items-center justify-center rounded-sm opacity-60 hover:opacity-100 hover:bg-accent transition-opacity"
-        style={{
-          opacity: showClose ? undefined : 0,
-          pointerEvents: showClose ? undefined : "none",
-        }}
-        onClick={handleClose}
-        title="Close tab"
-      >
-        <X className="size-3" />
-      </button>
-    </div>
+          Continue in terminal
+        </ContextMenuItem>
+        <ContextMenuItem
+          disabled={!sessionId}
+          onClick={handleCopySessionId}
+          data-testid="chat-tab__context-menu-item--copy-session-id"
+        >
+          Copy session ID
+        </ContextMenuItem>
+      </ContextMenuContent>
+    </ContextMenu>
   );
 }
 

--- a/apps/web/src/components/DockviewChatContainer.tsx
+++ b/apps/web/src/components/DockviewChatContainer.tsx
@@ -81,6 +81,29 @@ function chatLayoutKey(workspaceId: string) {
 }
 
 // ---------------------------------------------------------------------------
+// Shared settings fetch (PERF-7)
+//
+// `settings.get` is global. When a workspace with several chat tabs loads,
+// each tab's mount would otherwise fire its own `settings.get` (N small
+// server-side file reads). A short-TTL shared promise collapses that burst
+// into a single fetch, while staying fresh enough that an agent change made
+// in the Settings UI is picked up on the next tab mount.
+// ---------------------------------------------------------------------------
+
+let sharedSettingsPromise: Promise<unknown> | null = null;
+let sharedSettingsAt = 0;
+const SHARED_SETTINGS_TTL_MS = 5_000;
+
+function getSharedSettings(): Promise<unknown> {
+  const now = Date.now();
+  if (!sharedSettingsPromise || now - sharedSettingsAt > SHARED_SETTINGS_TTL_MS) {
+    sharedSettingsAt = now;
+    sharedSettingsPromise = trpc.settings.get.query().catch(() => null);
+  }
+  return sharedSettingsPromise;
+}
+
+// ---------------------------------------------------------------------------
 // Debounced server persistence (500ms) — also updates React Query cache
 // so the next mount renders instantly from cached data.
 // ---------------------------------------------------------------------------
@@ -261,9 +284,7 @@ function writeCachedTabMeta(chatId: string, patch: { title?: string; agentType?:
  * Coding-agent types whose vendor CLI can resume a session by ID in an
  * interactive terminal (`resumeCliInvocation`). Used to disable the chat
  * tab's "Continue in terminal" item for agents that can't (gemini-cli has
- * no session model; cursor-cli is SDK-only). Kept in sync with the
- * adapters' `resumeCliInvocation` implementations in
- * `packages/coding-agent/src/adapters/`.
+ * no session model; cursor-cli is SDK-only).
  */
 const RESUME_CAPABLE_AGENT_TYPES = new Set(["claude-code", "codex", "opencode"]);
 
@@ -339,7 +360,7 @@ function ChatTab(props: IDockviewPanelHeaderProps<ChatTabParams>) {
   const refreshTabMeta = useCallback(() => {
     if (!chatId || !workspaceId) return;
     Promise.all([
-      trpc.settings.get.query().catch(() => null),
+      getSharedSettings(),
       trpc.chats.get.query({ chatId }).catch(() => ({ chat: null })),
     ]).then(([settings, chatResult]) => {
       if (!mountedRef.current) return;

--- a/apps/web/src/components/DockviewChatContainer.tsx
+++ b/apps/web/src/components/DockviewChatContainer.tsx
@@ -98,7 +98,13 @@ function getSharedSettings(): Promise<unknown> {
   const now = Date.now();
   if (!sharedSettingsPromise || now - sharedSettingsAt > SHARED_SETTINGS_TTL_MS) {
     sharedSettingsAt = now;
-    sharedSettingsPromise = trpc.settings.get.query().catch(() => null);
+    sharedSettingsPromise = trpc.settings.get.query().catch(() => {
+      // Don't cache a failed fetch for the whole TTL — a transient error
+      // would otherwise leave every tab mount in the window with null
+      // settings. Reset so the next mount retries.
+      sharedSettingsPromise = null;
+      return null;
+    });
   }
   return sharedSettingsPromise;
 }
@@ -362,14 +368,19 @@ function ChatTab(props: IDockviewPanelHeaderProps<ChatTabParams>) {
     Promise.all([
       getSharedSettings(),
       trpc.chats.get.query({ chatId }).catch(() => ({ chat: null })),
-    ]).then(([settings, chatResult]) => {
-      if (!mountedRef.current) return;
-      const raw = (settings as Record<string, unknown> | null)?.codingAgents;
-      codingAgentsRef.current = Array.isArray(raw) ? (raw as CodingAgentDef[]) : [];
-      defaultAgentIdRef.current = (settings as Record<string, unknown> | null)
-        ?.defaultCodingAgent as string | undefined;
-      applyChatMeta(chatResult.chat);
-    });
+    ])
+      .then(([settings, chatResult]) => {
+        if (!mountedRef.current) return;
+        const raw = (settings as Record<string, unknown> | null)?.codingAgents;
+        codingAgentsRef.current = Array.isArray(raw) ? (raw as CodingAgentDef[]) : [];
+        defaultAgentIdRef.current = (settings as Record<string, unknown> | null)
+          ?.defaultCodingAgent as string | undefined;
+        applyChatMeta(chatResult.chat);
+      })
+      // Defensive: both inputs catch internally today, but guard the chain
+      // so a future change that drops one can't surface an unhandled
+      // rejection from this fire-and-forget mount effect.
+      .catch(() => {});
   }, [chatId, workspaceId, applyChatMeta]);
 
   // Lightweight refresh for the context-menu open path: re-reads only the

--- a/apps/web/src/components/SharedDockviewLayout.tsx
+++ b/apps/web/src/components/SharedDockviewLayout.tsx
@@ -143,6 +143,15 @@ interface CrossPanelHandlers {
    * doesn't hijack the panel switcher.
    */
   onActivateFilesPanel: (workspaceId: string) => void;
+  /**
+   * Bring the Terminal panel to the foreground. Used by the chat tab's
+   * "Continue in terminal" action: the server has already spawned the
+   * resume-command terminal pane (and emitted `terminal-created`), so the
+   * inner terminal dockview will add it; this just surfaces the outer
+   * Terminal panel so the user lands on the resumed session. Guarded on
+   * active-workspace, same as `onActivateFilesPanel`.
+   */
+  onActivateTerminalPanel: (workspaceId: string) => void;
 }
 
 // Mutable module-level handlers — SharedDockviewLayout writes them on every
@@ -156,6 +165,7 @@ export const crossPanelHandlers: CrossPanelHandlers = {
   onFileOpened: () => {},
   onFindInFile: () => {},
   onActivateFilesPanel: () => {},
+  onActivateTerminalPanel: () => {},
 };
 
 // ---------------------------------------------------------------------------
@@ -902,6 +912,20 @@ export function SharedDockviewLayout() {
     }
   }, []);
 
+  const handleActivateTerminalPanel = useCallback((workspaceId: string) => {
+    // Same active-workspace guard as `handleActivateFilesPanel`, plus the
+    // hidden-panel guard the Ctrl+` shortcut uses so we never try to
+    // activate a panel the user has removed from the layout. Mirror the
+    // shortcut's `band:focus-terminal` dispatch so the freshly-surfaced
+    // terminal grabs keyboard focus.
+    if (workspaceId !== activeWorkspaceIdRef.current) return;
+    if (hiddenPanelsRef.current.includes("terminal")) return;
+    apiRef.current?.getPanel("terminal")?.api.setActive();
+    queueMicrotask(() => {
+      window.dispatchEvent(new CustomEvent("band:focus-terminal"));
+    });
+  }, []);
+
   // Mirror the handlers into the module-level registry so panel children
   // (which can't reach into a closure across the dockview boundary) can
   // call them.
@@ -910,6 +934,7 @@ export function SharedDockviewLayout() {
   crossPanelHandlers.onSelectFile = handleSelectFile;
   crossPanelHandlers.onFindInFile = handleSetFindInFile;
   crossPanelHandlers.onActivateFilesPanel = handleActivateFilesPanel;
+  crossPanelHandlers.onActivateTerminalPanel = handleActivateTerminalPanel;
 
   // ---------------------------------------------------------------------
   // Command palette

--- a/apps/web/src/server/api/chats/router.ts
+++ b/apps/web/src/server/api/chats/router.ts
@@ -19,12 +19,16 @@
  * shape as the pre-migration legacy procedures.
  */
 
+import { randomUUID } from "node:crypto";
 import { createLogger } from "@band-app/logger";
 import { TRPCError } from "@trpc/server";
 import { z } from "zod";
+import { formatShellCommand } from "../../services/_utils/format-shell-command";
 import { agentService } from "../../services/agent-service";
 import { chatService, InvalidLabelsError } from "../../services/chat-service";
 import { TaskConflictError, taskService } from "../../services/task-service";
+import { terminalService } from "../../services/terminal-service";
+import { emit } from "../../services/watcher-service";
 import { workspaceService } from "../../services/workspace-service";
 import { publicProcedure, t } from "../trpc";
 
@@ -291,6 +295,69 @@ export const chatsRouter = t.router({
     chatService.updateStatus(input.chatId, "idle");
     return { ok: true };
   }),
+
+  /**
+   * Continue this chat's coding-agent session in a terminal pane.
+   *
+   * Resolves the chat's underlying agent session ID (`activeSessionId`) and
+   * the adapter for whichever coding agent it ran, asks the adapter for the
+   * vendor CLI's *resume* invocation (`claude --resume <id>`,
+   * `codex resume <id>`, `opencode --session <id>`), composes it into a
+   * shell-safe command, and spawns a fresh terminal pane running it — so the
+   * user keeps working in the very session the web chat was running.
+   *
+   * Mirrors the spawn+emit pair in `WorkspaceService.create`'s
+   * `via=terminal` branch (issue #551), and resolves the agent inline the
+   * same way `setActiveSession` above does. Errors surface to the client so
+   * the UI can keep the menu item disabled for agents that can't resume
+   * (Gemini CLI / Cursor CLI) or chats with no session yet.
+   */
+  continueInTerminal: publicProcedure
+    .input(z.object({ chatId: z.string() }))
+    .mutation(async ({ input }) => {
+      const chat = chatService.get(input.chatId);
+      if (!chat) {
+        throw new TRPCError({ code: "NOT_FOUND", message: "Chat not found" });
+      }
+      if (!chat.activeSessionId) {
+        throw new TRPCError({
+          code: "PRECONDITION_FAILED",
+          message: "Chat has no active session to continue",
+        });
+      }
+
+      const workspace = workspaceService.resolve(chat.workspaceId);
+      if (!workspace) {
+        throw new TRPCError({ code: "NOT_FOUND", message: "Workspace not found" });
+      }
+
+      const agent = await agentService.getOrCreateAgent(
+        input.chatId,
+        workspace.worktree.path,
+        chat.agent,
+      );
+      const invocation = agent.resumeCliInvocation?.(chat.activeSessionId);
+      if (!invocation || invocation.unsupported) {
+        throw new TRPCError({
+          code: "BAD_REQUEST",
+          message: invocation?.reason ?? "Agent does not support resuming in a terminal",
+        });
+      }
+
+      const command = formatShellCommand(invocation.command, invocation.args);
+      const terminalId = randomUUID();
+      await terminalService.spawn(chat.workspaceId, terminalId, { command });
+      // Broadcast so an already-open dashboard adds the pane to its terminal
+      // dockview without a reload — same pattern as `terminal.create` and the
+      // `via=terminal` workspace-create path.
+      emit({ kind: "terminal-created", workspaceId: chat.workspaceId, terminalId });
+
+      log.info(
+        { chatId: input.chatId, workspaceId: chat.workspaceId, terminalId },
+        "continue chat session in terminal",
+      );
+      return { terminalId, workspaceId: chat.workspaceId, sessionId: chat.activeSessionId };
+    }),
 });
 
 export type ChatsRouter = typeof chatsRouter;

--- a/apps/web/src/server/api/chats/router.ts
+++ b/apps/web/src/server/api/chats/router.ts
@@ -312,7 +312,7 @@ export const chatsRouter = t.router({
    * (Gemini CLI / Cursor CLI) or chats with no session yet.
    */
   continueInTerminal: publicProcedure
-    .input(z.object({ chatId: z.string() }))
+    .input(z.object({ chatId: z.string().max(512) }))
     .mutation(async ({ input }) => {
       const result = await workspaceService.continueChatInTerminal(input.chatId);
       if (!result.ok) {

--- a/apps/web/src/server/api/chats/router.ts
+++ b/apps/web/src/server/api/chats/router.ts
@@ -19,16 +19,12 @@
  * shape as the pre-migration legacy procedures.
  */
 
-import { randomUUID } from "node:crypto";
 import { createLogger } from "@band-app/logger";
 import { TRPCError } from "@trpc/server";
 import { z } from "zod";
-import { formatShellCommand } from "../../services/_utils/format-shell-command";
 import { agentService } from "../../services/agent-service";
 import { chatService, InvalidLabelsError } from "../../services/chat-service";
 import { TaskConflictError, taskService } from "../../services/task-service";
-import { terminalService } from "../../services/terminal-service";
-import { emit } from "../../services/watcher-service";
 import { workspaceService } from "../../services/workspace-service";
 import { publicProcedure, t } from "../trpc";
 
@@ -198,7 +194,10 @@ export const chatsRouter = t.router({
       z.object({
         workspaceId: z.string(),
         chatId: z.string(),
-        sessionId: z.string().optional(),
+        // Cap the length: this id is persisted as `activeSessionId` and later
+        // flows into the resume command line (`continueInTerminal` →
+        // `formatShellCommand` → PTY). Real provider ids are well under this.
+        sessionId: z.string().max(512).optional(),
       }),
     )
     .mutation(async ({ input }) => {
@@ -255,7 +254,7 @@ export const chatsRouter = t.router({
         workspaceId: z.string(),
         chatId: z.string(),
         message: z.string(),
-        sessionId: z.string().optional(),
+        sessionId: z.string().max(512).optional(),
       }),
     )
     .mutation(({ input }) => {
@@ -315,48 +314,15 @@ export const chatsRouter = t.router({
   continueInTerminal: publicProcedure
     .input(z.object({ chatId: z.string() }))
     .mutation(async ({ input }) => {
-      const chat = chatService.get(input.chatId);
-      if (!chat) {
-        throw new TRPCError({ code: "NOT_FOUND", message: "Chat not found" });
+      const result = await workspaceService.continueChatInTerminal(input.chatId);
+      if (!result.ok) {
+        throw new TRPCError({ code: result.code, message: result.message });
       }
-      if (!chat.activeSessionId) {
-        throw new TRPCError({
-          code: "PRECONDITION_FAILED",
-          message: "Chat has no active session to continue",
-        });
-      }
-
-      const workspace = workspaceService.resolve(chat.workspaceId);
-      if (!workspace) {
-        throw new TRPCError({ code: "NOT_FOUND", message: "Workspace not found" });
-      }
-
-      const agent = await agentService.getOrCreateAgent(
-        input.chatId,
-        workspace.worktree.path,
-        chat.agent,
-      );
-      const invocation = agent.resumeCliInvocation?.(chat.activeSessionId);
-      if (!invocation || invocation.unsupported) {
-        throw new TRPCError({
-          code: "BAD_REQUEST",
-          message: invocation?.reason ?? "Agent does not support resuming in a terminal",
-        });
-      }
-
-      const command = formatShellCommand(invocation.command, invocation.args);
-      const terminalId = randomUUID();
-      await terminalService.spawn(chat.workspaceId, terminalId, { command });
-      // Broadcast so an already-open dashboard adds the pane to its terminal
-      // dockview without a reload — same pattern as `terminal.create` and the
-      // `via=terminal` workspace-create path.
-      emit({ kind: "terminal-created", workspaceId: chat.workspaceId, terminalId });
-
-      log.info(
-        { chatId: input.chatId, workspaceId: chat.workspaceId, terminalId },
-        "continue chat session in terminal",
-      );
-      return { terminalId, workspaceId: chat.workspaceId, sessionId: chat.activeSessionId };
+      return {
+        terminalId: result.terminalId,
+        workspaceId: result.workspaceId,
+        sessionId: result.sessionId,
+      };
     }),
 });
 

--- a/apps/web/src/server/services/_utils/format-shell-command.ts
+++ b/apps/web/src/server/services/_utils/format-shell-command.ts
@@ -1,0 +1,53 @@
+/**
+ * Compose a `command + args[]` invocation into a single shell-safe command
+ * string for a terminal pane's PTY (`terminalService.spawn` writes the
+ * `command` option directly to the shell as text, see
+ * `terminal-pool.ts::spawn`).
+ *
+ * Each token is:
+ *
+ *   1. **Stripped of C0/C1 control characters** (`\x00..\x1f`, `\x7f`,
+ *      `\x80..\x9f`). The PTY driver interprets these *before* the shell
+ *      tokenises the line — e.g. `\x03` becomes SIGINT, `\x04` is EOF,
+ *      `\x1b[` opens a CSI sequence; some emulators also act on C1
+ *      single-byte controls (`\x80..\x9f`) before the shell sees them.
+ *      The user-controlled fields (`prompt`, and downstream the agent
+ *      session ID) are plain strings so a malicious or malformed input
+ *      could otherwise abort the vendor CLI before it ever started. The
+ *      strip is per-token because the shell-quote dance only protects
+ *      against shell metacharacters, not against control codes the PTY
+ *      layer eats.
+ *   2. **Wrapped in single quotes**, with any embedded `'` rewritten as
+ *      `'\''` (POSIX-style — the only escape sequence single-quoted
+ *      strings accept). This is the same algorithm `shell-quote` and
+ *      `child_process`'s POSIX shell helpers use; inlined here to avoid
+ *      the dependency.
+ *
+ * Empty `args` returns the bare command so an interactive REPL without
+ * positional arguments still launches cleanly.
+ *
+ * Shared by the two terminal-spawn paths that compose a vendor-CLI
+ * invocation: `workspaces.create --via terminal` (issue #551) and the chat
+ * tab's "Continue in terminal" action.
+ */
+
+// Hoisted to module scope so the regex compiles once at load time
+// instead of on every `formatShellCommand` invocation. Matches the C0
+// range (`\x00..\x1f`), DEL (`\x7f`), and the C1 range (`\x80..\x9f`).
+// The character-class bounds are spelled with `String.fromCharCode` so
+// biome's `noControlCharactersInRegex` rule (which flags any literal
+// control-char in regex source) doesn't misread the intent.
+const PTY_CONTROL_CHAR_RANGE = new RegExp(
+  `[${String.fromCharCode(0)}-${String.fromCharCode(0x1f)}${String.fromCharCode(
+    0x7f,
+  )}-${String.fromCharCode(0x9f)}]`,
+  "g",
+);
+
+export function formatShellCommand(command: string, args: string[]): string {
+  const stripControls = (s: string) => s.replace(PTY_CONTROL_CHAR_RANGE, "");
+  const quoted = [command, ...args].map(
+    (token) => `'${stripControls(token).replace(/'/g, "'\\''")}'`,
+  );
+  return quoted.join(" ");
+}

--- a/apps/web/src/server/services/task-service.ts
+++ b/apps/web/src/server/services/task-service.ts
@@ -924,6 +924,27 @@ async function runTask(chatId: string, task: InternalTask) {
             task.sessionId = event.resolvedSessionId;
             persistTask(task);
           }
+
+          // Persist the resolved id on the chat row too. `session-start`
+          // stored the placeholder id (OpenCode emits a UUID up front, then
+          // resolves its real `ses_…` id after the run). Without this the
+          // chat row keeps that placeholder forever — which breaks resume /
+          // "Continue in terminal" (OpenCode's `--session` rejects a
+          // non-`ses_` id) and any reload that reads the persisted
+          // `activeSessionId`. Guard on the placeholder still being the
+          // chat's active session so we never clobber a session the user
+          // switched to mid-run; preserve the cached summary so the tab
+          // title doesn't flicker (the next `chats.get` re-resolves it
+          // against the now-correct id).
+          const resolvedChat = chatService.get(chatId);
+          if (resolvedChat?.activeSessionId === event.previousSessionId) {
+            chatService.updateActiveSession(chatId, {
+              activeSessionId: event.resolvedSessionId,
+              summary: resolvedChat.activeSessionSummary,
+              lastModified: resolvedChat.activeSessionLastModified ?? Date.now(),
+            });
+          }
+
           // Notify the client so it can update its local session reference
           broadcast(chatId, {
             type: "data-session" as UIMessageChunk["type"],

--- a/apps/web/src/server/services/workspace-service.ts
+++ b/apps/web/src/server/services/workspace-service.ts
@@ -17,6 +17,7 @@ import { killWorkspaceServers } from "../infra/lsp/lsp-manager";
 import { loadProjectConfig } from "../infra/setup/project-config";
 import { runSetup } from "../infra/setup/setup-runner";
 import { copyWorkspaceFiles } from "../infra/setup/workspace-files";
+import { formatShellCommand } from "./_utils/format-shell-command";
 import { clearQueuedMessages } from "./_utils/queued-message-store";
 // FRAGILE: ESM cycle leg — `services/task-service` now imports
 // `workspaceService` directly from this file (the `services/workspace.ts`
@@ -225,54 +226,6 @@ export class PlainProjectError extends Error {
  */
 function isRebaseCollision(err: unknown): boolean {
   return String(err).includes("Cannot rebase onto multiple branches");
-}
-
-/**
- * Compose a `command + args[]` invocation into a single shell-safe command
- * string for the terminal pane's PTY (`terminalService.spawn` writes the
- * `command` option directly to the shell as text, see
- * `terminal-pool.ts::spawn`).
- *
- * Each token is:
- *
- *   1. **Stripped of C0/C1 control characters** (`\x00..\x1f`, `\x7f`,
- *      `\x80..\x9f`). The PTY driver interprets these *before* the shell
- *      tokenises the line — e.g. `\x03` becomes SIGINT, `\x04` is EOF,
- *      `\x1b[` opens a CSI sequence; some emulators also act on C1
- *      single-byte controls (`\x80..\x9f`) before the shell sees them.
- *      The user-controlled `prompt` field is `z.string()` so a malicious
- *      or malformed input could otherwise abort the vendor CLI before
- *      it ever started. The strip is per-token because the shell-quote
- *      dance only protects against shell metacharacters, not against
- *      control codes the PTY layer eats.
- *   2. **Wrapped in single quotes**, with any embedded `'` rewritten as
- *      `'\''` (POSIX-style — the only escape sequence single-quoted
- *      strings accept). This is the same algorithm `shell-quote` and
- *      `child_process`'s POSIX shell helpers use; inlined here to avoid
- *      the dependency.
- *
- * Empty `args` returns the bare command so an interactive REPL without
- * positional arguments still launches cleanly.
- */
-// Hoisted to module scope so the regex compiles once at load time
-// instead of on every `formatShellCommand` invocation. Matches the C0
-// range (`\x00..\x1f`), DEL (`\x7f`), and the C1 range (`\x80..\x9f`).
-// The character-class bounds are spelled with `String.fromCharCode` so
-// biome's `noControlCharactersInRegex` rule (which flags any literal
-// control-char in regex source) doesn't misread the intent.
-const PTY_CONTROL_CHAR_RANGE = new RegExp(
-  `[${String.fromCharCode(0)}-${String.fromCharCode(0x1f)}${String.fromCharCode(
-    0x7f,
-  )}-${String.fromCharCode(0x9f)}]`,
-  "g",
-);
-
-function formatShellCommand(command: string, args: string[]): string {
-  const stripControls = (s: string) => s.replace(PTY_CONTROL_CHAR_RANGE, "");
-  const quoted = [command, ...args].map(
-    (token) => `'${stripControls(token).replace(/'/g, "'\\''")}'`,
-  );
-  return quoted.join(" ");
 }
 
 export class WorkspaceService {

--- a/apps/web/src/server/services/workspace-service.ts
+++ b/apps/web/src/server/services/workspace-service.ts
@@ -542,8 +542,9 @@ export class WorkspaceService {
    * `via=terminal` branch of {@link create} (issue #551).
    *
    * Returns a discriminated result rather than throwing so the tRPC router
-   * stays a thin mapping layer (CODE-8): `{ ok: false, code }` maps straight
-   * onto a `TRPCError`, `{ ok: true, … }` is echoed back to the client.
+   * stays a thin mapping layer — it validates input, delegates here, maps a
+   * `{ ok: false, code }` straight onto a `TRPCError`, and echoes
+   * `{ ok: true, … }` back to the client.
    */
   async continueChatInTerminal(chatId: string): Promise<ContinueChatInTerminalResult> {
     const chat = chatService.get(chatId);

--- a/apps/web/src/server/services/workspace-service.ts
+++ b/apps/web/src/server/services/workspace-service.ts
@@ -123,6 +123,15 @@ export const workspaceRemoveInput = z.object({
 });
 export type WorkspaceRemoveInput = z.infer<typeof workspaceRemoveInput>;
 
+/**
+ * Result of {@link WorkspaceService.continueChatInTerminal}. A discriminated
+ * union so the (thin) tRPC router maps the failure `code` straight onto a
+ * `TRPCError` without owning the resolve / build / spawn business logic.
+ */
+export type ContinueChatInTerminalResult =
+  | { ok: true; terminalId: string; workspaceId: string; sessionId: string }
+  | { ok: false; code: "NOT_FOUND" | "PRECONDITION_FAILED" | "BAD_REQUEST"; message: string };
+
 export const workspaceSetPinnedInput = z.object({
   project: z.string(),
   branch: z.string(),
@@ -519,6 +528,64 @@ export class WorkspaceService {
       return { ok: true, path: worktreePath };
     }
     return { ok: true, path: worktreePath, via, terminalId };
+  }
+
+  /**
+   * Continue a chat's coding-agent session in a terminal pane.
+   *
+   * Resolves the chat's underlying session id + the adapter for whichever
+   * agent it ran, asks the adapter for the vendor CLI's *resume* invocation
+   * (`claude --resume <id>`, `codex resume <id>`, `opencode --session <id>`),
+   * composes it into a shell-safe command, and spawns a fresh terminal pane
+   * running it — so the user keeps working in the very session the web chat
+   * was running. Shares the spawn + `terminal-created` emit shape with the
+   * `via=terminal` branch of {@link create} (issue #551).
+   *
+   * Returns a discriminated result rather than throwing so the tRPC router
+   * stays a thin mapping layer (CODE-8): `{ ok: false, code }` maps straight
+   * onto a `TRPCError`, `{ ok: true, … }` is echoed back to the client.
+   */
+  async continueChatInTerminal(chatId: string): Promise<ContinueChatInTerminalResult> {
+    const chat = chatService.get(chatId);
+    if (!chat) {
+      return { ok: false, code: "NOT_FOUND", message: "Chat not found" };
+    }
+    if (!chat.activeSessionId) {
+      return {
+        ok: false,
+        code: "PRECONDITION_FAILED",
+        message: "Chat has no active session to continue",
+      };
+    }
+
+    const workspace = this.resolve(chat.workspaceId);
+    if (!workspace) {
+      return { ok: false, code: "NOT_FOUND", message: "Workspace not found" };
+    }
+
+    const agent = await agentService.getOrCreateAgent(chatId, workspace.worktree.path, chat.agent);
+    const invocation = agent.resumeCliInvocation?.(chat.activeSessionId);
+    if (!invocation || invocation.unsupported) {
+      return {
+        ok: false,
+        code: "BAD_REQUEST",
+        message: invocation?.reason ?? "Agent does not support resuming in a terminal",
+      };
+    }
+
+    const command = formatShellCommand(invocation.command, invocation.args);
+    const terminalId = randomUUID();
+    await terminalService.spawn(chat.workspaceId, terminalId, { command });
+    // Broadcast so an already-open dashboard adds the pane to its terminal
+    // dockview without a reload — same pattern as `terminal.create` and the
+    // `via=terminal` create path.
+    emit({ kind: "terminal-created", workspaceId: chat.workspaceId, terminalId });
+
+    log.info(
+      { chatId, workspaceId: chat.workspaceId, terminalId },
+      "continue chat session in terminal",
+    );
+    return { ok: true, terminalId, workspaceId: chat.workspaceId, sessionId: chat.activeSessionId };
   }
 
   /**

--- a/apps/web/tests/chat-continue-in-terminal.test.ts
+++ b/apps/web/tests/chat-continue-in-terminal.test.ts
@@ -1,0 +1,343 @@
+// Integration tests for `chats.continueInTerminal`.
+//
+// The chat tab's "Continue in terminal" action resolves the chat's
+// underlying coding-agent session ID + the adapter for whichever agent it
+// ran, asks the adapter for the vendor CLI's *resume* invocation
+// (`claude --resume <id>`, `codex resume <id>`, `opencode --session <id>`),
+// composes it into a shell-safe command, and spawns a terminal pane running
+// it. This file pins:
+//
+//   1. happy path — a claude-code chat with an active session spawns a PTY
+//      whose argv carries `--resume <sessionId>`, and the call returns the
+//      terminalId + sessionId.
+//   2. no-session — a fresh chat with no active session is rejected
+//      (412 Precondition Failed) and spawns no terminal.
+//   3. unsupported agent — a gemini-cli chat (no session-resume CLI) is
+//      rejected (400 Bad Request).
+//   4. auth — the mutation requires the band_token cookie (401).
+//
+// Real production server (`dist/start-server.mjs`), real PTY (node-pty),
+// real git repo, real SQLite. No tRPC mocking, no MSW. Each describe block
+// boots its own server with a tmp `$HOME`, mirroring
+// `workspace-create-via.test.ts`, so an adapter that misbehaves in one
+// scenario can't cascade into the next.
+//
+// The spawned-process surface is a `stub-claude.sh` shell stub (the same
+// pattern as the via=terminal happy-path test) that echoes its argv as
+// `ARGV:<arg0>|<arg1>|…` — enough to prove the resume args reached the PTY
+// without needing a real vendor CLI. Setting the active session does NOT
+// require an on-disk session file: `chats.setActiveSession` tolerates a
+// missing JSONL (it persists the id with a null summary), which is exactly
+// what we want here.
+
+import { execFileSync } from "node:child_process";
+import { chmodSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { toWorkspaceId } from "@/dashboard";
+import { seedSettings, seedState } from "./helpers/seed-state";
+import {
+  createTmpHome,
+  type ServerHandle,
+  startServer,
+  trpcMutate,
+  trpcQuery,
+} from "./helpers/server";
+import { waitFor } from "./helpers/wait-for";
+
+const gitEnv = {
+  ...process.env,
+  GIT_AUTHOR_NAME: "Test",
+  GIT_AUTHOR_EMAIL: "test@test.com",
+  GIT_COMMITTER_NAME: "Test",
+  GIT_COMMITTER_EMAIL: "test@test.com",
+};
+
+function git(cwd: string, args: string[]): string {
+  return execFileSync("git", args, { cwd, env: gitEnv, encoding: "utf-8" });
+}
+
+function createGitRepo(parentDir: string, name: string): string {
+  const repoPath = join(parentDir, name);
+  mkdirSync(repoPath, { recursive: true });
+  git(repoPath, ["init", "-b", "main"]);
+  writeFileSync(join(repoPath, "README.md"), "# continue-in-terminal test\n");
+  git(repoPath, ["add", "."]);
+  git(repoPath, ["commit", "-m", "init"]);
+  return repoPath;
+}
+
+/**
+ * Stub vendor CLI. Prints `ARGV:<arg0>|<arg1>|…` so the test can pin both
+ * the binary the adapter picked AND the resume args threaded through. The
+ * script exits immediately — we test the *invocation*, not an interactive
+ * REPL. The terminal pool drains stdout into its scrollback, read back via
+ * `terminal.output`.
+ */
+function writeStubVendorCli(tmpHome: string, name: string): string {
+  const binPath = join(tmpHome, name);
+  writeFileSync(
+    binPath,
+    `#!/bin/sh\nprintf 'ARGV:'\nfor arg in "$@"; do printf '%s|' "$arg"; done\nprintf '\\n'\n`,
+    "utf-8",
+  );
+  chmodSync(binPath, 0o755);
+  return binPath;
+}
+
+interface TerminalListEntry {
+  terminalId: string;
+  workspaceId: string;
+  pid: number;
+}
+
+async function listTerminals(
+  serverUrl: string,
+  workspaceId: string,
+  token: string,
+): Promise<TerminalListEntry[]> {
+  const res = await trpcQuery(serverUrl, "terminal.list", { workspaceId }, token);
+  const body = await res.text();
+  expect(res.status, `terminal.list failed: ${body}`).toBe(200);
+  return (JSON.parse(body) as { result: { data: { terminals: TerminalListEntry[] } } }).result.data
+    .terminals;
+}
+
+async function readTerminalOutput(
+  serverUrl: string,
+  terminalId: string,
+  token: string,
+): Promise<string | null> {
+  const res = await trpcQuery(serverUrl, "terminal.output", { terminalId }, token);
+  const body = await res.text();
+  if (res.status === 404) return null;
+  expect(res.status, `terminal.output failed: ${body}`).toBe(200);
+  return (JSON.parse(body) as { result: { data: { output: string } } }).result.data.output;
+}
+
+async function createChat(
+  serverUrl: string,
+  workspaceId: string,
+  agent: string,
+  token: string,
+): Promise<string> {
+  const res = await trpcMutate(serverUrl, "chats.create", { workspaceId, agent }, token);
+  const body = await res.text();
+  expect(res.status, `chats.create failed: ${body}`).toBe(200);
+  return (JSON.parse(body) as { result: { data: { chat: { id: string } } } }).result.data.chat.id;
+}
+
+async function setActiveSession(
+  serverUrl: string,
+  workspaceId: string,
+  chatId: string,
+  sessionId: string,
+  token: string,
+): Promise<void> {
+  const res = await trpcMutate(
+    serverUrl,
+    "chats.setActiveSession",
+    { workspaceId, chatId, sessionId },
+    token,
+  );
+  const body = await res.text();
+  expect(res.status, `chats.setActiveSession failed: ${body}`).toBe(200);
+}
+
+interface ContinueResponse {
+  terminalId: string;
+  workspaceId: string;
+  sessionId: string;
+}
+
+// ---------------------------------------------------------------------------
+// Happy path + no-active-session, on a single claude-code server.
+// ---------------------------------------------------------------------------
+
+describe("chats.continueInTerminal — claude-code", () => {
+  const TOKEN = "continue-terminal-claude-token";
+  const PROJECT = "cont-proj";
+  const WORKSPACE_ID = toWorkspaceId(PROJECT, "main");
+  let server: ServerHandle;
+  let tmpHome: string;
+
+  beforeAll(async () => {
+    tmpHome = createTmpHome("band-continue-terminal-claude-");
+    const repoPath = createGitRepo(tmpHome, PROJECT);
+    const stubBin = writeStubVendorCli(tmpHome, "stub-claude.sh");
+    seedState(tmpHome, {
+      projects: [
+        {
+          name: PROJECT,
+          path: repoPath,
+          defaultBranch: "main",
+          worktrees: [{ branch: "main", path: repoPath }],
+        },
+      ],
+    });
+    seedSettings(tmpHome, {
+      tokenSecret: TOKEN,
+      codingAgents: [
+        { id: "claude-code", type: "claude-code", label: "Claude Code", command: stubBin },
+      ],
+    });
+    // The fire-and-forget boot model refresh fires for this claude-code
+    // agent and can't complete a model query against the 2-line stub; the
+    // adapter's internal timeout catches it and the "refresh failed" log
+    // line is expected and benign (same note as workspace-create-via).
+    server = await startServer({ tmpHome });
+  });
+
+  afterAll(async () => {
+    await server.close();
+    rmSync(tmpHome, { recursive: true, force: true });
+  });
+
+  it("spawns a terminal running the resume command and returns the session id", async () => {
+    const SESSION_ID = "sess-resume-abc123";
+    const chatId = await createChat(server.url, WORKSPACE_ID, "claude-code", TOKEN);
+    await setActiveSession(server.url, WORKSPACE_ID, chatId, SESSION_ID, TOKEN);
+
+    const res = await trpcMutate(server.url, "chats.continueInTerminal", { chatId }, TOKEN);
+    const body = await res.text();
+    expect(res.status, body).toBe(200);
+    const data = (JSON.parse(body) as { result: { data: ContinueResponse } }).result.data;
+
+    expect(data.sessionId).toBe(SESSION_ID);
+    expect(typeof data.terminalId).toBe("string");
+    expect(data.terminalId.length).toBeGreaterThan(0);
+
+    // The terminal is registered against the workspace.
+    const terminals = await waitFor(
+      async () => {
+        const list = await listTerminals(server.url, WORKSPACE_ID, TOKEN);
+        return list.find((t) => t.terminalId === data.terminalId) ? list : undefined;
+      },
+      { label: "resume terminal registered" },
+    );
+    expect(terminals.some((t) => t.terminalId === data.terminalId)).toBe(true);
+
+    // The vendor CLI received `--resume <sessionId>` as its argv.
+    const output = await waitFor(
+      async () => {
+        const out = await readTerminalOutput(server.url, data.terminalId, TOKEN);
+        return out?.includes("ARGV:") && out.includes(`--resume|${SESSION_ID}|`) ? out : undefined;
+      },
+      { label: "stub vendor CLI resume argv echoed" },
+    );
+    expect(output).toContain(`--resume|${SESSION_ID}|`);
+  });
+
+  it("rejects a chat with no active session (412) and spawns no terminal", async () => {
+    const chatId = await createChat(server.url, WORKSPACE_ID, "claude-code", TOKEN);
+
+    const res = await trpcMutate(server.url, "chats.continueInTerminal", { chatId }, TOKEN);
+    const body = await res.text();
+    // tRPC maps PRECONDITION_FAILED → HTTP 412.
+    expect(res.status, body).toBe(412);
+    expect(body).toContain("no active session");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Unsupported agent — gemini-cli has no session-resume CLI, so the adapter
+// returns the `unsupported` sentinel and the server rejects with 400. The
+// gemini adapter's `runSession` is never invoked here (only the pure-data
+// `resumeCliInvocation`), so a stub binary is safe.
+// ---------------------------------------------------------------------------
+
+describe("chats.continueInTerminal — unsupported agent", () => {
+  const TOKEN = "continue-terminal-gemini-token";
+  const PROJECT = "cont-gem-proj";
+  const WORKSPACE_ID = toWorkspaceId(PROJECT, "main");
+  let server: ServerHandle;
+  let tmpHome: string;
+
+  beforeAll(async () => {
+    tmpHome = createTmpHome("band-continue-terminal-gemini-");
+    const repoPath = createGitRepo(tmpHome, PROJECT);
+    const stubBin = writeStubVendorCli(tmpHome, "stub-gemini.sh");
+    seedState(tmpHome, {
+      projects: [
+        {
+          name: PROJECT,
+          path: repoPath,
+          defaultBranch: "main",
+          worktrees: [{ branch: "main", path: repoPath }],
+        },
+      ],
+    });
+    seedSettings(tmpHome, {
+      tokenSecret: TOKEN,
+      codingAgents: [
+        { id: "gemini-cli", type: "gemini-cli", label: "Gemini CLI", command: stubBin },
+      ],
+      defaultCodingAgent: "gemini-cli",
+    });
+    server = await startServer({ tmpHome });
+  });
+
+  afterAll(async () => {
+    await server.close();
+    rmSync(tmpHome, { recursive: true, force: true });
+  });
+
+  it("rejects with 400 when the agent has no resume CLI", async () => {
+    const chatId = await createChat(server.url, WORKSPACE_ID, "gemini-cli", TOKEN);
+    await setActiveSession(server.url, WORKSPACE_ID, chatId, "gemini-session-1", TOKEN);
+
+    const res = await trpcMutate(server.url, "chats.continueInTerminal", { chatId }, TOKEN);
+    const body = await res.text();
+    expect(res.status, body).toBe(400);
+    expect(body).toContain("Gemini CLI");
+
+    // No terminal was spawned for the workspace.
+    const terminals = await listTerminals(server.url, WORKSPACE_ID, TOKEN);
+    expect(terminals).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Auth — the mutation is part of the chats router contract; it must reject
+// a call without the band_token cookie.
+// ---------------------------------------------------------------------------
+
+describe("chats.continueInTerminal — auth", () => {
+  const TOKEN = "continue-terminal-auth-token";
+  const PROJECT = "cont-auth-proj";
+  let server: ServerHandle;
+  let tmpHome: string;
+
+  beforeAll(async () => {
+    tmpHome = createTmpHome("band-continue-terminal-auth-");
+    const repoPath = createGitRepo(tmpHome, PROJECT);
+    seedState(tmpHome, {
+      projects: [
+        {
+          name: PROJECT,
+          path: repoPath,
+          defaultBranch: "main",
+          worktrees: [{ branch: "main", path: repoPath }],
+        },
+      ],
+    });
+    seedSettings(tmpHome, { tokenSecret: TOKEN });
+    server = await startServer({ tmpHome });
+  });
+
+  afterAll(async () => {
+    await server.close();
+    rmSync(tmpHome, { recursive: true, force: true });
+  });
+
+  it("rejects without the band_token cookie (401)", async () => {
+    // The shared `trpcMutate` always sends the cookie, so call `fetch`
+    // directly to omit it — mirrors the via-terminal auth guard.
+    const res = await fetch(`${server.url}/trpc/chats.continueInTerminal`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ chatId: "chat_whatever" }),
+    });
+    expect(res.status).toBe(401);
+  });
+});

--- a/apps/web/tests/chat-continue-in-terminal.test.ts
+++ b/apps/web/tests/chat-continue-in-terminal.test.ts
@@ -289,7 +289,9 @@ describe("chats.continueInTerminal — unsupported agent", () => {
     const res = await trpcMutate(server.url, "chats.continueInTerminal", { chatId }, TOKEN);
     const body = await res.text();
     expect(res.status, body).toBe(400);
-    expect(body).toContain("Gemini CLI");
+    // Pin the full reason (the literal from gemini-cli.ts) so a partial
+    // rename of the message still trips this.
+    expect(body).toContain("Gemini CLI has no session-resume invocation");
 
     // No terminal was spawned for the workspace.
     const terminals = await listTerminals(server.url, WORKSPACE_ID, TOKEN);

--- a/apps/web/tests/opencode-session-id-resolved.test.ts
+++ b/apps/web/tests/opencode-session-id-resolved.test.ts
@@ -157,8 +157,8 @@ describe("OpenCode session-id-resolved persists the real ses_ id on the chat row
   it("rejects chats.send without the band_token cookie (401)", async () => {
     // The shared `trpcMutate` always sends the cookie, so call `fetch`
     // directly to omit it — this file drives `chats.send`, so it owns the
-    // baseline auth guard for that surface (TEST-13). Mirrors the auth
-    // checks in `chat-continue-in-terminal.test.ts` / `workspace-create-via`.
+    // baseline auth guard for that surface. Mirrors the auth checks in
+    // `chat-continue-in-terminal.test.ts` / `workspace-create-via`.
     const res = await fetch(`${server.url}/trpc/chats.send`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },

--- a/apps/web/tests/opencode-session-id-resolved.test.ts
+++ b/apps/web/tests/opencode-session-id-resolved.test.ts
@@ -1,0 +1,156 @@
+// Integration test for the OpenCode `session-id-resolved` → chat-row
+// persistence path.
+//
+// OpenCode emits a placeholder UUID in its `session-start` event, then
+// resolves its real `ses_…` id after the run and emits `session-id-resolved`.
+// Band's `task-service` must persist that resolved id onto the chat row —
+// otherwise `chat.activeSessionId` keeps the placeholder UUID, and anything
+// that reads it (resume, the chat tab's "Continue in terminal") builds an
+// `opencode --session <uuid>` command that OpenCode rejects with
+// "Invalid session ID: Expected a string starting with 'ses'".
+//
+// This was a latent bug (in-app resume silently retried without `--session`,
+// creating a fresh session) surfaced by the "Continue in terminal" feature.
+//
+// Real production server (`dist/start-server.mjs`), real SQLite, real task
+// pipeline. The only stub is the `opencode` binary itself: a tiny Node
+// script that speaks the two subcommands the adapter drives — `run`
+// (NDJSON output) and `session list` (returns the real `ses_…` id). No
+// tRPC mocking.
+
+import { chmodSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { toWorkspaceId } from "@/dashboard";
+import { seedSettings, seedState } from "./helpers/seed-state";
+import {
+  createTmpHome,
+  type ServerHandle,
+  startServer,
+  trpcMutate,
+  trpcQuery,
+} from "./helpers/server";
+import { waitFor } from "./helpers/wait-for";
+
+const RESOLVED_SESSION_ID = "ses_stubresolved0123456789";
+
+/**
+ * Stub `opencode` binary. Handles the subcommands the adapter drives:
+ *   - `run --format json …` → one NDJSON text event, then exit 0.
+ *   - `session list --format json` → a one-element array carrying the real
+ *     `ses_…` id the adapter resolves to.
+ *   - anything else (`models --verbose`, `export …`) → no-op success, so the
+ *     boot model-refresh and the lazy summary lookup degrade gracefully.
+ */
+function writeOpencodeStub(tmpHome: string): string {
+  const binPath = join(tmpHome, "opencode-stub.mjs");
+  writeFileSync(
+    binPath,
+    `#!/usr/bin/env node
+const args = process.argv.slice(2);
+if (args[0] === "run") {
+  process.stdout.write(JSON.stringify({ type: "text", part: { text: "ok from opencode stub" } }) + "\\n");
+  process.exit(0);
+}
+if (args[0] === "session" && args[1] === "list") {
+  process.stdout.write(JSON.stringify([{ id: ${JSON.stringify(RESOLVED_SESSION_ID)}, updated: Date.now(), title: "stub session" }]));
+  process.exit(0);
+}
+process.exit(0);
+`,
+    "utf-8",
+  );
+  chmodSync(binPath, 0o755);
+  return binPath;
+}
+
+async function createChat(serverUrl: string, workspaceId: string, token: string): Promise<string> {
+  const res = await trpcMutate(
+    serverUrl,
+    "chats.create",
+    { workspaceId, agent: "opencode" },
+    token,
+  );
+  const body = await res.text();
+  expect(res.status, `chats.create failed: ${body}`).toBe(200);
+  return (JSON.parse(body) as { result: { data: { chat: { id: string } } } }).result.data.chat.id;
+}
+
+async function getChat(
+  serverUrl: string,
+  chatId: string,
+  token: string,
+): Promise<{ activeSessionId?: string } | null> {
+  const res = await trpcQuery(serverUrl, "chats.get", { chatId }, token);
+  const body = await res.text();
+  expect(res.status, `chats.get failed: ${body}`).toBe(200);
+  return (JSON.parse(body) as { result: { data: { chat: { activeSessionId?: string } | null } } })
+    .result.data.chat;
+}
+
+describe("OpenCode session-id-resolved persists the real ses_ id on the chat row", () => {
+  const TOKEN = "opencode-session-resolved-token";
+  const PROJECT = "ocproj";
+  const WORKSPACE_ID = toWorkspaceId(PROJECT, "main");
+  let server: ServerHandle;
+  let tmpHome: string;
+
+  beforeAll(async () => {
+    tmpHome = createTmpHome("band-opencode-session-resolved-");
+    // The worktree dir must exist on disk — the adapter spawns the stub
+    // with it as cwd.
+    const worktreePath = join(tmpHome, PROJECT);
+    mkdirSync(worktreePath, { recursive: true });
+    const stubBin = writeOpencodeStub(tmpHome);
+    seedState(tmpHome, {
+      projects: [
+        {
+          name: PROJECT,
+          path: worktreePath,
+          defaultBranch: "main",
+          worktrees: [{ branch: "main", path: worktreePath }],
+        },
+      ],
+    });
+    seedSettings(tmpHome, {
+      tokenSecret: TOKEN,
+      codingAgents: [{ id: "opencode", type: "opencode", label: "OpenCode", command: stubBin }],
+      defaultCodingAgent: "opencode",
+    });
+    server = await startServer({ tmpHome });
+  });
+
+  afterAll(async () => {
+    await server.close();
+    rmSync(tmpHome, { recursive: true, force: true });
+  });
+
+  it("chat.activeSessionId becomes the resolved ses_ id, not the placeholder UUID", async () => {
+    const chatId = await createChat(server.url, WORKSPACE_ID, TOKEN);
+
+    // Kick off a new session (no sessionId) — the adapter emits a
+    // placeholder UUID up front, then resolves the real ses_ id.
+    const sendRes = await trpcMutate(
+      server.url,
+      "chats.send",
+      { workspaceId: WORKSPACE_ID, chatId, message: "hello opencode" },
+      TOKEN,
+    );
+    const sendBody = await sendRes.text();
+    expect(sendRes.status, sendBody).toBe(200);
+
+    // Poll the persisted chat row until the resolved id lands. Before the
+    // fix this stayed the placeholder UUID forever and the poll would time
+    // out (the regression guard).
+    const activeSessionId = await waitFor(
+      async () => {
+        const chat = await getChat(server.url, chatId, TOKEN);
+        return chat?.activeSessionId === RESOLVED_SESSION_ID ? chat.activeSessionId : undefined;
+      },
+      { label: "chat row carries the resolved ses_ id" },
+    );
+    expect(activeSessionId).toBe(RESOLVED_SESSION_ID);
+    // And it is NOT a bare UUID placeholder.
+    expect(activeSessionId.startsWith("ses_")).toBe(true);
+  });
+});

--- a/apps/web/tests/opencode-session-id-resolved.test.ts
+++ b/apps/web/tests/opencode-session-id-resolved.test.ts
@@ -153,4 +153,17 @@ describe("OpenCode session-id-resolved persists the real ses_ id on the chat row
     // And it is NOT a bare UUID placeholder.
     expect(activeSessionId.startsWith("ses_")).toBe(true);
   });
+
+  it("rejects chats.send without the band_token cookie (401)", async () => {
+    // The shared `trpcMutate` always sends the cookie, so call `fetch`
+    // directly to omit it — this file drives `chats.send`, so it owns the
+    // baseline auth guard for that surface (TEST-13). Mirrors the auth
+    // checks in `chat-continue-in-terminal.test.ts` / `workspace-create-via`.
+    const res = await fetch(`${server.url}/trpc/chats.send`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ workspaceId: WORKSPACE_ID, chatId: "chat_whatever", message: "x" }),
+    });
+    expect(res.status).toBe(401);
+  });
 });

--- a/packages/coding-agent/src/adapters/claude-code.ts
+++ b/packages/coding-agent/src/adapters/claude-code.ts
@@ -769,6 +769,19 @@ export class ClaudeCodeAdapter implements CodingAgent {
   }
 
   /**
+   * Resume CLI invocation for the chat tab's "Continue in terminal" action.
+   * `claude --resume <session-id>` reopens the interactive REPL with that
+   * exact conversation restored (session-ID lookup is scoped to the
+   * project directory + its worktrees, which is where we spawn the PTY).
+   */
+  resumeCliInvocation(sessionId: string): CliInvocation {
+    return {
+      command: this.executablePath ?? CLAUDE_CODE_DEFAULT_BINARY,
+      args: ["--resume", sessionId],
+    };
+  }
+
+  /**
    * No static fallback. The live `supportedModels()` SDK call is the
    * single source of truth; `refreshModels()` populates
    * `~/.band/settings.json` at boot and on user request, and the

--- a/packages/coding-agent/src/adapters/codex.ts
+++ b/packages/coding-agent/src/adapters/codex.ts
@@ -510,6 +510,18 @@ export class CodexAdapter implements CodingAgent {
     };
   }
 
+  /**
+   * Resume CLI invocation for the chat tab's "Continue in terminal" action.
+   * `codex resume <session-id>` reopens the interactive Codex TUI with that
+   * thread restored.
+   */
+  resumeCliInvocation(sessionId: string): CliInvocation {
+    return {
+      command: this.executablePath ?? CODEX_DEFAULT_BINARY,
+      args: ["resume", sessionId],
+    };
+  }
+
   async listSessions(dir: string): Promise<SessionListItem[]> {
     log.info({ dir }, "listSessions");
     const sessions = await readCodexSessions();

--- a/packages/coding-agent/src/adapters/cursor-cli.ts
+++ b/packages/coding-agent/src/adapters/cursor-cli.ts
@@ -186,6 +186,19 @@ export class CursorCliAdapter implements CodingAgent {
       reason: "Cursor CLI has no interactive prompt-loading invocation; falling back to chat.",
     };
   }
+
+  /**
+   * The chat tab's "Continue in terminal" action has no Cursor equivalent:
+   * the agent runs over the SDK's managed JSON subprocess, with no
+   * interactive by-id resume CLI. Returning the `unsupported` sentinel
+   * keeps the menu item disabled.
+   */
+  resumeCliInvocation(_sessionId: string): CliInvocation {
+    return {
+      unsupported: true,
+      reason: "Cursor CLI has no interactive session-resume invocation.",
+    };
+  }
 }
 
 /**

--- a/packages/coding-agent/src/adapters/gemini-cli.ts
+++ b/packages/coding-agent/src/adapters/gemini-cli.ts
@@ -226,6 +226,18 @@ export class GeminiCliAdapter implements CodingAgent {
       args: ["--", prompt],
     };
   }
+
+  /**
+   * The chat tab's "Continue in terminal" action has no Gemini equivalent:
+   * the Gemini CLI has no session model, so there's no session ID to resume
+   * by. Returning the `unsupported` sentinel keeps the menu item disabled.
+   */
+  resumeCliInvocation(_sessionId: string): CliInvocation {
+    return {
+      unsupported: true,
+      reason: "Gemini CLI has no session-resume invocation.",
+    };
+  }
 }
 
 /** Default executable name for the Gemini CLI. */

--- a/packages/coding-agent/src/adapters/opencode.ts
+++ b/packages/coding-agent/src/adapters/opencode.ts
@@ -350,6 +350,19 @@ export class OpenCodeAdapter implements CodingAgent {
     };
   }
 
+  /**
+   * Resume CLI invocation for the chat tab's "Continue in terminal" action.
+   * `opencode --session <id>` launches the interactive TUI on that exact
+   * session (the same `--session` flag `runSession` uses for headless
+   * `opencode run`).
+   */
+  resumeCliInvocation(sessionId: string): CliInvocation {
+    return {
+      command: this.executablePath,
+      args: ["--session", sessionId],
+    };
+  }
+
   async listSessions(dir: string): Promise<SessionListItem[]> {
     // `opencode session list` already filters by CWD, so we just
     // pass `dir` as the working directory — no extra filtering needed.

--- a/packages/coding-agent/src/types.ts
+++ b/packages/coding-agent/src/types.ts
@@ -262,4 +262,18 @@ export interface CodingAgent {
    * so the create call still succeeds.
    */
   cliInvocation?(prompt: string): CliInvocation;
+  /**
+   * Resolve the CLI invocation that *resumes* an existing agent session in
+   * an interactive terminal pane (`claude --resume <id>`, `codex resume
+   * <id>`, `opencode --session <id>`). Powers the chat tab's "Continue in
+   * terminal" action: the server composes the returned `command + args`
+   * into a shell line and spawns it inside the workspace's PTY so the user
+   * keeps working in the very session the web chat was running.
+   *
+   * Adapters whose vendor binary has no by-id resume affordance (Gemini
+   * CLI has no session model; Cursor CLI is SDK-only) return
+   * `{ unsupported: true, reason: "..." }`; callers surface the reason and
+   * leave the menu item disabled rather than spawning a useless terminal.
+   */
+  resumeCliInvocation?(sessionId: string): CliInvocation;
 }


### PR DESCRIPTION
## What

Adds two right-click actions to a chat tab in the web chat view:

- **Continue in terminal** — resolves the chat's underlying coding-agent session ID and the agent it ran, builds that agent's CLI **resume** command, spawns a terminal pane running it, and switches the workspace to the Terminal panel so the user keeps working in the same session.
- **Copy session ID** — copies the chat's underlying session ID to the clipboard.

Items disable themselves when the action isn't possible (no active session, or an agent with no resume CLI).

## How

- **`resumeCliInvocation(sessionId)`** — new optional method on the `CodingAgent` interface, implemented across all five adapters:
  - claude-code → `claude --resume <id>`
  - codex → `codex resume <id>`
  - opencode → `opencode --session <id>`
  - gemini-cli / cursor-cli → `unsupported` (no interactive by-id resume)
- **`chats.continueInTerminal`** tRPC procedure — resolves chat session + agent, builds the resume command, shell-escapes it, spawns the PTY, and emits `terminal-created`. Mirrors the existing `workspaces.create --via terminal` flow.
- **`formatShellCommand`** extracted into a shared `_utils` helper, reused by both terminal-spawn paths.
- **`onActivateTerminalPanel`** cross-panel handler surfaces the Terminal panel after spawning.
- **Copy** uses the existing `writeClipboardText` helper so it works in non-secure contexts (LAN IP / non-HTTPS tunnel), not just secure-context `navigator.clipboard`.

## Bonus bug fix

Surfaced (and fixed) a latent OpenCode issue: OpenCode reports a placeholder UUID in `session-start`, then resolves its real `ses_…` id afterward. `task-service` persisted the placeholder onto the chat row but never updated it on `session-id-resolved`, so resume built `opencode --session <uuid>` which OpenCode rejects. The handler now persists the resolved `ses_…` id.

## Tests

- Backend integration (`chat-continue-in-terminal.test.ts`): asserts the resume argv reaches the PTY; negatives for no-session (412), unsupported agent (400), and auth (401).
- Backend integration (`opencode-session-id-resolved.test.ts`): an `opencode` stub binary proves the resolved `ses_…` id lands on the persisted chat row.
- Playwright e2e (`chat-continue-in-terminal.spec.ts` + `WorkspacePage` page-object additions): right-click → copy session id (with a non-secure-context clipboard guard) → continue in terminal switches to the Terminal panel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)