### PR TITLE
feat(web): auto-refresh open files when they change on disk

### DIFF
--- a/apps/web/e2e/file-auto-refresh.spec.ts
+++ b/apps/web/e2e/file-auto-refresh.spec.ts
@@ -1,0 +1,155 @@
+/**
+ * End-to-end coverage for the Files-view auto-refresh behaviour:
+ *
+ *   - When a file open in the viewer changes on disk and the buffer is
+ *     CLEAN, the viewer reloads and shows the new bytes.
+ *   - When the buffer has UNSAVED edits, an on-disk change must NOT
+ *     clobber what the user is typing.
+ *
+ * Architecture (mirrors the rest of the e2e suite):
+ *   - REAL production `dist/start-server.mjs` boots against a fresh tmp
+ *     `$HOME` with an on-disk git worktree. No tRPC mocking — the file
+ *     read and the `workspace.fileChanges` subscription run through the
+ *     same pipelines production uses.
+ *   - "External" changes are plain `writeFileSync` calls into the worktree
+ *     (the exact scenario the server watcher exists for: agents,
+ *     terminals, `git`, other editors), which the server's per-workspace
+ *     `fs.watch` reports to the client.
+ *
+ * Delivery determinism for the negative ("don't clobber") test: we write
+ * a *second* file (`src/marker.txt`) in the same directory as the edited
+ * file. The `FileBrowser` (Files tab) and the `FileViewer` both subscribe
+ * to the same coalesced `src` change event. The marker row appearing in
+ * the tree proves the `src` event was delivered to the client; the viewer
+ * handles the same broadcast and decides synchronously (it bails the
+ * moment it sees unsaved edits — no pending async write), so once the
+ * marker is visible we can assert the edited buffer survived.
+ */
+
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { test } from "@playwright/test";
+import { toWorkspaceId } from "@/dashboard";
+import { git } from "./helpers/git";
+import {
+  cleanupTmpHome,
+  createTmpHome,
+  type ServerHandle,
+  seedSettings,
+  seedState,
+  startServer,
+} from "./helpers/server";
+import { FileTreesPage } from "./pages/FileTreesPage";
+import { FileViewerPage } from "./pages/FileViewerPage";
+import { WorkspacePage } from "./pages/WorkspacePage";
+
+// Wide viewport so `useIsDesktop()` reports true and the dockview Files
+// panel + viewer render the desktop layout (same reasoning as the other
+// file-tree specs).
+test.use({ viewport: { width: 2400, height: 900 } });
+
+const TOKEN = "e2e-file-auto-refresh-token";
+const REPO_NAME = "auto-refresh-repo";
+const BRANCH = "main";
+const DIR_PATH = "src";
+const FILE_PATH = "src/notes.txt";
+const MARKER_PATH = "src/marker.txt";
+const ORIGINAL = "ALPHA-ORIGINAL";
+
+let server: ServerHandle;
+let tmpHome: string;
+let repoPath: string;
+let workspaceId: string;
+
+test.beforeAll(async () => {
+  tmpHome = createTmpHome();
+  repoPath = join(tmpHome, REPO_NAME);
+  mkdirSync(join(repoPath, DIR_PATH), { recursive: true });
+
+  git(repoPath, ["init", "-b", BRANCH]);
+  writeFileSync(join(repoPath, FILE_PATH), `${ORIGINAL}\n`);
+  git(repoPath, ["add", "."]);
+  git(repoPath, ["commit", "-m", "initial"]);
+
+  seedState(tmpHome, {
+    projects: [
+      {
+        name: REPO_NAME,
+        path: repoPath,
+        defaultBranch: BRANCH,
+        worktrees: [{ branch: BRANCH, path: repoPath }],
+      },
+    ],
+  });
+  seedSettings(tmpHome, { tokenSecret: TOKEN });
+  server = await startServer({ tmpHome });
+  workspaceId = toWorkspaceId(REPO_NAME, BRANCH);
+});
+
+test.afterAll(async () => {
+  await server.close();
+  cleanupTmpHome(tmpHome);
+});
+
+// Each test gets a fresh browser context (clean localStorage, so no tab
+// state / unsaved-edit leakage), but the worktree is shared — reset the
+// on-disk file to its committed contents and drop the marker so the two
+// tests don't observe each other's writes.
+test.beforeEach(() => {
+  writeFileSync(join(repoPath, FILE_PATH), `${ORIGINAL}\n`);
+  rmSync(join(repoPath, MARKER_PATH), { force: true });
+});
+
+test.describe("Files view auto-refresh", () => {
+  test("reloads an open file when it changes on disk and the buffer is clean", async ({ page }) => {
+    const workspace = new WorkspacePage(page, server.url, TOKEN);
+    const trees = new FileTreesPage(page, workspace);
+    const viewer = new FileViewerPage(page);
+
+    await workspace.goto(workspaceId);
+    await workspace.waitForReady();
+
+    await trees.openFilesTab(DIR_PATH);
+    await trees.expandFileTreeFolder(DIR_PATH, FILE_PATH);
+    await trees.openFile(FILE_PATH);
+    await viewer.expectContent(ORIGINAL);
+
+    // External change (a teammate's `git pull`, the agent rewriting the
+    // file, another editor saving). The server watcher reports it and the
+    // viewer reloads because there are no unsaved edits.
+    writeFileSync(join(repoPath, FILE_PATH), "BRAVO-REFRESHED\n");
+
+    await viewer.expectContent("BRAVO-REFRESHED");
+  });
+
+  test("does not clobber unsaved edits when the file changes on disk", async ({ page }) => {
+    const workspace = new WorkspacePage(page, server.url, TOKEN);
+    const trees = new FileTreesPage(page, workspace);
+    const viewer = new FileViewerPage(page);
+
+    await workspace.goto(workspaceId);
+    await workspace.waitForReady();
+
+    await trees.openFilesTab(DIR_PATH);
+    await trees.expandFileTreeFolder(DIR_PATH, FILE_PATH);
+    await trees.openFile(FILE_PATH);
+    await viewer.expectContent(ORIGINAL);
+
+    // Make the buffer dirty: replace its contents with a unique token.
+    await viewer.replaceAll("CHARLIE-EDIT");
+
+    // External change to the SAME file while the buffer is dirty, plus a
+    // marker file in the same directory whose appearance in the tree
+    // proves the `src` change event reached the client.
+    writeFileSync(join(repoPath, FILE_PATH), "DELTA-CLOBBER\n");
+    writeFileSync(join(repoPath, MARKER_PATH), "marker\n");
+
+    await trees.waitForFileTreeRow(MARKER_PATH);
+
+    // The change event was delivered (marker is visible), but the dirty
+    // buffer must be untouched — the user's edit survives and the on-disk
+    // bytes did not overwrite it.
+    await viewer.expectContent("CHARLIE-EDIT");
+    await viewer.expectNotContent("DELTA-CLOBBER");
+  });
+});

