### PR TITLE
ci(review): fix flaky Claude PR review (pin CLI, workflow-owned post, RED-on-empty guard)

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -23,14 +23,48 @@ name: Claude PR Review
 #     job level, not just the step level, so the runner never spins up for
 #     skipped PRs.
 #
-# OPTIONAL EXTENSION — issue_comment trigger:
-#   To let collaborators re-run the review by commenting `/claude review` on a
-#   PR, add `issue_comment: types: [created]` to `on:` and an `issues: write`
-#   permission, and extend the `if:` with a parallel branch that uses
-#   `github.event.comment.author_association` (different field) plus
-#   `startsWith(github.event.comment.body, '/claude review')`. The gate is
-#   *critical* there because issue_comment runs in the base repo context with
-#   secrets exposed.
+# WHY the Claude CLI version is pinned (the reliability fix):
+#   - This workflow dispatches a four-specialist review: a general-purpose
+#     orchestrator subagent that spawns coding/testing/security/performance
+#     reviewers via the `Agent` tool.
+#   - In a REGRESSED Claude CLI (~late-Jan 2026 onward) running under the
+#     claude-code-action headless Agent-SDK runtime (`claude -p` one-shot),
+#     parallel `Agent` dispatch launches subagents as BACKGROUND tasks. The
+#     one-shot run reaches a terminal `result` state and ENDS before the
+#     subagents finish, so no report is produced — yet the action still exits
+#     0, so a silent no-op looked like a passing review (it posted ~50% of the
+#     time, nondeterministically). Refs:
+#       - anthropics/claude-code-action#1124 (SDK session ends before
+#         subagents complete — open, no fix)
+#       - anthropics/claude-code#23909 (main thread ends prematurely while
+#         subagents run in background)
+#   - Fix: pin the CLI to a PRE-regression version where dispatched subagents
+#     run SYNCHRONOUSLY, pre-install it, and point the action at it via
+#     `path_to_claude_code_executable`. Modelled on the sibling dev-tools
+#     repo's `_pr-review.yaml`, which runs the same multi-specialist design
+#     reliably on 2.1.177. Bump CLAUDE_CLI_VERSION deliberately and only to a
+#     version verified to still dispatch Agent subagents synchronously.
+#   - An old CLI can reject a too-new default model, so we ALSO pin the model
+#     explicitly via `--model` (claude-code-action#1416: with no model pinned
+#     the action can fall back to a non-existent model and fail).
+#
+# WHY the workflow posts the comment (not the agent):
+#   - The agent used to build a `gh api ... --body "$(cat <<EOF ...)"` heredoc
+#     from arbitrary review text (backticks, $(), emojis) — a second,
+#     independent source of flakiness. Now the agent only WRITES its report to
+#     a file under RUNNER_TEMP; a deterministic github-script step reads that
+#     file and upserts a marker-keyed sticky comment via the REST API, passing
+#     the body as a JS string (no shell escaping). The action's own
+#     `use_sticky_comment` feature is NOT used: it requires claude[bot]
+#     authentication and breaks under a custom github_token
+#     (see claude-code-action FAQ), and we deliberately stay on GITHUB_TOKEN
+#     (no claude[bot] GitHub App install). Marker-keyed upsert works fine under
+#     the github-actions[bot] identity because it finds its own prior comment
+#     by the embedded marker, not by author.
+#   - The post step also GUARDS against silent no-ops: if the report file is
+#     missing/empty or is missing any of the four specialist sections or the
+#     Verdict line, it posts a clear failure notice AND fails the job (RED
+#     check) instead of leaving a green pass with no review.
 #
 # REQUIRED REPO SECRET:
 #   CLAUDE_CODE_OAUTH_TOKEN — generated locally by running `claude setup-token`
@@ -50,20 +84,27 @@ concurrency:
   group: claude-review-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
