### PR TITLE
feat(web): mobile fly-out project list + bottom-drawer dialogs

### DIFF
--- a/apps/web/e2e/dialog-bottom-drawer.spec.ts
+++ b/apps/web/e2e/dialog-bottom-drawer.spec.ts
@@ -1,0 +1,190 @@
+/**
+ * Mobile bottom-drawer dialog coverage.
+ *
+ * On a narrow viewport the app's modal dialogs (Settings, workspace picker)
+ * open as bottom sheets that slide up from the bottom edge. Two observable
+ * contracts:
+ *
+ *   1. The sheet is anchored to the bottom of the viewport (its bottom edge
+ *      meets the viewport bottom).
+ *   2. It does NOT reach the very top — a gap is left so that on iOS the
+ *      header/close button clears the notch / Dynamic Island. The gap is
+ *      `env(safe-area-inset-top) + 1.5rem`; headless Chromium reports a zero
+ *      safe-area inset, so the observable minimum gap here is the 1.5rem
+ *      (~24px) cap baked into the `bottom-sheet` variant's max-height. On a
+ *      real device the inset is added on top, widening the gap further.
+ *
+ * The desktop describe guards the "leave desktop unchanged" requirement: at a
+ * wide viewport the same dialogs render as centred cards, not bottom sheets.
+ *
+ * Real production binary, no tRPC mocks, page objects only.
+ */
+
+import { execFileSync } from "node:child_process";
+import { mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { expect, test } from "@playwright/test";
+import { toWorkspaceId } from "@/dashboard";
+import {
+  cleanupTmpHome,
+  createTmpHome,
+  type ServerHandle,
+  seedSettings,
+  seedState,
+  startServer,
+} from "./helpers/server";
+import { SettingsPage } from "./pages/SettingsPage";
+import { WorkspacePage } from "./pages/WorkspacePage";
+import { WorkspacePicker } from "./pages/WorkspacePicker";
+
+const TOKEN = "e2e-bottom-drawer-token";
+const PROJECT = "bottom-drawer-repo";
+const DEFAULT_BRANCH = "main";
+const WORKSPACE = toWorkspaceId(PROJECT, DEFAULT_BRANCH);
+
+function makeGitEnv(home: string): NodeJS.ProcessEnv {
+  return {
+    PATH: process.env.PATH,
+    HOME: home,
+    GIT_AUTHOR_NAME: "Test",
+    GIT_AUTHOR_EMAIL: "test@test.com",
+    GIT_COMMITTER_NAME: "Test",
+    GIT_COMMITTER_EMAIL: "test@test.com",
+    GIT_CONFIG_GLOBAL: "/dev/null",
+    GIT_CONFIG_SYSTEM: "/dev/null",
+  };
+}
+
+function git(cwd: string, args: string[], home: string): void {
+  execFileSync("git", args, { cwd, env: makeGitEnv(home) });
+}
+
+let server: ServerHandle;
+let tmpHome: string;
+
+test.beforeAll(async () => {
+  tmpHome = createTmpHome();
+
+  const repoPath = join(tmpHome, PROJECT);
+  mkdirSync(repoPath, { recursive: true });
+  git(repoPath, ["init", "-b", DEFAULT_BRANCH], tmpHome);
+  writeFileSync(join(repoPath, "README.md"), "# Bottom drawer test\n");
+  git(repoPath, ["add", "."], tmpHome);
+  git(repoPath, ["commit", "-m", "init"], tmpHome);
+
+  seedState(tmpHome, {
+    projects: [
+      {
+        name: PROJECT,
+        path: repoPath,
+        defaultBranch: DEFAULT_BRANCH,
+        worktrees: [{ branch: DEFAULT_BRANCH, path: repoPath }],
+      },
+    ],
+  });
+  seedSettings(tmpHome, { tokenSecret: TOKEN });
+  server = await startServer({ tmpHome });
+});
+
+test.afterAll(async () => {
+  await server.close();
+  cleanupTmpHome(tmpHome);
+});
+
+test.describe("Mobile bottom drawers", () => {
+  const VIEWPORT = { width: 800, height: 900 };
+  test.use({ viewport: VIEWPORT });
+
+  test("Settings opens as a bottom drawer with a top safe-area gap", async ({ page }) => {
+    const settingsPage = new SettingsPage(page, server.url, TOKEN);
+
+    await settingsPage.goto();
+    await settingsPage.openDialog();
+
+    // The bottom-sheet variant is applied on mobile.
+    await expect(settingsPage.dialog).toHaveAttribute("data-variant", "bottom-sheet");
+
+    const box = await settingsPage.dialogBox();
+    // Anchored to the bottom edge of the viewport.
+    expect(Math.abs(box.y + box.height - VIEWPORT.height)).toBeLessThanOrEqual(2);
+    // Spans the full width (bottom sheet, no side margins on mobile).
+    expect(box.width).toBeGreaterThanOrEqual(VIEWPORT.width - 4);
+    // Does NOT reach the top — a real gap is left for the notch. Settings is
+    // taller than the cap, so height is clamped and the top sits at ~1.5rem.
+    expect(box.y).toBeGreaterThanOrEqual(8);
+    expect(box.height).toBeLessThan(VIEWPORT.height);
+  });
+
+  test("the workspace picker opens as a bottom drawer", async ({ page }) => {
+    const workspacePage = new WorkspacePage(page, server.url, TOKEN);
+    const picker = new WorkspacePicker(page);
+
+    await workspacePage.goto(WORKSPACE);
+    await workspacePage.waitForMobileReady();
+    await workspacePage.openSwitcherFromHeader();
+    await picker.waitVisible();
+
+    await expect(picker.dialog).toHaveAttribute("data-variant", "bottom-sheet");
+
+    const box = await picker.dialogBox();
+    // Anchored to the bottom edge and spanning the full width.
+    expect(Math.abs(box.y + box.height - VIEWPORT.height)).toBeLessThanOrEqual(2);
+    expect(box.width).toBeGreaterThanOrEqual(VIEWPORT.width - 4);
+    // Sits below the top of the viewport (a bottom drawer, not a full-screen or
+    // top-anchored modal).
+    expect(box.y).toBeGreaterThan(8);
+  });
+
+  test("Quick Open opens as a bottom drawer", async ({ page }) => {
+    const workspacePage = new WorkspacePage(page, server.url, TOKEN);
+
+    await workspacePage.goto(WORKSPACE);
+    await workspacePage.waitForMobileReady();
+
+    // Same event the file-tree toolbar's "Quick Open" action fires.
+    await workspacePage.dispatchOpenQuickOpen();
+    await expect(workspacePage.quickOpenDialog()).toBeVisible();
+    await expect(workspacePage.quickOpenDialog()).toHaveAttribute("data-variant", "bottom-sheet");
+
+    const box = await workspacePage.settledBoxOf(workspacePage.quickOpenDialog());
+    expect(Math.abs(box.y + box.height - VIEWPORT.height)).toBeLessThanOrEqual(2);
+    expect(box.width).toBeGreaterThanOrEqual(VIEWPORT.width - 4);
+    expect(box.y).toBeGreaterThan(8);
+  });
+
+  test("Search in Files opens as a bottom drawer", async ({ page }) => {
+    const workspacePage = new WorkspacePage(page, server.url, TOKEN);
+
+    await workspacePage.goto(WORKSPACE);
+    await workspacePage.waitForMobileReady();
+
+    // Same event the file-tree toolbar's "Search in Files" action fires.
+    await workspacePage.dispatchOpenSearchFiles();
+    await expect(workspacePage.searchFilesDialog()).toBeVisible();
+    await expect(workspacePage.searchFilesDialog()).toHaveAttribute("data-variant", "bottom-sheet");
+
+    const box = await workspacePage.settledBoxOf(workspacePage.searchFilesDialog());
+    expect(Math.abs(box.y + box.height - VIEWPORT.height)).toBeLessThanOrEqual(2);
+    expect(box.width).toBeGreaterThanOrEqual(VIEWPORT.width - 4);
+    expect(box.y).toBeGreaterThan(8);
+  });
+});
+
+test.describe("Desktop dialogs stay centred", () => {
+  test.use({ viewport: { width: 1280, height: 800 } });
+
+  test("Settings renders as a centred card, not a bottom drawer", async ({ page }) => {
+    const settingsPage = new SettingsPage(page, server.url, TOKEN);
+
+    await settingsPage.goto();
+    await settingsPage.openDialog();
+
+    const box = await settingsPage.dialogBox();
+    // Not full-width — a centred card with side margins.
+    expect(box.width).toBeLessThan(1000);
+    // Horizontally centred within the viewport (±4px tolerance).
+    expect(Math.abs(box.x + box.width / 2 - 640)).toBeLessThanOrEqual(4);
+    // Not anchored to the bottom edge — there's a gap below it too.
+    expect(box.y + box.height).toBeLessThan(800 - 8);
+  });
+});

--- a/apps/web/e2e/pages/SettingsPage.ts
+++ b/apps/web/e2e/pages/SettingsPage.ts
@@ -104,6 +104,21 @@ export class SettingsPage {
     });
   }
 
