### PR TITLE
fix(web): route panel add/split/close to the workspace that owns the clicked group

### DIFF
--- a/apps/web/e2e/pages/WorkspacePage.ts
+++ b/apps/web/e2e/pages/WorkspacePage.ts
@@ -416,6 +416,115 @@ export class WorkspacePage {
     return this.page.locator(`.dv-tab:has([data-testid="workspace__tab--${panelComponent}"])`);
   }
 
+  // ──────────────────────────────────────────────────────────────────────
+  // Inner-dockview header toolbar actions ("+" / split). These live in each
+  // inner container's `rightHeaderActionsComponent` (`RightHeaderActions` in
+  // DockviewChatContainer.tsx etc.). The buttons carry no visible text — the
+  // accessible name comes from the `title` attribute ("New chat tab",
+  // "Split right", "Split down"), so `getByRole("button", { name })` resolves
+  // them. We scope to a workspace's cached panel host and filter to the
+  // visible button so the locator picks the active workspace's CENTRAL group
+  // toolbar, not the collapsed edge groups' hidden buttons nor the OTHER
+  // (hidden) cached workspace's chat header. This is the surface the
+  // wrong-workspace-panel regression test drives.
+  // ──────────────────────────────────────────────────────────────────────
+
+  /** The central (grid) group's header toolbar for a given inner container in
+   *  a workspace's panel host. Only grid groups render the split buttons (edge
+   *  groups render just the "+"), so anchoring on a toolbar that contains BOTH
+   *  a "Split right" button AND the container-specific add button
+   *  (`addTitle`) isolates the central group's action row from the collapsed
+   *  edge groups' "+"-only rows — whose buttons can overlap content and steal
+   *  the click. The `addTitle` anchor also disambiguates the chat toolbar from
+   *  the terminal toolbar when both inner dockviews are visible at once
+   *  (default outer layout shows Chat in one group and the active right-group
+   *  tab in another). Scoped to the workspace's cached entry + filtered to
+   *  visible so it never resolves the OTHER (hidden) workspace's header. */
+  private centralToolbar(workspaceId: string, addTitle: string): Locator {
+    return this.cachedPanelEntries(workspaceId)
+      .locator(`div:has(> button[title="Split right"]):has(> button[title="${addTitle}"])`)
+      .filter({ visible: true });
+  }
+
+  /** The visible "New chat tab" ("+") button for a workspace's chat host. */
+  chatAddTabButton(workspaceId: string): Locator {
+    return this.centralToolbar(workspaceId, "New chat tab").getByRole("button", {
+      name: "New chat tab",
+    });
+  }
+
+  /** The visible chat "Split right" button for a workspace's chat host. */
+  chatSplitRightButton(workspaceId: string): Locator {
+    return this.centralToolbar(workspaceId, "New chat tab").getByRole("button", {
+      name: "Split right",
+    });
+  }
+
+  /** The visible "New terminal" ("+") button for a workspace's terminal host. */
+  terminalAddTabButton(workspaceId: string): Locator {
+    return this.centralToolbar(workspaceId, "New terminal").getByRole("button", {
+      name: "New terminal",
+    });
+  }
+
+  /** The visible terminal "Split right" button for a workspace's terminal host. */
+  terminalSplitRightButton(workspaceId: string): Locator {
+    return this.centralToolbar(workspaceId, "New terminal").getByRole("button", {
+      name: "Split right",
+    });
+  }
+
+  /** Click the chat "+" (add tab) button in the given workspace's host. */
+  async clickChatAddTab(workspaceId: string): Promise<void> {
+    await test.step(`Click chat "+" in workspace ${workspaceId}`, async () => {
+      await this.chatAddTabButton(workspaceId).first().click();
+    });
+  }
+
+  /** Click the chat "Split right" button in the given workspace's host. */
+  async clickChatSplitRight(workspaceId: string): Promise<void> {
+    await test.step(`Click chat "Split right" in workspace ${workspaceId}`, async () => {
+      await this.chatSplitRightButton(workspaceId).first().click();
+    });
+  }
+
+  /** Click the terminal "+" (add tab) button in the given workspace's host. */
+  async clickTerminalAddTab(workspaceId: string): Promise<void> {
+    await test.step(`Click terminal "+" in workspace ${workspaceId}`, async () => {
+      await this.terminalAddTabButton(workspaceId).first().click();
+    });
+  }
+
+  /** Click the terminal "Split right" button in the given workspace's host. */
+  async clickTerminalSplitRight(workspaceId: string): Promise<void> {
+    await test.step(`Click terminal "Split right" in workspace ${workspaceId}`, async () => {
+      await this.terminalSplitRightButton(workspaceId).first().click();
+    });
+  }
+
+  /** Count the panels in a workspace's persisted inner layout for the given
+   *  container. Returns 0 when no layout has been persisted yet. Reads the
+   *  server-side layout (via `readInnerLayout`) so it reflects which
+   *  workspace's dockview an add/split actually mutated — the crux of the
+   *  wrong-workspace regression. */
+  async countInnerPanels(
+    container: "chat" | "terminal" | "browser",
+    workspaceId: string,
+  ): Promise<number> {
+    const tree = await this.readInnerLayout(container, workspaceId);
+    return tree ? Object.keys(tree.panels).length : 0;
+  }
+
+  /** Convenience: panel count for a workspace's persisted chat layout. */
+  async countChatPanels(workspaceId: string): Promise<number> {
+    return this.countInnerPanels("chat", workspaceId);
+  }
+
+  /** Convenience: panel count for a workspace's persisted terminal layout. */
+  async countTerminalPanels(workspaceId: string): Promise<number> {
+    return this.countInnerPanels("terminal", workspaceId);
+  }
+
   /** Navigate to the given workspace. The workspace URL no longer carries a
    *  sub-path for the active tab — see issue #467 for the route unification
    *  that folded `/changes`, `/code`, `/terminal` into `/workspace/:id`. */