+# Single source of truth for the CLI version and model. Bump CLAUDE_CLI_VERSION
+# in this one place — the cache key below keys on it (so a bump busts the cache
+# instead of restoring the old binary) and the install step installs exactly it.
+env:
+  # Pre-regression CLI: dispatched `Agent` subagents run synchronously here, so
+  # the one-shot run waits for all four specialists before it ends. See the
+  # header comment. Verify any bump still dispatches subagents synchronously.
+  CLAUDE_CLI_VERSION: "2.1.177"
+  # Pinned explicitly (a) so an older CLI doesn't reject a too-new default model
+  # and (b) to dodge claude-code-action#1416 (no-model fallback to a
+  # non-existent model). Must be a model the Pro/Max OAuth subscription grants.
+  ANTHROPIC_MODEL: "claude-sonnet-4-6"
+
 # Minimum permissions the action needs.
 #   contents: read       — to clone the PR head and fetch base for diff.
-#   pull-requests: write — to post review comments via the workflow's
-#                          auto-provisioned GITHUB_TOKEN (passed explicitly
-#                          to the action below). With github_token supplied,
-#                          the action does NOT require the Claude Code
-#                          GitHub App to be installed on the repo and does
-#                          not need id-token: write for an App-token OIDC
-#                          exchange. Trade-off: review comments are posted
-#                          as `github-actions[bot]` instead of `claude[bot]`.
-#                          If you'd rather have the claude[bot] identity,
-#                          install https://github.com/apps/claude on the
-#                          repo, drop the github_token input below, and
-#                          add `id-token: write` here.
+#   pull-requests: write — to post the review comment via the workflow's
+#                          auto-provisioned GITHUB_TOKEN. Comments post as
+#                          `github-actions[bot]`. If you'd rather have the
+#                          claude[bot] identity, install
+#                          https://github.com/apps/claude on the repo, drop the
+#                          github_token input below, and add `id-token: write`.
 permissions:
   contents: read
   pull-requests: write
@@ -90,15 +131,42 @@ jobs:
     # same definition the local `/review-and-apply` skill invokes. One source of
     # truth for "how to review" lives in that skill plus the four specialist
     # agent files under `.claude/agents/`.
-    #
-    # The parent agent (the one this workflow's `prompt:` addresses) has only
-    # three things to do: invoke the `review-changes` skill, receive its
-    # sectioned report, and post the findings as comments.
     steps:
       - name: Checkout PR head
         uses: actions/checkout@v6
         with:
           fetch-depth: 1
+
+      # Restore the pinned CLI from cache when available; keyed on the version
+      # so a CLAUDE_CLI_VERSION bump busts the cache (otherwise the old binary
+      # is restored and the new install is skipped).
+      - name: Cache Claude Code CLI
+        id: cache-claude
+        uses: actions/cache@v5
+        with:
+          path: ~/.local/bin/claude
+          key: claude-code-cli-${{ env.CLAUDE_CLI_VERSION }}
+
+      - name: Install Claude Code CLI
+        run: |
+          # Always verify the binary is present — a cache hit can be a false
+          # positive (e.g. a prior run cached an empty path after a failed
+          # download).
+          if [ -x "$HOME/.local/bin/claude" ]; then
+            echo "Claude Code CLI already present, skipping install"
+          else
+            echo "Installing Claude Code CLI ${CLAUDE_CLI_VERSION}..."
+            for attempt in 1 2 3; do
+              echo "Installation attempt ${attempt}..."
+              curl -fsSL https://claude.ai/install.sh | bash -s "${CLAUDE_CLI_VERSION}" && break
+              [ "${attempt}" -eq 3 ] && echo "Failed to install Claude Code after 3 attempts" && exit 1
+              echo "Retrying in 15s..."
+              sleep 15
+            done
+          fi
+          # Fail loudly (RED) if the pinned version is unusable, rather than
+          # silently letting the action fall back to auto-install.
+          "$HOME/.local/bin/claude" --version
 
       - name: Run Claude review
         # Pinned to the v1 stable tag of the official Anthropic action.
