### PR TITLE
Copy relative/absolute file path from tree context menus

### DIFF
--- a/apps/web/e2e/copy-file-path.spec.ts
+++ b/apps/web/e2e/copy-file-path.spec.ts
@@ -111,7 +111,7 @@ test.describe("Copy file path from the tree context menus", () => {
     // Copy relative path → the workspace-relative file path.
     await trees.openFileTreeMenu(FILE_PATH);
     await expect(trees.fileTreeCopyRelative).toBeVisible();
-    await trees.fileTreeCopyRelative.click();
+    await trees.clickFileCopyRelative();
     await expect
       .poll(async () => (await workspace.readCopied()).at(-1), {
         message: "relative path copied to clipboard",
@@ -122,7 +122,7 @@ test.describe("Copy file path from the tree context menus", () => {
     // Copy absolute path → worktree root joined with the relative path.
     await trees.openFileTreeMenu(FILE_PATH);
     await expect(trees.fileTreeCopyAbsolute).toBeVisible();
-    await trees.fileTreeCopyAbsolute.click();
+    await trees.clickFileCopyAbsolute();
     await expect
       .poll(async () => (await workspace.readCopied()).at(-1), {
         message: "absolute path copied to clipboard",
@@ -143,7 +143,7 @@ test.describe("Copy file path from the tree context menus", () => {
 
     await trees.openChangesTreeMenu(FILE_PATH);
     await expect(trees.changesTreeCopyRelative).toBeVisible();
-    await trees.changesTreeCopyRelative.click();
+    await trees.clickChangesCopyRelative();
     await expect
       .poll(async () => (await workspace.readCopied()).at(-1), {
         message: "relative path copied to clipboard",
@@ -153,7 +153,7 @@ test.describe("Copy file path from the tree context menus", () => {
 
     await trees.openChangesTreeMenu(FILE_PATH);
     await expect(trees.changesTreeCopyAbsolute).toBeVisible();
-    await trees.changesTreeCopyAbsolute.click();
+    await trees.clickChangesCopyAbsolute();
     await expect
       .poll(async () => (await workspace.readCopied()).at(-1), {
         message: "absolute path copied to clipboard",

--- a/apps/web/e2e/copy-file-path.spec.ts
+++ b/apps/web/e2e/copy-file-path.spec.ts
@@ -1,0 +1,164 @@
+/**
+ * End-to-end coverage for the "Copy relative path" / "Copy absolute path"
+ * right-click actions in BOTH workspace file trees:
+ *
+ *   - Files view  → `FileBrowser`.
+ *   - Changes view → `ChangesFileTree`.
+ *
+ * Architecture (mirrors the rest of the e2e suite):
+ *   - REAL production `dist/start-server.mjs` boots against a fresh tmp
+ *     `$HOME` with an on-disk git worktree. No tRPC mocking — the file
+ *     listing and diff come through the same pipelines production uses.
+ *   - Clipboard writes are captured via `WorkspacePage.installClipboardCapture`,
+ *     which removes `navigator.clipboard` (the non-secure / LAN-IP case) and
+ *     records the `execCommand("copy")` fallback payload. That doubles as a
+ *     regression guard: code that bypassed the shared `writeClipboardText`
+ *     helper and called `navigator.clipboard` directly would copy nothing
+ *     here and fail the assertion.
+ *
+ * The relative path is the workspace-relative file path; the absolute path is
+ * the worktree root (the seeded project path) joined with it.
+ */
+
+import { mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { expect, test } from "@playwright/test";
+import { toWorkspaceId } from "@/dashboard";
+import { git } from "./helpers/git";
+import {
+  cleanupTmpHome,
+  createTmpHome,
+  type ServerHandle,
+  seedSettings,
+  seedState,
+  startServer,
+} from "./helpers/server";
+import { FileTreesPage } from "./pages/FileTreesPage";
+import { WorkspacePage } from "./pages/WorkspacePage";
+
+// Wide viewport so `useIsDesktop()` reports true AND the Changes panel's
+// container clears the `@[40rem]/diff` query that gates the file-tree
+// sidebar — at 2400 px the Changes group lands well past 640 px so the
+// ChangesFileTree renders. (Same reasoning as diff-horizontal-scroll.spec.)
+test.use({ viewport: { width: 2400, height: 900 } });
+
+const TOKEN = "e2e-copy-file-path-token";
+const REPO_NAME = "copy-path-repo";
+const BRANCH = "main";
+// A NESTED file (not a flat top-level name) so the assertions actually
+// distinguish the relative path ("src/notes.txt") from the basename and
+// exercise `joinWorkspacePath`'s interior-slash joining for the absolute
+// path. A flat filename would pass even if the relative-copy handler copied
+// only the basename.
+const DIR_PATH = "src";
+const FILE_PATH = "src/notes.txt";
+
+let server: ServerHandle;
+let tmpHome: string;
+let repoPath: string;
+let workspaceId: string;
+
+test.beforeAll(async () => {
+  tmpHome = createTmpHome();
+  repoPath = join(tmpHome, REPO_NAME);
+  mkdirSync(repoPath, { recursive: true });
+
+  // Commit the file at HEAD, then leave a modification on disk so the
+  // Changes view lists it ("M") and the Files view lists it as a normal
+  // entry. The file lives in a subdirectory so the copied paths are
+  // multi-segment.
+  mkdirSync(join(repoPath, DIR_PATH), { recursive: true });
+  git(repoPath, ["init", "-b", BRANCH]);
+  writeFileSync(join(repoPath, FILE_PATH), "first line\n");
+  git(repoPath, ["add", "."]);
+  git(repoPath, ["commit", "-m", "initial"]);
+  writeFileSync(join(repoPath, FILE_PATH), "first line\nsecond line\n");
+
+  seedState(tmpHome, {
+    projects: [
+      {
+        name: REPO_NAME,
+        path: repoPath,
+        defaultBranch: BRANCH,
+        worktrees: [{ branch: BRANCH, path: repoPath }],
+      },
+    ],
+  });
+  seedSettings(tmpHome, { tokenSecret: TOKEN });
+  server = await startServer({ tmpHome });
+  workspaceId = toWorkspaceId(REPO_NAME, BRANCH);
+});
+
+test.afterAll(async () => {
+  await server.close();
+  cleanupTmpHome(tmpHome);
+});
+
+test.describe("Copy file path from the tree context menus", () => {
+  test("Files view copies relative and absolute paths", async ({ page }) => {
+    const workspace = new WorkspacePage(page, server.url, TOKEN);
+    const trees = new FileTreesPage(page);
+
+    await workspace.installClipboardCapture();
+    await workspace.goto(workspaceId);
+    await workspace.waitForReady();
+
+    // The Files tree lazy-loads directory contents, so expand `src` before
+    // the nested file row exists.
+    await trees.openFilesTab(DIR_PATH);
+    await trees.expandFileTreeFolder(DIR_PATH);
+
+    // Copy relative path → the workspace-relative file path.
+    await trees.openFileTreeMenu(FILE_PATH);
+    await expect(trees.fileTreeCopyRelative).toBeVisible();
+    await trees.fileTreeCopyRelative.click();
+    await expect
+      .poll(async () => (await workspace.readCopied()).at(-1), {
+        message: "relative path copied to clipboard",
+        timeout: 15_000,
+      })
+      .toBe(FILE_PATH);
+
+    // Copy absolute path → worktree root joined with the relative path.
+    await trees.openFileTreeMenu(FILE_PATH);
+    await expect(trees.fileTreeCopyAbsolute).toBeVisible();
+    await trees.fileTreeCopyAbsolute.click();
+    await expect
+      .poll(async () => (await workspace.readCopied()).at(-1), {
+        message: "absolute path copied to clipboard",
+        timeout: 15_000,
+      })
+      .toBe(`${repoPath}/${FILE_PATH}`);
+  });
+
+  test("Changes view copies relative and absolute paths", async ({ page }) => {
+    const workspace = new WorkspacePage(page, server.url, TOKEN);
+    const trees = new FileTreesPage(page);
+
+    await workspace.installClipboardCapture();
+    await workspace.goto(workspaceId);
+    await workspace.waitForReady();
+
+    await trees.openChangesTab(FILE_PATH);
+
+    await trees.openChangesTreeMenu(FILE_PATH);
+    await expect(trees.changesTreeCopyRelative).toBeVisible();
+    await trees.changesTreeCopyRelative.click();
+    await expect
+      .poll(async () => (await workspace.readCopied()).at(-1), {
+        message: "relative path copied to clipboard",
+        timeout: 15_000,
+      })
+      .toBe(FILE_PATH);
+
+    await trees.openChangesTreeMenu(FILE_PATH);
+    await expect(trees.changesTreeCopyAbsolute).toBeVisible();
+    await trees.changesTreeCopyAbsolute.click();
+    await expect
+      .poll(async () => (await workspace.readCopied()).at(-1), {
+        message: "absolute path copied to clipboard",
+        timeout: 15_000,
+      })
+      .toBe(`${repoPath}/${FILE_PATH}`);
+  });
+});

--- a/apps/web/e2e/copy-file-path.spec.ts
+++ b/apps/web/e2e/copy-file-path.spec.ts
@@ -97,7 +97,7 @@ test.afterAll(async () => {
 test.describe("Copy file path from the tree context menus", () => {
   test("Files view copies relative and absolute paths", async ({ page }) => {
     const workspace = new WorkspacePage(page, server.url, TOKEN);
-    const trees = new FileTreesPage(page);
+    const trees = new FileTreesPage(page, workspace);
 
     await workspace.installClipboardCapture();
     await workspace.goto(workspaceId);
@@ -106,7 +106,7 @@ test.describe("Copy file path from the tree context menus", () => {
     // The Files tree lazy-loads directory contents, so expand `src` before
     // the nested file row exists.
     await trees.openFilesTab(DIR_PATH);
-    await trees.expandFileTreeFolder(DIR_PATH);
+    await trees.expandFileTreeFolder(DIR_PATH, FILE_PATH);
 
     // Copy relative path → the workspace-relative file path.
     await trees.openFileTreeMenu(FILE_PATH);
@@ -133,7 +133,7 @@ test.describe("Copy file path from the tree context menus", () => {
 
   test("Changes view copies relative and absolute paths", async ({ page }) => {
     const workspace = new WorkspacePage(page, server.url, TOKEN);
-    const trees = new FileTreesPage(page);
+    const trees = new FileTreesPage(page, workspace);
 
     await workspace.installClipboardCapture();
     await workspace.goto(workspaceId);

--- a/apps/web/e2e/pages/FileTreesPage.ts
+++ b/apps/web/e2e/pages/FileTreesPage.ts
@@ -11,22 +11,20 @@
  * copy menu item carries a stable `data-testid` — so the test body never
  * depends on the localisable menu copy or on CSS structure.
  *
- * Navigation and clipboard capture live on `WorkspacePage`; this object
- * only owns the tree-specific locators and the open-menu/click actions, so
- * it needs the `page` alone (URL construction stays on `WorkspacePage`).
+ * Outer-dockview tab navigation and clipboard capture live on `WorkspacePage`
+ * (the suite's single owner of the `workspace__tab--*` locators), so this
+ * object takes a `WorkspacePage` and delegates tab switching to it rather than
+ * re-deriving the tab testids.
  */
 
 import { type Locator, type Page, test } from "@playwright/test";
+import type { WorkspacePage } from "./WorkspacePage";
 
 export class FileTreesPage {
-  constructor(private readonly page: Page) {}
-
-  /** The outer dockview tab for the given panel. Mirrors
-   *  `WorkspacePage.tab()` — the `workspace__tab--*` testid is set by
-   *  `DefaultTab` / `BadgeTab` in `SharedDockviewLayout.tsx`. */
-  private tab(panel: "files" | "changes"): Locator {
-    return this.page.getByTestId(`workspace__tab--${panel}`);
-  }
+  constructor(
+    private readonly page: Page,
+    private readonly workspace: WorkspacePage,
+  ) {}
 
   /** A row in the Files tree (`FileBrowser`), keyed by its
    *  workspace-relative path. */
@@ -64,7 +62,7 @@ export class FileTreesPage {
   /** Activate the Files tab and wait for the given row to render. */
   async openFilesTab(path: string): Promise<void> {
     await test.step("Open the Files tab", async () => {
-      await this.tab("files").click();
+      await this.workspace.tab("files").click();
       await this.fileTreeRow(path).waitFor({ state: "visible", timeout: 15_000 });
     });
   }
@@ -73,16 +71,20 @@ export class FileTreesPage {
    *  changes sidebar tree. */
   async openChangesTab(path: string): Promise<void> {
     await test.step("Open the Changes tab", async () => {
-      await this.tab("changes").click();
+      await this.workspace.tab("changes").click();
       await this.changesTreeRow(path).waitFor({ state: "visible", timeout: 15_000 });
     });
   }
 
-  /** Expand a directory row in the Files tree (lazy-loads its children).
-   *  Clicking a directory row toggles its expansion in `FileBrowser`. */
-  async expandFileTreeFolder(path: string): Promise<void> {
+  /** Expand a directory row in the Files tree (lazy-loads its children) and
+   *  wait for the expected child row to appear. Clicking a directory row
+   *  toggles its expansion in `FileBrowser`; the load is async, so callers
+   *  pass the child they're about to act on so the right-click can't race
+   *  the lazy fetch. */
+  async expandFileTreeFolder(path: string, awaitChild: string): Promise<void> {
     await test.step(`Expand Files-tree folder ${path}`, async () => {
       await this.fileTreeRow(path).click();
+      await this.fileTreeRow(awaitChild).waitFor({ state: "visible", timeout: 15_000 });
     });
   }
 

--- a/apps/web/e2e/pages/FileTreesPage.ts
+++ b/apps/web/e2e/pages/FileTreesPage.ts
@@ -11,10 +11,12 @@
  * copy menu item carries a stable `data-testid` — so the test body never
  * depends on the localisable menu copy or on CSS structure.
  *
- * Outer-dockview tab navigation and clipboard capture live on `WorkspacePage`
- * (the suite's single owner of the `workspace__tab--*` locators), so this
- * object takes a `WorkspacePage` and delegates tab switching to it rather than
- * re-deriving the tab testids.
+ * This is a SECONDARY page object: it owns no routes and constructs no URLs,
+ * so it intentionally does NOT follow the `(page, baseUrl, …)` + `goto()`
+ * convention of primary page objects. All navigation (URL construction,
+ * `goto`) and clipboard capture live on `WorkspacePage` — the suite's single
+ * owner of the `workspace__tab--*` locators — which is passed in and delegated
+ * to for tab switching rather than re-deriving the tab testids here.
  */
 
 import { type Locator, type Page, test } from "@playwright/test";
@@ -99,6 +101,31 @@ export class FileTreesPage {
   async openChangesTreeMenu(path: string): Promise<void> {
     await test.step(`Right-click Changes-tree row ${path}`, async () => {
       await this.changesTreeRow(path).click({ button: "right" });
+    });
+  }
+
+  /** Named action methods for the copy menu items, so the test body drives
+   *  interactions through the page object rather than clicking raw locators.
+   *  The matching getters above remain for `expect(...).toBeVisible()`
+   *  assertions. */
+  async clickFileCopyRelative(): Promise<void> {
+    await test.step("Click Files-tree Copy relative path", async () => {
+      await this.fileTreeCopyRelative.click();
+    });
+  }
+  async clickFileCopyAbsolute(): Promise<void> {
+    await test.step("Click Files-tree Copy absolute path", async () => {
+      await this.fileTreeCopyAbsolute.click();
+    });
+  }
+  async clickChangesCopyRelative(): Promise<void> {
+    await test.step("Click Changes-tree Copy relative path", async () => {
+      await this.changesTreeCopyRelative.click();
+    });
+  }
+  async clickChangesCopyAbsolute(): Promise<void> {
+    await test.step("Click Changes-tree Copy absolute path", async () => {
+      await this.changesTreeCopyAbsolute.click();
     });
   }
 }

--- a/apps/web/e2e/pages/FileTreesPage.ts
+++ b/apps/web/e2e/pages/FileTreesPage.ts
@@ -1,0 +1,102 @@
+/**
+ * Page object for the two workspace file trees and their right-click
+ * "Copy relative path" / "Copy absolute path" context-menu actions:
+ *
+ *   - Files view  → `FileBrowser` (the "files" outer dockview tab).
+ *   - Changes view → `ChangesFileTree` (the sidebar inside the "changes"
+ *     outer dockview tab's DiffView).
+ *
+ * Row buttons carry a `data-testid` of `file-tree__row--<path>` /
+ * `changes-tree__row--<path>` (set in the respective components), and each
+ * copy menu item carries a stable `data-testid` — so the test body never
+ * depends on the localisable menu copy or on CSS structure.
+ *
+ * Navigation and clipboard capture live on `WorkspacePage`; this object
+ * only owns the tree-specific locators and the open-menu/click actions, so
+ * it needs the `page` alone (URL construction stays on `WorkspacePage`).
+ */
+
+import { type Locator, type Page, test } from "@playwright/test";
+
+export class FileTreesPage {
+  constructor(private readonly page: Page) {}
+
+  /** The outer dockview tab for the given panel. Mirrors
+   *  `WorkspacePage.tab()` — the `workspace__tab--*` testid is set by
+   *  `DefaultTab` / `BadgeTab` in `SharedDockviewLayout.tsx`. */
+  private tab(panel: "files" | "changes"): Locator {
+    return this.page.getByTestId(`workspace__tab--${panel}`);
+  }
+
+  /** A row in the Files tree (`FileBrowser`), keyed by its
+   *  workspace-relative path. */
+  fileTreeRow(path: string): Locator {
+    return this.page.getByTestId(`file-tree__row--${path}`);
+  }
+
+  /** A row in the Changes tree (`ChangesFileTree`), keyed by its
+   *  workspace-relative path. */
+  changesTreeRow(path: string): Locator {
+    return this.page.getByTestId(`changes-tree__row--${path}`);
+  }
+
+  /** "Copy relative path" / "Copy absolute path" items for each tree.
+   *
+   *  These testids are NOT row-keyed — every row's menu uses the same id.
+   *  That's safe here because Radix keeps only the one open context menu
+   *  mounted, and these specs right-click a single row at a time. A future
+   *  multi-row scenario that opens one row's menu while another's is still
+   *  fading out (Radix portals during the close transition) would need to
+   *  scope these under the specific open menu container instead. */
+  get fileTreeCopyRelative(): Locator {
+    return this.page.getByTestId("file-tree__copy-relative-path");
+  }
+  get fileTreeCopyAbsolute(): Locator {
+    return this.page.getByTestId("file-tree__copy-absolute-path");
+  }
+  get changesTreeCopyRelative(): Locator {
+    return this.page.getByTestId("changes-tree__copy-relative-path");
+  }
+  get changesTreeCopyAbsolute(): Locator {
+    return this.page.getByTestId("changes-tree__copy-absolute-path");
+  }
+
+  /** Activate the Files tab and wait for the given row to render. */
+  async openFilesTab(path: string): Promise<void> {
+    await test.step("Open the Files tab", async () => {
+      await this.tab("files").click();
+      await this.fileTreeRow(path).waitFor({ state: "visible", timeout: 15_000 });
+    });
+  }
+
+  /** Activate the Changes tab and wait for the given row to render in the
+   *  changes sidebar tree. */
+  async openChangesTab(path: string): Promise<void> {
+    await test.step("Open the Changes tab", async () => {
+      await this.tab("changes").click();
+      await this.changesTreeRow(path).waitFor({ state: "visible", timeout: 15_000 });
+    });
+  }
+
+  /** Expand a directory row in the Files tree (lazy-loads its children).
+   *  Clicking a directory row toggles its expansion in `FileBrowser`. */
+  async expandFileTreeFolder(path: string): Promise<void> {
+    await test.step(`Expand Files-tree folder ${path}`, async () => {
+      await this.fileTreeRow(path).click();
+    });
+  }
+
+  /** Right-click a Files-tree row to open its context menu. */
+  async openFileTreeMenu(path: string): Promise<void> {
+    await test.step(`Right-click Files-tree row ${path}`, async () => {
+      await this.fileTreeRow(path).click({ button: "right" });
+    });
+  }
+
+  /** Right-click a Changes-tree row to open its context menu. */
+  async openChangesTreeMenu(path: string): Promise<void> {
+    await test.step(`Right-click Changes-tree row ${path}`, async () => {
+      await this.changesTreeRow(path).click({ button: "right" });
+    });
+  }
+}

--- a/apps/web/src/components/CodeBrowserView.tsx
+++ b/apps/web/src/components/CodeBrowserView.tsx
@@ -51,12 +51,11 @@ import {
   serializeEditorState,
   toFileUri,
   toLspServerLang,
-  toWorkspaceId,
   useCapabilities,
   useEditorHistory,
-  useProjects,
   useSearch,
   useSettingsQuery,
+  useWorkspacePath,
 } from "@/dashboard";
 import { isUntitledPath, useFileTabs } from "../hooks/useFileTabs";
 import { useIsDesktop } from "../hooks/useIsDesktop";
@@ -444,17 +443,7 @@ export function CodeBrowserView({
   const removeFileRef = useRef(tabState.removeFile);
   removeFileRef.current = tabState.removeFile;
   const { settings } = useSettingsQuery();
-  const { projects } = useProjects();
-  const workspacePath = (() => {
-    for (const proj of projects) {
-      for (const wt of proj.worktrees) {
-        if (toWorkspaceId(proj.name, wt.branch) === workspaceId) {
-          return wt.path;
-        }
-      }
-    }
-    return undefined;
-  })();
+  const workspacePath = useWorkspacePath(workspaceId);
   const [viewFilePath, setViewFilePath] = useState(() => {
     if (file) return parseFileLocation(file).filePath;
     // No file in route — restore the active tab from localStorage so the
@@ -2009,6 +1998,7 @@ export function CodeBrowserView({
               <FileBrowser
                 ref={fileBrowserRef}
                 workspaceId={workspaceId}
+                workspacePath={workspacePath}
                 onOpenFile={handleSelectFile}
                 onOpenFilePinned={handleSelectFilePinned}
                 selectedFile={viewFilePath}
@@ -2051,6 +2041,7 @@ export function CodeBrowserView({
                 <FileBrowser
                   ref={fileBrowserRef}
                   workspaceId={workspaceId}
+                  workspacePath={workspacePath}
                   onOpenFile={handleSelectFile}
                   onOpenFilePinned={handleSelectFilePinned}
                   compact

--- a/apps/web/src/dashboard/components/ChangesFileTree.tsx
+++ b/apps/web/src/dashboard/components/ChangesFileTree.tsx
@@ -3,6 +3,7 @@ import {
   ContextMenu,
   ContextMenuContent,
   ContextMenuItem,
+  ContextMenuSeparator,
   ContextMenuTrigger,
   Dialog,
   DialogContent,
@@ -11,11 +12,13 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@band-app/ui";
-import { AlertTriangle, ChevronDown, ChevronRight, RotateCcw } from "lucide-react";
+import { AlertTriangle, ChevronDown, ChevronRight, ClipboardCopy, RotateCcw } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { writeClipboardText } from "../../lib/clipboard";
 import { useDeferredMenuAction } from "../hooks/use-deferred-menu-action";
 import { buildFileTree, type FileTreeNode } from "../lib/build-file-tree";
 import { getFileIcon, getFolderIcon } from "../lib/file-icon";
+import { joinWorkspacePath } from "../lib/workspace-path";
 import type { FileStatus } from "../types";
 import { FileStatusBadge } from "./FileStatusBadge";
 
@@ -30,6 +33,12 @@ interface ChangesFileTreeProps {
    * (or leave the prop unset) to hide the menu item entirely.
    */
   onRevertPaths?: (paths: string[]) => void | Promise<void>;
+  /**
+   * Absolute filesystem path of the workspace root. When provided, the
+   * right-click menu offers "Copy absolute path"; when omitted (e.g. still
+   * loading) that item is hidden but "Copy relative path" remains.
+   */
+  workspacePath?: string;
 }
 
 interface ChangesTreeNodeProps {
@@ -40,6 +49,7 @@ interface ChangesTreeNodeProps {
   onSelectFile: (filePath: string) => void;
   onRequestReset: (node: FileTreeNode) => void;
   canReset: boolean;
+  workspacePath?: string;
   activeFile?: string | null;
 }
 
@@ -62,6 +72,7 @@ function ChangesTreeNode({
   onSelectFile,
   onRequestReset,
   canReset,
+  workspacePath,
   activeFile,
 }: ChangesTreeNodeProps) {
   const isDir = node.children !== undefined;
@@ -98,6 +109,7 @@ function ChangesTreeNode({
       // ⇧⌘G "focus Changes" handler can target it from outside the
       // file tree.
       data-band-active={isActive ? "true" : undefined}
+      data-testid={`changes-tree__row--${node.path}`}
       onClick={handleClick}
       // Suppress the iOS text-selection / callout that fires on
       // long-press alongside the Radix contextmenu event.
@@ -143,22 +155,43 @@ function ChangesTreeNode({
 
   return (
     <>
-      {canReset ? (
-        <ContextMenu>
-          <ContextMenuTrigger asChild>{button}</ContextMenuTrigger>
-          <ContextMenuContent onCloseAutoFocus={menu.flush}>
+      <ContextMenu>
+        <ContextMenuTrigger asChild>{button}</ContextMenuTrigger>
+        <ContextMenuContent onCloseAutoFocus={menu.flush}>
+          <ContextMenuItem
+            data-testid="changes-tree__copy-relative-path"
+            onSelect={() => menu.queue(() => void writeClipboardText(node.path))}
+          >
+            <ClipboardCopy className="size-4" />
+            Copy relative path
+          </ContextMenuItem>
+          {workspacePath && (
             <ContextMenuItem
-              variant="destructive"
-              onSelect={() => menu.queue(() => onRequestReset(node))}
+              data-testid="changes-tree__copy-absolute-path"
+              onSelect={() =>
+                menu.queue(
+                  () => void writeClipboardText(joinWorkspacePath(workspacePath, node.path)),
+                )
+              }
             >
-              <RotateCcw className="size-4" />
-              Reset changes
+              <ClipboardCopy className="size-4" />
+              Copy absolute path
             </ContextMenuItem>
-          </ContextMenuContent>
-        </ContextMenu>
-      ) : (
-        button
-      )}
+          )}
+          {canReset && (
+            <>
+              <ContextMenuSeparator />
+              <ContextMenuItem
+                variant="destructive"
+                onSelect={() => menu.queue(() => onRequestReset(node))}
+              >
+                <RotateCcw className="size-4" />
+                Reset changes
+              </ContextMenuItem>
+            </>
+          )}
+        </ContextMenuContent>
+      </ContextMenu>
 
       {/* Children — rendered when directory is expanded */}
       {isExpanded &&
@@ -172,6 +205,7 @@ function ChangesTreeNode({
             onSelectFile={onSelectFile}
             onRequestReset={onRequestReset}
             canReset={canReset}
+            workspacePath={workspacePath}
             activeFile={activeFile}
           />
         ))}
@@ -198,6 +232,7 @@ export function ChangesFileTree({
   onSelectFile,
   activeFile,
   onRevertPaths,
+  workspacePath,
 }: ChangesFileTreeProps) {
   const tree = useMemo(() => buildFileTree(fileStatuses), [fileStatuses]);
 
@@ -320,6 +355,7 @@ export function ChangesFileTree({
           onSelectFile={onSelectFile}
           onRequestReset={handleRequestReset}
           canReset={canReset}
+          workspacePath={workspacePath}
           activeFile={activeFile}
         />
       ))}

--- a/apps/web/src/dashboard/components/DiffView.tsx
+++ b/apps/web/src/dashboard/components/DiffView.tsx
@@ -43,6 +43,7 @@ import { readStoredCompareBranch, useDiffTarget } from "../hooks/use-diff-target
 import { useIsDark } from "../hooks/use-is-dark";
 import { useProjectKindForWorkspace } from "../hooks/use-project-kind";
 import { useSearch } from "../hooks/use-search";
+import { useWorkspacePath } from "../hooks/use-workspace-path";
 import { buildFileTree, flattenFileTreeOrder } from "../lib/build-file-tree";
 import { baseViewerExtensions, loadLanguage, searchHighlightOnly } from "../lib/codemirror-setup";
 import {
@@ -1227,6 +1228,10 @@ export function DiffView({
   // skips the diff fetch in that window. See #427.
   const projectKind = useProjectKindForWorkspace(workspaceId);
   const isPlain = projectKind === "plain";
+  // Absolute worktree path, used by the Changes tree's "Copy absolute path"
+  // context-menu action. `undefined` while projects load — the menu hides
+  // that item until it resolves.
+  const workspacePath = useWorkspacePath(workspaceId);
   const [summary, setSummary] = useState<WorkspaceDiffSummary | null>(null);
   const summaryRef = useRef<WorkspaceDiffSummary | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -2610,6 +2615,7 @@ export function DiffView({
               onSelectFile={handleScrollToFile}
               activeFile={activeFile}
               onRevertPaths={adapter.revertFile ? handleRevertPaths : undefined}
+              workspacePath={workspacePath}
             />
           </div>
         </div>

--- a/apps/web/src/dashboard/components/FileBrowser.tsx
+++ b/apps/web/src/dashboard/components/FileBrowser.tsx
@@ -549,8 +549,12 @@ function TreeNode({
           </ContextMenuItem>
         )}
         {/* Copy-path actions are always available (relative path is derivable
-            from the row alone; absolute path needs the workspace root). */}
-        {(isDir || canCut || canCopy) && <ContextMenuSeparator />}
+            from the row alone; absolute path needs the workspace root). Only
+            add a leading separator when there are Cut/Copy/Paste items
+            directly above — a directory's New File/New Folder block already
+            renders its own trailing separator, so gating on `isDir` here would
+            produce two consecutive separators for a read-only directory row. */}
+        {(canCut || canCopy || (isDir && canPaste)) && <ContextMenuSeparator />}
         <ContextMenuItem
           data-testid="file-tree__copy-relative-path"
           onSelect={() => menu.queue(() => void writeClipboardText(entryPath))}

--- a/apps/web/src/dashboard/components/FileBrowser.tsx
+++ b/apps/web/src/dashboard/components/FileBrowser.tsx
@@ -16,6 +16,7 @@ import {
   AlertTriangle,
   ChevronDown,
   ChevronRight,
+  ClipboardCopy,
   ClipboardPaste,
   Copy as CopyIcon,
   File as FileIconLucide,
@@ -26,13 +27,21 @@ import {
   Trash2,
 } from "lucide-react";
 import { forwardRef, useCallback, useEffect, useImperativeHandle, useRef, useState } from "react";
+import { writeClipboardText } from "../../lib/clipboard";
 import { useAdapter } from "../context";
 import { useDeferredMenuAction } from "../hooks/use-deferred-menu-action";
 import { getFileIcon, getFolderIcon } from "../lib/file-icon";
+import { joinWorkspacePath } from "../lib/workspace-path";
 import type { FileEntry } from "../types";
 
 interface FileBrowserProps {
   workspaceId: string;
+  /**
+   * Absolute filesystem path of the workspace root. When provided, each row's
+   * right-click menu offers "Copy absolute path"; when omitted (e.g. still
+   * loading) that item is hidden but "Copy relative path" remains.
+   */
+  workspacePath?: string;
   /**
    * Called on single-click on a file. The caller decides whether this
    * opens as a preview or pinned tab (this component just emits the
@@ -290,6 +299,8 @@ interface TreeNodeProps {
   canCut: boolean;
   canCopy: boolean;
   canPaste: boolean;
+  /** Absolute workspace root path, used to build the "Copy absolute path" value. */
+  workspacePath?: string;
   compact?: boolean;
   /** Single source of truth for the currently-highlighted tree row. */
   treeSelection: { path: string; kind: "file" | "directory" } | null;
@@ -332,6 +343,7 @@ function TreeNode({
   canCut,
   canCopy,
   canPaste,
+  workspacePath,
   compact,
   treeSelection,
   clipboard,
@@ -390,6 +402,7 @@ function TreeNode({
       // FileBrowser without depending on the brittle Tailwind class
       // pair below.
       data-band-active={isSelected ? "true" : undefined}
+      data-testid={`file-tree__row--${entryPath}`}
       onClick={handleClick}
       onDoubleClick={handleDoubleClick}
       // Stop the events Radix uses to detect a context-menu open from
@@ -535,9 +548,28 @@ function TreeNode({
             Paste
           </ContextMenuItem>
         )}
-        {(canCut || canCopy || (isDir && canPaste)) && (canRename || canDelete) && (
-          <ContextMenuSeparator />
+        {/* Copy-path actions are always available (relative path is derivable
+            from the row alone; absolute path needs the workspace root). */}
+        {(isDir || canCut || canCopy) && <ContextMenuSeparator />}
+        <ContextMenuItem
+          data-testid="file-tree__copy-relative-path"
+          onSelect={() => menu.queue(() => void writeClipboardText(entryPath))}
+        >
+          <ClipboardCopy className="size-4" />
+          Copy relative path
+        </ContextMenuItem>
+        {workspacePath && (
+          <ContextMenuItem
+            data-testid="file-tree__copy-absolute-path"
+            onSelect={() =>
+              menu.queue(() => void writeClipboardText(joinWorkspacePath(workspacePath, entryPath)))
+            }
+          >
+            <ClipboardCopy className="size-4" />
+            Copy absolute path
+          </ContextMenuItem>
         )}
+        {(canRename || canDelete) && <ContextMenuSeparator />}
         {canRename && (
           <ContextMenuItem onSelect={() => menu.queue(() => onRequestRename(entryPath))}>
             <Pencil className="size-4" />
@@ -603,6 +635,7 @@ function TreeNode({
               canCut={canCut}
               canCopy={canCopy}
               canPaste={canPaste}
+              workspacePath={workspacePath}
               compact={compact}
               treeSelection={treeSelection}
               clipboard={clipboard}
@@ -671,6 +704,7 @@ function TreeNode({
 export const FileBrowser = forwardRef<FileBrowserHandle, FileBrowserProps>(function FileBrowser(
   {
     workspaceId,
+    workspacePath,
     onOpenFile,
     onOpenFilePinned,
     compact,
@@ -1433,6 +1467,7 @@ export const FileBrowser = forwardRef<FileBrowserHandle, FileBrowserProps>(funct
                   canCut={canCutCopy}
                   canCopy={canCopyOp}
                   canPaste={canPaste}
+                  workspacePath={workspacePath}
                   compact={compact}
                   treeSelection={treeSelection}
                   clipboard={clipboard}

--- a/apps/web/src/dashboard/hooks/use-workspace-path.ts
+++ b/apps/web/src/dashboard/hooks/use-workspace-path.ts
@@ -1,0 +1,26 @@
+import { useMemo } from "react";
+import { toWorkspaceId } from "../lib/workspace-id";
+import { useProjects } from "./use-projects";
+
+/**
+ * Resolve a workspace's absolute filesystem path (the worktree root on disk)
+ * from its `workspaceId`. Matches against the projects list, where each
+ * worktree carries its absolute `path`.
+ *
+ * Returns `undefined` while projects are still loading or when no worktree
+ * matches the id — callers should treat that as "absolute path unavailable"
+ * (e.g. hide a "Copy absolute path" action).
+ */
+export function useWorkspacePath(workspaceId: string): string | undefined {
+  const { projects } = useProjects();
+  return useMemo(() => {
+    for (const proj of projects) {
+      for (const wt of proj.worktrees) {
+        if (toWorkspaceId(proj.name, wt.branch) === workspaceId) {
+          return wt.path;
+        }
+      }
+    }
+    return undefined;
+  }, [projects, workspaceId]);
+}

--- a/apps/web/src/dashboard/index.ts
+++ b/apps/web/src/dashboard/index.ts
@@ -72,6 +72,7 @@ export {
   useSetupStatusWatcher,
   useStatusWatcher,
 } from "./hooks/use-status";
+export { useWorkspacePath } from "./hooks/use-workspace-path";
 export {
   buildLspWsUrl,
   createLspExtension,

--- a/apps/web/src/dashboard/lib/workspace-path.ts
+++ b/apps/web/src/dashboard/lib/workspace-path.ts
@@ -1,0 +1,16 @@
+/**
+ * Join a workspace's absolute root path with a workspace-relative path to
+ * produce an absolute filesystem path.
+ *
+ * `workspaceRoot` is the worktree directory on disk (no trailing slash, as
+ * returned by `WorktreeInfo.path`); `relativePath` is the workspace-relative
+ * path the file trees operate in (no leading slash, `""` for the root).
+ *
+ * The empty relative path maps to the root itself. Any stray trailing slash on
+ * the root or leading slash on the relative path is tolerated.
+ */
+export function joinWorkspacePath(workspaceRoot: string, relativePath: string): string {
+  const root = workspaceRoot.replace(/\/+$/, "");
+  const rel = relativePath.replace(/^\/+/, "");
+  return rel ? `${root}/${rel}` : root;
+}


### PR DESCRIPTION
## Summary

Adds **Copy relative path** and **Copy absolute path** right-click context-menu actions to both workspace file trees:

- **Changes view** (`ChangesFileTree`)
- **Files view** (`FileBrowser`)

"Copy relative path" copies the file's path relative to the workspace/project root; "Copy absolute path" copies the full filesystem path (worktree root + relative path). Both work on file and folder rows.

## Implementation

- New `useWorkspacePath(workspaceId)` hook resolves a workspace's absolute worktree path from the projects list (replaces logic previously inlined in `CodeBrowserView`).
- New `joinWorkspacePath(root, relative)` helper joins the worktree root with a workspace-relative path.
- `ChangesFileTree` now always renders its context menu (previously only when "Reset changes" was available); the reset item moved below a separator.
- `FileBrowser` rows gain the two copy items between the Cut/Copy/Paste and Rename/Delete groups.
- `DiffView` and `CodeBrowserView` thread `workspacePath` into the trees.
- Reuses the existing `writeClipboardText` util (secure-context + `execCommand` fallback) and the `useDeferredMenuAction` queue pattern.

## Testing

- New Playwright integration test (`e2e/copy-file-path.spec.ts` + `e2e/pages/FileTreesPage.ts`) boots the real server against an on-disk git worktree (no tRPC mocking) and asserts both trees copy the correct relative (`src/notes.txt`) and absolute (`<worktree>/src/notes.txt`) paths via the clipboard. Uses a nested file so the relative/absolute distinction is genuinely exercised.
- Ran the local CI-style review (`/review-and-apply`): no blockers; coding/security/performance ✅, testing suggestions applied.
- `pnpm check` and the new e2e spec pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)