### PR TITLE
feat(web): split title bar into project-list and workspace halves

### DIFF
--- a/apps/web/e2e/pages/WorkspacePage.ts
+++ b/apps/web/e2e/pages/WorkspacePage.ts
@@ -403,10 +403,67 @@ export class WorkspacePage {
     return this.page.getByTestId("app-shell__sidebar");
   }
 
-  /** The header button that toggles the sidebar (⌘B). `data-testid` set in
-   *  `DesktopTitleBar.tsx`; its `aria-pressed` reflects current visibility. */
+  /** The header button that toggles the sidebar (⌘B). Rendered by
+   *  `NavControls` in `DesktopTitleBar.tsx`, hosted by `SidebarTitleBar` while
+   *  the sidebar is visible and by `WorkspaceTitleBar` while it's collapsed
+   *  (the cluster relocates so the controls stay reachable). Its `aria-pressed`
+   *  reflects current visibility. */
   get sidebarToggle(): Locator {
     return this.page.getByTestId("desktop-title-bar__sidebar-toggle");
+  }
+
+  /** The hamburger menu trigger (Tasks / Cronjobs / Settings …). Rendered by
+   *  `NavControls`, so it relocates between the two title-bar halves with the
+   *  rest of the cluster. Targeted by its system-controlled ARIA name. */
+  get menuTrigger(): Locator {
+    return this.page.getByRole("button", { name: "Menu" });
+  }
+
+  /** The workspace-history back arrow (⌘[). Part of the relocating
+   *  `NavControls` cluster. */
+  get backButton(): Locator {
+    return this.page.getByRole("button", { name: "Back" });
+  }
+
+  /** The workspace-history forward arrow (⌘]). Part of the relocating
+   *  `NavControls` cluster. */
+  get forwardButton(): Locator {
+    return this.page.getByRole("button", { name: "Forward" });
+  }
+
+  /** The sidebar-toggle button scoped to the project-list column — proves the
+   *  nav cluster is hosted in `SidebarTitleBar` (not the workspace bar) while
+   *  the sidebar is visible. */
+  get sidebarToggleWithinSidebar(): Locator {
+    return this.sidebar.getByTestId("desktop-title-bar__sidebar-toggle");
+  }
+
+  /** The hamburger menu trigger scoped to the project-list column. Count drops
+   *  to 0 once the sidebar collapses and the cluster relocates to the workspace
+   *  bar — the signal that the relocation actually happened. */
+  get menuTriggerWithinSidebar(): Locator {
+    return this.sidebar.getByRole("button", { name: "Menu" });
+  }
+
+  /** The open hamburger dropdown (Radix sets `role="menu"`). Used to prove the
+   *  relocated menu trigger is still wired/clickable, without asserting on
+   *  localisable item copy. */
+  get menuDropdown(): Locator {
+    return this.page.getByRole("menu");
+  }
+
+  /** Open the hamburger menu from wherever the cluster currently lives. */
+  async openTitleBarMenu(): Promise<void> {
+    await test.step("Open the title-bar hamburger menu", async () => {
+      await this.menuTrigger.click();
+    });
+  }
+
+  /** Dismiss any open menu/dropdown. */
+  async dismissMenu(): Promise<void> {
+    await test.step("Dismiss the open menu", async () => {
+      await this.page.keyboard.press("Escape");
+    });
   }
 
   /** Current rendered width of the sidebar in CSS px — ~0 when collapsed.

--- a/apps/web/e2e/pages/WorkspacePage.ts
+++ b/apps/web/e2e/pages/WorkspacePage.ts
@@ -420,15 +420,17 @@ export class WorkspacePage {
   }
 
   /** The workspace-history back arrow (⌘[). Part of the relocating
-   *  `NavControls` cluster. */
+   *  `NavControls` cluster. Targeted by testid: the "Back"/"Forward" ARIA
+   *  names aren't unique app-wide (ScreencastPanel's address bar reuses them). */
   get backButton(): Locator {
-    return this.page.getByRole("button", { name: "Back" });
+    return this.page.getByTestId("desktop-title-bar__back");
   }
 
   /** The workspace-history forward arrow (⌘]). Part of the relocating
-   *  `NavControls` cluster. */
+   *  `NavControls` cluster. Targeted by testid for the same uniqueness reason
+   *  as `backButton`. */
   get forwardButton(): Locator {
-    return this.page.getByRole("button", { name: "Forward" });
+    return this.page.getByTestId("desktop-title-bar__forward");
   }
 
   /** The sidebar-toggle button scoped to the project-list column — proves the
@@ -1151,7 +1153,7 @@ export class WorkspacePage {
 
   /** Press Escape — the user's universal "dismiss" gesture. Encapsulated so
    *  test bodies (and the helpers below) don't reach for `page.keyboard.*`
-   *  directly (TEST-21). */
+   *  directly; keyboard interactions belong on the page object. */
   async pressEscape(): Promise<void> {
     await test.step("Press Escape", async () => {
       await this.page.keyboard.press("Escape");

--- a/apps/web/e2e/pages/WorkspacePage.ts
+++ b/apps/web/e2e/pages/WorkspacePage.ts
@@ -705,11 +705,11 @@ export class WorkspacePage {
   }
 
   /** The desktop title-bar workspace-name button. On a wide viewport
-   *  `useDesktopLayout` is true, so __root.tsx mounts the DesktopTitleBar
-   *  with `onWorkspaceNameClick` wired — the name renders as a button that
-   *  opens the same picker as ⌘K. Targeted by its BEM testid rather than
-   *  the shared "Switch workspace" aria-label so it never collides with the
-   *  mobile header button of the same name. */
+   *  `useDesktopLayout` is true, so __root.tsx mounts the WorkspaceTitleBar
+   *  (in `DesktopTitleBar.tsx`) with `onWorkspaceNameClick` wired — the name
+   *  renders as a button that opens the same picker as ⌘K. Targeted by its
+   *  BEM testid rather than the shared "Switch workspace" aria-label so it
+   *  never collides with the mobile header button of the same name. */
   get desktopTitleWorkspaceNameButton(): Locator {
     return this.page.getByTestId("desktop-title-bar__workspace-name");
   }

--- a/apps/web/e2e/pages/WorkspacePage.ts
+++ b/apps/web/e2e/pages/WorkspacePage.ts
@@ -445,24 +445,12 @@ export class WorkspacePage {
     return this.sidebar.getByRole("button", { name: "Menu" });
   }
 
-  /** The open hamburger dropdown (Radix sets `role="menu"`). Used to prove the
-   *  relocated menu trigger is still wired/clickable, without asserting on
-   *  localisable item copy. */
-  get menuDropdown(): Locator {
-    return this.page.getByRole("menu");
-  }
-
-  /** Open the hamburger menu from wherever the cluster currently lives. */
+  /** Open the hamburger menu from wherever the cluster currently lives. The
+   *  open dropdown is exposed via the existing `contextMenu` getter (both are
+   *  Radix `role="menu"`). */
   async openTitleBarMenu(): Promise<void> {
     await test.step("Open the title-bar hamburger menu", async () => {
       await this.menuTrigger.click();
-    });
-  }
-
-  /** Dismiss any open menu/dropdown. */
-  async dismissMenu(): Promise<void> {
-    await test.step("Dismiss the open menu", async () => {
-      await this.page.keyboard.press("Escape");
     });
   }
 
@@ -1161,13 +1149,19 @@ export class WorkspacePage {
     return this.page.getByTestId("quick-open__root");
   }
 
-  /** Dismiss the QuickOpenDialog via the Escape key — same path a
-   *  real user would take. Encapsulated here so test bodies don't
-   *  reach for `page.keyboard.*` directly. */
-  async closeQuickOpenDialog(): Promise<void> {
-    await test.step("Press Escape to close Quick Open dialog", async () => {
+  /** Press Escape — the user's universal "dismiss" gesture. Encapsulated so
+   *  test bodies (and the helpers below) don't reach for `page.keyboard.*`
+   *  directly (TEST-21). */
+  async pressEscape(): Promise<void> {
+    await test.step("Press Escape", async () => {
       await this.page.keyboard.press("Escape");
     });
+  }
+
+  /** Dismiss the QuickOpenDialog via the Escape key — same path a
+   *  real user would take. */
+  async closeQuickOpenDialog(): Promise<void> {
+    await this.pressEscape();
   }
 
   /** Dispatch a synthetic `band:open-file` window event into the page

--- a/apps/web/e2e/sidebar-toggle.spec.ts
+++ b/apps/web/e2e/sidebar-toggle.spec.ts
@@ -146,8 +146,8 @@ test("the menu and back/forward relocate into the workspace bar when the sidebar
   await wp.toggleSidebarViaButton();
   await expect.poll(() => wp.sidebarWidth()).toBeLessThan(5);
 
-  // Assert the settled new state first (TEST-25): the controls are visible,
-  // now hosted by the workspace title bar...
+  // Assert the settled new state first — prove the controls rendered in their
+  // new home (the workspace title bar) before asserting the old node is gone...
   await expect(wp.menuTrigger).toBeVisible();
   await expect(wp.backButton).toBeVisible();
   await expect(wp.forwardButton).toBeVisible();

--- a/apps/web/e2e/sidebar-toggle.spec.ts
+++ b/apps/web/e2e/sidebar-toggle.spec.ts
@@ -146,17 +146,18 @@ test("the menu and back/forward relocate into the workspace bar when the sidebar
   await wp.toggleSidebarViaButton();
   await expect.poll(() => wp.sidebarWidth()).toBeLessThan(5);
 
-  // The cluster left the (now-collapsed) sidebar column...
-  await expect(wp.menuTriggerWithinSidebar).toHaveCount(0);
-  // ...and the controls are still visible (now in the workspace title bar).
+  // Assert the settled new state first (TEST-25): the controls are visible,
+  // now hosted by the workspace title bar...
   await expect(wp.menuTrigger).toBeVisible();
   await expect(wp.backButton).toBeVisible();
   await expect(wp.forwardButton).toBeVisible();
+  // ...and they've left the (now-collapsed) sidebar column.
+  await expect(wp.menuTriggerWithinSidebar).toHaveCount(0);
 
   // The relocated menu is still wired: clicking it opens the dropdown.
   await wp.openTitleBarMenu();
-  await expect(wp.menuDropdown).toBeVisible();
-  await wp.dismissMenu();
+  await expect(wp.contextMenu).toBeVisible();
+  await wp.pressEscape();
 });
 
 test("the collapsed state persists across a reload", async ({ page }) => {

--- a/apps/web/e2e/sidebar-toggle.spec.ts
+++ b/apps/web/e2e/sidebar-toggle.spec.ts
@@ -119,6 +119,46 @@ test("⌃0 (Focus Projects) reveals a collapsed sidebar", async ({ page }) => {
   await expect(wp.sidebarToggle).toHaveAttribute("aria-pressed", "true");
 });
 
+test("the nav cluster is hosted in the sidebar title bar while the sidebar is visible", async ({
+  page,
+}) => {
+  const wp = new WorkspacePage(page, server.url, TOKEN);
+  await wp.goto(WORKSPACE);
+  await wp.waitForReady();
+
+  // The split title bar puts the toggle + hamburger menu inside the
+  // project-list column (SidebarTitleBar) when the list is shown.
+  await expect.poll(() => wp.sidebarWidth()).toBeGreaterThan(200);
+  await expect(wp.sidebarToggleWithinSidebar).toBeVisible();
+  await expect(wp.menuTriggerWithinSidebar).toBeVisible();
+});
+
+test("the menu and back/forward relocate into the workspace bar when the sidebar collapses", async ({
+  page,
+}) => {
+  const wp = new WorkspacePage(page, server.url, TOKEN);
+  await wp.goto(WORKSPACE);
+  await wp.waitForReady();
+
+  // Precondition: while visible, the menu lives in the sidebar column.
+  await expect(wp.menuTriggerWithinSidebar).toBeVisible();
+
+  await wp.toggleSidebarViaButton();
+  await expect.poll(() => wp.sidebarWidth()).toBeLessThan(5);
+
+  // The cluster left the (now-collapsed) sidebar column...
+  await expect(wp.menuTriggerWithinSidebar).toHaveCount(0);
+  // ...and the controls are still visible (now in the workspace title bar).
+  await expect(wp.menuTrigger).toBeVisible();
+  await expect(wp.backButton).toBeVisible();
+  await expect(wp.forwardButton).toBeVisible();
+
+  // The relocated menu is still wired: clicking it opens the dropdown.
+  await wp.openTitleBarMenu();
+  await expect(wp.menuDropdown).toBeVisible();
+  await wp.dismissMenu();
+});
+
 test("the collapsed state persists across a reload", async ({ page }) => {
   const wp = new WorkspacePage(page, server.url, TOKEN);
   await wp.goto(WORKSPACE);

--- a/apps/web/src/components/DesktopTitleBar.tsx
+++ b/apps/web/src/components/DesktopTitleBar.tsx
@@ -163,6 +163,7 @@ function NavControls({
                 onClick={onGoBack}
                 disabled={!canGoBack}
                 aria-label="Back"
+                data-testid="desktop-title-bar__back"
                 className="flex items-center justify-center rounded p-1 text-muted-foreground hover:text-foreground hover:bg-accent/50 transition-colors disabled:opacity-30 disabled:hover:bg-transparent disabled:hover:text-muted-foreground"
               >
                 <ChevronLeft className="size-5" />
@@ -182,6 +183,7 @@ function NavControls({
                 onClick={onGoForward}
                 disabled={!canGoForward}
                 aria-label="Forward"
+                data-testid="desktop-title-bar__forward"
                 className="flex items-center justify-center rounded p-1 text-muted-foreground hover:text-foreground hover:bg-accent/50 transition-colors disabled:opacity-30 disabled:hover:bg-transparent disabled:hover:text-muted-foreground"
               >
                 <ChevronRight className="size-5" />

--- a/apps/web/src/components/DesktopTitleBar.tsx
+++ b/apps/web/src/components/DesktopTitleBar.tsx
@@ -30,7 +30,39 @@ export interface PanelItem {
   shortcut?: string;
 }
 
-interface DesktopTitleBarProps {
+/** Props for the navigation cluster (sidebar toggle + menu + back/forward).
+ *  This cluster lives in the SidebarTitleBar while the project list is
+ *  visible, and relocates into the WorkspaceTitleBar when the list is
+ *  collapsed — so both bars accept the same set of props. */
+interface NavControlsProps {
+  /** Items rendered inside the global hamburger dropdown. When undefined, the
+   *  hamburger button is not rendered. */
+  menuItems?: ReactNode;
+  /** Toggle the project-list sidebar's visibility (⌘B). When undefined, the
+   *  sidebar toggle button is not rendered. */
+  onToggleSidebar?: () => void;
+  /** Whether the sidebar is currently visible — drives the toggle button's
+   *  pressed state. */
+  sidebarVisible?: boolean;
+  /** Navigate to the previous workspace in the history stack (⌘[). */
+  onGoBack?: () => void;
+  /** Navigate to the next workspace in the history stack (⌘]). */
+  onGoForward?: () => void;
+  /** Whether back navigation is currently available (enables/disables the button). */
+  canGoBack?: boolean;
+  /** Whether forward navigation is currently available (enables/disables the button). */
+  canGoForward?: boolean;
+}
+
+interface SidebarTitleBarProps extends NavControlsProps {
+  /** When false, the bar renders empty (no nav cluster) — the cluster moves
+   *  to the WorkspaceTitleBar. The bar itself is clipped to 0px by the
+   *  collapsed sidebar Panel, but gating the cluster keeps it out of the DOM
+   *  so there's never a duplicate (e.g. two `…__sidebar-toggle` elements). */
+  sidebarVisible?: boolean;
+}
+
+interface WorkspaceTitleBarProps extends NavControlsProps {
   /** Static title. If omitted, fetches the app title from the desktop shell. */
   title?: string;
   /** Active workspace name to display prominently. */
@@ -50,28 +82,148 @@ interface DesktopTitleBarProps {
   hiddenPanels?: string[];
   /** Callback to toggle a panel's visibility on/off. */
   onTogglePanelVisibility?: (panelId: string) => void;
-  /** Navigate to the previous workspace in the history stack (⌘[). */
-  onGoBack?: () => void;
-  /** Navigate to the next workspace in the history stack (⌘]). */
-  onGoForward?: () => void;
-  /** Whether back navigation is currently available (enables/disables the button). */
-  canGoBack?: boolean;
-  /** Whether forward navigation is currently available (enables/disables the button). */
-  canGoForward?: boolean;
-  /** Items rendered inside the global hamburger dropdown (left of back/forward).
-   *  Pass DropdownMenu items (Tasks, Cronjobs, Settings, …). When undefined,
-   *  the hamburger button is not rendered. */
-  menuItems?: ReactNode;
-  /** Toggle the project-list sidebar's visibility (⌘B). When undefined, the
-   *  sidebar toggle button is not rendered. */
-  onToggleSidebar?: () => void;
-  /** Whether the sidebar is currently visible — drives the toggle button's
-   *  pressed state. */
-  sidebarVisible?: boolean;
 }
 
-/** Draggable desktop title bar that works with external-URL Electron webviews. */
-export function DesktopTitleBar({
+/** The traffic-light gutter: on macOS desktop (outside fullscreen) the window
+ *  controls occupy the top-left ~80px, so whichever title-bar half sits at the
+ *  window's left edge must clear that space before its first control. */
+function useTrafficLightOffsetClass(): string {
+  const isFullscreen = useIsFullscreen();
+  return isDesktop && !isFullscreen ? "pl-[80px]" : "pl-2";
+}
+
+/** Sidebar toggle + hamburger menu + back/forward arrows. Shared by both
+ *  title-bar halves; rendered in exactly one of them at a time. */
+function NavControls({
+  menuItems,
+  onToggleSidebar,
+  sidebarVisible,
+  onGoBack,
+  onGoForward,
+  canGoBack,
+  canGoForward,
+}: NavControlsProps) {
+  return (
+    <div className="flex items-center gap-0.5 pointer-events-auto" style={NO_DRAG_STYLE}>
+      {onToggleSidebar && (
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              type="button"
+              onClick={onToggleSidebar}
+              aria-label="Toggle sidebar"
+              aria-pressed={sidebarVisible ?? false}
+              data-testid="desktop-title-bar__sidebar-toggle"
+              className={`flex items-center justify-center rounded p-1 transition-colors hover:bg-accent/50 hover:text-foreground ${sidebarVisible ? "text-foreground" : "text-muted-foreground"}`}
+            >
+              <PanelLeft className="size-5" />
+            </button>
+          </TooltipTrigger>
+          <TooltipContent side="bottom" className="text-xs">
+            Toggle Sidebar{" "}
+            <kbd className="ml-1.5 rounded border border-popover-foreground/25 bg-popover-foreground/10 px-1 py-0.5 font-mono text-[14px]">
+              ⌘B
+            </kbd>
+          </TooltipContent>
+        </Tooltip>
+      )}
+      {menuItems && (
+        <DropdownMenu>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <DropdownMenuTrigger asChild>
+                <button
+                  type="button"
+                  className="flex items-center justify-center rounded p-1 text-muted-foreground hover:text-foreground hover:bg-accent/50 transition-colors"
+                  aria-label="Menu"
+                  // Mirrors the testid on the DashboardShell-version of
+                  // the same trigger (`DashboardShell.tsx`). The two
+                  // triggers are mutually exclusive by layout: this title
+                  // bar mounts when `useDesktopLayout` is true, and the
+                  // sidebar's DashboardShell trigger is suppressed by the
+                  // `hideMenu` prop `AppShell` passes in that case
+                  // (`__root.tsx`). Sharing the testid lets test
+                  // page-objects target "the toolbar menu trigger" without
+                  // branching on layout mode.
+                  data-testid="dashboard__menu-trigger"
+                >
+                  <Menu className="size-5" />
+                </button>
+              </DropdownMenuTrigger>
+            </TooltipTrigger>
+            <TooltipContent side="bottom" className="text-xs">
+              More
+            </TooltipContent>
+          </Tooltip>
+          <DropdownMenuContent align="start">{menuItems}</DropdownMenuContent>
+        </DropdownMenu>
+      )}
+      {(onGoBack || onGoForward) && (
+        <>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                type="button"
+                onClick={onGoBack}
+                disabled={!canGoBack}
+                className="flex items-center justify-center rounded p-1 text-muted-foreground hover:text-foreground hover:bg-accent/50 transition-colors disabled:opacity-30 disabled:hover:bg-transparent disabled:hover:text-muted-foreground"
+              >
+                <ChevronLeft className="size-5" />
+              </button>
+            </TooltipTrigger>
+            <TooltipContent side="bottom" className="text-xs">
+              Back{" "}
+              <kbd className="ml-1.5 rounded border border-popover-foreground/25 bg-popover-foreground/10 px-1 py-0.5 font-mono text-[14px]">
+                ⌘[
+              </kbd>
+            </TooltipContent>
+          </Tooltip>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                type="button"
+                onClick={onGoForward}
+                disabled={!canGoForward}
+                className="flex items-center justify-center rounded p-1 text-muted-foreground hover:text-foreground hover:bg-accent/50 transition-colors disabled:opacity-30 disabled:hover:bg-transparent disabled:hover:text-muted-foreground"
+              >
+                <ChevronRight className="size-5" />
+              </button>
+            </TooltipTrigger>
+            <TooltipContent side="bottom" className="text-xs">
+              Forward{" "}
+              <kbd className="ml-1.5 rounded border border-popover-foreground/25 bg-popover-foreground/10 px-1 py-0.5 font-mono text-[14px]">
+                ⌘]
+              </kbd>
+            </TooltipContent>
+          </Tooltip>
+        </>
+      )}
+    </div>
+  );
+}
+
+/** Draggable title bar over the project-list sidebar. Holds the navigation
+ *  cluster (sidebar toggle, menu, back/forward) while the list is visible.
+ *  Painted with the sidebar surface so it reads as one panel with the list
+ *  below it, visually separated from the workspace layout to its right. */
+export function SidebarTitleBar({ sidebarVisible, ...nav }: SidebarTitleBarProps) {
+  const offsetClass = useTrafficLightOffsetClass();
+  return (
+    <div
+      className={`h-[38px] shrink-0 flex items-center gap-0.5 border-b border-border bg-sidebar pr-2 ${offsetClass}`}
+      style={DRAG_STYLE}
+    >
+      {sidebarVisible && <NavControls sidebarVisible={sidebarVisible} {...nav} />}
+    </div>
+  );
+}
+
+/** Draggable title bar over the workspace layout. Holds the workspace name
+ *  (center), the open-in-editor picker, and the panel/layout switcher. When
+ *  the project-list sidebar is collapsed, the navigation cluster relocates
+ *  here (far left, clearing the traffic lights) so the menu and back/forward
+ *  arrows stay reachable. */
+export function WorkspaceTitleBar({
   title,
   workspaceName,
   workspacePath,
@@ -80,18 +232,11 @@ export function DesktopTitleBar({
   panelItems,
   hiddenPanels,
   onTogglePanelVisibility,
-  onGoBack,
-  onGoForward,
-  canGoBack,
-  canGoForward,
-  menuItems,
-  onToggleSidebar,
   sidebarVisible,
-}: DesktopTitleBarProps) {
+  ...nav
+}: WorkspaceTitleBarProps) {
   const [appTitle, setAppTitle] = useState(title ?? "Band");
-  // macOS native fullscreen hides the traffic lights — used below to drop
-  // the 80px left offset reserved for them.
-  const isFullscreen = useIsFullscreen();
+  const offsetClass = useTrafficLightOffsetClass();
 
   useEffect(() => {
     if (title) return;
@@ -108,159 +253,62 @@ export function DesktopTitleBar({
 
   return (
     <div
-      className="h-[38px] shrink-0 flex items-center justify-center relative border-b border-border"
+      // Left padding clears the macOS traffic lights only when this bar sits at
+      // the window's left edge — i.e. while the sidebar is collapsed and the
+      // nav cluster lives here. When the sidebar is visible it owns that gutter.
+      className={`h-[38px] shrink-0 flex items-center gap-1 border-b border-border bg-background pr-2 ${sidebarVisible ? "pl-2" : offsetClass}`}
       style={DRAG_STYLE}
     >
-      {(onGoBack || onGoForward || menuItems || onToggleSidebar) && (
-        <div
-          // Desktop: leave 80px clear for the macOS traffic lights.
-          // Web: no traffic lights exist, so park the controls near the edge.
-          className={`absolute ${isDesktop && !isFullscreen ? "left-[80px]" : "left-2"} top-1/2 -translate-y-1/2 flex items-center gap-0.5 pointer-events-auto`}
-          style={NO_DRAG_STYLE}
-        >
-          {onToggleSidebar && (
+      {/* Nav cluster relocates here (left-aligned, in normal flow) while the
+          project list is collapsed, so it never overlaps the centered title. */}
+      {!sidebarVisible && <NavControls sidebarVisible={sidebarVisible} {...nav} />}
+
+      <div className="flex flex-1 items-center justify-center min-w-0 px-1">
+        {workspaceName ? (
+          onWorkspaceNameClick ? (
+            // Interactive: clicking opens the workspace picker (mirrors the
+            // mobile header). Lives inside the drag region, so it must reapply
+            // NO_DRAG_STYLE and keep pointer events enabled, like the other
+            // interactive title-bar children (back/forward, dropdown triggers).
             <Tooltip>
               <TooltipTrigger asChild>
                 <button
                   type="button"
-                  onClick={onToggleSidebar}
-                  aria-label="Toggle sidebar"
-                  aria-pressed={sidebarVisible ?? false}
-                  data-testid="desktop-title-bar__sidebar-toggle"
-                  className={`flex items-center justify-center rounded p-1 transition-colors hover:bg-accent/50 hover:text-foreground ${sidebarVisible ? "text-foreground" : "text-muted-foreground"}`}
+                  onClick={onWorkspaceNameClick}
+                  aria-haspopup="dialog"
+                  aria-label="Switch workspace"
+                  data-testid="desktop-title-bar__workspace-name"
+                  className="flex items-center gap-1.5 rounded-md px-2 py-1 max-w-[50%] text-sm font-semibold text-foreground hover:bg-accent/50 transition-colors pointer-events-auto"
+                  style={NO_DRAG_STYLE}
                 >
-                  <PanelLeft className="size-5" />
+                  <span className="truncate">{workspaceName}</span>
+                  <ChevronsUpDown className="size-3.5 shrink-0 text-muted-foreground" />
                 </button>
               </TooltipTrigger>
               <TooltipContent side="bottom" className="text-xs">
-                Toggle Sidebar{" "}
+                {/* Both modifiers are shown: SharedDockviewLayout binds ⌘K on
+                  macOS and Ctrl+K on Windows/Linux (where this title bar also
+                  renders in the wide-viewport web layout). */}
+                Switch Workspace{" "}
                 <kbd className="ml-1.5 rounded border border-popover-foreground/25 bg-popover-foreground/10 px-1 py-0.5 font-mono text-[14px]">
-                  ⌘B
+                  ⌘K / Ctrl+K
                 </kbd>
               </TooltipContent>
             </Tooltip>
-          )}
-          {menuItems && (
-            <DropdownMenu>
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <DropdownMenuTrigger asChild>
-                    <button
-                      type="button"
-                      className="flex items-center justify-center rounded p-1 text-muted-foreground hover:text-foreground hover:bg-accent/50 transition-colors"
-                      aria-label="Menu"
-                      // Mirrors the testid on the DashboardShell-version of
-                      // the same trigger (`DashboardShell.tsx`). The two
-                      // triggers are mutually exclusive by layout: the
-                      // DesktopTitleBar mounts when `useDesktopLayout` is
-                      // true, and the sidebar's DashboardShell trigger is
-                      // suppressed by the `hideMenu` prop `AppShell` passes
-                      // in that case (`__root.tsx`). Sharing the testid lets
-                      // test page-objects target "the toolbar menu trigger"
-                      // without branching on layout mode.
-                      data-testid="dashboard__menu-trigger"
-                    >
-                      <Menu className="size-5" />
-                    </button>
-                  </DropdownMenuTrigger>
-                </TooltipTrigger>
-                <TooltipContent side="bottom" className="text-xs">
-                  More
-                </TooltipContent>
-              </Tooltip>
-              <DropdownMenuContent align="start">{menuItems}</DropdownMenuContent>
-            </DropdownMenu>
-          )}
-          {(onGoBack || onGoForward) && (
-            <>
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <button
-                    type="button"
-                    onClick={onGoBack}
-                    disabled={!canGoBack}
-                    className="flex items-center justify-center rounded p-1 text-muted-foreground hover:text-foreground hover:bg-accent/50 transition-colors disabled:opacity-30 disabled:hover:bg-transparent disabled:hover:text-muted-foreground"
-                  >
-                    <ChevronLeft className="size-5" />
-                  </button>
-                </TooltipTrigger>
-                <TooltipContent side="bottom" className="text-xs">
-                  Back{" "}
-                  <kbd className="ml-1.5 rounded border border-popover-foreground/25 bg-popover-foreground/10 px-1 py-0.5 font-mono text-[14px]">
-                    ⌘[
-                  </kbd>
-                </TooltipContent>
-              </Tooltip>
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <button
-                    type="button"
-                    onClick={onGoForward}
-                    disabled={!canGoForward}
-                    className="flex items-center justify-center rounded p-1 text-muted-foreground hover:text-foreground hover:bg-accent/50 transition-colors disabled:opacity-30 disabled:hover:bg-transparent disabled:hover:text-muted-foreground"
-                  >
-                    <ChevronRight className="size-5" />
-                  </button>
-                </TooltipTrigger>
-                <TooltipContent side="bottom" className="text-xs">
-                  Forward{" "}
-                  <kbd className="ml-1.5 rounded border border-popover-foreground/25 bg-popover-foreground/10 px-1 py-0.5 font-mono text-[14px]">
-                    ⌘]
-                  </kbd>
-                </TooltipContent>
-              </Tooltip>
-            </>
-          )}
-        </div>
-      )}
-
-      {workspaceName ? (
-        onWorkspaceNameClick ? (
-          // Interactive: clicking opens the workspace picker (mirrors the
-          // mobile header). Lives inside the drag region, so it must reapply
-          // NO_DRAG_STYLE and keep pointer events enabled, like the other
-          // interactive title-bar children (back/forward, dropdown triggers).
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <button
-                type="button"
-                onClick={onWorkspaceNameClick}
-                aria-haspopup="dialog"
-                aria-label="Switch workspace"
-                data-testid="desktop-title-bar__workspace-name"
-                className="flex items-center gap-1.5 rounded-md px-2 py-1 max-w-[50%] text-sm font-semibold text-foreground hover:bg-accent/50 transition-colors pointer-events-auto"
-                style={NO_DRAG_STYLE}
-              >
-                <span className="truncate">{workspaceName}</span>
-                <ChevronsUpDown className="size-3.5 shrink-0 text-muted-foreground" />
-              </button>
-            </TooltipTrigger>
-            <TooltipContent side="bottom" className="text-xs">
-              {/* Both modifiers are shown: SharedDockviewLayout binds ⌘K on
-                  macOS and Ctrl+K on Windows/Linux (where this title bar also
-                  renders in the wide-viewport web layout). */}
-              Switch Workspace{" "}
-              <kbd className="ml-1.5 rounded border border-popover-foreground/25 bg-popover-foreground/10 px-1 py-0.5 font-mono text-[14px]">
-                ⌘K / Ctrl+K
-              </kbd>
-            </TooltipContent>
-          </Tooltip>
+          ) : (
+            <span className="text-sm font-semibold text-foreground select-none pointer-events-none truncate max-w-[50%]">
+              {workspaceName}
+            </span>
+          )
         ) : (
-          <span className="text-sm font-semibold text-foreground select-none pointer-events-none truncate max-w-[50%]">
-            {workspaceName}
+          <span className="text-xs font-medium text-muted-foreground select-none pointer-events-none">
+            {appTitle}
           </span>
-        )
-      ) : (
-        <span className="text-xs font-medium text-muted-foreground select-none pointer-events-none">
-          {appTitle}
-        </span>
-      )}
+        )}
+      </div>
 
       {(hasEditorPicker || hasPanels) && (
-        <div
-          className="absolute right-2 top-1/2 -translate-y-1/2 flex items-center gap-1 pointer-events-auto"
-          style={NO_DRAG_STYLE}
-        >
+        <div className="flex shrink-0 items-center gap-1 pointer-events-auto" style={NO_DRAG_STYLE}>
           {hasEditorPicker && (
             <EditorPicker workspacePath={workspacePath} onCopyPath={onCopyPath} />
           )}

--- a/apps/web/src/components/DesktopTitleBar.tsx
+++ b/apps/web/src/components/DesktopTitleBar.tsx
@@ -10,7 +10,6 @@ import {
 } from "@band-app/ui";
 import { ChevronLeft, ChevronRight, ChevronsUpDown, Menu, PanelLeft, PanelTop } from "lucide-react";
 import { type ReactNode, useEffect, useState } from "react";
-import { useIsFullscreen } from "../hooks/useIsFullscreen";
 import { invoke as desktopInvoke } from "../lib/desktop-ipc";
 import { isDesktop } from "../lib/is-desktop";
 import { EditorPicker } from "./EditorPicker";
@@ -54,11 +53,20 @@ interface NavControlsProps {
   canGoForward?: boolean;
 }
 
+/** The traffic-light gutter class: on macOS desktop (outside fullscreen) the
+ *  window controls occupy the top-left ~80px, so whichever title-bar half sits
+ *  at the window's left edge must clear that space. Computed once in `AppShell`
+ *  (a single `useIsFullscreen` subscription) and passed to both halves. */
+interface TitleBarOffsetProps {
+  /** Left-padding class to apply when the bar is at the window's left edge. */
+  offsetClass: string;
+}
+
 /** The sidebar half takes the shared nav-control props verbatim;
  *  `sidebarVisible` (inherited from NavControlsProps) gates the cluster. */
-type SidebarTitleBarProps = NavControlsProps;
+type SidebarTitleBarProps = NavControlsProps & TitleBarOffsetProps;
 
-interface WorkspaceTitleBarProps extends NavControlsProps {
+interface WorkspaceTitleBarProps extends NavControlsProps, TitleBarOffsetProps {
   /** Static title. If omitted, fetches the app title from the desktop shell. */
   title?: string;
   /** Active workspace name to display prominently. */
@@ -78,14 +86,6 @@ interface WorkspaceTitleBarProps extends NavControlsProps {
   hiddenPanels?: string[];
   /** Callback to toggle a panel's visibility on/off. */
   onTogglePanelVisibility?: (panelId: string) => void;
-}
-
-/** The traffic-light gutter: on macOS desktop (outside fullscreen) the window
- *  controls occupy the top-left ~80px, so whichever title-bar half sits at the
- *  window's left edge must clear that space before its first control. */
-function useTrafficLightOffsetClass(): string {
-  const isFullscreen = useIsFullscreen();
-  return isDesktop && !isFullscreen ? "pl-[80px]" : "pl-2";
 }
 
 /** Sidebar toggle + hamburger menu + back/forward arrows. Shared by both
@@ -204,8 +204,7 @@ function NavControls({
  *  cluster (sidebar toggle, menu, back/forward) while the list is visible.
  *  Painted with the sidebar surface so it reads as one panel with the list
  *  below it, visually separated from the workspace layout to its right. */
-export function SidebarTitleBar({ sidebarVisible, ...nav }: SidebarTitleBarProps) {
-  const offsetClass = useTrafficLightOffsetClass();
+export function SidebarTitleBar({ sidebarVisible, offsetClass, ...nav }: SidebarTitleBarProps) {
   return (
     <div
       className={`h-[38px] shrink-0 flex items-center gap-0.5 border-b border-border bg-sidebar pr-2 ${offsetClass}`}
@@ -235,10 +234,10 @@ export function WorkspaceTitleBar({
   hiddenPanels,
   onTogglePanelVisibility,
   sidebarVisible,
+  offsetClass,
   ...nav
 }: WorkspaceTitleBarProps) {
   const [appTitle, setAppTitle] = useState(title ?? "Band");
-  const offsetClass = useTrafficLightOffsetClass();
 
   useEffect(() => {
     if (title) return;

--- a/apps/web/src/components/DesktopTitleBar.tsx
+++ b/apps/web/src/components/DesktopTitleBar.tsx
@@ -54,13 +54,9 @@ interface NavControlsProps {
   canGoForward?: boolean;
 }
 
-interface SidebarTitleBarProps extends NavControlsProps {
-  /** When false, the bar renders empty (no nav cluster) — the cluster moves
-   *  to the WorkspaceTitleBar. The bar itself is clipped to 0px by the
-   *  collapsed sidebar Panel, but gating the cluster keeps it out of the DOM
-   *  so there's never a duplicate (e.g. two `…__sidebar-toggle` elements). */
-  sidebarVisible?: boolean;
-}
+/** The sidebar half takes the shared nav-control props verbatim;
+ *  `sidebarVisible` (inherited from NavControlsProps) gates the cluster. */
+type SidebarTitleBarProps = NavControlsProps;
 
 interface WorkspaceTitleBarProps extends NavControlsProps {
   /** Static title. If omitted, fetches the app title from the desktop shell. */
@@ -166,6 +162,7 @@ function NavControls({
                 type="button"
                 onClick={onGoBack}
                 disabled={!canGoBack}
+                aria-label="Back"
                 className="flex items-center justify-center rounded p-1 text-muted-foreground hover:text-foreground hover:bg-accent/50 transition-colors disabled:opacity-30 disabled:hover:bg-transparent disabled:hover:text-muted-foreground"
               >
                 <ChevronLeft className="size-5" />
@@ -184,6 +181,7 @@ function NavControls({
                 type="button"
                 onClick={onGoForward}
                 disabled={!canGoForward}
+                aria-label="Forward"
                 className="flex items-center justify-center rounded p-1 text-muted-foreground hover:text-foreground hover:bg-accent/50 transition-colors disabled:opacity-30 disabled:hover:bg-transparent disabled:hover:text-muted-foreground"
               >
                 <ChevronRight className="size-5" />
@@ -213,6 +211,10 @@ export function SidebarTitleBar({ sidebarVisible, ...nav }: SidebarTitleBarProps
       className={`h-[38px] shrink-0 flex items-center gap-0.5 border-b border-border bg-sidebar pr-2 ${offsetClass}`}
       style={DRAG_STYLE}
     >
+      {/* Gate the cluster on visibility: when the list is collapsed the bar is
+          clipped to 0px but stays mounted, so rendering the cluster here would
+          duplicate it (the WorkspaceTitleBar shows it while collapsed) and put
+          two `…__sidebar-toggle` / `dashboard__menu-trigger` nodes in the DOM. */}
       {sidebarVisible && <NavControls sidebarVisible={sidebarVisible} {...nav} />}
     </div>
   );

--- a/apps/web/src/dashboard/components/DashboardShell.tsx
+++ b/apps/web/src/dashboard/components/DashboardShell.tsx
@@ -325,8 +325,11 @@ export function DashboardShell({ toolbarMenuItems, hideTitleBar, hideMenu }: Das
     <div
       ref={rootRef}
       className={cn(
-        "w-full overflow-hidden flex flex-col bg-background text-foreground p-0",
-        hideTitleBar && "h-full",
+        "w-full overflow-hidden flex flex-col text-foreground p-0",
+        // Embedded as the project-list sidebar (hideTitleBar): paint the
+        // `--sidebar` surface so the list reads as a panel distinct from the
+        // workspace layout. Standalone (mobile / narrow web): plain background.
+        hideTitleBar ? "h-full bg-sidebar" : "bg-background",
         !isDesktop && "pt-[env(safe-area-inset-top)]",
       )}
       // CSS `zoom` does not scale viewport units (vh, dvh, svh, lvh) per

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -28,7 +28,7 @@ import {
 import { DesktopDashboardAdapter, NativeShellCapabilities } from "@/dashboard/adapters/desktop";
 import { WebCapabilities, WebDashboardAdapter } from "@/dashboard/adapters/web";
 import { BrowserHostBridge } from "../components/BrowserHostBridge";
-import { DesktopTitleBar, type PanelItem } from "../components/DesktopTitleBar";
+import { type PanelItem, SidebarTitleBar, WorkspaceTitleBar } from "../components/DesktopTitleBar";
 import { crossPanelHandlers, SharedDockviewLayout } from "../components/SharedDockviewLayout";
 import { ToolbarOverflowMenuItems, ToolbarOverflowProvider } from "../components/ToolbarButtons";
 import { useIsDesktop } from "../hooks/useIsDesktop";
@@ -533,46 +533,38 @@ function AppShell() {
     return <Outlet />;
   }
 
+  // The hamburger menu and back/forward arrows belong to the project-list
+  // region: they ride in the SidebarTitleBar while the list is visible, and
+  // relocate into the WorkspaceTitleBar (far left) when the list is collapsed
+  // so they stay reachable. Both bars receive the same nav props; each renders
+  // the cluster only in the appropriate state (keyed off `sidebarVisible`).
+  const menuItems = (
+    <>
+      <ToolbarOverflowMenuItems />
+      <DropdownMenuItem
+        onClick={() => {
+          const fn = (window as unknown as { __bandOpenSettings?: () => void }).__bandOpenSettings;
+          fn?.();
+        }}
+      >
+        <SettingsIcon className="size-4" />
+        Settings
+      </DropdownMenuItem>
+    </>
+  );
+  const navControlProps = {
+    menuItems,
+    onGoBack: navigationHistory.goBack,
+    onGoForward: navigationHistory.goForward,
+    canGoBack: navigationHistory.canGoBack,
+    canGoForward: navigationHistory.canGoForward,
+    onToggleSidebar: toggleSidebar,
+    sidebarVisible,
+  };
+
   return (
     <ToolbarOverflowProvider>
       <div className="flex flex-col h-full w-full overflow-hidden bg-background text-foreground">
-        <DesktopTitleBar
-          menuItems={
-            <>
-              <ToolbarOverflowMenuItems />
-              <DropdownMenuItem
-                onClick={() => {
-                  const fn = (window as unknown as { __bandOpenSettings?: () => void })
-                    .__bandOpenSettings;
-                  fn?.();
-                }}
-              >
-                <SettingsIcon className="size-4" />
-                Settings
-              </DropdownMenuItem>
-            </>
-          }
-          workspaceName={activeWorkspaceId ?? undefined}
-          workspacePath={activeWorkspaceId ? workspacePath : undefined}
-          onCopyPath={activeWorkspaceId ? handleCopyPath : undefined}
-          // Clicking the title-bar workspace name opens the same picker as ⌘K.
-          // The picker state lives in SharedDockviewLayout (a sibling), so we
-          // signal it via the window event it listens for.
-          onWorkspaceNameClick={
-            activeWorkspaceId
-              ? () => window.dispatchEvent(new CustomEvent("band:open-workspace-picker"))
-              : undefined
-          }
-          panelItems={activeWorkspaceId ? panelItems : undefined}
-          hiddenPanels={activeWorkspaceId ? hiddenPanels : undefined}
-          onTogglePanelVisibility={activeWorkspaceId ? handleTogglePanelVisibility : undefined}
-          onGoBack={navigationHistory.goBack}
-          onGoForward={navigationHistory.goForward}
-          canGoBack={navigationHistory.canGoBack}
-          canGoForward={navigationHistory.canGoForward}
-          onToggleSidebar={toggleSidebar}
-          sidebarVisible={sidebarVisible}
-        />
         <div className="flex-1 min-h-0 overflow-hidden">
           <Group
             orientation="horizontal"
@@ -590,21 +582,50 @@ function AppShell() {
               collapsedSize="0%"
               onResize={handleSidebarResize}
             >
+              {/* The whole sidebar column (its title-bar half + the project
+                  list) is painted with the `--sidebar` surface so it reads as a
+                  distinct panel from the workspace layout to its right. */}
               <div
-                className="h-full overflow-hidden border-r border-border"
+                className="h-full flex flex-col overflow-hidden border-r border-border bg-sidebar"
                 data-testid="app-shell__sidebar"
               >
-                <DashboardShell hideMenu hideTitleBar />
+                <SidebarTitleBar {...navControlProps} />
+                <div className="flex-1 min-h-0">
+                  <DashboardShell hideMenu hideTitleBar />
+                </div>
               </div>
             </Panel>
             <Separator className="w-[3px] bg-transparent hover:bg-accent-foreground/20 active:bg-accent-foreground/30 transition-colors cursor-col-resize" />
             <Panel id="main" minSize="20%">
               {/* Stays mounted across sidebar toggles — never unmount this
                   subtree or the dockview tears down all cached workspaces. */}
-              <div className="h-full min-w-0 overflow-hidden relative">
-                <Outlet />
-                <SharedDockviewLayout />
-                <BrowserHostBridge />
+              <div className="h-full flex flex-col min-w-0 overflow-hidden">
+                <WorkspaceTitleBar
+                  {...navControlProps}
+                  workspaceName={activeWorkspaceId ?? undefined}
+                  workspacePath={activeWorkspaceId ? workspacePath : undefined}
+                  onCopyPath={activeWorkspaceId ? handleCopyPath : undefined}
+                  // Clicking the title-bar workspace name opens the same picker
+                  // as ⌘K. The picker state lives in SharedDockviewLayout (a
+                  // sibling), so we signal it via the window event it listens for.
+                  onWorkspaceNameClick={
+                    activeWorkspaceId
+                      ? () => window.dispatchEvent(new CustomEvent("band:open-workspace-picker"))
+                      : undefined
+                  }
+                  panelItems={activeWorkspaceId ? panelItems : undefined}
+                  hiddenPanels={activeWorkspaceId ? hiddenPanels : undefined}
+                  onTogglePanelVisibility={
+                    activeWorkspaceId ? handleTogglePanelVisibility : undefined
+                  }
+                />
+                {/* `relative` anchors SharedDockviewLayout's `absolute inset-0`
+                    overlay to the area BELOW the title bar. */}
+                <div className="flex-1 min-h-0 min-w-0 overflow-hidden relative">
+                  <Outlet />
+                  <SharedDockviewLayout />
+                  <BrowserHostBridge />
+                </div>
               </div>
             </Panel>
           </Group>

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -529,38 +529,58 @@ function AppShell() {
     [],
   );
 
-  if (!useDesktopLayout) {
-    return <Outlet />;
-  }
-
   // The hamburger menu and back/forward arrows belong to the project-list
   // region: they ride in the SidebarTitleBar while the list is visible, and
   // relocate into the WorkspaceTitleBar (far left) when the list is collapsed
   // so they stay reachable. Both bars receive the same nav props; each renders
   // the cluster only in the appropriate state (keyed off `sidebarVisible`).
-  const menuItems = (
-    <>
-      <ToolbarOverflowMenuItems />
-      <DropdownMenuItem
-        onClick={() => {
-          const fn = (window as unknown as { __bandOpenSettings?: () => void }).__bandOpenSettings;
-          fn?.();
-        }}
-      >
-        <SettingsIcon className="size-4" />
-        Settings
-      </DropdownMenuItem>
-    </>
+  //
+  // Memoized so both bars get a stable prop reference across the frequent
+  // AppShell re-renders (route changes, workspace switches, sidebar toggles).
+  // Hooks must run unconditionally, so these sit above the narrow/mobile early
+  // return below.
+  const menuItems = useMemo(
+    () => (
+      <>
+        <ToolbarOverflowMenuItems />
+        <DropdownMenuItem
+          onClick={() => {
+            const fn = (window as unknown as { __bandOpenSettings?: () => void })
+              .__bandOpenSettings;
+            fn?.();
+          }}
+        >
+          <SettingsIcon className="size-4" />
+          Settings
+        </DropdownMenuItem>
+      </>
+    ),
+    [],
   );
-  const navControlProps = {
-    menuItems,
-    onGoBack: navigationHistory.goBack,
-    onGoForward: navigationHistory.goForward,
-    canGoBack: navigationHistory.canGoBack,
-    canGoForward: navigationHistory.canGoForward,
-    onToggleSidebar: toggleSidebar,
-    sidebarVisible,
-  };
+  const navControlProps = useMemo(
+    () => ({
+      menuItems,
+      onGoBack: navigationHistory.goBack,
+      onGoForward: navigationHistory.goForward,
+      canGoBack: navigationHistory.canGoBack,
+      canGoForward: navigationHistory.canGoForward,
+      onToggleSidebar: toggleSidebar,
+      sidebarVisible,
+    }),
+    [
+      menuItems,
+      navigationHistory.goBack,
+      navigationHistory.goForward,
+      navigationHistory.canGoBack,
+      navigationHistory.canGoForward,
+      toggleSidebar,
+      sidebarVisible,
+    ],
+  );
+
+  if (!useDesktopLayout) {
+    return <Outlet />;
+  }
 
   return (
     <ToolbarOverflowProvider>

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -32,6 +32,7 @@ import { type PanelItem, SidebarTitleBar, WorkspaceTitleBar } from "../component
 import { crossPanelHandlers, SharedDockviewLayout } from "../components/SharedDockviewLayout";
 import { ToolbarOverflowMenuItems, ToolbarOverflowProvider } from "../components/ToolbarButtons";
 import { useIsDesktop } from "../hooks/useIsDesktop";
+import { useIsFullscreen } from "../hooks/useIsFullscreen";
 import { useNavigationHistory } from "../hooks/useNavigationHistory";
 import { useZoom } from "../hooks/useZoom";
 import { getElectronBridge } from "../lib/desktop-ipc";
@@ -390,6 +391,14 @@ function AppShell() {
     navigator.clipboard.writeText(workspacePath).catch(() => {});
   }, [workspacePath]);
 
+  // Clicking the title-bar workspace name opens the same picker as ⌘K. The
+  // picker state lives in SharedDockviewLayout (a sibling), so we signal it via
+  // the window event it listens for. Stable identity so the title bar can
+  // bail out of re-renders if ever memoized.
+  const handleWorkspaceNameClick = useCallback(() => {
+    window.dispatchEvent(new CustomEvent("band:open-workspace-picker"));
+  }, []);
+
   // Toggle panel visibility on/off (persisted in settings)
   const handleTogglePanelVisibility = useCallback(
     (panelId: string) => {
@@ -578,6 +587,13 @@ function AppShell() {
     ],
   );
 
+  // Single source for the macOS traffic-light gutter: compute it once here (one
+  // `useIsFullscreen` subscription) and pass to both title-bar halves, rather
+  // than each bar instantiating its own hook. The offset applies to whichever
+  // bar sits at the window's left edge.
+  const isFullscreen = useIsFullscreen();
+  const titleBarOffset = isDesktop && !isFullscreen ? "pl-[80px]" : "pl-2";
+
   if (!useDesktopLayout) {
     return <Outlet />;
   }
@@ -609,7 +625,7 @@ function AppShell() {
                 className="h-full flex flex-col overflow-hidden border-r border-border bg-sidebar"
                 data-testid="app-shell__sidebar"
               >
-                <SidebarTitleBar {...navControlProps} />
+                <SidebarTitleBar {...navControlProps} offsetClass={titleBarOffset} />
                 <div className="flex-1 min-h-0">
                   <DashboardShell hideMenu hideTitleBar />
                 </div>
@@ -622,17 +638,11 @@ function AppShell() {
               <div className="h-full flex flex-col min-w-0 overflow-hidden">
                 <WorkspaceTitleBar
                   {...navControlProps}
+                  offsetClass={titleBarOffset}
                   workspaceName={activeWorkspaceId ?? undefined}
                   workspacePath={activeWorkspaceId ? workspacePath : undefined}
                   onCopyPath={activeWorkspaceId ? handleCopyPath : undefined}
-                  // Clicking the title-bar workspace name opens the same picker
-                  // as ⌘K. The picker state lives in SharedDockviewLayout (a
-                  // sibling), so we signal it via the window event it listens for.
-                  onWorkspaceNameClick={
-                    activeWorkspaceId
-                      ? () => window.dispatchEvent(new CustomEvent("band:open-workspace-picker"))
-                      : undefined
-                  }
+                  onWorkspaceNameClick={activeWorkspaceId ? handleWorkspaceNameClick : undefined}
                   panelItems={activeWorkspaceId ? panelItems : undefined}
                   hiddenPanels={activeWorkspaceId ? hiddenPanels : undefined}
                   onTogglePanelVisibility={

--- a/apps/web/src/styles/globals.css
+++ b/apps/web/src/styles/globals.css
@@ -24,6 +24,7 @@
   --color-muted-foreground: var(--muted-foreground);
   --color-accent: var(--accent);
   --color-accent-foreground: var(--accent-foreground);
+  --color-sidebar: var(--sidebar);
   --color-destructive: var(--destructive);
   --color-border: var(--border);
   --color-input: var(--input);
@@ -60,6 +61,10 @@
   --muted-foreground: oklch(0.556 0 0);
   --accent: oklch(0.965 0 0);
   --accent-foreground: oklch(0.205 0 0);
+  /* Project-list sidebar surface. On light theme it sits a touch DARKER than
+     the white --background so the project list reads as a distinct panel from
+     the workspace layout. */
+  --sidebar: oklch(0.962 0 0);
   --destructive: oklch(0.577 0.245 27.325);
   --border: oklch(0.922 0 0);
   --input: oklch(0.922 0 0);
@@ -96,6 +101,10 @@
   --muted-foreground: oklch(0.556 0 0);
   --accent: oklch(0.269 0 0);
   --accent-foreground: oklch(0.922 0 0);
+  /* Project-list sidebar surface. On dark theme it sits a touch LIGHTER than
+     the #1e1e1e --background so the project list reads as a distinct panel
+     from the workspace layout (mirrors the VS Code editor/sidebar contrast). */
+  --sidebar: #252526;
   --destructive: oklch(0.704 0.191 22.216);
   --border: oklch(0.35 0 0);
   --input: oklch(0.269 0 0);


### PR DESCRIPTION
## Summary

Creates a visual separation between the project list and the workspace layout, and splits the title bar in two so each half belongs to its region.

- **Project-list surface** — the project list now sits on its own `--sidebar` background: a touch *lighter* than the background on the dark theme (`#252526` vs `#1e1e1e`), a touch *darker* than white on the light theme. Registered as `--color-sidebar` so `bg-sidebar` works in Tailwind.
- **Split title bar** — replaced the single full-width `DesktopTitleBar` with two halves rendered inside the resizable Group:
  - `SidebarTitleBar` (over the project list): sidebar toggle, hamburger menu, and back/forward arrows — painted with the sidebar surface.
  - `WorkspaceTitleBar` (over the workspace layout): centered workspace name, open-in-editor picker, and panel/layout switcher.
- **Collapsed-state relocation** — the nav cluster (toggle + menu + back/forward) renders in exactly one bar at a time. While the list is visible it lives in the sidebar bar; when the list is collapsed it relocates left-aligned into the workspace bar (clearing the macOS traffic lights) so the controls stay reachable and never overlap the centered title.

All existing test IDs (`app-shell__sidebar`, `desktop-title-bar__sidebar-toggle`, `dashboard__menu-trigger`, `desktop-title-bar__workspace-name`) are preserved.

## Testing

- `pnpm check` (biome + `cargo fmt --check` + `cargo clippy -D warnings`): pass
- Web build: compiles clean
- e2e (`sidebar-toggle`, `workspace-picker`, `copy-file-path`, `panel-visibility-context`): 14/14 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)