### PR TITLE
fix(web): open workspace picker on Ctrl+Shift+R instead of Ctrl+R

### DIFF
--- a/apps/web/e2e/pages/WorkspacePage.ts
+++ b/apps/web/e2e/pages/WorkspacePage.ts
@@ -590,17 +590,17 @@ export class WorkspacePage {
     });
   }
 
-  /** Open the workspace picker on desktop via its Ctrl+R shortcut. The
+  /** Open the workspace picker on desktop via its Ctrl+Shift+R shortcut. The
    *  handler lives on a window keydown listener in
    *  `SharedDockviewLayout.tsx`; it ignores the shortcut while the
    *  terminal is focused, so we route the keypress through the project
    *  list root (focusable, non-editable) — the same anchor the label
    *  shortcut test uses. */
   async openWorkspacePickerViaShortcut(): Promise<void> {
-    await test.step("Open workspace picker (Ctrl+R)", async () => {
+    await test.step("Open workspace picker (Ctrl+Shift+R)", async () => {
       const root = this.projectListRoot();
       await root.waitFor({ state: "visible" });
-      await root.press("Control+r");
+      await root.press("Control+Shift+R");
     });
   }
 

--- a/apps/web/e2e/pages/WorkspacePicker.ts
+++ b/apps/web/e2e/pages/WorkspacePicker.ts
@@ -2,7 +2,7 @@
  * Component object for the WorkspacePickerDialog
  * (`apps/web/src/dashboard/components/WorkspacePickerDialog.tsx`) — the
  * command-palette-style "Switch Workspace" dialog reachable on desktop via
- * Ctrl+R and on mobile by tapping the workspace header title.
+ * Ctrl+Shift+R and on mobile by tapping the workspace header title.
  *
  * Locators key off `data-testid` hooks the component sets:
  *   - `workspace-picker`                       — the dialog content

--- a/apps/web/e2e/workspace-picker.spec.ts
+++ b/apps/web/e2e/workspace-picker.spec.ts
@@ -39,7 +39,7 @@ const WS_ALPHA = toWorkspaceId(PROJECT_ALPHA, "main");
 const WS_BETA = toWorkspaceId(PROJECT_BETA, "main");
 
 // Wide viewport so `useIsDesktop()` reports true and the shared dockview (which
-// owns the Ctrl+R picker shortcut and the project-list sidebar) mounts.
+// owns the Ctrl+Shift+R picker shortcut and the project-list sidebar) mounts.
 test.use({ viewport: { width: 1280, height: 800 } });
 
 let server: ServerHandle;

--- a/apps/web/src/components/SharedDockviewLayout.tsx
+++ b/apps/web/src/components/SharedDockviewLayout.tsx
@@ -992,8 +992,8 @@ export function SharedDockviewLayout() {
       const ws = activeWorkspaceIdRef.current;
       const terminalFocused = document.activeElement?.closest(".xterm") != null;
 
-      // Ctrl+R → workspace picker — skip when terminal focused
-      if (e.ctrlKey && !e.metaKey && e.key.toLowerCase() === "r" && !e.shiftKey) {
+      // Ctrl+Shift+R → workspace picker — skip when terminal focused
+      if (e.ctrlKey && !e.metaKey && e.key.toLowerCase() === "r" && e.shiftKey) {
         if (terminalFocused) return;
         e.preventDefault();
         e.stopPropagation();

--- a/apps/web/src/dashboard/components/DashboardShell.tsx
+++ b/apps/web/src/dashboard/components/DashboardShell.tsx
@@ -163,7 +163,7 @@ export function DashboardShell({ toolbarMenuItems, hideTitleBar, hideMenu }: Das
   //   - `setLabelFilter` does an imperative save of the outgoing label
   //     so the user's most recent selection is captured even when they
   //     never explicitly clicked the workspace card after navigating to
-  //     it (e.g. direct URL / Cmd+R picker / page reload).
+  //     it (e.g. direct URL / Ctrl+Shift+R picker / page reload).
   const lastSeenActiveRef = useRef<string | null>(activeWorkspaceId);
   useEffect(() => {
     if (!activeWorkspaceId) {
@@ -195,7 +195,7 @@ export function DashboardShell({ toolbarMenuItems, hideTitleBar, hideMenu }: Das
   //   1. Saves only happen when the outgoing label is non-null (ALL has no
   //      per-label memory) AND the active workspace's project is actually
   //      labelled with the outgoing label. If the user navigated to a
-  //      workspace under a different label via the Cmd+R picker, we don't
+  //      workspace under a different label via the Ctrl+Shift+R picker, we don't
   //      want to record that workspace as Personal's "last" just because
   //      the filter happened to be Personal at the time.
   //   2. Restores only happen when the saved workspace still exists AND its

--- a/apps/web/src/dashboard/components/ProjectList.tsx
+++ b/apps/web/src/dashboard/components/ProjectList.tsx
@@ -663,7 +663,7 @@ export function ProjectList({ labelFilter }: ProjectListProps) {
   // Reveal the active workspace in the tree by auto-expanding the project
   // and label group it belongs to. This should run ONLY when
   // activeWorkspaceId changes — i.e. when the user switches workspaces via
-  // the Ctrl+R picker, URL nav, notifications, etc. After the initial
+  // the Ctrl+Shift+R picker, URL nav, notifications, etc. After the initial
   // reveal we deliberately leave the collapse state alone so the user can
   // collapse the ancestors of the active workspace (via the "Collapse all"
   // toolbar button or by clicking a header) without this effect fighting
@@ -682,7 +682,7 @@ export function ProjectList({ labelFilter }: ProjectListProps) {
   //
   // We also clear keyboardNavRef so the focusedIndex effect above can
   // re-run and move the highlight ring to the freshly-revealed workspace.
-  // Without that reset, arrow-key navigation followed by a Ctrl+R switch
+  // Without that reset, arrow-key navigation followed by a Ctrl+Shift+R switch
   // would leave the highlight stuck on the old position.
   //
   // Pinned workspaces are rendered exclusively in the Pinned section at

--- a/apps/web/src/dashboard/components/WorkspaceCard.tsx
+++ b/apps/web/src/dashboard/components/WorkspaceCard.tsx
@@ -43,7 +43,7 @@ import { SetupStatusIndicator } from "./SetupStatusIndicator";
 //
 // The active card auto-scrolls into view ONLY when the navigation came from
 // OUTSIDE the project list — direct URL navigation, browser back/forward,
-// or the Ctrl+R workspace picker. When the user clicked a card or pressed
+// or the Ctrl+Shift+R workspace picker. When the user clicked a card or pressed
 // Enter on a focused card inside the list, the card is already where their
 // cursor / keyboard focus is, so the scroll is unwanted.
 //
@@ -140,7 +140,7 @@ export const WorkspaceCard = memo(function WorkspaceCard({
   const href = capabilities.getWorkspaceHref?.(workspaceId);
 
   // Scroll this card into view when it becomes the active workspace via
-  // OUTSIDE-the-list navigation (direct URL, browser back/forward, Ctrl+R
+  // OUTSIDE-the-list navigation (direct URL, browser back/forward, Ctrl+Shift+R
   // workspace picker). The in-list paths (click or keyboard Enter) mark
   // the workspaceId via `markRecentActivation` before they navigate, and
   // we consume that marker here to bail out — the card is already where


### PR DESCRIPTION
## What

Moves the workspace-picker (`WorkspacePickerDialog`) keyboard shortcut from `Ctrl+R` to `Ctrl+Shift+R`.

## Why

Bare `Ctrl+R` collides conceptually with reload (and is already wired to *browser-tab reload* in `DockviewBrowserContainer`). Adding the `Shift` requirement frees `Ctrl+R` and gives the picker a dedicated combo.

## How

- `SharedDockviewLayout.tsx` — the global keydown handler now requires `e.shiftKey` (`Ctrl+Shift+R`) instead of excluding it.
- The new combo is conflict-free: both existing `r` handlers (this one and the browser-reload one) explicitly require `!shiftKey`, so `Ctrl+Shift+R` was unused.
- Kept the `Ctrl` modifier (consistent with the app's `Ctrl+\``, `Ctrl+0-9` family) rather than switching to `Cmd`, which would fight the browser's `Cmd+Shift+R` hard-reload.
- Updated the e2e page object so `WorkspacePage.openWorkspacePickerViaShortcut()` presses `Control+Shift+R`, keeping `workspace-picker.spec.ts` green.
- Refreshed stale `Ctrl+R` / `Cmd+R` comments across source and tests.

## Testing

- `pnpm check` — clean.
- `workspace-picker.spec.ts` — both tests pass against the rebuilt server bundle with the new binding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)