### PR TITLE
feat(web): run @band-app/server standalone on Linux (#594)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,20 @@
+# Keep the build context small and force a clean install/build inside the
+# image. Source, package.json files, lockfile and configs are all included;
+# build outputs and installed deps are rebuilt in the image.
+.git
+.gitignore
+**/node_modules
+**/dist
+**/.turbo
+apps/cli/target
+apps/desktop/out
+apps/desktop/dist
+apps/web/test-results
+apps/web/playwright-report
+apps/web/.band
+**/*.log
+.band
+.claude
+.vscode
+.idea
+docker/README.md

--- a/apps/web/src/server/infra/git/git-client.ts
+++ b/apps/web/src/server/infra/git/git-client.ts
@@ -2,6 +2,7 @@ import { execFile } from "node:child_process";
 import { readFile, stat } from "node:fs/promises";
 import { join } from "node:path";
 import { createLogger } from "@band-app/logger";
+import { prependBinDirs } from "../process/path";
 
 /**
  * Git infrastructure client — Phase 2 of the 3-tier refactor
@@ -173,15 +174,14 @@ async function resolveDetachedBranch(worktreePath: string): Promise<string> {
 }
 
 /**
- * Build the `{ command, env }` pair used to invoke git. Prepends Homebrew
- * paths to `PATH` so a desktop launch (which inherits a barebones PATH on
- * macOS) still finds the system `git` binary.
+ * Build the `{ command, env }` pair used to invoke git. Prepends the
+ * platform's extra bin dirs (Homebrew on macOS, `/usr/local/bin` +
+ * Linuxbrew-if-present on Linux) to `PATH` so a desktop/service launch
+ * (which inherits a barebones PATH) still finds the system `git` binary.
  */
 export function gitCmd(): { command: string; env: NodeJS.ProcessEnv } {
   const env = { ...process.env };
-  if (env.PATH) {
-    env.PATH = `/opt/homebrew/bin:/usr/local/bin:${env.PATH}`;
-  }
+  env.PATH = prependBinDirs(env.PATH);
   return { command: "git", env };
 }
 
@@ -213,9 +213,7 @@ export function execGit(args: string[], cwd: string): Promise<string> {
  */
 export function execGh(args: string[], cwd: string): Promise<string> {
   const env = { ...process.env };
-  if (env.PATH) {
-    env.PATH = `/opt/homebrew/bin:/usr/local/bin:${env.PATH}`;
-  }
+  env.PATH = prependBinDirs(env.PATH);
   return new Promise((resolve, reject) => {
     execFile("gh", args, { cwd, env, maxBuffer: MAX_BUFFER }, (err, stdout, stderr) => {
       if (err) {

--- a/apps/web/src/server/infra/process/path.ts
+++ b/apps/web/src/server/infra/process/path.ts
@@ -1,4 +1,6 @@
 import { execFile } from "node:child_process";
+import { existsSync } from "node:fs";
+import { delimiter } from "node:path";
 
 /**
  * Resolve the user's interactive `$PATH` by spawning a login shell and
@@ -17,12 +19,77 @@ import { execFile } from "node:child_process";
  * crossing back up to services.
  */
 
+/**
+ * Resolve the default interactive shell for the host, cross-platform.
+ *
+ * Honours `$SHELL` when set (the user's chosen login shell on macOS/Linux).
+ * Otherwise probes a platform-appropriate candidate list and returns the
+ * first that exists on disk: macOS ships zsh at `/bin/zsh`, most Linux
+ * distros ship bash (`/bin/bash`) with `/bin/sh` as the POSIX floor that is
+ * effectively always present. On Windows there is no `$SHELL`, so fall back
+ * to `%ComSpec%` (cmd.exe) — a best-effort stub for the Windows follow-up
+ * (#150), not a fully supported path yet.
+ */
+export function defaultShell(): string {
+  if (process.env.SHELL) return process.env.SHELL;
+  if (process.platform === "win32") return process.env.ComSpec || "cmd.exe";
+  for (const candidate of ["/bin/zsh", "/bin/bash", "/bin/sh"]) {
+    if (existsSync(candidate)) return candidate;
+  }
+  return "/bin/sh";
+}
+
+/**
+ * Extra `bin` directories to prepend to `PATH` so subprocesses (git, gh,
+ * setup scripts, cloudflared) still resolve system tools when the server
+ * was launched from a GUI/service with a stripped-down `PATH`.
+ *
+ * - macOS: Homebrew's Apple-Silicon (`/opt/homebrew/bin`) and Intel/general
+ *   (`/usr/local/bin`) prefixes.
+ * - Linux: `/usr/local/bin`, plus Linuxbrew (`/home/linuxbrew/.linuxbrew/bin`)
+ *   only when it actually exists — a stock host has neither Homebrew nor
+ *   that directory, so we must not blindly prepend a nonexistent path.
+ * - Windows: none yet (tracked in #150).
+ *
+ * Memoized: `process.platform` and the Linuxbrew directory's existence are
+ * stable for the process lifetime, so the `existsSync` probe runs once
+ * rather than on every `gitCmd()` / `execGh()` / setup / teardown call that
+ * prepends the PATH (mirrors the `cachedShellPath` cache below).
+ */
+let cachedBinDirs: readonly string[] | null = null;
+
+export function extraBinDirs(): readonly string[] {
+  if (cachedBinDirs) return cachedBinDirs;
+  if (process.platform === "darwin") {
+    cachedBinDirs = ["/opt/homebrew/bin", "/usr/local/bin"];
+  } else if (process.platform === "linux") {
+    const dirs: string[] = [];
+    const linuxbrew = "/home/linuxbrew/.linuxbrew/bin";
+    if (existsSync(linuxbrew)) dirs.push(linuxbrew);
+    dirs.push("/usr/local/bin");
+    cachedBinDirs = dirs;
+  } else {
+    cachedBinDirs = [];
+  }
+  return cachedBinDirs;
+}
+
+/**
+ * Prepend `extraBinDirs()` to an existing `PATH` string, joined with the
+ * platform's `path.delimiter` (`:` on POSIX, `;` on Windows). The extra
+ * dirs come first so they win the shell's left-to-right PATH search;
+ * returns the extra dirs alone when `path` is empty/undefined.
+ */
+export function prependBinDirs(path: string | undefined): string {
+  return [...extraBinDirs(), ...(path ? [path] : [])].join(delimiter);
+}
+
 let cachedShellPath: string | null = null;
 
 export async function shellPath(): Promise<string> {
   if (cachedShellPath) return cachedShellPath;
 
-  const shell = process.env.SHELL || "/bin/zsh";
+  const shell = defaultShell();
   try {
     const result = await new Promise<string>((resolve, reject) => {
       execFile(shell, ["-li", "-c", "echo $PATH"], { timeout: 5000 }, (err, stdout) => {
@@ -41,7 +108,7 @@ export async function shellPath(): Promise<string> {
     // Fall through to default
   }
 
-  const fallback = `/opt/homebrew/bin:/usr/local/bin:${process.env.PATH || ""}`;
+  const fallback = prependBinDirs(process.env.PATH);
   cachedShellPath = fallback;
   return fallback;
 }

--- a/apps/web/src/server/infra/setup/setup-runner.ts
+++ b/apps/web/src/server/infra/setup/setup-runner.ts
@@ -1,5 +1,6 @@
 import { type ChildProcess, spawn } from "node:child_process";
 import { emit } from "../events/status-event-bus";
+import { prependBinDirs } from "../process/path";
 import { loadProjectConfig } from "./project-config";
 
 /**
@@ -49,7 +50,7 @@ export function runSetup(
     cwd: worktreePath,
     env: {
       ...parentEnv,
-      PATH: `/opt/homebrew/bin:/usr/local/bin:${process.env.PATH}`,
+      PATH: prependBinDirs(process.env.PATH),
     },
     stdio: ["ignore", "pipe", "pipe"],
   });

--- a/apps/web/src/server/infra/terminals/terminal-pool.ts
+++ b/apps/web/src/server/infra/terminals/terminal-pool.ts
@@ -4,7 +4,7 @@ import { tmpdir } from "node:os";
 import { join, sep } from "node:path";
 import { createLogger } from "@band-app/logger";
 import type { IPty } from "node-pty";
-import { shellPath } from "../process/path";
+import { defaultShell, shellPath } from "../process/path";
 
 const log = createLogger("terminal-pool");
 
@@ -95,7 +95,7 @@ export class TerminalPool {
     workspaceRoot: string,
     options?: SpawnOptions,
   ): Promise<TerminalSession> {
-    const shell = process.env.SHELL || "/bin/zsh";
+    const shell = defaultShell();
     const resolvedPath = await shellPath();
 
     // Filter env to only string values — posix_spawnp fails on undefined/null

--- a/apps/web/src/server/services/system-service.ts
+++ b/apps/web/src/server/services/system-service.ts
@@ -83,8 +83,24 @@ export class SystemService {
    * `$PATH` (typically via `shellPath()`) so `brew` itself is locatable
    * even when the Node process inherited a stripped-down PATH from
    * launchd / Electron.
+   *
+   * Homebrew is macOS-only here: a stock Linux host has no `brew`, so
+   * shelling out to it would fail with an opaque ENOENT. Guard on
+   * `darwin` and surface a distro-appropriate hint on every other
+   * platform — the message bubbles up to the dashboard's install flow as
+   * a normal error instead of a crash.
    */
   async installCloudflared(resolvedPath: string): Promise<void> {
+    if (process.platform !== "darwin") {
+      throw new Error(
+        "Automatic cloudflared install is only supported on macOS (via Homebrew). " +
+          "On Linux, install it with your package manager " +
+          "(e.g. `sudo apt install cloudflared` or `sudo dnf install cloudflared`) " +
+          "or download it from " +
+          "https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/downloads/ " +
+          "and re-open the tunnel.",
+      );
+    }
     await brewInstall("cloudflared", resolvedPath);
   }
 

--- a/apps/web/src/server/services/workspace-service.ts
+++ b/apps/web/src/server/services/workspace-service.ts
@@ -15,6 +15,7 @@ import { UsageScanStateQueries } from "../infra/db/queries/usage-scan-state";
 import { WorkspaceQueries } from "../infra/db/queries/workspaces";
 import { DETACHED_BRANCH_PREFIX, execGit, gitCmd, listWorktrees } from "../infra/git/git-client";
 import { killWorkspaceServers } from "../infra/lsp/lsp-manager";
+import { prependBinDirs } from "../infra/process/path";
 import { loadProjectConfig } from "../infra/setup/project-config";
 import { runSetup } from "../infra/setup/setup-runner";
 import { copyWorkspaceFiles } from "../infra/setup/workspace-files";
@@ -752,7 +753,7 @@ export class WorkspaceService {
               cwd: worktreePath,
               env: {
                 ...process.env,
-                PATH: `/opt/homebrew/bin:/usr/local/bin:${process.env.PATH}`,
+                PATH: prependBinDirs(process.env.PATH),
               },
               encoding: "utf-8",
               timeout: 60_000,

--- a/apps/web/tests/terminal-shell-fallback.test.ts
+++ b/apps/web/tests/terminal-shell-fallback.test.ts
@@ -1,0 +1,128 @@
+// Integration test for the cross-platform shell fallback (issue #594,
+// Linux standalone). Black-box against the production server bundle
+// (`dist/start-server.mjs`) with a real terminal WebSocket client. No mocks.
+//
+// Regression guard: the terminal pool used to hardcode
+// `process.env.SHELL || "/bin/zsh"`. On a stock Linux host with no `$SHELL`
+// and no zsh installed, that resolved to `/bin/zsh`, failed the
+// `existsSync(shell)` guard, and the PTY never spawned — the WS handler
+// emitted a `{type:"error", message:"Shell not found: /bin/zsh"}` frame and
+// closed. `defaultShell()` now probes `/bin/zsh` → `/bin/bash` → `/bin/sh`,
+// so a terminal still spawns when `$SHELL` is unset.
+//
+// We reproduce the "no $SHELL" host by deleting `SHELL` from the parent env
+// BEFORE the server boots, so the spawned server inherits an environment
+// with no `SHELL` — exactly the stock-service case. `fileParallelism` is
+// off (see vitest.config.ts) so no other suite runs while `SHELL` is
+// removed, and we restore it as soon as the child has been spawned.
+
+import { mkdirSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { WebSocket } from "ws";
+import { seedSettings, seedState } from "./helpers/seed-state";
+import { createTmpHome, type ServerHandle, startServer } from "./helpers/server";
+
+const TOKEN = "terminal-shell-fallback-token";
+
+describe("terminal spawns with no $SHELL set (shell fallback)", () => {
+  let server: ServerHandle;
+  let tmpHome: string;
+
+  beforeAll(async () => {
+    tmpHome = createTmpHome("band-terminal-shell-fallback-");
+    const projectPath = join(tmpHome, "workspace");
+    mkdirSync(projectPath, { recursive: true });
+    seedState(tmpHome, {
+      projects: [
+        {
+          name: "workspace",
+          path: projectPath,
+          defaultBranch: "main",
+          worktrees: [{ branch: "main", path: projectPath }],
+        },
+      ],
+    });
+    seedSettings(tmpHome, {
+      tokenSecret: TOKEN,
+      worktreesDir: join(tmpHome, ".band", "worktrees"),
+    });
+
+    const savedShell = process.env.SHELL;
+    delete process.env.SHELL;
+    try {
+      server = await startServer({ tmpHome });
+    } finally {
+      // The child already inherited the SHELL-less env at spawn time, so
+      // restore the parent's value immediately.
+      if (savedShell === undefined) delete process.env.SHELL;
+      else process.env.SHELL = savedShell;
+    }
+  });
+
+  afterAll(async () => {
+    if (server) await server.close();
+    if (tmpHome) rmSync(tmpHome, { recursive: true, force: true });
+  });
+
+  it("attaches a live PTY and streams output instead of a shell-not-found error", async () => {
+    const port = new URL(server.url).port;
+    const workspaceId = "workspace-main";
+    const terminalId = "shell-fallback-terminal";
+    const wsUrl = `ws://127.0.0.1:${port}/terminal?workspaceId=${workspaceId}&terminalId=${terminalId}`;
+
+    const ws = new WebSocket(wsUrl, { headers: { Cookie: `band_token=${TOKEN}` } });
+
+    let sawOutput = false;
+    let errorFrame: string | undefined;
+
+    await new Promise<void>((resolve, reject) => {
+      ws.on("open", () => ws.send(JSON.stringify({ type: "init" })));
+      // The first server frame decides the outcome: a spawn failure sends a
+      // JSON `{type:"error"}` frame; a successful spawn streams scrollback /
+      // the shell prompt (binary or text). Either way we resolve on the
+      // first frame.
+      ws.on("message", (data: Buffer, isBinary: boolean) => {
+        if (!isBinary) {
+          try {
+            const parsed = JSON.parse(data.toString()) as { type?: string; message?: string };
+            if (parsed.type === "error") {
+              errorFrame = parsed.message;
+              resolve();
+              return;
+            }
+          } catch {
+            // Non-JSON text frame — that's PTY output.
+          }
+        }
+        sawOutput = true;
+        resolve();
+      });
+      ws.on("error", reject);
+      setTimeout(() => reject(new Error("No terminal frame within 10 s")), 10_000);
+    });
+
+    ws.close();
+
+    expect(errorFrame, `unexpected error frame: ${errorFrame}`).toBeUndefined();
+    expect(sawOutput).toBe(true);
+  });
+
+  it("rejects the terminal WebSocket upgrade without an auth token", async () => {
+    const port = new URL(server.url).port;
+    const wsUrl = `ws://127.0.0.1:${port}/terminal?workspaceId=workspace-main&terminalId=noauth-terminal`;
+
+    // No `Cookie` header — the upgrade must be destroyed before a PTY is
+    // ever attached, so the socket never reaches the "open" state.
+    const ws = new WebSocket(wsUrl);
+    const outcome = await new Promise<string>((resolve) => {
+      ws.on("open", () => resolve("open"));
+      ws.on("error", () => resolve("error"));
+      ws.on("close", () => resolve("closed"));
+      setTimeout(() => resolve("timeout"), 3000);
+    });
+    ws.close();
+
+    expect(outcome).not.toBe("open");
+  });
+});

--- a/apps/web/tests/tunnel-install-platform.test.ts
+++ b/apps/web/tests/tunnel-install-platform.test.ts
@@ -1,0 +1,69 @@
+// Integration test for the platform-guarded cloudflared installer (issue
+// #594, Linux standalone). Black-box against the production server bundle
+// (`dist/start-server.mjs`) over real HTTP tRPC. No mocks.
+//
+// The dashboard's "Install Tunnel" button hits `prereqs.installTunnel`,
+// which shells out to Homebrew (`brew install cloudflared`). Homebrew is
+// macOS-only, so on a stock Linux host the old code would fail with an
+// opaque `brew` ENOENT. The service now guards on `process.platform` and
+// throws a distro-appropriate hint on every non-darwin platform, which the
+// dashboard surfaces as a normal error instead of crashing.
+//
+// Only the platform-hint assertion is skipped on macOS: on darwin the
+// procedure would actually invoke `brew install cloudflared`, which must
+// never run from a test. The auth (401) assertion is platform-independent and
+// runs everywhere. CI runs on Linux, where the hint path is exercised.
+
+import { rmSync } from "node:fs";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { seedSettings } from "./helpers/seed-state";
+import { createTmpHome, type ServerHandle, startServer, trpcMutate } from "./helpers/server";
+
+const TOKEN = "tunnel-install-platform-token";
+
+describe("prereqs.installTunnel", () => {
+  let server: ServerHandle;
+  let tmpHome: string;
+
+  beforeAll(async () => {
+    tmpHome = createTmpHome("band-tunnel-install-platform-");
+    seedSettings(tmpHome, { tokenSecret: TOKEN });
+    server = await startServer({ tmpHome });
+  });
+
+  afterAll(async () => {
+    if (server) await server.close();
+    if (tmpHome) rmSync(tmpHome, { recursive: true, force: true });
+  });
+
+  // Skipped on darwin only — the assertion body reaches the brew shell-out on
+  // macOS. Everywhere else it exercises the non-darwin platform hint.
+  it.skipIf(process.platform === "darwin")(
+    "fails with a package-manager hint instead of shelling out to brew",
+    async () => {
+      const res = await trpcMutate(server.url, "prereqs.installTunnel", undefined, TOKEN);
+
+      // A plain thrown Error maps to tRPC INTERNAL_SERVER_ERROR → HTTP 500.
+      expect(res.status).toBe(500);
+      const body = (await res.json()) as { error: { message: string } };
+      expect(body.error.message).toContain("only supported on macOS");
+      expect(body.error.message).toMatch(/apt install cloudflared|dnf install cloudflared/);
+      expect(body.error.message).toContain(
+        "developers.cloudflare.com/cloudflare-one/connections/connect-networks/downloads",
+      );
+    },
+  );
+
+  it("returns 401 for prereqs.installTunnel without an auth token", async () => {
+    // Raw fetch with no `band_token` cookie — the shared `trpcMutate` helper
+    // always attaches one, so we bypass it to exercise the unauthenticated
+    // path. The auth gate must reject before any platform/brew logic runs.
+    // Platform-independent, so this runs on every OS (unlike the hint above).
+    const res = await fetch(`${server.url}/trpc/prereqs.installTunnel`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: "{}",
+    });
+    expect(res.status).toBe(401);
+  });
+});

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,37 @@
+# Run the standalone Band web server on Linux (issue #594) — no desktop app.
+#
+#   docker compose up --build
+#   → open the http://localhost:3456/?token=... URL printed on startup
+#
+# The image is a stock Debian host with NO zsh and NO Homebrew, so it
+# exercises the cross-platform shell/PATH fallbacks. State (SQLite DB,
+# settings, installed skills) lives in the `band-data` volume.
+#
+# To register a project: in the web UI use "Register Project" and enter the
+# container path of a repo you've mounted below (e.g. /projects/myrepo).
+services:
+  band:
+    build:
+      context: .
+      dockerfile: docker/Dockerfile
+    image: band-server:linux-test
+    # Host 3457 (not 3456): Band's default port is 3456, and if you already
+    # run Band natively it owns that port — the container would be shadowed.
+    ports:
+      - "3457:3456"
+    environment:
+      # Token for the ?token= access URL. Change it for anything shared.
+      BAND_ACCESS_TOKEN: band-local
+      # Host-side port (must match the left side of `ports` above) — used only
+      # for the access URL printed on startup.
+      BAND_HOST_PORT: "3457"
+    volumes:
+      - band-data:/data
+      # Mount a host git repo to register it as a Band project (read-write so
+      # worktrees can be created). Then add "/projects/myrepo" in the UI:
+      # - /absolute/path/to/your/repo:/projects/myrepo
+    tty: true
+    stop_grace_period: 10s
+
+volumes:
+  band-data:

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,87 @@
+# syntax=docker/dockerfile:1
+
+##############################################################################
+# Band server — Linux test image (issue #594)
+#
+# Builds the standalone @band-app/server (web-only, no Electron) plus the
+# Rust `band` CLI, then runs them on a stock Debian host that has NO zsh and
+# NO Homebrew — exactly the environment the Linux-compatibility work targets.
+# This is a test harness, not a production/publish image.
+##############################################################################
+
+# ---------------------------------------------------------------------------
+# Stage 1 — build the Rust `band` CLI.
+# Placing it on PATH in the runtime lets boot-time `band skills install`
+# resolve a binary (findBandBinary checks /usr/local/bin/band first) and lets
+# you exercise the CLI itself on Linux.
+# ---------------------------------------------------------------------------
+FROM rust:1-bookworm AS cli-builder
+WORKDIR /src
+COPY apps/cli ./apps/cli
+RUN cargo build --release --manifest-path apps/cli/Cargo.toml
+
+# ---------------------------------------------------------------------------
+# Stage 2 — build the self-contained web bundle (apps/web/dist).
+# Mirrors CI: node-pty 1.1.0 ships no linux-x64 prebuild, so it compiles via
+# node-gyp during `pnpm install` (node-pty is allow-listed in
+# pnpm-workspace.yaml's onlyBuiltDependencies) — the toolchain must be present.
+# ---------------------------------------------------------------------------
+FROM node:22-bookworm AS web-builder
+# `--max-old-space-size` mirrors CI (.github/workflows/ci.yml): the SSR vite
+# build otherwise hits the default ~2 GB V8 heap ceiling and aborts with
+# "JavaScript heap out of memory". Ensure Docker's VM has >=8 GB RAM.
+ENV ELECTRON_SKIP_BINARY_DOWNLOAD=1 \
+    PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 \
+    HUSKY=0 \
+    NODE_OPTIONS=--max-old-space-size=6144
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends python3 make g++ ca-certificates \
+ && rm -rf /var/lib/apt/lists/*
+RUN npm install -g pnpm@10 node-gyp
+WORKDIR /app
+COPY . .
+RUN pnpm install --frozen-lockfile
+RUN pnpm build:web
+
+# ---------------------------------------------------------------------------
+# Stage 3 — runtime: stock Debian slim, NO zsh, NO Homebrew.
+# node-pty's Linux .node is compiled against bookworm + Node 22 in stage 2;
+# keeping the runtime on the same base guarantees ABI/glibc compatibility.
+# ---------------------------------------------------------------------------
+FROM node:22-bookworm-slim AS runtime
+# git: workspaces / worktrees. ca-certificates: outbound HTTPS (gh, model
+# APIs). Deliberately no zsh — defaultShell() must fall back to /bin/bash.
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends git ca-certificates \
+ && rm -rf /var/lib/apt/lists/*
+
+# Install the CLI where the dashboard's checkCli() recognizes it as
+# "Installed": a symlink at /usr/local/bin/band resolving to a path ending in
+# "binaries/band" (the Electron-sidecar layout). A plain file at that path
+# instead reports as "ConflictingBinary", which makes the dashboard show a
+# spurious "Install band CLI / build it first" prompt. The symlink also keeps
+# `band` on PATH and lets skills-install resolve the binary.
+#
+# WORKAROUND (band-app/band#596): this exploits checkCli()'s brittle
+# `endsWith("binaries/band")` matcher because that detection is desktop-centric
+# and doesn't recognize a standalone Linux install. Remove this contrived path
+# once #596 makes CLI detection PATH/identity-aware — then a plain
+# `/usr/local/bin/band` (or any `band` on PATH) will read as Installed.
+COPY --from=cli-builder /src/apps/cli/target/release/band /opt/band/binaries/band
+RUN ln -sf /opt/band/binaries/band /usr/local/bin/band
+
+WORKDIR /app/apps/web
+COPY --from=web-builder /app/apps/web/dist ./dist
+COPY docker/entrypoint.sh /usr/local/bin/band-entrypoint.sh
+RUN chmod +x /usr/local/bin/band-entrypoint.sh
+
+# BAND_ACCESS_TOKEN is a convenience default for the ?token= access URL of
+# this LOCAL test harness only — it is NOT a real credential and this image
+# must never be published. In a real deployment the server generates a random
+# tokenSecret via getOrCreateToken(); this default never reaches one.
+ENV NODE_ENV=production \
+    PORT=3456 \
+    HOME=/data \
+    BAND_ACCESS_TOKEN=band-local
+EXPOSE 3456
+ENTRYPOINT ["/usr/local/bin/band-entrypoint.sh"]

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,135 @@
+# Band server on Linux — Docker test harness
+
+Runs the **standalone `@band-app/server`** (web-only, no Electron desktop app)
+on a stock Debian container with **no zsh and no Homebrew** — the exact
+environment the Linux-compatibility work (issue #594) targets. Use it to
+verify the server boots and the smoke flow works on Linux from a macOS host.
+
+## Run
+
+```sh
+# from the repo root
+docker compose up --build
+# (or, with the standalone v2 binary: docker-compose up --build)
+```
+
+On startup the container prints an access URL:
+
+```
+ Open:  http://localhost:3457/?token=band-local
+```
+
+> The container listens on 3456 internally but is published on host **3457**,
+> because Band's default port is 3456 — if you already run Band natively it
+> owns 3456 and would shadow the container. Change the mapping in
+> `docker-compose.yml` (`ports:` and `BAND_HOST_PORT`) if you like.
+
+Open that in your browser. The `?token=` sets the auth cookie (production
+mode enforces it); after the first load you can drop the query string.
+
+Change the token via `BAND_ACCESS_TOKEN` in `docker-compose.yml`.
+
+## What this exercises
+
+- **Shell fallback** — the container has bash + sh but no zsh and no `$SHELL`,
+  so `defaultShell()` falls back to `/bin/bash`. Spawn a terminal in the UI to
+  confirm it attaches.
+- **PATH resolution** — no Homebrew; `prependBinDirs()` uses `/usr/local/bin`
+  (+ Linuxbrew only if present) via `path.delimiter`.
+- **CLI + skills** — the Rust `band` binary is built and installed at
+  `/usr/local/bin/band`, so boot-time `band skills install` resolves and you
+  can run `band` inside the container:
+  ```sh
+  docker compose exec band band --help
+  docker compose exec band band skills install
+  ```
+- **Tunnel install hint** — clicking "Install Tunnel" surfaces the Linux
+  package-manager hint instead of shelling out to a nonexistent `brew`.
+
+## Add a project
+
+The container **auto-creates and registers a `sample` project** at
+`/data/projects/sample` on first boot, so there's always something to open.
+To add more, note: a "project" is just a directory the server can see (a git
+repo, or a plain folder — plain folders get a single implicit workspace).
+
+> **The path must exist inside the container.** Registering a path that isn't
+> there (e.g. the placeholder `/projects/myrepo` without a matching bind
+> mount) leaves a project whose directory is missing — terminals then fail
+> with `Workspace directory does not exist: <path>`. Either mount a real repo
+> at that path (option 2) or use an in-container path like
+> `/data/projects/...`. Remove a broken entry with `band projects remove <name>`.
+
+Three ways to add your own:
+
+### 1. Create a sample repo inside the container (quickest)
+
+Put it under `/data` so it lives in the persisted `band-data` volume, then
+register it with the bundled `band` CLI (which talks to the local server):
+
+```sh
+docker compose exec band sh -lc \
+  'mkdir -p /data/projects/sample && cd /data/projects/sample \
+   && git init -q && echo "# Sample" > README.md \
+   && git add -A && git commit -qm init'
+
+docker compose exec band band projects add /data/projects/sample
+```
+
+It appears immediately in the web UI. You can also drive it entirely from the
+CLI — e.g. create a workspace (git worktree):
+
+```sh
+docker compose exec band band workspaces create sample feat/demo
+docker compose exec band band projects list
+docker compose exec band band workspaces list
+```
+
+### 2. Mount a real host repo
+
+Uncomment the bind mount in `docker-compose.yml` (read-write, so `git
+worktree` can write its metadata into the repo's `.git`):
+
+```yaml
+    volumes:
+      - band-data:/data
+      - /absolute/path/to/your/repo:/projects/myrepo
+```
+
+Then register it (uid mismatches are already handled — the entrypoint sets
+`git config --global --add safe.directory '*'`):
+
+```sh
+docker compose exec band band projects add /projects/myrepo
+# …or use "Register Project" in the UI and enter /projects/myrepo
+```
+
+### 3. From the UI
+
+Use **Register Project** and type the container path (e.g. `/projects/myrepo`
+or `/data/projects/sample`).
+
+> Note: `--label` on `band projects add` refers to a pre-defined grouping
+> label, not a display name — omit it unless you've created labels. Remove a
+> project with `band projects remove <name>`.
+
+## Persisted state
+
+Everything the server writes (SQLite DB, `settings.json`, installed skills
+under `~/.agents`) lives in the `band-data` volume mounted at `/data`
+(`$HOME` in the container). Inspect or reset it:
+
+```sh
+docker compose down            # keep state
+docker compose down -v         # wipe state (removes the band-data volume)
+```
+
+## Known gaps (out of scope for #594)
+
+- **Coding agents aren't installed.** `claude` / `codex` / etc. are not in the
+  image, so "run an agent task" end-to-end won't work here — terminals, setup
+  scripts, git/worktrees, and skills install do. Mount an agent binary or
+  extend the image if you need to drive a real agent.
+- **This is not a publishable image.** It builds from source on every run and
+  ships the whole `dist/` bundle; it's meant for local Linux verification, not
+  distribution.

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,69 @@
+#!/bin/sh
+set -eu
+
+# Band server container entrypoint. Seeds a known access token (production
+# auth enforces the band_token cookie), configures git for bind-mounted
+# repos, provisions a ready-to-use sample project, prints the access URL,
+# then runs the server (auto-registering the sample once it's up).
+
+BAND_DIR="$HOME/.band"
+mkdir -p "$BAND_DIR"
+
+# getOrCreateToken() keeps an existing tokenSecret, so we only seed one on
+# first boot. Visiting /?token=<secret> sets the cookie for the session.
+if [ ! -f "$BAND_DIR/settings.json" ]; then
+  printf '{\n  "tokenSecret": "%s"\n}\n' "$BAND_ACCESS_TOKEN" > "$BAND_DIR/settings.json"
+fi
+
+# git needs an identity for worktree/commit operations and must trust
+# bind-mounted repos owned by a different uid than the container user.
+git config --global --add safe.directory '*' >/dev/null 2>&1 || true
+git config --global user.email "band@localhost" >/dev/null 2>&1 || true
+git config --global user.name "Band" >/dev/null 2>&1 || true
+git config --global init.defaultBranch main >/dev/null 2>&1 || true
+
+# A ready-to-use sample project on the persisted volume. A registered project
+# whose directory doesn't exist on disk fails to spawn terminals, so we always
+# provide at least one valid one.
+SAMPLE="$HOME/projects/sample"
+if [ ! -d "$SAMPLE/.git" ]; then
+  mkdir -p "$SAMPLE"
+  ( cd "$SAMPLE" \
+    && git init -q \
+    && printf '# Sample project\n\nCreated by the Band Linux test container.\n' > README.md \
+    && git add -A && git commit -qm "init" ) >/dev/null 2>&1 || true
+fi
+
+TOKEN="$(node -e "process.stdout.write(require('$BAND_DIR/settings.json').tokenSecret || '')" 2>/dev/null || echo "$BAND_ACCESS_TOKEN")"
+HOST_PORT="${BAND_HOST_PORT:-$PORT}"
+
+echo "──────────────────────────────────────────────────────────────"
+echo " Band server (Linux standalone) listening on container port ${PORT}"
+echo " Open:  http://localhost:${HOST_PORT}/?token=${TOKEN}"
+echo " State: ${BAND_DIR} (mounted volume)"
+echo " Sample project: ${SAMPLE} (auto-registered once the server is up)"
+echo "──────────────────────────────────────────────────────────────"
+
+# Run the server in the background so we can register the sample project once
+# it answers, while forwarding termination signals for a clean shutdown.
+term() { kill -TERM "$SERVER_PID" 2>/dev/null || true; }
+trap term TERM INT
+node dist/start-server.mjs &
+SERVER_PID=$!
+
+# Register the sample project once the server responds (idempotent, non-fatal).
+# `band projects list` doubles as the readiness probe — it talks to the local
+# server using the token from settings.json.
+(
+  i=0
+  while [ "$i" -lt 40 ]; do
+    if band projects list >/dev/null 2>&1; then
+      band projects add "$SAMPLE" >/dev/null 2>&1 || true
+      break
+    fi
+    i=$((i + 1))
+    sleep 0.5
+  done
+) &
+
+wait "$SERVER_PID"


### PR DESCRIPTION
Closes #594.

Makes the web-only `@band-app/server` boot and run on a stock Linux host — no Electron, no Homebrew, no zsh — by replacing macOS-specific runtime assumptions with cross-platform helpers that branch on `process.platform` / `path.delimiter` (the `lsp-manager.ts` model). Runtime-only; desktop packaging is out of scope.

## Changes

**Shell + PATH (`infra/process/path.ts`)**
- `defaultShell()` — honours `$SHELL`, else probes `/bin/zsh → /bin/bash → /bin/sh` (macOS still gets zsh, Linux gets bash/sh); win32 `ComSpec` stub for #150.
- `extraBinDirs()` / `prependBinDirs()` — Homebrew prefixes on macOS; `/usr/local/bin` + Linuxbrew-if-present on Linux; joined with `path.delimiter`; memoized so the git/gh hot path stays a string join.
- Threaded through `terminal-pool`, `setup-runner`, `git-client` (`gitCmd`/`execGh`) and `workspace-service` teardown, dropping the hardcoded `/opt/homebrew/bin:/usr/local/bin` prefix and `/bin/zsh` fallback.

**Tunnel install (`system-service.installCloudflared`)**
- Guards on `darwin`; on Linux throws a distro-appropriate hint (apt/dnf/download) instead of shelling out to a nonexistent `brew`. The dashboard already catches and displays it — no crash.

**Frontend / CLI**
- No changes needed: the dashboard already gates desktop-only affordances (folder picker, reveal, browser pane) on capability detection; `installCli`/CLI probes already degrade cleanly on Linux (sudo-hint fallthrough, swallowed at boot).

## Tests (integration, real `dist/start-server.mjs`)
- `terminal-shell-fallback` — a terminal spawns with `$SHELL` unset (regression guard for the old `/bin/zsh` hardcode) + WS auth-rejection case.
- `tunnel-install-platform` — `installTunnel` returns the Linux hint (runs off-darwin) + a platform-independent 401 auth case.

## Docker test harness
`docker/` + `docker-compose.yml` run the standalone server on stock Debian (no zsh/Homebrew) so the Linux smoke flow can be verified from a macOS host. Explicitly a local test harness, not a publishable image. Verified end-to-end: server boots, skills install, terminals spawn, tunnel hint fires, sample project auto-registered.

## CI
The existing `check` job already runs on `ubuntu-latest`, so the new tests run on Linux there.

## Follow-ups
- #596 — CLI detection (`checkCli`) is desktop-centric and nags on standalone Linux installs (the Docker harness works around it with a documented comment).
- #150 — Windows runtime (win32 branches are structural stubs here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)