### PR TITLE
feat(web): use VS Code Dark+ ANSI palette for the terminal

### DIFF
--- a/apps/web/src/components/TerminalPanel.tsx
+++ b/apps/web/src/components/TerminalPanel.tsx
@@ -67,6 +67,25 @@ const DARK_TERMINAL_THEME: ITheme = {
   foreground: "#e8e8e8",
   cursor: "#e8e8e8",
   selectionBackground: "rgba(255, 255, 255, 0.2)",
+  // VS Code Dark+ ANSI palette. Without these 16 entries xterm.js falls back to
+  // its dated "Tango" default, which renders low-contrast, muddy reds/greens on
+  // the dark background. These canonical Dark+ values fix that.
+  black: "#000000",
+  red: "#cd3131",
+  green: "#0dbc79",
+  yellow: "#e5e510",
+  blue: "#2472c8",
+  magenta: "#bc3fbc",
+  cyan: "#11a8cd",
+  white: "#e5e5e5",
+  brightBlack: "#666666",
+  brightRed: "#f14c4c",
+  brightGreen: "#23d18b",
+  brightYellow: "#f5f543",
+  brightBlue: "#3b8eea",
+  brightMagenta: "#d670d6",
+  brightCyan: "#29b8db",
+  brightWhite: "#e5e5e5",
 };
 
 const LIGHT_TERMINAL_THEME: ITheme = {


### PR DESCRIPTION
## Summary

The dark xterm.js terminal theme (`DARK_TERMINAL_THEME`) only set `background`/`foreground`/`cursor`/`selectionBackground`, leaving the 16 ANSI colors unset. xterm.js then fell back to its built-in dated "Tango" palette, which renders low-contrast, muddy reds/greens on the dark background.

This adds the full 16-color **VS Code Dark+** ANSI palette so terminal output matches VS Code's integrated terminal. The values are an exact match to VS Code's current (2026) built-in dark defaults from `terminalColorRegistry.ts`.

## Notes

- Only `apps/web/src/components/TerminalPanel.tsx` changes — theme constants only, no behavior/wiring changes (themes already flow through `getTerminalTheme()` + the MutationObserver).
- `background #1e1e1e` / `foreground #e8e8e8` are kept as intentional Band deviations to blend with the panel.
- `white` and `brightWhite` are both `#e5e5e5` — canonical VS Code Dark+ (not a typo).
- The light theme was intentionally left unchanged.

## Test plan

- Pure color-constant change; no new test (terminal ANSI rendering isn't assertable through the integration-test DOM/localStorage/URL surfaces).
- `biome check` clean; `tsc --noEmit` clean (`ITheme` from `@xterm/xterm` satisfied).
- Local PR review (`/review-and-apply`): Coding ✅ Testing ✅ Security ✅ Performance ✅ — approved 👍.

🤖 Generated with [Claude Code](https://claude.com/claude-code)