--- a/apps/web/e2e/pages/FileTreesPage.ts
+++ b/apps/web/e2e/pages/FileTreesPage.ts
@@ -20,6 +20,7 @@
  */
 
 import { type Locator, type Page, test } from "@playwright/test";
+import { FILE_VIEWER_ROOT_TESTID } from "./FileViewerPage";
 import type { WorkspacePage } from "./WorkspacePage";
 
 export class FileTreesPage {
@@ -87,6 +88,28 @@ export class FileTreesPage {
     await test.step(`Expand Files-tree folder ${path}`, async () => {
       await this.fileTreeRow(path).click();
       await this.fileTreeRow(awaitChild).waitFor({ state: "visible", timeout: 15_000 });
+    });
+  }
+
+  /** Click a file row in the Files tree to open it in the file viewer, and
+   *  wait for the viewer to mount. Clicking a *file* row (as opposed to a
+   *  directory row, which `expandFileTreeFolder` toggles) drives
+   *  `FileBrowser`'s `onSelectRow(..., "file")`, which opens the tab and
+   *  mounts `FileViewer`. */
+  async openFile(path: string): Promise<void> {
+    await test.step(`Open file ${path} in the viewer`, async () => {
+      await this.fileTreeRow(path).click();
+      await this.page
+        .getByTestId(FILE_VIEWER_ROOT_TESTID)
+        .waitFor({ state: "visible", timeout: 15_000 });
+    });
+  }
+
+  /** Wait for a Files-tree row to appear (e.g. after an external file was
+   *  created and the watcher-driven tree refresh should surface it). */
+  async waitForFileTreeRow(path: string): Promise<void> {
+    await test.step(`Wait for Files-tree row ${path}`, async () => {
+      await this.fileTreeRow(path).waitFor({ state: "visible", timeout: 15_000 });
     });
   }
 

--- a/apps/web/e2e/pages/FileViewerPage.ts
+++ b/apps/web/e2e/pages/FileViewerPage.ts
@@ -1,0 +1,68 @@
+/**
+ * Page object for the workspace file viewer/editor (`FileViewer` →
+ * `CodeMirrorEditor`).
+ *
+ * The viewer's root carries a `data-testid="file-viewer__root"` (set on
+ * the `FileViewer` root element — distinct from the dockview panel's own
+ * `file-viewer` test id) so we can scope the editor lookup to it and never
+ * collide with the diff editors rendered in the Changes panel.
+ *
+ * `.cm-content` is CodeMirror-owned DOM (3rd-party class, same fragility
+ * caveat as `ChangesPanelPage`'s `.cm-line`): the editor doesn't expose a
+ * stable hook of its own for its content surface, and a CodeMirror major
+ * upgrade that renamed it would flow through this one place. We scope it
+ * under our own `file-viewer__root` test id so the brittle part is bounded.
+ *
+ * This is a SECONDARY page object — it owns no routes and constructs no
+ * URLs, so it does NOT follow the `(page, baseUrl, …)` + `goto()`
+ * convention of primary page objects.
+ */
+
+import { expect, type Locator, type Page, test } from "@playwright/test";
+
+/** Test id on the `FileViewer` root element (set in FileViewer.tsx).
+ *  Exported so other page objects that need to wait for the viewer to mount
+ *  (e.g. `FileTreesPage.openFile`) reference the hook in one place rather
+ *  than re-hardcoding the string. */
+export const FILE_VIEWER_ROOT_TESTID = "file-viewer__root";
+
+export class FileViewerPage {
+  constructor(private readonly page: Page) {}
+
+  /** The active file viewer's CodeMirror content element. */
+  private get editor(): Locator {
+    return this.page.getByTestId(FILE_VIEWER_ROOT_TESTID).locator(".cm-content").first();
+  }
+
+  /** Assert (auto-retrying) that the editor's rendered text contains `text`. */
+  async expectContent(text: string): Promise<void> {
+    await test.step(`Editor shows "${text}"`, async () => {
+      await expect(this.editor).toContainText(text, { timeout: 15_000 });
+    });
+  }
+
+  /** Assert the editor's text does NOT contain `text`. Paired with a
+   *  positive `expectContent` anchor at the call site (which is the real
+   *  guard against a clobber); the generous window widens the chance of
+   *  catching a late-arriving stale render rather than racing past it. */
+  async expectNotContent(text: string): Promise<void> {
+    await test.step(`Editor does not show "${text}"`, async () => {
+      await expect(this.editor).not.toContainText(text, { timeout: 8_000 });
+    });
+  }
+
+  /**
+   * Replace the whole buffer with `text` (select-all + type). This makes
+   * the tab dirty — the edited content differs from the on-disk baseline —
+   * which is exactly the precondition for the "don't clobber unsaved edits"
+   * behaviour under test.
+   */
+  async replaceAll(text: string): Promise<void> {
+    await test.step(`Replace editor contents with "${text}"`, async () => {
+      await this.editor.click();
+      await this.page.keyboard.press("ControlOrMeta+a");
+      await this.page.keyboard.type(text);
+      await expect(this.editor).toContainText(text, { timeout: 15_000 });
+    });
+  }
+}

--- a/apps/web/src/dashboard/components/FileViewer.tsx
+++ b/apps/web/src/dashboard/components/FileViewer.tsx
@@ -138,6 +138,20 @@ function getExtension(path: string): string {
   return dot >= 0 ? name.slice(dot).toLowerCase() : "";
 }
 
+/**
+ * Workspace-relative parent directory of a path, matching the semantics
+ * of the server-side file watcher (`file-watcher.ts::parentDirOf`): a
+ * top-level file ("README.md") has parent `""`, a nested file
+ * ("src/app.ts") has parent "src". The `fileChanges` subscription emits
+ * the parent directory of any touched path, so a viewer auto-refreshes
+ * when the changed directory equals its own file's parent.
+ */
+function parentDirOf(path: string): string {
+  const normalised = path.split(/[\\/]+/).join("/");
+  const idx = normalised.lastIndexOf("/");
+  return idx === -1 ? "" : normalised.slice(0, idx);
+}
+
 function detectLanguage(filePath: string, serverHint?: string): string {
   if (serverHint) return serverHint;
   const ext = getExtension(filePath);
@@ -264,6 +278,12 @@ export function FileViewer({
   // pairs above so a reader sees all of them in one place.
   const onLoadErrorRef = useRef(onLoadError);
   onLoadErrorRef.current = onLoadError;
+  // Latest `filePath`, mirrored so `reloadFromDisk` can detect that the
+  // user switched files mid-fetch and bail before writing one file's
+  // bytes into another file's editor (the FileViewer instance is reused
+  // across file→file navigation — see the `key="file"` in CodeBrowserView).
+  const filePathRef = useRef(filePath);
+  filePathRef.current = filePath;
 
   // Untitled tabs are "dirty" whenever they have any content typed in —
   // there's no on-disk baseline to compare against. An empty buffer
@@ -674,6 +694,96 @@ export function FileViewer({
     [onEditorView],
   );
 
+  // ---- Auto-refresh on external disk changes -----------------------------
+  //
+  // Re-read the file from disk and reflect the new bytes in the viewer,
+  // but ONLY when the buffer is clean. If the user has unsaved edits
+  // (`editedContentRef.current !== null`) we leave the buffer untouched so
+  // a background change (a teammate's `git pull`, the agent rewriting the
+  // file) can't silently clobber what they're typing. The dirty check is
+  // re-evaluated after the async read because the user may start typing
+  // during the round-trip.
+  const reloadFromDisk = useCallback(async () => {
+    // Untitled buffers have no backing file; external files aren't covered
+    // by the workspace watcher. Both are out of scope for auto-refresh.
+    if (untitled || external) return;
+    if (!adapter.getWorkspaceFile) return;
+    // Don't clobber unsaved edits.
+    if (editedContentRef.current !== null) return;
+
+    let result: FileContentResult;
+    try {
+      result = await adapter.getWorkspaceFile(workspaceId, filePath);
+    } catch {
+      // The file may have just been deleted/renamed, or the read raced a
+      // write. Leave the current view as-is — the file tree handles
+      // removal, and the next change event will retry.
+      return;
+    }
+
+    // The user switched files while the read was in flight — this result
+    // belongs to the previously-viewed file. Dropping it here prevents the
+    // stale bytes from being dispatched into the now-current file's editor
+    // (the FileViewer instance is reused across file→file navigation).
+    if (filePathRef.current !== filePath) return;
+    // The user may have started editing while the read was in flight.
+    if (editedContentRef.current !== null) return;
+    // The read succeeded, so a prior load error (e.g. the file was missing
+    // and has since been created) is now stale — clear it so the content
+    // area isn't left gated behind the old error banner.
+    setError(null);
+    // The open file's own bytes are unchanged — typically a sibling file in
+    // the same directory triggered the event. (The O(1) size check
+    // short-circuits the O(n) content comparison in the common case where
+    // the file genuinely changed.) Only re-render when the server metadata
+    // actually drifted; otherwise a stream of sibling-file events would each
+    // force a gratuitous re-render of the editor for no visible change.
+    if (result.size === dataRef.current?.size && result.content === dataRef.current?.content) {
+      if (result.language !== dataRef.current?.language) setData(result);
+      return;
+    }
+
+    // Update the on-disk baseline first so the editor's change listener
+    // (`handleContentChange`) sees the new content and keeps the buffer
+    // marked clean rather than flipping it to dirty.
+    dataRef.current = result;
+    setData(result);
+
+    // The editable CodeMirror intentionally ignores `content` prop changes
+    // after creation (it owns its document), so drive the swap through the
+    // live EditorView — the same mechanism `handleFormat` uses. The
+    // read-only viewer and markdown preview key off `data`/`displayContent`
+    // and re-render from `setData` alone. We reach this only when the buffer
+    // is clean and the content genuinely changed, so the live doc already
+    // equals the old baseline — replacing it unconditionally avoids an
+    // O(file_size) `doc.toString()` just to confirm what we already know.
+    const view = editorViewRef.current;
+    if (view && typeof result.content === "string") {
+      view.dispatch({
+        changes: { from: 0, to: view.state.doc.length, insert: result.content },
+        userEvent: "band.reload",
+      });
+    }
+  }, [adapter, workspaceId, filePath, untitled, external]);
+
+  // Subscribe to the workspace file watcher and reload when the directory
+  // containing this file reports a change. The server coalesces events per
+  // parent directory, so we match on `parentDirOf(filePath)`. Image/PDF
+  // previews render straight off the raw file URL (no in-memory content to
+  // refresh), and untitled/external tabs have no watcher path — skip all
+  // of them.
+  useEffect(() => {
+    if (untitled || external) return;
+    if (previewType === "image" || previewType === "pdf") return;
+    if (!adapter.subscribeFileChanges) return;
+    const watchedDir = parentDirOf(filePath);
+    const unsubscribe = adapter.subscribeFileChanges(workspaceId, (changedDir) => {
+      if (changedDir !== watchedDir) return;
+      void reloadFromDisk();
+    });
+    return unsubscribe;
+  }, [adapter, workspaceId, filePath, untitled, external, previewType, reloadFromDisk]);
+
   const handleBack = useCallback(() => {
     if (isDirty && !window.confirm("You have unsaved changes. Discard?")) {
       return;
@@ -712,7 +822,7 @@ export function FileViewer({
     // lines, in particular) from forcing this box wider than its allocated
     // flex slot, which would propagate up and shove neighbouring layout
     // (e.g. the right-edge tab strip) off-screen.
-    <div className="flex h-full min-w-0 flex-col overflow-hidden">
+    <div data-testid="file-viewer__root" className="flex h-full min-w-0 flex-col overflow-hidden">
       {/* Title bar — full version (mobile / non-tab views) */}
       {!hideTitleBar && (
         <div className="flex h-9 shrink-0 items-center gap-2 border-b border-border/50 px-3">


### PR DESCRIPTION
## What

A file open in the Files view now automatically refreshes when it changes on disk — **but only when the buffer is clean**. Unsaved edits are never clobbered.

This covers the everyday cases where a file changes underneath the editor: an agent rewriting it, a teammate's `git pull`/branch switch, a terminal command, or another editor saving.

## How

- Reuses the existing per-workspace `workspace.fileChanges` watcher (no new server endpoint). `FileViewer` subscribes and, when the open file's parent directory reports a change, re-reads the file via `adapter.getWorkspaceFile`.
- The dirty guard (`editedContentRef.current !== null`) is checked **before and after** the async read, so unsaved edits block the refresh even if the user starts typing mid-fetch.
- The editable CodeMirror swap is driven through the live `EditorView` (the same mechanism `handleFormat` already uses, since CodeMirror owns its document after creation); read-only and markdown-preview views re-render from `setData` alone.
- A `filePathRef` guard drops a late fetch result when the user has switched files mid-read, so one file's bytes can't land in another file's editor.
- Untitled / external / image / PDF tabs are skipped (no workspace-watcher path or no in-memory text content).

## Testing

New e2e spec (`apps/web/e2e/file-auto-refresh.spec.ts`) boots the real server + Chromium and covers both branches:
- clean buffer → reloads to the new on-disk bytes;
- dirty buffer → on-disk change does **not** clobber the unsaved edit (delivery proven deterministically via a marker file appearing in the tree).

Both assertions were mutation-verified: disabling the refresh fails the clean-reload test; removing the dirty guard fails the no-clobber test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)