@@ -111,146 +179,194 @@ jobs:
           # claude[bot] GitHub App. Avoids the App-install requirement;
           # comments post as github-actions[bot]. See permissions comment.
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          # Point the action at the pinned, pre-installed binary instead of
+          # letting it auto-install a (regressed) newer CLI.
+          path_to_claude_code_executable: /home/runner/.local/bin/claude
           prompt: |
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ github.event.pull_request.number }}
 
-            You are a thin dispatcher running in GitHub Actions. You do
-            NOT review the PR yourself. You delegate the review to a
-            fresh general-purpose subagent and post that subagent's
-            output as a PR comment. Three steps only.
-
-            Step 1 — Gather context.
+            You are a thin dispatcher running in GitHub Actions. You do NOT
+            review the PR yourself, and you do NOT post any GitHub comment — a
+            later workflow step owns posting. Your ONLY job is to dispatch ONE
+            general-purpose subagent that runs the review and WRITES its report
+            to a file. Then you stop.
 
             Resolve these values:
-              REPO   = ${{ github.repository }}
-              PR     = ${{ github.event.pull_request.number }}
-              BASE   = origin/${{ github.event.pull_request.base.ref }}
-              HEAD   = ${{ github.event.pull_request.head.sha }}
-
-            Discover linked issues by extracting `closes #N`, `fixes #N`,
-            or `resolves #N` from the PR body and commit messages:
-
-              gh pr view ${{ github.event.pull_request.number }} --json body --jq .body
-              git log origin/${{ github.event.pull_request.base.ref }}..${{ github.event.pull_request.head.sha }} --format='%s%n%b'
-
-            Collect any matches. If none found, use the literal string
-            "none detected".
-
-            Step 2 — Dispatch ONE general-purpose subagent.
-
-            The subagent will follow the orchestration instructions in
-            the `review-changes` skill file directly. We Read the file
-            instead of going through the `Skill` tool because the GHA
-            action runtime does NOT auto-discover project-defined
-            skills under `.claude/skills/` — `Skill(skill="review-changes")`
-            returns "Unknown skill" in this environment.
+              REPO    = ${{ github.repository }}
+              PR      = ${{ github.event.pull_request.number }}
+              BASE    = origin/${{ github.event.pull_request.base.ref }}
+              HEAD    = ${{ github.event.pull_request.head.sha }}
+              REPORT  = ${{ runner.temp }}/claude-review-report.md
 
             Make exactly one Agent call:
 
               Agent(subagent_type="general-purpose", prompt=<see below>)
 
-            The subagent's prompt is exactly this (with values
-            substituted from Step 1):
+            The subagent's prompt is exactly this (with values substituted
+            from above):
 
-                You are running Band's CI PR review.
+                You are running Band's CI PR review. You must produce a
+                COMPLETE four-specialist review and WRITE it to a file. You
+                do NOT post any GitHub comment.
 
                 Step A — Read the orchestration spec:
                     Read `.claude/skills/review-changes/SKILL.md` end-to-end.
-                    This file tells you the four specialists to dispatch,
-                    the context bundle shape, the aggregation rules, and
-                    the exact output format.
+                    It defines the four specialists to dispatch, the context
+                    bundle shape, the aggregation rules, and the exact report
+                    format. Read the file directly with the Read tool — the
+                    `Skill` tool is NOT available in this runtime, so
+                    Skill(skill="review-changes") returns "Unknown skill".
 
-                Step B — Run the orchestration the file describes, using
-                these inputs:
+                Step B — Gather context:
+                    - Diff:       `gh pr diff <PR>`  (do NOT truncate)
+                    - PR meta:    `gh pr view <PR> --json title,body,headRefName,baseRefName`
+                    - Linked issues: extract `closes #N` / `fixes #N` /
+                      `resolves #N` from the PR body and from
+                      `git log <BASE>..<HEAD> --format=%s%n%b`; for each match
+                      run `gh issue view <N>`. If none, use "none detected".
 
