### PR TITLE
feat(web): move project list into a standalone toggleable sidebar

### DIFF
--- a/apps/web/e2e/pages/WorkspacePage.ts
+++ b/apps/web/e2e/pages/WorkspacePage.ts
@@ -442,6 +442,18 @@ export class WorkspacePage {
     return await this.page.evaluate(() => localStorage.getItem("band:sidebar-collapsed") === "1");
   }
 
+  /** Trigger the ⌃0 "Focus Projects" shortcut, which reveals the sidebar
+   *  (`band:show-sidebar`) and focuses the list (`band:focus-projects`). The
+   *  keydown is caught by the window listener in `SharedDockviewLayout.tsx`.
+   *  Anchored on the always-present toggle button so the key press has a
+   *  stable focus target even when the sidebar (and its list) is collapsed. */
+  async focusProjectsViaShortcut(): Promise<void> {
+    await test.step("Trigger ⌃0 (Focus Projects)", async () => {
+      await this.sidebarToggle.focus();
+      await this.page.keyboard.press("Control+0");
+    });
+  }
+
   /** Drive the ⌘1..9 / Ctrl+1..9 label shortcut as a real user keypress.
    *  Uses `projectListRoot.press(...)` so Playwright moves focus there
    *  before dispatching the key, bypassing the chat textarea autofocus

--- a/apps/web/e2e/pages/WorkspacePage.ts
+++ b/apps/web/e2e/pages/WorkspacePage.ts
@@ -390,6 +390,56 @@ export class WorkspacePage {
     return this.page.getByTestId("project-list__root");
   }
 
+  // ──────────────────────────────────────────────────────────────────────
+  // Project-list sidebar (lives left of the dockview, outside it) + its
+  // header toggle button. The sidebar is a collapsible resizable-panel:
+  // collapsing shrinks its width to ~0 rather than unmounting, so the
+  // user-observable signal for hidden/shown is its rendered width.
+  // ──────────────────────────────────────────────────────────────────────
+
+  /** The project-list sidebar wrapper. `data-testid` set in `__root.tsx`
+   *  (`AppShell`). */
+  get sidebar(): Locator {
+    return this.page.getByTestId("app-shell__sidebar");
+  }
+
+  /** The header button that toggles the sidebar (⌘B). `data-testid` set in
+   *  `DesktopTitleBar.tsx`; its `aria-pressed` reflects current visibility. */
+  get sidebarToggle(): Locator {
+    return this.page.getByTestId("desktop-title-bar__sidebar-toggle");
+  }
+
+  /** Current rendered width of the sidebar in CSS px — ~0 when collapsed.
+   *  The geometric, user-observable signal for show/hide (a collapsed Panel
+   *  shrinks its width rather than unmounting). */
+  async sidebarWidth(): Promise<number> {
+    return (await this.sidebar.boundingBox())?.width ?? 0;
+  }
+
+  /** Click the header sidebar-toggle button. */
+  async toggleSidebarViaButton(): Promise<void> {
+    await test.step("Toggle the sidebar via the header button", async () => {
+      await this.sidebarToggle.click();
+    });
+  }
+
+  /** Toggle the sidebar via the ⌘B keyboard shortcut. The handler is a window
+   *  keydown listener in `SharedDockviewLayout.tsx`; ⌘ is a meta key so it
+   *  fires regardless of focus. Anchored on the always-present toggle button
+   *  so the key press has a stable, non-editable focus target. */
+  async toggleSidebarViaShortcut(): Promise<void> {
+    await test.step("Toggle the sidebar via ⌘B", async () => {
+      await this.sidebarToggle.focus();
+      await this.page.keyboard.press("Meta+b");
+    });
+  }
+
+  /** Read the persisted sidebar-collapsed flag (`band:sidebar-collapsed`)
+   *  from localStorage. */
+  async readSidebarCollapsed(): Promise<boolean> {
+    return await this.page.evaluate(() => localStorage.getItem("band:sidebar-collapsed") === "1");
+  }
+
   /** Drive the ⌘1..9 / Ctrl+1..9 label shortcut as a real user keypress.
    *  Uses `projectListRoot.press(...)` so Playwright moves focus there
    *  before dispatching the key, bypassing the chat textarea autofocus

--- a/apps/web/e2e/pages/WorkspacePage.ts
+++ b/apps/web/e2e/pages/WorkspacePage.ts
@@ -304,10 +304,10 @@ export class WorkspacePage {
    *  issue #505 — so this is the right path for tests that need the
    *  full click→restore behaviour.
    *
-   *  Only the SharedDockviewLayout's DashboardShell is mounted on
-   *  desktop (see `apps/web/src/routes/index.tsx` and the comment in
-   *  `SharedDockviewLayout` § ProjectsPanelComponent), so a single
-   *  trigger / item pair is in the DOM at any time. The Radix
+   *  Only one DashboardShell is mounted on desktop — it now lives in the
+   *  sidebar `Panel` inside `AppShell` (`apps/web/src/routes/__root.tsx`),
+   *  separate from the dockview — so a single trigger / item pair is in the
+   *  DOM at any time. The Radix
    *  DropdownMenu portals its content to `document.body` with a fade
    *  animation on close, so a back-to-back reopen can briefly see the
    *  previous portal animating out while the new one mounts. Waiting

--- a/apps/web/e2e/pages/WorkspacePage.ts
+++ b/apps/web/e2e/pages/WorkspacePage.ts
@@ -423,10 +423,12 @@ export class WorkspacePage {
     });
   }
 
-  /** Toggle the sidebar via the ⌘B keyboard shortcut. The handler is a window
-   *  keydown listener in `SharedDockviewLayout.tsx`; ⌘ is a meta key so it
-   *  fires regardless of focus. Anchored on the always-present toggle button
-   *  so the key press has a stable, non-editable focus target. */
+  /** Toggle the sidebar via the ⌘B keyboard shortcut. The keydown is caught
+   *  by a window listener in `SharedDockviewLayout.tsx` and re-dispatched as
+   *  `band:toggle-sidebar`; the actual panel collapse/expand is handled in
+   *  `AppShell` (`__root.tsx`). ⌘ is a meta key so it fires regardless of
+   *  focus. Anchored on the always-present toggle button so the key press has
+   *  a stable, non-editable focus target. */
   async toggleSidebarViaShortcut(): Promise<void> {
     await test.step("Toggle the sidebar via ⌘B", async () => {
       await this.sidebarToggle.focus();

--- a/apps/web/e2e/sidebar-toggle.spec.ts
+++ b/apps/web/e2e/sidebar-toggle.spec.ts
@@ -1,0 +1,122 @@
+/**
+ * End-to-end coverage for the project-list sidebar toggle.
+ *
+ * The project list now lives in a standalone left sidebar, SEPARATE from the
+ * dockview (it used to be the dockview's `edge-left` "projects" panel). A
+ * header button — plus the ⌘B shortcut and the ⌃0 "Focus Projects" path —
+ * toggles its visibility, and the last-left state persists across reloads.
+ *
+ * Architecture (matches the repo's integration doctrine):
+ *   - The real production binary runs against a fresh tmp `~/.band/`.
+ *   - No tRPC mocking — the dashboard renders against the real backend. One
+ *     project (no real worktree on disk) is seeded into SQLite so a
+ *     workspace route mounts; background git calls fail gracefully but the
+ *     dockview + sidebar still render.
+ *   - All UI is driven through `WorkspacePage` (no raw `page.*` in the body).
+ *
+ * The sidebar is a collapsible resizable-panel: collapsing shrinks its width
+ * to ~0 rather than unmounting the sibling panel that holds the dockview
+ * (which must stay mounted so cached workspaces survive a toggle). So the
+ * user-observable signal for hidden/shown is the sidebar's rendered width,
+ * cross-checked against the toggle button's `aria-pressed` state.
+ */
+
+import { expect, test } from "@playwright/test";
+import { toWorkspaceId } from "@/dashboard";
+import {
+  cleanupTmpHome,
+  createTmpHome,
+  type ServerHandle,
+  seedSettings,
+  seedState,
+  startServer,
+} from "./helpers/server";
+import { WorkspacePage } from "./pages/WorkspacePage";
+
+const TOKEN = "e2e-sidebar-toggle-token";
+const PROJECT = "alpha-sidebar";
+const WORKSPACE = toWorkspaceId(PROJECT, "main");
+
+// Wide viewport so `useIsDesktop()` reports true and the desktop layout
+// (title bar + sidebar + dockview) renders (>= 1024px in useIsDesktop.ts).
+test.use({ viewport: { width: 1280, height: 800 } });
+
+let server: ServerHandle;
+let tmpHome: string;
+
+test.beforeAll(async () => {
+  tmpHome = createTmpHome();
+  seedState(tmpHome, {
+    projects: [
+      {
+        name: PROJECT,
+        path: `/tmp/fake/${PROJECT}`,
+        defaultBranch: "main",
+        worktrees: [{ branch: "main", path: `/tmp/fake/${PROJECT}` }],
+      },
+    ],
+  });
+  seedSettings(tmpHome, { tokenSecret: TOKEN });
+  server = await startServer({ tmpHome });
+});
+
+test.afterAll(async () => {
+  await server.close();
+  cleanupTmpHome(tmpHome);
+});
+
+test("the sidebar is visible by default and the toggle button reads pressed", async ({ page }) => {
+  const wp = new WorkspacePage(page, server.url, TOKEN);
+  await wp.goto(WORKSPACE);
+  await wp.waitForReady();
+
+  expect(await wp.sidebarWidth()).toBeGreaterThan(200);
+  await expect(wp.sidebarToggle).toHaveAttribute("aria-pressed", "true");
+});
+
+test("the header button hides and shows the sidebar", async ({ page }) => {
+  const wp = new WorkspacePage(page, server.url, TOKEN);
+  await wp.goto(WORKSPACE);
+  await wp.waitForReady();
+
+  // Hide.
+  await wp.toggleSidebarViaButton();
+  await expect.poll(() => wp.sidebarWidth()).toBeLessThan(5);
+  await expect(wp.sidebarToggle).toHaveAttribute("aria-pressed", "false");
+
+  // Show.
+  await wp.toggleSidebarViaButton();
+  await expect.poll(() => wp.sidebarWidth()).toBeGreaterThan(200);
+  await expect(wp.sidebarToggle).toHaveAttribute("aria-pressed", "true");
+});
+
+test("the ⌘B shortcut toggles the sidebar", async ({ page }) => {
+  const wp = new WorkspacePage(page, server.url, TOKEN);
+  await wp.goto(WORKSPACE);
+  await wp.waitForReady();
+
+  await wp.toggleSidebarViaShortcut();
+  await expect.poll(() => wp.sidebarWidth()).toBeLessThan(5);
+  await expect(wp.sidebarToggle).toHaveAttribute("aria-pressed", "false");
+
+  await wp.toggleSidebarViaShortcut();
+  await expect.poll(() => wp.sidebarWidth()).toBeGreaterThan(200);
+  await expect(wp.sidebarToggle).toHaveAttribute("aria-pressed", "true");
+});
+
+test("the collapsed state persists across a reload", async ({ page }) => {
+  const wp = new WorkspacePage(page, server.url, TOKEN);
+  await wp.goto(WORKSPACE);
+  await wp.waitForReady();
+
+  await wp.toggleSidebarViaButton();
+  await expect.poll(() => wp.sidebarWidth()).toBeLessThan(5);
+  expect(await wp.readSidebarCollapsed()).toBe(true);
+
+  await wp.reload();
+  await wp.waitForReady();
+
+  // The mount effect re-collapses from persisted state.
+  await expect.poll(() => wp.sidebarWidth()).toBeLessThan(5);
+  await expect(wp.sidebarToggle).toHaveAttribute("aria-pressed", "false");
+});

--- a/apps/web/e2e/sidebar-toggle.spec.ts
+++ b/apps/web/e2e/sidebar-toggle.spec.ts
@@ -71,6 +71,7 @@ test("the sidebar is visible by default and the toggle button reads pressed", as
   await wp.waitForReady();
 
   await expect.poll(() => wp.sidebarWidth()).toBeGreaterThan(200);
+  await expect(wp.sidebarToggle).toBeVisible();
   await expect(wp.sidebarToggle).toHaveAttribute("aria-pressed", "true");
 });
 
@@ -100,6 +101,20 @@ test("the ⌘B shortcut toggles the sidebar", async ({ page }) => {
   await expect(wp.sidebarToggle).toHaveAttribute("aria-pressed", "false");
 
   await wp.toggleSidebarViaShortcut();
+  await expect.poll(() => wp.sidebarWidth()).toBeGreaterThan(200);
+  await expect(wp.sidebarToggle).toHaveAttribute("aria-pressed", "true");
+});
+
+test("⌃0 (Focus Projects) reveals a collapsed sidebar", async ({ page }) => {
+  const wp = new WorkspacePage(page, server.url, TOKEN);
+  await wp.goto(WORKSPACE);
+  await wp.waitForReady();
+
+  // Hide first, then prove ⌃0 brings it back.
+  await wp.toggleSidebarViaButton();
+  await expect.poll(() => wp.sidebarWidth()).toBeLessThan(5);
+
+  await wp.focusProjectsViaShortcut();
   await expect.poll(() => wp.sidebarWidth()).toBeGreaterThan(200);
   await expect(wp.sidebarToggle).toHaveAttribute("aria-pressed", "true");
 });

--- a/apps/web/e2e/sidebar-toggle.spec.ts
+++ b/apps/web/e2e/sidebar-toggle.spec.ts
@@ -70,7 +70,7 @@ test("the sidebar is visible by default and the toggle button reads pressed", as
   await wp.goto(WORKSPACE);
   await wp.waitForReady();
 
-  expect(await wp.sidebarWidth()).toBeGreaterThan(200);
+  await expect.poll(() => wp.sidebarWidth()).toBeGreaterThan(200);
   await expect(wp.sidebarToggle).toHaveAttribute("aria-pressed", "true");
 });
 

--- a/apps/web/e2e/sidebar-toggle.spec.ts
+++ b/apps/web/e2e/sidebar-toggle.spec.ts
@@ -111,7 +111,7 @@ test("the collapsed state persists across a reload", async ({ page }) => {
 
   await wp.toggleSidebarViaButton();
   await expect.poll(() => wp.sidebarWidth()).toBeLessThan(5);
-  expect(await wp.readSidebarCollapsed()).toBe(true);
+  await expect.poll(() => wp.readSidebarCollapsed()).toBe(true);
 
   await wp.reload();
   await wp.waitForReady();

--- a/apps/web/src/components/DesktopTitleBar.tsx
+++ b/apps/web/src/components/DesktopTitleBar.tsx
@@ -8,7 +8,7 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@band-app/ui";
-import { ChevronLeft, ChevronRight, ChevronsUpDown, Menu, PanelTop } from "lucide-react";
+import { ChevronLeft, ChevronRight, ChevronsUpDown, Menu, PanelLeft, PanelTop } from "lucide-react";
 import { type ReactNode, useEffect, useState } from "react";
 import { useIsFullscreen } from "../hooks/useIsFullscreen";
 import { invoke as desktopInvoke } from "../lib/desktop-ipc";
@@ -62,6 +62,12 @@ interface DesktopTitleBarProps {
    *  Pass DropdownMenu items (Tasks, Cronjobs, Settings, …). When undefined,
    *  the hamburger button is not rendered. */
   menuItems?: ReactNode;
+  /** Toggle the project-list sidebar's visibility (⌘B). When undefined, the
+   *  sidebar toggle button is not rendered. */
+  onToggleSidebar?: () => void;
+  /** Whether the sidebar is currently visible — drives the toggle button's
+   *  pressed state. */
+  sidebarVisible?: boolean;
 }
 
 /** Draggable desktop title bar that works with external-URL Electron webviews. */
@@ -79,6 +85,8 @@ export function DesktopTitleBar({
   canGoBack,
   canGoForward,
   menuItems,
+  onToggleSidebar,
+  sidebarVisible,
 }: DesktopTitleBarProps) {
   const [appTitle, setAppTitle] = useState(title ?? "Band");
   // macOS native fullscreen hides the traffic lights — used below to drop
@@ -103,13 +111,35 @@ export function DesktopTitleBar({
       className="h-[38px] shrink-0 flex items-center justify-center relative border-b border-border"
       style={DRAG_STYLE}
     >
-      {(onGoBack || onGoForward || menuItems) && (
+      {(onGoBack || onGoForward || menuItems || onToggleSidebar) && (
         <div
           // Desktop: leave 80px clear for the macOS traffic lights.
           // Web: no traffic lights exist, so park the controls near the edge.
           className={`absolute ${isDesktop && !isFullscreen ? "left-[80px]" : "left-2"} top-1/2 -translate-y-1/2 flex items-center gap-0.5 pointer-events-auto`}
           style={NO_DRAG_STYLE}
         >
+          {onToggleSidebar && (
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <button
+                  type="button"
+                  onClick={onToggleSidebar}
+                  aria-label="Toggle sidebar"
+                  aria-pressed={sidebarVisible}
+                  data-testid="desktop-title-bar__sidebar-toggle"
+                  className={`flex items-center justify-center rounded p-1 transition-colors hover:bg-accent/50 hover:text-foreground ${sidebarVisible ? "text-foreground" : "text-muted-foreground"}`}
+                >
+                  <PanelLeft className="size-5" />
+                </button>
+              </TooltipTrigger>
+              <TooltipContent side="bottom" className="text-xs">
+                Toggle Sidebar{" "}
+                <kbd className="ml-1.5 rounded border border-popover-foreground/25 bg-popover-foreground/10 px-1 py-0.5 font-mono text-[14px]">
+                  ⌘B
+                </kbd>
+              </TooltipContent>
+            </Tooltip>
+          )}
           {menuItems && (
             <DropdownMenu>
               <Tooltip>

--- a/apps/web/src/components/DesktopTitleBar.tsx
+++ b/apps/web/src/components/DesktopTitleBar.tsx
@@ -153,12 +153,11 @@ export function DesktopTitleBar({
                       // the same trigger (`DashboardShell.tsx`). The two
                       // triggers are mutually exclusive by layout: the
                       // DesktopTitleBar mounts when `useDesktopLayout` is
-                      // true, and the DashboardShell trigger is suppressed
-                      // by `hideMenu` in that case (see
-                      // `SharedDockviewLayout.ProjectsPanelComponent`).
-                      // Sharing the testid lets test page-objects target
-                      // "the toolbar menu trigger" without branching on
-                      // layout mode.
+                      // true, and the sidebar's DashboardShell trigger is
+                      // suppressed by the `hideMenu` prop `AppShell` passes
+                      // in that case (`__root.tsx`). Sharing the testid lets
+                      // test page-objects target "the toolbar menu trigger"
+                      // without branching on layout mode.
                       data-testid="dashboard__menu-trigger"
                     >
                       <Menu className="size-5" />

--- a/apps/web/src/components/DesktopTitleBar.tsx
+++ b/apps/web/src/components/DesktopTitleBar.tsx
@@ -125,7 +125,7 @@ export function DesktopTitleBar({
                   type="button"
                   onClick={onToggleSidebar}
                   aria-label="Toggle sidebar"
-                  aria-pressed={sidebarVisible}
+                  aria-pressed={sidebarVisible ?? false}
                   data-testid="desktop-title-bar__sidebar-toggle"
                   className={`flex items-center justify-center rounded p-1 transition-colors hover:bg-accent/50 hover:text-foreground ${sidebarVisible ? "text-foreground" : "text-muted-foreground"}`}
                 >

--- a/apps/web/src/components/SharedDockviewLayout.tsx
+++ b/apps/web/src/components/SharedDockviewLayout.tsx
@@ -11,7 +11,6 @@ import {
 } from "dockview";
 import {
   FolderOpen,
-  Folders,
   GitCompare,
   Globe,
   Maximize2,
@@ -24,7 +23,6 @@ import {
   type AddToTerminalDetail,
   buildCommands,
   CommandPaletteDialog,
-  DashboardShell,
   DiffView,
   parseFileLocation,
   QuickOpenDialog,
@@ -74,7 +72,6 @@ const bandTheme: DockviewTheme = {
 // ---------------------------------------------------------------------------
 
 const PANEL_ICONS: Record<string, React.FC<{ className?: string }>> = {
-  projects: Folders,
   chat: MessageSquare,
   changes: GitCompare,
   files: FolderOpen,
@@ -184,17 +181,6 @@ function NoWorkspaceMessage({ Icon }: { Icon: React.FC<{ className?: string }> }
       </div>
     </div>
   );
-}
-
-function ProjectsPanelComponent() {
-  // DashboardShell is workspace-agnostic — it shows the global project list.
-  // With the shared layout, only ONE DashboardShell is mounted (one project
-  // list), so its useStatusWatcher / useBranchStatusWatcher /
-  // useSetupStatusWatcher subscriptions run exactly once.
-  // hideMenu suppresses the in-shell hamburger overflow menu — the global
-  // DesktopTitleBar in __root.tsx already exposes the same Tasks / Cronjobs
-  // / Settings entries via its own dropdown.
-  return <DashboardShell hideTitleBar={isDesktop} hideMenu />;
 }
 
 function ChatPanelComponent({ api }: IDockviewPanelProps) {
@@ -443,7 +429,6 @@ function BadgeTab(props: IDockviewPanelHeaderProps) {
 
 // biome-ignore lint/suspicious/noExplicitAny: dockview requires generic panel props
 const components: Record<string, React.FunctionComponent<IDockviewPanelProps<any>>> = {
-  projects: ProjectsPanelComponent,
   chat: ChatPanelComponent,
   changes: ChangesPanelComponent,
   files: FilesPanelComponent,
@@ -543,7 +528,7 @@ function useDiffFileCount(workspaceId: string | null): number {
 // Required panel definitions & layout persistence
 // ---------------------------------------------------------------------------
 
-const REQUIRED_PANEL_IDS = ["projects", "chat", "changes", "files", "terminal", "browser"] as const;
+const REQUIRED_PANEL_IDS = ["chat", "changes", "files", "terminal", "browser"] as const;
 
 /**
  * Panel ids that USED to be required and may live in saved layouts. We strip
@@ -551,7 +536,10 @@ const REQUIRED_PANEL_IDS = ["projects", "chat", "changes", "files", "terminal", 
  */
 const REMOVED_PANEL_IDS = ["screencast"] as const;
 
-const GLOBAL_LAYOUT_KEY = "band:dockview-layout-v6";
+// Bumped v6 → v7 when the project list moved out of the dockview into a
+// standalone sidebar: old saved layouts still contain the `projects` edge
+// panel, so we discard them and rebuild without it.
+const GLOBAL_LAYOUT_KEY = "band:dockview-layout-v7";
 const ACTIVE_STATE_KEY_PREFIX = "band:dockview-active:";
 
 const EDGE_GROUP_IDS = {
@@ -1032,15 +1020,14 @@ export function SharedDockviewLayout() {
         return;
       }
 
-      // Ctrl+0 → focus Projects in the left edge group.
+      // Ctrl+0 → reveal the project-list sidebar and focus it. The sidebar
+      // lives outside the dockview now (see __root.tsx AppShell), so we reveal
+      // it via the `band:show-sidebar` window event and let DashboardShell's
+      // `band:focus-projects` listener move keyboard focus into the list.
       if (e.ctrlKey && !e.metaKey && e.key === "0") {
         e.preventDefault();
         e.stopPropagation();
-        const dvApi = apiRef.current;
-        if (!dvApi) return;
-        const left = dvApi.groups.find((g) => g.id === EDGE_GROUP_IDS.left);
-        if (left?.api.isCollapsed()) left.api.expand();
-        dvApi.getPanel("projects")?.api.setActive();
+        window.dispatchEvent(new CustomEvent("band:show-sidebar"));
         queueMicrotask(() => {
           window.dispatchEvent(new CustomEvent("band:focus-projects"));
         });
@@ -1144,21 +1131,20 @@ export function SharedDockviewLayout() {
           });
         }
       } else if (key === "b" && !e.shiftKey && !e.altKey && api) {
-        // ⌘B → toggle LEFT edge. Focus-aware: if an inner dockview
-        // (terminal / chat / browser) is focused AND has panels on
-        // its left edge, toggle that inner edge; otherwise fall back
-        // to the main layout's left edge (Projects).
+        // ⌘B → toggle the project-list sidebar. Focus-aware: if an inner
+        // dockview (terminal / chat / browser) is focused AND has panels on
+        // its left edge, toggle that inner edge; otherwise toggle the
+        // sidebar that lives outside the dockview (see __root.tsx AppShell).
         //
-        // The fallback is driven by `toggleEdgeGroup`'s return value
-        // (`true` when it acted on a non-empty edge, `false` when
-        // there was nothing to act on) — so empty inner edges
-        // transparently delegate to the main layout. See
-        // `dockview-edge-groups.ts` for the registry that makes the
-        // focus lookup possible.
+        // The inner branch is driven by `toggleEdgeGroup`'s return value
+        // (`true` when it acted on a non-empty edge, `false` when there was
+        // nothing to act on) — so empty inner edges transparently delegate
+        // to the sidebar. See `dockview-edge-groups.ts` for the registry
+        // that makes the focus lookup possible.
         e.preventDefault();
         const inner = findFocusedInnerDockview();
         if (inner && toggleEdgeGroup(inner, "left")) return;
-        toggleEdgeGroup(api, "left");
+        window.dispatchEvent(new CustomEvent("band:toggle-sidebar"));
       } else if (e.code === "KeyB" && e.altKey && !e.shiftKey && api) {
         // ⌥⌘B → toggle RIGHT edge. Uses `e.code === "KeyB"` instead
         // of `key === "b"` because macOS substitutes Alt-layer
@@ -1291,7 +1277,6 @@ export function SharedDockviewLayout() {
       api.getPanel("chat");
 
     const titleMap: Record<string, string> = {
-      projects: "Projects",
       chat: "Chat",
       changes: "Changes",
       files: "Files",
@@ -1309,18 +1294,6 @@ export function SharedDockviewLayout() {
 
     if (panelId === "changes") {
       opts.tabComponent = "badge";
-    }
-
-    if (panelId === "projects") {
-      try {
-        if (!api.groups.some((g) => g.id === "edge-left")) {
-          api.addEdgeGroup("left", { id: "edge-left" });
-        }
-      } catch {}
-      opts.position = { referenceGroup: "edge-left", direction: "within" };
-      // biome-ignore lint/suspicious/noExplicitAny: dynamic panel options
-      api.addPanel(opts as any);
-      return;
     }
 
     if (panelId === "chat" && anyExisting) {
@@ -1426,19 +1399,6 @@ export function SharedDockviewLayout() {
     try {
       api.getPanel("chat")?.api.setSize({ width: api.width * 0.5 });
     } catch {}
-
-    try {
-      if (!api.groups.some((g) => g.id === "edge-left")) {
-        api.addEdgeGroup("left", { id: "edge-left", initialSize: 240 });
-      }
-    } catch {}
-    api.addPanel({
-      id: "projects",
-      component: "projects",
-      title: "Projects",
-      params: {},
-      position: { referenceGroup: "edge-left", direction: "within" },
-    });
   }, []);
 
   // onReady: restore or create the layout, heal missing panels, wire up
@@ -1643,13 +1603,11 @@ export function SharedDockviewLayout() {
   // AND that belong to a tab group with siblings. Every `setActive()` call
   // triggers a dockview focus dance: dockview tears down the previously
   // active panel content, mounts the new one, and calls .focus() on the
-  // new panel's content area WITHOUT `preventScroll`. Calling it on the
-  // projects edge group (which only has one tab — Projects) re-focuses the
-  // DashboardShell container and scrolls the project-list ScrollArea back
-  // to scrollTop=0; calling it on the already-active panel in the center
-  // group has the same effect for its content. Skipping both no-ops keeps
-  // the project list scroll + the user's keyboard focus intact when they
-  // navigate back to a previously-visited workspace.
+  // new panel's content area WITHOUT `preventScroll`. Calling it on an
+  // already-active panel in the center group re-focuses its content and can
+  // jump its scroll position. Skipping these no-ops keeps the user's
+  // keyboard focus + scroll intact when they navigate back to a
+  // previously-visited workspace.
   useEffect(() => {
     if (!initializedRef.current) return;
     const api = apiRef.current;
@@ -1677,12 +1635,10 @@ export function SharedDockviewLayout() {
     // accurate.
     if (activeState) {
       // Intentionally do NOT activate `activeState.activeGroup` here.
-      // The previous code activated the first panel of the saved
-      // active group to focus that group, which on the edge-left
-      // (projects) group meant re-focusing the DashboardShell
-      // container and resetting the project list scroll. The helper
-      // skips no-op activations + single-panel groups for the same
-      // reason.
+      // The previous code activated the first panel of the saved active
+      // group to focus that group, which re-focused that group's content
+      // and could reset its scroll. The helper skips no-op activations +
+      // single-panel groups for the same reason.
       applyGroupActiveViewsToApi(api, activeState);
     }
     // Apply (or clear) the maximize last. Even when the workspace has

--- a/apps/web/src/components/SharedDockviewLayout.tsx
+++ b/apps/web/src/components/SharedDockviewLayout.tsx
@@ -759,10 +759,10 @@ function loadLayout(workspaceId: string | null): unknown | null {
  * dockview instance for the whole app; per-workspace content is cached
  * inside each panel via `MultiWorkspacePanelHost`.
  *
- * Layout structure (panel positions, tab order, hidden panels, the project
- * list) is shared across all workspaces and persisted to
- * `band:dockview-layout-v6`. Per-workspace ACTIVE TAB state is persisted
- * separately under `band:dockview-active:${workspaceId}`.
+ * Layout structure (panel positions, tab order, hidden panels) is shared
+ * across all workspaces and persisted to `band:dockview-layout-v7`.
+ * Per-workspace ACTIVE TAB state is persisted separately under
+ * `band:dockview-active:${workspaceId}`.
  */
 export function SharedDockviewLayout() {
   const pathname = useRouterState({ select: (s) => s.location.pathname });

--- a/apps/web/src/components/SharedDockviewLayout.tsx
+++ b/apps/web/src/components/SharedDockviewLayout.tsx
@@ -1021,8 +1021,8 @@ export function SharedDockviewLayout() {
       }
 
       // Ctrl+0 → reveal the project-list sidebar and focus it. The sidebar
-      // lives outside the dockview now (see __root.tsx AppShell), so we reveal
-      // it via the `band:show-sidebar` window event and let DashboardShell's
+      // lives outside the dockview now, so we reveal it via the
+      // `band:show-sidebar` window event and let the sidebar's
       // `band:focus-projects` listener move keyboard focus into the list.
       if (e.ctrlKey && !e.metaKey && e.key === "0") {
         e.preventDefault();
@@ -1134,7 +1134,8 @@ export function SharedDockviewLayout() {
         // ⌘B → toggle the project-list sidebar. Focus-aware: if an inner
         // dockview (terminal / chat / browser) is focused AND has panels on
         // its left edge, toggle that inner edge; otherwise toggle the
-        // sidebar that lives outside the dockview (see __root.tsx AppShell).
+        // sidebar that lives outside the dockview, reached via the
+        // `band:toggle-sidebar` window event.
         //
         // The inner branch is driven by `toggleEdgeGroup`'s return value
         // (`true` when it acted on a non-empty edge, `false` when there was

--- a/apps/web/src/dashboard/lib/command-registry.ts
+++ b/apps/web/src/dashboard/lib/command-registry.ts
@@ -203,17 +203,15 @@ export function buildCommands(deps: CommandRegistryDeps): PaletteCommand[] {
       action: () => activatePanel(deps, "browser"),
     },
     {
-      // ⌃0 — focuses keyboard into the Projects list. The direct
-      // keyboard handler in DockviewWorkspaceLayout also expands the
-      // left edge group if it's collapsed; this palette path just
-      // activates the panel and dispatches the focus event. If the
-      // sidebar happens to be collapsed when invoked from the palette,
-      // press ⌘B first.
+      // ⌃0 — reveal the project-list sidebar (which lives outside the
+      // dockview) and move keyboard focus into the list. `band:show-sidebar`
+      // expands the sidebar if it's collapsed; DashboardShell's
+      // `band:focus-projects` listener then focuses the list.
       id: "focus-projects",
       label: "Focus Projects",
       shortcut: "Ctrl+0",
       action: () => {
-        activatePanel(deps, "projects");
+        window.dispatchEvent(new CustomEvent("band:show-sidebar"));
         queueMicrotask(() => {
           window.dispatchEvent(new CustomEvent("band:focus-projects"));
         });

--- a/apps/web/src/lib/sidebar-width.ts
+++ b/apps/web/src/lib/sidebar-width.ts
@@ -23,6 +23,26 @@ export function saveSidebarWidth(width: number): void {
   } catch {}
 }
 
+const SIDEBAR_COLLAPSED_KEY = "band:sidebar-collapsed";
+
+/**
+ * Whether the project-list sidebar was last left collapsed (hidden).
+ * Defaults to `false` (visible) when nothing is stored.
+ */
+export function loadSidebarCollapsed(): boolean {
+  try {
+    return localStorage.getItem(SIDEBAR_COLLAPSED_KEY) === "1";
+  } catch {
+    return false;
+  }
+}
+
+export function saveSidebarCollapsed(collapsed: boolean): void {
+  try {
+    localStorage.setItem(SIDEBAR_COLLAPSED_KEY, collapsed ? "1" : "0");
+  } catch {}
+}
+
 /** Minimum sidebar size (240px / 15rem) */
 export const SIDEBAR_MIN_SIZE = "15rem";
 

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -437,11 +437,17 @@ function AppShell() {
   // panel starts collapsed.
   const [sidebarVisible, setSidebarVisible] = useState(() => !sidebarInit.current.collapsed);
 
-  const sidebarDefaultLayout = sidebarInit.current.collapsed
-    ? { sidebar: 0, main: 100 }
-    : sidebarInit.current.width
-      ? { sidebar: sidebarInit.current.width, main: 100 - sidebarInit.current.width }
-      : undefined;
+  // Memoized at mount — values come from an immutable ref, and `<Group>`
+  // only reads `defaultLayout` on its first render.
+  const sidebarDefaultLayout = useMemo(
+    () =>
+      sidebarInit.current.collapsed
+        ? { sidebar: 0, main: 100 }
+        : sidebarInit.current.width
+          ? { sidebar: sidebarInit.current.width, main: 100 - sidebarInit.current.width }
+          : undefined,
+    [],
+  );
 
   // Skip the first layout callback: it fires during mount with the restored
   // layout, which we don't want to re-persist.
@@ -470,11 +476,13 @@ function AppShell() {
     (size: PanelSize, _id: string | number | undefined, prev: PanelSize | undefined) => {
       if (prev === undefined) return;
       const visible = size.asPercentage > 0;
+      // Bail unless the open/closed state actually flips — `onResize` fires
+      // on every drag pixel, so this avoids both a redundant re-render and a
+      // redundant localStorage write per pixel.
+      if (visible === lastSidebarVisibleRef.current) return;
+      lastSidebarVisibleRef.current = visible;
       setSidebarVisible(visible);
-      if (visible !== lastSidebarVisibleRef.current) {
-        lastSidebarVisibleRef.current = visible;
-        saveSidebarCollapsed(!visible);
-      }
+      saveSidebarCollapsed(!visible);
     },
     [],
   );

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -452,6 +452,10 @@ function AppShell() {
   // Skip the first layout callback: it fires during mount with the restored
   // layout, which we don't want to re-persist.
   const skipFirstSidebarLayout = useRef(true);
+  // `onLayoutChanged` fires for every distinct layout during a drag (~60/s),
+  // so coalesce the persist to at most one localStorage write per frame.
+  const pendingSidebarWidthRef = useRef<number | null>(null);
+  const sidebarWidthRafRef = useRef<number | null>(null);
   const handleSidebarLayoutChanged = useCallback((layout: Record<string, number>) => {
     if (skipFirstSidebarLayout.current) {
       skipFirstSidebarLayout.current = false;
@@ -460,9 +464,15 @@ function AppShell() {
     // Only persist a real (visible) width — a 0 here means the panel is
     // collapsed, and storing that would lose the user's chosen width on the
     // next expand.
-    if (layout.sidebar != null && layout.sidebar > 0) {
-      saveSidebarWidth(layout.sidebar);
-    }
+    if (layout.sidebar == null || layout.sidebar <= 0) return;
+    pendingSidebarWidthRef.current = layout.sidebar;
+    if (sidebarWidthRafRef.current != null) return;
+    sidebarWidthRafRef.current = requestAnimationFrame(() => {
+      sidebarWidthRafRef.current = null;
+      if (pendingSidebarWidthRef.current != null) {
+        saveSidebarWidth(pendingSidebarWidthRef.current);
+      }
+    });
   }, []);
 
   // Single source of truth for the toggle button's pressed state + the

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -16,9 +16,11 @@ import {
   Settings as SettingsIcon,
   Terminal as TerminalIcon,
 } from "lucide-react";
-import { useCallback, useEffect, useMemo, useRef } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { Group, Panel, type PanelSize, Separator, usePanelRef } from "react-resizable-panels";
 import {
   DashboardProvider,
+  DashboardShell,
   useDashboardStore,
   useSettingsQuery,
   useUpdateSettings,
@@ -36,6 +38,14 @@ import { getElectronBridge } from "../lib/desktop-ipc";
 import { dispatchOpenFileEvent } from "../lib/dispatch-open-file";
 import { isDesktop } from "../lib/is-desktop";
 import { parseWorkspaceFromPath } from "../lib/parse-workspace";
+import {
+  loadSidebarCollapsed,
+  loadSidebarWidth,
+  SIDEBAR_MAX_SIZE,
+  SIDEBAR_MIN_SIZE,
+  saveSidebarCollapsed,
+  saveSidebarWidth,
+} from "../lib/sidebar-width";
 import {
   applyZoomLevel,
   applyZoomLevelToDom,
@@ -403,6 +413,84 @@ function AppShell() {
     [settings, updateSettings],
   );
 
+  // ──────────────────────────────────────────────────────────────────────
+  // Project-list sidebar (separate from the dockview). Collapsing/expanding
+  // the sidebar Panel via its imperative handle hides/shows the list WITHOUT
+  // unmounting the sibling Panel that holds <SharedDockviewLayout /> — so the
+  // dockview (and every cached workspace's chat/terminal/browser + live PTYs)
+  // survives a toggle. Width is persisted as a percentage; the last-left
+  // visibility is persisted separately.
+  // ──────────────────────────────────────────────────────────────────────
+  const sidebarPanelRef = usePanelRef();
+
+  // Seed the initial visibility from the persisted collapsed flag directly
+  // into the Group's `defaultLayout`, rather than collapsing imperatively
+  // after mount — the Group applies `defaultLayout` during its own
+  // post-mount measurement, which would race (and override) an effect-driven
+  // `collapse()`. A sidebar size of 0 is below `minSize`, so a collapsible
+  // panel starts collapsed.
+  const sidebarInitiallyCollapsed = loadSidebarCollapsed();
+  const [sidebarVisible, setSidebarVisible] = useState(() => !sidebarInitiallyCollapsed);
+
+  const savedSidebarWidth = loadSidebarWidth();
+  const sidebarDefaultLayout = sidebarInitiallyCollapsed
+    ? { sidebar: 0, main: 100 }
+    : savedSidebarWidth
+      ? { sidebar: savedSidebarWidth, main: 100 - savedSidebarWidth }
+      : undefined;
+
+  // Skip the first layout callback: it fires during mount with the restored
+  // layout, which we don't want to re-persist.
+  const skipFirstSidebarLayout = useRef(true);
+  const handleSidebarLayoutChanged = useCallback((layout: Record<string, number>) => {
+    if (skipFirstSidebarLayout.current) {
+      skipFirstSidebarLayout.current = false;
+      return;
+    }
+    // Only persist a real (visible) width — a 0 here means the panel is
+    // collapsed, and storing that would lose the user's chosen width on the
+    // next expand.
+    if (layout.sidebar != null && layout.sidebar > 0) {
+      saveSidebarWidth(layout.sidebar);
+    }
+  }, []);
+
+  // Single source of truth for the toggle button's pressed state + the
+  // persisted visibility. Fires for the toggle button, ⌘B, and drag-to-
+  // collapse alike. `prevPanelSize === undefined` is the mount fire — skip
+  // it so it can't clobber a stored "collapsed" before the effect below
+  // collapses the panel.
+  const handleSidebarResize = useCallback(
+    (size: PanelSize, _id: string | number | undefined, prev: PanelSize | undefined) => {
+      if (prev === undefined) return;
+      const visible = size.asPercentage > 0;
+      setSidebarVisible(visible);
+      saveSidebarCollapsed(!visible);
+    },
+    [],
+  );
+
+  const toggleSidebar = useCallback(() => {
+    const panel = sidebarPanelRef.current;
+    if (!panel) return;
+    if (panel.isCollapsed()) panel.expand();
+    else panel.collapse();
+  }, [sidebarPanelRef]);
+
+  // ⌃0 / "Focus Projects" reveal the sidebar before focusing the list.
+  useEffect(() => {
+    const onToggle = () => toggleSidebar();
+    const onShow = () => {
+      if (sidebarPanelRef.current?.isCollapsed()) sidebarPanelRef.current.expand();
+    };
+    window.addEventListener("band:toggle-sidebar", onToggle);
+    window.addEventListener("band:show-sidebar", onShow);
+    return () => {
+      window.removeEventListener("band:toggle-sidebar", onToggle);
+      window.removeEventListener("band:show-sidebar", onShow);
+    };
+  }, [toggleSidebar, sidebarPanelRef]);
+
   if (!useDesktopLayout) {
     return <Outlet />;
   }
@@ -444,13 +532,44 @@ function AppShell() {
           onGoForward={navigationHistory.goForward}
           canGoBack={navigationHistory.canGoBack}
           canGoForward={navigationHistory.canGoForward}
+          onToggleSidebar={toggleSidebar}
+          sidebarVisible={sidebarVisible}
         />
         <div className="flex-1 min-h-0 overflow-hidden">
-          <div className="h-full min-w-0 overflow-hidden relative">
-            <Outlet />
-            <SharedDockviewLayout />
-            <BrowserHostBridge />
-          </div>
+          <Group
+            orientation="horizontal"
+            defaultLayout={sidebarDefaultLayout}
+            onLayoutChanged={handleSidebarLayoutChanged}
+            className="h-full w-full"
+          >
+            <Panel
+              id="sidebar"
+              panelRef={sidebarPanelRef}
+              defaultSize={SIDEBAR_MIN_SIZE}
+              minSize={SIDEBAR_MIN_SIZE}
+              maxSize={SIDEBAR_MAX_SIZE}
+              collapsible
+              collapsedSize="0%"
+              onResize={handleSidebarResize}
+            >
+              <div
+                className="h-full overflow-hidden border-r border-border"
+                data-testid="app-shell__sidebar"
+              >
+                <DashboardShell hideMenu hideTitleBar />
+              </div>
+            </Panel>
+            <Separator className="w-[3px] bg-transparent hover:bg-accent-foreground/20 active:bg-accent-foreground/30 transition-colors cursor-col-resize" />
+            <Panel id="main" minSize="20%">
+              {/* Stays mounted across sidebar toggles — never unmount this
+                  subtree or the dockview tears down all cached workspaces. */}
+              <div className="h-full min-w-0 overflow-hidden relative">
+                <Outlet />
+                <SharedDockviewLayout />
+                <BrowserHostBridge />
+              </div>
+            </Panel>
+          </Group>
         </div>
       </div>
     </ToolbarOverflowProvider>

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -423,20 +423,24 @@ function AppShell() {
   // ──────────────────────────────────────────────────────────────────────
   const sidebarPanelRef = usePanelRef();
 
+  // Read the persisted sidebar state ONCE at mount (these `<Group>`/`useState`
+  // seeds are only consumed on the first render). Stashing them in a ref keeps
+  // the localStorage reads off the re-render path, matching the `sidebarVisible`
+  // lazy initializer below.
+  const sidebarInit = useRef({ collapsed: loadSidebarCollapsed(), width: loadSidebarWidth() });
+
   // Seed the initial visibility from the persisted collapsed flag directly
   // into the Group's `defaultLayout`, rather than collapsing imperatively
   // after mount — the Group applies `defaultLayout` during its own
   // post-mount measurement, which would race (and override) an effect-driven
   // `collapse()`. A sidebar size of 0 is below `minSize`, so a collapsible
   // panel starts collapsed.
-  const sidebarInitiallyCollapsed = loadSidebarCollapsed();
-  const [sidebarVisible, setSidebarVisible] = useState(() => !sidebarInitiallyCollapsed);
+  const [sidebarVisible, setSidebarVisible] = useState(() => !sidebarInit.current.collapsed);
 
-  const savedSidebarWidth = loadSidebarWidth();
-  const sidebarDefaultLayout = sidebarInitiallyCollapsed
+  const sidebarDefaultLayout = sidebarInit.current.collapsed
     ? { sidebar: 0, main: 100 }
-    : savedSidebarWidth
-      ? { sidebar: savedSidebarWidth, main: 100 - savedSidebarWidth }
+    : sidebarInit.current.width
+      ? { sidebar: sidebarInit.current.width, main: 100 - sidebarInit.current.width }
       : undefined;
 
   // Skip the first layout callback: it fires during mount with the restored
@@ -458,14 +462,19 @@ function AppShell() {
   // Single source of truth for the toggle button's pressed state + the
   // persisted visibility. Fires for the toggle button, ⌘B, and drag-to-
   // collapse alike. `prevPanelSize === undefined` is the mount fire — skip
-  // it so it can't clobber a stored "collapsed" before the effect below
-  // collapses the panel.
+  // it so it can't clobber a stored "collapsed". `onResize` fires on every
+  // pixel of a drag, so only write localStorage when the collapsed/expanded
+  // state actually flips (not on every intermediate width).
+  const lastSidebarVisibleRef = useRef(!sidebarInit.current.collapsed);
   const handleSidebarResize = useCallback(
     (size: PanelSize, _id: string | number | undefined, prev: PanelSize | undefined) => {
       if (prev === undefined) return;
       const visible = size.asPercentage > 0;
       setSidebarVisible(visible);
-      saveSidebarCollapsed(!visible);
+      if (visible !== lastSidebarVisibleRef.current) {
+        lastSidebarVisibleRef.current = visible;
+        saveSidebarCollapsed(!visible);
+      }
     },
     [],
   );
@@ -477,7 +486,8 @@ function AppShell() {
     else panel.collapse();
   }, [sidebarPanelRef]);
 
-  // ⌃0 / "Focus Projects" reveal the sidebar before focusing the list.
+  // ⌘B toggles the sidebar; ⌃0 / "Focus Projects" reveal it before focusing
+  // the list.
   useEffect(() => {
     const onToggle = () => toggleSidebar();
     const onShow = () => {

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -519,6 +519,16 @@ function AppShell() {
     };
   }, [toggleSidebar, sidebarPanelRef]);
 
+  // Cancel a pending sidebar-width RAF on unmount so it can't fire (and write
+  // localStorage) after the component is gone — matches the cleanup discipline
+  // of the other effects in this file.
+  useEffect(
+    () => () => {
+      if (sidebarWidthRafRef.current != null) cancelAnimationFrame(sidebarWidthRafRef.current);
+    },
+    [],
+  );
+
   if (!useDesktopLayout) {
     return <Outlet />;
   }


### PR DESCRIPTION
## What

Moves the project list out of the shared dockview (where it lived as the `edge-left` "projects" panel) into a **first-class left sidebar, separate from the dockview**, with a **header button to toggle its visibility** (also bound to ⌘B; ⌃0 reveals + focuses it).

## Why

Coupling the project list to dockview's layout/serialization machinery brought along its quirks (e.g. the `setActive()`-on-projects scroll/focus bug). A standalone sidebar is simpler and decoupled.

## How

- **`__root.tsx` (`AppShell`)** — wraps the sidebar + dockview in a horizontal `react-resizable-panels` `Group`. The sidebar `Panel` is `collapsible`; the dockview lives in the sibling `Panel` and **never remounts on toggle**, so cached workspaces / live PTYs survive. Width persists (`band:sidebar-width`); collapsed state persists (`band:sidebar-collapsed`) and is seeded into the Group's `defaultLayout` to avoid a mount race.
- **`DesktopTitleBar.tsx`** — `PanelLeft` toggle button (`aria-pressed` reflects visibility, tooltip shows ⌘B).
- **`SharedDockviewLayout.tsx`** — removed the `projects` panel (component, icon, `REQUIRED_PANEL_IDS`, default layout, `addMissingPanel`); bumped the layout key `v6→v7` to discard stale saved layouts. ⌘B toggles the sidebar (still defers to inner-dockview left edges first); ⌃0 reveals + focuses it via window events.
- **`command-registry.ts`** — "Focus Projects" reveals the sidebar instead of activating the removed panel.
- **`sidebar-width.ts`** — added `load/saveSidebarCollapsed`.

## Testing

- New `apps/web/e2e/sidebar-toggle.spec.ts` (default-visible, button toggle, ⌘B toggle, reload persistence) — real server, no tRPC mock.
- Re-ran 21 existing dockview/project-list specs (scroll, maximize-state, panel-position, label-restore, context-menu-zoom, panel-visibility, switch-changes) — all green.
- `tsc --noEmit` + biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)