### PR TITLE
fix(web): clear stuck chat "Thinking…" indicator on reconnect

### DIFF
--- a/apps/web/e2e/chat-reconnect-thinking-indicator.spec.ts
+++ b/apps/web/e2e/chat-reconnect-thinking-indicator.spec.ts
@@ -169,14 +169,14 @@ test.describe("Chat reconnect — stuck thinking indicator recovers", () => {
       // `server` would otherwise still hold the already-closed `beforeAll`
       // handle. `afterAll` would then call `close()` on a child that has
       // already exited and await an `exit` event that never re-fires —
-      // hanging teardown (TEST-14). Swap in a no-op handle so teardown
-      // always resolves promptly, then fail the test.
+      // hanging teardown. Swap in a no-op handle so teardown always
+      // resolves promptly, then fail the test.
       server = { url: "", home: tmpHome, close: () => Promise.resolve() };
       throw err;
     }
 
-    // Positive anchor (TEST-25): assert the alternate post-reconnect state
-    // rendered BEFORE the negatives. The conversation DOM survives the
+    // Positive anchor: assert the alternate post-reconnect state rendered
+    // BEFORE the negatives below. The conversation DOM survives the
     // restart — the partial text the agent streamed is preserved in the
     // reducer (React state outlives the EventSource reconnect) — so this
     // proves the pane re-rendered rather than blanked.
@@ -192,7 +192,7 @@ test.describe("Chat reconnect — stuck thinking indicator recovers", () => {
     // slow CI it could lag the indicator's poll and spuriously time out.
     await expect(chatPane.stopButton).not.toBeVisible({ timeout: 30_000 });
 
-    // Positive anchor (TEST-25): the composer is genuinely back in the send
+    // Positive anchor: the composer is genuinely back in the send
     // state, not transiently flickering. A brand-new submission is accepted
     // and starts a fresh task. Two observable proofs that the task was SENT
     // (not queued):

--- a/apps/web/e2e/chat-reconnect-thinking-indicator.spec.ts
+++ b/apps/web/e2e/chat-reconnect-thinking-indicator.spec.ts
@@ -1,0 +1,198 @@
+/**
+ * Regression: the chat "Thinking…" indicator spinning forever after the
+ * agent has finished, until a full page reload.
+ *
+ * Failure mechanism (see the reducer's `subscription-opened` case):
+ *   1. A task is running → the client reducer holds `taskRunning: true`,
+ *      status `streaming`, so the thinking indicator + Stop button render.
+ *   2. The `task-completed` broadcast is LIVE-ONLY — never written to the
+ *      JSONL transcript and evicted from the in-memory session buffer on
+ *      server restart (or past MAX_BUFFER_SIZE). So if the completion fires
+ *      while the client is detached — or the server restarts mid-task — the
+ *      client never receives it.
+ *   3. On reconnect the server's `subscription-opened` correctly reports
+ *      `taskRunning: false`, but the pre-fix reducer only ever upgraded
+ *      false→true. The client kept `taskRunning: true` → status stayed
+ *      `streaming` → the indicator spun forever.
+ *
+ * This test reproduces (2)+(3) deterministically by RESTARTING the real
+ * server on the same port while a task is mid-stream: the restart wipes the
+ * in-memory buffer (so the completion is genuinely lost) and the client's
+ * `EventSource` auto-reconnects to the same URL and receives a fresh
+ * `subscription-opened{taskRunning:false}`.
+ *
+ * Under the fix the reducer trusts that authoritative `false` (no optimistic
+ * send is pending) and settles status to a terminal state — clearing the
+ * indicator and the Stop button and returning the composer to the send
+ * state. On the buggy code this test times out waiting for the indicator to
+ * disappear.
+ *
+ * Architecture (matches `chat-cancel.spec.ts`):
+ *   - REAL `dist/start-server.mjs` against a fresh `mkdtempSync()` home,
+ *     pinned to a fixed port so the restart rebinds the same address.
+ *   - NO tRPC mocking, no `page.route()` on our own routes.
+ *   - The stdio fake-agent (`apps/web/tests/fake-agent.mjs`) replays a
+ *     scenario: emit a `text-delta` immediately (→ status `streaming`,
+ *     indicator + Stop visible), then sleep 30 s so the task is still
+ *     "running" when we kill the server.
+ *   - UI driven through `ChatPanePage`.
+ */
+
+import { mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { expect, test } from "@playwright/test";
+import { toWorkspaceId } from "@/dashboard";
+import { fakeAgentPath } from "./helpers/fake-agent";
+import {
+  cleanupTmpHome,
+  createTmpHome,
+  getRandomPort,
+  type ServerHandle,
+  seedSettings,
+  seedState,
+  startServer,
+} from "./helpers/server";
+import { ChatPanePage } from "./pages/ChatPanePage";
+
+const TOKEN = "e2e-chat-reconnect-token";
+const PROJECT = "reconnectproj";
+const WORKSPACE = toWorkspaceId(PROJECT, "main");
+
+test.use({ viewport: { width: 1280, height: 800 } });
+
+const FAKE_AGENT_PATH = fakeAgentPath();
+
+let server: ServerHandle;
+let tmpHome: string;
+let scenarioPath: string;
+let port: number;
+
+test.beforeAll(async () => {
+  tmpHome = createTmpHome();
+
+  const repoDir = join(tmpHome, "repo");
+  mkdirSync(repoDir, { recursive: true });
+
+  seedState(tmpHome, {
+    projects: [
+      {
+        name: PROJECT,
+        path: repoDir,
+        defaultBranch: "main",
+        worktrees: [{ branch: "main", path: repoDir }],
+      },
+    ],
+  });
+  seedSettings(tmpHome, {
+    tokenSecret: TOKEN,
+    codingAgents: [
+      {
+        id: "claude-code",
+        type: "claude-code",
+        label: "Claude Code",
+        command: FAKE_AGENT_PATH,
+      },
+    ],
+  });
+
+  // Emit a short text-delta IMMEDIATELY so the client flips to
+  // status="streaming" (indicator + Stop button render), then sleep 30 s.
+  // The task is still "running" server-side when we kill it — the restart
+  // is what models the lost completion.
+  scenarioPath = join(tmpHome, "scenario.json");
+  writeFileSync(
+    scenarioPath,
+    JSON.stringify([
+      { type: "system", subtype: "init", session_id: "reconnect-session" },
+      {
+        type: "assistant",
+        message: { content: [{ type: "text", text: "partial reply " }] },
+      },
+      { _sleep_ms: 30_000 },
+      {
+        type: "assistant",
+        message: { content: [{ type: "text", text: "never observed" }] },
+      },
+      {
+        type: "result",
+        subtype: "success",
+        session_id: "reconnect-session",
+        duration_ms: 30_000,
+        num_turns: 1,
+        total_cost_usd: 0.0,
+      },
+    ]),
+  );
+
+  // Pin the port so the post-restart server rebinds the same address and
+  // the client's EventSource reconnects to it.
+  port = await getRandomPort();
+  server = await startServer({ tmpHome, port, env: { FAKE_AGENT_SCENARIO: scenarioPath } });
+});
+
+test.afterAll(async () => {
+  await server.close();
+  cleanupTmpHome(tmpHome);
+});
+
+test.describe("Chat reconnect — stuck thinking indicator recovers", () => {
+  test("a lost task-completed (server restart mid-task) clears the indicator on reconnect", async ({
+    page,
+  }) => {
+    // The restart + reconnect + a second streaming task can exceed the
+    // default 30 s test budget.
+    test.setTimeout(90_000);
+
+    const chatPane = new ChatPanePage(page, server.url, TOKEN);
+    await chatPane.goto(WORKSPACE);
+    await chatPane.waitForReady();
+
+    await chatPane.typeMessage("work for me");
+    await chatPane.submit();
+
+    // Streaming phase: the agent streamed "partial reply " then went to
+    // sleep, so status === "streaming" — the Stop button and the thinking
+    // indicator are both on screen.
+    await expect(chatPane.stopButton).toBeVisible({ timeout: 15_000 });
+    await expect(chatPane.assistantMessage("partial reply")).toBeVisible();
+    await expect(chatPane.thinkingIndicator).toBeVisible();
+
+    // Restart the real server on the SAME port. This wipes the in-memory
+    // session buffer (and kills the mid-sleep fake-agent), so the eventual
+    // task-completed is gone for good — the client never sees it. The
+    // EventSource auto-reconnects and gets subscription-opened{taskRunning:false}.
+    await server.close();
+    server = await startServer({ tmpHome, port, env: { FAKE_AGENT_SCENARIO: scenarioPath } });
+
+    // Positive anchor (TEST-25): assert the alternate post-reconnect state
+    // rendered BEFORE the negatives. The conversation DOM survives the
+    // restart — the partial text the agent streamed is preserved in the
+    // reducer (React state outlives the EventSource reconnect) — so this
+    // proves the pane re-rendered rather than blanked.
+    await expect(chatPane.assistantMessage("partial reply")).toBeVisible();
+    // The fix: with no optimistic send pending, the reducer trusts the
+    // authoritative taskRunning:false and settles status to a terminal
+    // state. The indicator and the Stop button disappear. On the buggy
+    // reducer (`state.taskRunning || event.taskRunning`) they never would,
+    // and these auto-retrying polls would time out.
+    await expect(chatPane.thinkingIndicator).not.toBeVisible({ timeout: 30_000 });
+    await expect(chatPane.stopButton).not.toBeVisible();
+
+    // Positive anchor (TEST-25): the composer is genuinely back in the send
+    // state, not transiently flickering. A brand-new submission is accepted
+    // and starts a fresh task. Two observable proofs that the task was SENT
+    // (not queued):
+    //   - The "second message" user bubble appears. `send()` only dispatches
+    //     the optimistic user bubble when the message is sent immediately; if
+    //     `taskRunning` were still stuck true (the bug), the message would be
+    //     QUEUED instead — it would land in the queue list, not as a
+    //     `chat-pane__user-message` bubble.
+    //   - The thinking indicator returns: the optimistic `task-started` flips
+    //     status back to `submitting` (a streaming-equivalent), so the
+    //     standalone indicator re-renders for the new trailing user message.
+    await chatPane.typeMessage("second message");
+    await chatPane.submit();
+    await expect(chatPane.userMessage("second message")).toBeVisible({ timeout: 15_000 });
+    await expect(chatPane.thinkingIndicator).toBeVisible({ timeout: 15_000 });
+  });
+});

--- a/apps/web/e2e/chat-reconnect-thinking-indicator.spec.ts
+++ b/apps/web/e2e/chat-reconnect-thinking-indicator.spec.ts
@@ -162,7 +162,18 @@ test.describe("Chat reconnect — stuck thinking indicator recovers", () => {
     // task-completed is gone for good — the client never sees it. The
     // EventSource auto-reconnects and gets subscription-opened{taskRunning:false}.
     await server.close();
-    server = await startServer({ tmpHome, port, env: { FAKE_AGENT_SCENARIO: scenarioPath } });
+    try {
+      server = await startServer({ tmpHome, port, env: { FAKE_AGENT_SCENARIO: scenarioPath } });
+    } catch (err) {
+      // If the re-bind fails (e.g. the OS hasn't released the port yet),
+      // `server` would otherwise still hold the already-closed `beforeAll`
+      // handle. `afterAll` would then call `close()` on a child that has
+      // already exited and await an `exit` event that never re-fires —
+      // hanging teardown (TEST-14). Swap in a no-op handle so teardown
+      // always resolves promptly, then fail the test.
+      server = { url: "", home: tmpHome, close: () => Promise.resolve() };
+      throw err;
+    }
 
     // Positive anchor (TEST-25): assert the alternate post-reconnect state
     // rendered BEFORE the negatives. The conversation DOM survives the
@@ -176,7 +187,10 @@ test.describe("Chat reconnect — stuck thinking indicator recovers", () => {
     // reducer (`state.taskRunning || event.taskRunning`) they never would,
     // and these auto-retrying polls would time out.
     await expect(chatPane.thinkingIndicator).not.toBeVisible({ timeout: 30_000 });
-    await expect(chatPane.stopButton).not.toBeVisible();
+    // Explicit 30 s timeout (not the 5 s config default): the Stop button
+    // clears from the same reducer transition as the indicator, but under
+    // slow CI it could lag the indicator's poll and spuriously time out.
+    await expect(chatPane.stopButton).not.toBeVisible({ timeout: 30_000 });
 
     // Positive anchor (TEST-25): the composer is genuinely back in the send
     // state, not transiently flickering. A brand-new submission is accepted

--- a/apps/web/e2e/helpers/server.ts
+++ b/apps/web/e2e/helpers/server.ts
@@ -109,7 +109,7 @@ export async function startServer(
   // URL, so a fresh random port would orphan the connection. Used by the
   // stuck-thinking-indicator reconnect spec, which kills and re-spawns the
   // server to model a lost `task-completed` (in-memory buffer wiped on
-  // restart). Defaults to an OS-assigned random port (TEST-10).
+  // restart). Defaults to an OS-assigned random port for isolation.
   const port = opts.port ?? (await getRandomPort());
 
   return new Promise((resolve, reject) => {

--- a/apps/web/e2e/helpers/server.ts
+++ b/apps/web/e2e/helpers/server.ts
@@ -101,10 +101,16 @@ export function getRandomPort(): Promise<number> {
 }
 
 export async function startServer(
-  opts: { tmpHome?: string; env?: Record<string, string> } = {},
+  opts: { tmpHome?: string; env?: Record<string, string>; port?: number } = {},
 ): Promise<ServerHandle> {
   const home = opts.tmpHome || createTmpHome();
-  const port = await getRandomPort();
+  // Allow pinning the port so a test can restart the server on the SAME
+  // address — the client's `EventSource` auto-reconnects to the original
+  // URL, so a fresh random port would orphan the connection. Used by the
+  // stuck-thinking-indicator reconnect spec, which kills and re-spawns the
+  // server to model a lost `task-completed` (in-memory buffer wiped on
+  // restart). Defaults to an OS-assigned random port (TEST-10).
+  const port = opts.port ?? (await getRandomPort());
 
   return new Promise((resolve, reject) => {
     // The production bundle runs under Node (see apps/web/README.md) and

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -748,56 +748,102 @@ export function ChatView({
   // length.
   const getMessageKey = useCallback((message: UIMessage) => message.id, []);
 
-  // Stabilise the `renderItem` closure too. Read the variable deps
-  // (`messages`, `isStreaming`) through refs so the callback identity
-  // stays stable across ALL renders, including the streaming hot path
-  // (~30 text-delta events/sec where `messages` is a fresh array each
-  // time). Same pattern as `itemsRef` in `VirtualizedMessageList`.
+  // Stabilise the `renderItem` closure across the streaming HOT PATH.
+  // `messages` is read through a ref because it's a fresh array on every
+  // text-delta (~30/sec); depending on it directly would change the
+  // callback identity 30×/sec and bust every windowed row's memo.
+  //
+  // `isStreaming` IS a real dependency, by contrast. It's a boolean that
+  // stays constant during streaming (so the hot path is unaffected) and
+  // flips only at task start/end. `VirtualRow` is `memo`-ized, so when a
+  // task ends WITHOUT a `messages` change — the reconnect-after-missed-
+  // `task-completed` case, where `subscription-opened{taskRunning:false}`
+  // updates only `status`/`taskRunning` and leaves the `messages`
+  // reference intact — the trailing row's `item` reference doesn't change.
+  // Reading `isStreaming` through a ref would then never re-run
+  // `renderItem`, so the "Thinking…" indicator on the last assistant
+  // message would spin forever. Making it a dep flips this callback's
+  // identity on the transition, busting the windowed rows' memo exactly
+  // once so the indicator clears. (Pairs with the reducer's authoritative
+  // `subscription-opened` clear: that fixes the state; this lets the
+  // per-message indicator observe it.)
   const messagesRef = useRef(messages);
   messagesRef.current = messages;
-  const isStreamingRef = useRef(isStreaming);
-  isStreamingRef.current = isStreaming;
-  const renderMessageItem = useCallback((message: UIMessage, messageIndex: number) => {
-    const currentMessages = messagesRef.current;
-    const currentIsStreaming = isStreamingRef.current;
-    const isLastMessage = messageIndex === currentMessages.length - 1;
-    const isLastAssistant = message.role === "assistant" && isLastMessage;
-    const hasPendingInteractiveTool =
-      isLastAssistant &&
-      message.parts.some((p) => {
-        if (!isToolUIPart(p) || !IN_PROGRESS_STATES.has(p.state)) return false;
-        // Hoist `getToolName(p)` so the second check doesn't re-invoke
-        // it for every tool part on every render (~30 renders/sec
-        // during streaming).
-        const name = getToolName(p);
-        return name === "AskUserQuestion" || name === "ExitPlanMode";
-      });
-    const showThinking = isLastAssistant && currentIsStreaming && !hasPendingInteractiveTool;
+  const renderMessageItem = useCallback(
+    (message: UIMessage, messageIndex: number) => {
+      const currentMessages = messagesRef.current;
+      const isLastMessage = messageIndex === currentMessages.length - 1;
+      const isLastAssistant = message.role === "assistant" && isLastMessage;
+      const hasPendingInteractiveTool =
+        isLastAssistant &&
+        message.parts.some((p) => {
+          if (!isToolUIPart(p) || !IN_PROGRESS_STATES.has(p.state)) return false;
+          // Hoist `getToolName(p)` so the second check doesn't re-invoke
+          // it for every tool part on every render (~30 renders/sec
+          // during streaming).
+          const name = getToolName(p);
+          return name === "AskUserQuestion" || name === "ExitPlanMode";
+        });
+      const showThinking = isLastAssistant && isStreaming && !hasPendingInteractiveTool;
 
-    // Compute the grouped segments ONCE per render — `groupMessageParts`
-    // allocates a fresh array, and the previous version called it twice
-    // per assistant render (once for the emptiness guard, once for the
-    // map). With N assistant messages and ~30 deltas/sec that's 60N
-    // redundant allocations/sec; one call cuts it in half.
-    const segments = groupMessageParts(message.parts);
+      // Compute the grouped segments ONCE per render — `groupMessageParts`
+      // allocates a fresh array, and the previous version called it twice
+      // per assistant render (once for the emptiness guard, once for the
+      // map). With N assistant messages and ~30 deltas/sec that's 60N
+      // redundant allocations/sec; one call cuts it in half.
+      const segments = groupMessageParts(message.parts);
 
-    if (message.role !== "assistant") {
-      // User messages render normally
-      if (segments.length === 0) return null;
+      if (message.role !== "assistant") {
+        // User messages render normally
+        if (segments.length === 0) return null;
+        return (
+          <Message from="user">
+            <MessageContent>
+              {segments.map((segment) => {
+                if (
+                  segment.type === "text" &&
+                  segment.part.type === "text" &&
+                  segment.part.text.trim()
+                ) {
+                  return (
+                    <MessageResponse key={`${message.id}-text-${segment.partIndex}`}>
+                      {segment.part.text}
+                    </MessageResponse>
+                  );
+                }
+                if (segment.type === "file") {
+                  return (
+                    <MessageFilePart
+                      key={`${message.id}-file-${segment.partIndex}`}
+                      part={segment.part}
+                    />
+                  );
+                }
+                return null;
+              })}
+            </MessageContent>
+          </Message>
+        );
+      }
+
+      // Assistant message — under the chat-events model every queued
+      // turn becomes its own user-role message, so we never need to
+      // split an assistant message at `data-prompt` boundaries.
+      if (segments.length === 0 && !showThinking) return null;
       return (
-        <Message from="user">
+        <Message from="assistant">
           <MessageContent>
             {segments.map((segment) => {
-              if (
-                segment.type === "text" &&
-                segment.part.type === "text" &&
-                segment.part.text.trim()
-              ) {
-                return (
-                  <MessageResponse key={`${message.id}-text-${segment.partIndex}`}>
-                    {segment.part.text}
-                  </MessageResponse>
-                );
+              if (segment.type === "text") {
+                const { part, partIndex } = segment;
+                if (part.type === "text" && part.text.trim()) {
+                  return (
+                    <MessageResponse key={`${message.id}-text-${partIndex}`}>
+                      {part.text}
+                    </MessageResponse>
+                  );
+                }
+                return null;
               }
               if (segment.type === "file") {
                 return (
@@ -807,49 +853,17 @@ export function ChatView({
                   />
                 );
               }
-              return null;
+              const item = toolPartToItem(segment.part);
+              if (isTaskTool(item.toolName)) return null;
+              return <ToolCall key={`${message.id}-tool-${segment.partIndex}`} item={item} />;
             })}
+            {showThinking && <ThinkingIndicator />}
           </MessageContent>
         </Message>
       );
-    }
-
-    // Assistant message — under the chat-events model every queued
-    // turn becomes its own user-role message, so we never need to
-    // split an assistant message at `data-prompt` boundaries.
-    if (segments.length === 0 && !showThinking) return null;
-    return (
-      <Message from="assistant">
-        <MessageContent>
-          {segments.map((segment) => {
-            if (segment.type === "text") {
-              const { part, partIndex } = segment;
-              if (part.type === "text" && part.text.trim()) {
-                return (
-                  <MessageResponse key={`${message.id}-text-${partIndex}`}>
-                    {part.text}
-                  </MessageResponse>
-                );
-              }
-              return null;
-            }
-            if (segment.type === "file") {
-              return (
-                <MessageFilePart
-                  key={`${message.id}-file-${segment.partIndex}`}
-                  part={segment.part}
-                />
-              );
-            }
-            const item = toolPartToItem(segment.part);
-            if (isTaskTool(item.toolName)) return null;
-            return <ToolCall key={`${message.id}-tool-${segment.partIndex}`} item={item} />;
-          })}
-          {showThinking && <ThinkingIndicator />}
-        </MessageContent>
-      </Message>
-    );
-  }, []);
+    },
+    [isStreaming],
+  );
 
   const getLastUserMessage = useCallback((): string | undefined => {
     // Under the chat-events model, queued/drained user messages emit their

--- a/apps/web/src/components/chat/chat-event-reducer.ts
+++ b/apps/web/src/components/chat/chat-event-reducer.ts
@@ -54,6 +54,20 @@ export interface ChatSubscriptionState {
    *  session's `user-message` is eventId=2). React would complain about
    *  duplicate keys without this. */
   messageIdCounter: number;
+  /** Internal: true while the current `taskRunning: true` originated from an
+   *  UNACKNOWLEDGED optimistic `send()` (a synthetic `task-started` with a
+   *  negative eventId), and the server hasn't confirmed it yet with a real
+   *  (positive-eventId) `task-started` / `task-completed` / `task-error`.
+   *
+   *  This is the one window in which `subscription-opened` must NOT trust the
+   *  server's `taskRunning: false`: a reconnect landing in the tiny pre-ack
+   *  gap reports false simply because the server task hasn't started, and
+   *  clearing the optimistic indicator there causes a visible blink. Outside
+   *  this window the server is authoritative in both directions — which is
+   *  what recovers a stuck "Thinking…" indicator after a missed
+   *  `task-completed` (buffer eviction, server restart, or the completion
+   *  broadcast firing while this client was detached). */
+  pendingOptimisticTask: boolean;
 }
 
 export const INITIAL_STATE: ChatSubscriptionState = {
@@ -67,6 +81,7 @@ export const INITIAL_STATE: ChatSubscriptionState = {
   taskErrorMessage: undefined,
   currentAssistantId: undefined,
   messageIdCounter: 0,
+  pendingOptimisticTask: false,
 };
 
 // ---------------------------------------------------------------------------
@@ -240,19 +255,50 @@ export function chatEventReducer(
 
   switch (event.type) {
     case "subscription-opened": {
-      // Don't downgrade an optimistic `taskRunning: true` set by `send()`'s
-      // synthetic task-started event. A reconnect mid-flight (visibility,
-      // workspace switch, network blip) can arrive with `taskRunning: false`
-      // because the server task hasn't started yet — that would clear the
-      // optimistic thinking indicator and cause a visible blink before the
-      // real `task-started` re-arrives. Only upgrade false→true.
-      const taskRunning = state.taskRunning || event.taskRunning;
+      if (state.pendingOptimisticTask) {
+        // Pre-ack window: `send()` just dispatched a synthetic optimistic
+        // task-started, but the server hasn't acknowledged it yet. A
+        // subscription-opened landing here reports `taskRunning: false`
+        // simply because the server task hasn't started — trusting it would
+        // clear the optimistic thinking indicator and blink before the real
+        // `task-started` arrives. Only upgrade false→true in this window.
+        const taskRunning = state.taskRunning || event.taskRunning;
+        return {
+          ...state,
+          lastEventId,
+          sessionId: event.sessionId ?? state.sessionId,
+          taskRunning,
+          status: taskRunning ? "streaming" : state.status,
+        };
+      }
+
+      // No optimistic task pending — the server's `taskRunning` is
+      // authoritative in BOTH directions. The server reports false for a
+      // task that completed (or was evicted) while we were detached, so
+      // honouring false is what clears a stuck "Thinking…" indicator after a
+      // missed `task-completed` (buffer eviction past MAX_BUFFER_SIZE, server
+      // restart, or the live-only completion broadcast firing while this
+      // client had no open EventSource). Previously this only ever upgraded
+      // false→true, so once the client believed a task was running no
+      // reconnect could ever clear it — the indicator spun until a full page
+      // reload reset the reducer.
+      const taskRunning = event.taskRunning;
+      let status = state.status;
+      if (taskRunning) {
+        status = "streaming";
+      } else if (state.taskRunning) {
+        // We believed a task was running; the server says it isn't. Settle to
+        // a terminal/idle state so the per-message indicator, the standalone
+        // indicator, and the composer Stop→Send affordance all recover.
+        // `completed` when there's an assistant reply to show, else `idle`.
+        status = state.messages.some((m) => m.role === "assistant") ? "completed" : "idle";
+      }
       return {
         ...state,
         lastEventId,
         sessionId: event.sessionId ?? state.sessionId,
         taskRunning,
-        status: taskRunning ? "streaming" : state.status,
+        status,
       };
     }
 
@@ -329,6 +375,10 @@ export function chatEventReducer(
         status: "submitting",
         taskErrorMessage: undefined,
         currentAssistantId: undefined,
+        // Negative eventId ⇒ this is `send()`'s synthetic pre-ack task-started.
+        // A real server task-started (positive eventId) acknowledges it and
+        // clears the pending flag, re-enabling authoritative downgrades.
+        pendingOptimisticTask: event.eventId < 0,
       };
 
     case "task-completed":
@@ -338,6 +388,7 @@ export function chatEventReducer(
         taskRunning: false,
         status: "completed",
         currentAssistantId: undefined,
+        pendingOptimisticTask: false,
       };
 
     case "task-error":
@@ -348,6 +399,7 @@ export function chatEventReducer(
         status: "error",
         taskErrorMessage: event.message,
         currentAssistantId: undefined,
+        pendingOptimisticTask: false,
       };
 
     case "text-start": {

--- a/apps/web/src/components/chat/use-chat-subscription.ts
+++ b/apps/web/src/components/chat/use-chat-subscription.ts
@@ -62,7 +62,10 @@ export interface UseChatSubscriptionOptions {
 }
 
 export interface UseChatSubscriptionResult
-  extends Omit<ChatSubscriptionState, "currentAssistantId" | "lastEventId" | "messageIdCounter"> {
+  extends Omit<
+    ChatSubscriptionState,
+    "currentAssistantId" | "lastEventId" | "messageIdCounter" | "pendingOptimisticTask"
+  > {
   /** True while the EventSource is connected to the server. */
   isConnected: boolean;
   /** Submit a new user message. Resolves once the server has accepted the

--- a/apps/web/tests/chat-event-reducer.test.ts
+++ b/apps/web/tests/chat-event-reducer.test.ts
@@ -600,4 +600,141 @@ describe("chatEventReducer", () => {
     expect(state.messages[1].id.startsWith("u-pending-")).toBe(true);
     expect(state.messages[0].id).not.toBe(state.messages[1].id);
   });
+
+  /**
+   * Regression: the "Thinking…" indicator spinning forever after a missed
+   * `task-completed` (issue — stuck thinking indicator).
+   *
+   * `task-completed` is a LIVE-ONLY broadcast: it's never written to the
+   * JSONL transcript and is evicted from the in-memory session buffer past
+   * MAX_BUFFER_SIZE (and wiped on server restart). So a client that was
+   * detached when the task finished (tab hidden > 1s, dockview pane
+   * deactivated, network blip, server restart) reconnects and never receives
+   * the completion. The server's `subscription-opened` correctly reports
+   * `taskRunning: false`, but the pre-fix reducer only ever upgraded
+   * false→true (`state.taskRunning || event.taskRunning`), so the client's
+   * `taskRunning` stayed true → `status` stayed `streaming` → the indicator
+   * spun until a full page reload reset the reducer.
+   *
+   * Under the fix, with no optimistic task pending, `subscription-opened` is
+   * authoritative in BOTH directions and settles a stale running belief to a
+   * terminal state.
+   */
+  it("real task-started then subscription-opened{taskRunning:false} clears the stuck running state", () => {
+    // A real (positive-eventId) task runs and streams an assistant reply,
+    // then the client detaches before `task-completed` arrives.
+    const running = applyEvents(
+      INITIAL_STATE,
+      seq([
+        { type: "user-message", text: "do the thing" },
+        { type: "task-started", taskId: "t1" },
+        { type: "text-start", id: "p1" },
+        { type: "text-delta", id: "p1", delta: "working on it" },
+      ]),
+    );
+    expect(running.taskRunning).toBe(true);
+    expect(running.status).toBe("streaming");
+    expect(running.pendingOptimisticTask).toBe(false);
+
+    // Reconnect: server reports the task is no longer running.
+    const reconnected = chatEventReducer(running, {
+      type: "subscription-opened",
+      sessionId: "sess-1",
+      taskRunning: false,
+      eventId: -1,
+    });
+
+    expect(reconnected.taskRunning).toBe(false);
+    // There's an assistant reply to show, so settle to `completed` — and
+    // crucially NOT `submitting`/`streaming`, so `isStreaming` is false and
+    // the thinking indicator + composer recover.
+    expect(reconnected.status).toBe("completed");
+    expect(["submitting", "streaming"]).not.toContain(reconnected.status);
+  });
+
+  it("subscription-opened{taskRunning:false} settles to idle when there's no assistant reply yet", () => {
+    // Task started but produced no assistant output before the client missed
+    // the completion (e.g. an immediate abort). Nothing to "complete" — go idle.
+    const running = applyEvents(
+      INITIAL_STATE,
+      seq([
+        { type: "user-message", text: "hi" },
+        { type: "task-started", taskId: "t1" },
+      ]),
+    );
+    expect(running.taskRunning).toBe(true);
+
+    const reconnected = chatEventReducer(running, {
+      type: "subscription-opened",
+      taskRunning: false,
+      eventId: -1,
+    });
+    expect(reconnected.taskRunning).toBe(false);
+    expect(reconnected.status).toBe("idle");
+  });
+
+  /**
+   * The protective counterpart: a `subscription-opened{taskRunning:false}`
+   * arriving in the tiny PRE-ACK window after `send()` dispatched its
+   * synthetic optimistic `task-started` (negative eventId) must NOT clear the
+   * optimistic indicator. The server reports false there only because the
+   * real task hasn't started yet; clearing would blink the indicator off then
+   * back on when the real `task-started` lands a few ms later.
+   */
+  it("optimistic task-started then subscription-opened{taskRunning:false} in the pre-ack window does NOT clear", () => {
+    // Mirror `send()`: optimistic user-message + task-started, both negative.
+    const optimistic = applyEvents(INITIAL_STATE, [
+      { type: "user-message", text: "ping", eventId: -1000 },
+      { type: "task-started", taskId: "pending-1000", eventId: -1001 },
+    ] as ChatEvent[]);
+    expect(optimistic.taskRunning).toBe(true);
+    expect(optimistic.status).toBe("submitting");
+    expect(optimistic.pendingOptimisticTask).toBe(true);
+
+    // A reconnect lands before the server acknowledges the task.
+    const midSend = chatEventReducer(optimistic, {
+      type: "subscription-opened",
+      taskRunning: false,
+      eventId: -1002,
+    });
+    // Still optimistically running — indicator stays up, no blink. Status is
+    // a streaming-equivalent (`submitting` or `streaming`), never a terminal
+    // one, so `isStreaming` stays true.
+    expect(midSend.taskRunning).toBe(true);
+    expect(["submitting", "streaming"]).toContain(midSend.status);
+    expect(midSend.pendingOptimisticTask).toBe(true);
+  });
+
+  /**
+   * Once the server's REAL `task-started` (positive eventId) acknowledges the
+   * optimistic send, the pending flag is cleared and a subsequent
+   * `subscription-opened{taskRunning:false}` becomes authoritative again — so
+   * a completion missed AFTER acknowledgement still recovers.
+   */
+  it("real task-started acknowledges the optimistic send, re-enabling authoritative downgrade", () => {
+    const optimistic = applyEvents(INITIAL_STATE, [
+      { type: "user-message", text: "ping", eventId: -1000 },
+      { type: "task-started", taskId: "pending-1000", eventId: -1001 },
+    ] as ChatEvent[]);
+    expect(optimistic.pendingOptimisticTask).toBe(true);
+
+    // Server echoes the real lifecycle: user-message echo + real task-started.
+    const acked = applyEvents(optimistic, [
+      { type: "user-message", text: "ping", eventId: 1 },
+      { type: "task-started", taskId: "t-real", eventId: 2 },
+      { type: "text-start", id: "p1", eventId: 3 },
+      { type: "text-delta", id: "p1", delta: "answer", eventId: 4 },
+    ] as ChatEvent[]);
+    expect(acked.pendingOptimisticTask).toBe(false);
+    expect(acked.taskRunning).toBe(true);
+
+    // Client detaches, misses task-completed, reconnects.
+    const reconnected = chatEventReducer(acked, {
+      type: "subscription-opened",
+      taskRunning: false,
+      eventId: -2,
+    });
+    expect(reconnected.taskRunning).toBe(false);
+    expect(reconnected.status).toBe("completed");
+  });
 });


### PR DESCRIPTION
## Problem

The chat **"Thinking…" indicator spun forever** after the agent finished and the full assistant message was already rendered. Only a full page reload cleared it; switching tabs/workspaces did not.

## Root cause — two layers

**1. Reducer never trusted the server's authoritative status downward.**
`subscription-opened` did `taskRunning = state.taskRunning || event.taskRunning` — it only ever upgraded `false→true`. The `task-completed` broadcast is **live-only**: never written to the JSONL transcript, evicted from the in-memory session buffer past `MAX_BUFFER_SIZE` (2000), and wiped on server restart. So when the completion was lost (server restart mid-task, or buffer eviction on long conversations) and the client reconnected, `subscription-opened{taskRunning:false}` was ignored and the client stayed stuck in `streaming`.

**2. The per-message indicator never re-rendered when only `status` changed.**
`renderMessageItem` read `isStreaming` through a ref with `useCallback([])`, and `VirtualRow` is `memo`-ized. A reconnect changes `status`/`taskRunning` but **not** the `messages` array reference, so the trailing row never re-ran `renderItem` — the indicator stayed even once the state was correct. (This normally hides because live streaming mutates `messages` ~30×/sec; it only surfaces when a task ends *without* a content change.)

## Fix

- **Reducer** (`chat-event-reducer.ts`): `subscription-opened`'s `taskRunning` is now authoritative in **both** directions (settles to `completed` if an assistant reply exists, else `idle`), guarded by a new internal `pendingOptimisticTask` flag that preserves the existing protection against the optimistic-send pre-ack blink. The flag is set on a negative-eventId (optimistic) `task-started` and cleared by any real `task-started` / `task-completed` / `task-error`.
- **Render** (`ChatView.tsx`): `renderMessageItem` now depends on `isStreaming` directly, so its identity flips on the streaming transition and busts the trailing row's memo exactly once. The hot path is unaffected (`isStreaming` is constant during streaming; `messages` is still read via ref).
- `use-chat-subscription.ts`: omit the internal `pendingOptimisticTask` from the public result type.

The server already reports the correct `taskRunning: false` after eviction/restart, so this client-side (Variant A) fix is complete; no server change is required.

## Tests

- **4 reducer unit tests** (vitest): authoritative clear → `completed`; clear → `idle` when no assistant reply; pre-ack optimistic window does **not** clear; real ack re-enables the downgrade.
- **New Playwright integration spec** (`chat-reconnect-thinking-indicator.spec.ts`): boots the real server, streams via the fake-agent, then **restarts the server on the same port mid-task** (wiping the buffer → lost `task-completed`) and asserts the indicator + Stop button clear on reconnect and the composer accepts a new send. Verified to **fail on the old code** and pass with the fix.
- `startServer` test helper gains an optional `port` so the restart rebinds the same address.

## Verification

- biome clean; reducer unit tests 28/28; new e2e + chat e2e suite (cancel, send-optimistic, tool-output-routing, virtualization, queue, session-history) all pass; full `apps/web` vitest 1100/1100.
- Local `/review-and-apply` (Coding ✅ · Testing ⚠️ · Security ✅ · Performance ✅): 0 blockers; applied the one nit (TEST-25 anchor ordering).

🤖 Generated with [Claude Code](https://claude.com/claude-code)