-                    Review this change set.
-                    - Repo:   <REPO>
-                    - PR:     <PR>
-                    - Base:   <BASE>
-                    - Head:   <HEAD>
-                    - Issues: <linked-issue list, or "none detected">
+                Step C — Dispatch the FOUR specialists IN PARALLEL, as four
+                Agent calls in a SINGLE message, each with the context bundle
+                described in the SKILL.md "Step 2 — Dispatch four specialists
+                in parallel" template:
 
-                Concretely: gather the diff via `gh pr diff <PR>`, fetch
-                any linked issue bodies via `gh issue view <N>`, then
-                dispatch the four specialist sub-agents IN PARALLEL via
-                FOUR `Agent` tool calls in a SINGLE message:
+                    Agent(subagent_type="coding-reviewer",      prompt=<bundle>)
+                    Agent(subagent_type="testing-reviewer",     prompt=<bundle>)
+                    Agent(subagent_type="security-reviewer",    prompt=<bundle>)
+                    Agent(subagent_type="performance-reviewer", prompt=<bundle>)
 
-                  Agent(subagent_type="coding-reviewer",      prompt=<bundle>)
-                  Agent(subagent_type="testing-reviewer",     prompt=<bundle>)
-                  Agent(subagent_type="security-reviewer",    prompt=<bundle>)
-                  Agent(subagent_type="performance-reviewer", prompt=<bundle>)
+                Wait for all four to return, then aggregate them per the
+                SKILL.md "Step 3 — Aggregate per section".
 
-                The bundle prompt template is in the skill file under
-                "Step 2 — Dispatch four specialists in parallel."
+                Step D — WRITE the output (do NOT print it as your final
+                message, do NOT post a comment):
 
-                Step C — Aggregate per the skill's "Step 3" and emit
-                per the skill's "Step 4". The OUTPUT FORMAT is fixed:
-                four `<Coding|Testing|Security|Performance> <emoji>`
-                headers in that exact order (emoji is one of 🚨 / ⚠️ /
-                ✅ computed per the skill), each followed by its
-                findings in standard `[N] severity:... <path>:<line>`
-                format, ending with a single
-                `Verdict: <approved 👍 | request changes 👎>` line.
+                    Using the Write tool, write the aggregated report to:
+                         <REPORT>
+                    The content is EXACTLY the SKILL.md "Step 4" report:
+                    the four domain headers in fixed order (Coding →
+                    Testing → Security → Performance), each on its own line
+                    as `<Domain> <emoji>` (emoji is one of 🚨 / ⚠️ / ✅),
+                    each followed by its findings, ending with a single
+                    `Verdict: <approved 👍 | request changes 👎>` line. The
+                    FIRST line of the file MUST be `Coding <emoji>` and the
+                    LAST line MUST be the `Verdict:` line. No code fences,
+                    no preamble, no wrapper text, no "Posted by" notes.
 
-                Step D — Your final message IS the report. The first
-                line must be `Coding <emoji>`. The last line must be
-                `Verdict: <emoji>`. Do not wrap, prefix, suffix, or
-                comment on the output. Do not add `## ` to the headers.
-                Do not swap the emojis — `🚨 / ⚠️ / ✅` for status,
-                `👍 / 👎` for verdict. Pass through verbatim from your
-                own aggregation step.
+                The file MUST be written even when every domain is ✅ (a clean
+                review is still `approved` with the four ✅ headers). After
+                writing the file, return the single word `done`.
 
