### PR TITLE
feat(web): move project-list actions to a persistent bottom action bar

### DIFF
--- a/apps/web/e2e/pages/ReportsDialog.ts
+++ b/apps/web/e2e/pages/ReportsDialog.ts
@@ -2,17 +2,16 @@
  * Page object for the Reports dialog (issue #425).
  *
  * Same shape as `ResourcesPage` — no dedicated route, the dialog is
- * opened from the dashboard's overflow menu. Owns the locators for the
- * stat cards, the recharts SVG container, and the four breakdown
- * tables.
+ * opened from the Usage icon in the project-list bottom action bar.
+ * Owns the locators for the stat cards, the recharts SVG container, and
+ * the four breakdown tables.
  *
  * Locator priority:
  *
- *   - `getByRole({ name })` for the title-bar Menu trigger (the
- *     `aria-label="Menu"` value is system-controlled).
  *   - `getByTestId(...)` for owned card / chart / table / button
  *     elements. The BEM-style `reports__*` prefix matches the
- *     `data-testid` attributes set in `ReportsPageContent.tsx`.
+ *     `data-testid` attributes set in `ReportsPageContent.tsx`; the
+ *     `project-list__usage-button` testid rides on the Usage icon button.
  */
 
 import { expect, type Locator, type Page, test } from "@playwright/test";
@@ -38,9 +37,8 @@ export class ReportsDialog {
   readonly byWorkspace: Locator;
   /** Period select. */
   readonly periodSelect: Locator;
-  /** Menu trigger + menu entry. */
-  readonly menuTrigger: Locator;
-  readonly reportsMenuItem: Locator;
+  /** Usage icon button in the project-list bottom action bar. */
+  readonly reportsButton: Locator;
 
   constructor(
     private readonly page: Page,
@@ -59,29 +57,28 @@ export class ReportsDialog {
     this.byAgent = page.getByTestId("reports__by-agent");
     this.byWorkspace = page.getByTestId("reports__by-workspace");
     this.periodSelect = page.getByTestId("reports__period-select");
-    this.menuTrigger = page.getByRole("button", { name: "Menu" });
-    this.reportsMenuItem = page.getByTestId("menu__reports");
+    this.reportsButton = page.getByTestId("project-list__usage-button");
   }
 
-  /** Navigate to the dashboard, open the title-bar menu, click Reports.
-   *  Uses the same `expect.poll` re-click pattern as `ResourcesPage` to
-   *  defeat the Radix `DropdownMenuTrigger` race where a fast Playwright
-   *  click can be swallowed before the menu stays open. */
+  /** Navigate to the dashboard, then click the Usage icon in the project-list
+   *  bottom action bar. The button is wrapped in a Radix Tooltip trigger whose
+   *  hover/pointer handling can swallow the first click during a fast run, so
+   *  re-click until the dialog actually opens. */
   async open(): Promise<void> {
-    await test.step("Open Reports via dashboard menu", async () => {
+    await test.step("Open Reports via the bottom action bar", async () => {
       await this.page.goto(`${this.baseUrl}/?token=${this.token}`);
-      await expect(this.menuTrigger).toBeVisible();
+      await this.page.waitForLoadState("networkidle");
+      await expect(this.reportsButton).toBeVisible();
       await expect
         .poll(
           async () => {
-            await this.menuTrigger.click();
-            return await this.reportsMenuItem.isVisible().catch(() => false);
+            if (await this.dialog.isVisible().catch(() => false)) return true;
+            await this.reportsButton.click();
+            return await this.dialog.isVisible().catch(() => false);
           },
           { timeout: 10_000 },
         )
         .toBe(true);
-      await this.reportsMenuItem.click();
-      await expect(this.dialog).toBeVisible();
     });
   }
 

--- a/apps/web/e2e/pages/ResourcesPage.ts
+++ b/apps/web/e2e/pages/ResourcesPage.ts
@@ -1,7 +1,7 @@
 /**
- * Page object for the Resources dialog opened from the dashboard
- * title-bar menu (no dedicated route — the page renders inside a
- * shared Dialog managed by `ToolbarOverflowProvider`).
+ * Page object for the Resources dialog opened from the Resources icon in
+ * the project-list bottom action bar (no dedicated route — the page renders
+ * inside a shared Dialog managed by `ToolbarOverflowProvider`).
  *
  * Owns the locators for the server snapshot card and the worktree
  * usage table, plus an `open()` that walks the user flow:

--- a/apps/web/e2e/pages/ResourcesPage.ts
+++ b/apps/web/e2e/pages/ResourcesPage.ts
@@ -4,18 +4,16 @@
  * shared Dialog managed by `ToolbarOverflowProvider`).
  *
  * Owns the locators for the server snapshot card and the worktree
- * usage table, plus a `goto()` that walks the user flow:
- * dashboard → Menu → Resources.
+ * usage table, plus an `open()` that walks the user flow:
+ * dashboard → Resources icon (project-list bottom action bar).
  *
  * Locator priority:
  *
- *   - `getByRole({ name })` for the dashboard title bar Menu trigger
- *     (the `aria-label="Menu"` value is system-controlled and not
- *     localisable user copy).
  *   - `getByTestId(...)` for owned card / button / table elements,
  *     using the BEM-style `resources-*` prefix the page component sets
- *     in `ResourcesPage.tsx`, plus `menu__resources` for the menu item
- *     and `resources-dialog` for the dialog body itself.
+ *     in `ResourcesPage.tsx`, plus `project-list__resources-button` for
+ *     the Resources icon button and `resources-dialog` for the dialog
+ *     body itself.
  */
 
 import { expect, type Locator, type Page, test } from "@playwright/test";
@@ -39,10 +37,8 @@ export class ResourcesPage {
   readonly projectsTable: Locator;
   /** Grand-total cell inside the per-project rollup's footer. */
   readonly projectsTotal: Locator;
-  /** Menu trigger button in the desktop title bar. */
-  readonly menuTrigger: Locator;
-  /** Resources entry inside the dashboard menu. */
-  readonly resourcesMenuItem: Locator;
+  /** Resources icon button in the project-list bottom action bar. */
+  readonly resourcesButton: Locator;
 
   constructor(
     private readonly page: Page,
@@ -56,37 +52,33 @@ export class ResourcesPage {
     this.refreshWorktreesButton = page.getByTestId("resources-refresh-worktrees");
     this.projectsTable = page.getByTestId("resources-projects-table");
     this.projectsTotal = page.getByTestId("resources-projects-total");
-    // The desktop title bar exposes its hamburger trigger with
-    // `aria-label="Menu"` (see DesktopTitleBar.tsx). System-controlled
-    // ARIA name — getByRole is the preferred locator.
-    this.menuTrigger = page.getByRole("button", { name: "Menu" });
-    this.resourcesMenuItem = page.getByTestId("menu__resources");
+    // Resources is a standalone icon button in the project-list bottom
+    // action bar, testid `project-list__resources-button` (set in
+    // `ToolbarButtons.tsx::ToolbarActionBar`). Distinct from the overflow
+    // menu's `menu__resources` item so a collapsed-sidebar fallback menu
+    // can't put two same-testid nodes in the DOM.
+    this.resourcesButton = page.getByTestId("project-list__resources-button");
   }
 
-  /** Navigate to the dashboard root, then open the title-bar Menu and
-   *  click Resources. Mirrors the user flow described in the issue.
-   *
-   *  Radix's DropdownMenuTrigger sometimes swallows the first click
-   *  that lands on it inside `asChild` button wrappers during a fast
-   *  Playwright run — the trigger's mousedown handler fires before
-   *  the click's pointerdown bubbles back up, and the dropdown closes
-   *  again. Polling the menu item's visibility via `expect.poll` lets
-   *  us re-click the trigger until the dropdown stays open. */
+  /** Navigate to the dashboard root, then click the Resources icon in the
+   *  project-list bottom action bar. The button is wrapped in a Radix Tooltip
+   *  trigger whose hover/pointer handling can swallow the first click during a
+   *  fast run, so re-click until the dialog actually opens. */
   async open(): Promise<void> {
-    await test.step("Open Resources via dashboard menu", async () => {
+    await test.step("Open Resources via the bottom action bar", async () => {
       await this.page.goto(`${this.baseUrl}/?token=${this.token}`);
-      await expect(this.menuTrigger).toBeVisible();
+      await this.page.waitForLoadState("networkidle");
+      await expect(this.resourcesButton).toBeVisible();
       await expect
         .poll(
           async () => {
-            await this.menuTrigger.click();
-            return await this.resourcesMenuItem.isVisible().catch(() => false);
+            if (await this.dialog.isVisible().catch(() => false)) return true;
+            await this.resourcesButton.click();
+            return await this.dialog.isVisible().catch(() => false);
           },
           { timeout: 10_000 },
         )
         .toBe(true);
-      await this.resourcesMenuItem.click();
-      await expect(this.dialog).toBeVisible();
     });
   }
 

--- a/apps/web/e2e/pages/SettingsPage.ts
+++ b/apps/web/e2e/pages/SettingsPage.ts
@@ -1,10 +1,11 @@
 /**
  * Page object for the dashboard's Settings dialog.
  *
- * Owns the locators for the toolbar Menu trigger, the dialog itself, and
- * every per-row control we exercise in `e2e/settings-page.spec.ts`. Test
- * bodies never call `page.goto()`, `page.locator()`, `getByText`, or CSS-id
- * selectors directly — they go through this class.
+ * Owns the locators for the Settings button in the project-list bottom
+ * action bar, the dialog itself, and every per-row control we exercise in
+ * `e2e/settings-page.spec.ts`. Test bodies never call `page.goto()`,
+ * `page.locator()`, `getByText`, or CSS-id selectors directly — they go
+ * through this class.
  *
  * Locator priority for elements this app owns:
  *   1. `getByRole({ name })` when the ARIA name is system-controlled.
@@ -12,10 +13,9 @@
  *
  * Every Settings row's control has either an explicit `aria-label` or an
  * associated `<label htmlFor>` that contributes the accessible name, so
- * `getByRole(..., { name })` is the preferred shape here. The toolbar
- * "Menu" trigger button is anchored via its `data-testid` (set in
- * `DashboardShell.tsx`) since `aria-label="Menu"` is a generic value and
- * there are other "Menu" buttons elsewhere in the dashboard chrome.
+ * `getByRole(..., { name })` is the preferred shape here. The Settings
+ * gear button in the bottom action bar is anchored via its `data-testid`
+ * (`project-list__settings-button`, set in `DashboardShell.tsx`).
  *
  * CARVE-OUT (locator priority): a strict reading of the doctrine
  * bans `getByText`/`getByRole({ name })` against user-visible English copy
@@ -38,16 +38,10 @@ export class SettingsPage {
   readonly dialog: Locator;
   /** Save button in the dialog footer. Disabled until something is dirty. */
   readonly saveButton: Locator;
-  /** "Menu" dropdown trigger in the dashboard toolbar that opens the
-   *  menu containing the "Settings" item. Anchored via `data-testid`
-   *  (set in `DashboardShell.tsx`) because the bare `aria-label="Menu"`
-   *  is ambiguous across the dashboard chrome. */
-  readonly menuTrigger: Locator;
-  /** "Settings" menuitem inside the open toolbar dropdown. Promoted to a
-   *  named property (rather than inlined in `openDialog`) so the locator
-   *  lives alongside every other actionable element this POM owns — every
-   *  control elsewhere in this class is exposed the same way. */
-  readonly settingsMenuItem: Locator;
+  /** Settings gear icon button in the project-list bottom action bar.
+   *  Anchored via `data-testid` (set in `DashboardShell.tsx`). Opens the
+   *  Settings dialog directly — no intermediate dropdown. */
+  readonly settingsButton: Locator;
 
   constructor(
     private readonly page: Page,
@@ -55,9 +49,8 @@ export class SettingsPage {
     private readonly token: string,
   ) {
     this.dialog = page.getByRole("dialog", { name: "Settings" });
-    this.menuTrigger = page.getByTestId("dashboard__menu-trigger");
+    this.settingsButton = page.getByTestId("project-list__settings-button");
     this.saveButton = this.dialog.getByRole("button", { name: "Save" });
-    this.settingsMenuItem = page.getByRole("menuitem", { name: "Settings" });
   }
 
   /** Navigate to the dashboard root with the test token. */
@@ -65,42 +58,34 @@ export class SettingsPage {
     await test.step("Open dashboard", async () => {
       await this.page.goto(`${this.baseUrl}/?token=${this.token}`);
       // The dashboard React app fetches projects via tRPC on mount, so the
-      // toolbar's React click handlers may not be bound by the time `load`
+      // action bar's React click handlers may not be bound by the time `load`
       // fires. Wait for the network to settle before any subsequent step
-      // tries to drive the dropdown — without this, the first click on the
-      // menu trigger is silently lost in CI (matches the workaround already
+      // tries to click the Settings button — without this, the first click on
+      // the button can be silently lost in CI (matches the workaround already
       // in `tasks-page.spec.ts:openTasksDialog`).
       await this.page.waitForLoadState("networkidle");
     });
   }
 
   /**
-   * Open the "Menu" dropdown in the dashboard toolbar and click "Settings".
-   *
-   * The Radix DropdownMenu has a portal + small mount delay during the
-   * initial dashboard hydration, so we wrap the click in an
-   * `expect(...).toPass({ timeout })` poll — clicking too early loses the
-   * event before the menu mounts. Once the menu is visible we click the
-   * "Settings" item and wait for the dialog to render.
-   *
-   * The bare `getByRole("menu")` locator does not carry an accessible name —
-   * Radix's `DropdownMenuContent` portal does not accept an `aria-label`
-   * without further plumbing, and on the dashboard root the toolbar menu
-   * is the only `role="menu"` element in the DOM until something else
-   * opens (the label-filter dropdown is gated on `labels.length > 0` and
-   * the test seeds an empty project list). If a second menu is ever added
-   * unconditionally to the toolbar, scope this locator via an explicit
-   * `aria-label` on the `DropdownMenuContent`.
+   * Click the Settings button in the project-list bottom action bar and wait
+   * for the dialog to render. The button opens the dialog directly, but a
+   * hydration-swallowed first click (see `goto`) can drop the event, so
+   * re-click until the dialog is actually visible.
    */
   async openDialog(): Promise<void> {
-    await test.step("Open Settings dialog from toolbar menu", async () => {
-      await expect(this.menuTrigger).toBeVisible();
-      await expect(async () => {
-        await this.menuTrigger.click();
-        await expect(this.page.getByRole("menu")).toBeVisible({ timeout: 1_000 });
-      }).toPass({ timeout: 15_000 });
-      await this.settingsMenuItem.click();
-      await expect(this.dialog).toBeVisible();
+    await test.step("Open Settings dialog from the bottom action bar", async () => {
+      await expect(this.settingsButton).toBeVisible();
+      await expect
+        .poll(
+          async () => {
+            if (await this.dialog.isVisible().catch(() => false)) return true;
+            await this.settingsButton.click();
+            return await this.dialog.isVisible().catch(() => false);
+          },
+          { timeout: 10_000 },
+        )
+        .toBe(true);
     });
   }
 

--- a/apps/web/e2e/pages/TasksDialog.ts
+++ b/apps/web/e2e/pages/TasksDialog.ts
@@ -25,8 +25,6 @@ export type TaskStatus = "running" | "completed" | "failed";
 export class TasksDialog {
   /** The Tasks dialog body. */
   readonly dialog: Locator;
-  /** Root of the tasks content — the "content mounted" anchor. */
-  readonly root: Locator;
   /** 3-dot overflow trigger in the project-list bottom action bar. */
   readonly overflowTrigger: Locator;
   /** "Tasks" entry inside the overflow dropdown. */
@@ -54,7 +52,6 @@ export class TasksDialog {
     private readonly token: string,
   ) {
     this.dialog = page.getByRole("dialog", { name: "Tasks" });
-    this.root = page.getByTestId("tasks__root");
     this.overflowTrigger = page.getByTestId("project-list__overflow-trigger");
     this.tasksMenuItem = page.getByRole("menuitem", { name: "Tasks" });
     this.projectFilter = page.getByTestId("tasks__project-filter");

--- a/apps/web/e2e/pages/TasksDialog.ts
+++ b/apps/web/e2e/pages/TasksDialog.ts
@@ -1,0 +1,131 @@
+/**
+ * Page object for the Tasks dialog.
+ *
+ * Same shape as `ReportsDialog` — no dedicated route; the dialog is opened
+ * from the 3-dot overflow menu in the project-list bottom action bar. Owns
+ * the locators for the filter controls, task cards, status badges, the
+ * empty state, and the nested New Task dialog.
+ *
+ * Locator priority:
+ *
+ *   - `getByRole({ name })` for the Tasks / New Task dialogs and the overflow
+ *     menu item (system-controlled ARIA names).
+ *   - `getByTestId(...)` (BEM `tasks__*`, set in `TasksPageContent.tsx`) for
+ *     every owned control — filters, per-task cards (`tasks__card--<id>`),
+ *     status badges (`tasks__status-badge--<status>`), empty state, and the
+ *     New Task form fields. This keeps assertions off localisable copy.
+ *   - `getByRole("option", { name })` for Radix select options, whose name is
+ *     the option value (project name / status enum), not free product copy.
+ */
+
+import { expect, type Locator, type Page, test } from "@playwright/test";
+
+export type TaskStatus = "running" | "completed" | "failed";
+
+export class TasksDialog {
+  /** The Tasks dialog body. */
+  readonly dialog: Locator;
+  /** Root of the tasks content — the "content mounted" anchor. */
+  readonly root: Locator;
+  /** 3-dot overflow trigger in the project-list bottom action bar. */
+  readonly overflowTrigger: Locator;
+  /** "Tasks" entry inside the overflow dropdown. */
+  readonly tasksMenuItem: Locator;
+  /** Project filter select trigger. */
+  readonly projectFilter: Locator;
+  /** Status filter select trigger. */
+  readonly statusFilter: Locator;
+  /** Empty-state container (shown when no task matches the filters). */
+  readonly emptyState: Locator;
+  /** "New Task" button in the Tasks toolbar (desktop variant). */
+  readonly newTaskButton: Locator;
+  /** The nested New Task dialog body. */
+  readonly newTaskDialog: Locator;
+  /** Project / Workspace / Prompt controls inside the New Task dialog. */
+  readonly newTaskProject: Locator;
+  readonly newTaskWorkspace: Locator;
+  readonly newTaskPrompt: Locator;
+  /** Session deep-link on a completed task card. */
+  readonly sessionLink: Locator;
+
+  constructor(
+    private readonly page: Page,
+    private readonly baseUrl: string,
+    private readonly token: string,
+  ) {
+    this.dialog = page.getByRole("dialog", { name: "Tasks" });
+    this.root = page.getByTestId("tasks__root");
+    this.overflowTrigger = page.getByTestId("project-list__overflow-trigger");
+    this.tasksMenuItem = page.getByRole("menuitem", { name: "Tasks" });
+    this.projectFilter = page.getByTestId("tasks__project-filter");
+    this.statusFilter = page.getByTestId("tasks__status-filter");
+    this.emptyState = page.getByTestId("tasks__empty-state");
+    this.newTaskButton = page.getByTestId("tasks__new-task-button");
+    this.newTaskDialog = page.getByTestId("tasks__new-task-dialog");
+    this.newTaskProject = page.getByTestId("tasks__new-task-project");
+    this.newTaskWorkspace = page.getByTestId("tasks__new-task-workspace");
+    this.newTaskPrompt = page.getByTestId("tasks__new-task-prompt");
+    this.sessionLink = this.dialog.getByTestId("tasks__session-link");
+  }
+
+  /** Navigate to the dashboard root with the test token. */
+  async goto(): Promise<void> {
+    await test.step("Open dashboard", async () => {
+      await this.page.goto(`${this.baseUrl}/?token=${this.token}`);
+      // The dashboard fetches projects via tRPC on mount, so the action bar's
+      // click handlers may not be bound by the time `load` fires. Wait for the
+      // network to settle before driving the overflow dropdown.
+      await this.page.waitForLoadState("networkidle");
+    });
+  }
+
+  /** Open the overflow menu and click Tasks. Re-clicks the trigger until the
+   *  menu actually appears (covers the hydration race where a fast first click
+   *  is lost before React binds the dropdown's onClick). */
+  async open(): Promise<void> {
+    await test.step("Open Tasks via the bottom action bar overflow", async () => {
+      await expect(this.overflowTrigger).toBeVisible();
+      await expect(async () => {
+        await this.overflowTrigger.click();
+        await expect(this.tasksMenuItem).toBeVisible({ timeout: 1_000 });
+      }).toPass({ timeout: 15_000 });
+      await this.tasksMenuItem.click();
+      await expect(this.dialog).toBeVisible();
+    });
+  }
+
+  /** Task card for a seeded task id. */
+  card(taskId: string): Locator {
+    return this.dialog.getByTestId(`tasks__card--${taskId}`);
+  }
+
+  /** Status badge (any card) for a given status. */
+  statusBadge(status: TaskStatus): Locator {
+    return this.dialog.getByTestId(`tasks__status-badge--${status}`);
+  }
+
+  /** Pick a project from the project filter. Pass a project name, or
+   *  "All Projects" to clear it. */
+  async filterByProject(optionName: string): Promise<void> {
+    await test.step(`Filter tasks by project "${optionName}"`, async () => {
+      await this.projectFilter.click();
+      await this.page.getByRole("option", { name: optionName }).click();
+    });
+  }
+
+  /** Pick a status from the status filter (e.g. "completed"). */
+  async filterByStatus(optionName: string): Promise<void> {
+    await test.step(`Filter tasks by status "${optionName}"`, async () => {
+      await this.statusFilter.click();
+      await this.page.getByRole("option", { name: optionName }).click();
+    });
+  }
+
+  /** Open the nested New Task dialog. */
+  async openNewTask(): Promise<void> {
+    await test.step("Open the New Task dialog", async () => {
+      await this.newTaskButton.click();
+      await expect(this.newTaskDialog).toBeVisible();
+    });
+  }
+}

--- a/apps/web/e2e/pages/WorkspacePage.ts
+++ b/apps/web/e2e/pages/WorkspacePage.ts
@@ -412,11 +412,19 @@ export class WorkspacePage {
     return this.page.getByTestId("desktop-title-bar__sidebar-toggle");
   }
 
-  /** The hamburger menu trigger (Tasks / Cronjobs / Settings …). Rendered by
-   *  `NavControls`, so it relocates between the two title-bar halves with the
-   *  rest of the cluster. Targeted by its system-controlled ARIA name. */
+  /** The hamburger menu trigger (Tasks / Cronjobs / Settings …). Now rendered
+   *  by `NavControls` only in the WorkspaceTitleBar as the fallback for the
+   *  collapsed-sidebar state — while the sidebar is visible those actions live
+   *  in the project-list bottom action bar instead. Targeted by its
+   *  system-controlled ARIA name. */
   get menuTrigger(): Locator {
     return this.page.getByRole("button", { name: "Menu" });
+  }
+
+  /** The project-list bottom action bar (Settings + Resources/Usage/overflow),
+   *  scoped to the sidebar column. Present whenever the list is visible. */
+  get actionBarWithinSidebar(): Locator {
+    return this.sidebar.getByTestId("project-list__action-bar");
   }
 
   /** The workspace-history back arrow (⌘[). Part of the relocating
@@ -440,9 +448,10 @@ export class WorkspacePage {
     return this.sidebar.getByTestId("desktop-title-bar__sidebar-toggle");
   }
 
-  /** The hamburger menu trigger scoped to the project-list column. Count drops
-   *  to 0 once the sidebar collapses and the cluster relocates to the workspace
-   *  bar — the signal that the relocation actually happened. */
+  /** The hamburger menu trigger scoped to the project-list column. The menu no
+   *  longer rides in the SidebarTitleBar (its actions moved to the bottom
+   *  action bar), so this is count 0 while the list is visible; the menu only
+   *  appears in the WorkspaceTitleBar once the sidebar collapses. */
   get menuTriggerWithinSidebar(): Locator {
     return this.sidebar.getByRole("button", { name: "Menu" });
   }

--- a/apps/web/e2e/sidebar-toggle.spec.ts
+++ b/apps/web/e2e/sidebar-toggle.spec.ts
@@ -126,11 +126,14 @@ test("the nav cluster is hosted in the sidebar title bar while the sidebar is vi
   await wp.goto(WORKSPACE);
   await wp.waitForReady();
 
-  // The split title bar puts the toggle + hamburger menu inside the
-  // project-list column (SidebarTitleBar) when the list is shown.
+  // The split title bar puts the sidebar toggle inside the project-list
+  // column (SidebarTitleBar) when the list is shown. The overflow actions
+  // no longer ride in a title-bar hamburger — they live in the project-list
+  // bottom action bar — so the sidebar menu trigger is absent here.
   await expect.poll(() => wp.sidebarWidth()).toBeGreaterThan(200);
   await expect(wp.sidebarToggleWithinSidebar).toBeVisible();
-  await expect(wp.menuTriggerWithinSidebar).toBeVisible();
+  await expect(wp.actionBarWithinSidebar).toBeVisible();
+  await expect(wp.menuTriggerWithinSidebar).toHaveCount(0);
 });
 
 test("the menu and back/forward relocate into the workspace bar when the sidebar collapses", async ({
@@ -140,8 +143,10 @@ test("the menu and back/forward relocate into the workspace bar when the sidebar
   await wp.goto(WORKSPACE);
   await wp.waitForReady();
 
-  // Precondition: while visible, the menu lives in the sidebar column.
-  await expect(wp.menuTriggerWithinSidebar).toBeVisible();
+  // Precondition: while visible, the actions live in the project-list bottom
+  // action bar and no hamburger rides in the sidebar title bar.
+  await expect(wp.actionBarWithinSidebar).toBeVisible();
+  await expect(wp.menuTriggerWithinSidebar).toHaveCount(0);
 
   await wp.toggleSidebarViaButton();
   await expect.poll(() => wp.sidebarWidth()).toBeLessThan(5);

--- a/apps/web/e2e/tasks-page.spec.ts
+++ b/apps/web/e2e/tasks-page.spec.ts
@@ -1,6 +1,6 @@
 import { join } from "node:path";
 import { DatabaseSync } from "node:sqlite";
-import { expect, type Page, test } from "@playwright/test";
+import { expect, test } from "@playwright/test";
 import { drizzle } from "drizzle-orm/node-sqlite";
 import { migrate } from "drizzle-orm/node-sqlite/migrator";
 import {
@@ -11,6 +11,7 @@ import {
   seedState,
   startServer,
 } from "./helpers/server";
+import { TasksDialog } from "./pages/TasksDialog";
 
 const TOKEN = "e2e-test-token";
 
@@ -88,30 +89,6 @@ function deleteTask(tmpHome: string, taskId: string): void {
   } finally {
     sqlite.close();
   }
-}
-
-/**
- * Open the Tasks dialog from the project-list bottom action bar's 3-dot
- * overflow menu. Returns the dialog locator for further interaction. Use
- * after `page.goto` has loaded the dashboard.
- */
-async function openTasksDialog(page: Page) {
-  // The dashboard React app fetches projects via tRPC on mount, so the
-  // action bar's React click handlers may not be bound by the time `load`
-  // fires. Wait for the network to settle before driving the dropdown.
-  await page.waitForLoadState("networkidle");
-  const trigger = page.getByTestId("project-list__overflow-trigger");
-  // Retry the open until the menu actually appears — covers any remaining
-  // hydration race between the click reaching the DOM and React binding
-  // the dropdown's onClick.
-  await expect(async () => {
-    await trigger.click();
-    await expect(page.getByRole("menu")).toBeVisible({ timeout: 1_000 });
-  }).toPass({ timeout: 15_000 });
-  await page.getByRole("menuitem", { name: "Tasks" }).click();
-  const dialog = page.getByRole("dialog", { name: "Tasks" });
-  await expect(dialog).toBeVisible();
-  return dialog;
 }
 
 test.beforeAll(async () => {
@@ -210,108 +187,113 @@ test.afterAll(async () => {
   cleanupTmpHome(tmpHome);
 });
 
-test.beforeEach(async ({ page }) => {
-  await page.goto(`${server.url}/?token=${TOKEN}`);
-});
-
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
+//
+// Seeded task ids (from `beforeAll`):
+//   tsk_1000 — myapp/main,      completed, has session
+//   tsk_2000 — myapp/feat/auth, failed
+//   tsk_3000 — backend/main,    running
 
 test("tasks dialog renders and shows seeded tasks", async ({ page }) => {
-  const dialog = await openTasksDialog(page);
+  const tasks = new TasksDialog(page, server.url, TOKEN);
+  await tasks.goto();
+  await tasks.open();
 
-  await expect(dialog.getByText("Add authentication to the API")).toBeVisible();
-  await expect(dialog.getByText("Fix login validation bug")).toBeVisible();
-  await expect(dialog.getByText("Optimize database queries")).toBeVisible();
+  await expect(tasks.card("tsk_1000")).toBeVisible();
+  await expect(tasks.card("tsk_2000")).toBeVisible();
+  await expect(tasks.card("tsk_3000")).toBeVisible();
 });
 
 test("tasks dialog shows status badges", async ({ page }) => {
-  const dialog = await openTasksDialog(page);
+  const tasks = new TasksDialog(page, server.url, TOKEN);
+  await tasks.goto();
+  await tasks.open();
 
-  // Scope badge checks to task cards to avoid matching select dropdown options.
-  // The card outline is `rounded-lg border-2` — match either width so this
-  // doesn't break the next time we re-tune the border thickness.
-  const cards = dialog.locator(".rounded-lg.border-2, .rounded-lg.border");
-  await expect(cards.getByText("Completed")).toBeVisible();
-  await expect(cards.getByText("Failed")).toBeVisible();
-  await expect(cards.getByText("Running")).toBeVisible();
+  await expect(tasks.statusBadge("completed")).toBeVisible();
+  await expect(tasks.statusBadge("failed")).toBeVisible();
+  await expect(tasks.statusBadge("running")).toBeVisible();
 });
 
 test("filtering by status works", async ({ page }) => {
-  const dialog = await openTasksDialog(page);
+  const tasks = new TasksDialog(page, server.url, TOKEN);
+  await tasks.goto();
+  await tasks.open();
 
-  // Wait for tasks to load
-  await expect(dialog.getByText("Add authentication to the API")).toBeVisible();
+  // Wait for tasks to load.
+  await expect(tasks.card("tsk_1000")).toBeVisible();
 
-  // Open status filter dropdown (second select trigger) and pick "completed"
-  await dialog.locator('[data-slot="select-trigger"]').nth(1).click();
-  await page.getByRole("option", { name: "completed" }).click();
+  await tasks.filterByStatus("completed");
 
-  // Only the completed task should be visible
-  await expect(dialog.getByText("Add authentication to the API")).toBeVisible();
-  await expect(dialog.getByText("Fix login validation bug")).not.toBeVisible();
-  await expect(dialog.getByText("Optimize database queries")).not.toBeVisible();
+  // The completed task stays visible (positive anchor proving the filter
+  // applied); the failed + running tasks drop out.
+  await expect(tasks.card("tsk_1000")).toBeVisible();
+  await expect(tasks.card("tsk_2000")).toHaveCount(0);
+  await expect(tasks.card("tsk_3000")).toHaveCount(0);
 });
 
 test("filtering by project works", async ({ page }) => {
-  const dialog = await openTasksDialog(page);
+  const tasks = new TasksDialog(page, server.url, TOKEN);
+  await tasks.goto();
+  await tasks.open();
 
-  // Wait for tasks to load
-  await expect(dialog.getByText("Add authentication to the API")).toBeVisible();
+  // Wait for tasks to load.
+  await expect(tasks.card("tsk_1000")).toBeVisible();
 
-  // Select "backend" project from dropdown
-  await dialog.locator('[data-slot="select-trigger"]').first().click();
-  await page.getByRole("option", { name: "backend" }).click();
+  await tasks.filterByProject("backend");
 
-  // Only the backend task should be visible
-  await expect(dialog.getByText("Optimize database queries")).toBeVisible();
-  await expect(dialog.getByText("Add authentication to the API")).not.toBeVisible();
-  await expect(dialog.getByText("Fix login validation bug")).not.toBeVisible();
+  // Only the backend task remains (positive anchor); the myapp tasks drop out.
+  await expect(tasks.card("tsk_3000")).toBeVisible();
+  await expect(tasks.card("tsk_1000")).toHaveCount(0);
+  await expect(tasks.card("tsk_2000")).toHaveCount(0);
 });
 
 test("empty state shows when no tasks match filters", async ({ page }) => {
-  const dialog = await openTasksDialog(page);
+  const tasks = new TasksDialog(page, server.url, TOKEN);
+  await tasks.goto();
+  await tasks.open();
 
-  // Wait for tasks to load
-  await expect(dialog.getByText("Add authentication to the API")).toBeVisible();
+  // Wait for tasks to load.
+  await expect(tasks.card("tsk_1000")).toBeVisible();
 
-  // Select "backend" project + "completed" status — no tasks match
-  await dialog.locator('[data-slot="select-trigger"]').first().click();
-  await page.getByRole("option", { name: "backend" }).click();
-  await dialog.locator('[data-slot="select-trigger"]').nth(1).click();
-  await page.getByRole("option", { name: "completed" }).click();
+  // backend + completed matches no seeded task.
+  await tasks.filterByProject("backend");
+  await tasks.filterByStatus("completed");
 
-  await expect(dialog.getByText("No tasks found")).toBeVisible();
-  await expect(dialog.getByText("Try adjusting your filters")).toBeVisible();
+  await expect(tasks.emptyState).toBeVisible();
+  await expect(tasks.card("tsk_3000")).toHaveCount(0);
 });
 
 test("completed task shows session link", async ({ page }) => {
-  const dialog = await openTasksDialog(page);
+  const tasks = new TasksDialog(page, server.url, TOKEN);
+  await tasks.goto();
+  await tasks.open();
 
-  // The completed task with a sessionId should have a "Session" link
-  await expect(dialog.getByText("Add authentication to the API")).toBeVisible();
-  const sessionLink = dialog.getByRole("link", { name: "Session" });
-  await expect(sessionLink.first()).toBeVisible();
+  // The completed task with a sessionId exposes a session deep-link.
+  await expect(tasks.card("tsk_1000")).toBeVisible();
+  await expect(tasks.sessionLink.first()).toBeVisible();
 });
 
 test("new task dialog opens and shows project/workspace selectors", async ({ page }) => {
-  const dialog = await openTasksDialog(page);
+  const tasks = new TasksDialog(page, server.url, TOKEN);
+  await tasks.goto();
+  await tasks.open();
 
-  // Wait for the tasks dialog to load
-  await expect(dialog.getByText("Add authentication to the API")).toBeVisible();
+  await expect(tasks.card("tsk_1000")).toBeVisible();
 
-  // Click "New Task" button (inside the Tasks dialog)
-  await dialog.getByRole("button", { name: "New Task" }).click();
+  await tasks.openNewTask();
 
-  // Nested "New Task" dialog should open with form elements
-  await expect(page.getByText("Dispatch a new task to a coding agent")).toBeVisible();
-  await expect(page.getByText("Project", { exact: true })).toBeVisible();
-  await expect(page.getByText("Workspace", { exact: true })).toBeVisible();
-  await expect(page.getByText("Prompt", { exact: true })).toBeVisible();
+  await expect(tasks.newTaskProject).toBeVisible();
+  await expect(tasks.newTaskWorkspace).toBeVisible();
+  await expect(tasks.newTaskPrompt).toBeVisible();
 });
 
 test("tasks dialog renders filter controls", async ({ page }) => {
-  const dialog = await openTasksDialog(page);
-  await expect(dialog.getByText("All Projects")).toBeVisible();
+  const tasks = new TasksDialog(page, server.url, TOKEN);
+  await tasks.goto();
+  await tasks.open();
+
+  await expect(tasks.projectFilter).toBeVisible();
+  await expect(tasks.statusFilter).toBeVisible();
 });

--- a/apps/web/e2e/tasks-page.spec.ts
+++ b/apps/web/e2e/tasks-page.spec.ts
@@ -91,16 +91,16 @@ function deleteTask(tmpHome: string, taskId: string): void {
 }
 
 /**
- * Open the Tasks dialog from the dashboard's hamburger ("Menu") toolbar
- * dropdown. Returns the dialog locator for further interaction. Use after
- * `page.goto` has loaded the dashboard.
+ * Open the Tasks dialog from the project-list bottom action bar's 3-dot
+ * overflow menu. Returns the dialog locator for further interaction. Use
+ * after `page.goto` has loaded the dashboard.
  */
 async function openTasksDialog(page: Page) {
   // The dashboard React app fetches projects via tRPC on mount, so the
-  // toolbar's React click handlers may not be bound by the time `load`
+  // action bar's React click handlers may not be bound by the time `load`
   // fires. Wait for the network to settle before driving the dropdown.
   await page.waitForLoadState("networkidle");
-  const trigger = page.locator('button[aria-label="Menu"]');
+  const trigger = page.getByTestId("project-list__overflow-trigger");
   // Retry the open until the menu actually appears — covers any remaining
   // hydration race between the click reaching the DOM and React binding
   // the dropdown's onClick.

--- a/apps/web/src/components/DashboardView.tsx
+++ b/apps/web/src/components/DashboardView.tsx
@@ -2,7 +2,7 @@ import { DashboardShell } from "@/dashboard";
 import { useIsDesktop } from "../hooks/useIsDesktop";
 import { isDesktop } from "../lib/is-desktop";
 import { DesktopLayout } from "./DesktopLayout";
-import { ToolbarOverflowMenuItems, ToolbarOverflowProvider } from "./ToolbarButtons";
+import { ToolbarActionBar, ToolbarOverflowProvider } from "./ToolbarButtons";
 
 export function DashboardView() {
   const isWideScreen = useIsDesktop();
@@ -11,14 +11,14 @@ export function DashboardView() {
   if (useDesktopLayout) {
     return (
       <ToolbarOverflowProvider>
-        <DesktopLayout toolbarMenuItems={<ToolbarOverflowMenuItems />} />
+        <DesktopLayout bottomActions={<ToolbarActionBar />} />
       </ToolbarOverflowProvider>
     );
   }
 
   return (
     <ToolbarOverflowProvider>
-      <DashboardShell toolbarMenuItems={<ToolbarOverflowMenuItems />} />
+      <DashboardShell bottomActions={<ToolbarActionBar />} />
     </ToolbarOverflowProvider>
   );
 }

--- a/apps/web/src/components/DesktopLayout.tsx
+++ b/apps/web/src/components/DesktopLayout.tsx
@@ -10,10 +10,10 @@ import {
 } from "../lib/sidebar-width";
 
 interface DesktopLayoutProps {
-  toolbarMenuItems?: ReactNode;
+  bottomActions?: ReactNode;
 }
 
-export function DesktopLayout({ toolbarMenuItems }: DesktopLayoutProps) {
+export function DesktopLayout({ bottomActions }: DesktopLayoutProps) {
   const savedWidth = loadSidebarWidth();
   const defaultLayout = savedWidth ? { sidebar: savedWidth, main: 100 - savedWidth } : undefined;
   const skipFirstLayoutCallback = useRef(true);
@@ -43,7 +43,7 @@ export function DesktopLayout({ toolbarMenuItems }: DesktopLayoutProps) {
           collapsedSize="0%"
         >
           <div className="h-full border-r border-border overflow-hidden">
-            <DashboardShell toolbarMenuItems={toolbarMenuItems} />
+            <DashboardShell bottomActions={bottomActions} />
           </div>
         </Panel>
         <Separator className="w-[3px] bg-transparent hover:bg-accent-foreground/20 active:bg-accent-foreground/30 transition-colors cursor-col-resize" />

--- a/apps/web/src/components/DesktopTitleBar.tsx
+++ b/apps/web/src/components/DesktopTitleBar.tsx
@@ -30,9 +30,11 @@ export interface PanelItem {
 }
 
 /** Props for the navigation cluster (sidebar toggle + menu + back/forward).
- *  This cluster lives in the SidebarTitleBar while the project list is
- *  visible, and relocates into the WorkspaceTitleBar when the list is
- *  collapsed — so both bars accept the same set of props. */
+ *  While the project list is visible the SidebarTitleBar renders only the
+ *  toggle + back/forward arrows (its `menuItems` is left undefined — the
+ *  overflow actions live in DashboardShell's bottom action bar). When the list
+ *  is collapsed the arrows and the fallback hamburger menu render in the
+ *  WorkspaceTitleBar instead — so both bars accept the same set of props. */
 interface NavControlsProps {
   /** Items rendered inside the global hamburger dropdown. When undefined, the
    *  hamburger button is not rendered. */

--- a/apps/web/src/components/DesktopTitleBar.tsx
+++ b/apps/web/src/components/DesktopTitleBar.tsx
@@ -132,15 +132,12 @@ function NavControls({
                   type="button"
                   className="flex items-center justify-center rounded p-1 text-muted-foreground hover:text-foreground hover:bg-accent/50 transition-colors"
                   aria-label="Menu"
-                  // Mirrors the testid on the DashboardShell-version of
-                  // the same trigger (`DashboardShell.tsx`). The two
-                  // triggers are mutually exclusive by layout: this title
-                  // bar mounts when `useDesktopLayout` is true, and the
-                  // sidebar's DashboardShell trigger is suppressed by the
-                  // `hideMenu` prop `AppShell` passes in that case
-                  // (`__root.tsx`). Sharing the testid lets test
-                  // page-objects target "the toolbar menu trigger" without
-                  // branching on layout mode.
+                  // This hamburger is the collapsed-sidebar fallback: while
+                  // the project list is visible its actions live in the
+                  // list's bottom action bar (`DashboardShell.tsx`), and
+                  // `AppShell` (`__root.tsx`) only passes `menuItems` to the
+                  // WorkspaceTitleBar — so this renders once the list
+                  // collapses. Keeps the historical testid for page-objects.
                   data-testid="dashboard__menu-trigger"
                 >
                   <Menu className="size-5" />
@@ -215,7 +212,10 @@ export function SidebarTitleBar({ sidebarVisible, offsetClass, ...nav }: Sidebar
       {/* Gate the cluster on visibility: when the list is collapsed the bar is
           clipped to 0px but stays mounted, so rendering the cluster here would
           duplicate it (the WorkspaceTitleBar shows it while collapsed) and put
-          two `…__sidebar-toggle` / `dashboard__menu-trigger` nodes in the DOM. */}
+          two `…__sidebar-toggle` nodes in the DOM. `AppShell` passes
+          `menuItems={undefined}` here, so this variant renders only the toggle
+          + back/forward arrows — the overflow menu lives in the WorkspaceTitleBar
+          fallback (collapsed) and the project-list bottom action bar (visible). */}
       {sidebarVisible && <NavControls sidebarVisible={sidebarVisible} {...nav} />}
     </div>
   );

--- a/apps/web/src/components/DesktopTitleBar.tsx
+++ b/apps/web/src/components/DesktopTitleBar.tsx
@@ -137,7 +137,9 @@ function NavControls({
                   // list's bottom action bar (`DashboardShell.tsx`), and
                   // `AppShell` (`__root.tsx`) only passes `menuItems` to the
                   // WorkspaceTitleBar — so this renders once the list
-                  // collapses. Keeps the historical testid for page-objects.
+                  // collapses. Retains the historical testid for any direct
+                  // `page.getByTestId` spec use (page objects target the
+                  // bottom-bar buttons now).
                   data-testid="dashboard__menu-trigger"
                 >
                   <Menu className="size-5" />

--- a/apps/web/src/components/TasksPageContent.tsx
+++ b/apps/web/src/components/TasksPageContent.tsx
@@ -155,10 +155,10 @@ export function TasksPageContent() {
   );
 
   return (
-    <div className="flex flex-col overflow-hidden">
+    <div className="flex flex-col overflow-hidden" data-testid="tasks__root">
       <div className="flex shrink-0 items-center gap-2 border-b border-border/50 px-4 py-2">
         <Select value={projectFilter} onValueChange={setProjectFilter}>
-          <SelectTrigger className="h-8 w-40 text-xs">
+          <SelectTrigger className="h-8 w-40 text-xs" data-testid="tasks__project-filter">
             <SelectValue placeholder="All Projects" />
           </SelectTrigger>
           <SelectContent>
@@ -172,7 +172,7 @@ export function TasksPageContent() {
         </Select>
 
         <Select value={statusFilter} onValueChange={(v) => setStatusFilter(v as StatusFilter)}>
-          <SelectTrigger className="h-8 w-40 text-xs">
+          <SelectTrigger className="h-8 w-40 text-xs" data-testid="tasks__status-filter">
             <SelectValue placeholder="All Statuses" />
           </SelectTrigger>
           <SelectContent>
@@ -196,6 +196,7 @@ export function TasksPageContent() {
             variant="outline"
             size="xs"
             className="hidden sm:inline-flex"
+            data-testid="tasks__new-task-button"
             onClick={() => setShowNewTask(true)}
           >
             <Plus className="size-3" />
@@ -230,7 +231,10 @@ export function TasksPageContent() {
         )}
 
         {!loading && !error && filteredTasks.length === 0 && (
-          <div className="flex flex-col items-center justify-center gap-3 py-16 text-center">
+          <div
+            className="flex flex-col items-center justify-center gap-3 py-16 text-center"
+            data-testid="tasks__empty-state"
+          >
             <ListTodo className="size-10 text-muted-foreground" />
             <div>
               <p className="font-medium">No tasks found</p>
@@ -265,21 +269,25 @@ function StatusBadge({ status }: { status: TaskRecord["status"] }) {
   switch (status) {
     case "running":
       return (
-        <Badge variant="secondary" className="gap-1.5">
+        <Badge variant="secondary" className="gap-1.5" data-testid="tasks__status-badge--running">
           <Loader2 className="size-3 animate-spin" />
           Running
         </Badge>
       );
     case "completed":
       return (
-        <Badge variant="secondary" className="gap-1.5 text-green-600 dark:text-green-400">
+        <Badge
+          variant="secondary"
+          className="gap-1.5 text-green-600 dark:text-green-400"
+          data-testid="tasks__status-badge--completed"
+        >
           <CheckCircle2 className="size-3" />
           Completed
         </Badge>
       );
     case "failed":
       return (
-        <Badge variant="destructive" className="gap-1.5">
+        <Badge variant="destructive" className="gap-1.5" data-testid="tasks__status-badge--failed">
           <AlertCircle className="size-3" />
           Failed
         </Badge>
@@ -329,7 +337,10 @@ function TaskCard({
   }, [task.id, onAction]);
 
   return (
-    <div className="flex flex-col gap-2 rounded-lg border-2 border-border/50 p-4 transition-colors hover:border-border">
+    <div
+      className="flex flex-col gap-2 rounded-lg border-2 border-border/50 p-4 transition-colors hover:border-border"
+      data-testid={`tasks__card--${task.id}`}
+    >
       <div className="flex items-start justify-between gap-3">
         <p className="line-clamp-2 min-w-0 flex-1 text-sm font-medium text-foreground">
           {task.prompt}
@@ -406,6 +417,7 @@ function TaskCard({
             <Link
               to={sessionHref}
               className="inline-flex items-center gap-1 text-primary hover:underline"
+              data-testid="tasks__session-link"
             >
               <ExternalLink className="size-3" />
               Session
@@ -556,7 +568,7 @@ function NewTaskDialog({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent>
+      <DialogContent data-testid="tasks__new-task-dialog">
         <DialogHeader>
           <DialogTitle>New Task</DialogTitle>
           <DialogDescription>Dispatch a new task to a coding agent</DialogDescription>
@@ -568,7 +580,7 @@ function NewTaskDialog({
               Project
             </label>
             <Select value={selectedProject} onValueChange={handleProjectChange}>
-              <SelectTrigger id="project-select">
+              <SelectTrigger id="project-select" data-testid="tasks__new-task-project">
                 <SelectValue placeholder="Select a project" />
               </SelectTrigger>
               <SelectContent>
@@ -590,7 +602,7 @@ function NewTaskDialog({
               onValueChange={setSelectedBranch}
               disabled={!selectedProject}
             >
-              <SelectTrigger id="branch-select">
+              <SelectTrigger id="branch-select" data-testid="tasks__new-task-workspace">
                 <SelectValue
                   placeholder={selectedProject ? "Select a workspace" : "Select a project first"}
                 />
@@ -611,6 +623,7 @@ function NewTaskDialog({
             </label>
             <Textarea
               id="task-prompt"
+              data-testid="tasks__new-task-prompt"
               placeholder="Describe what the agent should do..."
               value={prompt}
               onChange={(e) => setPrompt(e.target.value)}

--- a/apps/web/src/components/TasksPageContent.tsx
+++ b/apps/web/src/components/TasksPageContent.tsx
@@ -155,7 +155,7 @@ export function TasksPageContent() {
   );
 
   return (
-    <div className="flex flex-col overflow-hidden" data-testid="tasks__root">
+    <div className="flex flex-col overflow-hidden">
       <div className="flex shrink-0 items-center gap-2 border-b border-border/50 px-4 py-2">
         <Select value={projectFilter} onValueChange={setProjectFilter}>
           <SelectTrigger className="h-8 w-40 text-xs" data-testid="tasks__project-filter">

--- a/apps/web/src/components/ToolbarButtons.tsx
+++ b/apps/web/src/components/ToolbarButtons.tsx
@@ -168,7 +168,10 @@ export function ToolbarOverflowProvider({ children }: { children: ReactNode }) {
 }
 
 /**
- * Menu items for the dashboard's overflow ("3 dots") dropdown.
+ * Menu items for the title-bar hamburger dropdown shown when the project-list
+ * sidebar is collapsed (the `WorkspaceTitleBar` fallback). While the sidebar
+ * is visible these actions live in the project-list bottom action bar
+ * (`ToolbarActionBar`) instead.
  *
  * Must be rendered inside a <ToolbarOverflowProvider>. Returns a fragment of
  * DropdownMenuItem so it can be embedded directly in a DropdownMenuContent.

--- a/apps/web/src/components/ToolbarButtons.tsx
+++ b/apps/web/src/components/ToolbarButtons.tsx
@@ -1,5 +1,18 @@
-import { Dialog, DialogContent, DialogHeader, DialogTitle, DropdownMenuItem } from "@band-app/ui";
-import { Activity, BarChart3, Globe, ListTodo, Timer } from "lucide-react";
+import {
+  Button,
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@band-app/ui";
+import { Activity, BarChart3, Globe, ListTodo, MoreHorizontal, Timer } from "lucide-react";
 import { createContext, type ReactNode, useCallback, useContext, useMemo, useState } from "react";
 import { useTunnel } from "@/hooks/use-tunnel";
 import { CronjobsPageContent } from "./CronjobsPageContent";
@@ -196,6 +209,97 @@ export function ToolbarOverflowMenuItems() {
         <Activity className="size-4" />
         Resources
       </DropdownMenuItem>
+    </>
+  );
+}
+
+/**
+ * Bottom action row cluster for the project list (right-hand side).
+ *
+ * Surfaces Resources and Usage as standalone icon buttons and tucks the
+ * remaining actions (Tasks, Cronjobs, tunnel) behind a 3-dot overflow menu.
+ * Rendered inside `DashboardShell`'s persistent footer; passed in as a
+ * `ReactNode` prop because the `dashboard/` module must not import from
+ * `components/`. Must be mounted inside a <ToolbarOverflowProvider>.
+ */
+export function ToolbarActionBar() {
+  const ctx = useContext(ToolbarOverflowContext);
+  if (!ctx) {
+    throw new Error("ToolbarActionBar must be used inside ToolbarOverflowProvider");
+  }
+
+  return (
+    <>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Button
+            size="icon-sm"
+            variant="ghost"
+            className="text-muted-foreground"
+            aria-label="Resources"
+            data-testid="project-list__resources-button"
+            onClick={ctx.openResources}
+          >
+            <Activity className="size-4" />
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent side="top">Resources</TooltipContent>
+      </Tooltip>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Button
+            size="icon-sm"
+            variant="ghost"
+            className="text-muted-foreground"
+            aria-label="Usage"
+            data-testid="project-list__usage-button"
+            onClick={ctx.openReports}
+          >
+            <BarChart3 className="size-4" />
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent side="top">Usage</TooltipContent>
+      </Tooltip>
+      <DropdownMenu>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <DropdownMenuTrigger asChild>
+              <Button
+                size="icon-sm"
+                variant="ghost"
+                className="text-muted-foreground"
+                aria-label="More actions"
+                data-testid="project-list__overflow-trigger"
+              >
+                <MoreHorizontal className="size-4" />
+              </Button>
+            </DropdownMenuTrigger>
+          </TooltipTrigger>
+          <TooltipContent side="top">More</TooltipContent>
+        </Tooltip>
+        <DropdownMenuContent align="end">
+          <DropdownMenuItem onClick={ctx.openTasks}>
+            <ListTodo className="size-4" />
+            Tasks
+          </DropdownMenuItem>
+          <DropdownMenuItem onClick={ctx.openCronjobs}>
+            <Timer className="size-4" />
+            Cronjobs
+          </DropdownMenuItem>
+          <DropdownMenuItem onClick={ctx.openTunnel}>
+            <Globe
+              className={
+                ctx.tunnelStatus === "error"
+                  ? "size-4 text-red-500"
+                  : ctx.tunnelStatus === "running"
+                    ? "size-4 text-green-500"
+                    : "size-4"
+              }
+            />
+            {ctx.tunnelStatus === "running" ? "Mobile access" : "Start tunnel"}
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
     </>
   );
 }

--- a/apps/web/src/dashboard/components/DashboardShell.tsx
+++ b/apps/web/src/dashboard/components/DashboardShell.tsx
@@ -17,7 +17,7 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@band-app/ui";
-import { Check, ChevronsDownUp, FolderPlus, Menu, Plus, Settings, Tag, X } from "lucide-react";
+import { Check, ChevronsDownUp, FolderPlus, Plus, Settings, Tag, X } from "lucide-react";
 import { type ReactNode, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useCapabilities } from "../context";
 import { useAppUpdate } from "../hooks/use-app-update";
@@ -48,15 +48,13 @@ import { ProjectList } from "./ProjectList";
 import { SettingsPage } from "./SettingsPage";
 
 interface DashboardShellProps {
-  /** Extra menu items rendered inside the toolbar's overflow dropdown,
-   *  appended after the built-in Settings entry. */
-  toolbarMenuItems?: ReactNode;
+  /** Action cluster rendered on the right of the persistent bottom action
+   *  bar (Resources / Usage icons + a 3-dot overflow). Passed in as a node
+   *  because the `dashboard/` module must not import from `components/`;
+   *  callers supply `<ToolbarActionBar />`. */
+  bottomActions?: ReactNode;
   /** Hide the desktop title bar (e.g. when the parent renders a full-width one). */
   hideTitleBar?: boolean;
-  /** Suppress the in-shell hamburger overflow menu. Used when this shell is
-   *  embedded under a global title bar that already exposes the same items
-   *  (Tasks / Cronjobs / Settings / …). */
-  hideMenu?: boolean;
 }
 
 // Desktop-shell detection. The Electron preload
@@ -80,7 +78,7 @@ async function desktopInvoke<T>(cmd: string, args?: Record<string, unknown>): Pr
   throw new Error(`desktopInvoke('${cmd}') called outside the desktop shell`);
 }
 
-export function DashboardShell({ toolbarMenuItems, hideTitleBar, hideMenu }: DashboardShellProps) {
+export function DashboardShell({ bottomActions, hideTitleBar }: DashboardShellProps) {
   const { projects, isLoading: loading } = useProjects();
   const { settings } = useSettingsQuery();
   const labels = settings.labels ?? [];
@@ -374,33 +372,6 @@ export function DashboardShell({ toolbarMenuItems, hideTitleBar, hideMenu }: Das
       <div className="flex h-9 shrink-0 items-center justify-between border-b border-border">
         <div className="flex min-w-0 items-center">
           <div className="flex items-center gap-1 pl-2">
-            {!hideMenu && (
-              <DropdownMenu>
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <DropdownMenuTrigger asChild>
-                      <Button
-                        size="icon-sm"
-                        variant="ghost"
-                        className="text-muted-foreground"
-                        aria-label="Menu"
-                        data-testid="dashboard__menu-trigger"
-                      >
-                        <Menu className="size-5" />
-                      </Button>
-                    </DropdownMenuTrigger>
-                  </TooltipTrigger>
-                  <TooltipContent side="bottom">More</TooltipContent>
-                </Tooltip>
-                <DropdownMenuContent align="start">
-                  {toolbarMenuItems}
-                  <DropdownMenuItem onClick={handleSettingsClick}>
-                    <Settings className="size-4" />
-                    Settings
-                  </DropdownMenuItem>
-                </DropdownMenuContent>
-              </DropdownMenu>
-            )}
             {labels.length > 0 && (
               <DropdownMenu>
                 <DropdownMenuTrigger asChild>
@@ -608,6 +579,28 @@ export function DashboardShell({ toolbarMenuItems, hideTitleBar, hideMenu }: Das
           </Button>
         </div>
       )}
+
+      {/* Persistent bottom action bar. Left: a single Settings button (gear
+          icon + label) that opens the Settings dialog. Right: the
+          Resources/Usage icons + 3-dot overflow supplied by the caller
+          (`bottomActions` — a <ToolbarActionBar />), kept outside the
+          `dashboard/` seam. */}
+      <div
+        className="shrink-0 flex h-9 items-center justify-between gap-1 border-t border-border px-2"
+        data-testid="project-list__action-bar"
+      >
+        <Button
+          size="sm"
+          variant="ghost"
+          className="text-muted-foreground"
+          data-testid="project-list__settings-button"
+          onClick={handleSettingsClick}
+        >
+          <Settings className="size-4" />
+          Settings
+        </Button>
+        <div className="flex items-center gap-0.5">{bottomActions}</div>
+      </div>
 
       <Dialog open={showErrorDialog} onOpenChange={setShowErrorDialog}>
         <DialogContent>

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -30,7 +30,11 @@ import { WebCapabilities, WebDashboardAdapter } from "@/dashboard/adapters/web";
 import { BrowserHostBridge } from "../components/BrowserHostBridge";
 import { type PanelItem, SidebarTitleBar, WorkspaceTitleBar } from "../components/DesktopTitleBar";
 import { crossPanelHandlers, SharedDockviewLayout } from "../components/SharedDockviewLayout";
-import { ToolbarOverflowMenuItems, ToolbarOverflowProvider } from "../components/ToolbarButtons";
+import {
+  ToolbarActionBar,
+  ToolbarOverflowMenuItems,
+  ToolbarOverflowProvider,
+} from "../components/ToolbarButtons";
 import { useIsDesktop } from "../hooks/useIsDesktop";
 import { useIsFullscreen } from "../hooks/useIsFullscreen";
 import { useNavigationHistory } from "../hooks/useNavigationHistory";
@@ -625,9 +629,18 @@ function AppShell() {
                 className="h-full flex flex-col overflow-hidden border-r border-border bg-sidebar"
                 data-testid="app-shell__sidebar"
               >
-                <SidebarTitleBar {...navControlProps} offsetClass={titleBarOffset} />
+                {/* The hamburger menu is dropped here: while the list is
+                    visible its actions live in DashboardShell's bottom action
+                    bar. Only the sidebar toggle + back/forward arrows ride in
+                    the SidebarTitleBar. The menu stays in the WorkspaceTitleBar
+                    (below) as the fallback for the collapsed-list state. */}
+                <SidebarTitleBar
+                  {...navControlProps}
+                  menuItems={undefined}
+                  offsetClass={titleBarOffset}
+                />
                 <div className="flex-1 min-h-0">
-                  <DashboardShell hideMenu hideTitleBar />
+                  <DashboardShell hideTitleBar bottomActions={<ToolbarActionBar />} />
                 </div>
               </div>
             </Panel>

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -542,11 +542,14 @@ function AppShell() {
     [],
   );
 
-  // The hamburger menu and back/forward arrows belong to the project-list
-  // region: they ride in the SidebarTitleBar while the list is visible, and
-  // relocate into the WorkspaceTitleBar (far left) when the list is collapsed
-  // so they stay reachable. Both bars receive the same nav props; each renders
-  // the cluster only in the appropriate state (keyed off `sidebarVisible`).
+  // The back/forward arrows (and, when the list is collapsed, the hamburger
+  // menu) belong to the project-list region. While the list is visible the
+  // SidebarTitleBar shows only the sidebar toggle + arrows — the overflow
+  // actions live in DashboardShell's bottom action bar, so `menuItems` is not
+  // passed there. When the list collapses, the arrows + the fallback hamburger
+  // relocate into the WorkspaceTitleBar (far left) so they stay reachable. Both
+  // bars receive the same nav props; each renders the cluster only in the
+  // appropriate state (keyed off `sidebarVisible`).
   //
   // Memoized so both bars get a stable prop reference across the frequent
   // AppShell re-renders (route changes, workspace switches, sidebar toggles).

--- a/apps/web/src/routes/workspace.$workspaceId.tsx
+++ b/apps/web/src/routes/workspace.$workspaceId.tsx
@@ -18,7 +18,7 @@ import { agentTypeSupportsSessionListing } from "../components/ChatPane";
 import { ChatView } from "../components/ChatView";
 import { CodeBrowserView } from "../components/CodeBrowserView";
 import { DesktopDragRegion } from "../components/DesktopTitleBar";
-import { ToolbarOverflowMenuItems, ToolbarOverflowProvider } from "../components/ToolbarButtons";
+import { ToolbarActionBar, ToolbarOverflowProvider } from "../components/ToolbarButtons";
 import { AgentSwitcherContext, useAgentSwitcherContext } from "../hooks/useAgentSwitcherContext";
 import { useIsDesktop } from "../hooks/useIsDesktop";
 import { SessionListContext, useSessionListContext } from "../hooks/useSessionListContext";
@@ -430,7 +430,7 @@ function MobileWorkspaceLayout({ workspaceId }: { workspaceId: string }) {
                 Browse projects and open a workspace
               </SheetDescription>
               <ToolbarOverflowProvider>
-                <DashboardShell toolbarMenuItems={<ToolbarOverflowMenuItems />} hideTitleBar />
+                <DashboardShell bottomActions={<ToolbarActionBar />} hideTitleBar />
               </ToolbarOverflowProvider>
             </SheetContent>
           </Sheet>


### PR DESCRIPTION
## What & why

The project-list's global actions (Settings, Resources, Usage, Tasks, Cronjobs, tunnel) were buried one dropdown deep in a top **☰ hamburger** menu, and Settings had no persistent affordance. This replaces that hamburger with a **persistent bottom action bar** inside the project list, so the actions are always visible in every layout that shows the list.

## Changes

- **New `ToolbarActionBar`** (`ToolbarButtons.tsx`) — **Resources** and **Usage** as icon buttons, plus a **3-dot overflow** (Tasks / Cronjobs / Start tunnel), consuming the existing `ToolbarOverflowContext`.
- **Settings** — a single labeled ghost button (gear icon + "Settings") on the bottom-left.
- **`DashboardShell`** — top hamburger removed; new persistent footer bar. Prop `toolbarMenuItems` → **`bottomActions`** (`ReactNode`, kept outside the `dashboard/` seam); `hideMenu` prop removed.
- **`__root.tsx`** — passes `menuItems={undefined}` to `SidebarTitleBar`; the fallback hamburger now lives only in the collapsed `WorkspaceTitleBar` (so actions stay reachable when the list is hidden).
- Distinct testids for the icon buttons (`project-list__resources-button` / `project-list__usage-button`) so they never collide with the overflow menu's `menu__*` items.
- Callers (`DashboardView`, `DesktopLayout`, `workspace.$workspaceId`, `__root`) pass `bottomActions={<ToolbarActionBar/>}`.

## Testing

- Updated e2e page objects (`ResourcesPage`, `ReportsDialog`, `SettingsPage`, `WorkspacePage`) and specs (`sidebar-toggle`, `tasks-page`) to drive the new bar.
- Affected e2e suite: **27 passed**. Local `pnpm check` (biome + cargo fmt --check + clippy) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)