### PR TITLE
fix(web): repaint terminal on become-visible to clear background-mount garble

### DIFF
--- a/apps/web/e2e/pages/WorkspacePage.ts
+++ b/apps/web/e2e/pages/WorkspacePage.ts
@@ -643,6 +643,82 @@ export class WorkspacePage {
     await this.terminalInput.first().waitFor({ state: "attached", timeout: timeoutMs });
   }
 
+  // ──────────────────────────────────────────────────────────────────────
+  // Terminal WebGL render-surface probing (terminal-garbled-until-resize).
+  //
+  // These read xterm.js's own internal DOM (`.xterm-screen > canvas`). That
+  // DOM belongs to the xterm library, not to our code, so there is no
+  // `data-testid` to hook and a class selector is the only option — the
+  // locator-priority "no CSS selectors" rule applies to elements WE own.
+  // We scope every query to the terminal panel host for a specific
+  // workspace (one `workspace-panel-host__cached-entry--<id>` per panel
+  // kind; the terminal one is the entry that contains a
+  // `dockview-terminal-tab__*` marker) so a cached background workspace's
+  // surface can be inspected independently of the active one.
+  //
+  // The WebGL renderer is the production default (`useWebGLTerminalRenderer
+  // ?? true`) and the corruption this fix addresses is a GPU-canvas
+  // artifact, so these helpers assume the WebGL addon attached a <canvas>.
+  // Tests force the SwiftShader WebGL path on via Chromium launch flags
+  // and assert `webglCanvasCount > 0` as a precondition.
+  // ──────────────────────────────────────────────────────────────────────
+
+  /** Stamp a `data-band-probe` marker on every canvas currently inside the
+   *  given workspace's terminal render surface. Lets a later read detect
+   *  whether the surface was rebuilt (markers gone = the WebGL addon was
+   *  disposed + re-attached, i.e. a brand-new backing store) or merely
+   *  resized in place (markers survive on the same elements). Returns the
+   *  number of canvases stamped. */
+  async tagTerminalCanvases(workspaceId: string): Promise<number> {
+    return await test.step(`Tag terminal canvases for ${workspaceId}`, async () =>
+      await this.page.evaluate((id) => {
+        const hosts = Array.from(
+          document.querySelectorAll(`[data-testid="workspace-panel-host__cached-entry--${id}"]`),
+        );
+        const host = hosts.find((h) => h.querySelector('[data-testid^="dockview-terminal-tab__"]'));
+        const canvases = host
+          ? Array.from(host.querySelectorAll<HTMLCanvasElement>(".xterm-screen canvas"))
+          : [];
+        canvases.forEach((c, i) => {
+          c.dataset.bandProbe = `tagged-${i}`;
+        });
+        return canvases.length;
+      }, workspaceId));
+  }
+
+  /** Read the state of the given workspace's terminal render surface:
+   *  total canvas count, how many still carry the `tagTerminalCanvases`
+   *  marker (i.e. were NOT rebuilt), and each canvas's backing-store size
+   *  alongside the `.xterm-screen` CSS size. A rebuilt surface reports
+   *  `survivingTags: 0`; a correctly-sized surface reports backing sizes
+   *  matching the screen rect (× devicePixelRatio). */
+  async readTerminalSurface(workspaceId: string): Promise<{
+    canvasCount: number;
+    survivingTags: number;
+    screen: { w: number; h: number };
+    backing: { w: number; h: number }[];
+    dpr: number;
+  }> {
+    return await this.page.evaluate((id) => {
+      const hosts = Array.from(
+        document.querySelectorAll(`[data-testid="workspace-panel-host__cached-entry--${id}"]`),
+      );
+      const host = hosts.find((h) => h.querySelector('[data-testid^="dockview-terminal-tab__"]'));
+      const screenEl = host?.querySelector(".xterm-screen") as HTMLElement | null;
+      const canvases = host
+        ? Array.from(host.querySelectorAll<HTMLCanvasElement>(".xterm-screen canvas"))
+        : [];
+      const rect = screenEl?.getBoundingClientRect();
+      return {
+        canvasCount: canvases.length,
+        survivingTags: canvases.filter((c) => c.dataset.bandProbe).length,
+        screen: { w: Math.round(rect?.width ?? 0), h: Math.round(rect?.height ?? 0) },
+        backing: canvases.map((c) => ({ w: c.width, h: c.height })),
+        dpr: window.devicePixelRatio,
+      };
+    }, workspaceId);
+  }
+
   /** Type a line into the focused terminal and submit it with Enter.
    *  Routes the keystrokes through the real xterm input (which calls
    *  `terminal.onData` → `ws.send`), exactly as a user typing would.

--- a/apps/web/e2e/terminal-background-repaint.spec.ts
+++ b/apps/web/e2e/terminal-background-repaint.spec.ts
@@ -1,0 +1,236 @@
+/**
+ * Regression coverage for the "terminal renders garbled until you resize the
+ * window" bug (branch `fix/terminal-garbled-until-resize`).
+ *
+ * The bug
+ * -------
+ * A terminal whose FIRST paint happens while its workspace is a hidden
+ * background tab (kept mounted by the `MultiWorkspacePanelHost` LRU cache
+ * under `content-visibility: hidden` / `visibility: hidden`) establishes its
+ * WebGL render surface against a hidden / degenerate layout. When the
+ * workspace later becomes visible, the old "became visible" effect only
+ * called `fitAddon.fit()`. If the now-visible container resolves to the SAME
+ * cols/rows `fit()` already computed while hidden, xterm's `resize()`
+ * early-returns — no reflow, no renderer repaint — so the surface built
+ * against the hidden layout stays on screen, garbled, until a manual window
+ * resize changes the dimensions and forces a real reflow.
+ *
+ * The fix (`TerminalPanel.tsx`)
+ * -----------------------------
+ * On become-visible we now re-measure cell geometry and **re-attach the
+ * WebGL addon** (dispose the surface built while hidden, size a fresh
+ * <canvas> against the live layout) instead of relying on `fit()` alone —
+ * the same recovery the DPR / zoom paths already use. A fresh surface
+ * repaints every cell from scratch regardless of whether cols/rows changed.
+ *
+ * Why this test observes the surface REBUILD, not pixels
+ * ------------------------------------------------------
+ * The visible garble is a GPU-pixel artifact. It is NOT reproducible in
+ * headless Chromium for two independent reasons, both confirmed empirically
+ * while writing this test:
+ *
+ *   1. xterm measures cell geometry from FONT metrics, which are
+ *      layout-independent — so even a terminal that boots under
+ *      `content-visibility: hidden` gets a *valid* default-sized surface
+ *      (80x24), never a pixel-mangled one.
+ *   2. Whenever the hidden and visible layouts differ, `fit()` changes
+ *      cols/rows on become-visible and xterm resizes the surface anyway, so
+ *      the old code "self-heals" in the cases headless can construct.
+ *
+ * The single behaviour that DOES differ between the old and new code in
+ * every case — and the exact action that repairs the corruption in
+ * production — is the surface rebuild: the fix disposes the
+ * established-while-hidden <canvas> and attaches a new one. We make that
+ * observable by tagging the hidden surface's canvases, switching the
+ * workspace to the foreground, and asserting the tags are gone (a brand-new
+ * backing store) AND the rebuilt surface is correctly sized to the visible
+ * container. The old code leaves the tagged canvases in place (resized at
+ * most), so this fails before the fix and passes after.
+ *
+ * Doctrine notes
+ * --------------
+ *  - Real production server (`startServer`), real PTYs (the two projects are
+ *    `git init`-ed real dirs so they classify as "git" — which both renders
+ *    the sidebar workspace cards `switchWorkspace` needs AND gives the PTY a
+ *    real cwd to spawn in).
+ *  - No tRPC mocking, no `page.route` on our own routes. The only external-
+ *    boundary control is the Chromium launch flags that turn on SwiftShader
+ *    WebGL so the headless renderer matches production's WebGL default.
+ *  - Driven entirely through `WorkspacePage`.
+ */
+
+import { execSync } from "node:child_process";
+import { mkdtempSync, realpathSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { expect, test } from "@playwright/test";
+import { toWorkspaceId } from "@/dashboard";
+import {
+  cleanupTmpHome,
+  createTmpHome,
+  type ServerHandle,
+  seedSettings,
+  seedState,
+  startServer,
+} from "./helpers/server";
+import { WorkspacePage } from "./pages/WorkspacePage";
+
+const TOKEN = "e2e-terminal-bg-repaint-token";
+
+const PROJECT_A = "alpha-bg-repaint";
+const PROJECT_B = "bravo-bg-repaint";
+const WORKSPACE_A = toWorkspaceId(PROJECT_A, "main");
+const WORKSPACE_B = toWorkspaceId(PROJECT_B, "main");
+
+// Wide viewport so `useIsDesktop()` reports true and the shared dockview (which
+// hosts the terminal container) renders. The WebGL flags force the SwiftShader
+// renderer on so xterm attaches a real <canvas> — without them headless
+// Chromium falls back to xterm's DOM renderer and there is no surface to
+// rebuild, which would make this test vacuous.
+test.use({
+  viewport: { width: 1280, height: 800 },
+  launchOptions: {
+    args: [
+      "--use-gl=angle",
+      "--use-angle=swiftshader",
+      "--enable-unsafe-swiftshader",
+      "--ignore-gpu-blocklist",
+      "--enable-webgl",
+    ],
+  },
+});
+
+let server: ServerHandle;
+let tmpHome: string;
+let workdirA: string;
+let workdirB: string;
+
+/** A `git init`-ed temp dir: real on disk (so the PTY can spawn with it as
+ *  cwd) and containing a `.git` (so the project classifies as "git" and the
+ *  sidebar renders a clickable workspace card for its default branch). */
+function makeGitWorkdir(prefix: string): string {
+  const dir = realpathSync(mkdtempSync(join(tmpdir(), prefix)));
+  execSync("git init -q && git commit -q --allow-empty -m init", {
+    cwd: dir,
+    env: {
+      ...process.env,
+      GIT_AUTHOR_NAME: "Test",
+      GIT_AUTHOR_EMAIL: "test@example.com",
+      GIT_COMMITTER_NAME: "Test",
+      GIT_COMMITTER_EMAIL: "test@example.com",
+    },
+  });
+  return dir;
+}
+
+test.beforeAll(async () => {
+  tmpHome = createTmpHome();
+  workdirA = makeGitWorkdir("band-bg-repaint-a-");
+  workdirB = makeGitWorkdir("band-bg-repaint-b-");
+  seedState(tmpHome, {
+    projects: [
+      {
+        name: PROJECT_A,
+        path: workdirA,
+        defaultBranch: "main",
+        worktrees: [{ branch: "main", path: workdirA }],
+      },
+      {
+        name: PROJECT_B,
+        path: workdirB,
+        defaultBranch: "main",
+        worktrees: [{ branch: "main", path: workdirB }],
+      },
+    ],
+  });
+  seedSettings(tmpHome, { tokenSecret: TOKEN });
+  server = await startServer({ tmpHome });
+});
+
+test.afterAll(async () => {
+  await server.close();
+  cleanupTmpHome(tmpHome);
+  rmSync(workdirA, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 });
+  rmSync(workdirB, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 });
+});
+
+test.describe("Terminal background-workspace first paint", () => {
+  test("a terminal that first paints in a hidden background workspace rebuilds its WebGL surface when it becomes visible", async ({
+    page,
+  }) => {
+    const workspacePage = new WorkspacePage(page, server.url, TOKEN);
+
+    // Land on A (active), then switch to B via the sidebar so A stays MOUNTED
+    // in the LRU cache but inactive (`wsActive=false`). In-app navigation
+    // (sidebar click), not `goto()`, is what keeps A cached — a full
+    // navigation would tear the cache down.
+    await workspacePage.goto(WORKSPACE_A);
+    await workspacePage.waitForReady();
+    await workspacePage.switchWorkspace(WORKSPACE_B);
+
+    // Activate the outer Terminal tab. The shared outer dockview means BOTH
+    // cached workspaces' terminal containers now mount: B's mounts visible,
+    // A's mounts while A's host is `content-visibility: hidden` — i.e. A's
+    // terminal takes its FIRST paint while hidden, which is the bug's
+    // precondition.
+    await workspacePage.openTerminalTab();
+
+    // Positive anchors: B's terminal observed visible, A's observed hidden.
+    await expect(workspacePage.terminalTabVisibilityMarker(WORKSPACE_B, true)).toBeVisible({
+      timeout: 20_000,
+    });
+    await expect(workspacePage.terminalTabVisibilityMarker(WORKSPACE_A, false)).toBeAttached({
+      timeout: 20_000,
+    });
+
+    // Wait for A's hidden terminal to attach its WebGL surface. This also
+    // asserts the WebGL precondition: if SwiftShader weren't available the
+    // addon would fall back to the DOM renderer, no <canvas> would exist, and
+    // this poll would (correctly) fail loudly rather than the test passing
+    // vacuously.
+    await expect
+      .poll(async () => (await workspacePage.readTerminalSurface(WORKSPACE_A)).canvasCount, {
+        timeout: 20_000,
+      })
+      .toBeGreaterThan(0);
+
+    // Tag the canvases that make up A's established-while-hidden surface.
+    const tagged = await workspacePage.tagTerminalCanvases(WORKSPACE_A);
+    expect(tagged).toBeGreaterThan(0);
+
+    // Bring A to the foreground and re-activate its Terminal tab so A's
+    // terminal flips from hidden → visible (A's restored layout may show a
+    // different outer tab). This is the become-visible transition the fix
+    // hooks.
+    await workspacePage.switchWorkspace(WORKSPACE_A);
+    await workspacePage.openTerminalTab();
+    await expect(workspacePage.terminalTabVisibilityMarker(WORKSPACE_A, true)).toBeVisible({
+      timeout: 20_000,
+    });
+
+    // The discriminating assertion: on become-visible the fix disposes the
+    // surface built while hidden and re-attaches a fresh WebGL addon, so none
+    // of the tagged canvases survive. The pre-fix code only called `fit()`
+    // (resizing the SAME canvases in place at most), so its tags would
+    // survive and this poll would time out → the test fails before the fix.
+    await expect
+      .poll(async () => (await workspacePage.readTerminalSurface(WORKSPACE_A)).survivingTags, {
+        timeout: 20_000,
+      })
+      .toBe(0);
+
+    // Positive correctness anchor: the rebuilt surface is sized to the
+    // now-visible container — its WebGL backing store matches the
+    // `.xterm-screen` rect (× devicePixelRatio). This is the user-observable
+    // "the terminal grid matches the visible container size" guarantee; a
+    // surface left sized to the hidden layout would mismatch here.
+    const surface = await workspacePage.readTerminalSurface(WORKSPACE_A);
+    expect(surface.canvasCount).toBeGreaterThan(0);
+    expect(surface.screen.w).toBeGreaterThan(0);
+    expect(surface.screen.h).toBeGreaterThan(0);
+    for (const backing of surface.backing) {
+      expect(Math.abs(backing.w - surface.screen.w * surface.dpr)).toBeLessThanOrEqual(2);
+      expect(Math.abs(backing.h - surface.screen.h * surface.dpr)).toBeLessThanOrEqual(2);
+    }
+  });
+});