+  /** Bounding box of the dialog surface. Used to assert the mobile
+   *  bottom-drawer geometry (anchored to the bottom edge, with a top
+   *  safe-area gap) versus the desktop centred card. Throws if the dialog
+   *  isn't rendered so a caller never silently asserts against `null`. */
+  async dialogBox(): Promise<{ x: number; y: number; width: number; height: number }> {
+    // Wait for the open/slide animation to finish so the measured box is the
+    // settled position, not a mid-animation frame.
+    await this.dialog.evaluate((el) =>
+      Promise.all(el.getAnimations({ subtree: true }).map((a) => a.finished.catch(() => {}))),
+    );
+    const box = await this.dialog.boundingBox();
+    if (!box) throw new Error("Settings dialog has no bounding box (not visible)");
+    return box;
+  }
+
   /** Locator for every SettingsSection card in the dialog. Anchored on the
    *  `data-testid="settings__section-card"` attribute set by
    *  `SettingsSection.tsx` (BEM convention). */

--- a/apps/web/e2e/pages/WorkspacePage.ts
+++ b/apps/web/e2e/pages/WorkspacePage.ts
@@ -701,10 +701,27 @@ export class WorkspacePage {
     return this.page.getByRole("button", { name: "Switch workspace" });
   }
 
-  /** The mobile header's back button — navigates (in-app) to the project
-   *  list at `/`. aria-label set in MobileWorkspaceLayout. */
-  get backToProjectListButton(): Locator {
-    return this.page.getByRole("button", { name: "Back to project list" });
+  /** The mobile header's hamburger button — opens the project-list fly-out
+   *  drawer *over* the current workspace (no route change). aria-label set in
+   *  MobileWorkspaceLayout. */
+  get projectListTrigger(): Locator {
+    return this.page.getByTestId("mobile-workspace__project-list-trigger");
+  }
+
+  /** The left project-list fly-out drawer (a `Sheet side="left"` wrapping the
+   *  DashboardShell). data-testid set in MobileWorkspaceLayout. */
+  get projectListFlyout(): Locator {
+    return this.page.getByTestId("project-list-flyout");
+  }
+
+  /** The active workspace card *scoped to the project-list fly-out* — proves
+   *  the card rendered inside the drawer (not elsewhere on the page) and
+   *  carries the `data-active` marker. Same `[data-active]` state-filter
+   *  rationale as `activeWorkspaceCard`. */
+  activeWorkspaceCardInFlyout(workspaceId: string): Locator {
+    return this.projectListFlyout
+      .getByTestId(`project-list__workspace-card--${workspaceId}`)
+      .and(this.page.locator("[data-active]"));
   }
 
   /** Open the workspace switcher from the mobile header title. */
@@ -714,13 +731,28 @@ export class WorkspacePage {
     });
   }
 
