### PR TITLE
feat(web): upper-third command dialogs with mobile input-above-keyboard

### DIFF
--- a/apps/web/e2e/command-dialog-layout.spec.ts
+++ b/apps/web/e2e/command-dialog-layout.spec.ts
@@ -1,0 +1,143 @@
+/**
+ * Layout coverage for the command-palette-style dialogs, exercised through the
+ * WorkspacePickerDialog (which lists real seeded workspaces and filters them
+ * client-side, so the result count — and therefore the card height — changes
+ * as the user types).
+ *
+ * The dialogs share the `command-palette` `DialogContent` variant
+ * (`packages/ui/src/components/dialog.tsx`), so pinning its geometry on one
+ * dialog pins it for all five (quick open, find in files, switch workspace,
+ * command palette, language picker).
+ *
+ * Two user-observable contracts, both asserted via real Chromium DOM geometry
+ * (`boundingBox()`), no CSS-class introspection:
+ *
+ *   1. Desktop (wide viewport): the card is anchored in the upper third by its
+ *      TOP edge, so the search input stays at a FIXED Y as results appear and
+ *      disappear — only the list below it grows/shrinks. The old centred layout
+ *      re-centred the whole card, bobbing the input up and down; this spec
+ *      fails on that behaviour.
+ *   2. Mobile (narrow viewport): the input is pinned BELOW the results list
+ *      (bottom of the sheet, easy thumb reach), so the input's Y is greater
+ *      than the last (bottom-most) result row's Y — proving it's below the
+ *      entire list, not merely mid-list.
+ *
+ * Architecture: real production binary against a fresh tmp `~/.band/`, no tRPC
+ * mocks. One project with several worktrees is seeded so the picker has enough
+ * rows to shrink meaningfully when filtered. All interaction is via page
+ * objects.
+ */
+
+import { expect, test } from "@playwright/test";
+import { toWorkspaceId } from "@/dashboard";
+import {
+  cleanupTmpHome,
+  createTmpHome,
+  type ServerHandle,
+  seedSettings,
+  seedState,
+  startServer,
+} from "./helpers/server";
+import { WorkspacePage } from "./pages/WorkspacePage";
+import { WorkspacePicker } from "./pages/WorkspacePicker";
+
+const TOKEN = "e2e-command-dialog-layout-token";
+const PROJECT = "layout-demo";
+
+// A handful of worktrees so the picker list is tall when unfiltered and
+// collapses to a single row when a unique branch is typed — the height delta
+// that would move a centred card's input. The names are deliberately
+// dissimilar (cmdk filters by fuzzy *subsequence*, so near-identical names
+// like `feature-a`/`feature-b` would all survive a single-letter query):
+// only `epsilon` contains an "s", so typing it narrows the list to one row.
+const BRANCHES = ["main", "alpha", "bravo", "charlie", "delta", "epsilon"];
+const FILTER_TO_ONE = "epsilon";
+const WS_MAIN = toWorkspaceId(PROJECT, "main");
+
+let server: ServerHandle;
+let tmpHome: string;
+
+test.beforeAll(async () => {
+  tmpHome = createTmpHome();
+  seedState(tmpHome, {
+    projects: [
+      {
+        name: PROJECT,
+        path: `/tmp/fake/${PROJECT}`,
+        defaultBranch: "main",
+        worktrees: BRANCHES.map((branch) => ({
+          branch,
+          path: `/tmp/fake/${PROJECT}/${branch}`,
+        })),
+      },
+    ],
+  });
+  seedSettings(tmpHome, { tokenSecret: TOKEN });
+  server = await startServer({ tmpHome });
+});
+
+test.afterAll(async () => {
+  await server.close();
+  cleanupTmpHome(tmpHome);
+});
+
+test.describe("Command dialog layout — desktop (upper third, input anchored)", () => {
+  // Wide viewport so `useIsDesktop()` is true, the shared dockview mounts, and
+  // the ⌘K picker uses the desktop (top-anchored) branch of the variant.
+  test.use({ viewport: { width: 1280, height: 800 } });
+
+  test("input stays at a fixed Y as the result list shrinks, list sits below the input", async ({
+    page,
+  }) => {
+    const workspacePage = new WorkspacePage(page, server.url, TOKEN);
+    const picker = new WorkspacePicker(page);
+
+    await workspacePage.goto(WS_MAIN);
+    await workspacePage.waitForReady();
+
+    await workspacePage.openWorkspacePickerViaShortcut();
+    await picker.waitVisible();
+
+    // All rows visible: on desktop the input is at the TOP, the list below it.
+    await expect(picker.options).toHaveCount(BRANCHES.length);
+    const inputFull = await picker.inputBox();
+    const firstRowFull = await picker.firstOptionBox();
+    expect(firstRowFull.y).toBeGreaterThan(inputFull.y);
+
+    // Filter down to a single row — the card gets much shorter. A centred
+    // dialog would re-centre and pull the input downward; the top-anchored
+    // command-palette variant must keep the input at the same Y.
+    await picker.typeQuery(FILTER_TO_ONE);
+    await expect(picker.options).toHaveCount(1);
+
+    const inputFiltered = await picker.inputBox();
+    expect(Math.abs(inputFiltered.y - inputFull.y)).toBeLessThanOrEqual(2);
+  });
+});
+
+test.describe("Command dialog layout — mobile (input below the list)", () => {
+  // Narrow viewport so `useIsDesktop()` is false and the picker renders as the
+  // bottom-sheet variant with the input pinned below the results list.
+  test.use({ viewport: { width: 390, height: 844 } });
+
+  test("input sits below the last result row", async ({ page }) => {
+    const workspacePage = new WorkspacePage(page, server.url, TOKEN);
+    const picker = new WorkspacePicker(page);
+
+    await workspacePage.goto(WS_MAIN);
+    await workspacePage.waitForMobileReady();
+
+    // Mobile opens the picker from the workspace header title.
+    await workspacePage.openSwitcherFromHeader();
+    await picker.waitVisible();
+
+    await expect(picker.options.first()).toBeVisible();
+    const inputBox = await picker.inputBox();
+    const lastRowBox = await picker.lastOptionBox();
+
+    // Input pinned below the ENTIRE list → its top edge is below the top of the
+    // last (bottom-most) row. Measuring against the last row (not the first)
+    // proves the input isn't merely mid-list.
+    expect(inputBox.y).toBeGreaterThan(lastRowBox.y);
+  });
+});