-            Wait for the subagent to return. Treat its return value as
-            opaque text — that IS the comment body content.
-
-            Step 3 — Post as a PR comment, idempotently.
-
-            The comment body is exactly:
-              `<!-- claude-review-summary -->` + newline + the subagent's
-              returned string, unchanged.
-
-            On subsequent workflow runs (e.g. when the author pushes a
-            new commit), the SAME comment must be UPDATED — do not post
-            a new comment each time. Strategy:
-
-              (a) Search for existing marker comment:
-                  gh api "repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments" \
-                    --jq '.[] | select(.body | contains("<!-- claude-review-summary -->")) | .id' \
-                    | head -1
-
-              (b) If the search returns a comment ID, UPDATE it in place:
-                  gh api "repos/${{ github.repository }}/issues/comments/<id>" \
-                    -X PATCH -f body="<full body>"
-
-              (c) If the search returns nothing, CREATE a new comment:
-                  gh pr comment ${{ github.event.pull_request.number }} --body "<full body>"
-                  Pass the body as the `--body` argument directly; do
-                  not try to pipe via `--body-file -` (your allowlist
-                  does not include the upstream command needed to pipe).
-
-            Hard bans on this dispatcher:
-            - Do NOT do any review work yourself.
-            - Do NOT Read criteria files or repo source.
-            - Do NOT add headers, footers, signatures, or "Posted by"
-              notes around the subagent's output.
-            - Do NOT reformat, decorate, paraphrase, or "improve" the
-              subagent's output. It is the comment body verbatim.
+            Wait for the subagent to return `done`. You may Read <REPORT> to
+            confirm it exists. You are then finished — do NOT post anything, do
+            NOT run git or gh yourself, do NOT reformat or echo the report.
           # allowedTools notes for maintainers:
+          # - `Write` is required so the general-purpose subagent can persist
+          #   the report file that the workflow's post step reads.
           # - `Skill` is omitted. The claude-code-action@v1 runtime does NOT
           #   auto-discover project-defined skills under .claude/skills/, so
           #   Skill(skill="review-changes") returns "Unknown skill" in CI.
-          #   The dispatcher Reads the SKILL.md file directly instead and
-          #   the subagent follows its instructions inline.
-          # - `Bash(gh api:*)` is the broad form. We tested narrower patterns
-          #   (single-`*` `repos/*/issues/*`, two-`*` `repos/*/*/issues/*`,
-          #   and even hardcoded `repos/band-app/band/issues/*`) on the
-          #   working subagent architecture; none match the actual call
-          #   shape inside the action's Bash-allowlist matcher, and the
-          #   idempotent-update PATCH gets silently denied so the agent
-          #   falls back to creating a fresh comment per push. The broad
-          #   form is bounded by the workflow's GITHUB_TOKEN scope
-          #   (`pull-requests: write`), so the practical blast radius is
-          #   the same as the narrow forms would have provided.
+          #   The subagent Reads the SKILL.md file directly instead.
+          # - `gh pr comment` / `gh api` are intentionally NOT allowed: the
+          #   agent no longer posts anything. The deterministic post step below
+          #   owns the GitHub write, which removes the fragile heredoc that was
+          #   an independent source of flakiness.
           claude_args: |-
