### PR TITLE
fix(web): browser pane native-view overlap + allow closing last tab

### DIFF
--- a/apps/web/src/components/DockviewBrowserContainer.tsx
+++ b/apps/web/src/components/DockviewBrowserContainer.tsx
@@ -221,7 +221,6 @@ function BrowserTabPanel({ params, api }: IDockviewPanelProps<BrowserTabParams>)
 
 function BrowserTab(props: IDockviewPanelHeaderProps<BrowserTabParams>) {
   const [title, setTitle] = useState(props.api.title ?? "New Tab");
-  const [panelCount, setPanelCount] = useState(props.containerApi.panels.length);
   const [faviconError, setFaviconError] = useState(false);
 
   const browserId = props.params.browserId;
@@ -239,18 +238,6 @@ function BrowserTab(props: IDockviewPanelHeaderProps<BrowserTabParams>) {
     return () => d.dispose();
   }, [props.api]);
 
-  // Track panel count reactively for close button visibility
-  useEffect(() => {
-    const cApi = props.containerApi;
-    const update = () => setPanelCount(cApi.panels.length);
-    const d1 = cApi.onDidAddPanel(update);
-    const d2 = cApi.onDidRemovePanel(update);
-    return () => {
-      d1.dispose();
-      d2.dispose();
-    };
-  }, [props.containerApi]);
-
   const handleClose = useCallback(
     (e: React.MouseEvent) => {
       e.stopPropagation();
@@ -258,8 +245,6 @@ function BrowserTab(props: IDockviewPanelHeaderProps<BrowserTabParams>) {
     },
     [browserId],
   );
-
-  const showClose = panelCount > 1;
 
   const showFavicon = faviconUrl && !faviconError;
 
@@ -278,16 +263,14 @@ function BrowserTab(props: IDockviewPanelHeaderProps<BrowserTabParams>) {
         )}
         <span className="truncate">{title}</span>
       </div>
-      {showClose && (
-        <button
-          type="button"
-          className="ml-1 inline-flex size-4 items-center justify-center rounded-sm opacity-60 hover:opacity-100 hover:bg-accent transition-colors"
-          onClick={handleClose}
-          title="Close tab"
-        >
-          <X className="size-3" />
-        </button>
-      )}
+      <button
+        type="button"
+        className="ml-1 inline-flex size-4 items-center justify-center rounded-sm opacity-60 hover:opacity-100 hover:bg-accent transition-colors"
+        onClick={handleClose}
+        title="Close tab"
+      >
+        <X className="size-3" />
+      </button>
     </div>
   );
 }