--- a/apps/web/e2e/command-dialog-layout.spec.ts
+++ b/apps/web/e2e/command-dialog-layout.spec.ts
@@ -131,13 +131,16 @@ test.describe("Command dialog layout — mobile (input below the list)", () => {
     await workspacePage.openSwitcherFromHeader();
     await picker.waitVisible();
 
-    await expect(picker.options.first()).toBeVisible();
+    // Pin the full count before measuring so `options.last()` can't be
+    // snapshotted while later rows are still rendering (same anchor the
+    // desktop test uses).
+    await expect(picker.options).toHaveCount(BRANCHES.length);
     const inputBox = await picker.inputBox();
     const lastRowBox = await picker.lastOptionBox();
 
-    // Input pinned below the ENTIRE list → its top edge is below the top of the
-    // last (bottom-most) row. Measuring against the last row (not the first)
-    // proves the input isn't merely mid-list.
-    expect(inputBox.y).toBeGreaterThan(lastRowBox.y);
+    // Input pinned below the ENTIRE list → its top edge is at or below the
+    // BOTTOM edge of the last (bottom-most) row. Comparing against the row's
+    // bottom (not its top) proves the input doesn't overlap the list at all.
+    expect(inputBox.y).toBeGreaterThanOrEqual(lastRowBox.y + lastRowBox.height);
   });
 });

--- a/apps/web/e2e/command-dialog-layout.spec.ts
+++ b/apps/web/e2e/command-dialog-layout.spec.ts
@@ -48,8 +48,10 @@ const PROJECT = "layout-demo";
 // collapses to a single row when a unique branch is typed — the height delta
 // that would move a centred card's input. The names are deliberately
 // dissimilar (cmdk filters by fuzzy *subsequence*, so near-identical names
-// like `feature-a`/`feature-b` would all survive a single-letter query):
-// only `epsilon` contains an "s", so typing it narrows the list to one row.
+// like `feature-a`/`feature-b` would all survive a single-letter query).
+// Only `epsilon` contains an "s", so filtering on it narrows the list to one
+// row; `FILTER_TO_ONE` types the whole word (even more selective than a bare
+// "s") for readability.
 const BRANCHES = ["main", "alpha", "bravo", "charlie", "delta", "epsilon"];
 const FILTER_TO_ONE = "epsilon";
 const WS_MAIN = toWorkspaceId(PROJECT, "main");