--- a/apps/web/e2e/terminal-background-repaint.spec.ts
+++ b/apps/web/e2e/terminal-background-repaint.spec.ts
@@ -1,6 +1,6 @@
 /**
  * Regression coverage for the "terminal renders garbled until you resize the
- * window" bug (branch `fix/terminal-garbled-until-resize`).
+ * window" bug.
  *
  * The bug
  * -------
@@ -100,19 +100,23 @@ test.use({
   },
 });
 
-let server: ServerHandle;
-let tmpHome: string;
-let workdirA: string;
-let workdirB: string;
+// Definite-assignment: all four are set in `beforeAll`. The `!` lets
+// `afterAll` reference them while still guarding `server` (the only one
+// that can be left unassigned if `startServer` throws mid-boot).
+let server!: ServerHandle;
+let tmpHome!: string;
+let workdirA!: string;
+let workdirB!: string;
 
 /** Hermetic git environment: an explicit allowlist (no `process.env`
  *  spread) with `GIT_CONFIG_GLOBAL` / `GIT_CONFIG_SYSTEM` pointed at
  *  /dev/null so a contributor's host git config (templates, signing-key
  *  prompts, hooks) can't leak in and hang or skew the setup. Mirrors the
  *  pattern in `workspace-cache-eviction.spec.ts`. */