-            --allowedTools "Agent,Bash(git diff:*),Bash(git log:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh issue view:*),Read,Glob,Grep,Bash(gh pr comment:*),Bash(gh api:*)"
+            --model ${{ env.ANTHROPIC_MODEL }}
+            --permission-mode default
+            --allowedTools "Agent,Read,Write,Glob,Grep,Bash(git diff:*),Bash(git log:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh issue view:*)"
+
+      # Deterministic, workflow-owned posting + silent-no-op guard. Runs even if
+      # the action step failed, so an incomplete/aborted run still posts a
+      # notice and turns the check RED instead of silently green.
+      - name: Post review comment
+        if: always()
+        uses: actions/github-script@v7
+        env:
+          REPORT_FILE: ${{ runner.temp }}/claude-review-report.md
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const fs = require('fs');
+            const MARKER = '<!-- claude-review-summary -->';
+
+            let report = '';
+            if (fs.existsSync(process.env.REPORT_FILE)) {
+              report = fs.readFileSync(process.env.REPORT_FILE, 'utf8').trim();
+            }
+
+            // A complete run emits all four specialist section headers plus a
+            // Verdict line. Anything less means the run ended before producing
+            // a real four-specialist review (e.g. the subagent-race no-op).
+            // Match each header as a STANDALONE line — `<Domain> <emoji>` — so
+            // ordinary finding prose like "Performance regression in ..." can't
+            // satisfy the guard: require the domain word, a space, then a short
+            // (emoji-length) token to end of line.
+            const hasAllSections = ['Coding', 'Testing', 'Security', 'Performance']
+              .every((s) => new RegExp('^' + s + ' .{1,3}$', 'm').test(report));
+            const hasVerdict = /^Verdict:/m.test(report);
+            const complete = report.length > 0 && hasAllSections && hasVerdict;
+
+            // GitHub's hard comment limit is 65,536 chars; leave headroom for
+            // the marker + a truncation note so a verbose review still posts.
+            const MAX_BODY = 64000;
+            let body;
+            if (complete) {
+              const shown =
+                report.length > MAX_BODY
+                  ? report.slice(0, MAX_BODY) +
+                    '\n\n_…review truncated to fit GitHub\'s comment limit; see the workflow logs for the full report._'
+                  : report;
+              body = `${MARKER}\n${shown}`;
+            } else {
+              body =
+                `${MARKER}\n` +
+                '## ⚠️ Automated review did not complete\n\n' +
+                'The Claude PR review ran but did not produce a complete ' +
+                'four-specialist report on this run, so this check is failing ' +
+                'rather than silently passing. Check the workflow logs, then ' +
+                're-run the job.\n';
+              if (report.length > 0) {
+                body +=
+                  '\n<details><summary>Partial output</summary>\n\n```\n' +
+                  report.slice(0, 60000) +
+                  '\n```\n</details>\n';
+              }
+            }
+
+            const { owner, repo } = context.repo;
+            const issue_number = context.payload.pull_request.number;
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner,
+              repo,
+              issue_number,
+              per_page: 100,
+            });
+            // Upsert by embedded marker — survives across runs and works under
+            // the github-actions[bot] identity (matched by marker, not author).
+            const existing = comments.find((c) => (c.body || '').includes(MARKER));
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner,
+                repo,
+                comment_id: existing.id,
+                body,
+              });
+              core.info(`Updated existing review comment ${existing.id}`);
+            } else {
+              const { data } = await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number,
+                body,
+              });
+              core.info(`Created review comment ${data.id}`);
+            }
+
+            if (!complete) {
+              core.setFailed(
+                'Claude review did not produce a complete four-specialist ' +
+                  'report — see logs. Posted a failure notice on the PR.'
+              );
+            }


### PR DESCRIPTION
## Problem

The **Claude PR Review** workflow (`anthropics/claude-code-action@v1`, `pull_request` trigger, `CLAUDE_CODE_OAUTH_TOKEN` + `GITHUB_TOKEN`) posted a review comment only **~50% of the time** — and when it failed it still exited **green**, so a silent no-op looked like a passing review.

## Root cause

The workflow dispatches a four-specialist review: a general-purpose orchestrator subagent that spawns coding / testing / security / performance reviewers via the `Agent` tool. In a **regressed Claude CLI** (~late-Jan 2026 onward) running under claude-code-action's **headless Agent-SDK runtime** (`claude -p` one-shot), parallel `Agent` dispatch launches the subagents as **background/async tasks**. The one-shot run reaches a terminal `result` state and **ends before the subagents finish**, so no report is produced — nondeterministically winning/losing the race (~50%). The agent's final message was literally *"still waiting on the security and performance specialist reviews to complete"*, then the run ended.

This is a known, unfixed action limitation, not a prompt bug:
- anthropics/claude-code-action#1124 — SDK session lifecycle ends before subagents complete (open, no fix)
- anthropics/claude-code#23909 — main thread ends prematurely while subagents run in background

## The fix

