### PR TITLE
ci(release): pin CLI test threads to 4 to fix flaky worktree tests

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -121,10 +121,17 @@ jobs:
       - name: Build CLI
         run: cargo build --release --manifest-path apps/cli/Cargo.toml
 
+      # Pin --test-threads=4 to match ci.yml. Each CLI integration test boots
+      # a real node Band server on its own port (TestEnv::new), and
+      # `workspaces create` dispatches to it. With unbounded parallelism the
+      # macos-latest runner boots too many servers at once; some aren't ready
+      # when create dispatches, so the worktree never registers and the
+      # workspaces_list_*/chat_auto_detects_workspace_from_cwd tests flake
+      # (see run 28698582656). CI already caps this; mirror it here.
       - name: Test
         run: |
           pnpm --filter @band-app/server test
-          cargo test --manifest-path apps/cli/Cargo.toml
+          cargo test --manifest-path apps/cli/Cargo.toml -- --test-threads=4
 
       - name: Build frontend
         env:


### PR DESCRIPTION
## Problem

The `Release` workflow failed twice in a row at the **Test** step (runs [28698582656](https://github.com/band-app/band/actions/runs/28698582656) and [28699608254](https://github.com/band-app/band/actions/runs/28699608254)), each time on the same 4 CLI integration tests:

- `chat_auto_detects_workspace_from_cwd`
- `workspaces_list_filters_by_project`
- `workspaces_list_json_output`
- `workspaces_list_shows_created_worktrees`

All four fail identically (`90 passed; 4 failed`): `workspaces create` succeeds but the worktree never shows up in `workspaces list` (`No workspace found for '...'`, `assertion failed: ...contains("feat/filtered")`).

## Root cause

Each CLI integration test's `TestEnv::new()` boots a **real node Band server** on its own port, and `workspaces create` dispatches to it. `ci.yml` caps this with `-- --test-threads=4`; `release.yml` ran `cargo test` with **unbounded parallelism**. On `macos-latest` too many servers boot at once, some aren't ready when `create` dispatches, and the worktree never registers — a pure resource-contention flake, not a code regression (the same commit passes `ci.yml`).

## Fix

Pin `--test-threads=4` in the release Test step to mirror `ci.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)