--- a/apps/web/e2e/pages/WorkspacePage.ts
+++ b/apps/web/e2e/pages/WorkspacePage.ts
@@ -430,46 +430,42 @@ export class WorkspacePage {
   // ──────────────────────────────────────────────────────────────────────
 
   /** The central (grid) group's header toolbar for a given inner container in
-   *  a workspace's panel host. Only grid groups render the split buttons (edge
-   *  groups render just the "+"), so anchoring on a toolbar that contains BOTH
-   *  a "Split right" button AND the container-specific add button
-   *  (`addTitle`) isolates the central group's action row from the collapsed
-   *  edge groups' "+"-only rows — whose buttons can overlap content and steal
-   *  the click. The `addTitle` anchor also disambiguates the chat toolbar from
-   *  the terminal toolbar when both inner dockviews are visible at once
-   *  (default outer layout shows Chat in one group and the active right-group
-   *  tab in another). Scoped to the workspace's cached entry + filtered to
-   *  visible so it never resolves the OTHER (hidden) workspace's header. */
-  private centralToolbar(workspaceId: string, addTitle: string): Locator {
+   *  a workspace's panel host. Each container's `RightHeaderActions` tags its
+   *  GRID-group toolbar with `dockview-<container>__toolbar` (edge groups get
+   *  no testid), so `getByTestId` resolves only the central action row — never
+   *  the collapsed edge groups' "+"-only rows whose buttons can overlap
+   *  content and steal a click. The container-specific testid also keeps the
+   *  chat toolbar distinct from the terminal toolbar when both inner dockviews
+   *  are visible at once (default outer layout shows Chat in one group and the
+   *  active right-group tab in another). Scoped to the workspace's cached
+   *  entry + filtered to visible so it never resolves the OTHER (hidden)
+   *  workspace's header. */
+  private centralToolbar(workspaceId: string, container: "chat" | "terminal" | "browser"): Locator {
     return this.cachedPanelEntries(workspaceId)
-      .locator(`div:has(> button[title="Split right"]):has(> button[title="${addTitle}"])`)
+      .getByTestId(`dockview-${container}__toolbar`)
       .filter({ visible: true });
   }
 
   /** The visible "New chat tab" ("+") button for a workspace's chat host. */
   chatAddTabButton(workspaceId: string): Locator {
-    return this.centralToolbar(workspaceId, "New chat tab").getByRole("button", {
-      name: "New chat tab",
-    });
+    return this.centralToolbar(workspaceId, "chat").getByRole("button", { name: "New chat tab" });
   }
 
   /** The visible chat "Split right" button for a workspace's chat host. */
   chatSplitRightButton(workspaceId: string): Locator {
-    return this.centralToolbar(workspaceId, "New chat tab").getByRole("button", {
-      name: "Split right",
-    });
+    return this.centralToolbar(workspaceId, "chat").getByRole("button", { name: "Split right" });
   }
 
   /** The visible "New terminal" ("+") button for a workspace's terminal host. */
   terminalAddTabButton(workspaceId: string): Locator {
-    return this.centralToolbar(workspaceId, "New terminal").getByRole("button", {
+    return this.centralToolbar(workspaceId, "terminal").getByRole("button", {
       name: "New terminal",
     });
   }
 
   /** The visible terminal "Split right" button for a workspace's terminal host. */
   terminalSplitRightButton(workspaceId: string): Locator {
-    return this.centralToolbar(workspaceId, "New terminal").getByRole("button", {
+    return this.centralToolbar(workspaceId, "terminal").getByRole("button", {
       name: "Split right",
     });
   }

--- a/apps/web/e2e/panel-toolbar-target-workspace.spec.ts
+++ b/apps/web/e2e/panel-toolbar-target-workspace.spec.ts
@@ -189,19 +189,17 @@ async function mountBothAndSettle(
   await expect(workspacePage.chatAddTabButton(visible).first()).toBeVisible();
 
   // Settle both persisted baselines (each defaults to a single chat tab).
-  let baseVisible = 0;
-  let baseCached = 0;
+  // Two sequential polls so the actual counts surface in the Playwright
+  // reporter on failure, then read the stabilised values once.
   await expect
-    .poll(
-      async () => {
-        baseVisible = await workspacePage.countChatPanels(visible);
-        baseCached = await workspacePage.countChatPanels(cached);
-        return baseVisible >= 1 && baseCached >= 1;
-      },
-      { timeout: 10_000 },
-    )
-    .toBe(true);
+    .poll(() => workspacePage.countChatPanels(visible), { timeout: 10_000 })
+    .toBeGreaterThanOrEqual(1);
+  await expect
+    .poll(() => workspacePage.countChatPanels(cached), { timeout: 10_000 })
+    .toBeGreaterThanOrEqual(1);
 
+  const baseVisible = await workspacePage.countChatPanels(visible);
+  const baseCached = await workspacePage.countChatPanels(cached);
   return { baseVisible, baseCached };
 }
 
@@ -237,19 +235,17 @@ async function mountBothTerminalsAndSettle(
   // button is actionable. Positive anchor for the click target.
   await expect(workspacePage.terminalAddTabButton(visible).first()).toBeVisible();
 
-  let baseVisible = 0;
-  let baseCached = 0;
+  // Two sequential polls so the actual counts surface in the Playwright
+  // reporter on failure, then read the stabilised values once.
   await expect
-    .poll(
-      async () => {
-        baseVisible = await workspacePage.countTerminalPanels(visible);
-        baseCached = await workspacePage.countTerminalPanels(cached);
-        return baseVisible >= 1 && baseCached >= 1;
-      },
-      { timeout: 10_000 },
-    )
-    .toBe(true);
+    .poll(() => workspacePage.countTerminalPanels(visible), { timeout: 10_000 })
+    .toBeGreaterThanOrEqual(1);
+  await expect
+    .poll(() => workspacePage.countTerminalPanels(cached), { timeout: 10_000 })
+    .toBeGreaterThanOrEqual(1);
 
+  const baseVisible = await workspacePage.countTerminalPanels(visible);
+  const baseCached = await workspacePage.countTerminalPanels(cached);
   return { baseVisible, baseCached };
 }
 

--- a/apps/web/e2e/panel-toolbar-target-workspace.spec.ts
+++ b/apps/web/e2e/panel-toolbar-target-workspace.spec.ts
@@ -223,12 +223,12 @@ async function mountBothTerminalsAndSettle(
 ): Promise<{ baseVisible: number; baseCached: number }> {
   await workspacePage.goto(visible);
   await workspacePage.waitForReady();
-  await workspacePage.tab("terminal").click();
+  await workspacePage.openTerminalTab();
   await expect(workspacePage.terminalTabVisibilityMarker(visible, true)).toBeVisible();
 
   await workspacePage.switchWorkspace(cached);
   await workspacePage.waitForReady();
-  await workspacePage.tab("terminal").click();
+  await workspacePage.openTerminalTab();
   await expect(workspacePage.terminalTabVisibilityMarker(cached, true)).toBeVisible();
 
   await workspacePage.switchWorkspace(visible);

--- a/apps/web/e2e/panel-toolbar-target-workspace.spec.ts
+++ b/apps/web/e2e/panel-toolbar-target-workspace.spec.ts
@@ -269,8 +269,11 @@ test.describe("Inner-dockview toolbar targets the visible workspace", () => {
 
     // ...and the hidden, cached workspace was NOT touched. On the buggy
     // module-level-singleton code the panel landed in the cached workspace
-    // instead, so this is the assertion that fails on the regression.
-    expect(await workspacePage.countChatPanels(ADD_CACHED)).toBe(baseCached);
+    // instead. Poll (not a bare read) so a debounce-delayed wrong-workspace
+    // persist can't slip in after a stale baseline read and pass falsely.
+    await expect
+      .poll(() => workspacePage.countChatPanels(ADD_CACHED), { timeout: 3_000 })
+      .toBe(baseCached);
   });
 
   test("clicking the chat 'Split right' splits in the VISIBLE workspace, not the cached one", async ({
@@ -290,8 +293,11 @@ test.describe("Inner-dockview toolbar targets the visible workspace", () => {
       .poll(() => workspacePage.countChatPanels(SPLIT_VISIBLE), { timeout: 10_000 })
       .toBe(baseVisible + 1);
 
-    // ...and leaves the cached workspace untouched.
-    expect(await workspacePage.countChatPanels(SPLIT_CACHED)).toBe(baseCached);
+    // ...and leaves the cached workspace untouched (poll to absorb a
+    // debounce-delayed wrong-workspace persist — see the add-tab test).
+    await expect
+      .poll(() => workspacePage.countChatPanels(SPLIT_CACHED), { timeout: 3_000 })
+      .toBe(baseCached);
   });
 
   test("clicking the terminal '+' creates the tab in the VISIBLE workspace, not the cached one", async ({
@@ -314,8 +320,10 @@ test.describe("Inner-dockview toolbar targets the visible workspace", () => {
     // ...and the hidden, cached workspace was NOT touched. The buggy
     // module-level singleton resolved the cached workspace's handler at
     // click time, creating the terminal there — this assertion fails on
-    // the broken code.
-    expect(await workspacePage.countTerminalPanels(TERM_ADD_CACHED)).toBe(baseCached);
+    // the broken code. Poll to absorb a debounce-delayed persist.
+    await expect
+      .poll(() => workspacePage.countTerminalPanels(TERM_ADD_CACHED), { timeout: 3_000 })
+      .toBe(baseCached);
   });
 
   test("clicking the terminal 'Split right' splits in the VISIBLE workspace, not the cached one", async ({
@@ -335,7 +343,10 @@ test.describe("Inner-dockview toolbar targets the visible workspace", () => {
       .poll(() => workspacePage.countTerminalPanels(TERM_SPLIT_VISIBLE), { timeout: 10_000 })
       .toBe(baseVisible + 1);
 
-    // ...and leaves the cached workspace untouched.
-    expect(await workspacePage.countTerminalPanels(TERM_SPLIT_CACHED)).toBe(baseCached);
+    // ...and leaves the cached workspace untouched (poll to absorb a
+    // debounce-delayed wrong-workspace persist — see the add-tab test).
+    await expect
+      .poll(() => workspacePage.countTerminalPanels(TERM_SPLIT_CACHED), { timeout: 3_000 })
+      .toBe(baseCached);
   });
 });

--- a/apps/web/e2e/panel-toolbar-target-workspace.spec.ts
+++ b/apps/web/e2e/panel-toolbar-target-workspace.spec.ts
@@ -1,0 +1,345 @@
+/**
+ * Regression coverage: the inner-dockview header toolbar buttons ("+" /
+ * split) in the Chat panel must create the new panel in the VISIBLE
+ * workspace — never in a different, cached-but-hidden one.
+ *
+ * The bug
+ * -------
+ * `MultiWorkspacePanelHost` keeps up to `DEFAULT_MAX_CACHED_WORKSPACES`
+ * (3) workspaces mounted at once; inactive ones are only
+ * `visibility: hidden`, so several `DockviewChatContainer` instances are
+ * live simultaneously and all keep re-rendering. The add/split handlers
+ * used to live in a MODULE-LEVEL singleton ref that every instance
+ * overwrote on render — last-writer-wins. Whichever (possibly hidden)
+ * instance rendered most recently left ITS `workspaceId` + dockview api
+ * baked into the global, so clicking "+" / split in the visible workspace
+ * could create the chat in the wrong workspace's dockview.
+ *
+ * Keyboard shortcuts were unaffected (each instance handles its own
+ * focus-scoped keydown and calls its own closures), so only the toolbar
+ * buttons misfired — and only intermittently, depending on render order.
+ *
+ * The fix keys the handlers by the owning dockview's `api.id` (dockview
+ * passes the owning `containerApi` into the header-action component), so a
+ * click always routes to the workspace that owns the clicked group.
+ *
+ * Reproduction setup
+ * ------------------
+ * `MultiWorkspacePanelHost` renders its cached entries in Map INSERTION
+ * order (`Array.from(cache.values())`). A full `goto(A)` resets the cache
+ * to `{A}`; an in-app `switchWorkspace(B)` makes it `{A, B}`; switching
+ * back in-app to A leaves the order `[A, B]` — so A is VISIBLE but B (now
+ * hidden) is the LAST entry rendered each commit, i.e. the last writer the
+ * buggy module-level singleton would capture. Clicking "+" in A then
+ * created the panel in B on the broken code.
+ *
+ * Each test uses its OWN workspace pair (visible + cached). The toolbar
+ * "+"/split path creates a chat panel with no server-side chat record, so
+ * sharing a pair across tests would let one test's added panel be
+ * orphan-pruned on the next test's restore — separate pairs keep each
+ * test's baseline clean and the assertions deterministic.
+ *
+ * Architecture (same doctrine as the sibling specs)
+ * -------------------------------------------------
+ *   - Real production binary booted against a fresh tmp `~/.band/`.
+ *   - No tRPC mocking; the dashboard renders against real procedures.
+ *   - All UI driven through `WorkspacePage` (no raw `getByRole` / `goto`
+ *     in the test body).
+ *   - Assertions read the server-persisted inner layout via
+ *     `chatLayout.get` / `terminalLayout.get` (`countChatPanels` /
+ *     `countTerminalPanels`) so they observe WHICH workspace's dockview
+ *     the click actually mutated — the exact bug surface — rather than
+ *     something cosmetic.
+ *
+ * Chat vs terminal coverage
+ * -------------------------
+ * The terminal tests are the DETERMINISTIC regression catch: the buggy
+ * terminal `RightHeaderActions` reads the module-level `addTabRef.current`
+ * at CLICK time, so after the switch dance above it resolves the trailing
+ * (hidden) workspace's handler every time — clicking the visible
+ * workspace's "+"/split creates the terminal in the hidden workspace, and
+ * these tests fail on the broken code. The chat `RightHeaderActions`
+ * instead captured `addTabRef.current` at RENDER time, so the visible
+ * workspace's chat header — mounted when its own workspace was the most
+ * recent writer — held the correct handler and the bug only surfaced on a
+ * later stale re-render. The chat tests therefore lock in the FIXED chat
+ * routing (handlers keyed by `containerApi.id`) for the buttons named in
+ * the bug report, while the terminal tests prove the regression itself is
+ * caught. Both containers received the identical fix.
+ *
+ * Out of scope: browser container
+ * -------------------------------
+ * `DockviewBrowserContainer` got the SAME keyed-by-`api.id` fix (add /
+ * split / close), but it is only mounted in the Electron DESKTOP build:
+ * `BrowserPanelComponent` in `SharedDockviewLayout.tsx` renders a
+ * "desktop only" web fallback under `if (!isDesktop)` and mounts
+ * `DockviewBrowserContainer` solely on desktop. This Playwright suite
+ * boots the WEB build (`dist/start-server.mjs` driven by Chromium), where
+ * `isDesktop` is false, so the browser container never mounts and a
+ * runtime browser test can't run here — identical reasoning and exemption
+ * to `panel-default-position.spec.ts`'s browser carve-out. The browser
+ * half of the fix is covered by TypeScript + structural review (it is the
+ * same transformation applied to chat/terminal) and would need a desktop
+ * e2e harness to exercise at runtime; the `WorkspacePage` helpers already
+ * accept `"browser"` (`countInnerPanels`) so that future harness can wire
+ * it up without re-deriving the path.
+ */
+
+import { expect, test } from "@playwright/test";
+import { toWorkspaceId } from "@/dashboard";
+import {
+  cleanupTmpHome,
+  createTmpHome,
+  type ServerHandle,
+  seedSettings,
+  seedState,
+  startServer,
+} from "./helpers/server";
+import { WorkspacePage } from "./pages/WorkspacePage";
+
+const TOKEN = "e2e-panel-toolbar-target-token";
+
+// One dedicated workspace pair per test (visible + cached), so no test's
+// toolbar-added panel can leak into another's restore/prune path.
+const ADD_VISIBLE = toWorkspaceId("alpha-add", "main");
+const ADD_CACHED = toWorkspaceId("bravo-add", "main");
+const SPLIT_VISIBLE = toWorkspaceId("alpha-split", "main");
+const SPLIT_CACHED = toWorkspaceId("bravo-split", "main");
+const TERM_ADD_VISIBLE = toWorkspaceId("alpha-term-add", "main");
+const TERM_ADD_CACHED = toWorkspaceId("bravo-term-add", "main");
+const TERM_SPLIT_VISIBLE = toWorkspaceId("alpha-term-split", "main");
+const TERM_SPLIT_CACHED = toWorkspaceId("bravo-term-split", "main");
+
+function project(name: string) {
+  return {
+    name,
+    path: `/tmp/fake/${name}`,
+    defaultBranch: "main",
+    worktrees: [{ branch: "main", path: `/tmp/fake/${name}` }],
+  };
+}
+
+// Wide viewport so `useIsDesktop()` reports true and the shared dockview
+// (which hosts the inner chat container under test) renders.
+test.use({ viewport: { width: 1280, height: 800 } });
+
+let server: ServerHandle;
+let tmpHome: string;
+
+test.beforeAll(async () => {
+  tmpHome = createTmpHome();
+  seedState(tmpHome, {
+    projects: [
+      project("alpha-add"),
+      project("bravo-add"),
+      project("alpha-split"),
+      project("bravo-split"),
+      project("alpha-term-add"),
+      project("bravo-term-add"),
+      project("alpha-term-split"),
+      project("bravo-term-split"),
+    ],
+  });
+  seedSettings(tmpHome, { tokenSecret: TOKEN });
+  server = await startServer({ tmpHome });
+});
+
+test.afterAll(async () => {
+  await server.close();
+  cleanupTmpHome(tmpHome);
+});
+
+/**
+ * Mount BOTH workspaces (so both chat containers are live) with `visible`
+ * shown and `cached` the trailing cache entry, then return a settled
+ * baseline of each workspace's persisted chat panel count.
+ *
+ *   1. `goto(visible)` — full navigation, cache resets to `{visible}`.
+ *   2. `switchWorkspace(cached)` — in-app nav, cache `{visible, cached}`,
+ *      `cached` shown, `visible` hidden but still mounted.
+ *   3. `switchWorkspace(visible)` — in-app nav, `visible` shown again;
+ *      cache order stays `[visible, cached]`, so `cached` is the trailing
+ *      (last-rendered) entry — the writer the buggy singleton would
+ *      capture.
+ *
+ * Both chat containers seed a default tab on cold mount and debounce-save
+ * it, so we poll until each side reports its baseline before acting.
+ */
+async function mountBothAndSettle(
+  workspacePage: WorkspacePage,
+  visible: string,
+  cached: string,
+): Promise<{ baseVisible: number; baseCached: number }> {
+  await workspacePage.goto(visible);
+  await workspacePage.waitForReady();
+  // The default chat tab is visible — proves the chat container's onReady
+  // ran (its layout will persist) before we move on.
+  await expect(workspacePage.chatTabVisibilityMarker(visible, true)).toBeVisible();
+
+  await workspacePage.switchWorkspace(cached);
+  await workspacePage.waitForReady();
+  // The cached workspace's chat container is now mounted and visible — its
+  // onReady ran too, so it has a persisted baseline.
+  await expect(workspacePage.chatTabVisibilityMarker(cached, true)).toBeVisible();
+
+  await workspacePage.switchWorkspace(visible);
+  await workspacePage.waitForReady();
+  // `visible` is shown again; its chat "+" button is actionable. Positive
+  // anchor that the visible toolbar we're about to click is the right one.
+  await expect(workspacePage.chatAddTabButton(visible).first()).toBeVisible();
+
+  // Settle both persisted baselines (each defaults to a single chat tab).
+  let baseVisible = 0;
+  let baseCached = 0;
+  await expect
+    .poll(
+      async () => {
+        baseVisible = await workspacePage.countChatPanels(visible);
+        baseCached = await workspacePage.countChatPanels(cached);
+        return baseVisible >= 1 && baseCached >= 1;
+      },
+      { timeout: 10_000 },
+    )
+    .toBe(true);
+
+  return { baseVisible, baseCached };
+}
+
+/**
+ * Terminal counterpart of `mountBothAndSettle`. The inner terminal
+ * container only mounts when the outer Terminal tab is active, so we
+ * activate it on each workspace while it's shown — that also mounts the
+ * cached workspace's terminal container (the last-writer the buggy
+ * read-at-click handler resolves). On the final return to `visible` the
+ * per-workspace active-view restore re-activates Terminal automatically
+ * (it was the saved active view), so we don't re-click the tab — clicking
+ * it again would re-render `visible`'s terminal container and reset the
+ * module-level ref, masking the bug.
+ */
+async function mountBothTerminalsAndSettle(
+  workspacePage: WorkspacePage,
+  visible: string,
+  cached: string,
+): Promise<{ baseVisible: number; baseCached: number }> {
+  await workspacePage.goto(visible);
+  await workspacePage.waitForReady();
+  await workspacePage.tab("terminal").click();
+  await expect(workspacePage.terminalTabVisibilityMarker(visible, true)).toBeVisible();
+
+  await workspacePage.switchWorkspace(cached);
+  await workspacePage.waitForReady();
+  await workspacePage.tab("terminal").click();
+  await expect(workspacePage.terminalTabVisibilityMarker(cached, true)).toBeVisible();
+
+  await workspacePage.switchWorkspace(visible);
+  await workspacePage.waitForReady();
+  // Terminal is restored as the visible workspace's active view; its "+"
+  // button is actionable. Positive anchor for the click target.
+  await expect(workspacePage.terminalAddTabButton(visible).first()).toBeVisible();
+
+  let baseVisible = 0;
+  let baseCached = 0;
+  await expect
+    .poll(
+      async () => {
+        baseVisible = await workspacePage.countTerminalPanels(visible);
+        baseCached = await workspacePage.countTerminalPanels(cached);
+        return baseVisible >= 1 && baseCached >= 1;
+      },
+      { timeout: 10_000 },
+    )
+    .toBe(true);
+
+  return { baseVisible, baseCached };
+}
+
+test.describe("Inner-dockview toolbar targets the visible workspace", () => {
+  test("clicking the chat '+' creates the tab in the VISIBLE workspace, not the cached one", async ({
+    page,
+  }) => {
+    const workspacePage = new WorkspacePage(page, server.url, TOKEN);
+    const { baseVisible, baseCached } = await mountBothAndSettle(
+      workspacePage,
+      ADD_VISIBLE,
+      ADD_CACHED,
+    );
+
+    await workspacePage.clickChatAddTab(ADD_VISIBLE);
+
+    // The visible workspace gained a chat panel...
+    await expect
+      .poll(() => workspacePage.countChatPanels(ADD_VISIBLE), { timeout: 10_000 })
+      .toBe(baseVisible + 1);
+
+    // ...and the hidden, cached workspace was NOT touched. On the buggy
+    // module-level-singleton code the panel landed in the cached workspace
+    // instead, so this is the assertion that fails on the regression.
+    expect(await workspacePage.countChatPanels(ADD_CACHED)).toBe(baseCached);
+  });
+
+  test("clicking the chat 'Split right' splits in the VISIBLE workspace, not the cached one", async ({
+    page,
+  }) => {
+    const workspacePage = new WorkspacePage(page, server.url, TOKEN);
+    const { baseVisible, baseCached } = await mountBothAndSettle(
+      workspacePage,
+      SPLIT_VISIBLE,
+      SPLIT_CACHED,
+    );
+
+    await workspacePage.clickChatSplitRight(SPLIT_VISIBLE);
+
+    // Split adds a panel (in a new group) to the VISIBLE workspace...
+    await expect
+      .poll(() => workspacePage.countChatPanels(SPLIT_VISIBLE), { timeout: 10_000 })
+      .toBe(baseVisible + 1);
+
+    // ...and leaves the cached workspace untouched.
+    expect(await workspacePage.countChatPanels(SPLIT_CACHED)).toBe(baseCached);
+  });
+
+  test("clicking the terminal '+' creates the tab in the VISIBLE workspace, not the cached one", async ({
+    page,
+  }) => {
+    const workspacePage = new WorkspacePage(page, server.url, TOKEN);
+    const { baseVisible, baseCached } = await mountBothTerminalsAndSettle(
+      workspacePage,
+      TERM_ADD_VISIBLE,
+      TERM_ADD_CACHED,
+    );
+
+    await workspacePage.clickTerminalAddTab(TERM_ADD_VISIBLE);
+
+    // The visible workspace gained a terminal panel...
+    await expect
+      .poll(() => workspacePage.countTerminalPanels(TERM_ADD_VISIBLE), { timeout: 10_000 })
+      .toBe(baseVisible + 1);
+
+    // ...and the hidden, cached workspace was NOT touched. The buggy
+    // module-level singleton resolved the cached workspace's handler at
+    // click time, creating the terminal there — this assertion fails on
+    // the broken code.
+    expect(await workspacePage.countTerminalPanels(TERM_ADD_CACHED)).toBe(baseCached);
+  });
+
+  test("clicking the terminal 'Split right' splits in the VISIBLE workspace, not the cached one", async ({
+    page,
+  }) => {
+    const workspacePage = new WorkspacePage(page, server.url, TOKEN);
+    const { baseVisible, baseCached } = await mountBothTerminalsAndSettle(
+      workspacePage,
+      TERM_SPLIT_VISIBLE,
+      TERM_SPLIT_CACHED,
+    );
+
+    await workspacePage.clickTerminalSplitRight(TERM_SPLIT_VISIBLE);
+
+    // Split adds a panel (in a new group) to the VISIBLE workspace...
+    await expect
+      .poll(() => workspacePage.countTerminalPanels(TERM_SPLIT_VISIBLE), { timeout: 10_000 })
+      .toBe(baseVisible + 1);
+
+    // ...and leaves the cached workspace untouched.
+    expect(await workspacePage.countTerminalPanels(TERM_SPLIT_CACHED)).toBe(baseCached);
+  });
+});

--- a/apps/web/src/components/DockviewBrowserContainer.tsx
+++ b/apps/web/src/components/DockviewBrowserContainer.tsx
@@ -347,7 +347,12 @@ const RightHeaderActions = React.memo(function RightHeaderActions(
   // resolves to the same content width and the button row looks
   // identical to before.
   return (
-    <div className="flex h-full w-full items-center justify-center">
+    // `data-testid` on grid-group toolbars only (edge groups get no testid)
+    // gives integration tests a stable hook for the central action row.
+    <div
+      className="flex h-full w-full items-center justify-center"
+      data-testid={isGridGroup ? "dockview-browser__toolbar" : undefined}
+    >
       {isGridGroup && (
         <>
           <button

--- a/apps/web/src/components/DockviewBrowserContainer.tsx
+++ b/apps/web/src/components/DockviewBrowserContainer.tsx
@@ -238,12 +238,15 @@ function BrowserTab(props: IDockviewPanelHeaderProps<BrowserTabParams>) {
     return () => d.dispose();
   }, [props.api]);
 
+  const containerApi = props.containerApi;
   const handleClose = useCallback(
     (e: React.MouseEvent) => {
       e.stopPropagation();
-      closeTabRef.current?.(browserId);
+      // Route to the handlers owned by THIS tab's dockview (keyed by
+      // `containerApi.id`) so closing a tab never hits a cached workspace.
+      panelActionsByApiId.get(containerApi.id)?.current?.onClose(browserId);
     },
-    [browserId],
+    [containerApi, browserId],
   );
 
   const showFavicon = faviconUrl && !faviconError;
@@ -276,20 +279,26 @@ function BrowserTab(props: IDockviewPanelHeaderProps<BrowserTabParams>) {
 }
 
 // ---------------------------------------------------------------------------
-// Shared refs for stable Dockview components
+// Per-instance action registry for stable Dockview components
+//
+// dockview's `rightHeaderActionsComponent` and tab header components must be
+// STABLE references, but the handlers they invoke are per-container-instance
+// (each mounted DockviewBrowserContainer has its own `workspaceId` + inner
+// dockview api). MultiWorkspacePanelHost keeps up to 3 workspaces mounted at
+// once (inactive ones only `visibility: hidden`), so a module-level handler
+// ref suffered last-writer-wins: a hidden instance's handlers would handle a
+// click made in the visible workspace, creating the browser tab in the wrong
+// (cached) workspace.
+//
+// Fix: key the handlers by the owning dockview's `api.id`. dockview passes the
+// owning `containerApi` into header-action + tab-header props; every wrapper
+// shares the same underlying component `id` even though the DockviewApi object
+// differs per group. The value is the instance's `useRef` holder so clicks
+// always read the latest closures via `.current`.
 // ---------------------------------------------------------------------------
 
-const addTabRef: {
-  current: {
-    onAdd: (groupId?: string, options?: AddTabOptions) => void;
-    onSplit: (groupId: string, direction: "right" | "below") => void;
-  };
-} = {
-  current: { onAdd: () => {}, onSplit: () => {} },
-};
-
 /**
- * Options for `handleAddTab` and `addTabRef.current.onAdd`.
+ * Options for `handleAddTab` and `BrowserPanelActions.onAdd`.
  *
  * `initialUrl` lets callers materialize a tab that loads a specific
  * URL on mount — used by the `browser-open-window` listener (issue
@@ -301,15 +310,20 @@ interface AddTabOptions {
   initialUrl?: string;
 }
 
-/** Shared ref for the close-tab action — used by BrowserTab's close button. */
-const closeTabRef: { current: ((browserId: string) => void) | null } = {
-  current: null,
-};
+interface BrowserPanelActions {
+  onAdd: (groupId?: string, options?: AddTabOptions) => void;
+  onSplit: (groupId: string, direction: "right" | "below") => void;
+  onClose: (browserId: string) => void;
+}
+
+const panelActionsByApiId = new Map<string, { current: BrowserPanelActions }>();
 
 /**
  * Stable component for DockviewReact's rightHeaderActionsComponent.
- * Reads callback from the module-level ref to avoid the
- * "only React.memo/forwardRef/function components accepted" error.
+ * Resolves the per-instance handlers from `panelActionsByApiId` keyed by the
+ * owning `containerApi.id` (see the registry comment above) to avoid the
+ * "only React.memo/forwardRef/function components accepted" error while still
+ * routing each click to the workspace that owns the clicked group.
  */
 const RightHeaderActions = React.memo(function RightHeaderActions(
   props: IDockviewHeaderActionsProps,
@@ -321,6 +335,9 @@ const RightHeaderActions = React.memo(function RightHeaderActions(
   // edge group; only the split buttons are hidden. Defaults to "grid"
   // when `location` is missing (older dockview versions / tests).
   const isGridGroup = (props.location?.type ?? "grid") === "grid";
+  // Resolve the owning dockview at click time so the action always targets the
+  // workspace that owns THIS group, never a last-writer-wins global.
+  const apiId = props.containerApi.id;
   const groupId = props.group.id;
   // `w-full justify-center` keeps the "+" centered horizontally inside
   // the vertical (left/right) edge action strip, which dockview sizes
@@ -336,7 +353,7 @@ const RightHeaderActions = React.memo(function RightHeaderActions(
           <button
             type="button"
             className="inline-flex size-8 items-center justify-center text-muted-foreground hover:text-foreground hover:bg-accent rounded transition-colors"
-            onClick={() => addTabRef.current.onSplit(groupId, "right")}
+            onClick={() => panelActionsByApiId.get(apiId)?.current?.onSplit(groupId, "right")}
             title="Split right"
           >
             <Columns2 className="size-3.5" />
@@ -344,7 +361,7 @@ const RightHeaderActions = React.memo(function RightHeaderActions(
           <button
             type="button"
             className="inline-flex size-8 items-center justify-center text-muted-foreground hover:text-foreground hover:bg-accent rounded transition-colors"
-            onClick={() => addTabRef.current.onSplit(groupId, "below")}
+            onClick={() => panelActionsByApiId.get(apiId)?.current?.onSplit(groupId, "below")}
             title="Split down"
           >
             <Rows2 className="size-3.5" />
@@ -354,7 +371,7 @@ const RightHeaderActions = React.memo(function RightHeaderActions(
       <button
         type="button"
         className="inline-flex size-8 items-center justify-center text-muted-foreground hover:text-foreground hover:bg-accent rounded transition-colors"
-        onClick={() => addTabRef.current.onAdd(groupId)}
+        onClick={() => panelActionsByApiId.get(apiId)?.current?.onAdd(groupId)}
         title="New browser tab"
       >
         <Plus className="size-4" />
@@ -1024,14 +1041,23 @@ export function DockviewBrowserContainer({
   // Visibility is now propagated via PanelVisibilityContext (React context)
   // instead of updateParameters — see the Provider wrapping DockviewReact.
 
-  // Keep module-level refs in sync for stable Dockview components
-  addTabRef.current = { onAdd: handleAddTab, onSplit: handleSplit };
-  closeTabRef.current = closeTab;
+  // Per-instance action handlers for the stable Dockview header/tab
+  // components. Registered in `panelActionsByApiId` (keyed by this inner
+  // dockview's `api.id`) from `onReady`; mutated every render so the registry
+  // always holds this instance's latest closures.
+  const actionsRef = useRef<BrowserPanelActions>({
+    onAdd: () => {},
+    onSplit: () => {},
+    onClose: () => {},
+  });
+  actionsRef.current = { onAdd: handleAddTab, onSplit: handleSplit, onClose: closeTab };
 
   // Detach edge-group drag-visibility listeners + inner-dockview
-  // registration on unmount.
+  // registration, and drop this instance's action handlers, on unmount.
   useEffect(() => {
     return () => {
+      const api = apiRef.current;
+      if (api) panelActionsByApiId.delete(api.id);
       edgeDragDisposerRef.current?.();
       edgeDragDisposerRef.current = null;
       innerRegisterDisposerRef.current?.();
@@ -1055,6 +1081,9 @@ export function DockviewBrowserContainer({
   const onReady = useCallback(
     (event: DockviewReadyEvent) => {
       apiRef.current = event.api;
+      // Register this instance's handlers under the inner dockview's id so the
+      // header/tab components resolve to the correct workspace (see registry).
+      panelActionsByApiId.set(event.api.id, actionsRef);
       const savedLayout = initialLayoutRef.current;
       const knownBrowserIds = initialBrowserIdsRef.current;
       const knownUrls = initialUrlsRef.current;

--- a/apps/web/src/components/DockviewBrowserContainer.tsx
+++ b/apps/web/src/components/DockviewBrowserContainer.tsx
@@ -1085,6 +1085,11 @@ export function DockviewBrowserContainer({
 
   const onReady = useCallback(
     (event: DockviewReadyEvent) => {
+      // Defensive double-onReady guard (mirrors the disposer guards below):
+      // if onReady fires again with a fresh api, drop the previous registry
+      // entry so it doesn't orphan — unmount only deletes the last-seen id.
+      const prevApi = apiRef.current;
+      if (prevApi && prevApi.id !== event.api.id) panelActionsByApiId.delete(prevApi.id);
       apiRef.current = event.api;
       // Register this instance's handlers under the inner dockview's id so the
       // header/tab components resolve to the correct workspace (see registry).

--- a/apps/web/src/components/DockviewChatContainer.tsx
+++ b/apps/web/src/components/DockviewChatContainer.tsx
@@ -556,10 +556,6 @@ const RightHeaderActions = React.memo(function RightHeaderActions(
   // Resolve the owning dockview at click time so the action always targets the
   // workspace that owns THIS group, never a last-writer-wins global.
   const apiId = props.containerApi.id;
-  const onAdd: ChatPanelActions["onAdd"] = (agentId, groupIdArg) =>
-    panelActionsByApiId.get(apiId)?.current?.onAdd(agentId, groupIdArg);
-  const onSplit: ChatPanelActions["onSplit"] = (groupIdArg, direction) =>
-    panelActionsByApiId.get(apiId)?.current?.onSplit(groupIdArg, direction);
   const groupId = props.group.id;
   // `w-full justify-center` keeps the "+" centered horizontally inside
   // the vertical (left/right) edge action strip, which dockview sizes
@@ -569,13 +565,19 @@ const RightHeaderActions = React.memo(function RightHeaderActions(
   // resolves to the same content width and the button row looks
   // identical to before.
   return (
-    <div className="flex h-full w-full items-center justify-center">
+    // `data-testid` on grid-group toolbars only (edge groups get no testid)
+    // gives integration tests a stable hook for the central action row
+    // without the fragile CSS `:has(button[title=...])` workaround.
+    <div
+      className="flex h-full w-full items-center justify-center"
+      data-testid={isGridGroup ? "dockview-chat__toolbar" : undefined}
+    >
       {isGridGroup && (
         <>
           <button
             type="button"
             className="inline-flex size-8 items-center justify-center text-muted-foreground hover:text-foreground hover:bg-accent rounded transition-colors"
-            onClick={() => onSplit(groupId, "right")}
+            onClick={() => panelActionsByApiId.get(apiId)?.current?.onSplit(groupId, "right")}
             title="Split right"
           >
             <Columns2 className="size-3.5" />
@@ -583,7 +585,7 @@ const RightHeaderActions = React.memo(function RightHeaderActions(
           <button
             type="button"
             className="inline-flex size-8 items-center justify-center text-muted-foreground hover:text-foreground hover:bg-accent rounded transition-colors"
-            onClick={() => onSplit(groupId, "below")}
+            onClick={() => panelActionsByApiId.get(apiId)?.current?.onSplit(groupId, "below")}
             title="Split down"
           >
             <Rows2 className="size-3.5" />
@@ -593,7 +595,7 @@ const RightHeaderActions = React.memo(function RightHeaderActions(
       <button
         type="button"
         className="inline-flex size-8 items-center justify-center text-muted-foreground hover:text-foreground hover:bg-accent rounded transition-colors"
-        onClick={() => onAdd(undefined, groupId)}
+        onClick={() => panelActionsByApiId.get(apiId)?.current?.onAdd(undefined, groupId)}
         title="New chat tab"
       >
         <Plus className="size-4" />

--- a/apps/web/src/components/DockviewChatContainer.tsx
+++ b/apps/web/src/components/DockviewChatContainer.tsx
@@ -974,6 +974,11 @@ export function DockviewChatContainer({
 
   const onReady = useCallback(
     (event: DockviewReadyEvent) => {
+      // Defensive double-onReady guard (mirrors the disposer guards below):
+      // if onReady fires again with a fresh api, drop the previous registry
+      // entry so it doesn't orphan — unmount only deletes the last-seen id.
+      const prevApi = apiRef.current;
+      if (prevApi && prevApi.id !== event.api.id) panelActionsByApiId.delete(prevApi.id);
       apiRef.current = event.api;
       // Register this instance's handlers under the inner dockview's id so the
       // header/tab components resolve to the correct workspace (see registry).

--- a/apps/web/src/components/DockviewChatContainer.tsx
+++ b/apps/web/src/components/DockviewChatContainer.tsx
@@ -424,12 +424,16 @@ function ChatTab(props: IDockviewPanelHeaderProps<ChatTabParams>) {
     void writeClipboardText(sessionId);
   }, [sessionId]);
 
+  const containerApi = props.containerApi;
   const handleClose = useCallback(
     (e: React.MouseEvent) => {
       e.stopPropagation();
-      closeTabRef.current?.(chatId);
+      // Route to the handlers owned by THIS tab's dockview (keyed by
+      // `containerApi.id`) so closing a tab in the visible workspace never
+      // operates on a cached, hidden workspace's dockview.
+      panelActionsByApiId.get(containerApi.id)?.current?.onClose(chatId);
     },
-    [chatId],
+    [containerApi, chatId],
   );
 
   const showClose = panelCount > 1;
@@ -498,27 +502,46 @@ function ChatTab(props: IDockviewPanelHeaderProps<ChatTabParams>) {
 }
 
 // ---------------------------------------------------------------------------
-// Shared refs for stable Dockview components
+// Per-instance action registry for stable Dockview components
+//
+// dockview's `rightHeaderActionsComponent` and tab header components must be
+// STABLE references — a closure-capturing component can't be passed directly
+// (see the comment on `RightHeaderActions`). The handlers those components
+// invoke, however, are per-container-instance: each mounted
+// DockviewChatContainer has its own `workspaceId` and inner dockview api.
+//
+// MultiWorkspacePanelHost keeps up to `DEFAULT_MAX_CACHED_WORKSPACES` (3)
+// workspaces mounted at once — inactive ones are only `visibility: hidden`,
+// so several DockviewChatContainer instances are live simultaneously and all
+// keep re-rendering. A single module-level handler ref therefore suffered
+// last-writer-wins: whichever hidden instance rendered most recently left ITS
+// handlers in the global, and clicking "+" / split in the VISIBLE workspace
+// created the chat in the wrong (cached, hidden) workspace.
+//
+// Fix: key the handlers by the owning dockview's `api.id`. dockview passes the
+// owning `containerApi` into both header-action props and tab-header props, so
+// the visible group always resolves to its own workspace's handlers. We key by
+// `api.id` (not the DockviewApi object): dockview hands out a fresh
+// `DockviewApi` *wrapper* per group, so `props.containerApi !== onReadyApi` by
+// reference — but every wrapper exposes the same underlying component `id`.
+// The value is the instance's `useRef` holder, so clicks always read the
+// latest closures via `.current`.
 // ---------------------------------------------------------------------------
 
-const addTabRef: {
-  current: {
-    onAdd: (agentId?: string, groupId?: string) => void;
-    onSplit: (groupId: string, direction: "right" | "below") => void;
-  };
-} = {
-  current: { onAdd: () => {}, onSplit: () => {} },
-};
+interface ChatPanelActions {
+  onAdd: (agentId?: string, groupId?: string) => void;
+  onSplit: (groupId: string, direction: "right" | "below") => void;
+  onClose: (chatId: string) => void;
+}
 
-/** Shared ref for the close-tab action — used by ChatTab's close button. */
-const closeTabRef: { current: ((chatId: string) => void) | null } = {
-  current: null,
-};
+const panelActionsByApiId = new Map<string, { current: ChatPanelActions }>();
 
 /**
  * Stable component for DockviewReact's rightHeaderActionsComponent.
- * Reads callback from the module-level ref to avoid the
- * "only React.memo/forwardRef/function components accepted" error.
+ * Resolves the per-instance handlers from `panelActionsByApiId` keyed by the
+ * owning `containerApi.id` (see the registry comment above) to avoid the
+ * "only React.memo/forwardRef/function components accepted" error while still
+ * routing each click to the workspace that owns the clicked group.
  */
 const RightHeaderActions = React.memo(function RightHeaderActions(
   props: IDockviewHeaderActionsProps,
@@ -530,7 +553,13 @@ const RightHeaderActions = React.memo(function RightHeaderActions(
   // edge group; only the split buttons are hidden. Defaults to "grid"
   // when `location` is missing (older dockview versions / tests).
   const isGridGroup = (props.location?.type ?? "grid") === "grid";
-  const { onAdd, onSplit } = addTabRef.current;
+  // Resolve the owning dockview at click time so the action always targets the
+  // workspace that owns THIS group, never a last-writer-wins global.
+  const apiId = props.containerApi.id;
+  const onAdd: ChatPanelActions["onAdd"] = (agentId, groupIdArg) =>
+    panelActionsByApiId.get(apiId)?.current?.onAdd(agentId, groupIdArg);
+  const onSplit: ChatPanelActions["onSplit"] = (groupIdArg, direction) =>
+    panelActionsByApiId.get(apiId)?.current?.onSplit(groupIdArg, direction);
   const groupId = props.group.id;
   // `w-full justify-center` keeps the "+" centered horizontally inside
   // the vertical (left/right) edge action strip, which dockview sizes
@@ -910,14 +939,24 @@ export function DockviewChatContainer({
   // Visibility is now propagated via PanelVisibilityContext (React context)
   // instead of updateParameters — see the Provider wrapping DockviewReact.
 
-  // Keep module-level refs in sync for stable Dockview components
-  addTabRef.current = { onAdd: handleAddTab, onSplit: handleSplit };
-  closeTabRef.current = closeTab;
+  // Per-instance action handlers for the stable Dockview header/tab
+  // components. Registered in `panelActionsByApiId` (keyed by this inner
+  // dockview's `api.id`) from `onReady`; mutated every render so the registry
+  // always holds this instance's latest closures. See the registry comment
+  // for why a module-level singleton was wrong.
+  const actionsRef = useRef<ChatPanelActions>({
+    onAdd: () => {},
+    onSplit: () => {},
+    onClose: () => {},
+  });
+  actionsRef.current = { onAdd: handleAddTab, onSplit: handleSplit, onClose: closeTab };
 
   // Detach edge-group drag-visibility listeners + inner-dockview
-  // registration on unmount.
+  // registration, and drop this instance's action handlers, on unmount.
   useEffect(() => {
     return () => {
+      const api = apiRef.current;
+      if (api) panelActionsByApiId.delete(api.id);
       edgeDragDisposerRef.current?.();
       edgeDragDisposerRef.current = null;
       innerRegisterDisposerRef.current?.();
@@ -934,6 +973,9 @@ export function DockviewChatContainer({
   const onReady = useCallback(
     (event: DockviewReadyEvent) => {
       apiRef.current = event.api;
+      // Register this instance's handlers under the inner dockview's id so the
+      // header/tab components resolve to the correct workspace (see registry).
+      panelActionsByApiId.set(event.api.id, actionsRef);
       const savedLayout = initialLayoutRef.current;
       const knownChatIds = initialChatIdsRef.current;
 

--- a/apps/web/src/components/DockviewTerminalContainer.tsx
+++ b/apps/web/src/components/DockviewTerminalContainer.tsx
@@ -225,12 +225,16 @@ function TerminalTab(props: IDockviewPanelHeaderProps<TerminalTabParams>) {
     };
   }, [props.containerApi]);
 
+  const containerApi = props.containerApi;
+  const terminalId = props.params.terminalId;
   const handleClose = useCallback(
     (e: React.MouseEvent) => {
       e.stopPropagation();
-      closeTabRef.current?.(props.params.terminalId);
+      // Route to the handlers owned by THIS tab's dockview (keyed by
+      // `containerApi.id`) so closing a tab never hits a cached workspace.
+      panelActionsByApiId.get(containerApi.id)?.current?.onClose(terminalId);
     },
-    [props.params.terminalId],
+    [containerApi, terminalId],
   );
 
   const showClose = panelCount > 1;
@@ -256,21 +260,31 @@ function TerminalTab(props: IDockviewPanelHeaderProps<TerminalTabParams>) {
 }
 
 // ---------------------------------------------------------------------------
-// Shared refs for stable Dockview components
+// Per-instance action registry for stable Dockview components
+//
+// dockview's `rightHeaderActionsComponent` and tab header components must be
+// STABLE references, but the handlers they invoke are per-container-instance
+// (each mounted DockviewTerminalContainer has its own `workspaceId` + inner
+// dockview api). MultiWorkspacePanelHost keeps up to 3 workspaces mounted at
+// once (inactive ones only `visibility: hidden`), so a module-level handler
+// ref suffered last-writer-wins: a hidden instance's handlers would handle a
+// click made in the visible workspace, creating the terminal in the wrong
+// (cached) workspace.
+//
+// Fix: key the handlers by the owning dockview's `api.id`. dockview passes the
+// owning `containerApi` into header-action + tab-header props; every wrapper
+// shares the same underlying component `id` even though the DockviewApi object
+// differs per group. The value is the instance's `useRef` holder so clicks
+// always read the latest closures via `.current`.
 // ---------------------------------------------------------------------------
 
-const addTabRef: {
-  current: {
-    onAdd: (groupId?: string) => void;
-    onSplit: (groupId: string, direction: "right" | "below") => void;
-  };
-} = {
-  current: { onAdd: () => {}, onSplit: () => {} },
-};
+interface TerminalPanelActions {
+  onAdd: (groupId?: string) => void;
+  onSplit: (groupId: string, direction: "right" | "below") => void;
+  onClose: (terminalId: string) => void;
+}
 
-const closeTabRef: { current: ((terminalId: string) => void) | null } = {
-  current: null,
-};
+const panelActionsByApiId = new Map<string, { current: TerminalPanelActions }>();
 
 const RightHeaderActions = React.memo(function RightHeaderActions(
   props: IDockviewHeaderActionsProps,
@@ -282,6 +296,9 @@ const RightHeaderActions = React.memo(function RightHeaderActions(
   // edge group; only the split buttons are hidden. Defaults to "grid"
   // when `location` is missing (older dockview versions / tests).
   const isGridGroup = (props.location?.type ?? "grid") === "grid";
+  // Resolve the owning dockview at click time so the action always targets the
+  // workspace that owns THIS group, never a last-writer-wins global.
+  const apiId = props.containerApi.id;
   const groupId = props.group.id;
   // `w-full justify-center` keeps the "+" centered horizontally inside
   // the vertical (left/right) edge action strip, which dockview sizes
@@ -297,7 +314,7 @@ const RightHeaderActions = React.memo(function RightHeaderActions(
           <button
             type="button"
             className="inline-flex size-7 items-center justify-center text-muted-foreground hover:text-foreground hover:bg-accent rounded transition-colors"
-            onClick={() => addTabRef.current.onSplit(groupId, "right")}
+            onClick={() => panelActionsByApiId.get(apiId)?.current?.onSplit(groupId, "right")}
             title="Split right"
           >
             <Columns2 className="size-3.5" />
@@ -305,7 +322,7 @@ const RightHeaderActions = React.memo(function RightHeaderActions(
           <button
             type="button"
             className="inline-flex size-7 items-center justify-center text-muted-foreground hover:text-foreground hover:bg-accent rounded transition-colors"
-            onClick={() => addTabRef.current.onSplit(groupId, "below")}
+            onClick={() => panelActionsByApiId.get(apiId)?.current?.onSplit(groupId, "below")}
             title="Split down"
           >
             <Rows2 className="size-3.5" />
@@ -315,7 +332,7 @@ const RightHeaderActions = React.memo(function RightHeaderActions(
       <button
         type="button"
         className="inline-flex size-7 items-center justify-center text-muted-foreground hover:text-foreground hover:bg-accent rounded transition-colors"
-        onClick={() => addTabRef.current.onAdd(groupId)}
+        onClick={() => panelActionsByApiId.get(apiId)?.current?.onAdd(groupId)}
         title="New terminal"
       >
         <Plus className="size-4" />
@@ -726,14 +743,23 @@ export function DockviewTerminalContainer({
     });
   }, [adapter, workspaceId]);
 
-  // Keep module-level refs in sync for stable Dockview components
-  addTabRef.current = { onAdd: handleAddTab, onSplit: handleSplit };
-  closeTabRef.current = closeTab;
+  // Per-instance action handlers for the stable Dockview header/tab
+  // components. Registered in `panelActionsByApiId` (keyed by this inner
+  // dockview's `api.id`) from `onReady`; mutated every render so the registry
+  // always holds this instance's latest closures.
+  const actionsRef = useRef<TerminalPanelActions>({
+    onAdd: () => {},
+    onSplit: () => {},
+    onClose: () => {},
+  });
+  actionsRef.current = { onAdd: handleAddTab, onSplit: handleSplit, onClose: closeTab };
 
   // Detach edge-group drag-visibility listeners + inner-dockview
-  // registration on unmount.
+  // registration, and drop this instance's action handlers, on unmount.
   useEffect(() => {
     return () => {
+      const api = apiRef.current;
+      if (api) panelActionsByApiId.delete(api.id);
       edgeDragDisposerRef.current?.();
       edgeDragDisposerRef.current = null;
       innerRegisterDisposerRef.current?.();
@@ -757,6 +783,9 @@ export function DockviewTerminalContainer({
   const onReady = useCallback(
     (event: DockviewReadyEvent) => {
       apiRef.current = event.api;
+      // Register this instance's handlers under the inner dockview's id so the
+      // header/tab components resolve to the correct workspace (see registry).
+      panelActionsByApiId.set(event.api.id, actionsRef);
       const savedLayout = initialLayoutRef.current;
       const knownTerminalIds = initialTerminalIdsRef.current;
 

--- a/apps/web/src/components/DockviewTerminalContainer.tsx
+++ b/apps/web/src/components/DockviewTerminalContainer.tsx
@@ -787,6 +787,11 @@ export function DockviewTerminalContainer({
 
   const onReady = useCallback(
     (event: DockviewReadyEvent) => {
+      // Defensive double-onReady guard (mirrors the disposer guards below):
+      // if onReady fires again with a fresh api, drop the previous registry
+      // entry so it doesn't orphan — unmount only deletes the last-seen id.
+      const prevApi = apiRef.current;
+      if (prevApi && prevApi.id !== event.api.id) panelActionsByApiId.delete(prevApi.id);
       apiRef.current = event.api;
       // Register this instance's handlers under the inner dockview's id so the
       // header/tab components resolve to the correct workspace (see registry).

--- a/apps/web/src/components/DockviewTerminalContainer.tsx
+++ b/apps/web/src/components/DockviewTerminalContainer.tsx
@@ -308,7 +308,12 @@ const RightHeaderActions = React.memo(function RightHeaderActions(
   // resolves to the same content width and the button row looks
   // identical to before.
   return (
-    <div className="flex h-full w-full items-center justify-center">
+    // `data-testid` on grid-group toolbars only (edge groups get no testid)
+    // gives integration tests a stable hook for the central action row.
+    <div
+      className="flex h-full w-full items-center justify-center"
+      data-testid={isGridGroup ? "dockview-terminal__toolbar" : undefined}
+    >
       {isGridGroup && (
         <>
           <button


### PR DESCRIPTION
## Problem

Clicking the **+** (add tab) or **split** buttons in the Chat, Terminal, and Browser panel headers sometimes created the new panel in a **different, cached (not-currently-visible) workspace**. Keyboard shortcuts (cmd+t, cmd+shift+d) always targeted the correct workspace — only the toolbar buttons misfired, and only intermittently.

## Root cause

Each container stored its add/split/close handlers in a **module-level singleton ref** (`addTabRef`, `closeTabRef`). `MultiWorkspacePanelHost` keeps up to 3 workspaces mounted at once (inactive ones only `visibility: hidden`), so several `DockviewChatContainer`/`Terminal`/`Browser` instances are live simultaneously and all keep re-rendering. Whichever instance rendered **last** left *its* `workspaceId` + dockview api baked into the shared ref — last-writer-wins. A toolbar click in the visible workspace then invoked the handler bound to the wrong (last-rendered, possibly hidden) workspace.

Keyboard shortcuts were unaffected because each instance registers its own focus-scoped `keydown` listener and calls its own closures directly — never the shared ref. That asymmetry was the tell.

## Fix

Replace the singleton with a `Map<string, { current: Handlers }>` keyed by the owning dockview's **`api.id`**. dockview passes the owning `containerApi` into both header-action and tab-header props; it hands out a fresh `DockviewApi` *wrapper* per group (so `props.containerApi !== onReadyApi` by reference) but every wrapper exposes the same underlying `component.id` — so keying by `api.id` resolves the visible group to its own workspace's handlers every time.

- Each container registers its per-instance handler ref in `onReady` and deletes it on unmount.
- Header `RightHeaderActions` and the tab close button resolve handlers via `panelActionsByApiId.get(props.containerApi.id)`.
- Applied identically to **chat, terminal, and browser** containers, for **add, split, AND close**.

## Tests

New Playwright integration test `panel-toolbar-target-workspace.spec.ts` (real server boot, no tRPC mocking, Page Object Model). It mounts two workspaces, makes the cached one the trailing (last-writer) cache entry, clicks the visible workspace's toolbar, and asserts via the server-persisted inner dockview layout that the **visible** workspace's panel set grew and the **cached** one was untouched.

- **Terminal** add + split are the deterministic regression catch (buggy code reads the singleton at click time → resolves the trailing cached entry). Verified to **fail on the pre-fix build** and pass on the fixed build.
- **Chat** add + split lock in the fixed routing for the buttons named in the bug report.
- **Browser** is documented as out-of-scope for the web e2e harness (`DockviewBrowserContainer` only mounts in the Electron desktop build), mirroring `panel-default-position.spec.ts`.

Ran a local Band CI review (coding / testing / security / performance) before pushing; the one blocker (missing browser test) was resolved by documenting the harness exemption.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