Modelled on the sibling **dev-tools** repo's `.github/workflows/_pr-review.yaml`, which runs the same multi-specialist design reliably. Three changes:

### 1. Pin the Claude CLI to a pre-regression version (primary fix)
`CLAUDE_CLI_VERSION: "2.1.177"` — a version where dispatched `Agent` subagents run **synchronously**, so the one-shot run waits for all four specialists before ending. Added a cache step (`actions/cache@v5`, keyed on the version) + an install step (`curl … install.sh | bash -s "$VERSION"`, 3× retry, `claude --version` verify), and pointed the action at it via `path_to_claude_code_executable`. The model is pinned explicitly via `--model claude-sonnet-4-6` — an older CLI can reject a too-new default, and it dodges claude-code-action#1416 (no-model fallback to a non-existent model).

### 2. Workflow owns the GitHub write (not the agent)
The agent used to build a fragile `gh api … --body "$(cat <<EOF …)"` heredoc from arbitrary review text (backticks, `$()`, emojis) — a second, independent flakiness source. Now the general-purpose subagent only **Writes** its aggregated report to a `RUNNER_TEMP` file, and a deterministic `actions/github-script` step reads it and **upserts a marker-keyed sticky comment** via the REST API (body passed as a JS string — no shell escaping). `gh pr comment` / `gh api` were removed from `--allowedTools`; `Write` was added.

> **Deviation from a forked-action technique — deliberate.** dev-tools uses the action's native `use_sticky_comment` + the `github_comment` MCP tool, but that path requires **claude[bot] App authentication** (per the action's FAQ, it *breaks* under a custom `github_token`) and dev-tools' forked action + Portkey gateway. We intentionally stay on the **public action + `GITHUB_TOKEN`** (no claude[bot] App install), so I implemented the same *spirit* — workflow-owned, structured, deterministic write — with a marker-keyed upsert that works fine under the `github-actions[bot]` identity (it finds its prior comment by the embedded marker, not by author).

### 3. RED-on-empty guard
The post step (`if: always()`) validates the report has all four standalone `Coding/Testing/Security/Performance` section headers **and** a `Verdict:` line. If it's missing / empty / incomplete, it posts a clear "review did not complete" notice **and** calls `core.setFailed` → the check goes **RED** instead of silently green. This also doubles as the safety net for #1 (see caveat).

## Preserved / constraints honored
- `pull_request` trigger — **never** `pull_request_target` (pwn-request).
- `author_association` budget gate (OWNER / MEMBER / COLLABORATOR).
- `contents: read` + `pull-requests: write` only.
- No `show_full_output` (would stream the transcript to world-readable public logs).
- Kept the four-specialist review (`.claude/skills/review-changes/SKILL.md` + the four `.claude/agents/*-reviewer.md`) — this PR touches **only** the workflow file.

## Verification
- `actionlint` — clean.
- Embedded github-script — `node --check` syntax OK; guard logic verified against clean / missing-header / empty / no-verdict inputs.
- `pnpm check`: biome ignores workflow YAML (confirmed) and no Rust changed → cargo fmt/clippy unaffected.
- Ran the repo's own `/review-and-apply` (the four specialists) against this diff → **Verdict: approved 👍** (0 blockers). Applied the coding-reviewer's nit (cap the posted body under GitHub's 65,536-char limit) and two suggestions (tighten the section-header guard so finding prose can't satisfy it; drop a dead verdict-file instruction).

### ⚠️ Caveat — first live run is the real confirmation
This workflow only takes effect once merged to `main`, so the **CLI 2.1.177 + `claude-sonnet-4-6` under a Pro/Max OAuth subscription** combination is verified here only by dev-tools precedent (synchronous dispatch) + docs (model/flags) — **not** by a live run (can't exercise the GHA offline). If the combo is ever wrong, the **RED-on-empty guard (#3) fails the check loudly** rather than passing silently, and both the CLI version and model are single top-of-file knobs that are trivial to bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