-function makeGitEnv(): NodeJS.ProcessEnv {
+function makeGitEnv(home: string): NodeJS.ProcessEnv {
   return {
     PATH: process.env.PATH,
+    HOME: home,
     GIT_AUTHOR_NAME: "Test",
     GIT_AUTHOR_EMAIL: "test@example.com",
     GIT_COMMITTER_NAME: "Test",
@@ -130,9 +134,9 @@ function makeGitEnv(): NodeJS.ProcessEnv {
  *  runner) whose git defaults to `master` would make the worktree-sync
  *  poller rewrite the seeded `main` worktree to `master`, and the
  *  `--<project>-main` card testid the test clicks would never appear. */
-function makeGitWorkdir(prefix: string): string {
+function makeGitWorkdir(prefix: string, home: string): string {
   const dir = realpathSync(mkdtempSync(join(tmpdir(), prefix)));
-  const env = makeGitEnv();
+  const env = makeGitEnv(home);
   execFileSync("git", ["init", "-q", "-b", "main"], { cwd: dir, env });
   execFileSync("git", ["commit", "-q", "--allow-empty", "-m", "init"], { cwd: dir, env });
   return dir;
@@ -140,8 +144,8 @@ function makeGitWorkdir(prefix: string): string {
 
 test.beforeAll(async () => {
   tmpHome = createTmpHome();
-  workdirA = makeGitWorkdir("band-bg-repaint-a-");
-  workdirB = makeGitWorkdir("band-bg-repaint-b-");
+  workdirA = makeGitWorkdir("band-bg-repaint-a-", tmpHome);
+  workdirB = makeGitWorkdir("band-bg-repaint-b-", tmpHome);
   seedState(tmpHome, {
     projects: [
       {
@@ -163,10 +167,12 @@ test.beforeAll(async () => {
 });
 
 test.afterAll(async () => {
-  await server.close();
-  cleanupTmpHome(tmpHome);
-  rmSync(workdirA, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 });
-  rmSync(workdirB, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 });
+  // Guard `server`: if `startServer` threw mid-boot it's unassigned, and a
+  // bare `server.close()` would mask the real boot failure with a TypeError.
+  if (server) await server.close();
+  if (tmpHome) cleanupTmpHome(tmpHome);
+  if (workdirA) rmSync(workdirA, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 });
+  if (workdirB) rmSync(workdirB, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 });
 });
 
 test.describe("Terminal background-workspace first paint", () => {
@@ -238,11 +244,19 @@ test.describe("Terminal background-workspace first paint", () => {
     // now-visible container — its WebGL backing store matches the
     // `.xterm-screen` rect (× devicePixelRatio). This is the user-observable
     // "the terminal grid matches the visible container size" guarantee; a
-    // surface left sized to the hidden layout would mismatch here.
+    // surface left sized to the hidden layout would mismatch here. Poll
+    // until the screen rect has settled to a non-zero size before asserting,
+    // so a snapshot taken mid-layout can't read a transient 0×0.
+    await expect
+      .poll(
+        async () => {
+          const s = await workspacePage.readTerminalSurface(WORKSPACE_A);
+          return s.canvasCount > 0 && s.screen.w > 0 && s.screen.h > 0;
+        },
+        { timeout: 20_000 },
+      )
+      .toBe(true);
     const surface = await workspacePage.readTerminalSurface(WORKSPACE_A);
-    expect(surface.canvasCount).toBeGreaterThan(0);
-    expect(surface.screen.w).toBeGreaterThan(0);
-    expect(surface.screen.h).toBeGreaterThan(0);
     for (const backing of surface.backing) {
       expect(Math.abs(backing.w - surface.screen.w * surface.dpr)).toBeLessThanOrEqual(2);
       expect(Math.abs(backing.h - surface.screen.h * surface.dpr)).toBeLessThanOrEqual(2);

--- a/apps/web/e2e/terminal-background-repaint.spec.ts
+++ b/apps/web/e2e/terminal-background-repaint.spec.ts
@@ -59,7 +59,7 @@
  *  - Driven entirely through `WorkspacePage`.
  */
 
-import { execSync } from "node:child_process";
+import { execFileSync } from "node:child_process";
 import { mkdtempSync, realpathSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -105,21 +105,36 @@ let tmpHome: string;
 let workdirA: string;
 let workdirB: string;
 
+/** Hermetic git environment: an explicit allowlist (no `process.env`
+ *  spread) with `GIT_CONFIG_GLOBAL` / `GIT_CONFIG_SYSTEM` pointed at
+ *  /dev/null so a contributor's host git config (templates, signing-key
+ *  prompts, hooks) can't leak in and hang or skew the setup. Mirrors the
+ *  pattern in `workspace-cache-eviction.spec.ts`. */
+function makeGitEnv(): NodeJS.ProcessEnv {
+  return {
+    PATH: process.env.PATH,
+    GIT_AUTHOR_NAME: "Test",
+    GIT_AUTHOR_EMAIL: "test@example.com",
+    GIT_COMMITTER_NAME: "Test",
+    GIT_COMMITTER_EMAIL: "test@example.com",
+    GIT_CONFIG_GLOBAL: "/dev/null",
+    GIT_CONFIG_SYSTEM: "/dev/null",
+  };
+}
+
 /** A `git init`-ed temp dir: real on disk (so the PTY can spawn with it as
  *  cwd) and containing a `.git` (so the project classifies as "git" and the
- *  sidebar renders a clickable workspace card for its default branch). */
+ *  sidebar renders a clickable workspace card for its default branch).
+ *
+ *  `init -b main` forces the initial branch name: without it, a host (or CI
+ *  runner) whose git defaults to `master` would make the worktree-sync
+ *  poller rewrite the seeded `main` worktree to `master`, and the
+ *  `--<project>-main` card testid the test clicks would never appear. */
 function makeGitWorkdir(prefix: string): string {
   const dir = realpathSync(mkdtempSync(join(tmpdir(), prefix)));
-  execSync("git init -q && git commit -q --allow-empty -m init", {
-    cwd: dir,
-    env: {
-      ...process.env,
-      GIT_AUTHOR_NAME: "Test",
-      GIT_AUTHOR_EMAIL: "test@example.com",
-      GIT_COMMITTER_NAME: "Test",
-      GIT_COMMITTER_EMAIL: "test@example.com",
-    },
-  });
+  const env = makeGitEnv();
+  execFileSync("git", ["init", "-q", "-b", "main"], { cwd: dir, env });
+  execFileSync("git", ["commit", "-q", "--allow-empty", "-m", "init"], { cwd: dir, env });
   return dir;
 }
 

--- a/apps/web/src/components/TerminalPanel.tsx
+++ b/apps/web/src/components/TerminalPanel.tsx
@@ -141,10 +141,25 @@ export function TerminalPanel({
   // separate visibility-change effect below. Same ref-routing pattern as
   // `fitAddonRef` / `terminalRef` — the closure has local context (the
   // live `attachWebGL`, `fitAddon`, etc.) that can't be reconstructed
-  // outside the init effect. Used to force a real repaint when a terminal
-  // that first painted while its workspace was a hidden background tab
-  // becomes visible (see band-app/band terminal-garbled-until-resize).
+  // outside the init effect. Used to force one clean repaint when a
+  // terminal whose first paint happened while hidden becomes visible: such
+  // a terminal renders garbled (its WebGL surface was built against a
+  // hidden/degenerate layout) and a plain `fit()` won't repair it when the
+  // visible layout resolves to the same cols/rows.
   const remeasureAndReattachRef = useRef<(() => void) | null>(null);
+  // True once this terminal has completed a paint while visible — i.e. its
+  // render surface is known-good. Set when the WebGL addon attaches while
+  // the panel is already visible (the common case), or after the one-shot
+  // hidden-surface repair below. Gates that repair so it fires AT MOST ONCE
+  // per mount: without this gate the `remeasureAndReattach` ref is non-null
+  // forever after init, so every workspace tab-switch back to this terminal
+  // would needlessly dispose + re-attach the WebGL addon.
+  const firstVisiblePaintDoneRef = useRef(false);
+  // Mirrors the latest `visible` prop so the async init effect can read the
+  // panel's visibility at WebGL-attach time (its deps don't include
+  // `visible`, so the closure would otherwise see the stale mount value).
+  const visibleRef = useRef(visible);
+  visibleRef.current = visible;
   const onTitleChangeRef = useRef(onTitleChange);
   onTitleChangeRef.current = onTitleChange;
 
@@ -932,6 +947,11 @@ export function TerminalPanel({
       // the zoom path keeps calling the local closure directly with its
       // `{ newFontSize }` argument.
       remeasureAndReattachRef.current = () => remeasureAndReattach();
+      // Record whether the WebGL surface was built against a VISIBLE layout.
+      // If so it's already correct and the become-visible effect must NOT
+      // rebuild it; if the panel is hidden right now, the surface is suspect
+      // and the first become-visible will repair it exactly once.
+      firstVisiblePaintDoneRef.current = visibleRef.current;
       // DPR-only path: bail out if DPR didn't actually change; otherwise
       // run the re-measure dance. DOM renderer is a no-op (CSS sizing
       // handles DPR natively) — `remeasureAndReattach` already handles
@@ -1043,6 +1063,8 @@ export function TerminalPanel({
         searchAddonRef.current = null;
         webglAddonRef.current = null;
         remeasureAndReattachRef.current = null;
+        // Re-arm the one-shot hidden-surface repair for the next mount.
+        firstVisiblePaintDoneRef.current = false;
         wsRef.current = null;
         // Reset toolbar state so a remount (e.g. terminal reconnect) doesn't
         // come back up with selection mode armed against a buffer row that
@@ -1071,22 +1093,29 @@ export function TerminalPanel({
   // resolves to the SAME cols/rows `fit()` already computed while hidden,
   // xterm's `resize()` early-returns (no reflow, no renderer repaint) so
   // the stale garbled frame stays on screen until a manual window resize
-  // changes the dimensions. To guarantee a clean frame we re-measure cell
-  // size and re-attach the WebGL addon (disposing the corrupted backing
-  // store and sizing a fresh canvas against the live layout) — the same
-  // recovery the DPR/zoom paths use — which repaints every cell from
-  // scratch regardless of whether the dimensions changed.
+  // changes the dimensions.
+  //
+  // So the FIRST time a terminal with a hidden first paint becomes visible
+  // we re-measure cell size and re-attach the WebGL addon (disposing the
+  // corrupted backing store and sizing a fresh canvas against the live
+  // layout) — the same recovery the DPR/zoom paths use — which repaints
+  // every cell from scratch regardless of whether the dimensions changed.
+  // This repair runs at most once per mount (`firstVisiblePaintDoneRef`):
+  // a terminal that first painted while visible never needs it, and every
+  // later visibility flip just re-fits, so we don't pay a full WebGL
+  // dispose + re-attach on every workspace tab-switch back to the terminal.
   useEffect(() => {
     if (visible && fitAddonRef.current) {
       requestAnimationFrame(() => {
         const remeasure = remeasureAndReattachRef.current;
-        if (remeasure) {
+        if (remeasure && !firstVisiblePaintDoneRef.current) {
           // `remeasureAndReattach` fits internally, so we don't call
           // `fit()` again here.
           remeasure();
         } else {
           fitAddonRef.current?.fit();
         }
+        firstVisiblePaintDoneRef.current = true;
         const term = terminalRef.current;
         const ws = wsRef.current;
         if (term && ws?.readyState === WebSocket.OPEN && term.cols > 0 && term.rows > 0) {

--- a/apps/web/src/components/TerminalPanel.tsx
+++ b/apps/web/src/components/TerminalPanel.tsx
@@ -137,6 +137,14 @@ export function TerminalPanel({
   const searchAddonRef = useRef<SearchAddon | null>(null);
   const webglAddonRef = useRef<WebglAddon | null>(null);
   const wsRef = useRef<WebSocket | null>(null);
+  // Exposes the init effect's `remeasureAndReattach` closure to the
+  // separate visibility-change effect below. Same ref-routing pattern as
+  // `fitAddonRef` / `terminalRef` — the closure has local context (the
+  // live `attachWebGL`, `fitAddon`, etc.) that can't be reconstructed
+  // outside the init effect. Used to force a real repaint when a terminal
+  // that first painted while its workspace was a hidden background tab
+  // becomes visible (see band-app/band terminal-garbled-until-resize).
+  const remeasureAndReattachRef = useRef<(() => void) | null>(null);
   const onTitleChangeRef = useRef(onTitleChange);
   onTitleChangeRef.current = onTitleChange;
 
@@ -918,6 +926,12 @@ export function TerminalPanel({
         }
         fitAddon.fit();
       };
+      // Expose to the visibility-change effect so a terminal that first
+      // painted while hidden can force a clean re-measure + repaint when
+      // it becomes visible. Bound to the no-arg (re-measure-only) form;
+      // the zoom path keeps calling the local closure directly with its
+      // `{ newFontSize }` argument.
+      remeasureAndReattachRef.current = () => remeasureAndReattach();
       // DPR-only path: bail out if DPR didn't actually change; otherwise
       // run the re-measure dance. DOM renderer is a no-op (CSS sizing
       // handles DPR natively) — `remeasureAndReattach` already handles
@@ -1028,6 +1042,7 @@ export function TerminalPanel({
         fitAddonRef.current = null;
         searchAddonRef.current = null;
         webglAddonRef.current = null;
+        remeasureAndReattachRef.current = null;
         wsRef.current = null;
         // Reset toolbar state so a remount (e.g. terminal reconnect) doesn't
         // come back up with selection mode armed against a buffer row that
@@ -1047,11 +1062,31 @@ export function TerminalPanel({
     };
   }, [terminalId, workspaceId, paneMetadata, autoFocus]);
 
-  // Refit when visibility changes and notify server of new size
+  // Refit when visibility changes and notify server of new size.
+  //
+  // A terminal whose first paint happened while its workspace was a hidden
+  // background tab establishes its WebGL backing store and cell geometry
+  // against a hidden/degenerate layout — the first frames render garbled.
+  // Re-fitting alone does NOT repair that: when the now-visible container
+  // resolves to the SAME cols/rows `fit()` already computed while hidden,
+  // xterm's `resize()` early-returns (no reflow, no renderer repaint) so
+  // the stale garbled frame stays on screen until a manual window resize
+  // changes the dimensions. To guarantee a clean frame we re-measure cell
+  // size and re-attach the WebGL addon (disposing the corrupted backing
+  // store and sizing a fresh canvas against the live layout) — the same
+  // recovery the DPR/zoom paths use — which repaints every cell from
+  // scratch regardless of whether the dimensions changed.
   useEffect(() => {
     if (visible && fitAddonRef.current) {
       requestAnimationFrame(() => {
-        fitAddonRef.current?.fit();
+        const remeasure = remeasureAndReattachRef.current;
+        if (remeasure) {
+          // `remeasureAndReattach` fits internally, so we don't call
+          // `fit()` again here.
+          remeasure();
+        } else {
+          fitAddonRef.current?.fit();
+        }
         const term = terminalRef.current;
         const ws = wsRef.current;
         if (term && ws?.readyState === WebSocket.OPEN && term.cols > 0 && term.rows > 0) {


### PR DESCRIPTION
## Problem

Terminal output sometimes rendered **completely garbled** until the user resized the window, after which it re-rendered correctly.

The bug affected terminals whose **first paint happened while their container was hidden** — a terminal belonging to a background workspace. The chain:

1. `TerminalPanel`'s init effect runs on mount regardless of the `visible` prop: it calls `terminal.open()`, attaches the WebGL renderer, and on `ws.onopen` does the first `fitAddon.fit()`. For a panel in a **background** workspace (kept mounted by the `MultiWorkspacePanelHost` LRU cache under `content-visibility: hidden` / `visibility: hidden`), this all happens against a hidden/degenerate layout — the WebGL backing store and cell geometry get established wrong, so the first frames render garbled.
2. The "became visible" effect only called `fitAddonRef.current?.fit()`. When the now-visible container resolves to the **same** cols/rows `fit()` already computed while hidden, xterm's `resize()` early-returns — no reflow, no WebGL repaint — so the stale garbled frame stays on screen.
3. A manual window resize fixes it precisely because it *changes* cols/rows, forcing a real resize → full reflow → full WebGL redraw.

## Fix

On become-visible, force a real repaint instead of relying on `fit()` alone: re-measure cell geometry and **re-attach the WebGL addon** (dispose the surface built while hidden, size a fresh `<canvas>` against the live layout) — the same recovery the existing DPR / zoom paths already use. This repaints every cell from scratch regardless of whether cols/rows changed.

Implementation reuses the existing `remeasureAndReattach()` closure, exposing it to the separate visibility effect via a ref (the same `fitAddonRef` / `terminalRef` ref-routing pattern already in the file). The PTY resize message and the DPR/zoom paths are unchanged.

## Test

`apps/web/e2e/terminal-background-repaint.spec.ts` boots the real server, reproduces a terminal that first-paints in a hidden background workspace (two-workspace LRU + the shared outer Terminal tab), switches it to the foreground, and asserts its WebGL render surface is **rebuilt** and correctly sized to the visible container.

The visible garble is a GPU-pixel artifact that headless Chromium can't reproduce (xterm cell metrics are font-based/layout-independent, and any dims-change self-heals), so the test observes the one behaviour that differs old-vs-new in every case — the surface rebuild. Confirmed to **fail before the fix** (the hidden canvases survive, only resized in place) and **pass after** (fresh canvases sized to the visible screen). The test file documents this limitation in detail.

## Verification

- `pnpm check` — clean.
- Full web e2e suite — **82 passed**, including the new test.
- Local CI-style review (coding / testing / security / performance) — no findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)