### PR TITLE
feat(desktop): Electron process stats on the Resources page

### DIFF
--- a/apps/desktop/src/main/ipc/app-metrics.ts
+++ b/apps/desktop/src/main/ipc/app-metrics.ts
@@ -1,0 +1,142 @@
+/**
+ * `get_app_metrics` — per-process Electron/Chromium resource stats.
+ *
+ * Surfaces what `app.getAppMetrics()` reports: the Electron main (Browser)
+ * process, the GPU process, each Chromium renderer (the dashboard webview
+ * plus every browser-tab `WebContentsView`), and the Utility processes
+ * (network service, audio, storage, helpers). The web server has no
+ * visibility into any of this — it's all Electron-side — so this lives on
+ * the desktop side and is rendered by a self-gating card in the renderer.
+ *
+ * The mapping from raw `ProcessMetric` to the renderer's shape is a PURE
+ * function (`mapAppMetrics`) so it can be unit-tested without booting
+ * Electron; only `getAppMetrics()` touches `app` / `webContents`, and it
+ * imports them lazily so `node:test` can load this module without the
+ * `electron` package (whose top-level `import` throws outside the Electron
+ * runtime) — same testability split as `save-helpers.ts`.
+ */
+
+/** One Electron/Chromium process, flattened for the renderer table. */
+export interface AppProcessMetric {
+  pid: number;
+  /** Friendly label, e.g. "Main", "GPU", "Dashboard", "Browser tab: …". */
+  label: string;
+  /** Raw Electron process type ("Browser", "Tab", "Utility", "GPU", …). */
+  type: string;
+  cpuPercent: number;
+  /** Working-set size in KB (as Electron reports it). */
+  memoryKB: number;
+}
+
+/** Aggregate snapshot returned to the renderer. */
+export interface AppMetrics {
+  processCount: number;
+  totalMemoryKB: number;
+  totalCpuPercent: number;
+  /** Processes sorted by `memoryKB` descending. */
+  processes: AppProcessMetric[];
+}
+
+/**
+ * Friendly names for the Utility processes we recognise. Keyed by the
+ * non-localised `serviceName` (e.g. `network.mojom.NetworkService`) so the
+ * label is stable across locales. Anything not in the map falls back to the
+ * localised `name`, then a bare "Utility".
+ */
+const UTILITY_FRIENDLY_NAMES: Record<string, string> = {
+  "network.mojom.NetworkService": "Network service",
+  "storage.mojom.StorageService": "Storage service",
+  "audio.mojom.AudioService": "Audio service",
+  "video_capture.mojom.VideoCaptureService": "Video capture service",
+  "data_decoder.mojom.DataDecoderService": "Data decoder service",
+  "tracing.mojom.TracingService": "Tracing service",
+};
+
+/**
+ * Compute the display label for a single process metric.
+ *
+ * `pidLabels` carries renderer-specific names resolved from live
+ * `webContents` (the dashboard window, each browser tab) — only "Tab"
+ * processes look themselves up there.
+ */
+function labelFor(m: Electron.ProcessMetric, pidLabels: Map<number, string>): string {
+  switch (m.type) {
+    case "Browser":
+      return "Main";
+    case "GPU":
+      return "GPU";
+    case "Utility":
+      return (m.serviceName && UTILITY_FRIENDLY_NAMES[m.serviceName]) ?? m.name ?? "Utility";
+    case "Tab":
+      return pidLabels.get(m.pid) ?? "Renderer";
+    default:
+      // Zygote, Sandbox helper, Pepper Plugin, Unknown, … — the raw type
+      // is already the most useful thing we can show.
+      return m.type;
+  }
+}
+
+/**
+ * Pure mapper from Electron's raw `ProcessMetric[]` to the renderer shape.
+ * Exported so it can be tested without Electron.
+ */
+export function mapAppMetrics(
+  raw: Electron.ProcessMetric[],
+  pidLabels: Map<number, string>,
+): AppMetrics {
+  const processes: AppProcessMetric[] = raw.map((m) => ({
+    pid: m.pid,
+    label: labelFor(m, pidLabels),
+    type: m.type,
+    cpuPercent: m.cpu?.percentCPUUsage ?? 0,
+    memoryKB: m.memory?.workingSetSize ?? 0,
+  }));
+
+  processes.sort((a, b) => b.memoryKB - a.memoryKB);
+
+  return {
+    processCount: processes.length,
+    totalMemoryKB: processes.reduce((sum, p) => sum + p.memoryKB, 0),
+    totalCpuPercent: processes.reduce((sum, p) => sum + p.cpuPercent, 0),
+    processes,
+  };
+}
+
+/**
+ * Build the pid → friendly-name map from live `webContents`. The main
+ * dashboard window (a top-level `BrowserWindow`, type `"window"`) is labelled
+ * "Dashboard"; every other `webContents` is a browser-tab `WebContentsView`
+ * and gets `Browser tab: <title or url>`.
+ *
+ * `getOSProcessId()` throws if the renderer has already gone away (a tab
+ * closing mid-refresh), so each lookup is guarded.
+ */
+function buildPidLabels(allWebContents: Electron.WebContents[]): Map<number, string> {
+  const pidLabels = new Map<number, string>();
+  for (const wc of allWebContents) {
+    let pid: number;
+    try {
+      pid = wc.getOSProcessId();
+    } catch {
+      continue;
+    }
+    if (!pid) continue;
+    if (wc.getType() === "window") {
+      pidLabels.set(pid, "Dashboard");
+    } else {
+      const title = wc.getTitle() || wc.getURL();
+      pidLabels.set(pid, title ? `Browser tab: ${title}` : "Browser tab");
+    }
+  }
+  return pidLabels;
+}
+
+/**
+ * Gather the live Electron/Chromium process metrics for the renderer.
+ * `electron` is imported lazily (see the module header) so this file stays
+ * loadable under `node:test`.
+ */
+export async function getAppMetrics(): Promise<AppMetrics> {
+  const { app, webContents } = await import("electron");
+  return mapAppMetrics(app.getAppMetrics(), buildPidLabels(webContents.getAllWebContents()));
+}

--- a/apps/desktop/src/main/ipc/app-metrics.ts
+++ b/apps/desktop/src/main/ipc/app-metrics.ts
@@ -16,6 +16,11 @@
  * runtime) — same testability split as `save-helpers.ts`.
  */
 