-  /** Tap the mobile header back button to return to the project list via
-   *  client-side navigation (not a full reload — so the in-memory
-   *  `activeWorkspaceId` store survives, which is the behaviour the
-   *  active-persistence test asserts). */
-  async goBackToProjectList(): Promise<void> {
-    await test.step("Tap back to project list", async () => {
-      await this.backToProjectListButton.click();
+  /** Tap the hamburger to open the project-list fly-out over this workspace.
+   *  Opening it must not change the route — the workspace stays mounted
+   *  underneath. */
+  async openProjectListFlyout(): Promise<void> {
+    await test.step("Open the project-list fly-out", async () => {
+      await this.projectListTrigger.click();
+      await this.projectListFlyout.waitFor({ state: "visible", timeout: 15_000 });
+    });
+  }
+
+  /** Dismiss the fly-out by clicking the backdrop overlay (tap-outside). The
+   *  overlay sits behind the drawer, so we click near the right edge of the
+   *  viewport where only the overlay is present. */
+  async dismissProjectListFlyoutViaBackdrop(): Promise<void> {
+    await test.step("Dismiss the project-list fly-out via the backdrop", async () => {
+      // The Radix overlay covers the full viewport; the drawer is on the left
+      // (max-w-sm). Click far right so the click lands on the overlay, not the
+      // drawer content.
+      const viewport = this.page.viewportSize();
+      const x = viewport ? viewport.width - 10 : 780;
+      const y = viewport ? Math.floor(viewport.height / 2) : 400;
+      await this.page.mouse.click(x, y);
     });
   }
 
@@ -1165,6 +1197,52 @@ export class WorkspacePage {
    *  cross-workspace event filtering (issue #539). */
   quickOpenDialog(): Locator {
     return this.page.getByTestId("quick-open__root");
+  }
+
+  /** The SearchFilesDialog content root. `data-testid` set on `DialogContent`
+   *  in `SearchFilesDialog.tsx` (BEM convention), so the locator survives
+   *  placeholder / visible-copy changes. */
+  searchFilesDialog(): Locator {
+    return this.page.getByTestId("search-files__root");
+  }
+
+  /** Dispatch the `band:open-quick-open` window event — the same event the
+   *  file-tree toolbar's "Quick Open" action fires (see `CodeBrowserView.tsx`).
+   *  MobileWorkspaceLayout listens for it and opens the QuickOpenDialog with an
+   *  empty query (unlike `band:open-file`, which pre-fills a query and can
+   *  auto-open a single match without ever showing the dialog). */
+  async dispatchOpenQuickOpen(): Promise<void> {
+    await test.step("Dispatch band:open-quick-open", async () => {
+      await this.page.evaluate(() => {
+        window.dispatchEvent(new CustomEvent("band:open-quick-open"));
+      });
+    });
+  }
+
+  /** Dispatch the `band:open-search-files` window event — the same event the
+   *  file-tree toolbar's "Search in Files" action fires (see
+   *  `CodeBrowserView.tsx`). MobileWorkspaceLayout listens for it and opens
+   *  the SearchFilesDialog. Mirrors `dispatchOpenFileEvent`. */
+  async dispatchOpenSearchFiles(): Promise<void> {
+    await test.step("Dispatch band:open-search-files", async () => {
+      await this.page.evaluate(() => {
+        window.dispatchEvent(new CustomEvent("band:open-search-files"));
+      });
+    });
+  }
+
+  /** Bounding box of a locator once its open/slide animation has settled —
+   *  used to assert bottom-drawer geometry deterministically. Throws if the
+   *  element isn't rendered so a caller never asserts against `null`. */
+  async settledBoxOf(
+    locator: Locator,
+  ): Promise<{ x: number; y: number; width: number; height: number }> {
+    await locator.evaluate((el) =>
+      Promise.all(el.getAnimations({ subtree: true }).map((a) => a.finished.catch(() => {}))),
+    );
+    const box = await locator.boundingBox();
+    if (!box) throw new Error("Locator has no bounding box (not visible)");
+    return box;
   }
 
   /** Press Escape — the user's universal "dismiss" gesture. Encapsulated so

--- a/apps/web/e2e/pages/WorkspacePicker.ts
+++ b/apps/web/e2e/pages/WorkspacePicker.ts
@@ -44,6 +44,19 @@ export class WorkspacePicker {
     });
   }
 
+  /** Bounding box of the picker surface. Used to assert the mobile
+   *  bottom-drawer geometry. Throws if the dialog isn't rendered. */
+  async dialogBox(): Promise<{ x: number; y: number; width: number; height: number }> {
+    // Wait for the open/slide animation to finish so the measured box is the
+    // settled position, not a mid-animation frame.
+    await this.dialog.evaluate((el) =>
+      Promise.all(el.getAnimations({ subtree: true }).map((a) => a.finished.catch(() => {}))),
+    );
+    const box = await this.dialog.boundingBox();
+    if (!box) throw new Error("Workspace picker has no bounding box (not visible)");
+    return box;
+  }
+
   /** Tap a row's pin/unpin button. This must NOT select the workspace —
    *  the dialog stays open and no navigation happens. */
   async togglePin(workspaceId: string): Promise<void> {

--- a/apps/web/e2e/project-list-flyout.spec.ts
+++ b/apps/web/e2e/project-list-flyout.spec.ts
@@ -1,0 +1,137 @@
+/**
+ * Mobile project-list fly-out coverage.
+ *
+ * On a narrow viewport the workspace header's hamburger opens the full project
+ * list as a left-edge drawer *over* the current workspace. The defining
+ * contract is that opening or closing the drawer is a pure overlay — it never
+ * changes the route/URL, so the workspace stays mounted underneath.
+ *
+ * A real git repo backs the project so its branch reconciles to a
+ * WorkspaceCard (whose `data-active` attribute is the observable active
+ * marker) and the DashboardShell inside the drawer renders its
+ * `project-list__root`. Real production binary, no tRPC mocks, page objects
+ * only.
+ */
+
+import { execFileSync } from "node:child_process";
+import { mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { expect, test } from "@playwright/test";
+import { toWorkspaceId } from "@/dashboard";
+import {
+  cleanupTmpHome,
+  createTmpHome,
+  type ServerHandle,
+  seedSettings,
+  seedState,
+  startServer,
+} from "./helpers/server";
+import { WorkspacePage } from "./pages/WorkspacePage";
+
+const TOKEN = "e2e-project-list-flyout-token";
+const PROJECT = "flyout-repo";
+const DEFAULT_BRANCH = "main";
+const WORKSPACE = toWorkspaceId(PROJECT, DEFAULT_BRANCH);
+
+// Narrow viewport so `useIsDesktop()` reports false (threshold 1024px) and the
+// mobile branch of `workspace.$workspaceId.tsx` mounts (header hamburger).
+test.use({ viewport: { width: 800, height: 900 } });
+
+function makeGitEnv(home: string): NodeJS.ProcessEnv {
+  return {
+    PATH: process.env.PATH,
+    HOME: home,
+    GIT_AUTHOR_NAME: "Test",
+    GIT_AUTHOR_EMAIL: "test@test.com",
+    GIT_COMMITTER_NAME: "Test",
+    GIT_COMMITTER_EMAIL: "test@test.com",
+    GIT_CONFIG_GLOBAL: "/dev/null",
+    GIT_CONFIG_SYSTEM: "/dev/null",
+  };
+}
+
+function git(cwd: string, args: string[], home: string): void {
+  execFileSync("git", args, { cwd, env: makeGitEnv(home) });
+}
+
+let server: ServerHandle;
+let tmpHome: string;
+
+test.beforeAll(async () => {
+  tmpHome = createTmpHome();
+
+  const repoPath = join(tmpHome, PROJECT);
+  mkdirSync(repoPath, { recursive: true });
+  git(repoPath, ["init", "-b", DEFAULT_BRANCH], tmpHome);
+  writeFileSync(join(repoPath, "README.md"), "# Flyout test\n");
+  git(repoPath, ["add", "."], tmpHome);
+  git(repoPath, ["commit", "-m", "init"], tmpHome);
+
+  seedState(tmpHome, {
+    projects: [
+      {
+        name: PROJECT,
+        path: repoPath,
+        defaultBranch: DEFAULT_BRANCH,
+        worktrees: [{ branch: DEFAULT_BRANCH, path: repoPath }],
+      },
+    ],
+  });
+  seedSettings(tmpHome, { tokenSecret: TOKEN });
+  server = await startServer({ tmpHome });
+});
+
+test.afterAll(async () => {
+  await server.close();
+  cleanupTmpHome(tmpHome);
+});
+
+test.describe("Mobile project-list fly-out", () => {
+  test("the hamburger opens the project list as an overlay without changing the route", async ({
+    page,
+  }) => {
+    const workspacePage = new WorkspacePage(page, server.url, TOKEN);
+
+    await workspacePage.goto(WORKSPACE);
+    await workspacePage.waitForMobileReady();
+    await expect(page).toHaveURL(new RegExp(WORKSPACE));
+
+    await workspacePage.openProjectListFlyout();
+
+    // The full project list rendered inside the drawer…
+    await expect(workspacePage.projectListRoot()).toBeVisible();
+    // …and opening it did NOT navigate — still on the same workspace route.
+    await expect(page).toHaveURL(new RegExp(WORKSPACE));
+  });
+
+  test("dismissing via the backdrop closes the drawer and keeps the route", async ({ page }) => {
+    const workspacePage = new WorkspacePage(page, server.url, TOKEN);
+
+    await workspacePage.goto(WORKSPACE);
+    await workspacePage.waitForMobileReady();
+
+    await workspacePage.openProjectListFlyout();
+    await workspacePage.dismissProjectListFlyoutViaBackdrop();
+
+    // Positive anchor first: the workspace is interactive again and we're
+    // still on the same route (dismissing did not navigate). Only then assert
+    // the drawer is gone.
+    await workspacePage.waitForMobileReady();
+    await expect(page).toHaveURL(new RegExp(WORKSPACE));
+    await expect(workspacePage.projectListFlyout).toBeHidden();
+  });
+
+  test("dismissing via Escape closes the drawer and keeps the route", async ({ page }) => {
+    const workspacePage = new WorkspacePage(page, server.url, TOKEN);
+
+    await workspacePage.goto(WORKSPACE);
+    await workspacePage.waitForMobileReady();
+
+    await workspacePage.openProjectListFlyout();
+    await workspacePage.pressEscape();
+
+    await workspacePage.waitForMobileReady();
+    await expect(page).toHaveURL(new RegExp(WORKSPACE));
+    await expect(workspacePage.projectListFlyout).toBeHidden();
+  });
+});

--- a/apps/web/e2e/workspace-switcher-mobile.spec.ts
+++ b/apps/web/e2e/workspace-switcher-mobile.spec.ts
@@ -8,12 +8,12 @@
  *     stay on the current workspace — the user is never forced to make a
  *     selection to get out of it.
  *
- *  2. The active workspace stays marked active after navigating back to the
- *     project-list menu route (`/`). This guards the removal of the
- *     `setActiveWorkspace(null)` unmount-clear effect in
- *     `workspace.$workspaceId.tsx`: on mobile the menu lives on a separate
- *     route from the workspace, so clearing the store on unmount would leave
- *     the menu unable to highlight the workspace the user just came from.
+ *  2. The active workspace stays marked active inside the project-list
+ *     fly-out. The hamburger opens the project list as a drawer *over* the
+ *     still-mounted workspace (no route change / no unmount), so the store
+ *     retains `activeWorkspaceId` and the card inside the drawer keeps its
+ *     `data-active` marker — the affordance the user relies on to see which
+ *     workspace they're currently in.
  *
  * A real git repo backs the project so it reconciles to kind "git" and its
  * branch renders as a WorkspaceCard (whose `data-active` attribute is the
@@ -44,8 +44,9 @@ const DEFAULT_BRANCH = "main";
 const WORKSPACE = toWorkspaceId(PROJECT, DEFAULT_BRANCH);
 
 // Narrow viewport — `useIsDesktop()` reports false (threshold 1024 px), so the
-// mobile branch of `workspace.$workspaceId.tsx` mounts (header title button +
-// back button) and the `/` route renders the full-screen DashboardShell menu.
+// mobile branch of `workspace.$workspaceId.tsx` mounts: a header with the
+// title "Switch workspace" button and the hamburger that opens the
+// project-list fly-out.
 test.use({ viewport: { width: 800, height: 900 } });
 
 function makeGitEnv(home: string): NodeJS.ProcessEnv {
@@ -121,18 +122,19 @@ test.describe("Mobile workspace switcher", () => {
     await expect(picker.dialog).toBeHidden();
   });
 
-  test("the workspace stays active after returning to the project-list menu", async ({ page }) => {
+  test("the current workspace is marked active in the project-list fly-out", async ({ page }) => {
     const workspacePage = new WorkspacePage(page, server.url, TOKEN);
 
     await workspacePage.goto(WORKSPACE);
     await workspacePage.waitForMobileReady();
 
-    await workspacePage.goBackToProjectList();
+    // Open the project-list fly-out over the workspace (no route change).
+    await workspacePage.openProjectListFlyout();
 
-    // On the menu route, the workspace we came from is still marked active
-    // (data-active) — the store retained `activeWorkspaceId` across the
-    // route change. Asserting on the active-scoped locator proves both that
-    // the card rendered and that it carries the active marker.
-    await expect(workspacePage.activeWorkspaceCard(WORKSPACE)).toBeVisible();
+    // Inside the fly-out the workspace we're viewing is still marked active
+    // (data-active) — the store retained `activeWorkspaceId`. The locator is
+    // scoped to the drawer, so it proves both that the card rendered *inside
+    // the fly-out* and that it carries the active marker.
+    await expect(workspacePage.activeWorkspaceCardInFlyout(WORKSPACE)).toBeVisible();
   });
 });

--- a/apps/web/src/dashboard/components/AddProjectDialog.tsx
+++ b/apps/web/src/dashboard/components/AddProjectDialog.tsx
@@ -111,7 +111,7 @@ export function AddProjectDialog({ open, onOpenChange, defaultLabel }: Props) {
 
   return (
     <Dialog open={open} onOpenChange={handleOpenChange}>
-      <DialogContent className="sm:max-w-[425px]">
+      <DialogContent variant="bottom-sheet" className="lg:max-w-[425px]">
         <form onSubmit={handleSubmit}>
           <DialogHeader>
             <DialogTitle>Register Project</DialogTitle>

--- a/apps/web/src/dashboard/components/QuickOpenDialog.tsx
+++ b/apps/web/src/dashboard/components/QuickOpenDialog.tsx
@@ -300,7 +300,10 @@ export function QuickOpenDialog({
     <Dialog open={open && dialogVisible} onOpenChange={onOpenChange}>
       <DialogContent
         data-testid="quick-open__root"
-        className="overflow-hidden p-0 sm:max-w-[520px]"
+        // Mobile: bottom drawer (with a top safe-area gap). Desktop: the
+        // floating command-palette card — unchanged.
+        variant="bottom-sheet"
+        className="overflow-hidden p-0 lg:max-w-[520px]"
         showCloseButton={false}
       >
         <DialogHeader className="sr-only">

--- a/apps/web/src/dashboard/components/SearchFilesDialog.tsx
+++ b/apps/web/src/dashboard/components/SearchFilesDialog.tsx
@@ -133,7 +133,14 @@ export function SearchFilesDialog({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="overflow-hidden p-0 sm:max-w-[640px]" showCloseButton={false}>
+      <DialogContent
+        data-testid="search-files__root"
+        // Mobile: bottom drawer (with a top safe-area gap). Desktop: the
+        // floating command-palette card — unchanged.
+        variant="bottom-sheet"
+        className="overflow-hidden p-0 lg:max-w-[640px]"
+        showCloseButton={false}
+      >
         <DialogHeader className="sr-only">
           <DialogTitle>Search in Files</DialogTitle>
           <DialogDescription>Text search across workspace files</DialogDescription>

--- a/apps/web/src/dashboard/components/SettingsPage.tsx
+++ b/apps/web/src/dashboard/components/SettingsPage.tsx
@@ -466,16 +466,12 @@ export function SettingsPage({ open, onOpenChange }: Props) {
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent
-        className={
-          // Mobile: take the full viewport — no margin, no rounded corners,
-          // top-anchored so the address-bar doesn't clip the footer.
-          // Desktop (sm+): float as a centered, capped-width card.
-          [
-            "inset-0 left-0 top-0 h-dvh w-full max-w-none translate-x-0 translate-y-0 rounded-none",
-            "sm:inset-auto sm:top-[50%] sm:left-[50%] sm:h-[80vh] sm:w-full sm:max-w-2xl sm:translate-x-[-50%] sm:translate-y-[-50%] sm:rounded-lg",
-            "overflow-hidden p-0 flex flex-col gap-0",
-          ].join(" ")
-        }
+        // Mobile: a bottom drawer that slides up and stops short of the top so
+        // the header + close button clear the iOS notch (the `bottom-sheet`
+        // variant caps height with env(safe-area-inset-top)). Desktop (sm+):
+        // the centered, capped-width card — unchanged.
+        variant="bottom-sheet"
+        className="flex flex-col gap-0 overflow-hidden p-0 lg:h-[80vh] lg:max-w-2xl"
       >
         <DialogHeader className="px-6 pt-6 pb-4 shrink-0">
           <DialogTitle>Settings</DialogTitle>

--- a/apps/web/src/dashboard/components/WorkspacePickerDialog.tsx
+++ b/apps/web/src/dashboard/components/WorkspacePickerDialog.tsx
@@ -109,11 +109,14 @@ export function WorkspacePickerDialog({ open, onOpenChange }: WorkspacePickerDia
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent
+        // Mobile: slides up as a bottom drawer (with a top safe-area gap).
+        // Desktop (sm+): the floating command-palette card — unchanged.
         // No border ("white frame") and the app's floating-surface colour
         // (`bg-popover`, same as dropdowns / context menus) so the picker reads
         // as part of the app rather than a stock modal. `shadow-2xl` + the
         // blurred overlay give it depth without a hard edge.
-        className="overflow-hidden border-0 bg-popover p-0 shadow-2xl sm:max-w-[520px]"
+        variant="bottom-sheet"
+        className="overflow-hidden border-0 bg-popover p-0 shadow-2xl lg:max-w-[520px] lg:border-0"
         overlayClassName="backdrop-blur-sm"
         showCloseButton={false}
         data-testid="workspace-picker"

--- a/apps/web/src/routes/workspace.$workspaceId.tsx
+++ b/apps/web/src/routes/workspace.$workspaceId.tsx
@@ -1,7 +1,9 @@
-import { createFileRoute, Navigate, useNavigate } from "@tanstack/react-router";
-import { ArrowLeft, ChevronsUpDown } from "lucide-react";
+import { Sheet, SheetContent, SheetDescription, SheetTitle } from "@band-app/ui";
+import { createFileRoute, Navigate } from "@tanstack/react-router";
+import { ChevronsUpDown, Menu } from "lucide-react";
 import { lazy, Suspense, useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
 import {
+  DashboardShell,
   DiffView,
   QuickOpenDialog,
   SearchFilesDialog,
@@ -16,6 +18,7 @@ import { agentTypeSupportsSessionListing } from "../components/ChatPane";
 import { ChatView } from "../components/ChatView";
 import { CodeBrowserView } from "../components/CodeBrowserView";
 import { DesktopDragRegion } from "../components/DesktopTitleBar";
+import { ToolbarOverflowMenuItems, ToolbarOverflowProvider } from "../components/ToolbarButtons";
 import { AgentSwitcherContext, useAgentSwitcherContext } from "../hooks/useAgentSwitcherContext";
 import { useIsDesktop } from "../hooks/useIsDesktop";
 import { SessionListContext, useSessionListContext } from "../hooks/useSessionListContext";
@@ -175,7 +178,6 @@ interface CodingAgentDef {
 }
 
 function MobileWorkspaceLayout({ workspaceId }: { workspaceId: string }) {
-  const navigate = useNavigate();
   const { height: appHeight, offsetTop: appOffsetTop } = useAppHeight();
   const diffFileCount = useDiffFileCount(workspaceId);
 
@@ -244,6 +246,13 @@ function MobileWorkspaceLayout({ workspaceId }: { workspaceId: string }) {
   // Esc) to stay on the current workspace if they change their mind.
   const [pickerOpen, setPickerOpen] = useState(false);
 
+  // Project-list fly-out. The hamburger opens the full project list as a
+  // left-edge drawer *over* the current workspace. This is pure local state:
+  // opening or closing it never changes the route, so the workspace stays
+  // mounted underneath. Selecting a workspace inside the drawer navigates
+  // (remounting this keyed layout), which resets this back to closed.
+  const [projectListOpen, setProjectListOpen] = useState(false);
+
   // Quick Open state for file link clicks from chat
   const [quickOpenOpen, setQuickOpenOpen] = useState(false);
   const [quickOpenQuery, setQuickOpenQuery] = useState<string | undefined>(undefined);
@@ -307,10 +316,6 @@ function MobileWorkspaceLayout({ workspaceId }: { workspaceId: string }) {
     [workspaceId, currentAgentId],
   );
 
-  const handleBack = useCallback(() => {
-    navigate({ to: "/" });
-  }, [navigate]);
-
   const handleSetShowSessionList = useCallback((show: boolean) => {
     setShowSessionList(show);
   }, []);
@@ -344,13 +349,17 @@ function MobileWorkspaceLayout({ workspaceId }: { workspaceId: string }) {
         >
           {isDesktop && <DesktopDragRegion />}
           <header className="flex h-[calc(2.5rem+env(safe-area-inset-top))] shrink-0 items-center gap-2 border-b border-border/50 px-3 pt-[env(safe-area-inset-top)]">
+            {/* Hamburger — opens the project list as a left fly-out drawer over
+                this workspace. Purely local state; the route never changes. */}
             <button
               type="button"
-              onClick={handleBack}
-              aria-label="Back to project list"
+              onClick={() => setProjectListOpen(true)}
+              aria-label="Open project list"
+              aria-haspopup="dialog"
+              data-testid="mobile-workspace__project-list-trigger"
               className="inline-flex size-7 shrink-0 items-center justify-center rounded-md hover:bg-accent"
             >
-              <ArrowLeft className="size-4" />
+              <Menu className="size-4" />
             </button>
             {/* Tapping the title opens the workspace switcher — the fast path
                 to jump to a recent/previous worktree without going back to the
@@ -411,6 +420,20 @@ function MobileWorkspaceLayout({ workspaceId }: { workspaceId: string }) {
             onOpenFile={handleOpenFile}
           />
           <WorkspacePickerDialog open={pickerOpen} onOpenChange={setPickerOpen} />
+          <Sheet open={projectListOpen} onOpenChange={setProjectListOpen}>
+            {/* The project list fly-out reuses the exact same DashboardShell
+                the `/` home route renders, so labels, add-project, settings
+                and the full workspace tree are all available from here. */}
+            <SheetContent side="left" showCloseButton={false} data-testid="project-list-flyout">
+              <SheetTitle className="sr-only">Projects</SheetTitle>
+              <SheetDescription className="sr-only">
+                Browse projects and open a workspace
+              </SheetDescription>
+              <ToolbarOverflowProvider>
+                <DashboardShell toolbarMenuItems={<ToolbarOverflowMenuItems />} hideTitleBar />
+              </ToolbarOverflowProvider>
+            </SheetContent>
+          </Sheet>
         </div>
       </AgentSwitcherContext.Provider>
     </SessionListContext.Provider>

--- a/packages/ui/src/components/dialog.tsx
+++ b/packages/ui/src/components/dialog.tsx
@@ -37,26 +37,60 @@ function DialogOverlay({
   );
 }
 
+// Base positioning + entry/exit animation per DialogContent variant. The
+// `default` variant is the classic centred modal. `bottom-sheet` anchors to
+// the bottom edge as a drawer on mobile (slide up, rounded top, capped
+// height with a safe-area gap so the header clears the iOS notch), then
+// reverts to the centred modal at the `lg` breakpoint — desktop is left
+// exactly as the default variant.
+//
+// The breakpoint is `lg` (1024px), NOT `sm`, so it matches the app's own
+// mobile/desktop switch (`useIsDesktop` = `min-width: 1024px`): below 1024px
+// the app renders its mobile layout, so the dialogs must be bottom drawers
+// across that whole range. The `max-lg:`/`lg:` split keeps the slide
+// animation mobile-only and the zoom animation desktop-only.
+const DIALOG_CONTENT_VARIANTS = {
+  default:
+    "fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border bg-background p-6 shadow-lg duration-200 outline-none data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 sm:max-w-lg",
+  "bottom-sheet": [
+    // Shared
+    "fixed z-50 flex flex-col bg-background shadow-lg duration-200 outline-none",
+    "data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:animate-in data-[state=open]:fade-in-0",
+    // Mobile (< lg): bottom drawer
+    "inset-x-0 bottom-0 w-full max-w-none rounded-t-2xl border border-b-0 p-6",
+    "max-h-[calc(100dvh-env(safe-area-inset-top)-1.5rem)]",
+    "max-lg:data-[state=open]:slide-in-from-bottom max-lg:data-[state=closed]:slide-out-to-bottom",
+    // Desktop (lg+): revert to the centred modal
+    "lg:inset-auto lg:top-[50%] lg:left-[50%] lg:bottom-auto lg:w-full lg:max-w-lg lg:max-h-[85vh] lg:translate-x-[-50%] lg:translate-y-[-50%] lg:rounded-lg lg:border-b",
+    "lg:data-[state=open]:zoom-in-95 lg:data-[state=closed]:zoom-out-95",
+  ].join(" "),
+} as const;
+
 function DialogContent({
   className,
   overlayClassName,
   children,
   showCloseButton = true,
+  variant = "default",
   ...props
 }: React.ComponentProps<typeof DialogPrimitive.Content> & {
   showCloseButton?: boolean;
   /** Extra classes for the backdrop overlay (e.g. `backdrop-blur-sm`). */
   overlayClassName?: string;
+  /**
+   * Layout variant. `default` is the centred modal; `bottom-sheet` renders a
+   * bottom drawer on mobile (with a top safe-area gap) that reverts to the
+   * centred modal on desktop (`lg`+, 1024px — matching `useIsDesktop`).
+   */
+  variant?: keyof typeof DIALOG_CONTENT_VARIANTS;
 }) {
   return (
     <DialogPortal data-slot="dialog-portal">
       <DialogOverlay className={overlayClassName} />
       <DialogPrimitive.Content
         data-slot="dialog-content"
-        className={cn(
-          "fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border bg-background p-6 shadow-lg duration-200 outline-none data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 sm:max-w-lg",
-          className,
-        )}
+        data-variant={variant}
+        className={cn(DIALOG_CONTENT_VARIANTS[variant], className)}
         {...props}
       >
         {children}

--- a/packages/ui/src/components/sheet.tsx
+++ b/packages/ui/src/components/sheet.tsx
@@ -1,0 +1,157 @@
+import { XIcon } from "lucide-react";
+import { Dialog as SheetPrimitive } from "radix-ui";
+import type * as React from "react";
+
+import { cn } from "../utils";
+
+/**
+ * Sheet — a Radix Dialog styled as an edge-anchored drawer.
+ *
+ * Shares Radix Dialog's semantics with the `Dialog` primitive (focus trap,
+ * Escape to close, click-outside to close, portal + backdrop overlay) but
+ * slides in from a screen edge rather than fading into the centre. Used for
+ * the mobile project-list fly-out (`side="left"`). The `side="bottom"` variant
+ * is provided for parity; the app's modal dialogs that morph into bottom
+ * drawers on mobile use `DialogContent variant="bottom-sheet"` instead so the
+ * desktop centred layout is preserved.
+ */
+
+function Sheet({ ...props }: React.ComponentProps<typeof SheetPrimitive.Root>) {
+  return <SheetPrimitive.Root data-slot="sheet" {...props} />;
+}
+
+function SheetTrigger({ ...props }: React.ComponentProps<typeof SheetPrimitive.Trigger>) {
+  return <SheetPrimitive.Trigger data-slot="sheet-trigger" {...props} />;
+}
+
+function SheetClose({ ...props }: React.ComponentProps<typeof SheetPrimitive.Close>) {
+  return <SheetPrimitive.Close data-slot="sheet-close" {...props} />;
+}
+
+function SheetPortal({ ...props }: React.ComponentProps<typeof SheetPrimitive.Portal>) {
+  return <SheetPrimitive.Portal data-slot="sheet-portal" {...props} />;
+}
+
+function SheetOverlay({
+  className,
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Overlay>) {
+  return (
+    <SheetPrimitive.Overlay
+      data-slot="sheet-overlay"
+      className={cn(
+        "fixed inset-0 z-50 bg-black/50 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:animate-in data-[state=open]:fade-in-0",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function SheetContent({
+  className,
+  children,
+  side = "left",
+  showCloseButton = true,
+  overlayClassName,
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Content> & {
+  /** Which edge the sheet slides in from. Defaults to "left". */
+  side?: "left" | "right" | "bottom" | "top";
+  showCloseButton?: boolean;
+  /** Extra classes for the backdrop overlay (e.g. `backdrop-blur-sm`). */
+  overlayClassName?: string;
+}) {
+  return (
+    <SheetPortal data-slot="sheet-portal">
+      <SheetOverlay className={overlayClassName} />
+      <SheetPrimitive.Content
+        data-slot="sheet-content"
+        className={cn(
+          "fixed z-50 flex flex-col bg-background shadow-lg outline-none transition ease-in-out data-[state=closed]:animate-out data-[state=closed]:duration-300 data-[state=open]:animate-in data-[state=open]:duration-500",
+          side === "left" &&
+            "inset-y-0 left-0 h-full w-[85%] max-w-sm border-r data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left",
+          side === "right" &&
+            "inset-y-0 right-0 h-full w-[85%] max-w-sm border-l data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right",
+          // Bottom sheet: leave a safe-area gap at the top so the header/close
+          // button stay clear of the iOS notch / status bar. env() insets are
+          // additive to the fixed 1.5rem so the gap is never smaller than the
+          // physical safe area.
+          side === "bottom" &&
+            "inset-x-0 bottom-0 max-h-[calc(100dvh-env(safe-area-inset-top)-1.5rem)] w-full rounded-t-2xl border-t data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom",
+          side === "top" &&
+            "inset-x-0 top-0 w-full rounded-b-2xl border-b data-[state=closed]:slide-out-to-top data-[state=open]:slide-in-from-top",
+          className,
+        )}
+        {...props}
+      >
+        {children}
+        {showCloseButton && (
+          <SheetPrimitive.Close
+            data-slot="sheet-close"
+            className="absolute top-4 right-4 rounded-xs opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:ring-2 focus:ring-ring focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4"
+          >
+            <XIcon />
+            <span className="sr-only">Close</span>
+          </SheetPrimitive.Close>
+        )}
+      </SheetPrimitive.Content>
+    </SheetPortal>
+  );
+}
+
+function SheetHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="sheet-header"
+      className={cn("flex flex-col gap-1.5 p-4", className)}
+      {...props}
+    />
+  );
+}
+
+function SheetFooter({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="sheet-footer"
+      className={cn("mt-auto flex flex-col gap-2 p-4", className)}
+      {...props}
+    />
+  );
+}
+
+function SheetTitle({ className, ...props }: React.ComponentProps<typeof SheetPrimitive.Title>) {
+  return (
+    <SheetPrimitive.Title
+      data-slot="sheet-title"
+      className={cn("text-foreground font-semibold", className)}
+      {...props}
+    />
+  );
+}
+
+function SheetDescription({
+  className,
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Description>) {
+  return (
+    <SheetPrimitive.Description
+      data-slot="sheet-description"
+      className={cn("text-muted-foreground text-sm", className)}
+      {...props}
+    />
+  );
+}
+
+export {
+  Sheet,
+  SheetClose,
+  SheetContent,
+  SheetDescription,
+  SheetFooter,
+  SheetHeader,
+  SheetOverlay,
+  SheetPortal,
+  SheetTitle,
+  SheetTrigger,
+};

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -19,6 +19,7 @@ export * from "./components/scroll-area";
 export * from "./components/segmented-control";
 export * from "./components/select";
 export * from "./components/separator";
+export * from "./components/sheet";
 export * from "./components/spinner";
 export * from "./components/switch";
 export * from "./components/textarea";


### PR DESCRIPTION
## Summary

Reworks the small-screen (mobile) web UI with two changes:

1. **Project list as a left fly-out.** On mobile the workspace header's back-arrow is now a hamburger that opens the full project list (`DashboardShell`) as a left-edge drawer sliding in over the current workspace — with backdrop, tap-outside/Escape close, and a slide animation. Opening or closing it is pure local state and **never changes the route/URL**; the workspace stays mounted underneath.

2. **Dialogs as bottom drawers.** A new `variant="bottom-sheet"` on the shared `DialogContent` renders modals as bottom sheets on mobile — slide-up, rounded top, height capped by `env(safe-area-inset-top)` so the header/close button clear the iOS notch / Dynamic Island. They revert to the centered desktop card unchanged. Applied to **Settings, Workspace Picker, Add Project, Quick Open, and Search in Files**.

The mobile/desktop switch uses the `lg` (1024px) breakpoint to match the app's own `useIsDesktop`, not Tailwind's default `sm`.

## Implementation notes

- New `Sheet` primitive in `packages/ui` (Radix Dialog based, `side` = left/right/bottom/top), mirroring the existing `Dialog` conventions.
- `data-testid` hooks added where needed (BEM): `mobile-workspace__project-list-trigger`, `project-list-flyout`, `search-files__root`, plus a `data-variant` attribute on `DialogContent`.
- Desktop layout behavior is unchanged.

## Tests

- `project-list-flyout.spec.ts` — fly-out opens over the workspace without a route change; closes via backdrop and via Escape, route preserved; active workspace marked inside the drawer.
- `dialog-bottom-drawer.spec.ts` — Settings / Workspace Picker / Quick Open / Search in Files render bottom-anchored with the top safe-area gap on mobile; Settings stays a centered card on desktop.
- Real production server boot, no tRPC mocks, Page Object Model — per the repo's integration-testing doctrine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)