### PR TITLE
feat(web): track last-focused panel per type; route Add to Chat/Terminal to it

### DIFF
--- a/apps/web/e2e/add-to-chat-last-focused.spec.ts
+++ b/apps/web/e2e/add-to-chat-last-focused.spec.ts
@@ -119,20 +119,30 @@ test.describe("Add to Chat — routes to the last-focused chat pane", () => {
     await workspace.clickChatSplitRight(workspaceId);
     await expect.poll(() => chat.promptCount(), { timeout: 15_000 }).toBe(2);
 
+    // Focus pane 0 first and capture the chat id the server records for it.
     await chat.focusPromptAt(0);
     await chat.fillPromptAt(0, "AAA");
-    await chat.focusPromptAt(1);
-    await chat.fillPromptAt(1, "BBB");
-
-    // Barrier: wait until the server has recorded a chat focus (the last report
-    // was pane 1's). "Add to Chat" reads this exactly once, so it must settle
-    // before we trigger the action.
     await expect
       .poll(() => workspace.readServerPanelFocus(workspaceId).then((f) => f.chat), {
-        message: "server records the last-focused chat",
+        message: "pane 0 recorded as the focused chat",
         timeout: 15_000,
       })
       .toBeTruthy();
+    const pane0ChatId = (await workspace.readServerPanelFocus(workspaceId)).chat;
+
+    // Focus pane 1 and wait until the server focus actually FLIPS away from
+    // pane 0 — the barrier that matters, since "Add to Chat" reads the focus
+    // exactly once (a mere truthy poll could pass on pane 0's earlier report
+    // and route the reference into the wrong pane, which the one-shot read
+    // can't self-heal). Mirrors the terminal spec's `.toBe(...)` barrier.
+    await chat.focusPromptAt(1);
+    await chat.fillPromptAt(1, "BBB");
+    await expect
+      .poll(() => workspace.readServerPanelFocus(workspaceId).then((f) => f.chat), {
+        message: "focus flips to pane 1 (the last-focused chat)",
+        timeout: 15_000,
+      })
+      .not.toBe(pane0ChatId);
 
     // Trigger "Add to Chat" from the diff selection tooltip.
     await workspace.activateTab("changes");

--- a/apps/web/e2e/add-to-chat-last-focused.spec.ts
+++ b/apps/web/e2e/add-to-chat-last-focused.spec.ts
@@ -1,0 +1,153 @@
+/**
+ * End-to-end coverage for "Add to Chat" routing to the workspace's LAST-FOCUSED
+ * chat pane when several chats are open.
+ *
+ * Before this feature every mounted `PromptInput` in the active workspace
+ * listened to the raw `band:add-to-chat` event, so a file reference was
+ * appended to *all* open chat panes. Now `SharedDockviewLayout` resolves the
+ * server's last-focused chat (recorded as the user switches panes) and
+ * re-dispatches a `band:chat-insert` scoped to that one chatId, so only the
+ * pane the user was last using receives the reference.
+ *
+ * Architecture (mirrors `selection-tooltip-actions.spec.ts`): the REAL
+ * production `dist/start-server.mjs` boots against a fresh tmp `$HOME` with an
+ * on-disk git worktree; no tRPC mocking. The chat prompt values are read
+ * straight from the rendered DOM, so the delivered reference is observed on the
+ * real textarea it landed in.
+ *
+ * Determinism: focus is reported to the server fire-and-forget, so the test
+ * polls `panelFocus.get` (via the page object) until the second pane is the
+ * recorded chat focus before triggering "Add to Chat" — the action reads the
+ * focus exactly once, so the record must be settled first. The two panes are
+ * seeded with distinct markers ("AAA" / "BBB") so the assertion is independent
+ * of dockview's DOM ordering of the split groups.
+ */
+
+import { mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { expect, test } from "@playwright/test";
+import { toWorkspaceId } from "@/dashboard";
+import { git } from "./helpers/git";
+import {
+  cleanupTmpHome,
+  createTmpHome,
+  type ServerHandle,
+  seedSettings,
+  seedState,
+  startServer,
+} from "./helpers/server";
+import { ChangesPanelPage } from "./pages/ChangesPanelPage";
+import { ChatPanePage } from "./pages/ChatPanePage";
+import { SelectionTooltipPage } from "./pages/SelectionTooltipPage";
+import { WorkspacePage } from "./pages/WorkspacePage";
+
+// Wide viewport so `useIsDesktop()` reports true and the diff editor renders
+// (same reasoning as selection-tooltip-actions.spec / diff-horizontal-scroll).
+test.use({ viewport: { width: 2400, height: 900 } });
+
+const TOKEN = "e2e-add-to-chat-focus-token";
+const REPO_NAME = "add-to-chat-focus-repo";
+const BRANCH = "main";
+const FILE_PATH = "src/notes.txt";
+const FIRST_LINE = "alpha";
+const EXPECTED_REFERENCE = `${FILE_PATH}:1`;
+// Chat wraps the bare reference in a markdown code span (clickable file link)
+// and appends a trailing space to separate it from the next keystroke.
+const EXPECTED_CHAT_INSERT = `\`${EXPECTED_REFERENCE}\` `;
+
+let server: ServerHandle;
+let tmpHome: string;
+let repoPath: string;
+let workspaceId: string;
+
+test.beforeAll(async () => {
+  tmpHome = createTmpHome();
+  repoPath = join(tmpHome, REPO_NAME);
+  mkdirSync(join(repoPath, "src"), { recursive: true });
+
+  git(repoPath, ["init", "-b", BRANCH]);
+  writeFileSync(join(repoPath, FILE_PATH), `${FIRST_LINE}\n`);
+  git(repoPath, ["add", "."]);
+  git(repoPath, ["commit", "-m", "initial"]);
+  // Leave a second line modified on disk so the Changes view lists the file.
+  writeFileSync(join(repoPath, FILE_PATH), `${FIRST_LINE}\nbeta\n`);
+
+  seedState(tmpHome, {
+    projects: [
+      {
+        name: REPO_NAME,
+        path: repoPath,
+        defaultBranch: BRANCH,
+        worktrees: [{ branch: BRANCH, path: repoPath }],
+      },
+    ],
+  });
+  seedSettings(tmpHome, { tokenSecret: TOKEN });
+  server = await startServer({ tmpHome });
+  workspaceId = toWorkspaceId(REPO_NAME, BRANCH);
+});
+
+test.afterAll(async () => {
+  await server.close();
+  cleanupTmpHome(tmpHome);
+});
+
+test.describe("Add to Chat — routes to the last-focused chat pane", () => {
+  test("appends the reference only to the pane the user last focused", async ({ page }) => {
+    const workspace = new WorkspacePage(page, server.url, TOKEN);
+    const chat = new ChatPanePage(page, server.url, TOKEN);
+    const tooltip = new SelectionTooltipPage(page);
+
+    // Open the Changes panel (expand-all) so the diff is ready to select from,
+    // then wait for the shared dockview to be interactive.
+    const changes = await ChangesPanelPage.openWithFileExpanded({
+      page,
+      baseUrl: server.url,
+      token: TOKEN,
+      workspaceId,
+      filename: FILE_PATH,
+      fileStatus: "M",
+      viewMode: "unified",
+    });
+    await workspace.waitForReady();
+
+    // Open a second chat pane by splitting the chat group, then seed each pane
+    // with a distinct marker. Filling a pane focuses it; the last one filled
+    // (pane index 1) is the workspace's last-focused chat.
+    await workspace.activateTab("chat");
+    await chat.waitForReady();
+    await workspace.clickChatSplitRight(workspaceId);
+    await expect.poll(() => chat.promptCount(), { timeout: 15_000 }).toBe(2);
+
+    await chat.focusPromptAt(0);
+    await chat.fillPromptAt(0, "AAA");
+    await chat.focusPromptAt(1);
+    await chat.fillPromptAt(1, "BBB");
+
+    // Barrier: wait until the server has recorded a chat focus (the last report
+    // was pane 1's). "Add to Chat" reads this exactly once, so it must settle
+    // before we trigger the action.
+    await expect
+      .poll(() => workspace.readServerPanelFocus(workspaceId).then((f) => f.chat), {
+        message: "server records the last-focused chat",
+        timeout: 15_000,
+      })
+      .toBeTruthy();
+
+    // Trigger "Add to Chat" from the diff selection tooltip.
+    await workspace.activateTab("changes");
+    await changes.selectWordInDiff(FIRST_LINE);
+    await tooltip.waitVisible();
+    await tooltip.clickAddToChat();
+
+    // Exactly one pane receives the reference — the last-focused one ("BBB") —
+    // and the other ("AAA") is left untouched. Sorted comparison so the
+    // assertion doesn't depend on dockview's DOM ordering of the split groups.
+    await expect
+      .poll(() => chat.allPromptValues().then((v) => [...v].sort()), {
+        message: "reference lands only in the last-focused pane",
+        timeout: 15_000,
+      })
+      .toEqual(["AAA", `BBB${EXPECTED_CHAT_INSERT}`].sort());
+  });
+});

--- a/apps/web/e2e/add-to-terminal-last-focused.spec.ts
+++ b/apps/web/e2e/add-to-terminal-last-focused.spec.ts
@@ -1,0 +1,162 @@
+/**
+ * End-to-end coverage for "Add to Terminal" routing to the workspace's
+ * LAST-FOCUSED terminal when several terminals are open.
+ *
+ * The mirror of `add-to-chat-last-focused.spec.ts` for the terminal path.
+ * Before this feature the reference went to whichever terminal happened to be
+ * *visible*; now `SharedDockviewLayout` resolves the server's last-focused
+ * terminal and re-dispatches a `band:terminal-insert` carrying that terminalId,
+ * so only that terminal's PTY receives it.
+ *
+ * Architecture (mirrors `selection-tooltip-actions.spec.ts`): the REAL
+ * production `dist/start-server.mjs` boots against a fresh tmp `$HOME` with an
+ * on-disk git worktree; no tRPC mocking. Terminal input is captured via the
+ * outgoing WebSocket frames (the `ws.send(reference)` → server → `pty.write`
+ * path IS the delivery, and the WebGL-rendered terminal text can't be read from
+ * the DOM). `installTerminalSendUrlCapture` records each frame with its socket
+ * URL, so `terminalIdsThatReceived` can prove WHICH terminal got the reference.
+ *
+ * The two terminals are distinguished purely by server-recorded focus: after
+ * splitting (which activates the NEW terminal), the test clicks back into the
+ * FIRST terminal so the last-focused terminal is the older, non-newest one —
+ * a meaningful "follows focus, not just the newest/visible tab" signal. Focus
+ * is reported fire-and-forget, so the test polls `panelFocus.get` until the
+ * recorded terminal actually changes to the re-focused pane before triggering
+ * "Add to Terminal" (which reads the focus exactly once).
+ */
+
+import { mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { expect, test } from "@playwright/test";
+import { toWorkspaceId } from "@/dashboard";
+import { git } from "./helpers/git";
+import {
+  cleanupTmpHome,
+  createTmpHome,
+  type ServerHandle,
+  seedSettings,
+  seedState,
+  startServer,
+} from "./helpers/server";
+import { ChangesPanelPage } from "./pages/ChangesPanelPage";
+import { SelectionTooltipPage } from "./pages/SelectionTooltipPage";
+import { WorkspacePage } from "./pages/WorkspacePage";
+
+// Wide viewport so `useIsDesktop()` reports true and the diff editor renders.
+test.use({ viewport: { width: 2400, height: 900 } });
+
+const TOKEN = "e2e-add-to-terminal-focus-token";
+const REPO_NAME = "add-to-terminal-focus-repo";
+const BRANCH = "main";
+const FILE_PATH = "src/notes.txt";
+const FIRST_LINE = "alpha";
+const EXPECTED_REFERENCE = `${FILE_PATH}:1`;
+// Terminal receives the bare reference + trailing space, no newline.
+const EXPECTED_TERMINAL_INSERT = `${EXPECTED_REFERENCE} `;
+
+let server: ServerHandle;
+let tmpHome: string;
+let repoPath: string;
+let workspaceId: string;
+
+test.beforeAll(async () => {
+  tmpHome = createTmpHome();
+  repoPath = join(tmpHome, REPO_NAME);
+  mkdirSync(join(repoPath, "src"), { recursive: true });
+
+  git(repoPath, ["init", "-b", BRANCH]);
+  writeFileSync(join(repoPath, FILE_PATH), `${FIRST_LINE}\n`);
+  git(repoPath, ["add", "."]);
+  git(repoPath, ["commit", "-m", "initial"]);
+  writeFileSync(join(repoPath, FILE_PATH), `${FIRST_LINE}\nbeta\n`);
+
+  seedState(tmpHome, {
+    projects: [
+      {
+        name: REPO_NAME,
+        path: repoPath,
+        defaultBranch: BRANCH,
+        worktrees: [{ branch: BRANCH, path: repoPath }],
+      },
+    ],
+  });
+  seedSettings(tmpHome, { tokenSecret: TOKEN });
+  server = await startServer({ tmpHome });
+  workspaceId = toWorkspaceId(REPO_NAME, BRANCH);
+});
+
+test.afterAll(async () => {
+  await server.close();
+  cleanupTmpHome(tmpHome);
+});
+
+test.describe("Add to Terminal — routes to the last-focused terminal", () => {
+  test("types the reference only into the terminal the user last focused", async ({ page }) => {
+    const workspace = new WorkspacePage(page, server.url, TOKEN);
+    const tooltip = new SelectionTooltipPage(page);
+
+    // Must register before the navigation the factory performs.
+    await workspace.installTerminalSendUrlCapture();
+
+    const changes = await ChangesPanelPage.openWithFileExpanded({
+      page,
+      baseUrl: server.url,
+      token: TOKEN,
+      workspaceId,
+      filename: FILE_PATH,
+      fileStatus: "M",
+      viewMode: "unified",
+    });
+    await workspace.waitForReady();
+
+    // Open a first terminal (live PTY socket) and capture its id from the
+    // server-recorded focus.
+    await workspace.openTerminalTab();
+    await workspace.waitForTerminalReady();
+    await expect
+      .poll(() => workspace.readServerPanelFocus(workspaceId).then((f) => f.terminal), {
+        message: "first terminal recorded as focused",
+        timeout: 15_000,
+      })
+      .toBeTruthy();
+    const firstTerminalId = (await workspace.readServerPanelFocus(workspaceId)).terminal;
+
+    // Split into a second terminal. Splitting activates the NEW terminal, so it
+    // becomes the recorded focus (confirming focus tracking follows the split).
+    await workspace.clickTerminalSplitRight(workspaceId);
+    await expect
+      .poll(() => workspace.countTerminalPanels(workspaceId), { timeout: 15_000 })
+      .toBe(2);
+    await expect
+      .poll(() => workspace.readServerPanelFocus(workspaceId).then((f) => f.terminal), {
+        message: "split terminal becomes the recorded focus",
+        timeout: 15_000,
+      })
+      .not.toBe(firstTerminalId);
+
+    // Click back into the FIRST terminal so the last-focused terminal is the
+    // older pane — proving routing follows focus, not the newest/visible tab.
+    await workspace.focusTerminalPane(0);
+    await expect
+      .poll(() => workspace.readServerPanelFocus(workspaceId).then((f) => f.terminal), {
+        message: "re-focused (older) terminal becomes the recorded focus",
+        timeout: 15_000,
+      })
+      .toBe(firstTerminalId);
+    const targetTerminalId = firstTerminalId;
+
+    // Trigger "Add to Terminal" from the diff selection tooltip.
+    await workspace.activateTab("changes");
+    await changes.selectWordInDiff(FIRST_LINE);
+    await tooltip.waitVisible();
+    await tooltip.clickAddToTerminal();
+
+    // The reference reaches exactly the last-focused terminal — no sibling.
+    await expect
+      .poll(() => workspace.terminalIdsThatReceived(EXPECTED_TERMINAL_INSERT), {
+        message: "reference typed only into the last-focused terminal",
+        timeout: 15_000,
+      })
+      .toEqual([targetTerminalId]);
+  });
+});

--- a/apps/web/e2e/pages/ChatPanePage.ts
+++ b/apps/web/e2e/pages/ChatPanePage.ts
@@ -119,6 +119,44 @@ export class ChatPanePage {
     return await this.promptInput.inputValue();
   }
 
+  /** All prompt textareas currently mounted for the active workspace — one per
+   *  open chat pane. Used by the last-focused-routing test, where a split
+   *  produces two panes and the reference must land in exactly one of them. */
+  get promptInputs(): Locator {
+    return this.page.getByPlaceholder("Type a message...");
+  }
+
+  /** Number of open chat panes (prompt textareas) in the active workspace. */
+  async promptCount(): Promise<number> {
+    return await this.promptInputs.count();
+  }
+
+  /** Click into the Nth chat pane's prompt so it becomes the focused (active)
+   *  pane — this is what the container reports to the server as the workspace's
+   *  last-focused chat. Click (not `focus()`) so dockview's focusin tracking
+   *  fires and the active panel actually switches. */
+  async focusPromptAt(index: number): Promise<void> {
+    await test.step(`Focus chat pane #${index}`, async () => {
+      await this.promptInputs.nth(index).click();
+    });
+  }
+
+  /** Type text into the Nth chat pane's prompt (replacing its content). */
+  async fillPromptAt(index: number, text: string): Promise<void> {
+    await test.step(`Fill chat pane #${index} with "${text}"`, async () => {
+      await this.promptInputs.nth(index).fill(text);
+    });
+  }
+
+  /** Snapshot every open pane's prompt value. Order-independent assertions
+   *  (which pane received the reference) sort these rather than depending on
+   *  dockview's DOM ordering of split groups. */
+  async allPromptValues(): Promise<string[]> {
+    return await this.promptInputs.evaluateAll((els) =>
+      els.map((el) => (el as HTMLTextAreaElement).value),
+    );
+  }
+
   /** Clear the prompt textarea. Most submit paths empty the textarea
    *  already, but the draft-persistence logic in `PromptInput` can
    *  leave whitespace behind — call this before tests that need a

--- a/apps/web/e2e/pages/WorkspacePage.ts
+++ b/apps/web/e2e/pages/WorkspacePage.ts
@@ -1386,6 +1386,65 @@ export class WorkspacePage {
     );
   }
 
+  /** Like `installTerminalSendCapture`, but records each STRING frame together
+   *  with the socket URL it was written to (`/terminal?…&terminalId=<id>`) so a
+   *  test with several open terminals can prove WHICH terminal received a
+   *  reference. Must run BEFORE `goto` (uses `addInitScript`). */
+  async installTerminalSendUrlCapture(): Promise<void> {
+    await this.page.addInitScript(() => {
+      const w = window as unknown as { __terminalSentUrls: { url: string; data: string }[] };
+      w.__terminalSentUrls = [];
+      const origSend = WebSocket.prototype.send;
+      WebSocket.prototype.send = function patchedSend(
+        this: WebSocket,
+        data: string | ArrayBufferLike | Blob | ArrayBufferView,
+      ) {
+        try {
+          if (
+            typeof this.url === "string" &&
+            this.url.includes("/terminal?") &&
+            typeof data === "string"
+          ) {
+            w.__terminalSentUrls.push({ url: this.url, data });
+          }
+        } catch {
+          // Ignore — never let instrumentation break the real send.
+        }
+        return origSend.call(this, data as never);
+      };
+    });
+  }
+
+  /** The terminalIds whose socket received a frame containing `needle`. Reads
+   *  the `{url, data}` pairs captured by `installTerminalSendUrlCapture()` and
+   *  extracts each matching frame's `terminalId` query param. Used to assert a
+   *  reference reached exactly the last-focused terminal and no sibling. */
+  async terminalIdsThatReceived(needle: string): Promise<string[]> {
+    return await this.page.evaluate((n) => {
+      const frames =
+        (window as unknown as { __terminalSentUrls?: { url: string; data: string }[] })
+          .__terminalSentUrls ?? [];
+      const ids = new Set<string>();
+      for (const f of frames) {
+        if (!f.data.includes(n)) continue;
+        const id = new URL(f.url).searchParams.get("terminalId");
+        if (id) ids.add(id);
+      }
+      return [...ids];
+    }, needle);
+  }
+
+  /** Click into the Nth terminal pane's render surface so it becomes the active
+   *  (focused) terminal — what the container reports to the server as the
+   *  workspace's last-focused terminal. `.xterm-screen` is xterm-owned DOM (no
+   *  testid to hook; same FRAGILITY carve-out as the other xterm probes here),
+   *  and clicking it routes focus through xterm → dockview's focusin tracking. */
+  async focusTerminalPane(index: number): Promise<void> {
+    await test.step(`Focus terminal pane #${index}`, async () => {
+      await this.page.locator(".xterm-screen").nth(index).click();
+    });
+  }
+
   // ──────────────────────────────────────────────────────────────────────
   // Terminal file links → file browser
   // ──────────────────────────────────────────────────────────────────────

--- a/apps/web/e2e/pages/WorkspacePage.ts
+++ b/apps/web/e2e/pages/WorkspacePage.ts
@@ -811,6 +811,22 @@ export class WorkspacePage {
     });
   }
 
+  /** Read the server's recorded last-focused panel ids for a workspace via the
+   *  `panelFocus.get` tRPC query. Used as a synchronisation barrier: focus is
+   *  reported fire-and-forget, so a test polls this until the pane it just
+   *  focused is recorded before triggering an "Add to …" action that reads it.
+   *  Auth is the `band_token` cookie, matching the tRPC HTTP helpers. */
+  async readServerPanelFocus(
+    workspaceId: string,
+  ): Promise<{ chat?: string; terminal?: string; browser?: string }> {
+    const input = encodeURIComponent(JSON.stringify({ workspaceId }));
+    const res = await this.page.request.get(`${this.baseUrl}/trpc/panelFocus.get?input=${input}`, {
+      headers: { Cookie: `band_token=${this.token}` },
+    });
+    const body = (await res.json()) as { result?: { data?: Record<string, string> } };
+    return body.result?.data ?? {};
+  }
+
   /** Wait for the terminal's xterm input to be attached — the DOM-level
    *  signal that the xterm instance mounted. xterm keeps its input as an
    *  offscreen "helper" textarea (Playwright reports it as hidden, never

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -1051,6 +1051,8 @@ export function ChatView({
             draftKey={workspaceId}
             visible={visible}
             wsActive={wsActive}
+            workspaceId={workspaceId}
+            chatId={chatId}
           >
             <SlashCommandSuggestions skills={skills} />
             <FileMentionSuggestions workspaceId={workspaceId} />

--- a/apps/web/src/components/DockviewBrowserContainer.tsx
+++ b/apps/web/src/components/DockviewBrowserContainer.tsx
@@ -423,6 +423,11 @@ export function DockviewBrowserContainer({
   const apiRef = useRef<DockviewApi | null>(null);
   const isRestoringRef = useRef(false);
   const containerRef = useRef<HTMLDivElement>(null);
+  // Mirror `wsActive` for use inside stable closures so focus reporting only
+  // fires for the workspace the user is looking at — never for the cached,
+  // hidden workspaces MultiWorkspacePanelHost keeps alive.
+  const wsActiveRef = useRef(wsActive);
+  wsActiveRef.current = wsActive;
   // Tracks the cleanup function returned by `attachEdgeGroupDragVisibility`
   // so the drag-visibility listeners can be detached on unmount (or on a
   // hypothetical re-`onReady`).
@@ -466,6 +471,17 @@ export function DockviewBrowserContainer({
     const api = apiRef.current;
     if (!api) return;
     persistToServer(workspaceId, api.toJSON(), { queryClient: queryClientRef.current });
+  }, [workspaceId]);
+
+  // Report the active browser tab to the server as the workspace's last-focused
+  // browser. Gated on `wsActive` and skipped during layout restore.
+  // Fire-and-forget — tracked for symmetry with chat/terminal focus.
+  const reportBrowserFocus = useCallback(() => {
+    if (isRestoringRef.current) return;
+    if (wsActiveRef.current === false) return;
+    const panelId = apiRef.current?.activePanel?.id;
+    if (!panelId) return;
+    trpc.panelFocus.set.mutate({ workspaceId, panelType: "browser", panelId }).catch(() => {});
   }, [workspaceId]);
 
   const handleAddTab = useCallback(
@@ -1180,7 +1196,10 @@ export function DockviewBrowserContainer({
       event.api.onDidLayoutChange(persist);
       event.api.onDidAddPanel(persist);
       event.api.onDidRemovePanel(persist);
-      event.api.onDidActivePanelChange(persist);
+      event.api.onDidActivePanelChange(() => {
+        persist();
+        reportBrowserFocus();
+      });
       event.api.onDidAddGroup(persist);
       event.api.onDidRemoveGroup(persist);
 
@@ -1196,7 +1215,7 @@ export function DockviewBrowserContainer({
         }
       }
     },
-    [workspaceId, schedulePersist],
+    [workspaceId, schedulePersist, reportBrowserFocus],
   );
 
   const visibilityValue = useMemo(

--- a/apps/web/src/components/DockviewChatContainer.tsx
+++ b/apps/web/src/components/DockviewChatContainer.tsx
@@ -11,7 +11,7 @@ import {
 } from "dockview";
 import { Columns2, Plus, Rows2, X } from "lucide-react";
 import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { AgentIcon, useAdapter } from "@/dashboard";
+import { AgentIcon, type ChatInsertDetail, useAdapter } from "@/dashboard";
 import { writeClipboardText } from "../lib/clipboard";
 import {
   attachEdgeGroupDragVisibility,
@@ -642,6 +642,11 @@ export function DockviewChatContainer({
   const apiRef = useRef<DockviewApi | null>(null);
   const isRestoringRef = useRef(false);
   const containerRef = useRef<HTMLDivElement>(null);
+  // Mirror `wsActive` for use inside stable closures (onReady, event handlers)
+  // so focus reporting only fires for the workspace the user is looking at —
+  // never for the cached, hidden workspaces MultiWorkspacePanelHost keeps alive.
+  const wsActiveRef = useRef(wsActive);
+  wsActiveRef.current = wsActive;
   // Tracks the cleanup function returned by `attachEdgeGroupDragVisibility`
   // so the drag-visibility listeners can be detached on unmount (or on a
   // hypothetical re-`onReady`).
@@ -677,6 +682,18 @@ export function DockviewChatContainer({
     const api = apiRef.current;
     if (!api) return;
     persistToServer(workspaceId, api.toJSON(), { queryClient: queryClientRef.current });
+  }, [workspaceId]);
+
+  // Report the active chat tab to the server as the workspace's last-focused
+  // chat. Gated on `wsActive` (skip cached/hidden workspaces) and skipped while
+  // restoring the saved layout (fromJSON fires spurious activePanelChange).
+  // Fire-and-forget — this is a best-effort hint for "Add to Chat" routing.
+  const reportChatFocus = useCallback(() => {
+    if (isRestoringRef.current) return;
+    if (wsActiveRef.current === false) return;
+    const panelId = apiRef.current?.activePanel?.id;
+    if (!panelId) return;
+    trpc.panelFocus.set.mutate({ workspaceId, panelType: "chat", panelId }).catch(() => {});
   }, [workspaceId]);
 
   const handleAddTab = useCallback(
@@ -893,9 +910,27 @@ export function DockviewChatContainer({
       const group = apiRef.current?.activeGroup;
       if (!group) return;
       group.model.focusContent();
+      // Record a baseline last-focused chat as soon as the section is shown,
+      // so "Add to Chat" has a target even if the user never switches tabs.
+      reportChatFocus();
     });
     return () => cancelAnimationFrame(id);
-  }, [visible]);
+  }, [visible, reportChatFocus]);
+
+  // Bring the last-focused chat tab forward when "Add to Chat" targets it.
+  // SharedDockviewLayout resolves the workspace's last-focused chat, surfaces
+  // the outer Chat panel, and dispatches the scoped `band:chat-insert`; here we
+  // activate the matching inner tab so the pane that receives the reference is
+  // the one the user sees. PromptInput does the actual text insertion.
+  useEffect(() => {
+    const handler = (e: Event) => {
+      const detail = (e as CustomEvent<ChatInsertDetail>).detail;
+      if (!detail?.chatId || detail.workspaceId !== workspaceId) return;
+      apiRef.current?.getPanel(detail.chatId)?.api.setActive();
+    };
+    window.addEventListener("band:chat-insert", handler);
+    return () => window.removeEventListener("band:chat-insert", handler);
+  }, [workspaceId]);
 
   // Sync dockview panels when chats are created/removed externally (e.g. CLI).
   // Mirrors the `browser-created` / `terminal-created` subscription in the
@@ -1071,11 +1106,14 @@ export function DockviewChatContainer({
       event.api.onDidLayoutChange(persist);
       event.api.onDidAddPanel(persist);
       event.api.onDidRemovePanel(persist);
-      event.api.onDidActivePanelChange(persist);
+      event.api.onDidActivePanelChange(() => {
+        persist();
+        reportChatFocus();
+      });
       event.api.onDidAddGroup(persist);
       event.api.onDidRemoveGroup(persist);
     },
-    [workspaceId, schedulePersist],
+    [workspaceId, schedulePersist, reportChatFocus],
   );
 
   const visibilityValue = useMemo(

--- a/apps/web/src/components/DockviewTerminalContainer.tsx
+++ b/apps/web/src/components/DockviewTerminalContainer.tsx
@@ -19,7 +19,7 @@ import React, {
   useRef,
   useState,
 } from "react";
-import { useAdapter } from "@/dashboard";
+import { type TerminalInsertDetail, useAdapter } from "@/dashboard";
 import {
   attachEdgeGroupDragVisibility,
   centralPanelPosition,
@@ -384,6 +384,11 @@ export function DockviewTerminalContainer({
   const apiRef = useRef<DockviewApi | null>(null);
   const isRestoringRef = useRef(false);
   const containerRef = useRef<HTMLDivElement>(null);
+  // Mirror `wsActive` for use inside stable closures (onReady, effects) so
+  // focus reporting only fires for the workspace the user is looking at — never
+  // for the cached, hidden workspaces MultiWorkspacePanelHost keeps alive.
+  const wsActiveRef = useRef(wsActive);
+  wsActiveRef.current = wsActive;
   // Tracks the cleanup function returned by `attachEdgeGroupDragVisibility`
   // so the drag-visibility listeners can be detached on unmount (or on a
   // hypothetical re-`onReady`).
@@ -419,6 +424,17 @@ export function DockviewTerminalContainer({
     const api = apiRef.current;
     if (!api) return;
     persistToServer(workspaceId, api.toJSON(), { queryClient: queryClientRef.current });
+  }, [workspaceId]);
+
+  // Report the active terminal tab to the server as the workspace's last-focused
+  // terminal — the target "Add to Terminal" routes references to. Gated on
+  // `wsActive` and skipped during layout restore. Fire-and-forget.
+  const reportTerminalFocus = useCallback(() => {
+    if (isRestoringRef.current) return;
+    if (wsActiveRef.current === false) return;
+    const panelId = apiRef.current?.activePanel?.id;
+    if (!panelId) return;
+    trpc.panelFocus.set.mutate({ workspaceId, panelType: "terminal", panelId }).catch(() => {});
   }, [workspaceId]);
 
   const handleAddTab = useCallback(
@@ -707,9 +723,27 @@ export function DockviewTerminalContainer({
       panel.view.content.element
         .querySelector<HTMLTextAreaElement>(".xterm-helper-textarea")
         ?.focus();
+      // Record a baseline last-focused terminal as soon as the section is shown,
+      // so "Add to Terminal" has a target even if the user never switches tabs.
+      reportTerminalFocus();
     });
     return () => cancelAnimationFrame(id);
-  }, [visible]);
+  }, [visible, reportTerminalFocus]);
+
+  // Bring the last-focused terminal tab forward when "Add to Terminal" targets
+  // it. SharedDockviewLayout resolves the workspace's last-focused terminal and
+  // dispatches the scoped `band:terminal-insert` with that id; activating the
+  // matching inner tab makes it visible so `TerminalPanel` flushes the pending
+  // reference into it. Mirrors the chat container's `band:chat-insert` handler.
+  useEffect(() => {
+    const handler = (e: Event) => {
+      const detail = (e as CustomEvent<TerminalInsertDetail>).detail;
+      if (!detail?.terminalId || detail.workspaceId !== workspaceId) return;
+      apiRef.current?.getPanel(detail.terminalId)?.api.setActive();
+    };
+    window.addEventListener("band:terminal-insert", handler);
+    return () => window.removeEventListener("band:terminal-insert", handler);
+  }, [workspaceId]);
 
   // Sync dockview panels when terminals are created/killed externally (e.g. CLI).
   useEffect(() => {
@@ -876,7 +910,10 @@ export function DockviewTerminalContainer({
       event.api.onDidLayoutChange(persist);
       event.api.onDidAddPanel(persist);
       event.api.onDidRemovePanel(persist);
-      event.api.onDidActivePanelChange(persist);
+      event.api.onDidActivePanelChange(() => {
+        persist();
+        reportTerminalFocus();
+      });
       event.api.onDidAddGroup(persist);
       event.api.onDidRemoveGroup(persist);
 
@@ -896,7 +933,7 @@ export function DockviewTerminalContainer({
         }
       }
     },
-    [workspaceId, schedulePersist],
+    [workspaceId, schedulePersist, reportTerminalFocus],
   );
 
   const visibilityValue = useMemo(

--- a/apps/web/src/components/SharedDockviewLayout.tsx
+++ b/apps/web/src/components/SharedDockviewLayout.tsx
@@ -22,12 +22,14 @@ import { lazy, memo, Suspense, useCallback, useEffect, useMemo, useRef, useState
 import {
   type AddToTerminalDetail,
   buildCommands,
+  type ChatInsertDetail,
   CommandPaletteDialog,
   DiffView,
   parseFileLocation,
   QuickOpenDialog,
   recordWorkspaceAccess,
   SearchFilesDialog,
+  type SelectionToChatDetail,
   useDiffTarget,
   useSettingsQuery,
   WorkspacePickerDialog,
@@ -1253,14 +1255,66 @@ export function SharedDockviewLayout() {
       if (!reference || !workspaceId) return;
       if (hiddenPanelsRef.current.includes("terminal")) return;
       apiRef.current?.getPanel("terminal")?.api.setActive();
-      queueMicrotask(() => {
+      // Resolve the workspace's last-focused terminal so the reference lands in
+      // the one the user was actually using (not just whichever tab is visible).
+      // The awaited query naturally defers the dispatch past the `setActive`
+      // render, so the target terminal is surfaced by the time it flushes. Falls
+      // back to an undefined terminalId (visible-terminal behavior) on error or
+      // when no focus has been recorded yet.
+      void (async () => {
+        let terminalId: string | undefined;
+        try {
+          const focus = await trpc.panelFocus.get.query({ workspaceId });
+          terminalId = focus.terminal;
+        } catch {
+          // best-effort — fall back to visible-terminal delivery
+        }
         window.dispatchEvent(
-          new CustomEvent("band:terminal-insert", { detail: { reference, workspaceId } }),
+          new CustomEvent("band:terminal-insert", {
+            detail: { reference, workspaceId, terminalId },
+          }),
         );
-      });
+      })();
     };
     window.addEventListener("band:add-to-terminal", handler);
     return () => window.removeEventListener("band:add-to-terminal", handler);
+  }, []);
+
+  // "Add to Chat" from the diff/file selection tooltip. Symmetric to the
+  // terminal handler above: the tooltip dispatches the workspace-agnostic
+  // `band:add-to-chat` intent; here we resolve the active workspace and its
+  // last-focused chat, surface the Chat panel, and re-dispatch the scoped
+  // `band:chat-insert` delivery so only that specific chat pane appends the
+  // reference. Previously every mounted PromptInput in the active workspace
+  // listened to `band:add-to-chat` directly, so the reference was appended to
+  // *all* open chat panes; scoping by chatId fixes that.
+  useEffect(() => {
+    const handler = (e: Event) => {
+      const detail = (e as CustomEvent<SelectionToChatDetail>).detail;
+      const workspaceId = activeWorkspaceIdRef.current;
+      if (!detail || !workspaceId) return;
+      if (hiddenPanelsRef.current.includes("chat")) return;
+      apiRef.current?.getPanel("chat")?.api.setActive();
+      void (async () => {
+        let chatId: string | undefined;
+        try {
+          const focus = await trpc.panelFocus.get.query({ workspaceId });
+          chatId = focus.chat;
+        } catch {
+          // best-effort — fall back to visible-chat delivery
+        }
+        const insert: ChatInsertDetail = {
+          filePath: detail.filePath,
+          startLine: detail.startLine,
+          endLine: detail.endLine,
+          workspaceId,
+          chatId,
+        };
+        window.dispatchEvent(new CustomEvent("band:chat-insert", { detail: insert }));
+      })();
+    };
+    window.addEventListener("band:add-to-chat", handler);
+    return () => window.removeEventListener("band:add-to-chat", handler);
   }, []);
 
   // ---------------------------------------------------------------------

--- a/apps/web/src/components/TerminalPanel.tsx
+++ b/apps/web/src/components/TerminalPanel.tsx
@@ -1253,14 +1253,22 @@ export function TerminalPanel({
     const handler = (e: Event) => {
       const detail = (e as CustomEvent<TerminalInsertDetail>).detail;
       if (!detail?.reference || detail.workspaceId !== workspaceId) return;
+      // When the delivery names a specific terminal (the workspace's
+      // last-focused one, resolved server-side), only that terminal accepts —
+      // so a split-visible sibling doesn't also receive the reference. When no
+      // terminalId is set (no focus recorded yet), fall back to the pre-focus
+      // behavior: the currently visible terminal takes it.
+      if (detail.terminalId && detail.terminalId !== terminalId) return;
       pendingInsertRef.current = detail.reference;
       // Send immediately when already visible; otherwise the `visible` effect
-      // above flushes once the layout finishes surfacing this terminal.
+      // above flushes once the layout finishes surfacing this terminal. The
+      // terminal container activates the target inner tab in parallel, so a
+      // targeted (non-visible) terminal becomes visible and flushes shortly.
       if (visible) flushPendingInsert();
     };
     window.addEventListener("band:terminal-insert", handler);
     return () => window.removeEventListener("band:terminal-insert", handler);
-  }, [visible, workspaceId, flushPendingInsert]);
+  }, [visible, workspaceId, terminalId, flushPendingInsert]);
 
   // ---- Find-in-terminal handlers ----
   const handleOpenSearch = useCallback(() => {

--- a/apps/web/src/components/ai-elements/prompt-input.tsx
+++ b/apps/web/src/components/ai-elements/prompt-input.tsx
@@ -11,7 +11,7 @@ import type {
   RefObject,
 } from "react";
 import { createContext, useCallback, useContext, useEffect, useRef, useState } from "react";
-import { buildLineReference, type SelectionToChatDetail } from "@/dashboard";
+import { buildLineReference, type ChatInsertDetail } from "@/dashboard";
 
 let fileIdCounter = 0;
 
@@ -54,6 +54,14 @@ export type PromptInputProps = Omit<HTMLAttributes<HTMLFormElement>, "onSubmit">
    *  Used to accept "Add to Chat" events from sibling panels (Changes, Files)
    *  when the Chat tab isn't in front. Falls back to `visible` if not set. */
   wsActive?: boolean;
+  /** The workspace this chat pane belongs to. Used to scope `band:chat-insert`
+   *  delivery so a reference never leaks into another workspace's chat. */
+  workspaceId?: string;
+  /** The chat pane this input belongs to. When a `band:chat-insert` names a
+   *  specific `chatId` (the workspace's last-focused chat), only the matching
+   *  input appends the reference — fixing the old behavior where every open
+   *  chat pane received it. */
+  chatId?: string;
 };
 
 function readDraft(key: string | null): string {
@@ -71,6 +79,8 @@ export const PromptInput = ({
   draftKey,
   visible,
   wsActive,
+  workspaceId,
+  chatId,
   children,
   ...props
 }: PromptInputProps) => {
@@ -126,6 +136,12 @@ export const PromptInput = ({
   // (Changes, Files) are still processed.
   const wsActiveRef = useRef(wsActive ?? visible);
   wsActiveRef.current = wsActive ?? visible;
+  // Mirror workspace/chat identity for the stable `band:chat-insert` handler
+  // (registered once with `[]` deps) so it always matches against current props.
+  const workspaceIdRef = useRef(workspaceId);
+  workspaceIdRef.current = workspaceId;
+  const chatIdRef = useRef(chatId);
+  chatIdRef.current = chatId;
 
   const addFiles = useCallback((newFiles: FileList | File[]) => {
     const valid = Array.from(newFiles).filter((f) => f.size <= MAX_FILE_SIZE);
@@ -219,23 +235,32 @@ export const PromptInput = ({
     textarea.selectionStart = textarea.selectionEnd = value.length;
   }, []);
 
-  // Listen for "Add to Chat" events from CodeMirror editors.
-  // Only process the event when this workspace is active — with workspace
-  // show/hide, multiple PromptInput instances are mounted simultaneously
-  // and we must not modify hidden workspaces' textareas.  We gate on
-  // wsActive (not visible) so that events from sibling panels like
-  // Changes or Files are still processed even when the Chat tab isn't focused.
+  // Deliver an "Add to Chat" reference from the CodeMirror selection tooltip.
+  // SharedDockviewLayout owns the workspace-agnostic `band:add-to-chat` intent:
+  // it resolves the active workspace's last-focused chat and re-dispatches the
+  // scoped `band:chat-insert` handled here. Many PromptInput instances are
+  // mounted at once (one per chat pane × one per cached workspace), so we only
+  // append when the delivery targets this pane:
+  //   - workspace must match (skip cached background workspaces), and
+  //   - when the delivery names a chatId, it must be *this* chat; when it
+  //     doesn't (no focus recorded yet), only the visible pane accepts.
   useEffect(() => {
     const handler = (e: Event) => {
-      if (wsActiveRef.current === false) return;
-      const { filePath, startLine, endLine } = (e as CustomEvent<SelectionToChatDetail>).detail;
+      const detail = (e as CustomEvent<ChatInsertDetail>).detail;
+      if (!detail) return;
+      if (workspaceIdRef.current && detail.workspaceId !== workspaceIdRef.current) return;
+      if (detail.chatId) {
+        if (detail.chatId !== chatIdRef.current) return;
+      } else if (wsActiveRef.current === false || visibleRef.current === false) {
+        return;
+      }
 
       // Wrap the shared bare reference in a markdown code span so the chat
       // renderer turns it into a clickable file link (see `rehypeFileLinkedCode`
       // in file-link-components.tsx — it only links paths inside inline `<code>`).
       // The terminal/copy actions intentionally use the bare form instead.
       // Trailing space keeps it separated from any text the user types next.
-      const reference = `\`${buildLineReference(filePath, startLine, endLine)}\` `;
+      const reference = `\`${buildLineReference(detail.filePath, detail.startLine, detail.endLine)}\` `;
 
       const textarea = textareaRef.current;
       const current = textarea?.value ?? "";
@@ -258,8 +283,8 @@ export const PromptInput = ({
       }
     };
 
-    window.addEventListener("band:add-to-chat", handler);
-    return () => window.removeEventListener("band:add-to-chat", handler);
+    window.addEventListener("band:chat-insert", handler);
+    return () => window.removeEventListener("band:chat-insert", handler);
   }, []);
 
   return (

--- a/apps/web/src/dashboard/index.ts
+++ b/apps/web/src/dashboard/index.ts
@@ -116,6 +116,7 @@ export { getRecentWorkspaceOrder, recordWorkspaceAccess } from "./lib/recent-wor
 export {
   type AddToTerminalDetail,
   buildLineReference,
+  type ChatInsertDetail,
   type SelectionToChatDetail,
   type TerminalInsertDetail,
 } from "./lib/selection-to-chat";

--- a/apps/web/src/dashboard/lib/selection-to-chat.ts
+++ b/apps/web/src/dashboard/lib/selection-to-chat.ts
@@ -51,6 +51,40 @@ export interface TerminalInsertDetail {
   reference: string;
   /** The workspace whose terminal should receive the reference. */
   workspaceId: string;
+  /**
+   * The specific terminal that should receive the reference — the workspace's
+   * last-focused terminal, resolved by `SharedDockviewLayout` from the server's
+   * panel-focus record. When absent (no focus recorded yet), each mounted
+   * `TerminalPanel` falls back to accepting the reference if it's the currently
+   * *visible* terminal, preserving the pre-focus-tracking behavior.
+   */
+  terminalId?: string;
+}
+
+/**
+ * Payload dispatched via the `band:chat-insert` window CustomEvent by
+ * `SharedDockviewLayout` after it has resolved the workspace's last-focused
+ * chat and surfaced the Chat panel. The chat mirror of
+ * {@link TerminalInsertDetail}: each mounted `PromptInput` (one per chat pane ×
+ * one per cached workspace) only appends the reference when the delivery
+ * targets its own workspace AND its own chat, so a reference never leaks into
+ * a sibling pane or a cached background workspace.
+ */
+export interface ChatInsertDetail {
+  /** The workspace-relative file path shown in the reference. */
+  filePath: string;
+  /** 1-based start line of the selection. */
+  startLine: number;
+  /** 1-based end line of the selection. */
+  endLine: number;
+  /** The workspace whose chat should receive the reference. */
+  workspaceId: string;
+  /**
+   * The specific chat pane that should receive the reference — the workspace's
+   * last-focused chat. When absent (no focus recorded yet), the currently
+   * *visible* chat pane accepts it instead.
+   */
+  chatId?: string;
 }
 
 /**

--- a/apps/web/src/server/api/panel-focus/router.ts
+++ b/apps/web/src/server/api/panel-focus/router.ts
@@ -1,0 +1,36 @@
+/**
+ * `panelFocus.*` sub-router — records and exposes the last-focused panel per
+ * type (chat, terminal, browser) for a workspace.
+ *
+ * The dashboard's inner dockview containers call `set` when the user switches
+ * the active chat/terminal/browser tab; the "Add to Chat" / "Add to Terminal"
+ * selection-tooltip actions call `get` to resolve which pane should receive the
+ * pasted reference. Thin pass-through to `PanelFocusService`.
+ */
+
+import { z } from "zod";
+import { panelFocusService } from "../../services/panel-focus-service";
+import { publicProcedure, t } from "../trpc";
+
+const focusPanelType = z.enum(["chat", "terminal", "browser"]);
+
+export const panelFocusRouter = t.router({
+  get: publicProcedure.input(z.object({ workspaceId: z.string() })).query(({ input }) => {
+    return panelFocusService.get(input.workspaceId);
+  }),
+
+  set: publicProcedure
+    .input(
+      z.object({
+        workspaceId: z.string(),
+        panelType: focusPanelType,
+        panelId: z.string(),
+      }),
+    )
+    .mutation(({ input }) => {
+      panelFocusService.set(input.workspaceId, input.panelType, input.panelId);
+      return { ok: true };
+    }),
+});
+
+export type PanelFocusRouter = typeof panelFocusRouter;

--- a/apps/web/src/server/api/router.ts
+++ b/apps/web/src/server/api/router.ts
@@ -49,6 +49,7 @@ import { historyRouter } from "./history/router";
 import { hooksRouter } from "./hooks/router";
 import { modelsRouter } from "./models/router";
 import { modesRouter } from "./modes/router";
+import { panelFocusRouter } from "./panel-focus/router";
 import { prereqsRouter } from "./prereqs/router";
 import { projectsRouter } from "./projects/router";
 import { queueRouter } from "./queue/router";
@@ -76,6 +77,7 @@ export const appRouter = t.router({
   chat: chatRouter,
   browsers: browsersRouter,
   browserLayout: browserLayoutRouter,
+  panelFocus: panelFocusRouter,
   tasks: tasksRouter,
   sessions: sessionsRouter,
   ...terminalsRouters,

--- a/apps/web/src/server/services/panel-focus-service.ts
+++ b/apps/web/src/server/services/panel-focus-service.ts
@@ -1,0 +1,145 @@
+/**
+ * Tracks the last-focused panel per type (chat, terminal, browser) for each
+ * workspace.
+ *
+ * Powers the "Add to Chat" / "Add to Terminal" selection-tooltip actions: they
+ * ask this service which chat/terminal the user last had focused in a workspace
+ * and route the pasted reference into exactly that panel, rather than
+ * broadcasting to every open pane.
+ *
+ * Persisted in the generic `panel_states` table (one row per workspace under
+ * `panelType: "panel_focus"`, keyed by a deterministic id) so the recorded
+ * focus survives a page reload / server restart. The in-memory map is the hot
+ * path; the DB is the write-through backing store — mirroring the lazy-hydrate
+ * + write-through pattern used by `ChatService`.
+ */
+
+import { createLogger } from "@band-app/logger";
+import {
+  deletePanelState,
+  insertPanelState,
+  listPanelStatesForWorkspace,
+  updatePanelState,
+} from "../infra/db/queries/panel-states";
+
+const log = createLogger("panel-focus-service");
+
+/** `panel_states.panelType` value used for the per-workspace focus row. */
+const PANEL_FOCUS_TYPE = "panel_focus";
+
+/** Panel kinds whose focus we track. */
+export type FocusPanelType = "chat" | "terminal" | "browser";
+
+/**
+ * The last-focused panel id per type for a single workspace. A missing key
+ * means "nothing focused yet" (fresh workspace, or the panel was never opened).
+ */
+export interface WorkspaceFocus {
+  chat?: string;
+  terminal?: string;
+  browser?: string;
+}
+
+/** Deterministic `panel_states.id` for a workspace's focus row. */
+function focusRowId(workspaceId: string): string {
+  return `${PANEL_FOCUS_TYPE}:${workspaceId}`;
+}
+
+export class PanelFocusService {
+  /** workspaceId → last-focused panel ids. */
+  private readonly focus = new Map<string, WorkspaceFocus>();
+
+  /**
+   * Workspaces whose focus row has been loaded from the DB into `focus`.
+   * Separate from the map's own key presence because a workspace can have a
+   * loaded-but-empty record (row absent) — we still don't want to re-hit the
+   * DB on every read.
+   */
+  private readonly hydrated = new Set<string>();
+
+  /** Workspaces that already have a `panel_states` row (drives insert vs update). */
+  private readonly persisted = new Set<string>();
+
+  /**
+   * Load a workspace's focus row from the DB on first access. Cheap and
+   * idempotent — subsequent calls short-circuit on the `hydrated` set.
+   */
+  private ensureHydrated(workspaceId: string): void {
+    if (this.hydrated.has(workspaceId)) return;
+    this.hydrated.add(workspaceId);
+
+    const rows = listPanelStatesForWorkspace(workspaceId, PANEL_FOCUS_TYPE);
+    const row = rows[0];
+    if (!row) return;
+
+    this.persisted.add(workspaceId);
+    try {
+      const parsed = JSON.parse(row.state) as WorkspaceFocus;
+      this.focus.set(workspaceId, {
+        chat: parsed.chat,
+        terminal: parsed.terminal,
+        browser: parsed.browser,
+      });
+    } catch (err) {
+      log.warn({ workspaceId, err }, "failed to parse persisted panel focus; ignoring");
+    }
+  }
+
+  /** Get the last-focused panel ids for a workspace. */
+  get(workspaceId: string): WorkspaceFocus {
+    this.ensureHydrated(workspaceId);
+    return { ...(this.focus.get(workspaceId) ?? {}) };
+  }
+
+  /**
+   * Record that `panelId` is the last-focused panel of `panelType` in
+   * `workspaceId`. Write-through: updates the in-memory map and upserts the
+   * backing `panel_states` row.
+   */
+  set(workspaceId: string, panelType: FocusPanelType, panelId: string): void {
+    this.ensureHydrated(workspaceId);
+
+    const current = this.focus.get(workspaceId) ?? {};
+    if (current[panelType] === panelId) return; // no-op — nothing changed
+
+    const next: WorkspaceFocus = { ...current, [panelType]: panelId };
+    this.focus.set(workspaceId, next);
+
+    const now = Date.now();
+    const state = JSON.stringify(next);
+    if (this.persisted.has(workspaceId)) {
+      updatePanelState(focusRowId(workspaceId), { state, updatedAt: now });
+    } else {
+      insertPanelState({
+        id: focusRowId(workspaceId),
+        workspaceId,
+        panelType: PANEL_FOCUS_TYPE,
+        state,
+        createdAt: now,
+        updatedAt: now,
+      });
+      this.persisted.add(workspaceId);
+    }
+  }
+
+  /**
+   * Drop all focus tracking for a workspace. Called from the workspace delete
+   * path so the row doesn't outlive the workspace.
+   */
+  remove(workspaceId: string): void {
+    this.focus.delete(workspaceId);
+    this.hydrated.delete(workspaceId);
+    this.persisted.delete(workspaceId);
+    // Delete unconditionally: even a fresh boot that never read this workspace
+    // (so `persisted` is empty) may still have a row on disk. `deletePanelState`
+    // is a no-op when the id is absent.
+    deletePanelState(focusRowId(workspaceId));
+  }
+}
+
+/**
+ * Shared singleton consumed by the API tier (`panelFocus` router) and the
+ * workspace delete path. Holds in-memory state, so callers MUST go through
+ * this instance rather than constructing their own.
+ */
+export const panelFocusService = new PanelFocusService();

--- a/apps/web/src/server/services/workspace-service.ts
+++ b/apps/web/src/server/services/workspace-service.ts
@@ -40,6 +40,7 @@ import { chatService } from "./chat-service";
 // function body. Capturing `const cs = cronjobService;` at module load
 // would silently get `undefined`.
 import { cronjobService } from "./cronjob-service";
+import { panelFocusService } from "./panel-focus-service";
 import { SettingsService, settingsService } from "./settings-service";
 import {
   bandHome,
@@ -687,6 +688,9 @@ export class WorkspaceService {
     // Kill any running terminal PTY sessions + layout
     terminalService.killWorkspace(workspaceId);
     terminalService.deleteLayout(workspaceId);
+
+    // Drop the last-focused-panel record so it doesn't outlive the workspace.
+    panelFocusService.remove(workspaceId);
 
     // Kill any running language server processes
     killWorkspaceServers(workspaceId);

--- a/apps/web/tests/panel-focus.test.ts
+++ b/apps/web/tests/panel-focus.test.ts
@@ -1,0 +1,172 @@
+/**
+ * Integration tests for the `panelFocus.*` tRPC surface — the server-side
+ * record of the last-focused panel per type (chat / terminal / browser) for a
+ * workspace. This is what "Add to Chat" / "Add to Terminal" query to route a
+ * pasted reference into the pane the user was last using.
+ *
+ * Driven end-to-end through the production server bundle (real HTTP, real auth,
+ * real SQLite), asserting on both the tRPC response shape AND the on-disk
+ * `panel_states` row. A final test restarts the server against the same home to
+ * prove the focus record is hydrated from disk after a fresh boot — not just
+ * held in the first process's memory.
+ */
+
+import { execFileSync } from "node:child_process";
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { seedSettings, seedState } from "./helpers/seed-state";
+import {
+  createTmpHome,
+  type ServerHandle,
+  trpcMutate as sharedTrpcMutate,
+  trpcQuery as sharedTrpcQuery,
+  startServer,
+  trpcData,
+} from "./helpers/server";
+
+const DEFAULT_TOKEN = "panel-focus-test-token";
+const WORKSPACE_ID = "focusproject-main";
+
+function trpcMutate(serverUrl: string, procedure: string, input?: unknown) {
+  return sharedTrpcMutate(serverUrl, procedure, input, DEFAULT_TOKEN);
+}
+
+function trpcQuery(serverUrl: string, procedure: string, input?: unknown) {
+  return sharedTrpcQuery(serverUrl, procedure, input, DEFAULT_TOKEN);
+}
+
+const gitEnv = {
+  ...process.env,
+  GIT_AUTHOR_NAME: "Test",
+  GIT_AUTHOR_EMAIL: "test@test.com",
+  GIT_COMMITTER_NAME: "Test",
+  GIT_COMMITTER_EMAIL: "test@test.com",
+};
+
+function createGitRepo(parentDir: string, name: string): string {
+  const repoPath = join(parentDir, name);
+  mkdirSync(repoPath, { recursive: true });
+  execFileSync("git", ["init", "-b", "main"], { cwd: repoPath, env: gitEnv });
+  writeFileSync(join(repoPath, "README.md"), "# Test\n");
+  execFileSync("git", ["add", "."], { cwd: repoPath, env: gitEnv });
+  execFileSync("git", ["commit", "-m", "init"], { cwd: repoPath, env: gitEnv });
+  return repoPath;
+}
+
+/** Read the persisted focus row straight from SQLite. Id is deterministic:
+ *  `panel_focus:${workspaceId}` (see `PanelFocusService.focusRowId`). */
+function readFocusRow(tmpHome: string): { state: string; panelType: string } | undefined {
+  const sqlite = new DatabaseSync(join(tmpHome, ".band", "band.db"), { readOnly: true });
+  try {
+    return sqlite
+      .prepare("SELECT state, panel_type as panelType FROM panel_states WHERE id = ?")
+      .get(`panel_focus:${WORKSPACE_ID}`) as { state: string; panelType: string } | undefined;
+  } finally {
+    sqlite.close();
+  }
+}
+
+type Focus = { chat?: string; terminal?: string; browser?: string };
+
+describe("panelFocus — last-focused panel per type", () => {
+  let server: ServerHandle;
+  let tmpHome: string;
+
+  beforeAll(async () => {
+    tmpHome = createTmpHome("band-panel-focus-");
+    const repoPath = createGitRepo(tmpHome, "focusproject");
+    seedState(tmpHome, {
+      projects: [
+        {
+          name: "focusproject",
+          path: repoPath,
+          defaultBranch: "main",
+          worktrees: [{ branch: "main", path: repoPath }],
+        },
+      ],
+    });
+    seedSettings(tmpHome, { tokenSecret: DEFAULT_TOKEN });
+    server = await startServer({ tmpHome });
+  });
+
+  afterAll(async () => {
+    await server.close();
+    rmSync(tmpHome, { recursive: true, force: true });
+  });
+
+  it("rejects panelFocus.set without the band_token cookie (401)", async () => {
+    // The shared helpers always send the cookie, so call fetch directly to
+    // omit it — mirrors the negative-auth guard in browsers.test.ts.
+    const res = await fetch(`${server.url}/trpc/panelFocus.set`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ workspaceId: WORKSPACE_ID, panelType: "chat", panelId: "chat_x" }),
+    });
+    expect(res.status).toBe(401);
+  });
+
+  it("returns an empty record before anything is focused", async () => {
+    const res = await trpcQuery(server.url, "panelFocus.get", { workspaceId: WORKSPACE_ID });
+    expect(res.status).toBe(200);
+    const data = await trpcData<Focus>(res);
+    expect(data).toEqual({});
+  });
+
+  it("records the last-focused panel per type independently", async () => {
+    await trpcMutate(server.url, "panelFocus.set", {
+      workspaceId: WORKSPACE_ID,
+      panelType: "chat",
+      panelId: "chat_alpha",
+    });
+    await trpcMutate(server.url, "panelFocus.set", {
+      workspaceId: WORKSPACE_ID,
+      panelType: "terminal",
+      panelId: "term_one",
+    });
+    await trpcMutate(server.url, "panelFocus.set", {
+      workspaceId: WORKSPACE_ID,
+      panelType: "browser",
+      panelId: "browser_z",
+    });
+
+    const res = await trpcQuery(server.url, "panelFocus.get", { workspaceId: WORKSPACE_ID });
+    const data = await trpcData<Focus>(res);
+    expect(data).toEqual({ chat: "chat_alpha", terminal: "term_one", browser: "browser_z" });
+
+    // The record is a single row on disk under the deterministic id.
+    const row = readFocusRow(tmpHome);
+    expect(row).toBeDefined();
+    expect(row!.panelType).toBe("panel_focus");
+    expect(JSON.parse(row!.state)).toEqual({
+      chat: "chat_alpha",
+      terminal: "term_one",
+      browser: "browser_z",
+    });
+  });
+
+  it("overwrites only the named type, leaving the others intact", async () => {
+    await trpcMutate(server.url, "panelFocus.set", {
+      workspaceId: WORKSPACE_ID,
+      panelType: "chat",
+      panelId: "chat_beta",
+    });
+
+    const res = await trpcQuery(server.url, "panelFocus.get", { workspaceId: WORKSPACE_ID });
+    const data = await trpcData<Focus>(res);
+    expect(data).toEqual({ chat: "chat_beta", terminal: "term_one", browser: "browser_z" });
+  });
+
+  it("hydrates the persisted record after a fresh server boot", async () => {
+    // Restart against the SAME home: a new process with an empty in-memory map
+    // must still resolve the focus from the SQLite row written above. Reassign
+    // `server` so afterAll tears down the new instance.
+    await server.close();
+    server = await startServer({ tmpHome });
+
+    const res = await trpcQuery(server.url, "panelFocus.get", { workspaceId: WORKSPACE_ID });
+    const data = await trpcData<Focus>(res);
+    expect(data).toEqual({ chat: "chat_beta", terminal: "term_one", browser: "browser_z" });
+  });
+});


### PR DESCRIPTION
## Summary

The server now tracks the **last-focused panel per type (chat, terminal, browser) per workspace**, and the "Add to Chat" / "Add to Terminal" selection-tooltip actions route the pasted file reference into that specific pane instead of broadcasting.

Previously "Add to Chat" appended the reference to **every** open chat pane (each mounted `PromptInput` listened to the raw `band:add-to-chat` event), and "Add to Terminal" landed in whichever terminal happened to be visible. Now the target is the pane the user was last using.

## What changed

**Server (source of truth)**
- New `PanelFocusService` (`apps/web/src/server/services/panel-focus-service.ts`) — in-memory `Map<workspaceId, {chat?,terminal?,browser?}>` with lazy hydration + write-through to the existing `panel_states` table (`panel_type: "panel_focus"`, one row per workspace), so focus survives reload/restart.
- New `panelFocus.get` / `panelFocus.set` tRPC router.
- `workspace-service` drops the focus row on workspace delete.

**Frontend**
- The three inner dockview containers report the active tab to `panelFocus.set` on active-panel change and on first-visible (gated on `wsActive`, skipped during layout restore).
- `SharedDockviewLayout` resolves the last-focused chat/terminal via `panelFocus.get`, surfaces the panel, and re-dispatches a **scoped** `band:chat-insert` / `band:terminal-insert` carrying the target id.
- `PromptInput` (threaded `chatId`/`workspaceId`) and `TerminalPanel` only accept a delivery that targets them; when no focus is recorded yet they fall back to the previous visible-pane behavior.

This also fixes the latent multi-chat-pane double-append bug.

## Tests
- `apps/web/tests/panel-focus.test.ts` — backend, real server: 401, empty default, per-type set/get, on-disk persistence, and hydration after a fresh server boot.
- `apps/web/e2e/add-to-chat-last-focused.spec.ts` — two chat panes, focus the second → reference lands only in the focused pane.
- `apps/web/e2e/add-to-terminal-last-focused.spec.ts` — two terminals, focus the older one → reference typed only into that terminal's PTY socket.

Verified locally: `pnpm check` (biome + fmt + clippy) passes, all new tests pass (stable on repeat), and existing `selection-tooltip-actions` / panel / chat specs still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)