@@ -99,7 +101,7 @@ test.describe("Command dialog layout — desktop (upper third, input anchored)",
     await picker.waitVisible();
 
     // All rows visible: on desktop the input is at the TOP, the list below it.
-    await expect(picker.options).toHaveCount(BRANCHES.length);
+    await picker.expectOptionCount(BRANCHES.length);
     const inputFull = await picker.inputBox();
     const firstRowFull = await picker.firstOptionBox();
     expect(firstRowFull.y).toBeGreaterThan(inputFull.y);
@@ -108,7 +110,7 @@ test.describe("Command dialog layout — desktop (upper third, input anchored)",
     // dialog would re-centre and pull the input downward; the top-anchored
     // command-palette variant must keep the input at the same Y.
     await picker.typeQuery(FILTER_TO_ONE);
-    await expect(picker.options).toHaveCount(1);
+    await picker.expectOptionCount(1);
 
     const inputFiltered = await picker.inputBox();
     expect(Math.abs(inputFiltered.y - inputFull.y)).toBeLessThanOrEqual(2);
@@ -134,7 +136,7 @@ test.describe("Command dialog layout — mobile (input below the list)", () => {
     // Pin the full count before measuring so `options.last()` can't be
     // snapshotted while later rows are still rendering (same anchor the
     // desktop test uses).
-    await expect(picker.options).toHaveCount(BRANCHES.length);
+    await picker.expectOptionCount(BRANCHES.length);
     const inputBox = await picker.inputBox();
     const lastRowBox = await picker.lastOptionBox();
 

--- a/apps/web/e2e/dialog-bottom-drawer.spec.ts
+++ b/apps/web/e2e/dialog-bottom-drawer.spec.ts
@@ -115,7 +115,7 @@ test.describe("Mobile bottom drawers", () => {
     expect(box.height).toBeLessThan(VIEWPORT.height);
   });
 
-  test("the workspace picker opens as a bottom drawer", async ({ page }) => {
+  test("the workspace picker opens as a command-palette bottom drawer", async ({ page }) => {
     const workspacePage = new WorkspacePage(page, server.url, TOKEN);
     const picker = new WorkspacePicker(page);
 
@@ -137,7 +137,7 @@ test.describe("Mobile bottom drawers", () => {
     expect(box.y).toBeGreaterThan(8);
   });
 
-  test("Quick Open opens as a bottom drawer", async ({ page }) => {
+  test("Quick Open opens as a command-palette bottom drawer", async ({ page }) => {
     const workspacePage = new WorkspacePage(page, server.url, TOKEN);
 
     await workspacePage.goto(WORKSPACE);
@@ -157,7 +157,7 @@ test.describe("Mobile bottom drawers", () => {
     expect(box.y).toBeGreaterThan(8);
   });
 
-  test("Search in Files opens as a bottom drawer", async ({ page }) => {
+  test("Search in Files opens as a command-palette bottom drawer", async ({ page }) => {
     const workspacePage = new WorkspacePage(page, server.url, TOKEN);
 
     await workspacePage.goto(WORKSPACE);

--- a/apps/web/e2e/dialog-bottom-drawer.spec.ts
+++ b/apps/web/e2e/dialog-bottom-drawer.spec.ts
@@ -124,7 +124,9 @@ test.describe("Mobile bottom drawers", () => {
     await workspacePage.openSwitcherFromHeader();
     await picker.waitVisible();
 
-    await expect(picker.dialog).toHaveAttribute("data-variant", "bottom-sheet");
+    // The command-palette variant is a bottom drawer on mobile (input pinned
+    // below the list) — see command-dialog-layout.spec.ts for the ordering.
+    await expect(picker.dialog).toHaveAttribute("data-variant", "command-palette");
 
     const box = await picker.dialogBox();
     // Anchored to the bottom edge and spanning the full width.
@@ -144,7 +146,10 @@ test.describe("Mobile bottom drawers", () => {
     // Same event the file-tree toolbar's "Quick Open" action fires.
     await workspacePage.dispatchOpenQuickOpen();
     await expect(workspacePage.quickOpenDialog()).toBeVisible();
-    await expect(workspacePage.quickOpenDialog()).toHaveAttribute("data-variant", "bottom-sheet");
+    await expect(workspacePage.quickOpenDialog()).toHaveAttribute(
+      "data-variant",
+      "command-palette",
+    );
 
     const box = await workspacePage.settledBoxOf(workspacePage.quickOpenDialog());
     expect(Math.abs(box.y + box.height - VIEWPORT.height)).toBeLessThanOrEqual(2);
@@ -161,7 +166,10 @@ test.describe("Mobile bottom drawers", () => {
     // Same event the file-tree toolbar's "Search in Files" action fires.
     await workspacePage.dispatchOpenSearchFiles();
     await expect(workspacePage.searchFilesDialog()).toBeVisible();
-    await expect(workspacePage.searchFilesDialog()).toHaveAttribute("data-variant", "bottom-sheet");
+    await expect(workspacePage.searchFilesDialog()).toHaveAttribute(
+      "data-variant",
+      "command-palette",
+    );
 
     const box = await workspacePage.settledBoxOf(workspacePage.searchFilesDialog());
     expect(Math.abs(box.y + box.height - VIEWPORT.height)).toBeLessThanOrEqual(2);

--- a/apps/web/e2e/pages/WorkspacePicker.ts
+++ b/apps/web/e2e/pages/WorkspacePicker.ts
@@ -21,7 +21,7 @@
  * and expose interaction methods.
  */
 
-import { type Locator, type Page, test } from "@playwright/test";
+import { expect, type Locator, type Page, test } from "@playwright/test";
 
 interface Box {
   x: number;
@@ -59,6 +59,13 @@ export class WorkspacePicker {
     return this.dialog.getByRole("option");
   }
 
+  /** Assert the number of workspace rows currently rendered. Wraps the
+   *  `options` locator so test bodies assert row counts through the page
+   *  object rather than consuming the raw locator. */
+  async expectOptionCount(count: number): Promise<void> {
+    await expect(this.options).toHaveCount(count);
+  }
+
   async waitVisible(): Promise<void> {
     await test.step("Wait for the workspace picker to open", async () => {
       await this.dialog.waitFor({ state: "visible", timeout: 15_000 });
@@ -68,7 +75,12 @@ export class WorkspacePicker {
   /** Wait for the dialog's open/slide/zoom animations (and any descendant's)
    *  to finish. The zoom/slide animation runs on the dialog CONTENT element,
    *  so a child (input, row) must wait on the DIALOG's subtree — not its own —
-   *  or it may be measured mid-zoom while the ancestor is still scaling. */
+   *  or it may be measured mid-zoom while the ancestor is still scaling.
+   *
+   *  NOTE: this intentionally differs from `WorkspacePage.settledBoxOf`, which
+   *  waits on the passed locator itself. Here the animation always lives on the
+   *  ancestor dialog, so every measurement anchors on `this.dialog` regardless
+   *  of which child is being measured. */
   private async waitAnimationsSettled(): Promise<void> {
     await this.dialog.evaluate((el) =>
       Promise.all(el.getAnimations({ subtree: true }).map((a) => a.finished.catch(() => {}))),

--- a/apps/web/e2e/pages/WorkspacePicker.ts
+++ b/apps/web/e2e/pages/WorkspacePicker.ts
@@ -23,6 +23,13 @@
 
 import { type Locator, type Page, test } from "@playwright/test";
 
+interface Box {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
 export class WorkspacePicker {
   readonly dialog: Locator;
 
@@ -38,23 +45,74 @@ export class WorkspacePicker {
     return this.page.getByTestId(`workspace-picker__pin--${workspaceId}`);
   }
 
+  /** The search input inside the picker. cmdk's `Command.Input` renders an
+   *  `<input role="combobox" aria-autocomplete="list">`; scoping to the dialog
+   *  keeps it from resolving any other combobox on the page. Used by the
+   *  layout specs to measure where the input sits relative to the results
+   *  list. */
+  get input(): Locator {
+    return this.dialog.getByRole("combobox");
+  }
+
+  /** The workspace rows. cmdk's `Command.Item` renders with role "option". */
+  get options(): Locator {
+    return this.dialog.getByRole("option");
+  }
+
   async waitVisible(): Promise<void> {
     await test.step("Wait for the workspace picker to open", async () => {
       await this.dialog.waitFor({ state: "visible", timeout: 15_000 });
     });
   }
 
-  /** Bounding box of the picker surface. Used to assert the mobile
-   *  bottom-drawer geometry. Throws if the dialog isn't rendered. */
-  async dialogBox(): Promise<{ x: number; y: number; width: number; height: number }> {
-    // Wait for the open/slide animation to finish so the measured box is the
-    // settled position, not a mid-animation frame.
+  /** Wait for the dialog's open/slide/zoom animations (and any descendant's)
+   *  to finish. The zoom/slide animation runs on the dialog CONTENT element,
+   *  so a child (input, row) must wait on the DIALOG's subtree — not its own —
+   *  or it may be measured mid-zoom while the ancestor is still scaling. */
+  private async waitAnimationsSettled(): Promise<void> {
     await this.dialog.evaluate((el) =>
       Promise.all(el.getAnimations({ subtree: true }).map((a) => a.finished.catch(() => {}))),
     );
-    const box = await this.dialog.boundingBox();
-    if (!box) throw new Error("Workspace picker has no bounding box (not visible)");
+  }
+
+  /** Settled bounding box of `locator`, measured only after the dialog's
+   *  animations have finished. Throws if the element isn't rendered so a
+   *  caller never asserts against `null`. */
+  private async settledBoxOf(locator: Locator): Promise<Box> {
+    await this.waitAnimationsSettled();
+    const box = await locator.boundingBox();
+    if (!box) throw new Error("Locator has no bounding box (not visible)");
     return box;
+  }
+
+  /** Bounding box of the picker surface. Used to assert the mobile
+   *  bottom-drawer geometry. Throws if the dialog isn't rendered. */
+  async dialogBox(): Promise<Box> {
+    return this.settledBoxOf(this.dialog);
+  }
+
+  /** Settled bounding box of the search input. */
+  async inputBox(): Promise<Box> {
+    return this.settledBoxOf(this.input);
+  }
+
+  /** Settled bounding box of the first (top) workspace row. */
+  async firstOptionBox(): Promise<Box> {
+    return this.settledBoxOf(this.options.first());
+  }
+
+  /** Settled bounding box of the last (bottom) workspace row. Used to prove
+   *  the input sits below the ENTIRE list on mobile, not just the top row. */
+  async lastOptionBox(): Promise<Box> {
+    return this.settledBoxOf(this.options.last());
+  }
+
+  /** Type a filter query into the picker. cmdk filters the list client-side,
+   *  so this changes the number of visible rows (and thus the card height). */
+  async typeQuery(text: string): Promise<void> {
+    await test.step(`Filter the picker by "${text}"`, async () => {
+      await this.input.fill(text);
+    });
   }
 
   /** Tap a row's pin/unpin button. This must NOT select the workspace —

--- a/apps/web/src/dashboard/components/CommandPaletteDialog.tsx
+++ b/apps/web/src/dashboard/components/CommandPaletteDialog.tsx
@@ -33,7 +33,11 @@ export function CommandPaletteDialog({ open, onOpenChange, commands }: CommandPa
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="overflow-hidden p-0 sm:max-w-[520px]" showCloseButton={false}>
+      <DialogContent
+        variant="command-palette"
+        className="overflow-hidden p-0 lg:max-w-[520px]"
+        showCloseButton={false}
+      >
         <DialogHeader className="sr-only">
           <DialogTitle>Command Palette</DialogTitle>
           <DialogDescription>Search for a command to run</DialogDescription>

--- a/apps/web/src/dashboard/components/LanguagePickerDialog.tsx
+++ b/apps/web/src/dashboard/components/LanguagePickerDialog.tsx
@@ -91,7 +91,11 @@ export function LanguagePickerDialog({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="overflow-hidden p-0 sm:max-w-[480px]" showCloseButton={false}>
+      <DialogContent
+        variant="command-palette"
+        className="overflow-hidden p-0 lg:max-w-[480px]"
+        showCloseButton={false}
+      >
         <DialogHeader className="sr-only">
           <DialogTitle>Select Language Mode</DialogTitle>
           <DialogDescription>Search for a language to syntax-highlight the file</DialogDescription>

--- a/apps/web/src/dashboard/components/QuickOpenDialog.tsx
+++ b/apps/web/src/dashboard/components/QuickOpenDialog.tsx
@@ -300,9 +300,10 @@ export function QuickOpenDialog({
     <Dialog open={open && dialogVisible} onOpenChange={onOpenChange}>
       <DialogContent
         data-testid="quick-open__root"
-        // Mobile: bottom drawer (with a top safe-area gap). Desktop: the
-        // floating command-palette card — unchanged.
-        variant="bottom-sheet"
+        // Mobile: bottom drawer with the input pinned below the results list.
+        // Desktop: floating card anchored in the upper third, input fixed while
+        // results grow downward.
+        variant="command-palette"
         className="overflow-hidden p-0 lg:max-w-[520px]"
         showCloseButton={false}
       >

--- a/apps/web/src/dashboard/components/SearchBar.tsx
+++ b/apps/web/src/dashboard/components/SearchBar.tsx
@@ -1,3 +1,4 @@
+import { cn } from "@band-app/ui";
 import { CaseSensitive, ChevronDown, ChevronUp, Regex, Search, WholeWord, X } from "lucide-react";
 import { forwardRef, useCallback, useImperativeHandle, useRef } from "react";
 
@@ -112,7 +113,10 @@ export const SearchBar = forwardRef<SearchBarHandle, SearchBarProps>(function Se
 
   return (
     <div
-      className={`flex shrink-0 items-center gap-1.5 border-b border-border bg-muted/30 px-3 py-1.5 ${className ?? ""}`}
+      className={cn(
+        "flex shrink-0 items-center gap-1.5 border-b border-border bg-muted/30 px-3 py-1.5",
+        className,
+      )}
     >
       <Search className="size-3.5 shrink-0 text-muted-foreground" />
       <input

--- a/apps/web/src/dashboard/components/SearchFilesDialog.tsx
+++ b/apps/web/src/dashboard/components/SearchFilesDialog.tsx
@@ -135,9 +135,10 @@ export function SearchFilesDialog({
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent
         data-testid="search-files__root"
-        // Mobile: bottom drawer (with a top safe-area gap). Desktop: the
-        // floating command-palette card — unchanged.
-        variant="bottom-sheet"
+        // Mobile: bottom drawer with the search bar pinned below the results
+        // list. Desktop: floating card anchored in the upper third, search bar
+        // fixed while results grow downward.
+        variant="command-palette"
         className="overflow-hidden p-0 lg:max-w-[640px]"
         showCloseButton={false}
       >
@@ -153,6 +154,9 @@ export function SearchFilesDialog({
             options={searchOptions}
             onOptionsChange={setSearchOptions}
             placeholder="Search in files..."
+            // On mobile the search bar sits at the bottom of the sheet (below
+            // the list), so its divider flips to a top border.
+            className="max-lg:border-t max-lg:border-b-0"
           />
           <CommandList className="max-h-[400px]">
             <CommandEmpty>

--- a/apps/web/src/dashboard/components/WorkspacePickerDialog.tsx
+++ b/apps/web/src/dashboard/components/WorkspacePickerDialog.tsx
@@ -113,15 +113,14 @@ export function WorkspacePickerDialog({ open, onOpenChange }: WorkspacePickerDia
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent
-        // Mobile: slides up as a bottom drawer (with a top safe-area gap).
-        // Desktop (sm+): the floating command-palette card — unchanged.
-        // No border ("white frame") and the app's floating-surface colour
-        // (`bg-popover`, same as dropdowns / context menus) so the picker reads
-        // as part of the app rather than a stock modal. `shadow-2xl` + the
-        // blurred overlay give it depth without a hard edge.
-        variant="bottom-sheet"
-        className="overflow-hidden border-0 bg-popover p-0 shadow-2xl lg:max-w-[520px] lg:border-0"
-        overlayClassName="backdrop-blur-sm"
+        // Mobile: slides up as a bottom drawer with the search input pinned
+        // below the list. Desktop: floating card anchored in the upper third,
+        // input fixed while the list grows downward. Uses the shared
+        // command-palette surface + dark overlay so it matches the other four
+        // command dialogs (quick open, find in files, command palette, language
+        // picker).
+        variant="command-palette"
+        className="overflow-hidden p-0 lg:max-w-[520px]"
         showCloseButton={false}
         data-testid="workspace-picker"
         // On touch devices, don't auto-focus the search input on open — that

--- a/packages/ui/src/components/dialog.tsx
+++ b/packages/ui/src/components/dialog.tsx
@@ -1,6 +1,7 @@
 import { XIcon } from "lucide-react";
 import { Dialog as DialogPrimitive } from "radix-ui";
 import type * as React from "react";
+import { useEffect } from "react";
 
 import { cn } from "../utils";
 import { Button } from "./button";
@@ -44,6 +45,24 @@ function DialogOverlay({
 // reverts to the centred modal at the `lg` breakpoint — desktop is left
 // exactly as the default variant.
 //
+// `command-palette` is the layout for the searchable command dialogs (quick
+// open, find in files, switch workspace, command palette, language picker).
+// Unlike the other variants it deliberately does NOT centre vertically:
+//   - Desktop (lg+): the card is anchored in the upper third by its TOP edge
+//     with no `translate-y`, so the search input (the first child) stays at a
+//     fixed Y while the results list grows/shrinks downward beneath it. A
+//     centred modal would bob the input up and down as results change.
+//   - Mobile (< lg): a bottom drawer whose input is pinned to the BOTTOM,
+//     just above the on-screen keyboard (easy thumb reach), with the results
+//     list above it. The input/list order is flipped visually only, by
+//     reversing the `<Command>` flex direction (DOM order + cmdk keyboard nav
+//     are untouched). The sheet sits at `bottom: var(--kb-inset)` (see
+//     `useKeyboardInset`), a JS-maintained variable equal to the keyboard's
+//     occluded height, so the input rides *above* the keyboard on iOS Safari
+//     too — where the layout viewport is never resized and a `bottom: 0` sheet
+//     would otherwise be drawn under the keyboard. The `max-h` subtracts the
+//     same inset so the sheet's top can't run past the safe-area gap.
+//
 // The breakpoint is `lg` (1024px), NOT `sm`, so it matches the app's own
 // mobile/desktop switch (`useIsDesktop` = `min-width: 1024px`): below 1024px
 // the app renders its mobile layout, so the dialogs must be bottom drawers
@@ -64,7 +83,64 @@ const DIALOG_CONTENT_VARIANTS = {
     "lg:inset-auto lg:top-[50%] lg:left-[50%] lg:bottom-auto lg:w-full lg:max-w-lg lg:max-h-[85vh] lg:translate-x-[-50%] lg:translate-y-[-50%] lg:rounded-lg lg:border-b",
     "lg:data-[state=open]:zoom-in-95 lg:data-[state=closed]:zoom-out-95",
   ].join(" "),
+  "command-palette": [
+    // Shared
+    "fixed z-50 flex flex-col bg-background shadow-lg duration-200 outline-none",
+    "data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:animate-in data-[state=open]:fade-in-0",
+    // Mobile (< lg): bottom drawer with the input pinned to the bottom. Flip
+    // the command's flex direction so the input sits below the results list,
+    // and flip the input wrapper's divider to a top border to match. The sheet
+    // floats at `bottom: var(--kb-inset)` (keyboard height; 0 when closed) so
+    // the input clears the on-screen keyboard — see `useKeyboardInset`.
+    "inset-x-0 bottom-[var(--kb-inset,0px)] w-full max-w-none rounded-t-2xl border border-b-0",
+    "max-h-[calc(100dvh-var(--kb-inset,0px)-env(safe-area-inset-top)-1.5rem)]",
+    "max-lg:[&_[data-slot=command]]:flex-col-reverse",
+    "max-lg:[&_[cmdk-input-wrapper]]:border-t max-lg:[&_[cmdk-input-wrapper]]:border-b-0",
+    "max-lg:data-[state=open]:slide-in-from-bottom max-lg:data-[state=closed]:slide-out-to-bottom",
+    // Desktop (lg+): anchored in the upper third by its TOP edge — no
+    // `translate-y`, so the input never moves as the list grows downward.
+    "lg:inset-x-auto lg:bottom-auto lg:top-[12vh] lg:left-1/2 lg:w-full lg:max-w-lg lg:max-h-[70vh] lg:-translate-x-1/2 lg:rounded-lg lg:border",
+    "lg:data-[state=open]:zoom-in-95 lg:data-[state=closed]:zoom-out-95",
+  ].join(" "),
 } as const;
+
+/**
+ * Keep a `--kb-inset` CSS variable on the document root in sync with the
+ * on-screen keyboard's occluded height, so the mobile `command-palette` bottom
+ * sheet can float above the keyboard rather than be drawn under it.
+ *
+ * Only Chrome Android honours the `interactive-widget=resizes-content` viewport
+ * hint (which shrinks the layout viewport so a `bottom: 0` sheet already clears
+ * the keyboard). iOS Safari never resizes the layout viewport for the keyboard,
+ * so a `position: fixed; bottom: 0` element stays put and the keyboard overlays
+ * it. `visualViewport` reports the occluded height on both platforms, so we
+ * drive the sheet's `bottom` (and `max-height`) off it. On
+ * Android-with-resizes-content the computed inset is ~0 (the layout viewport
+ * already shrank), making this a no-op there — no double offset.
+ *
+ * Runs only while a `command-palette` dialog is mounted (Radix mounts content
+ * on open, unmounts after the close animation), so the listeners are scoped to
+ * the dialog's lifetime.
+ */
+function useKeyboardInset(active: boolean) {
+  useEffect(() => {
+    const vv = window.visualViewport;
+    if (!active || !vv) return;
+    const root = document.documentElement;
+    const update = () => {
+      const inset = Math.max(0, window.innerHeight - vv.height - vv.offsetTop);
+      root.style.setProperty("--kb-inset", `${inset}px`);
+    };
+    update();
+    vv.addEventListener("resize", update);
+    vv.addEventListener("scroll", update);
+    return () => {
+      vv.removeEventListener("resize", update);
+      vv.removeEventListener("scroll", update);
+      root.style.removeProperty("--kb-inset");
+    };
+  }, [active]);
+}
 
 function DialogContent({
   className,
@@ -81,9 +157,15 @@ function DialogContent({
    * Layout variant. `default` is the centred modal; `bottom-sheet` renders a
    * bottom drawer on mobile (with a top safe-area gap) that reverts to the
    * centred modal on desktop (`lg`+, 1024px — matching `useIsDesktop`).
+   * `command-palette` is for searchable command dialogs: upper-third
+   * top-anchored on desktop (fixed input, list grows downward) and a
+   * bottom drawer with the input pinned below the list on mobile.
    */
   variant?: keyof typeof DIALOG_CONTENT_VARIANTS;
 }) {
+  // Track the keyboard height for the mobile command-palette bottom sheet so
+  // its input clears the on-screen keyboard. No-op for the other variants.
+  useKeyboardInset(variant === "command-palette");
   return (
     <DialogPortal data-slot="dialog-portal">
       <DialogOverlay className={overlayClassName} />

--- a/packages/ui/src/components/dialog.tsx
+++ b/packages/ui/src/components/dialog.tsx
@@ -120,8 +120,13 @@ const DIALOG_CONTENT_VARIANTS = {
  *
  * Runs only while a `command-palette` dialog is mounted (Radix mounts content
  * on open, unmounts after the close animation), so the listeners are scoped to
- * the dialog's lifetime.
+ * the dialog's lifetime. Instances are ref-counted: when one command-palette
+ * dialog closes while another is still open (e.g. overlapping open/close
+ * animations), the variable is only cleared once the last one unmounts — so
+ * the surviving dialog isn't collapsed back to `bottom: 0`.
  */
+let keyboardInsetRefCount = 0;
+
 function useKeyboardInset(active: boolean) {
   useEffect(() => {
     const vv = window.visualViewport;
@@ -131,13 +136,16 @@ function useKeyboardInset(active: boolean) {
       const inset = Math.max(0, window.innerHeight - vv.height - vv.offsetTop);
       root.style.setProperty("--kb-inset", `${inset}px`);
     };
+    keyboardInsetRefCount += 1;
     update();
     vv.addEventListener("resize", update);
     vv.addEventListener("scroll", update);
     return () => {
       vv.removeEventListener("resize", update);
       vv.removeEventListener("scroll", update);
-      root.style.removeProperty("--kb-inset");
+      keyboardInsetRefCount -= 1;
+      // Only clear once the last command-palette dialog has unmounted.
+      if (keyboardInsetRefCount === 0) root.style.removeProperty("--kb-inset");
     };
   }, [active]);
 }

--- a/packages/ui/src/components/dialog.tsx
+++ b/packages/ui/src/components/dialog.tsx
@@ -120,32 +120,36 @@ const DIALOG_CONTENT_VARIANTS = {
  *
  * Runs only while a `command-palette` dialog is mounted (Radix mounts content
  * on open, unmounts after the close animation), so the listeners are scoped to
- * the dialog's lifetime. Instances are ref-counted: when one command-palette
- * dialog closes while another is still open (e.g. overlapping open/close
- * animations), the variable is only cleared once the last one unmounts — so
- * the surviving dialog isn't collapsed back to `bottom: 0`.
+ * the dialog's lifetime. Live instances are tracked in a `Set` of per-effect
+ * tokens rather than an integer counter: when one command-palette dialog closes
+ * while another is still open (e.g. overlapping open/close animations), the
+ * variable is only cleared once the set is empty — so the surviving dialog
+ * isn't collapsed back to `bottom: 0`. A `Set` (vs. a bare `+1/-1` counter) also
+ * can't go negative under HMR module re-evaluation or React StrictMode's
+ * double-invoked effects, both of which would corrupt a plain counter.
  */
-let keyboardInsetRefCount = 0;
+const keyboardInsetHolders = new Set<object>();
 
 function useKeyboardInset(active: boolean) {
   useEffect(() => {
     const vv = window.visualViewport;
     if (!active || !vv) return;
     const root = document.documentElement;
+    const token = {};
     const update = () => {
       const inset = Math.max(0, window.innerHeight - vv.height - vv.offsetTop);
       root.style.setProperty("--kb-inset", `${inset}px`);
     };
-    keyboardInsetRefCount += 1;
+    keyboardInsetHolders.add(token);
     update();
     vv.addEventListener("resize", update);
     vv.addEventListener("scroll", update);
     return () => {
       vv.removeEventListener("resize", update);
       vv.removeEventListener("scroll", update);
-      keyboardInsetRefCount -= 1;
+      keyboardInsetHolders.delete(token);
       // Only clear once the last command-palette dialog has unmounted.
-      if (keyboardInsetRefCount === 0) root.style.removeProperty("--kb-inset");
+      if (keyboardInsetHolders.size === 0) root.style.removeProperty("--kb-inset");
     };
   }, [active]);
 }


### PR DESCRIPTION
## What

Introduce a shared `command-palette` `DialogContent` variant and point all five command-style dialogs at it — **quick open, find in files, switch workspace, command palette, and language picker** — so their layout is consistent and defined in one place.

**Desktop:** anchored in the upper third by the top edge (no vertical centering), so the search input holds a **fixed Y** while the results list grows/shrinks *downward* — no more input bobbing up and down as you type.

**Mobile:** a bottom sheet with the input pinned **below** the results list (easy thumb reach). The input/list order is flipped visually only (`flex-col-reverse` on the `Command`); DOM order and cmdk keyboard nav are untouched.

**Keyboard clearance (iOS + Android):** the sheet floats at `bottom: var(--kb-inset)`, a JS-maintained variable driven by the `visualViewport` API (`useKeyboardInset`), equal to the on-screen keyboard's occluded height. Previously the sheet relied on `interactive-widget=resizes-content`, which is Chrome-Android-only — on iOS Safari the keyboard was drawn *over* the input. The inset is `0` when the keyboard is closed (identical to the old `bottom: 0`) and ~0 on Android-with-resizes-content (no double offset), so only iOS changes behavior.

**Consistency:** the workspace switcher dropped its bespoke blurred backdrop + `bg-popover`/`shadow-2xl` overrides so all five dialogs share the same dark overlay and surface.

## Tests

- New `apps/web/e2e/command-dialog-layout.spec.ts` (real-server geometry): desktop input stays at a fixed Y as results shrink; mobile input sits below the entire results list.
- Extended the `WorkspacePicker` page object (`input`/`options` role locators, settled-box helpers, `typeQuery`).
- Updated `dialog-bottom-drawer.spec.ts` variant assertions to `command-palette`.

The keyboard-lift itself isn't e2e-tested — headless Chromium has no soft keyboard that resizes `visualViewport`, so the condition can't be materialized. Specs cover the layout ordering and the keyboard-closed geometry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)