@@ -571,32 +554,42 @@ export function DockviewBrowserContainer({
     [workspaceId],
   );
 
-  const closeTab = useCallback((browserId: string) => {
-    const api = apiRef.current;
-    if (!api || api.panels.length <= 1) return; // don't close last tab
+  const closeTab = useCallback(
+    (browserId: string) => {
+      const api = apiRef.current;
+      if (!api) return;
 
-    selectNeighbourBeforeRemove(api, browserId);
-    const panel = api.getPanel(browserId);
-    if (panel) {
-      api.removePanel(panel);
-    }
+      selectNeighbourBeforeRemove(api, browserId);
+      const panel = api.getPanel(browserId);
+      if (panel) {
+        api.removePanel(panel);
+      }
 
-    // After closing, focus the address bar in the newly active panel so the
-    // section-scoped keydown handler still sees Cmd+W on the next press.
-    requestAnimationFrame(() => {
-      const activePanel = api.activePanel;
-      if (!activePanel) return;
-      activePanel.view.content.element
-        .querySelector<HTMLInputElement>("[data-band-address-input]")
-        ?.focus();
-    });
+      // Closing the last tab would leave an empty pane — spawn a fresh
+      // blank tab so the browser section is never a dead end (matches the
+      // self-heal in the `browser-removed` status-event handler).
+      if (api.panels.length === 0) {
+        createDefaultPanel(api, workspaceId);
+      }
 
-    // Delete the server-side browser record so closed tabs don't linger.
-    trpc.browsers.remove.mutate({ browserId }).catch((err) => {
-      console.error("[DockviewBrowserContainer] failed to remove browser:", err);
-    });
-    // Layout change listeners will auto-persist
-  }, []);
+      // After closing, focus the address bar in the newly active panel so the
+      // section-scoped keydown handler still sees Cmd+W on the next press.
+      requestAnimationFrame(() => {
+        const activePanel = api.activePanel;
+        if (!activePanel) return;
+        activePanel.view.content.element
+          .querySelector<HTMLInputElement>("[data-band-address-input]")
+          ?.focus();
+      });
+
+      // Delete the server-side browser record so closed tabs don't linger.
+      trpc.browsers.remove.mutate({ browserId }).catch((err) => {
+        console.error("[DockviewBrowserContainer] failed to remove browser:", err);
+      });
+      // Layout change listeners will auto-persist
+    },
+    [workspaceId],
+  );
 
   // Keyboard shortcuts (capture phase, scoped to this section's focus):
   // - Cmd/Ctrl+T              → open a new browser tab
@@ -681,7 +674,7 @@ export function DockviewBrowserContainer({
         });
       } else if (key === "w" && !e.shiftKey) {
         const api = apiRef.current;
-        if (!api || api.panels.length <= 1) return;
+        if (!api) return;
         e.preventDefault();
         e.stopPropagation();
         const active = api.activePanel;

--- a/apps/web/src/hooks/useBrowserPaneFreeze.ts
+++ b/apps/web/src/hooks/useBrowserPaneFreeze.ts
@@ -136,8 +136,19 @@ export function useBrowserPaneFreeze(args: UseBrowserPaneFreezeArgs): UseBrowser
         desktopInvoke("browser_hide", ipcKey).catch(() => {});
       })();
     } else {
-      if (freezeAppliedRef.current) {
-        freezeAppliedRef.current = false;
+      const wasApplied = freezeAppliedRef.current;
+      freezeAppliedRef.current = false;
+      // Only surface the native view if we hid it AND this pane is
+      // still the one the user is looking at. If the pane went hidden
+      // between freeze and unfreeze — the user switched workspaces or
+      // dockview tabs while the overlay was open — calling
+      // `browser_show` here would float this workspace's
+      // `WebContentsView` (an OS-compositor layer that ignores CSS
+      // opacity/z-index) on top of whatever workspace is now active,
+      // stuck until app restart. When the pane becomes visible again
+      // the `wsActive` effect in `BrowserPanel` re-shows it; we don't
+      // need to here.
+      if (wasApplied && visible) {
         const ipcKey = ipcKeyRef.current;
         desktopInvoke("browser_show", ipcKey).catch(() => {});
         // Resume after show so the page is visible by the time


### PR DESCRIPTION
## PO Summary

Two fixes to the in-app **Browser** pane (desktop app):

1. **No more stuck browser overlapping the wrong workspace.** Previously, if you opened a dialog/overlay and then switched workspaces or tabs while it was open, the browser view could get "stuck" floating on top of the wrong workspace until you restarted the app. It now stays put.
2. **You can close the last browser tab.** Before, the last/only tab couldn't be closed (no close button, Cmd/Ctrl+W did nothing). Now closing the final tab works and instantly opens a fresh blank tab, so the pane is never left empty.

Closes #567

## What changed

- `useBrowserPaneFreeze.ts` — on unfreeze, only re-show the native browser view if it was actually hidden by us **and** the pane is still visible. Avoids floating one workspace's native `WebContentsView` over another (it ignores CSS opacity/z-index). The `wsActive` effect re-shows it when the pane becomes visible again.
- `DockviewBrowserContainer.tsx` — close button always renders; removed the `panels.length <= 1` guards in `closeTab` and the Cmd/Ctrl+W handler. Closing the last tab spawns a fresh blank tab (mirrors the existing `browser-removed` self-heal).

## Testing

- `tsc --noEmit` (apps/web): clean
- `biome check` on changed file: clean
- No e2e test added: `DockviewBrowserContainer` is desktop-only (`SharedDockviewLayout` renders a "desktop only" fallback in the plain web build), so the changed code is unreachable by the Playwright web harness — matching the existing `panel-default-position.spec.ts` precedent that omits the browser container.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hqeo3osngo3DEuRikhUBYz