+// Type-only import — erased at compile time, so it does NOT reintroduce the
+// runtime `electron` dependency the module header is careful to avoid (that's
+// why `getAppMetrics` still imports `app`/`webContents` lazily below).
+import type { ProcessMetric, WebContents } from "electron";
+
 /** One Electron/Chromium process, flattened for the renderer table. */
 export interface AppProcessMetric {
   pid: number;
@@ -59,14 +64,20 @@ const UTILITY_FRIENDLY_NAMES: Record<string, string> = {
  * `webContents` (the dashboard window, each browser tab) — only "Tab"
  * processes look themselves up there.
  */
-function labelFor(m: Electron.ProcessMetric, pidLabels: Map<number, string>): string {
+function labelFor(m: ProcessMetric, pidLabels: Map<number, string>): string {
   switch (m.type) {
     case "Browser":
       return "Main";
     case "GPU":
       return "GPU";
     case "Utility":
-      return (m.serviceName && UTILITY_FRIENDLY_NAMES[m.serviceName]) ?? m.name ?? "Utility";
+      // `serviceName` first (locale-stable), then the localised `name`. Guard
+      // with a truthiness check rather than `&& … ?? …`: an empty-string
+      // `serviceName` is falsy-but-not-nullish, so `?? m.name` wouldn't catch
+      // it and we'd render a blank label.
+      return m.serviceName
+        ? (UTILITY_FRIENDLY_NAMES[m.serviceName] ?? m.name ?? "Utility")
+        : (m.name ?? "Utility");
     case "Tab":
       return pidLabels.get(m.pid) ?? "Renderer";
     default:
@@ -80,10 +91,7 @@ function labelFor(m: Electron.ProcessMetric, pidLabels: Map<number, string>): st
  * Pure mapper from Electron's raw `ProcessMetric[]` to the renderer shape.
  * Exported so it can be tested without Electron.
  */
-export function mapAppMetrics(
-  raw: Electron.ProcessMetric[],
-  pidLabels: Map<number, string>,
-): AppMetrics {
+export function mapAppMetrics(raw: ProcessMetric[], pidLabels: Map<number, string>): AppMetrics {
   const processes: AppProcessMetric[] = raw.map((m) => ({
     pid: m.pid,
     label: labelFor(m, pidLabels),
@@ -103,15 +111,22 @@ export function mapAppMetrics(
 }
 
 /**
- * Build the pid → friendly-name map from live `webContents`. The main
- * dashboard window (a top-level `BrowserWindow`, type `"window"`) is labelled
- * "Dashboard"; every other `webContents` is a browser-tab `WebContentsView`
- * and gets `Browser tab: <title or url>`.
+ * Build the pid → friendly-name map from live `webContents`. Labels:
+ *
+ *   - `"Dashboard"` — only the real dashboard window, matched by its
+ *     `webContents.id` (`dashboardWcId`). Other top-level `BrowserWindow`s
+ *     (type `"window"`) — e.g. the hidden CDP-parking window created when the
+ *     screencast experiment is on — are labelled `"Window"` so they aren't
+ *     mistaken for the dashboard.
+ *   - `"DevTools"` — a docked DevTools view, recognised by its
+ *     `devtools://` URL (these are non-`"window"` `WebContentsView`s that
+ *     would otherwise be mislabelled as browser tabs).
+ *   - `"Browser tab: <title or url>"` — every other `WebContentsView`.
  *
  * `getOSProcessId()` throws if the renderer has already gone away (a tab
  * closing mid-refresh), so each lookup is guarded.
  */
-function buildPidLabels(allWebContents: Electron.WebContents[]): Map<number, string> {
+function buildPidLabels(allWebContents: WebContents[], dashboardWcId: number): Map<number, string> {
   const pidLabels = new Map<number, string>();
   for (const wc of allWebContents) {
     let pid: number;
@@ -122,11 +137,16 @@ function buildPidLabels(allWebContents: Electron.WebContents[]): Map<number, str
     }
     if (!pid) continue;
     if (wc.getType() === "window") {
-      pidLabels.set(pid, "Dashboard");
-    } else {
-      const title = wc.getTitle() || wc.getURL();
-      pidLabels.set(pid, title ? `Browser tab: ${title}` : "Browser tab");
+      pidLabels.set(pid, wc.id === dashboardWcId ? "Dashboard" : "Window");
+      continue;
     }
+    const url = wc.getURL();
+    if (url.startsWith("devtools://")) {
+      pidLabels.set(pid, "DevTools");
+      continue;
+    }
+    const title = wc.getTitle() || url;
+    pidLabels.set(pid, title ? `Browser tab: ${title}` : "Browser tab");
   }
   return pidLabels;
 }
@@ -134,9 +154,14 @@ function buildPidLabels(allWebContents: Electron.WebContents[]): Map<number, str
 /**
  * Gather the live Electron/Chromium process metrics for the renderer.
  * `electron` is imported lazily (see the module header) so this file stays
- * loadable under `node:test`.
+ * loadable under `node:test`. `dashboardWcId` is the main window's
+ * `webContents.id`, passed in from `register.ts` so the mapper can single out
+ * the real dashboard renderer from other top-level windows.
  */
-export async function getAppMetrics(): Promise<AppMetrics> {
+export async function getAppMetrics(dashboardWcId: number): Promise<AppMetrics> {
   const { app, webContents } = await import("electron");
-  return mapAppMetrics(app.getAppMetrics(), buildPidLabels(webContents.getAllWebContents()));
+  return mapAppMetrics(
+    app.getAppMetrics(),
+    buildPidLabels(webContents.getAllWebContents(), dashboardWcId),
+  );
 }

--- a/apps/desktop/src/main/ipc/register.ts
+++ b/apps/desktop/src/main/ipc/register.ts
@@ -93,7 +93,9 @@ export function registerIpc(opts: RegisterOptions): () => void {
   handle(Channels.getAppTitle, () => getAppTitle());
   handle(Channels.getWindowFullscreen, () => opts.mainWindow.isFullScreen());
   // Per-process Electron/Chromium resource metrics for the Resources page.
-  handle(Channels.getAppMetrics, () => getAppMetrics());
+  // Pass the dashboard window's webContents id so the mapper can label its
+  // renderer "Dashboard" and not confuse it with other top-level windows.
+  handle(Channels.getAppMetrics, () => getAppMetrics(opts.mainWindow.webContents.id));
 
   // ---- macOS shell ----
   // Args are camelCase because they're forwarded to the handlers as typed

--- a/apps/desktop/src/main/ipc/register.ts
+++ b/apps/desktop/src/main/ipc/register.ts
@@ -28,6 +28,7 @@ import type {
 } from "../../shared/types.js";
 import type { CliPathOptions } from "../services/cli-paths.js";
 import { type ManagedProcess, webserverStart, webserverStop } from "../services/web-server.js";
+import { getAppMetrics } from "./app-metrics.js";
 import { browserHandlers } from "./browser.js";
 import {
   checkAppExists,
@@ -91,6 +92,8 @@ export function registerIpc(opts: RegisterOptions): () => void {
   );
   handle(Channels.getAppTitle, () => getAppTitle());
   handle(Channels.getWindowFullscreen, () => opts.mainWindow.isFullScreen());
+  // Per-process Electron/Chromium resource metrics for the Resources page.
+  handle(Channels.getAppMetrics, () => getAppMetrics());
 
   // ---- macOS shell ----
   // Args are camelCase because they're forwarded to the handlers as typed

--- a/apps/desktop/src/preload/index.cts
+++ b/apps/desktop/src/preload/index.cts
@@ -39,6 +39,7 @@ const ALLOWED_INVOKE_CHANNELS = new Set<string>([
   "webserver_stop",
   "get_app_title",
   "get_window_fullscreen",
+  "get_app_metrics",
   // Phase 2 — macOS shell + open_external
   "pick_folder",
   "pick_file",

--- a/apps/desktop/src/shared/ipc-channels.ts
+++ b/apps/desktop/src/shared/ipc-channels.ts
@@ -13,6 +13,9 @@ export const Channels = {
   webserverStop: "webserver_stop",
   getAppTitle: "get_app_title",
   getWindowFullscreen: "get_window_fullscreen",
+  // Per-process Electron/Chromium resource metrics (app.getAppMetrics()).
+  // Surfaced on the Resources page's "Desktop app (Electron)" card.
+  getAppMetrics: "get_app_metrics",
 
   // macOS shell bridges + open_external
   pickFolder: "pick_folder",

--- a/apps/desktop/tests/app-metrics.test.ts
+++ b/apps/desktop/tests/app-metrics.test.ts
@@ -8,22 +8,23 @@
 
 import { strict as assert } from "node:assert";
 import { describe, test } from "node:test";
+import type { ProcessMetric } from "electron";
 
 import { mapAppMetrics } from "../src/main/ipc/app-metrics.ts";
 
 /** Minimal `ProcessMetric` factory — only the fields the mapper reads. */
 function metric(
-  overrides: Partial<Electron.ProcessMetric> & {
+  overrides: Partial<ProcessMetric> & {
     pid: number;
-    type: Electron.ProcessMetric["type"];
+    type: ProcessMetric["type"];
   },
-): Electron.ProcessMetric {
+): ProcessMetric {
   return {
     creationTime: 0,
     cpu: { percentCPUUsage: 0, idleWakeupsPerSecond: 0 },
     memory: { workingSetSize: 0, peakWorkingSetSize: 0 },
     ...overrides,
-  } as Electron.ProcessMetric;
+  } as ProcessMetric;
 }
 
 describe("mapAppMetrics", () => {
@@ -32,7 +33,7 @@ describe("mapAppMetrics", () => {
     [202, "Browser tab: Example Domain"],
   ]);
 
-  const raw: Electron.ProcessMetric[] = [
+  const raw: ProcessMetric[] = [
     metric({
       pid: 100,
       type: "Browser",
@@ -113,7 +114,7 @@ describe("mapAppMetrics", () => {
   });
 
   test("falls back to defaults when cpu/memory are absent", () => {
-    const out = mapAppMetrics([{ pid: 1, type: "Utility" } as Electron.ProcessMetric], new Map());
+    const out = mapAppMetrics([{ pid: 1, type: "Utility" } as ProcessMetric], new Map());
     assert.equal(out.processes[0].cpuPercent, 0);
     assert.equal(out.processes[0].memoryKB, 0);
     assert.equal(out.processes[0].label, "Utility");
@@ -125,5 +126,15 @@ describe("mapAppMetrics", () => {
       new Map(),
     );
     assert.equal(out.processes[0].label, "Foo Service");
+  });
+
+  test("empty-string Utility serviceName falls back to the localised name", () => {
+    // Guards the `&&`→`??` edge: an empty (but defined) serviceName is falsy
+    // but not nullish, so it must not produce a blank label.
+    const out = mapAppMetrics(
+      [metric({ pid: 3, type: "Utility", serviceName: "", name: "Fallback Service" })],
+      new Map(),
+    );
+    assert.equal(out.processes[0].label, "Fallback Service");
   });
 });

--- a/apps/desktop/tests/app-metrics.test.ts
+++ b/apps/desktop/tests/app-metrics.test.ts
@@ -7,9 +7,14 @@
  */
 
 import { strict as assert } from "node:assert";
-import { describe, test } from "node:test";
+import { before, describe, test } from "node:test";
 import type { ProcessMetric } from "electron";
 
+// `mapAppMetrics` is a deliberately-exported pure seam: `getAppMetrics()` in
+// the same module touches `app` / `webContents`, which throw outside the
+// Electron runtime, so the mapping logic is split out and exported so it can
+// be exercised under `node:test`. This is an intentional TEST-1 exception
+// (same spirit as the CLAUDE.md carve-outs), not accidental pattern drift.
 import { mapAppMetrics } from "../src/main/ipc/app-metrics.ts";
 
 /** Minimal `ProcessMetric` factory — only the fields the mapper reads. */
@@ -77,7 +82,12 @@ describe("mapAppMetrics", () => {
     metric({ pid: 104, type: "Zygote", memory: { workingSetSize: 2_000, peakWorkingSetSize: 0 } }),
   ];
 
-  const result = mapAppMetrics(raw, pidLabels);
+  // Computed in `before` (not at describe scope) so a throw surfaces as a
+  // clean hook failure instead of aborting the whole describe block.
+  let result: ReturnType<typeof mapAppMetrics>;
+  before(() => {
+    result = mapAppMetrics(raw, pidLabels);
+  });
 
   test("labels each process by type and pidLabels lookup", () => {
     const byPid = new Map(result.processes.map((p) => [p.pid, p.label]));

--- a/apps/desktop/tests/app-metrics.test.ts
+++ b/apps/desktop/tests/app-metrics.test.ts
@@ -1,0 +1,129 @@
+/**
+ * Pure-logic tests for `mapAppMetrics` — the mapper from Electron's raw
+ * `app.getAppMetrics()` output to the renderer's process-table shape. No
+ * Electron deps (the `getAppMetrics()` wrapper that touches `app` /
+ * `webContents` is deliberately excluded), so this runs under `node:test`
+ * like the other desktop pure-logic tests.
+ */
+
+import { strict as assert } from "node:assert";
+import { describe, test } from "node:test";
+
+import { mapAppMetrics } from "../src/main/ipc/app-metrics.ts";
+
+/** Minimal `ProcessMetric` factory — only the fields the mapper reads. */
+function metric(
+  overrides: Partial<Electron.ProcessMetric> & {
+    pid: number;
+    type: Electron.ProcessMetric["type"];
+  },
+): Electron.ProcessMetric {
+  return {
+    creationTime: 0,
+    cpu: { percentCPUUsage: 0, idleWakeupsPerSecond: 0 },
+    memory: { workingSetSize: 0, peakWorkingSetSize: 0 },
+    ...overrides,
+  } as Electron.ProcessMetric;
+}
+
+describe("mapAppMetrics", () => {
+  const pidLabels = new Map<number, string>([
+    [201, "Dashboard"],
+    [202, "Browser tab: Example Domain"],
+  ]);
+
+  const raw: Electron.ProcessMetric[] = [
+    metric({
+      pid: 100,
+      type: "Browser",
+      cpu: { percentCPUUsage: 3, idleWakeupsPerSecond: 0 },
+      memory: { workingSetSize: 50_000, peakWorkingSetSize: 0 },
+    }),
+    metric({
+      pid: 101,
+      type: "GPU",
+      cpu: { percentCPUUsage: 1, idleWakeupsPerSecond: 0 },
+      memory: { workingSetSize: 30_000, peakWorkingSetSize: 0 },
+    }),
+    metric({
+      pid: 102,
+      type: "Utility",
+      serviceName: "network.mojom.NetworkService",
+      name: "Network Service",
+      cpu: { percentCPUUsage: 0.5, idleWakeupsPerSecond: 0 },
+      memory: { workingSetSize: 10_000, peakWorkingSetSize: 0 },
+    }),
+    metric({
+      pid: 201,
+      type: "Tab",
+      cpu: { percentCPUUsage: 2, idleWakeupsPerSecond: 0 },
+      memory: { workingSetSize: 80_000, peakWorkingSetSize: 0 },
+    }),
+    metric({
+      pid: 202,
+      type: "Tab",
+      cpu: { percentCPUUsage: 4, idleWakeupsPerSecond: 0 },
+      memory: { workingSetSize: 40_000, peakWorkingSetSize: 0 },
+    }),
+    // Tab with no matching pidLabel entry → generic "Renderer".
+    metric({
+      pid: 203,
+      type: "Tab",
+      cpu: { percentCPUUsage: 0, idleWakeupsPerSecond: 0 },
+      memory: { workingSetSize: 5_000, peakWorkingSetSize: 0 },
+    }),
+    // Unknown/other type → passed through verbatim.
+    metric({ pid: 104, type: "Zygote", memory: { workingSetSize: 2_000, peakWorkingSetSize: 0 } }),
+  ];
+
+  const result = mapAppMetrics(raw, pidLabels);
+
+  test("labels each process by type and pidLabels lookup", () => {
+    const byPid = new Map(result.processes.map((p) => [p.pid, p.label]));
+    assert.equal(byPid.get(100), "Main");
+    assert.equal(byPid.get(101), "GPU");
+    assert.equal(byPid.get(102), "Network service");
+    assert.equal(byPid.get(201), "Dashboard");
+    assert.equal(byPid.get(202), "Browser tab: Example Domain");
+    assert.equal(byPid.get(203), "Renderer");
+    assert.equal(byPid.get(104), "Zygote");
+  });
+
+  test("maps cpuPercent and memoryKB from the raw metric", () => {
+    const main = result.processes.find((p) => p.pid === 100);
+    assert.ok(main);
+    assert.equal(main.cpuPercent, 3);
+    assert.equal(main.memoryKB, 50_000);
+  });
+
+  test("computes totals across all processes", () => {
+    assert.equal(result.processCount, 7);
+    assert.equal(result.totalMemoryKB, 50_000 + 30_000 + 10_000 + 80_000 + 40_000 + 5_000 + 2_000);
+    // 3 + 1 + 0.5 + 2 + 4 + 0 + 0 = 10.5
+    assert.equal(result.totalCpuPercent, 10.5);
+  });
+
+  test("sorts processes by memoryKB descending", () => {
+    const mem = result.processes.map((p) => p.memoryKB);
+    const sorted = [...mem].sort((a, b) => b - a);
+    assert.deepEqual(mem, sorted);
+    // Largest is the 80_000 KB Dashboard tab, smallest the 2_000 KB Zygote.
+    assert.equal(result.processes[0].pid, 201);
+    assert.equal(result.processes.at(-1)?.pid, 104);
+  });
+
+  test("falls back to defaults when cpu/memory are absent", () => {
+    const out = mapAppMetrics([{ pid: 1, type: "Utility" } as Electron.ProcessMetric], new Map());
+    assert.equal(out.processes[0].cpuPercent, 0);
+    assert.equal(out.processes[0].memoryKB, 0);
+    assert.equal(out.processes[0].label, "Utility");
+  });
+
+  test("unknown Utility serviceName falls back to the localised name", () => {
+    const out = mapAppMetrics(
+      [metric({ pid: 2, type: "Utility", serviceName: "unknown.mojom.Foo", name: "Foo Service" })],
+      new Map(),
+    );
+    assert.equal(out.processes[0].label, "Foo Service");
+  });
+});

--- a/apps/web/e2e/pages/ResourcesPage.ts
+++ b/apps/web/e2e/pages/ResourcesPage.ts
@@ -26,6 +26,10 @@ export class ResourcesPage {
   readonly dialog: Locator;
   /** Outer server snapshot card (PID, uptime, memory, CPU). */
   readonly serverCard: Locator;
+  /** Desktop-only "Desktop app (Electron)" card. Never rendered in the
+   *  web-build harness (self-gates on `isDesktop`) — used only to assert
+   *  its absence. */
+  readonly electronCard: Locator;
   /** Title-row trigger that expands/collapses the server card. */
   readonly serverToggle: Locator;
   /** Headline total shown next to the server title while collapsed
@@ -60,6 +64,7 @@ export class ResourcesPage {
   ) {
     this.dialog = page.getByTestId("resources-dialog");
     this.serverCard = page.getByTestId("resources-server-card");
+    this.electronCard = page.getByTestId("resources-electron-card");
     this.serverToggle = page.getByTestId("resources-server-toggle");
     this.serverTotal = page.getByTestId("resources-server-total");
     this.serverPid = page.getByTestId("resources-server-pid");

--- a/apps/web/e2e/pages/ResourcesPage.ts
+++ b/apps/web/e2e/pages/ResourcesPage.ts
@@ -26,9 +26,18 @@ export class ResourcesPage {
   readonly dialog: Locator;
   /** Outer server snapshot card (PID, uptime, memory, CPU). */
   readonly serverCard: Locator;
+  /** Title-row trigger that expands/collapses the server card. */
+  readonly serverToggle: Locator;
+  /** Headline total shown next to the server title while collapsed
+   *  (the process RSS). Absent from the DOM once the card is open. */
+  readonly serverTotal: Locator;
   /** PID cell inside the server card — primary "the snapshot loaded"
-   *  assertion target. */
+   *  assertion target. Only mounted while the card is expanded. */
   readonly serverPid: Locator;
+  /** Title-row trigger that expands/collapses the worktrees card. */
+  readonly worktreesToggle: Locator;
+  /** Headline total shown next to the worktrees title while collapsed. */
+  readonly worktreesTotal: Locator;
   /** Refresh button on the server card. */
   readonly refreshServerButton: Locator;
   /** Refresh button on the worktrees card. */
@@ -51,7 +60,11 @@ export class ResourcesPage {
   ) {
     this.dialog = page.getByTestId("resources-dialog");
     this.serverCard = page.getByTestId("resources-server-card");
+    this.serverToggle = page.getByTestId("resources-server-toggle");
+    this.serverTotal = page.getByTestId("resources-server-total");
     this.serverPid = page.getByTestId("resources-server-pid");
+    this.worktreesToggle = page.getByTestId("resources-worktrees-toggle");
+    this.worktreesTotal = page.getByTestId("resources-worktrees-total");
     this.refreshServerButton = page.getByTestId("resources-refresh-server");
     this.refreshWorktreesButton = page.getByTestId("resources-refresh-worktrees");
     this.projectsTable = page.getByTestId("resources-projects-table");
@@ -90,11 +103,31 @@ export class ResourcesPage {
     });
   }
 
-  /** Wait for the initial server card render. The card mounts with a
-   *  Spinner before the query resolves; the pid testid only appears
-   *  once the query data lands. */
+  /** Wait for the initial page render. All cards start collapsed, so
+   *  the server card's header (its expand trigger) is the first
+   *  reliable "the page mounted" anchor — the PID cell only mounts
+   *  once the card is expanded. */
   async waitForReady(): Promise<void> {
-    await expect(this.serverPid).toBeVisible({ timeout: 15_000 });
+    await expect(this.serverToggle).toBeVisible({ timeout: 15_000 });
+  }
+
+  /** Expand the (collapsed-by-default) server card and wait for its
+   *  body to mount. The PID cell only renders once the snapshot query
+   *  has resolved, so this doubles as the "snapshot loaded" wait. */
+  async expandServer(): Promise<void> {
+    await test.step("Expand the server card", async () => {
+      await this.serverToggle.click();
+      await expect(this.serverPid).toBeVisible({ timeout: 15_000 });
+    });
+  }
+
+  /** Expand the (collapsed-by-default) worktrees card and wait for its
+   *  table to mount. */
+  async expandWorktrees(): Promise<void> {
+    await test.step("Expand the worktrees card", async () => {
+      await this.worktreesToggle.click();
+      await expect(this.projectsTable).toBeVisible({ timeout: 15_000 });
+    });
   }
 
   /** Trigger a server-card refresh. */

--- a/apps/web/e2e/resources.spec.ts
+++ b/apps/web/e2e/resources.spec.ts
@@ -6,6 +6,20 @@
  * the React UI through `ResourcesPage` (page-object model). The page
  * is no longer a separate route — it lives inside a Radix Dialog
  * opened from the dashboard's overflow menu.
+ *
+ * Out of scope: the "Desktop app (Electron)" card
+ * ------------------------------------------------
+ * `ElectronCard` in `ResourcesPage.tsx` self-gates on `isDesktop`
+ * (`if (!isDesktop) return null`) and pulls its data over the Electron
+ * IPC bridge (`invoke("get_app_metrics")`). This web-build harness
+ * never boots Electron, so `window.__BAND_DESKTOP__` is absent and the
+ * card is never rendered — a runtime regression catch for it requires
+ * desktop e2e coverage this spec can't provide (same shape and
+ * rationale as the browser-panel / macOS-shell IPC surfaces). We do
+ * assert the negative below (`electronCard` has zero DOM nodes) so the
+ * self-gate has an empirical check on the web path; the positive
+ * behaviour is covered by the pure `mapAppMetrics` unit test in
+ * `apps/desktop/tests/app-metrics.test.ts`.
  */
 
 import { execFileSync } from "node:child_process";
@@ -98,13 +112,19 @@ test.describe("Resources dialog (issue #506)", () => {
     await resources.open();
     await resources.waitForReady();
 
-    // Cards start collapsed: the body content (server PID, project
-    // table) is not mounted, and each card shows its headline total
-    // next to the title instead.
-    await expect(resources.serverPid).not.toBeVisible();
-    await expect(resources.projectsTable).not.toBeVisible();
+    // Cards start collapsed. Prove the collapsed-state UI rendered
+    // first — each card shows its headline total next to the title —
+    // then assert the expanded-state body content (server PID, project
+    // table) is not mounted.
     await expect(resources.serverTotal).toBeVisible();
     await expect(resources.worktreesTotal).toBeVisible();
+    await expect(resources.serverPid).not.toBeVisible();
+    await expect(resources.projectsTable).not.toBeVisible();
+
+    // The Electron card is desktop-only (self-gates on isDesktop) and
+    // never renders in this web-build harness — see the scope note at
+    // the top of this file.
+    await expect(resources.electronCard).toHaveCount(0);
 
     // Server card: expand it, then assert a numeric PID is present.
     await resources.expandServer();

--- a/apps/web/e2e/resources.spec.ts
+++ b/apps/web/e2e/resources.spec.ts
@@ -98,15 +98,25 @@ test.describe("Resources dialog (issue #506)", () => {
     await resources.open();
     await resources.waitForReady();
 
-    // Server card: numeric PID present.
+    // Cards start collapsed: the body content (server PID, project
+    // table) is not mounted, and each card shows its headline total
+    // next to the title instead.
+    await expect(resources.serverPid).not.toBeVisible();
+    await expect(resources.projectsTable).not.toBeVisible();
+    await expect(resources.serverTotal).toBeVisible();
+    await expect(resources.worktreesTotal).toBeVisible();
+
+    // Server card: expand it, then assert a numeric PID is present.
+    await resources.expandServer();
     const pid = await resources.getServerPidValue();
     expect(Number.isFinite(pid)).toBe(true);
     expect(pid).toBeGreaterThan(0);
 
-    // Worktrees card: the project row appears immediately on open
-    // (no Refresh click needed). The per-project size cell starts
-    // as a "measuring…" spinner and resolves to MB-class output
-    // when the server's `du` finishes.
+    // Worktrees card: expand it, then the project row appears (no
+    // Refresh click needed). The per-project size cell starts as a
+    // "measuring…" spinner and resolves to MB-class output when the
+    // server's `du` finishes.
+    await resources.expandWorktrees();
     const projectRow = resources.getProjectRow(PROJECT);
     await expect(projectRow).toBeVisible({ timeout: 15_000 });
     const sizeCell = resources.getProjectSize(PROJECT);

--- a/apps/web/e2e/resources.spec.ts
+++ b/apps/web/e2e/resources.spec.ts
@@ -17,9 +17,13 @@
  * desktop e2e coverage this spec can't provide (same shape and
  * rationale as the browser-panel / macOS-shell IPC surfaces). We do
  * assert the negative below (`electronCard` has zero DOM nodes) so the
- * self-gate has an empirical check on the web path; the positive
- * behaviour is covered by the pure `mapAppMetrics` unit test in
- * `apps/desktop/tests/app-metrics.test.ts`.
+ * self-gate has an empirical check on the web path.
+ *
+ * Only the data-mapping layer is unit-tested (`mapAppMetrics` in
+ * `apps/desktop/tests/app-metrics.test.ts`). The IPC channel
+ * registration (`register.ts`), the preload allowlist entry
+ * (`index.cts`), and the `ElectronCard` React rendering remain
+ * uncovered, pending desktop e2e infrastructure.
  */
 
 import { execFileSync } from "node:child_process";

--- a/apps/web/src/components/ResourcesPage.tsx
+++ b/apps/web/src/components/ResourcesPage.tsx
@@ -1,7 +1,9 @@
 import { Button, ScrollArea, Spinner } from "@band-app/ui";
-import { useQuery } from "@tanstack/react-query";
+import { type UseQueryResult, useQuery } from "@tanstack/react-query";
 import { ChevronRight, RefreshCw } from "lucide-react";
 import { Fragment, useCallback, useEffect, useMemo, useState } from "react";
+import { invoke } from "../lib/desktop-ipc";
+import { isDesktop } from "../lib/is-desktop";
 import { trpc } from "../lib/trpc-client";
 
 interface ServerSnapshot {
@@ -21,6 +23,25 @@ interface ServerSnapshot {
     userMicros: number;
     systemMicros: number;
   };
+}
+
+// Mirrors the mapper output in
+// apps/desktop/src/main/ipc/app-metrics.ts. Defined inline (not imported)
+// so the web app never gains a build-time dependency on desktop types —
+// same pattern as `ServerSnapshot` above.
+interface AppProcessMetric {
+  pid: number;
+  label: string;
+  type: string;
+  cpuPercent: number;
+  memoryKB: number;
+}
+
+interface AppMetrics {
+  processCount: number;
+  totalMemoryKB: number;
+  totalCpuPercent: number;
+  processes: AppProcessMetric[];
 }
 
 interface ProjectListing {
@@ -137,6 +158,15 @@ export function ResourcesPage() {
   const serverQuery = useQuery<ServerSnapshot>({
     queryKey: ["resources", "server"],
     queryFn: () => trpc.services.resourcesServer.query(),
+  });
+
+  // Electron/Chromium process metrics — desktop shell only. The web app
+  // never launches Electron, so this stays disabled (and the card below
+  // returns null) outside the desktop shell.
+  const appMetricsQuery = useQuery<AppMetrics>({
+    queryKey: ["resources", "app-metrics"],
+    queryFn: () => invoke<AppMetrics>("get_app_metrics"),
+    enabled: isDesktop,
   });
 
   // Cheap query — just `git worktree list --porcelain` per project,
@@ -328,6 +358,8 @@ export function ResourcesPage() {
           )}
         </section>
 
+        <ElectronCard query={appMetricsQuery} />
+
         <section data-testid="resources-worktrees-card" className="space-y-3">
           <div className="flex flex-row items-start justify-between gap-2">
             <div className="space-y-1">
@@ -506,6 +538,109 @@ export function ResourcesPage() {
         </section>
       </div>
     </ScrollArea>
+  );
+}
+
+/**
+ * "Desktop app (Electron)" card — a per-process breakdown of the Electron
+ * main process, GPU process, Chromium renderers (dashboard + browser tabs),
+ * and Utility helpers, via `app.getAppMetrics()`.
+ *
+ * Self-gating: renders nothing outside the Electron shell (the web-server
+ * build has no `get_app_metrics` handler and no Electron processes to
+ * report), so the whole card is desktop-only.
+ */
+function ElectronCard({ query }: { query: UseQueryResult<AppMetrics> }) {
+  if (!isDesktop) return null;
+
+  const metrics = query.data;
+
+  return (
+    <section data-testid="resources-electron-card" className="space-y-3">
+      <div className="flex flex-row items-start justify-between gap-2">
+        <div className="space-y-1">
+          <h2 className="text-base font-semibold leading-none">Desktop app (Electron)</h2>
+          <p className="text-sm text-muted-foreground">
+            Per-process CPU and memory for the Electron main process, GPU process, Chromium
+            renderers (the dashboard and each browser tab), and utility helpers.
+          </p>
+        </div>
+        <Button
+          variant="outline"
+          size="sm"
+          data-testid="resources-refresh-electron"
+          onClick={() => query.refetch()}
+          disabled={query.isFetching}
+        >
+          {query.isFetching ? <Spinner className="size-3.5" /> : <RefreshCw className="size-3.5" />}
+          Refresh
+        </Button>
+      </div>
+      {query.isError ? (
+        <p className="text-sm text-destructive">
+          Failed to load Electron metrics: {String(query.error)}
+        </p>
+      ) : !metrics ? (
+        <div className="flex items-center gap-2 text-sm text-muted-foreground">
+          <Spinner className="size-4" />
+          Loading…
+        </div>
+      ) : (
+        <div className="relative overflow-x-auto">
+          <table data-testid="resources-electron-table" className="w-full border-collapse text-sm">
+            <thead>
+              <tr className="border-b border-border text-left text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                <th className="py-2 pr-3">Process</th>
+                <th className="py-2 pr-3">Type</th>
+                <th className="py-2 pr-3 text-right">PID</th>
+                <th className="py-2 pr-3 text-right">CPU</th>
+                <th className="py-2 pr-3 text-right">Memory</th>
+              </tr>
+            </thead>
+            <tbody>
+              {metrics.processes.map((p) => (
+                <tr
+                  key={p.pid}
+                  data-testid={`resources-electron-row-${p.pid}`}
+                  className="border-b border-border/60 last:border-0 hover:bg-muted/40"
+                >
+                  <td className="py-1.5 pr-3">{p.label}</td>
+                  <td className="py-1.5 pr-3 text-muted-foreground">{p.type}</td>
+                  <td className="py-1.5 pr-3 text-right tabular-nums">{p.pid}</td>
+                  <td className="py-1.5 pr-3 text-right tabular-nums">
+                    {p.cpuPercent.toFixed(1)}%
+                  </td>
+                  <td className="py-1.5 pr-3 text-right tabular-nums">
+                    {formatBytes(p.memoryKB * 1024)}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+            <tfoot>
+              <tr className="border-t-2 border-border font-medium">
+                <td className="py-2 pr-3" data-testid="resources-electron-total-count">
+                  Total ({metrics.processCount})
+                </td>
+                <td className="py-2 pr-3" />
+                <td className="py-2 pr-3" />
+                <td
+                  className="py-2 pr-3 text-right tabular-nums"
+                  data-testid="resources-electron-total-cpu"
+                >
+                  {metrics.totalCpuPercent.toFixed(1)}%
+                </td>
+                <td
+                  className="py-2 pr-3 text-right tabular-nums"
+                  data-testid="resources-electron-total-memory"
+                >
+                  {formatBytes(metrics.totalMemoryKB * 1024)}
+                </td>
+              </tr>
+            </tfoot>
+          </table>
+        </div>
+      )}
+    </section>
   );
 }
 

--- a/apps/web/src/components/ResourcesPage.tsx
+++ b/apps/web/src/components/ResourcesPage.tsx
@@ -285,16 +285,28 @@ export function ResourcesPage() {
   // zero-byte project; both end up at the bottom of the
   // size-known group. We treat that as acceptable because errors
   // are also surfaced inline (the size cell renders "error").
-  const sortedProjects = [...projects].sort((a, b) => {
-    const sa = sizes.get(a.project);
-    const sb = sizes.get(b.project);
-    if (sa && sb) return sb.sizeBytes - sa.sizeBytes;
-    if (sa && !sb) return -1;
-    if (!sa && sb) return 1;
-    return 0;
-  });
+  const sortedProjects = useMemo(
+    () =>
+      [...projects].sort((a, b) => {
+        const sa = sizes.get(a.project);
+        const sb = sizes.get(b.project);
+        if (sa && sb) return sb.sizeBytes - sa.sizeBytes;
+        if (sa && !sb) return -1;
+        if (!sa && sb) return 1;
+        return 0;
+      }),
+    [projects, sizes],
+  );
 
-  const knownTotalBytes = Array.from(sizes.values()).reduce((sum, s) => sum + s.sizeBytes, 0);
+  const knownTotalBytes = useMemo(
+    () => Array.from(sizes.values()).reduce((sum, s) => sum + s.sizeBytes, 0),
+    [sizes],
+  );
+  // Total worktree count across all projects — shown in the table footer.
+  const totalWorktreeCount = useMemo(
+    () => projects.reduce((sum, p) => sum + p.worktrees.length, 0),
+    [projects],
+  );
   // "All sizes accounted for" — true when every project has either
   // a known size or there are no projects at all. The latter case
   // matters because the user with zero tracked repos would
@@ -570,7 +582,7 @@ export function ResourcesPage() {
                             <tr className="border-t-2 border-border font-medium">
                               <td className="py-2 pr-3">Total{allLoaded ? "" : " (partial)"}</td>
                               <td className="py-2 pr-3 text-right tabular-nums">
-                                {projects.reduce((sum, p) => sum + p.worktrees.length, 0)}
+                                {totalWorktreeCount}
                               </td>
                               <td
                                 className="py-2 pr-3 text-right tabular-nums"

--- a/apps/web/src/components/ResourcesPage.tsx
+++ b/apps/web/src/components/ResourcesPage.tsx
@@ -1,4 +1,11 @@
-import { Button, ScrollArea, Spinner } from "@band-app/ui";
+import {
+  Button,
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+  ScrollArea,
+  Spinner,
+} from "@band-app/ui";
 import { type UseQueryResult, useQuery } from "@tanstack/react-query";
 import { ChevronRight, RefreshCw } from "lucide-react";
 import { Fragment, useCallback, useEffect, useMemo, useState } from "react";
@@ -296,246 +303,292 @@ export function ResourcesPage() {
   // excluded that path).
   const allLoaded = sizes.size === projects.length;
 
+  // Each card starts collapsed (issue: compact overview by default) —
+  // its headline total shows next to the title until the user expands
+  // it. Per-panel state so opening one doesn't touch the others.
+  const [serverOpen, setServerOpen] = useState(false);
+  const [worktreesOpen, setWorktreesOpen] = useState(false);
+
   return (
     <ScrollArea className="h-full w-full">
-      <div className="mx-auto flex max-w-5xl flex-col gap-8 px-6 py-4">
-        <section data-testid="resources-server-card" className="space-y-3">
-          <div className="flex flex-row items-start justify-between gap-2">
-            <div className="space-y-1">
-              <h2 className="text-base font-semibold leading-none">Server</h2>
-              <p className="text-sm text-muted-foreground">
-                The Node process serving the Band dashboard ({server ? `pid ${server.pid}` : "…"}).
-              </p>
-            </div>
-            <Button
-              variant="outline"
-              size="sm"
-              data-testid="resources-refresh-server"
-              onClick={() => serverQuery.refetch()}
-              disabled={serverQuery.isFetching}
-            >
-              {serverQuery.isFetching ? (
-                <Spinner className="size-3.5" />
-              ) : (
-                <RefreshCw className="size-3.5" />
-              )}
-              Refresh
-            </Button>
-          </div>
-          {serverQuery.isError ? (
-            <p className="text-sm text-destructive">
-              Failed to load server snapshot: {String(serverQuery.error)}
-            </p>
-          ) : !server ? (
-            <div className="flex items-center gap-2 text-sm text-muted-foreground">
-              <Spinner className="size-4" />
-              Loading…
-            </div>
-          ) : (
-            <div className="grid grid-cols-2 gap-x-6 gap-y-2 text-sm md:grid-cols-3">
-              <ServerField label="PID">
-                <span data-testid="resources-server-pid">{server.pid}</span>
-              </ServerField>
-              <ServerField label="Uptime">{formatUptime(server.uptimeSeconds)}</ServerField>
-              <ServerField label="Node">{server.nodeVersion}</ServerField>
-              <ServerField label="Platform">
-                {server.platform} ({server.arch})
-              </ServerField>
-              <ServerField label="RSS">{formatMB(server.memory.rssBytes)}</ServerField>
-              <ServerField label="Heap used">{formatMB(server.memory.heapUsedBytes)}</ServerField>
-              <ServerField label="Heap total">{formatMB(server.memory.heapTotalBytes)}</ServerField>
-              <ServerField label="External">{formatMB(server.memory.externalBytes)}</ServerField>
-              <ServerField label="Array buffers">
-                {formatMB(server.memory.arrayBuffersBytes)}
-              </ServerField>
-              <ServerField label="Total CPU time (user)">
-                {formatCpuMs(server.cpu.userMicros)}
-              </ServerField>
-              <ServerField label="Total CPU time (system)">
-                {formatCpuMs(server.cpu.systemMicros)}
-              </ServerField>
-            </div>
-          )}
-        </section>
-
-        <ElectronCard query={appMetricsQuery} />
-
-        <section data-testid="resources-worktrees-card" className="space-y-3">
-          <div className="flex flex-row items-start justify-between gap-2">
-            <div className="space-y-1">
-              <h2 className="text-base font-semibold leading-none">Worktrees</h2>
-              <p className="text-sm text-muted-foreground">
-                Disk usage per tracked git project (allocated blocks, as reported by{" "}
-                <code className="rounded bg-muted px-1 py-0.5 text-xs">du</code>). Sizes load per
-                project in batches of {PROJECT_FETCH_CONCURRENCY}. Click a project to see its
-                per-worktree breakdown.
-              </p>
-            </div>
-            <Button
-              variant="outline"
-              size="sm"
-              data-testid="resources-refresh-worktrees"
-              onClick={handleRefreshSizes}
-              disabled={projectsQuery.isFetching || !allLoaded}
-            >
-              {projectsQuery.isFetching || !allLoaded ? (
-                <Spinner className="size-3.5" />
-              ) : (
-                <RefreshCw className="size-3.5" />
-              )}
-              Refresh
-            </Button>
-          </div>
-          {projectsQuery.isError ? (
-            <p className="text-sm text-destructive">
-              Failed to load projects: {String(projectsQuery.error)}
-            </p>
-          ) : (
-            <div className="relative overflow-x-auto">
-              <table
-                data-testid="resources-projects-table"
-                className="w-full border-collapse text-sm"
-              >
-                <thead>
-                  <tr className="border-b border-border text-left text-xs font-medium uppercase tracking-wide text-muted-foreground">
-                    <th className="py-2 pr-3">Project</th>
-                    <th className="py-2 pr-3 text-right">Worktrees</th>
-                    <th className="py-2 pr-3 text-right">Total size</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {sortedProjects.length === 0 ? (
-                    <tr>
-                      <td colSpan={3} className="py-6 text-center text-sm text-muted-foreground">
-                        {projectsQuery.isFetching ? "Loading…" : "No git projects found"}
-                      </td>
-                    </tr>
+      <div className="mx-auto max-w-5xl px-6 py-4">
+        {/* One settings-style section: a single rounded border wrapping
+            every panel, with 1px dividers auto-inserted between them
+            (`[&>*+*]:border-t`). Panels carry no border of their own. */}
+        <div className="overflow-hidden rounded-xl border border-border [&>*+*]:border-t [&>*+*]:border-border">
+          <Collapsible open={serverOpen} onOpenChange={setServerOpen} asChild>
+            <section data-testid="resources-server-card">
+              <PanelHeader
+                title="Server"
+                toggleTestId="resources-server-toggle"
+                open={serverOpen}
+                totalTestId="resources-server-total"
+                total={server ? formatMB(server.memory.rssBytes) : "…"}
+                description={`The Node process serving the Band dashboard (${
+                  server ? `pid ${server.pid}` : "…"
+                }).`}
+                refresh={
+                  <Button
+                    variant="outline"
+                    size="icon-sm"
+                    aria-label="Refresh"
+                    title="Refresh"
+                    data-testid="resources-refresh-server"
+                    onClick={() => serverQuery.refetch()}
+                    disabled={serverQuery.isFetching}
+                  >
+                    {serverQuery.isFetching ? (
+                      <Spinner className="size-3.5" />
+                    ) : (
+                      <RefreshCw className="size-3.5" />
+                    )}
+                  </Button>
+                }
+              />
+              <CollapsibleContent>
+                <div className="border-t border-border p-4">
+                  {serverQuery.isError ? (
+                    <p className="text-sm text-destructive">
+                      Failed to load server snapshot: {String(serverQuery.error)}
+                    </p>
+                  ) : !server ? (
+                    <div className="flex items-center gap-2 text-sm text-muted-foreground">
+                      <Spinner className="size-4" />
+                      Loading…
+                    </div>
                   ) : (
-                    sortedProjects.map((project) => {
-                      const size = sizes.get(project.project);
-                      const isExpanded = expandedProjects.has(project.project);
-                      return (
-                        <Fragment key={project.project}>
-                          {/* See the cell-scoped <button> below — a
+                    <div className="grid grid-cols-2 gap-x-6 gap-y-2 text-sm md:grid-cols-3">
+                      <ServerField label="PID">
+                        <span data-testid="resources-server-pid">{server.pid}</span>
+                      </ServerField>
+                      <ServerField label="Uptime">{formatUptime(server.uptimeSeconds)}</ServerField>
+                      <ServerField label="Node">{server.nodeVersion}</ServerField>
+                      <ServerField label="Platform">
+                        {server.platform} ({server.arch})
+                      </ServerField>
+                      <ServerField label="RSS">{formatMB(server.memory.rssBytes)}</ServerField>
+                      <ServerField label="Heap used">
+                        {formatMB(server.memory.heapUsedBytes)}
+                      </ServerField>
+                      <ServerField label="Heap total">
+                        {formatMB(server.memory.heapTotalBytes)}
+                      </ServerField>
+                      <ServerField label="External">
+                        {formatMB(server.memory.externalBytes)}
+                      </ServerField>
+                      <ServerField label="Array buffers">
+                        {formatMB(server.memory.arrayBuffersBytes)}
+                      </ServerField>
+                      <ServerField label="Total CPU time (user)">
+                        {formatCpuMs(server.cpu.userMicros)}
+                      </ServerField>
+                      <ServerField label="Total CPU time (system)">
+                        {formatCpuMs(server.cpu.systemMicros)}
+                      </ServerField>
+                    </div>
+                  )}
+                </div>
+              </CollapsibleContent>
+            </section>
+          </Collapsible>
+
+          <ElectronCard query={appMetricsQuery} />
+
+          <Collapsible open={worktreesOpen} onOpenChange={setWorktreesOpen} asChild>
+            <section data-testid="resources-worktrees-card">
+              <PanelHeader
+                title="Worktrees"
+                toggleTestId="resources-worktrees-toggle"
+                open={worktreesOpen}
+                totalTestId="resources-worktrees-total"
+                total={`${formatBytes(knownTotalBytes)}${allLoaded ? "" : " (partial)"}`}
+                description={
+                  <>
+                    Disk usage per tracked git project (allocated blocks, as reported by{" "}
+                    <code className="rounded bg-muted px-1 py-0.5 text-xs">du</code>). Sizes load
+                    per project in batches of {PROJECT_FETCH_CONCURRENCY}. Click a project to see
+                    its per-worktree breakdown.
+                  </>
+                }
+                refresh={
+                  <Button
+                    variant="outline"
+                    size="icon-sm"
+                    aria-label="Refresh"
+                    title="Refresh"
+                    data-testid="resources-refresh-worktrees"
+                    onClick={handleRefreshSizes}
+                    disabled={projectsQuery.isFetching || !allLoaded}
+                  >
+                    {projectsQuery.isFetching || !allLoaded ? (
+                      <Spinner className="size-3.5" />
+                    ) : (
+                      <RefreshCw className="size-3.5" />
+                    )}
+                  </Button>
+                }
+              />
+              <CollapsibleContent>
+                <div className="border-t border-border p-4">
+                  {projectsQuery.isError ? (
+                    <p className="text-sm text-destructive">
+                      Failed to load projects: {String(projectsQuery.error)}
+                    </p>
+                  ) : (
+                    <div className="relative overflow-x-auto">
+                      <table
+                        data-testid="resources-projects-table"
+                        className="w-full border-collapse text-sm"
+                      >
+                        <thead>
+                          <tr className="border-b border-border text-left text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                            <th className="py-2 pr-3">Project</th>
+                            <th className="py-2 pr-3 text-right">Worktrees</th>
+                            <th className="py-2 pr-3 text-right">Total size</th>
+                          </tr>
+                        </thead>
+                        <tbody>
+                          {sortedProjects.length === 0 ? (
+                            <tr>
+                              <td
+                                colSpan={3}
+                                className="py-6 text-center text-sm text-muted-foreground"
+                              >
+                                {projectsQuery.isFetching ? "Loading…" : "No git projects found"}
+                              </td>
+                            </tr>
+                          ) : (
+                            sortedProjects.map((project) => {
+                              const size = sizes.get(project.project);
+                              const isExpanded = expandedProjects.has(project.project);
+                              return (
+                                <Fragment key={project.project}>
+                                  {/* See the cell-scoped <button> below — a
                               row-level click handler can't be a
                               real <button> (must be a direct
                               <tbody> child), so we put the button
                               in the first cell and let it span the
                               click target. */}
-                          <tr
-                            data-testid={`resources-project-row-${project.project}`}
-                            data-expanded={isExpanded ? "true" : "false"}
-                            className="border-b border-border/60 last:border-0 hover:bg-muted/40"
-                          >
-                            <td className="py-2 pr-3 font-medium">
-                              <button
-                                type="button"
-                                aria-expanded={isExpanded}
-                                onClick={() => toggleProject(project.project)}
-                                className="inline-flex w-full cursor-pointer items-center gap-1 text-left"
-                              >
-                                <ChevronRight
-                                  className={`size-3.5 shrink-0 transition-transform ${
-                                    isExpanded ? "rotate-90" : ""
-                                  }`}
-                                />
-                                {project.project}
-                              </button>
-                            </td>
-                            <td className="py-2 pr-3 text-right tabular-nums">
-                              {project.worktrees.length}
-                            </td>
-                            <td
-                              className="py-2 pr-3 text-right tabular-nums"
-                              data-testid={`resources-project-size-${project.project}`}
-                            >
-                              {size === undefined ? (
-                                <span className="inline-flex items-center justify-end gap-1.5 text-muted-foreground">
-                                  <Spinner className="size-3.5" />
-                                  <span className="text-xs">measuring…</span>
-                                </span>
-                              ) : size.error ? (
-                                <span className="text-destructive" title={size.error}>
-                                  error
-                                </span>
-                              ) : (
-                                formatBytes(size.sizeBytes)
-                              )}
-                            </td>
-                          </tr>
-                          {isExpanded &&
-                            (size === undefined ? (
-                              // Sizes haven't landed yet — show one
-                              // child row with a spinner so the
-                              // expand isn't an empty void.
-                              <tr className="border-b border-border/40 bg-muted/20">
-                                <td colSpan={3} className="py-2 pl-8 pr-3">
-                                  <span className="inline-flex items-center gap-2 text-xs text-muted-foreground">
-                                    <Spinner className="size-3.5" />
-                                    Measuring worktrees…
-                                  </span>
-                                </td>
-                              </tr>
-                            ) : size.worktrees.length === 0 ? (
-                              <tr className="border-b border-border/40 bg-muted/20">
-                                <td
-                                  colSpan={3}
-                                  className="py-2 pl-8 pr-3 text-xs text-muted-foreground"
-                                >
-                                  No worktrees
-                                </td>
-                              </tr>
-                            ) : (
-                              size.worktrees.map((wt) => (
-                                <tr
-                                  key={`${project.project}::${wt.branch}::${wt.path}`}
-                                  data-testid={`resources-worktree-row-${testIdForWorktree(project.project, wt.branch)}`}
-                                  className="border-b border-border/40 bg-muted/20 last:border-0"
-                                >
-                                  <td className="py-1.5 pl-8 pr-3">
-                                    <div className="flex flex-col">
-                                      <span className="font-mono text-xs">{wt.branch || "—"}</span>
-                                      <span className="truncate font-mono text-[11px] text-muted-foreground">
-                                        {wt.path}
-                                      </span>
-                                    </div>
-                                  </td>
-                                  <td className="py-1.5 pr-3" />
-                                  <td className="py-1.5 pr-3 text-right tabular-nums">
-                                    {wt.error ? (
-                                      <span className="text-destructive">error</span>
+                                  <tr
+                                    data-testid={`resources-project-row-${project.project}`}
+                                    data-expanded={isExpanded ? "true" : "false"}
+                                    className="border-b border-border/60 last:border-0 hover:bg-muted/40"
+                                  >
+                                    <td className="py-2 pr-3 font-medium">
+                                      <button
+                                        type="button"
+                                        aria-expanded={isExpanded}
+                                        onClick={() => toggleProject(project.project)}
+                                        className="inline-flex w-full cursor-pointer items-center gap-1 text-left"
+                                      >
+                                        <ChevronRight
+                                          className={`size-3.5 shrink-0 transition-transform ${
+                                            isExpanded ? "rotate-90" : ""
+                                          }`}
+                                        />
+                                        {project.project}
+                                      </button>
+                                    </td>
+                                    <td className="py-2 pr-3 text-right tabular-nums">
+                                      {project.worktrees.length}
+                                    </td>
+                                    <td
+                                      className="py-2 pr-3 text-right tabular-nums"
+                                      data-testid={`resources-project-size-${project.project}`}
+                                    >
+                                      {size === undefined ? (
+                                        <span className="inline-flex items-center justify-end gap-1.5 text-muted-foreground">
+                                          <Spinner className="size-3.5" />
+                                          <span className="text-xs">measuring…</span>
+                                        </span>
+                                      ) : size.error ? (
+                                        <span className="text-destructive" title={size.error}>
+                                          error
+                                        </span>
+                                      ) : (
+                                        formatBytes(size.sizeBytes)
+                                      )}
+                                    </td>
+                                  </tr>
+                                  {isExpanded &&
+                                    (size === undefined ? (
+                                      // Sizes haven't landed yet — show one
+                                      // child row with a spinner so the
+                                      // expand isn't an empty void.
+                                      <tr className="border-b border-border/40 bg-muted/20">
+                                        <td colSpan={3} className="py-2 pl-8 pr-3">
+                                          <span className="inline-flex items-center gap-2 text-xs text-muted-foreground">
+                                            <Spinner className="size-3.5" />
+                                            Measuring worktrees…
+                                          </span>
+                                        </td>
+                                      </tr>
+                                    ) : size.worktrees.length === 0 ? (
+                                      <tr className="border-b border-border/40 bg-muted/20">
+                                        <td
+                                          colSpan={3}
+                                          className="py-2 pl-8 pr-3 text-xs text-muted-foreground"
+                                        >
+                                          No worktrees
+                                        </td>
+                                      </tr>
                                     ) : (
-                                      formatBytes(wt.sizeBytes)
-                                    )}
-                                  </td>
-                                </tr>
-                              ))
-                            ))}
-                        </Fragment>
-                      );
-                    })
+                                      size.worktrees.map((wt) => (
+                                        <tr
+                                          key={`${project.project}::${wt.branch}::${wt.path}`}
+                                          data-testid={`resources-worktree-row-${testIdForWorktree(project.project, wt.branch)}`}
+                                          className="border-b border-border/40 bg-muted/20 last:border-0"
+                                        >
+                                          <td className="py-1.5 pl-8 pr-3">
+                                            <div className="flex flex-col">
+                                              <span className="font-mono text-xs">
+                                                {wt.branch || "—"}
+                                              </span>
+                                              <span className="truncate font-mono text-[11px] text-muted-foreground">
+                                                {wt.path}
+                                              </span>
+                                            </div>
+                                          </td>
+                                          <td className="py-1.5 pr-3" />
+                                          <td className="py-1.5 pr-3 text-right tabular-nums">
+                                            {wt.error ? (
+                                              <span className="text-destructive">error</span>
+                                            ) : (
+                                              formatBytes(wt.sizeBytes)
+                                            )}
+                                          </td>
+                                        </tr>
+                                      ))
+                                    ))}
+                                </Fragment>
+                              );
+                            })
+                          )}
+                        </tbody>
+                        {projects.length > 0 && (
+                          <tfoot>
+                            <tr className="border-t-2 border-border font-medium">
+                              <td className="py-2 pr-3">Total{allLoaded ? "" : " (partial)"}</td>
+                              <td className="py-2 pr-3 text-right tabular-nums">
+                                {projects.reduce((sum, p) => sum + p.worktrees.length, 0)}
+                              </td>
+                              <td
+                                className="py-2 pr-3 text-right tabular-nums"
+                                data-testid="resources-projects-total"
+                              >
+                                {formatBytes(knownTotalBytes)}
+                              </td>
+                            </tr>
+                          </tfoot>
+                        )}
+                      </table>
+                    </div>
                   )}
-                </tbody>
-                {projects.length > 0 && (
-                  <tfoot>
-                    <tr className="border-t-2 border-border font-medium">
-                      <td className="py-2 pr-3">Total{allLoaded ? "" : " (partial)"}</td>
-                      <td className="py-2 pr-3 text-right tabular-nums">
-                        {projects.reduce((sum, p) => sum + p.worktrees.length, 0)}
-                      </td>
-                      <td
-                        className="py-2 pr-3 text-right tabular-nums"
-                        data-testid="resources-projects-total"
-                      >
-                        {formatBytes(knownTotalBytes)}
-                      </td>
-                    </tr>
-                  </tfoot>
-                )}
-              </table>
-            </div>
-          )}
-        </section>
+                </div>
+              </CollapsibleContent>
+            </section>
+          </Collapsible>
+        </div>
       </div>
     </ScrollArea>
   );
@@ -551,96 +604,165 @@ export function ResourcesPage() {
  * report), so the whole card is desktop-only.
  */
 function ElectronCard({ query }: { query: UseQueryResult<AppMetrics> }) {
+  const [open, setOpen] = useState(false);
+
   if (!isDesktop) return null;
 
   const metrics = query.data;
 
   return (
-    <section data-testid="resources-electron-card" className="space-y-3">
-      <div className="flex flex-row items-start justify-between gap-2">
-        <div className="space-y-1">
-          <h2 className="text-base font-semibold leading-none">Desktop app (Electron)</h2>
-          <p className="text-sm text-muted-foreground">
-            Per-process CPU and memory for the Electron main process, GPU process, Chromium
-            renderers (the dashboard and each browser tab), and utility helpers.
-          </p>
-        </div>
-        <Button
-          variant="outline"
-          size="sm"
-          data-testid="resources-refresh-electron"
-          onClick={() => query.refetch()}
-          disabled={query.isFetching}
-        >
-          {query.isFetching ? <Spinner className="size-3.5" /> : <RefreshCw className="size-3.5" />}
-          Refresh
-        </Button>
+    <Collapsible open={open} onOpenChange={setOpen} asChild>
+      <section data-testid="resources-electron-card">
+        <PanelHeader
+          title="Desktop app (Electron)"
+          toggleTestId="resources-electron-toggle"
+          open={open}
+          totalTestId="resources-electron-total"
+          total={metrics ? formatBytes(metrics.totalMemoryKB * 1024) : "…"}
+          description="Per-process CPU and memory for the Electron main process, GPU process, Chromium renderers (the dashboard and each browser tab), and utility helpers."
+          refresh={
+            <Button
+              variant="outline"
+              size="icon-sm"
+              aria-label="Refresh"
+              title="Refresh"
+              data-testid="resources-refresh-electron"
+              onClick={() => query.refetch()}
+              disabled={query.isFetching}
+            >
+              {query.isFetching ? (
+                <Spinner className="size-3.5" />
+              ) : (
+                <RefreshCw className="size-3.5" />
+              )}
+            </Button>
+          }
+        />
+        <CollapsibleContent>
+          <div className="border-t border-border p-4">
+            {query.isError ? (
+              <p className="text-sm text-destructive">
+                Failed to load Electron metrics: {String(query.error)}
+              </p>
+            ) : !metrics ? (
+              <div className="flex items-center gap-2 text-sm text-muted-foreground">
+                <Spinner className="size-4" />
+                Loading…
+              </div>
+            ) : (
+              <div className="relative overflow-x-auto">
+                <table
+                  data-testid="resources-electron-table"
+                  className="w-full border-collapse text-sm"
+                >
+                  <thead>
+                    <tr className="border-b border-border text-left text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                      <th className="py-2 pr-3">Process</th>
+                      <th className="py-2 pr-3">Type</th>
+                      <th className="py-2 pr-3 text-right">PID</th>
+                      <th className="py-2 pr-3 text-right">CPU</th>
+                      <th className="py-2 pr-3 text-right">Memory</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {metrics.processes.map((p) => (
+                      <tr
+                        key={p.pid}
+                        data-testid={`resources-electron-row-${p.pid}`}
+                        className="border-b border-border/60 last:border-0 hover:bg-muted/40"
+                      >
+                        <td className="py-1.5 pr-3">{p.label}</td>
+                        <td className="py-1.5 pr-3 text-muted-foreground">{p.type}</td>
+                        <td className="py-1.5 pr-3 text-right tabular-nums">{p.pid}</td>
+                        <td className="py-1.5 pr-3 text-right tabular-nums">
+                          {p.cpuPercent.toFixed(1)}%
+                        </td>
+                        <td className="py-1.5 pr-3 text-right tabular-nums">
+                          {formatBytes(p.memoryKB * 1024)}
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                  <tfoot>
+                    <tr className="border-t-2 border-border font-medium">
+                      <td className="py-2 pr-3" data-testid="resources-electron-total-count">
+                        Total ({metrics.processCount})
+                      </td>
+                      <td className="py-2 pr-3" />
+                      <td className="py-2 pr-3" />
+                      <td
+                        className="py-2 pr-3 text-right tabular-nums"
+                        data-testid="resources-electron-total-cpu"
+                      >
+                        {metrics.totalCpuPercent.toFixed(1)}%
+                      </td>
+                      <td
+                        className="py-2 pr-3 text-right tabular-nums"
+                        data-testid="resources-electron-total-memory"
+                      >
+                        {formatBytes(metrics.totalMemoryKB * 1024)}
+                      </td>
+                    </tr>
+                  </tfoot>
+                </table>
+              </div>
+            )}
+          </div>
+        </CollapsibleContent>
+      </section>
+    </Collapsible>
+  );
+}
+
+/**
+ * Shared card header for the collapsible Resources panels: a chevron +
+ * title trigger (the whole title row toggles the panel), the panel's
+ * headline `total` shown to the right of the title only while collapsed,
+ * the `description` shown in both states, and a `refresh` control kept
+ * as a sibling of the trigger (never nested — Radix's trigger is a
+ * `<button>`, and buttons can't nest).
+ */
+function PanelHeader({
+  title,
+  toggleTestId,
+  open,
+  total,
+  totalTestId,
+  description,
+  refresh,
+}: {
+  title: string;
+  toggleTestId: string;
+  open: boolean;
+  total: string;
+  totalTestId: string;
+  description: React.ReactNode;
+  refresh: React.ReactNode;
+}) {
+  return (
+    <div className="flex flex-row items-start justify-between gap-2 p-4">
+      <div className="min-w-0 flex-1 space-y-1">
+        <h2 className="text-base font-semibold leading-none">
+          <CollapsibleTrigger
+            data-testid={toggleTestId}
+            className="group flex w-full items-center gap-2 text-left"
+          >
+            <ChevronRight className="size-4 shrink-0 text-muted-foreground transition-transform group-data-[state=open]:rotate-90" />
+            <span>{title}</span>
+            {!open && (
+              <span
+                data-testid={totalTestId}
+                className="ml-auto pl-2 font-mono text-sm font-normal text-muted-foreground"
+              >
+                {total}
+              </span>
+            )}
+          </CollapsibleTrigger>
+        </h2>
+        <p className="pl-6 text-sm text-muted-foreground">{description}</p>
       </div>
-      {query.isError ? (
-        <p className="text-sm text-destructive">
-          Failed to load Electron metrics: {String(query.error)}
-        </p>
-      ) : !metrics ? (
-        <div className="flex items-center gap-2 text-sm text-muted-foreground">
-          <Spinner className="size-4" />
-          Loading…
-        </div>
-      ) : (
-        <div className="relative overflow-x-auto">
-          <table data-testid="resources-electron-table" className="w-full border-collapse text-sm">
-            <thead>
-              <tr className="border-b border-border text-left text-xs font-medium uppercase tracking-wide text-muted-foreground">
-                <th className="py-2 pr-3">Process</th>
-                <th className="py-2 pr-3">Type</th>
-                <th className="py-2 pr-3 text-right">PID</th>
-                <th className="py-2 pr-3 text-right">CPU</th>
-                <th className="py-2 pr-3 text-right">Memory</th>
-              </tr>
-            </thead>
-            <tbody>
-              {metrics.processes.map((p) => (
-                <tr
-                  key={p.pid}
-                  data-testid={`resources-electron-row-${p.pid}`}
-                  className="border-b border-border/60 last:border-0 hover:bg-muted/40"
-                >
-                  <td className="py-1.5 pr-3">{p.label}</td>
-                  <td className="py-1.5 pr-3 text-muted-foreground">{p.type}</td>
-                  <td className="py-1.5 pr-3 text-right tabular-nums">{p.pid}</td>
-                  <td className="py-1.5 pr-3 text-right tabular-nums">
-                    {p.cpuPercent.toFixed(1)}%
-                  </td>
-                  <td className="py-1.5 pr-3 text-right tabular-nums">
-                    {formatBytes(p.memoryKB * 1024)}
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-            <tfoot>
-              <tr className="border-t-2 border-border font-medium">
-                <td className="py-2 pr-3" data-testid="resources-electron-total-count">
-                  Total ({metrics.processCount})
-                </td>
-                <td className="py-2 pr-3" />
-                <td className="py-2 pr-3" />
-                <td
-                  className="py-2 pr-3 text-right tabular-nums"
-                  data-testid="resources-electron-total-cpu"
-                >
-                  {metrics.totalCpuPercent.toFixed(1)}%
-                </td>
-                <td
-                  className="py-2 pr-3 text-right tabular-nums"
-                  data-testid="resources-electron-total-memory"
-                >
-                  {formatBytes(metrics.totalMemoryKB * 1024)}
-                </td>
-              </tr>
-            </tfoot>
-          </table>
-        </div>
-      )}
-    </section>
+      {refresh}
+    </div>
   );
 }
 


### PR DESCRIPTION
## What

Adds a **Desktop app (Electron)** card to the Resources page. Until now the page showed only the single Node web-server process (via `services.resourcesServer`) plus per-project worktree disk usage — the entire Electron/Chromium side was invisible.

The new card surfaces, via `app.getAppMetrics()`:
- the Electron **main** (Browser) process
- the **GPU** process
- each Chromium **renderer** — the dashboard webview + each browser-tab `WebContentsView` (labelled `Dashboard` / `Browser tab: <title>`)
- **Utility** processes (network service, audio, storage, helpers)

It's a per-process table (Process / Type / PID / CPU% / Memory) with a totals footer, plus a **Refresh** button — the **pull model** (React Query + manual refresh), matching the existing Server card. No new push event.

## Architecture

Follows the web/desktop split (CLAUDE.md → *Architecture: Web Server vs Desktop App*):
- All Electron logic lives on the **desktop** side: a new `get_app_metrics` IPC channel, a handler module (`apps/desktop/src/main/ipc/app-metrics.ts`), registration, and the preload allowlist entry.
- The web server gains **no** Electron knowledge. The renderer card **self-gates on `isDesktop`** (returns `null` otherwise) and defines its result shape **inline**, so the web bundle takes no build-time dependency on desktop types.
- `app-metrics.ts` splits a **pure** `mapAppMetrics(raw, pidLabels)` mapper from the Electron-touching `getAppMetrics()` (which lazy-imports `electron`), the same testability seam as `save-helpers.ts`.

## Testing

- New `apps/desktop/tests/app-metrics.test.ts` (node:test) exercises `mapAppMetrics`: labeling (Main/GPU/Network service/Dashboard/Browser tab/Renderer/unknown-utility fallback/passthrough), totals, and memory-desc sort order.
- **The card itself cannot be covered at the e2e layer** — the `apps/web/e2e` harness boots the web-server bundle through Chromium and never launches Electron, so `window.__BAND_DESKTOP__` is absent and the card never renders there (same limitation as the browser-panel / macos-shell IPC surfaces). The pure `mapAppMetrics` test is the meaningful automated coverage.

Verification: desktop suite 200/200, `biome check` clean, `tsc --noEmit` clean for main/preload/web. Ran `/review-and-apply` locally — verdict **approved 👍** (0 blockers, 0 nits; the one suggestion, an extra Utility-fallback test case, was applied).

🤖 Generated with [Claude Code](https://claude.com/claude-code)