### PR TITLE
fix(test): canonicalize temp HOME so macOS worktree paths match git

### DIFF
--- a/apps/cli/tests/integration.rs
+++ b/apps/cli/tests/integration.rs
@@ -21,29 +21,39 @@ struct TestEnv {
 impl TestEnv {
     fn new() -> Self {
         let tmp = tempfile::tempdir().expect("create tempdir");
-        // home_dir is the fake HOME — server computes band_home as HOME/.band
-        let home_dir = tmp.path().to_path_buf();
+        // Canonicalize the temp HOME up front. On macOS `tempfile::tempdir()`
+        // hands back `/var/folders/...` while git (and `fs::canonicalize`)
+        // resolve that symlink to `/private/var/folders/...`. Every Band path
+        // derives from HOME, and since #606 both `syncWorktrees` and
+        // `project-service.list` reconcile on-disk worktrees against tracked
+        // rows by *path string equality*. If `worktreesDir` stayed
+        // non-canonical, worktrees created under it (stored as
+        // `/var/folders/...`) would never match git's `/private/var/folders/...`
+        // report and would be dropped from `workspaces list` — the exact
+        // macOS-only failure that passes on Linux CI (`ubuntu-latest`, no
+        // `/private` symlink) but fails on the `macos-latest` release runner.
+        // Canonicalizing here keeps band_dir, worktreesDir, and repo_path all
+        // aligned with git. See #427 (same fix, previously only for repo_path).
+        let home_dir = fs::canonicalize(tmp.path()).expect("canonicalize home_dir");
         // band_dir is HOME/.band — used as BAND_HOME for the CLI
         let band_dir = home_dir.join(".band");
-        let repo_path = tmp.path().join("my-project");
+        let repo_path = home_dir.join("my-project");
         let token = "test-token-12345";
 
         // Create .band dirs
         fs::create_dir_all(band_dir.join("status")).unwrap();
         fs::create_dir_all(band_dir.join("worktrees")).unwrap();
 
-        // Create a real git repo. Canonicalize the path immediately so it
-        // matches what `git worktree list --porcelain` reports — on
-        // macOS, `tempfile::tempdir()` gives `/var/folders/...` while
-        // git resolves the symlink to `/private/var/folders/...`. The
-        // server's syncWorktrees (now invoked at boot via
-        // runFirstTimeSetup) compares the seeded worktree path against
-        // git's canonical form with string equality, so without this
-        // shadowing the seeded row would be reconciled away on the very
-        // first boot, leaving `statuses.resolve` unable to map the
-        // CLI's cwd back to a workspaceId. See #427.
+        // Create a real git repo. `repo_path` is already canonical (it
+        // derives from the canonicalized `home_dir` above), so it matches
+        // what `git worktree list --porcelain` reports. This matters because
+        // the server's syncWorktrees (invoked at boot via runFirstTimeSetup)
+        // compares the seeded worktree path against git's canonical form with
+        // string equality — a `/var/folders` vs `/private/var/folders`
+        // mismatch would reconcile the seeded row away on the first boot,
+        // leaving `statuses.resolve` unable to map the CLI's cwd back to a
+        // workspaceId. See #427.
         fs::create_dir_all(&repo_path).unwrap();
-        let repo_path = fs::canonicalize(&repo_path).expect("canonicalize repo_path");
         git(&repo_path, &["init", "-b", "main"]);
         git(&repo_path, &["commit", "--allow-empty", "-m", "init"]);
 


### PR DESCRIPTION
## Problem

The `Release` workflow (`macos-latest`) failed at the **Test** step on 4 CLI integration tests, every run:

- `workspaces_list_shows_created_worktrees`
- `workspaces_list_filters_by_project`
- `workspaces_list_json_output`
- `chat_auto_detects_workspace_from_cwd`

Each creates a workspace then finds it missing from `workspaces list` (only base `main` returned). CI (`ubuntu-latest`) passed the identical suite, which masked it — including in the `--test-threads=4` PR #607.

## Root cause

`TestEnv::new()` builds `worktreesDir` from `tempfile::tempdir()`, which on macOS returns `/var/folders/…` while git canonicalizes worktree paths to `/private/var/folders/…`. Since #606, `syncWorktrees` and `project-service.list` reconcile on-disk worktrees against tracked rows by **path string equality**. On macOS the created worktrees (stored under the non-canonical `worktreesDir`) never matched git's canonical report, so they were dropped from `list`. Linux has no `/private` symlink, so paths matched and CI stayed green.

The harness already canonicalized `repo_path` for exactly this reason (#427) — it just missed the temp HOME / `worktreesDir`.

## Fix

Canonicalize the temp HOME once, up front, so every derived path (`band_dir`, `worktreesDir`, `repo_path`) aligns with git. Also removes the now-redundant `repo_path` re-canonicalization.

## Verification

- Full CLI suite **94/94 on macOS** (was 90/94). Reproduced the failure locally first, confirmed green after.
- `cargo fmt --check`, `cargo clippy -D warnings` clean.

## Follow-up (not in this PR)

`ci.yml` runs the CLI tests only on `ubuntu-latest`, so this class of macOS-only path bug can't be caught pre-release. Consider adding a macOS CLI-test leg to CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)