### PR TITLE
feat(web): add Git Graph tab with commit details

### DIFF
--- a/apps/web/e2e/commit-graph-actions.spec.ts
+++ b/apps/web/e2e/commit-graph-actions.spec.ts
@@ -1,0 +1,117 @@
+// Frontend integration test for the Graph tab's interactive layer: the
+// commit-details panel and a context-menu write action. Boots the real
+// production server against a real on-disk git repo, drives a real Chromium
+// through the shared dockview, and asserts on the real rendered DOM + the
+// real git effect on disk.
+//
+// No tRPC mocking — the details panel renders against the real
+// `workspace.getCommitDetails` procedure and "Create branch…" runs the real
+// `workspace.createBranch` mutation against the workspace's worktree.
+
+import { execFileSync } from "node:child_process";
+import { mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { expect, test } from "@playwright/test";
+import { toWorkspaceId } from "@/dashboard";
+import { git, gitEnv } from "./helpers/git";
+import {
+  cleanupTmpHome,
+  createTmpHome,
+  type ServerHandle,
+  seedSettings,
+  seedState,
+  startServer,
+} from "./helpers/server";
+import { WorkspacePage } from "./pages/WorkspacePage";
+
+/** Read a git command's stdout (the shared `git` helper returns void). */
+function gitOut(cwd: string, args: string[]): string {
+  return execFileSync("git", args, { cwd, env: gitEnv, encoding: "utf-8" }).trim();
+}
+
+const TOKEN = "e2e-commit-graph-actions-token";
+const REPO_NAME = "graph-actions-repo";
+const BRANCH = "main";
+
+test.use({ viewport: { width: 1280, height: 800 } });
+
+let server: ServerHandle;
+let tmpHome: string;
+let repoPath: string;
+let workspaceId: string;
+
+test.beforeAll(async () => {
+  tmpHome = createTmpHome();
+  repoPath = join(tmpHome, REPO_NAME);
+  mkdirSync(repoPath, { recursive: true });
+
+  // main: initial ─ second
+  git(repoPath, ["init", "-b", BRANCH]);
+  writeFileSync(join(repoPath, "README.md"), "# graph-actions-repo\n");
+  git(repoPath, ["add", "."]);
+  git(repoPath, ["commit", "-m", "initial"]);
+
+  writeFileSync(join(repoPath, "second.md"), "# second\n");
+  git(repoPath, ["add", "."]);
+  git(repoPath, ["commit", "-m", "second"]);
+
+  seedState(tmpHome, {
+    projects: [
+      {
+        name: REPO_NAME,
+        path: repoPath,
+        defaultBranch: BRANCH,
+        worktrees: [{ branch: BRANCH, path: repoPath }],
+      },
+    ],
+  });
+  seedSettings(tmpHome, { tokenSecret: TOKEN });
+  server = await startServer({ tmpHome });
+  workspaceId = toWorkspaceId(REPO_NAME, BRANCH);
+});
+
+test.afterAll(async () => {
+  await server.close();
+  cleanupTmpHome(tmpHome);
+});
+
+test.describe("Graph tab — interactive", () => {
+  test("opens the commit-details panel with the changed-file list on click", async ({ page }) => {
+    const workspacePage = new WorkspacePage(page, server.url, TOKEN);
+    await workspacePage.goto(workspaceId);
+    await workspacePage.waitForReady();
+    await workspacePage.openGraphTab();
+    await expect(workspacePage.commitGraph).toBeVisible();
+
+    // Selecting the `second` commit opens the details panel, which lists the
+    // file that commit changed (second.md, read via getCommitDetails).
+    await workspacePage.openCommitDetails("second");
+    await expect(workspacePage.commitDetails).toBeVisible();
+    // The changed-file list entry (exact match avoids the diff-header lines
+    // that also contain "second.md").
+    await expect(workspacePage.commitDetails.getByText("second.md", { exact: true })).toBeVisible();
+  });
+
+  test("creates a branch from a commit's context menu (real mutation)", async ({ page }) => {
+    const workspacePage = new WorkspacePage(page, server.url, TOKEN);
+    await workspacePage.goto(workspaceId);
+    await workspacePage.waitForReady();
+    await workspacePage.openGraphTab();
+    await expect(workspacePage.commitGraph).toBeVisible();
+    await expect(workspacePage.commitRow("initial")).toBeVisible();
+
+    // Right-click "initial" → Create branch… → name it → submit. The mutation
+    // creates `topic` at that commit and checks it out; the graph refetches.
+    await workspacePage.createBranchFromCommit("initial", "topic");
+
+    // The new branch's ref badge now decorates the graph (HEAD -> topic).
+    await expect(workspacePage.refBadge("topic")).toBeVisible();
+
+    // …and it exists on disk as a real branch at the `initial` commit.
+    // `main` still points at `second`, so `main~1` is the `initial` commit.
+    const initialSha = gitOut(repoPath, ["rev-parse", "main~1"]);
+    const topicSha = gitOut(repoPath, ["rev-parse", "topic"]);
+    expect(topicSha).toBe(initialSha);
+    expect(gitOut(repoPath, ["symbolic-ref", "--short", "HEAD"])).toBe("topic");
+  });
+});

--- a/apps/web/e2e/commit-graph.spec.ts
+++ b/apps/web/e2e/commit-graph.spec.ts
@@ -1,0 +1,141 @@
+// Frontend integration test for the Graph tab/panel. Boots the real
+// production server against a real on-disk git repo with commits across
+// two branches, drives a real Chromium through the shared dockview, and
+// asserts the commit-graph SVG + seeded commit subjects render in the DOM.
+//
+// No tRPC mocking — the Graph panel renders against the real
+// `workspace.getCommitGraph` procedure reading real `git log` output.
+
+import { mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { expect, test } from "@playwright/test";
+import { toWorkspaceId } from "@/dashboard";
+import { git } from "./helpers/git";
+import {
+  cleanupTmpHome,
+  createTmpHome,
+  type ServerHandle,
+  seedSettings,
+  seedState,
+  startServer,
+} from "./helpers/server";
+import { WorkspacePage } from "./pages/WorkspacePage";
+
+const TOKEN = "e2e-commit-graph-token";
+const REPO_NAME = "graph-repo";
+const BRANCH = "main";
+
+// Wide viewport so useIsDesktop() reports true and the shared dockview
+// (which owns the outer Graph tab) renders instead of the mobile layout.
+test.use({ viewport: { width: 1280, height: 800 } });
+
+let server: ServerHandle;
+let tmpHome: string;
+let workspaceId: string;
+
+test.beforeAll(async () => {
+  tmpHome = createTmpHome();
+  const repoPath = join(tmpHome, REPO_NAME);
+  mkdirSync(repoPath, { recursive: true });
+
+  // main: initial ─ second
+  // feature:       └─ feature-work
+  git(repoPath, ["init", "-b", BRANCH]);
+  writeFileSync(join(repoPath, "README.md"), "# graph-repo\n");
+  git(repoPath, ["add", "."]);
+  git(repoPath, ["commit", "-m", "initial"]);
+
+  git(repoPath, ["checkout", "-b", "feature"]);
+  writeFileSync(join(repoPath, "feature.md"), "# feature\n");
+  git(repoPath, ["add", "."]);
+  git(repoPath, ["commit", "-m", "feature-work"]);
+
+  git(repoPath, ["checkout", BRANCH]);
+  writeFileSync(join(repoPath, "second.md"), "# second\n");
+  git(repoPath, ["add", "."]);
+  git(repoPath, ["commit", "-m", "second"]);
+
+  // Stash an untracked change. `git stash -u` writes three bookkeeping
+  // commits (the stash tip, its index snapshot, and a *parentless* untracked
+  // root) — the untracked root is what used to render as a floating,
+  // disconnected node once the stash tip is hidden.
+  writeFileSync(join(repoPath, "scratch.md"), "wip\n");
+  git(repoPath, ["stash", "push", "-u", "-m", "explore empty message"]);
+
+  seedState(tmpHome, {
+    projects: [
+      {
+        name: REPO_NAME,
+        path: repoPath,
+        defaultBranch: BRANCH,
+        worktrees: [{ branch: BRANCH, path: repoPath }],
+      },
+    ],
+  });
+  seedSettings(tmpHome, { tokenSecret: TOKEN });
+  server = await startServer({ tmpHome });
+  workspaceId = toWorkspaceId(REPO_NAME, BRANCH);
+});
+
+test.afterAll(async () => {
+  await server.close();
+  cleanupTmpHome(tmpHome);
+});
+
+test.describe("Graph tab", () => {
+  test("renders the commit graph with every branch's commits", async ({ page }) => {
+    const workspacePage = new WorkspacePage(page, server.url, TOKEN);
+    await workspacePage.goto(workspaceId);
+    await workspacePage.waitForReady();
+
+    await workspacePage.openGraphTab();
+
+    // The commit-graph SVG renders (positive anchor before any assertions
+    // about specific rows).
+    await expect(workspacePage.commitGraph).toBeVisible();
+
+    // Every branch's commit is listed — `getCommitGraph` runs `git log
+    // --all`, so both the main tip and the side-branch commit show up.
+    await expect(workspacePage.commitRow("initial")).toBeVisible();
+    await expect(workspacePage.commitRow("second")).toBeVisible();
+    await expect(workspacePage.commitRow("feature-work")).toBeVisible();
+  });
+
+  test("hides git stash bookkeeping commits by default", async ({ page }) => {
+    const workspacePage = new WorkspacePage(page, server.url, TOKEN);
+    await workspacePage.goto(workspaceId);
+    await workspacePage.waitForReady();
+
+    await workspacePage.openGraphTab();
+
+    // Positive anchor: the real history renders.
+    await expect(workspacePage.commitGraph).toBeVisible();
+    await expect(workspacePage.commitRow("second")).toBeVisible();
+
+    // With "Hide stash" on (the default), none of the three stash
+    // bookkeeping commits — including the parentless untracked root that
+    // used to float disconnected — appear in the graph.
+    await expect(workspacePage.stashBookkeepingRows()).toHaveCount(0);
+  });
+
+  test("shows the stash tip as one node but never its index/untracked internals", async ({
+    page,
+  }) => {
+    const workspacePage = new WorkspacePage(page, server.url, TOKEN);
+    await workspacePage.goto(workspaceId);
+    await workspacePage.waitForReady();
+
+    await workspacePage.openGraphTab();
+    await expect(workspacePage.commitGraph).toBeVisible();
+
+    // Turn "Hide stash" off — the stash tip now renders as a single node
+    // (positive anchor that toggling worked and the stash is shown).
+    await workspacePage.toggleHideStash();
+    await expect(workspacePage.stashTipRow("explore empty message")).toBeVisible();
+
+    // …but its index/untracked snapshot commits are still never surfaced as
+    // their own nodes (they'd draw extra dangling lanes — Fork/GitKraken hide
+    // them too).
+    await expect(workspacePage.stashInternalRows()).toHaveCount(0);
+  });
+});

--- a/apps/web/e2e/pages/WorkspacePage.ts
+++ b/apps/web/e2e/pages/WorkspacePage.ts
@@ -577,7 +577,7 @@ export class WorkspacePage {
    *  locator never collides with nested dockview tab strips (which
    *  render their own per-instance tab components and never carry
    *  `workspace__tab--*` testids). */
-  tab(panelComponent: "chat" | "changes" | "files" | "terminal" | "browser"): Locator {
+  tab(panelComponent: "chat" | "changes" | "files" | "terminal" | "browser" | "graph"): Locator {
     return this.page.getByTestId(`workspace__tab--${panelComponent}`);
   }
 
@@ -591,7 +591,9 @@ export class WorkspacePage {
    *  than waiting for the panel's content (e.g. xterm) to finish
    *  booting, and it isn't affected by xterm's offscreen helper textarea
    *  visibility quirks. */
-  tabContainer(panelComponent: "chat" | "changes" | "files" | "terminal" | "browser"): Locator {
+  tabContainer(
+    panelComponent: "chat" | "changes" | "files" | "terminal" | "browser" | "graph",
+  ): Locator {
     // Anchor on our own testid (the one on `.dv-default-tab`) and walk
     // up to dockview's `.dv-tab` wrapper via the `:has(...)` pseudo —
     // a Playwright-supported CSS selector that picks the parent
@@ -902,10 +904,55 @@ export class WorkspacePage {
    *  raw tab click in a `test.step` so spec bodies switch tabs through the page
    *  object instead of touching the `tab(...)` locator directly. */
   async activateTab(
-    panelComponent: "chat" | "changes" | "files" | "terminal" | "browser",
+    panelComponent: "chat" | "changes" | "files" | "terminal" | "browser" | "graph",
   ): Promise<void> {
     await test.step(`Activate the ${panelComponent} tab`, async () => {
       await this.tab(panelComponent).click();
+    });
+  }
+
+  /** Activate the Graph tab. The commit-graph SVG is then reachable via
+   *  `commitGraph`. */
+  async openGraphTab(): Promise<void> {
+    await this.activateTab("graph");
+  }
+
+  /** The commit-graph SVG rendered by `GitGraphView`. Its ARIA name
+   *  ("Commit graph") is system-controlled, so `getByRole` is the
+   *  highest-priority locator. */
+  get commitGraph(): Locator {
+    return this.page.getByRole("img", { name: "Commit graph" });
+  }
+
+  /** A commit row in the graph, located by its subject line. The subject is
+   *  runtime data the test itself committed, so `getByText` is appropriate. */
+  commitRow(subject: string): Locator {
+    return this.page.getByText(subject, { exact: true });
+  }
+
+  /** Rows whose subject is git-generated stash bookkeeping ("index on …",
+   *  "untracked files on …", "WIP on …", "On …: …"). Hidden while the
+   *  graph's "Hide stash" toggle is on (the default). */
+  stashBookkeepingRows(): Locator {
+    return this.page.getByText(/^(?:WIP on|On|index on|untracked files on) \S+: /);
+  }
+
+  /** The stash's index/untracked snapshot rows — never surfaced as their own
+   *  nodes regardless of the "Hide stash" toggle. */
+  stashInternalRows(): Locator {
+    return this.page.getByText(/^(?:index on|untracked files on) \S+: /);
+  }
+
+  /** The stash tip row (git subject "On <branch>: <message>"), located by its
+   *  message — runtime data the test itself stashed. */
+  stashTipRow(message: string): Locator {
+    return this.page.getByText(new RegExp(`^On \\S+: .*${message}`));
+  }
+
+  /** Toggle the graph's "Hide stash" checkbox (Graph tab must be open). */
+  async toggleHideStash(): Promise<void> {
+    await test.step("Toggle Hide stash", async () => {
+      await this.page.getByTestId("git-graph__hide-stash").click();
     });
   }
 

--- a/apps/web/e2e/pages/WorkspacePage.ts
+++ b/apps/web/e2e/pages/WorkspacePage.ts
@@ -956,6 +956,50 @@ export class WorkspacePage {
     });
   }
 
+  /** The Graph tab's bottom commit-details panel. `data-testid` set by
+   *  `CommitDetailsPanel` in `GitCommitDetails.tsx`; visible after a commit
+   *  row is selected. */
+  get commitDetails(): Locator {
+    return this.page.getByTestId("git-graph__commit-details");
+  }
+
+  /** Select a commit row (by subject) to open its details panel. */
+  async openCommitDetails(subject: string): Promise<void> {
+    await test.step(`Open details for commit "${subject}"`, async () => {
+      await this.commitRow(subject).click();
+    });
+  }
+
+  /** Right-click a commit row (by subject) to open its context menu. The
+   *  opened menu is a Radix `role="menu"`, reachable via `contextMenu`. */
+  async openCommitContextMenu(subject: string): Promise<void> {
+    await test.step(`Right-click commit "${subject}"`, async () => {
+      await this.commitRow(subject).click({ button: "right" });
+      await expect(this.contextMenu).toBeVisible();
+    });
+  }
+
+  /** Drive the "Create branch…" flow from a commit's context menu: right-click
+   *  the row, pick the item, type the name in the dialog, and submit. Exercises
+   *  the real `workspace.createBranch` mutation end-to-end. */
+  async createBranchFromCommit(subject: string, branchName: string): Promise<void> {
+    await test.step(`Create branch "${branchName}" from commit "${subject}"`, async () => {
+      await this.openCommitContextMenu(subject);
+      await this.page.getByTestId("git-graph__create-branch").click();
+      const input = this.page.getByTestId("git-graph__branch-name-input");
+      await input.waitFor({ state: "visible" });
+      await input.fill(branchName);
+      await this.page.getByTestId("git-graph__create-branch-submit").click();
+    });
+  }
+
+  /** A ref badge in the graph rendered with the given label (branch / HEAD /
+   *  tag / stash). The label is runtime data the test itself created, so
+   *  `getByText` is appropriate. */
+  refBadge(label: string): Locator {
+    return this.page.getByText(label, { exact: true });
+  }
+
   /** Read the server's recorded last-focused panel ids for a workspace via the
    *  `panelFocus.get` tRPC query. Used as a synchronisation barrier: focus is
    *  reported fire-and-forget, so a test polls this until the pane it just

--- a/apps/web/src/components/GitCommitDetails.tsx
+++ b/apps/web/src/components/GitCommitDetails.tsx
@@ -1,0 +1,212 @@
+import { X } from "lucide-react";
+import { useEffect, useState } from "react";
+import { trpc } from "../lib/trpc-client";
+
+interface CommitFileChange {
+  path: string;
+  status: string;
+}
+
+interface CommitDetails {
+  sha: string;
+  parents: string[];
+  author: string;
+  email: string;
+  authorTs: number;
+  committer: string;
+  committerTs: number;
+  subject: string;
+  body: string;
+  files: CommitFileChange[];
+}
+
+/** Colour + label for a git name-status code. */
+function statusMeta(status: string): { label: string; className: string } {
+  switch (status[0]) {
+    case "A":
+      return { label: "A", className: "text-emerald-600 dark:text-emerald-400" };
+    case "M":
+      return { label: "M", className: "text-amber-600 dark:text-amber-400" };
+    case "D":
+      return { label: "D", className: "text-red-600 dark:text-red-400" };
+    case "R":
+      return { label: "R", className: "text-sky-600 dark:text-sky-400" };
+    case "C":
+      return { label: "C", className: "text-sky-600 dark:text-sky-400" };
+    default:
+      return { label: status[0] ?? "?", className: "text-muted-foreground" };
+  }
+}
+
+function formatFull(ts: number): string {
+  if (!ts) return "";
+  return new Date(ts * 1000).toLocaleString(undefined, {
+    dateStyle: "medium",
+    timeStyle: "short",
+  });
+}
+
+/** Renders a unified git diff string with +/- line colouring. */
+function UnifiedDiff({ diff }: { diff: string }) {
+  if (!diff.trim()) {
+    return (
+      <div className="p-4 text-xs text-muted-foreground">
+        No textual diff (binary file or no changes).
+      </div>
+    );
+  }
+  const lines = diff.split("\n");
+  return (
+    <pre className="overflow-x-auto p-2 font-mono text-[11px] leading-[1.5]">
+      {lines.map((line, i) => {
+        let cls = "text-foreground/80";
+        if (line.startsWith("@@")) cls = "text-sky-600 dark:text-sky-400 bg-sky-500/5";
+        else if (line.startsWith("+++") || line.startsWith("---") || line.startsWith("diff --git"))
+          cls = "text-muted-foreground";
+        else if (line.startsWith("+"))
+          cls = "text-emerald-700 dark:text-emerald-300 bg-emerald-500/10";
+        else if (line.startsWith("-")) cls = "text-red-700 dark:text-red-300 bg-red-500/10";
+        return (
+          // biome-ignore lint/suspicious/noArrayIndexKey: diff lines are positional and static
+          <div key={i} className={`whitespace-pre px-2 ${cls}`}>
+            {line || " "}
+          </div>
+        );
+      })}
+    </pre>
+  );
+}
+
+interface CommitDetailsPanelProps {
+  workspaceId: string;
+  sha: string;
+  onClose: () => void;
+}
+
+/** Bottom panel showing a selected commit's metadata, changed files, and the
+ *  diff of whichever file is selected. */
+export function CommitDetailsPanel({ workspaceId, sha, onClose }: CommitDetailsPanelProps) {
+  const [details, setDetails] = useState<CommitDetails | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [activeFile, setActiveFile] = useState<string | null>(null);
+  const [fileDiff, setFileDiff] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    setDetails(null);
+    setError(null);
+    setActiveFile(null);
+    setFileDiff(null);
+    trpc.workspace.getCommitDetails
+      .query({ workspaceId, sha })
+      .then((res) => {
+        if (cancelled) return;
+        setDetails(res);
+        if (res.files.length > 0) setActiveFile(res.files[0].path);
+      })
+      .catch((err) => {
+        if (cancelled) return;
+        setError(err instanceof Error ? err.message : String(err));
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [workspaceId, sha]);
+
+  useEffect(() => {
+    if (!activeFile) {
+      setFileDiff(null);
+      return;
+    }
+    let cancelled = false;
+    setFileDiff(null);
+    trpc.workspace.getCommitFileDiff
+      .query({ workspaceId, sha, filePath: activeFile })
+      .then((res) => {
+        if (!cancelled) setFileDiff(res.diff);
+      })
+      .catch(() => {
+        if (!cancelled) setFileDiff("");
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [workspaceId, sha, activeFile]);
+
+  return (
+    <div
+      className="flex min-h-0 shrink-0 flex-col border-t border-border bg-background"
+      style={{ height: "45%" }}
+      data-testid="git-graph__commit-details"
+    >
+      <div className="flex shrink-0 items-start gap-2 border-b border-border/60 px-3 py-2">
+        <div className="min-w-0 flex-1">
+          <div className="truncate text-sm font-medium">{details?.subject ?? "Loading…"}</div>
+          {details && (
+            <div className="mt-0.5 flex flex-wrap items-center gap-x-3 gap-y-0.5 text-xs text-muted-foreground">
+              <span>
+                {details.author} &lt;{details.email}&gt;
+              </span>
+              <span>{formatFull(details.committerTs)}</span>
+              <span className="font-mono">{details.sha.slice(0, 10)}</span>
+            </div>
+          )}
+        </div>
+        <button
+          type="button"
+          onClick={onClose}
+          className="rounded p-1 text-muted-foreground hover:bg-accent hover:text-foreground"
+          aria-label="Close commit details"
+        >
+          <X className="size-4" />
+        </button>
+      </div>
+
+      {error ? (
+        <div className="p-4 text-sm text-destructive">Failed to load commit: {error}</div>
+      ) : (
+        <div className="flex min-h-0 flex-1">
+          <div className="flex w-64 shrink-0 flex-col overflow-auto border-r border-border/60">
+            {details?.body && (
+              <div className="whitespace-pre-wrap border-b border-border/40 p-2 text-xs text-muted-foreground">
+                {details.body}
+              </div>
+            )}
+            {details?.files.map((f) => {
+              const meta = statusMeta(f.status);
+              const isActive = activeFile === f.path;
+              return (
+                <button
+                  key={f.path}
+                  type="button"
+                  onClick={() => setActiveFile(f.path)}
+                  title={f.path}
+                  className={`flex items-center gap-2 px-2 py-1 text-left text-xs transition-colors ${
+                    isActive ? "bg-accent text-foreground" : "hover:bg-accent/40"
+                  }`}
+                >
+                  <span className={`w-3 shrink-0 font-mono font-semibold ${meta.className}`}>
+                    {meta.label}
+                  </span>
+                  <span className="truncate" dir="rtl">
+                    {f.path}
+                  </span>
+                </button>
+              );
+            })}
+            {details && details.files.length === 0 && (
+              <div className="p-2 text-xs text-muted-foreground">No file changes.</div>
+            )}
+          </div>
+          <div className="min-w-0 flex-1 overflow-auto">
+            {fileDiff == null ? (
+              <div className="p-4 text-xs text-muted-foreground">Loading diff…</div>
+            ) : (
+              <UnifiedDiff diff={fileDiff} />
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/GitGraphView.tsx
+++ b/apps/web/src/components/GitGraphView.tsx
@@ -1,6 +1,38 @@
-import { useEffect, useMemo, useState } from "react";
+import {
+  Button,
+  ContextMenu,
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuSeparator,
+  ContextMenuTrigger,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  Input,
+  Label,
+} from "@band-app/ui";
+import { ClipboardCopy, GitBranchPlus, GitCommitHorizontal, RotateCcw, Undo2 } from "lucide-react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { SearchBar, type SearchOptions } from "../dashboard/components/SearchBar";
+import { useDeferredMenuAction } from "../dashboard/hooks/use-deferred-menu-action";
+import { useDashboardStore } from "../dashboard/stores/index";
+import { writeClipboardText } from "../lib/clipboard";
 import { trpc } from "../lib/trpc-client";
 import { CommitDetailsPanel } from "./GitCommitDetails";
+
+/**
+ * A state-changing action queued from a context menu. The confirm /
+ * name-input dialog it maps to is rendered at the `GitGraphView` root and
+ * runs the matching `workspace.*` mutation on confirm.
+ */
+type PendingAction =
+  | { kind: "cherry-pick"; sha: string; subject: string }
+  | { kind: "revert"; sha: string; subject: string }
+  | { kind: "checkout"; branch: string }
+  | { kind: "create-branch"; sha: string };
 
 interface Commit {
   sha: string;
@@ -177,6 +209,28 @@ function refClasses(kind: RefBadge["kind"]): string {
   }
 }
 
+/**
+ * Build a predicate that tests a commit's subject / author / sha against the
+ * find query. Returns `null` when there's nothing to match (empty query, or an
+ * invalid regex) so the caller reports zero hits instead of throwing.
+ */
+function buildMatcher(query: string, options: SearchOptions): ((c: Commit) => boolean) | null {
+  if (!query) return null;
+  let test: (s: string) => boolean;
+  if (options.regex) {
+    try {
+      const re = new RegExp(query, options.caseSensitive ? "" : "i");
+      test = (s) => re.test(s);
+    } catch {
+      return null;
+    }
+  } else {
+    const q = options.caseSensitive ? query : query.toLowerCase();
+    test = (s) => (options.caseSensitive ? s : s.toLowerCase()).includes(q);
+  }
+  return (c) => test(c.subject) || test(c.author) || test(c.sha);
+}
+
 interface GitGraphViewProps {
   workspaceId: string;
 }
@@ -236,6 +290,118 @@ export function GitGraphView({ workspaceId }: GitGraphViewProps) {
     [filteredCommits],
   );
 
+  const setGlobalError = useDashboardStore((s) => s.setError);
+  const menu = useDeferredMenuAction();
+  const [pending, setPending] = useState<PendingAction | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  const rootRef = useRef<HTMLDivElement>(null);
+  const scrollRef = useRef<HTMLDivElement>(null);
+
+  const [searchOpen, setSearchOpen] = useState(false);
+  const [searchQuery, setSearchQuery] = useState("");
+  const [searchOptions, setSearchOptions] = useState<SearchOptions>({
+    caseSensitive: false,
+    wholeWord: false,
+    regex: false,
+  });
+  const [matchIndex, setMatchIndex] = useState(0);
+
+  // Row indices (into `graph.rows`) whose commit matches the find query.
+  const matches = useMemo(() => {
+    if (!graph || !searchOpen) return [];
+    const matcher = buildMatcher(searchQuery, searchOptions);
+    if (!matcher) return [];
+    const out: number[] = [];
+    for (let i = 0; i < graph.rows.length; i++) {
+      if (matcher(graph.rows[i].commit)) out.push(i);
+    }
+    return out;
+  }, [graph, searchOpen, searchQuery, searchOptions]);
+
+  // Reset to the first hit whenever the match set changes.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: keyed on the match set, not matchIndex
+  useEffect(() => {
+    setMatchIndex(0);
+  }, [matches]);
+
+  // Scroll the current match into the middle of the viewport. Rows are a
+  // fixed `ROW_HEIGHT`, so the target scrollTop is derived from its index
+  // — no per-row refs needed.
+  useEffect(() => {
+    if (matches.length === 0) return;
+    const rowIndex = matches[matchIndex];
+    if (rowIndex == null) return;
+    const el = scrollRef.current;
+    if (!el) return;
+    const target = rowIndex * ROW_HEIGHT - el.clientHeight / 2 + ROW_HEIGHT / 2;
+    el.scrollTo({ top: Math.max(0, target), behavior: "smooth" });
+  }, [matches, matchIndex]);
+
+  const openSearch = useCallback(() => setSearchOpen(true), []);
+  const closeSearch = useCallback(() => {
+    setSearchOpen(false);
+    setSearchQuery("");
+  }, []);
+  const nextMatch = useCallback(() => {
+    setMatchIndex((i) => (matches.length === 0 ? 0 : (i + 1) % matches.length));
+  }, [matches.length]);
+  const prevMatch = useCallback(() => {
+    setMatchIndex((i) => (matches.length === 0 ? 0 : (i - 1 + matches.length) % matches.length));
+  }, [matches.length]);
+
+  // ⌘F / Ctrl+F opens the find widget — but only while focus is inside this
+  // panel, so it never clobbers the diff editor's own ⌘F in another dockview
+  // group. Clicking any commit row (a <button>) puts focus here.
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      const mod = e.metaKey || e.ctrlKey;
+      if (mod && e.key.toLowerCase() === "f" && !e.shiftKey) {
+        if (!rootRef.current?.contains(document.activeElement)) return;
+        e.preventDefault();
+        openSearch();
+      }
+    };
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, [openSearch]);
+
+  const refresh = useCallback(() => setRefreshKey((k) => k + 1), []);
+
+  const performAction = useCallback(
+    async (action: PendingAction, branchName?: string) => {
+      setBusy(true);
+      try {
+        switch (action.kind) {
+          case "checkout":
+            await trpc.workspace.checkoutBranch.mutate({ workspaceId, branch: action.branch });
+            break;
+          case "cherry-pick":
+            await trpc.workspace.cherryPick.mutate({ workspaceId, sha: action.sha });
+            break;
+          case "revert":
+            await trpc.workspace.revertCommit.mutate({ workspaceId, sha: action.sha });
+            break;
+          case "create-branch":
+            await trpc.workspace.createBranch.mutate({
+              workspaceId,
+              sha: action.sha,
+              name: branchName ?? "",
+              checkout: true,
+            });
+            break;
+        }
+        setPending(null);
+        refresh();
+      } catch (err) {
+        setGlobalError(err instanceof Error ? err.message : String(err));
+      } finally {
+        setBusy(false);
+      }
+    },
+    [workspaceId, refresh, setGlobalError],
+  );
+
   if (error) {
     return (
       <div className="flex h-full flex-col">
@@ -271,16 +437,32 @@ export function GitGraphView({ workspaceId }: GitGraphViewProps) {
 
   const graphWidth = GRAPH_PADDING_X * 2 + graph.maxLanes * LANE_WIDTH;
   const totalHeight = graph.rows.length * ROW_HEIGHT;
+  const currentRowIndex = matches.length > 0 ? matches[matchIndex] : -1;
+  const matchSet = new Set(matches);
 
   return (
-    <div className="flex h-full flex-col bg-background text-sm">
+    <div ref={rootRef} className="flex h-full flex-col bg-background text-sm">
       <Toolbar
-        onRefresh={() => setRefreshKey((k) => k + 1)}
+        onRefresh={refresh}
         hideStash={hideStash}
         onToggleStash={() => setHideStash((v) => !v)}
         commitCount={graph.rows.length}
       />
-      <div className="relative flex-1 overflow-auto">
+      {searchOpen && (
+        <SearchBar
+          query={searchQuery}
+          onQueryChange={setSearchQuery}
+          options={searchOptions}
+          onOptionsChange={setSearchOptions}
+          placeholder="Find commit (subject, author, sha)…"
+          visibleOptions={["caseSensitive", "regex"]}
+          matchInfo={{ total: matches.length, current: matches.length ? matchIndex + 1 : 0 }}
+          onNext={nextMatch}
+          onPrevious={prevMatch}
+          onClose={closeSearch}
+        />
+      )}
+      <div ref={scrollRef} className="relative flex-1 overflow-auto">
         <div className="flex min-h-full" style={{ minWidth: "max-content" }}>
           <svg
             width={graphWidth}
@@ -460,7 +642,12 @@ export function GitGraphView({ workspaceId }: GitGraphViewProps) {
                   isSelected={selected === row.commit.sha}
                   isHead={data?.head === row.commit.sha}
                   showAvatar={!sameAuthor}
+                  matchState={
+                    i === currentRowIndex ? "current" : matchSet.has(i) ? "match" : "none"
+                  }
+                  menu={menu}
                   onSelect={() => setSelected(row.commit.sha)}
+                  onAction={setPending}
                 />
               );
             })}
@@ -474,7 +661,158 @@ export function GitGraphView({ workspaceId }: GitGraphViewProps) {
           onClose={() => setSelected(null)}
         />
       )}
+      {pending?.kind === "create-branch" ? (
+        <CreateBranchDialog
+          sha={pending.sha}
+          busy={busy}
+          onSubmit={(name) => performAction(pending, name)}
+          onCancel={() => {
+            if (!busy) setPending(null);
+          }}
+        />
+      ) : pending ? (
+        <ConfirmActionDialog
+          action={pending}
+          busy={busy}
+          onConfirm={() => performAction(pending)}
+          onCancel={() => {
+            if (!busy) setPending(null);
+          }}
+        />
+      ) : null}
     </div>
+  );
+}
+
+/** Confirm dialog for the state-changing actions (checkout / cherry-pick /
+ *  revert). Every one of these mutates the working tree, so the user always
+ *  gets a chance to back out first. */
+function ConfirmActionDialog({
+  action,
+  busy,
+  onConfirm,
+  onCancel,
+}: {
+  action: Extract<PendingAction, { kind: "checkout" | "cherry-pick" | "revert" }>;
+  busy: boolean;
+  onConfirm: () => void;
+  onCancel: () => void;
+}) {
+  const copy =
+    action.kind === "checkout"
+      ? {
+          title: "Checkout branch",
+          body: `Switch the working tree to “${action.branch}”. Uncommitted changes may block the checkout.`,
+          confirm: "Checkout",
+          variant: "default" as const,
+        }
+      : action.kind === "cherry-pick"
+        ? {
+            title: "Cherry-pick commit",
+            body: `Apply “${action.subject}” (${action.sha.slice(0, 7)}) onto the current branch. Conflicts will stop the pick.`,
+            confirm: "Cherry-pick",
+            variant: "default" as const,
+          }
+        : {
+            title: "Revert commit",
+            body: `Create a commit that undoes “${action.subject}” (${action.sha.slice(0, 7)}).`,
+            confirm: "Revert",
+            variant: "destructive" as const,
+          };
+
+  return (
+    <Dialog
+      open
+      onOpenChange={(o) => {
+        if (!o) onCancel();
+      }}
+    >
+      <DialogContent data-testid="git-graph__confirm-dialog">
+        <DialogHeader>
+          <DialogTitle>{copy.title}</DialogTitle>
+          <DialogDescription>{copy.body}</DialogDescription>
+        </DialogHeader>
+        <DialogFooter>
+          <Button variant="ghost" onClick={onCancel} disabled={busy}>
+            Cancel
+          </Button>
+          <Button
+            variant={copy.variant}
+            onClick={onConfirm}
+            disabled={busy}
+            data-testid="git-graph__confirm-action"
+          >
+            {copy.confirm}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+/** Name-input dialog for "Create branch…". The new branch is created at the
+ *  right-clicked commit and checked out. */
+function CreateBranchDialog({
+  sha,
+  busy,
+  onSubmit,
+  onCancel,
+}: {
+  sha: string;
+  busy: boolean;
+  onSubmit: (name: string) => void;
+  onCancel: () => void;
+}) {
+  const [name, setName] = useState("");
+  const trimmed = name.trim();
+
+  return (
+    <Dialog
+      open
+      onOpenChange={(o) => {
+        if (!o) onCancel();
+      }}
+    >
+      <DialogContent data-testid="git-graph__create-branch-dialog">
+        <form
+          onSubmit={(e) => {
+            e.preventDefault();
+            if (trimmed) onSubmit(trimmed);
+          }}
+        >
+          <DialogHeader>
+            <DialogTitle>Create branch</DialogTitle>
+            <DialogDescription>
+              New branch at {sha.slice(0, 7)}. It will be checked out.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="flex flex-col gap-1.5 py-3">
+            <Label htmlFor="git-graph-branch-name">Branch name</Label>
+            <Input
+              id="git-graph-branch-name"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="my-feature"
+              autoFocus
+              autoComplete="off"
+              data-testid="git-graph__branch-name-input"
+            />
+          </div>
+          <DialogFooter>
+            <Button type="button" variant="ghost" onClick={onCancel} disabled={busy}>
+              Cancel
+            </Button>
+            <Button
+              type="submit"
+              disabled={busy || !trimmed}
+              data-testid="git-graph__create-branch-submit"
+            >
+              Create
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
   );
 }
 
@@ -523,77 +861,175 @@ function CommitRow({
   isSelected,
   isHead,
   showAvatar,
+  matchState,
+  menu,
   onSelect,
+  onAction,
 }: {
   row: GraphRow;
   isSelected: boolean;
   isHead: boolean;
   showAvatar: boolean;
+  matchState: "none" | "match" | "current";
+  menu: ReturnType<typeof useDeferredMenuAction>;
   onSelect: () => void;
+  onAction: (action: PendingAction) => void;
 }) {
+  const sha = row.commit.sha;
   const badges = row.commit.refs.map(classifyRef).filter((b): b is RefBadge => b !== null);
   const visibleBadges = badges.slice(0, 3);
   const overflow = badges.length - visibleBadges.length;
 
+  const matchClass =
+    matchState === "current"
+      ? "ring-2 ring-inset ring-amber-500 dark:ring-amber-400"
+      : matchState === "match"
+        ? "bg-amber-400/10"
+        : "";
+
   return (
-    <button
-      type="button"
-      onClick={onSelect}
-      title={row.commit.sha}
-      style={{ height: ROW_HEIGHT }}
-      className={`group flex w-full items-center gap-2 border-l-2 px-3 text-left transition-colors ${
-        isSelected ? "border-l-foreground bg-accent" : "border-l-transparent hover:bg-accent/40"
-      }`}
-    >
-      {showAvatar ? (
-        <span
-          className="flex size-5 shrink-0 items-center justify-center rounded-full text-[10px] font-semibold text-white"
-          style={{ backgroundColor: authorColor(row.commit.email) }}
-          title={`${row.commit.author} <${row.commit.email}>`}
+    <ContextMenu>
+      <ContextMenuTrigger asChild>
+        <button
+          type="button"
+          onClick={onSelect}
+          title={sha}
+          style={{ height: ROW_HEIGHT }}
+          className={`group flex w-full items-center gap-2 border-l-2 px-3 text-left transition-colors ${
+            isSelected ? "border-l-foreground bg-accent" : "border-l-transparent hover:bg-accent/40"
+          } ${matchClass}`}
         >
-          {authorInitials(row.commit.author)}
-        </span>
-      ) : (
-        <span
-          className="flex size-5 shrink-0 items-center justify-center"
-          title={`${row.commit.author} <${row.commit.email}>`}
-        >
-          <span
-            className="size-1.5 rounded-full opacity-50"
-            style={{ backgroundColor: authorColor(row.commit.email) }}
-          />
-        </span>
-      )}
-
-      {visibleBadges.length > 0 && (
-        <span className="flex shrink-0 items-center gap-1">
-          {visibleBadges.map((b) => (
+          {showAvatar ? (
             <span
-              key={`${b.kind}-${b.label}`}
-              className={`inline-flex max-w-[140px] items-center truncate rounded px-1.5 py-0.5 text-[10px] font-semibold ${refClasses(b.kind)}`}
+              className="flex size-5 shrink-0 items-center justify-center rounded-full text-[10px] font-semibold text-white"
+              style={{ backgroundColor: authorColor(row.commit.email) }}
+              title={`${row.commit.author} <${row.commit.email}>`}
             >
-              {b.label}
+              {authorInitials(row.commit.author)}
             </span>
-          ))}
-          {overflow > 0 && <span className="text-[10px] text-muted-foreground">+{overflow}</span>}
-        </span>
-      )}
+          ) : (
+            <span
+              className="flex size-5 shrink-0 items-center justify-center"
+              title={`${row.commit.author} <${row.commit.email}>`}
+            >
+              <span
+                className="size-1.5 rounded-full opacity-50"
+                style={{ backgroundColor: authorColor(row.commit.email) }}
+              />
+            </span>
+          )}
 
-      <span className={`min-w-0 flex-1 truncate ${isHead ? "font-medium" : ""}`}>
-        {row.commit.subject}
-      </span>
+          {visibleBadges.length > 0 && (
+            <span className="flex shrink-0 items-center gap-1">
+              {visibleBadges.map((b) => (
+                <RefBadgeChip
+                  key={`${b.kind}-${b.label}`}
+                  badge={b}
+                  menu={menu}
+                  onAction={onAction}
+                />
+              ))}
+              {overflow > 0 && (
+                <span className="text-[10px] text-muted-foreground">+{overflow}</span>
+              )}
+            </span>
+          )}
 
-      <span className="hidden shrink-0 truncate text-xs text-muted-foreground md:inline md:max-w-[140px]">
-        {row.commit.author}
-      </span>
+          <span className={`min-w-0 flex-1 truncate ${isHead ? "font-medium" : ""}`}>
+            {row.commit.subject}
+          </span>
 
-      <span className="shrink-0 font-mono text-xs text-muted-foreground/80">
-        {row.commit.sha.slice(0, 7)}
-      </span>
+          <span className="hidden shrink-0 truncate text-xs text-muted-foreground md:inline md:max-w-[140px]">
+            {row.commit.author}
+          </span>
 
-      <span className="w-10 shrink-0 text-right text-xs text-muted-foreground tabular-nums">
-        {formatRelative(row.commit.ts)}
-      </span>
-    </button>
+          <span className="shrink-0 font-mono text-xs text-muted-foreground/80">
+            {sha.slice(0, 7)}
+          </span>
+
+          <span className="w-10 shrink-0 text-right text-xs text-muted-foreground tabular-nums">
+            {formatRelative(row.commit.ts)}
+          </span>
+        </button>
+      </ContextMenuTrigger>
+      <ContextMenuContent onCloseAutoFocus={menu.flush}>
+        <ContextMenuItem
+          data-testid="git-graph__copy-hash"
+          onSelect={() => menu.queue(() => void writeClipboardText(sha))}
+        >
+          <ClipboardCopy className="size-4" />
+          Copy hash
+        </ContextMenuItem>
+        <ContextMenuItem
+          data-testid="git-graph__create-branch"
+          onSelect={() => menu.queue(() => onAction({ kind: "create-branch", sha }))}
+        >
+          <GitBranchPlus className="size-4" />
+          Create branch…
+        </ContextMenuItem>
+        <ContextMenuSeparator />
+        <ContextMenuItem
+          data-testid="git-graph__cherry-pick"
+          onSelect={() =>
+            menu.queue(() => onAction({ kind: "cherry-pick", sha, subject: row.commit.subject }))
+          }
+        >
+          <GitCommitHorizontal className="size-4" />
+          Cherry-pick
+        </ContextMenuItem>
+        <ContextMenuItem
+          variant="destructive"
+          data-testid="git-graph__revert"
+          onSelect={() =>
+            menu.queue(() => onAction({ kind: "revert", sha, subject: row.commit.subject }))
+          }
+        >
+          <Undo2 className="size-4" />
+          Revert
+        </ContextMenuItem>
+      </ContextMenuContent>
+    </ContextMenu>
+  );
+}
+
+/** A single ref badge. Local branches carry their own context menu ("Checkout")
+ *  nested inside the row's menu; the `stopPropagation` on the trigger keeps a
+ *  right-click on the badge from also opening the row-level menu. Other ref
+ *  kinds (HEAD / remote / tag / stash) render as a plain, non-interactive
+ *  chip. */
+function RefBadgeChip({
+  badge,
+  menu,
+  onAction,
+}: {
+  badge: RefBadge;
+  menu: ReturnType<typeof useDeferredMenuAction>;
+  onAction: (action: PendingAction) => void;
+}) {
+  const chip = (
+    <span
+      className={`inline-flex max-w-[140px] items-center truncate rounded px-1.5 py-0.5 text-[10px] font-semibold ${refClasses(badge.kind)}`}
+    >
+      {badge.label}
+    </span>
+  );
+
+  if (badge.kind !== "branch") return chip;
+
+  return (
+    <ContextMenu>
+      <ContextMenuTrigger asChild onContextMenu={(e) => e.stopPropagation()}>
+        {chip}
+      </ContextMenuTrigger>
+      <ContextMenuContent onCloseAutoFocus={menu.flush}>
+        <ContextMenuItem
+          data-testid="git-graph__checkout-branch"
+          onSelect={() => menu.queue(() => onAction({ kind: "checkout", branch: badge.label }))}
+        >
+          <RotateCcw className="size-4" />
+          Checkout {badge.label}
+        </ContextMenuItem>
+      </ContextMenuContent>
+    </ContextMenu>
   );
 }

--- a/apps/web/src/components/GitGraphView.tsx
+++ b/apps/web/src/components/GitGraphView.tsx
@@ -1,0 +1,599 @@
+import { useEffect, useMemo, useState } from "react";
+import { trpc } from "../lib/trpc-client";
+import { CommitDetailsPanel } from "./GitCommitDetails";
+
+interface Commit {
+  sha: string;
+  parents: string[];
+  author: string;
+  email: string;
+  ts: number;
+  subject: string;
+  refs: string[];
+}
+
+interface GraphRow {
+  commit: Commit;
+  lane: number;
+  color: string;
+  /** Lane occupants AFTER this commit is processed (drives outgoing edges). */
+  outgoing: (string | null)[];
+  /** Lane occupants BEFORE this commit (drives incoming pass-throughs). */
+  incoming: (string | null)[];
+}
+
+const LANE_COLORS = [
+  "#60a5fa", // blue-400
+  "#4ade80", // green-400
+  "#f87171", // red-400
+  "#c084fc", // purple-400
+  "#fb923c", // orange-400
+  "#22d3ee", // cyan-400
+  "#f472b6", // pink-400
+  "#a3e635", // lime-400
+  "#a78bfa", // violet-400
+  "#2dd4bf", // teal-400
+];
+
+// Git records a stash as up to three commits: the stash tip
+// ("WIP on <branch>: …" or "On <branch>: …"), an index snapshot
+// ("index on <branch>: …"), and — with `-u` — a parentless untracked-files
+// root ("untracked files on <branch>: …"). The index/untracked pair are pure
+// bookkeeping: like Fork/GitKraken we never surface them as their own nodes
+// (they'd render as extra dangling lanes). The tip is shown as a single node
+// unless "Hide stash" is on.
+const STASH_INTERNAL_SUBJECT = /^(?:index on|untracked files on) \S+: /;
+const STASH_TIP_SUBJECT = /^(?:WIP on|On) \S+: /;
+
+const LANE_WIDTH = 18;
+const ROW_HEIGHT = 26;
+const NODE_RADIUS = 5;
+const GRAPH_PADDING_X = 12;
+const STROKE_WIDTH = 2;
+
+function colorForLane(lane: number): string {
+  return LANE_COLORS[lane % LANE_COLORS.length];
+}
+
+function buildGraph(commits: Commit[]): { rows: GraphRow[]; maxLanes: number } {
+  const rows: GraphRow[] = [];
+  const lanes: (string | null)[] = [];
+  let maxLanes = 0;
+
+  for (const commit of commits) {
+    const incoming = lanes.slice();
+
+    let lane = lanes.indexOf(commit.sha);
+    if (lane === -1) {
+      lane = lanes.indexOf(null);
+      if (lane === -1) {
+        lane = lanes.length;
+        lanes.push(commit.sha);
+      } else {
+        lanes[lane] = commit.sha;
+      }
+    }
+
+    for (let i = 0; i < lanes.length; i++) {
+      if (i !== lane && lanes[i] === commit.sha) {
+        lanes[i] = null;
+      }
+    }
+
+    const color = colorForLane(lane);
+
+    const [firstParent, ...otherParents] = commit.parents;
+    // The first parent inherits this commit's lane, so a first-parent chain
+    // (e.g. the develop/main spine) stays in one stable column top-to-bottom.
+    // If the first parent was ALSO reserved by another lane (a branch based on
+    // it), that duplicate is intentional: when the parent is finally processed
+    // it takes the lowest reserved lane and the higher one converges into it
+    // (the dedup pass above), rendering the branch as an excursion that merges
+    // back — instead of the spine hopping columns.
+    lanes[lane] = firstParent ?? null;
+
+    for (const p of otherParents) {
+      if (lanes.indexOf(p) !== -1) continue;
+      let slot = lanes.indexOf(null);
+      if (slot === -1) {
+        slot = lanes.length;
+        lanes.push(p);
+      } else {
+        lanes[slot] = p;
+      }
+    }
+
+    while (lanes.length > 0 && lanes[lanes.length - 1] === null) {
+      lanes.pop();
+    }
+
+    const outgoing = lanes.slice();
+    maxLanes = Math.max(maxLanes, incoming.length, outgoing.length, lane + 1);
+
+    rows.push({ commit, lane, color, incoming, outgoing });
+  }
+
+  return { rows, maxLanes };
+}
+
+function laneX(lane: number): number {
+  return GRAPH_PADDING_X + lane * LANE_WIDTH + LANE_WIDTH / 2;
+}
+
+function formatRelative(ts: number): string {
+  const now = Date.now() / 1000;
+  const delta = Math.max(0, now - ts);
+  if (delta < 60) return `${Math.floor(delta)}s`;
+  if (delta < 3600) return `${Math.floor(delta / 60)}m`;
+  if (delta < 86400) return `${Math.floor(delta / 3600)}h`;
+  if (delta < 86400 * 30) return `${Math.floor(delta / 86400)}d`;
+  if (delta < 86400 * 365) return `${Math.floor(delta / 86400 / 30)}mo`;
+  return `${Math.floor(delta / 86400 / 365)}y`;
+}
+
+function authorInitials(name: string): string {
+  const parts = name.trim().split(/\s+/);
+  if (parts.length === 0) return "?";
+  if (parts.length === 1) return parts[0].slice(0, 2).toUpperCase();
+  return (parts[0][0] + parts[parts.length - 1][0]).toUpperCase();
+}
+
+function authorColor(email: string): string {
+  let h = 0;
+  for (let i = 0; i < email.length; i++) h = (h * 31 + email.charCodeAt(i)) >>> 0;
+  return `hsl(${h % 360}, 55%, 45%)`;
+}
+
+interface RefBadge {
+  label: string;
+  kind: "head" | "branch" | "remote" | "tag" | "stash";
+}
+
+function classifyRef(raw: string): RefBadge | null {
+  const ref = raw.trim();
+  if (!ref) return null;
+  if (ref.startsWith("HEAD -> ")) return { label: ref.slice(8), kind: "head" };
+  if (ref === "HEAD") return { label: "HEAD", kind: "head" };
+  if (ref.startsWith("tag: ")) return { label: ref.slice(5), kind: "tag" };
+  if (ref.startsWith("refs/stash")) return { label: "stash", kind: "stash" };
+  if (ref.includes("/")) return { label: ref, kind: "remote" };
+  return { label: ref, kind: "branch" };
+}
+
+function refClasses(kind: RefBadge["kind"]): string {
+  // Soft pastel fills with a clear ring so refs read at a glance in both
+  // themes: darker text on light backgrounds, light-pastel text on dark.
+  switch (kind) {
+    case "head":
+      return "bg-emerald-400/25 text-emerald-800 ring-1 ring-emerald-500/40 dark:text-emerald-200 dark:ring-emerald-400/40";
+    case "branch":
+      return "bg-sky-400/25 text-sky-800 ring-1 ring-sky-500/40 dark:text-sky-200 dark:ring-sky-400/40";
+    case "remote":
+      return "bg-indigo-400/25 text-indigo-800 ring-1 ring-indigo-500/40 dark:text-indigo-200 dark:ring-indigo-400/40";
+    case "tag":
+      return "bg-amber-400/30 text-amber-900 ring-1 ring-amber-500/50 dark:text-amber-200 dark:ring-amber-400/40";
+    case "stash":
+      return "bg-fuchsia-400/25 text-fuchsia-800 ring-1 ring-fuchsia-500/40 dark:text-fuchsia-200 dark:ring-fuchsia-400/40";
+  }
+}
+
+interface GitGraphViewProps {
+  workspaceId: string;
+}
+
+export function GitGraphView({ workspaceId }: GitGraphViewProps) {
+  const [data, setData] = useState<{ commits: Commit[]; head: string | null } | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [selected, setSelected] = useState<string | null>(null);
+  const [hideStash, setHideStash] = useState(true);
+  const [refreshKey, setRefreshKey] = useState(0);
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: refreshKey intentionally triggers refetch
+  useEffect(() => {
+    let cancelled = false;
+    setData(null);
+    setError(null);
+    trpc.workspace.getCommitGraph
+      .query({ workspaceId, limit: 500 })
+      .then((res) => {
+        if (cancelled) return;
+        setData({ commits: res.commits, head: res.head });
+      })
+      .catch((err) => {
+        if (cancelled) return;
+        setError(err instanceof Error ? err.message : String(err));
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [workspaceId, refreshKey]);
+
+  const filteredCommits = useMemo(() => {
+    if (!data) return null;
+    const kept = data.commits.filter((c) => {
+      // Index/untracked bookkeeping commits are never shown.
+      if (STASH_INTERNAL_SUBJECT.test(c.subject)) return false;
+      // The stash tip is shown as a single node unless "Hide stash" is on.
+      if (
+        hideStash &&
+        (c.refs.some((r) => r.startsWith("refs/stash")) || STASH_TIP_SUBJECT.test(c.subject))
+      ) {
+        return false;
+      }
+      return true;
+    });
+    // Prune parent links that point at a dropped commit (e.g. a shown stash
+    // tip's index/untracked parents) so no lane dangles toward a hidden node.
+    const present = new Set(kept.map((c) => c.sha));
+    return kept.map((c) => ({
+      ...c,
+      parents: c.parents.filter((p) => present.has(p)),
+    }));
+  }, [data, hideStash]);
+
+  const graph = useMemo(
+    () => (filteredCommits ? buildGraph(filteredCommits) : null),
+    [filteredCommits],
+  );
+
+  if (error) {
+    return (
+      <div className="flex h-full flex-col">
+        <Toolbar onRefresh={() => setRefreshKey((k) => k + 1)} />
+        <div className="flex flex-1 items-center justify-center p-4 text-sm text-destructive">
+          Failed to load git graph: {error}
+        </div>
+      </div>
+    );
+  }
+
+  if (!graph) {
+    return (
+      <div className="flex h-full flex-col">
+        <Toolbar onRefresh={() => setRefreshKey((k) => k + 1)} />
+        <div className="flex flex-1 items-center justify-center text-sm text-muted-foreground">
+          Loading…
+        </div>
+      </div>
+    );
+  }
+
+  if (graph.rows.length === 0) {
+    return (
+      <div className="flex h-full flex-col">
+        <Toolbar onRefresh={() => setRefreshKey((k) => k + 1)} />
+        <div className="flex flex-1 items-center justify-center text-sm text-muted-foreground">
+          No commits.
+        </div>
+      </div>
+    );
+  }
+
+  const graphWidth = GRAPH_PADDING_X * 2 + graph.maxLanes * LANE_WIDTH;
+  const totalHeight = graph.rows.length * ROW_HEIGHT;
+
+  return (
+    <div className="flex h-full flex-col bg-background text-sm">
+      <Toolbar
+        onRefresh={() => setRefreshKey((k) => k + 1)}
+        hideStash={hideStash}
+        onToggleStash={() => setHideStash((v) => !v)}
+        commitCount={graph.rows.length}
+      />
+      <div className="relative flex-1 overflow-auto">
+        <div className="flex min-h-full" style={{ minWidth: "max-content" }}>
+          <svg
+            width={graphWidth}
+            height={totalHeight}
+            className="shrink-0"
+            style={{ display: "block" }}
+            role="img"
+            aria-label="Commit graph"
+          >
+            <title>Commit graph</title>
+            {(() => {
+              const lines: React.ReactNode[] = [];
+              const nodes: React.ReactNode[] = [];
+
+              // Draw edges as two half-segments per row so every lane occupant
+              // connects cleanly to the node at its centre with no gaps: the
+              // top half joins incoming lanes down to the node (or their
+              // straight continuation), the bottom half joins the node down to
+              // each parent's lane, plus any straight pass-through lanes.
+              // Adjacent rows' half-segments share endpoints, so continuous
+              // lanes render as unbroken vertical lines.
+              const seg = (
+                x1: number,
+                y1: number,
+                x2: number,
+                y2: number,
+                color: string,
+                key: string,
+              ) => {
+                lines.push(
+                  <line
+                    key={key}
+                    x1={x1}
+                    y1={y1}
+                    x2={x2}
+                    y2={y2}
+                    stroke={color}
+                    strokeWidth={STROKE_WIDTH}
+                  />,
+                );
+              };
+              const curve = (
+                x1: number,
+                y1: number,
+                x2: number,
+                y2: number,
+                color: string,
+                key: string,
+              ) => {
+                const my = (y1 + y2) / 2;
+                lines.push(
+                  <path
+                    key={key}
+                    d={`M${x1},${y1} C${x1},${my} ${x2},${my} ${x2},${y2}`}
+                    stroke={color}
+                    strokeWidth={STROKE_WIDTH}
+                    fill="none"
+                  />,
+                );
+              };
+
+              for (let i = 0; i < graph.rows.length; i++) {
+                const row = graph.rows[i];
+                const yTop = i * ROW_HEIGHT;
+                const y = yTop + ROW_HEIGHT / 2;
+                const yBot = yTop + ROW_HEIGHT;
+                const lane = row.lane;
+                const nodeX = laneX(lane);
+                const sha = row.commit.sha;
+
+                // Top half: every incoming lane occupant reaches the node (when
+                // it's awaiting this commit) or continues straight to the centre.
+                for (let l = 0; l < row.incoming.length; l++) {
+                  const occ = row.incoming[l];
+                  if (!occ) continue;
+                  const x = laneX(l);
+                  if (occ === sha) {
+                    if (l === lane) {
+                      seg(x, yTop, nodeX, y, colorForLane(lane), `t-${sha}-${l}`);
+                    } else {
+                      curve(x, yTop, nodeX, y, colorForLane(l), `tc-${sha}-${l}`);
+                    }
+                  } else {
+                    seg(x, yTop, x, y, colorForLane(l), `tp-${sha}-${l}`);
+                  }
+                }
+
+                // Bottom half: lane-driven so every outgoing lane gets a
+                // segment (no gaps). Each non-null outgoing lane is one of:
+                //   - the node's own lane        → straight node → yBot
+                //   - unchanged from incoming     → straight pass-through
+                //   - freshly placed this row     → curve out from the node
+                //     (a parent fanning into a new lane)
+                // Driving off the lane occupancy (rather than
+                // `outgoing.indexOf(parent)`, which returns only the first of a
+                // duplicated sha) is what keeps the node's own lane connected
+                // when its first parent already occupies a lower lane.
+                for (let l = 0; l < row.outgoing.length; l++) {
+                  const occ = row.outgoing[l];
+                  if (!occ) continue;
+                  const x = laneX(l);
+                  if (l === lane) {
+                    seg(nodeX, y, x, yBot, colorForLane(lane), `b-${sha}-${l}`);
+                  } else if (row.incoming[l] === occ) {
+                    seg(x, y, x, yBot, colorForLane(l), `bp-${sha}-${l}`);
+                  } else {
+                    curve(nodeX, y, x, yBot, colorForLane(l), `bd-${sha}-${l}`);
+                  }
+                }
+
+                // Merge joins: a parent that already occupied its own lane
+                // (a pass-through above) still needs a connector from the merge
+                // node into that lane, drawn on top of the straight line.
+                for (const parent of row.commit.parents) {
+                  const l = row.outgoing.indexOf(parent);
+                  if (l === -1 || l === lane) continue;
+                  if (row.incoming[l] === parent) {
+                    curve(nodeX, y, laneX(l), yBot, colorForLane(l), `bm-${sha}-${l}`);
+                  }
+                }
+              }
+
+              for (let i = 0; i < graph.rows.length; i++) {
+                const row = graph.rows[i];
+                const y = i * ROW_HEIGHT + ROW_HEIGHT / 2;
+
+                // Defer node into the top layer.
+                const isHead = data?.head === row.commit.sha;
+                nodes.push(
+                  isHead ? (
+                    <g key={`node-${row.commit.sha}`}>
+                      <circle
+                        cx={laneX(row.lane)}
+                        cy={y}
+                        r={NODE_RADIUS + 2}
+                        fill="none"
+                        stroke={row.color}
+                        strokeWidth={2}
+                      />
+                      <circle cx={laneX(row.lane)} cy={y} r={NODE_RADIUS - 1} fill={row.color} />
+                    </g>
+                  ) : (
+                    <circle
+                      key={`node-${row.commit.sha}`}
+                      cx={laneX(row.lane)}
+                      cy={y}
+                      r={NODE_RADIUS}
+                      fill={row.color}
+                    />
+                  ),
+                );
+              }
+
+              return (
+                <>
+                  <g>{lines}</g>
+                  <g>{nodes}</g>
+                </>
+              );
+            })()}
+          </svg>
+
+          <div
+            className="border-l border-border/40"
+            style={{ width: 0, marginLeft: 4 }}
+            aria-hidden
+          />
+
+          <div className="min-w-0 flex-1">
+            {graph.rows.map((row, i) => {
+              const prev = i > 0 ? graph.rows[i - 1] : null;
+              const sameAuthor = prev?.commit.email === row.commit.email;
+              return (
+                <CommitRow
+                  key={row.commit.sha}
+                  row={row}
+                  isSelected={selected === row.commit.sha}
+                  isHead={data?.head === row.commit.sha}
+                  showAvatar={!sameAuthor}
+                  onSelect={() => setSelected(row.commit.sha)}
+                />
+              );
+            })}
+          </div>
+        </div>
+      </div>
+      {selected && (
+        <CommitDetailsPanel
+          workspaceId={workspaceId}
+          sha={selected}
+          onClose={() => setSelected(null)}
+        />
+      )}
+    </div>
+  );
+}
+
+function Toolbar({
+  onRefresh,
+  hideStash,
+  onToggleStash,
+  commitCount,
+}: {
+  onRefresh: () => void;
+  hideStash?: boolean;
+  onToggleStash?: () => void;
+  commitCount?: number;
+}) {
+  return (
+    <div className="flex shrink-0 items-center gap-3 border-b border-border/60 px-3 py-1.5 text-xs">
+      <button
+        type="button"
+        onClick={onRefresh}
+        className="rounded px-2 py-1 text-muted-foreground hover:bg-accent hover:text-foreground"
+      >
+        Refresh
+      </button>
+      {onToggleStash && (
+        <label className="flex cursor-pointer items-center gap-1.5 text-muted-foreground">
+          <input
+            type="checkbox"
+            checked={hideStash}
+            onChange={onToggleStash}
+            className="size-3.5 cursor-pointer"
+            data-testid="git-graph__hide-stash"
+          />
+          Hide stash
+        </label>
+      )}
+      <div className="flex-1" />
+      {commitCount != null && (
+        <span className="text-muted-foreground tabular-nums">{commitCount} commits</span>
+      )}
+    </div>
+  );
+}
+
+function CommitRow({
+  row,
+  isSelected,
+  isHead,
+  showAvatar,
+  onSelect,
+}: {
+  row: GraphRow;
+  isSelected: boolean;
+  isHead: boolean;
+  showAvatar: boolean;
+  onSelect: () => void;
+}) {
+  const badges = row.commit.refs.map(classifyRef).filter((b): b is RefBadge => b !== null);
+  const visibleBadges = badges.slice(0, 3);
+  const overflow = badges.length - visibleBadges.length;
+
+  return (
+    <button
+      type="button"
+      onClick={onSelect}
+      title={row.commit.sha}
+      style={{ height: ROW_HEIGHT }}
+      className={`group flex w-full items-center gap-2 border-l-2 px-3 text-left transition-colors ${
+        isSelected ? "border-l-foreground bg-accent" : "border-l-transparent hover:bg-accent/40"
+      }`}
+    >
+      {showAvatar ? (
+        <span
+          className="flex size-5 shrink-0 items-center justify-center rounded-full text-[10px] font-semibold text-white"
+          style={{ backgroundColor: authorColor(row.commit.email) }}
+          title={`${row.commit.author} <${row.commit.email}>`}
+        >
+          {authorInitials(row.commit.author)}
+        </span>
+      ) : (
+        <span
+          className="flex size-5 shrink-0 items-center justify-center"
+          title={`${row.commit.author} <${row.commit.email}>`}
+        >
+          <span
+            className="size-1.5 rounded-full opacity-50"
+            style={{ backgroundColor: authorColor(row.commit.email) }}
+          />
+        </span>
+      )}
+
+      {visibleBadges.length > 0 && (
+        <span className="flex shrink-0 items-center gap-1">
+          {visibleBadges.map((b) => (
+            <span
+              key={`${b.kind}-${b.label}`}
+              className={`inline-flex max-w-[140px] items-center truncate rounded px-1.5 py-0.5 text-[10px] font-semibold ${refClasses(b.kind)}`}
+            >
+              {b.label}
+            </span>
+          ))}
+          {overflow > 0 && <span className="text-[10px] text-muted-foreground">+{overflow}</span>}
+        </span>
+      )}
+
+      <span className={`min-w-0 flex-1 truncate ${isHead ? "font-medium" : ""}`}>
+        {row.commit.subject}
+      </span>
+
+      <span className="hidden shrink-0 truncate text-xs text-muted-foreground md:inline md:max-w-[140px]">
+        {row.commit.author}
+      </span>
+
+      <span className="shrink-0 font-mono text-xs text-muted-foreground/80">
+        {row.commit.sha.slice(0, 7)}
+      </span>
+
+      <span className="w-10 shrink-0 text-right text-xs text-muted-foreground tabular-nums">
+        {formatRelative(row.commit.ts)}
+      </span>
+    </button>
+  );
+}

--- a/apps/web/src/components/SharedDockviewLayout.tsx
+++ b/apps/web/src/components/SharedDockviewLayout.tsx
@@ -11,6 +11,7 @@ import {
 } from "dockview";
 import {
   FolderOpen,
+  GitBranch,
   GitCompare,
   Globe,
   Maximize2,
@@ -54,6 +55,7 @@ import { parseWorkspaceFromPath } from "../lib/parse-workspace";
 import { trpc } from "../lib/trpc-client";
 import { CodeBrowserView } from "./CodeBrowserView";
 import { DockviewChatContainer } from "./DockviewChatContainer";
+import { GitGraphView } from "./GitGraphView";
 import { MultiWorkspacePanelHost } from "./MultiWorkspacePanelHost";
 import {
   getPerWorkspaceState,
@@ -83,6 +85,7 @@ const PANEL_ICONS: Record<string, React.FC<{ className?: string }>> = {
   files: FolderOpen,
   terminal: TerminalIcon,
   browser: Globe,
+  graph: GitBranch,
 };
 
 const PANEL_SHORTCUTS: Record<string, string> = {
@@ -91,6 +94,7 @@ const PANEL_SHORTCUTS: Record<string, string> = {
   files: "⇧⌘E",
   terminal: "⌃`",
   browser: "⇧⌘B",
+  graph: "⇧⌘Y",
 };
 
 // ---------------------------------------------------------------------------
@@ -326,6 +330,14 @@ function BrowserPanelComponent({ api }: IDockviewPanelProps) {
   );
 }
 
+function GraphPanelComponent(_props: IDockviewPanelProps) {
+  return (
+    <MultiWorkspacePanelHost emptyState={<NoWorkspaceMessage Icon={GitBranch} />}>
+      {(workspaceId) => <GitGraphView workspaceId={workspaceId} />}
+    </MultiWorkspacePanelHost>
+  );
+}
+
 // ---------------------------------------------------------------------------
 // Tab components (icon + title, no close button)
 // ---------------------------------------------------------------------------
@@ -440,6 +452,7 @@ const components: Record<string, React.FunctionComponent<IDockviewPanelProps<any
   files: FilesPanelComponent,
   terminal: TerminalPanelComponent,
   browser: BrowserPanelComponent,
+  graph: GraphPanelComponent,
 };
 
 const tabComponents: Record<string, React.FunctionComponent<IDockviewPanelHeaderProps>> = {
@@ -534,7 +547,7 @@ function useDiffFileCount(workspaceId: string | null): number {
 // Required panel definitions & layout persistence
 // ---------------------------------------------------------------------------
 
-const REQUIRED_PANEL_IDS = ["chat", "changes", "files", "terminal", "browser"] as const;
+const REQUIRED_PANEL_IDS = ["chat", "changes", "files", "terminal", "browser", "graph"] as const;
 
 /**
  * Panel ids that USED to be required and may live in saved layouts. We strip
@@ -1155,6 +1168,11 @@ export function SharedDockviewLayout() {
             window.dispatchEvent(new CustomEvent("band:focus-browser"));
           });
         }
+      } else if (key === "y" && e.shiftKey && api) {
+        e.preventDefault();
+        if (!hiddenPanelsRef.current.includes("graph")) {
+          api.getPanel("graph")?.api.setActive();
+        }
       } else if (key === "b" && !e.shiftKey && !e.altKey && api) {
         // ⌘B → toggle the project-list sidebar. Focus-aware: if an inner
         // dockview (terminal / chat / browser) is focused AND has panels on
@@ -1360,6 +1378,7 @@ export function SharedDockviewLayout() {
       files: "Files",
       terminal: "Terminal",
       browser: "Browser",
+      graph: "Graph",
     };
 
     const opts: Record<string, unknown> = {
@@ -1468,6 +1487,28 @@ export function SharedDockviewLayout() {
           id: "browser",
           component: "browser",
           title: "Browser",
+          params: {},
+          position: { referencePanel: "chat", direction: "right" },
+        });
+        rightGroupRef = "browser";
+      }
+    }
+
+    if (!hidden.includes("graph")) {
+      if (rightGroupRef) {
+        api.addPanel({
+          id: "graph",
+          component: "graph",
+          title: "Graph",
+          params: {},
+          position: { referencePanel: rightGroupRef, direction: "within" },
+          inactive: true,
+        });
+      } else {
+        api.addPanel({
+          id: "graph",
+          component: "graph",
+          title: "Graph",
           params: {},
           position: { referencePanel: "chat", direction: "right" },
         });

--- a/apps/web/src/dashboard/components/WorkspaceTabNav.tsx
+++ b/apps/web/src/dashboard/components/WorkspaceTabNav.tsx
@@ -1,6 +1,6 @@
-import { FolderOpen, GitCompare, MessageSquare, TerminalSquare } from "lucide-react";
+import { FolderOpen, GitBranch, GitCompare, MessageSquare, TerminalSquare } from "lucide-react";
 
-export type WorkspaceTab = "chat" | "diff" | "code" | "terminal";
+export type WorkspaceTab = "chat" | "diff" | "code" | "terminal" | "graph";
 
 interface WorkspaceTabNavProps {
   activeTab: WorkspaceTab;
@@ -13,6 +13,7 @@ const tabs: { id: WorkspaceTab; label: string; icon: typeof MessageSquare }[] = 
   { id: "diff", label: "Changes", icon: GitCompare },
   { id: "code", label: "Files", icon: FolderOpen },
   { id: "terminal", label: "Terminal", icon: TerminalSquare },
+  { id: "graph", label: "Graph", icon: GitBranch },
 ];
 
 export function WorkspaceTabNav({ activeTab, onTabChange, diffFileCount }: WorkspaceTabNavProps) {

--- a/apps/web/src/dashboard/lib/command-registry.ts
+++ b/apps/web/src/dashboard/lib/command-registry.ts
@@ -213,6 +213,12 @@ export function buildCommands(deps: CommandRegistryDeps): PaletteCommand[] {
       action: () => activatePanel(deps, "browser"),
     },
     {
+      id: "show-graph",
+      label: "Show Git Graph",
+      shortcut: "Cmd+Shift+Y",
+      action: () => activatePanel(deps, "graph"),
+    },
+    {
       // ⌃0 — reveal the project-list sidebar (which lives outside the
       // dockview) and move keyboard focus into the list. `band:show-sidebar`
       // expands the sidebar if it's collapsed; DashboardShell's

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -10,6 +10,7 @@ import {
 } from "@tanstack/react-router";
 import {
   FolderOpen,
+  GitBranch,
   GitCompare,
   Globe,
   MessageSquare,
@@ -380,6 +381,7 @@ function AppShell() {
       // Browser pane works on both desktop (native webviews) and web (CDP
       // screencast of the desktop app's tabs — see ScreencastPanel).
       { id: "browser", label: "Browser", icon: Globe, shortcut: "⇧⌘B" },
+      { id: "graph", label: "Graph", icon: GitBranch, shortcut: "⇧⌘Y" },
     ],
     [],
   );

--- a/apps/web/src/routes/workspace.$workspaceId.tsx
+++ b/apps/web/src/routes/workspace.$workspaceId.tsx
@@ -18,6 +18,7 @@ import { agentTypeSupportsSessionListing } from "../components/ChatPane";
 import { ChatView } from "../components/ChatView";
 import { CodeBrowserView } from "../components/CodeBrowserView";
 import { DesktopDragRegion } from "../components/DesktopTitleBar";
+import { GitGraphView } from "../components/GitGraphView";
 import { ToolbarActionBar, ToolbarOverflowProvider } from "../components/ToolbarButtons";
 import { AgentSwitcherContext, useAgentSwitcherContext } from "../hooks/useAgentSwitcherContext";
 import { useIsDesktop } from "../hooks/useIsDesktop";
@@ -401,6 +402,7 @@ function MobileWorkspaceLayout({ workspaceId }: { workspaceId: string }) {
                 <DockviewTerminalContainer workspaceId={workspaceId} visible={true} />
               </Suspense>
             )}
+            {activeTab === "graph" && <GitGraphView workspaceId={workspaceId} />}
           </main>
           <QuickOpenDialog
             workspaceId={workspaceId}

--- a/apps/web/src/server/api/workspace/router.ts
+++ b/apps/web/src/server/api/workspace/router.ts
@@ -4,6 +4,7 @@ import { diffService } from "../../services/diff-service";
 import { editorService } from "../../services/editor-service";
 import { filesService } from "../../services/files-service";
 import { FormatterError } from "../../services/formatter";
+import { gitGraphService } from "../../services/git-graph-service";
 import { searchService } from "../../services/search-service";
 import { terminalService } from "../../services/terminal-service";
 import { WorkspaceNotFoundError, workspaceService } from "../../services/workspace-service";
@@ -56,6 +57,27 @@ const compareBranchSchema = z
 const mergeBaseSchema = z
   .string()
   .regex(/^[0-9a-f]{40}$/i, "mergeBase must be a 40-character hex SHA");
+
+/**
+ * A commit SHA passed to the Graph tab's detail/action procedures. Pinned to
+ * 7–40 hex chars so it can never be read by git as a flag (`--exec=…`) or a
+ * symbolic ref — the graph always hands us a real object id.
+ */
+const commitShaSchema = z
+  .string()
+  .regex(/^[0-9a-f]{7,40}$/i, "sha must be a 7–40 character hex commit id");
+
+/**
+ * A branch name for checkout/create. Forbids a leading `-` (flag injection)
+ * and the characters git itself rejects in ref names; git's own
+ * `check-ref-format` still guards the create path, this is the transport gate.
+ */
+const refNameSchema = z
+  .string()
+  .min(1)
+  .max(255)
+  .regex(/^[^-]/, "branch name must not start with '-'")
+  .regex(/^[^\s~^:?*[\\]+$/, "branch name contains invalid characters");
 
 /**
  * Wire-contract note: every workspace-tier service error (including
@@ -216,6 +238,63 @@ export const workspaceRouter = t.router({
   listBranches: publicProcedure
     .input(z.object({ workspaceId: z.string() }))
     .query(({ input }) => diffService.listBranches(input.workspaceId)),
+
+  getCommitGraph: publicProcedure
+    .input(
+      z.object({
+        workspaceId: z.string(),
+        limit: z.number().int().min(1).max(2000).optional(),
+      }),
+    )
+    .query(({ input }) => diffService.getCommitGraph(input.workspaceId, { limit: input.limit })),
+
+  // ── Graph tab: commit details + essentials actions (issue: git-graph) ──
+
+  getCommitDetails: publicProcedure
+    .input(z.object({ workspaceId: z.string(), sha: commitShaSchema }))
+    .query(({ input }) => gitGraphService.getCommitDetails(input.workspaceId, input.sha)),
+
+  getCommitFileDiff: publicProcedure
+    .input(
+      z.object({
+        workspaceId: z.string(),
+        sha: commitShaSchema,
+        filePath: z.string().min(1).regex(/^[^-]/, "filePath must not start with '-'"),
+      }),
+    )
+    .query(({ input }) =>
+      gitGraphService.getCommitFileDiff(input.workspaceId, input.sha, input.filePath),
+    ),
+
+  checkoutBranch: publicProcedure
+    .input(z.object({ workspaceId: z.string(), branch: refNameSchema }))
+    .mutation(({ input }) => gitGraphService.checkoutBranch(input.workspaceId, input.branch)),
+
+  createBranch: publicProcedure
+    .input(
+      z.object({
+        workspaceId: z.string(),
+        sha: commitShaSchema,
+        name: refNameSchema,
+        checkout: z.boolean().optional(),
+      }),
+    )
+    .mutation(({ input }) =>
+      gitGraphService.createBranch(
+        input.workspaceId,
+        input.sha,
+        input.name,
+        input.checkout ?? false,
+      ),
+    ),
+
+  cherryPick: publicProcedure
+    .input(z.object({ workspaceId: z.string(), sha: commitShaSchema }))
+    .mutation(({ input }) => gitGraphService.cherryPick(input.workspaceId, input.sha)),
+
+  revertCommit: publicProcedure
+    .input(z.object({ workspaceId: z.string(), sha: commitShaSchema }))
+    .mutation(({ input }) => gitGraphService.revert(input.workspaceId, input.sha)),
 
   getDiff: publicProcedure
     .input(

--- a/apps/web/src/server/services/diff-service.ts
+++ b/apps/web/src/server/services/diff-service.ts
@@ -80,6 +80,22 @@ export interface DiffResult {
   fileStatuses: Record<string, string>;
 }
 
+/** A single commit in the workspace's `git log --all` history. */
+export interface GraphCommit {
+  sha: string;
+  parents: string[];
+  author: string;
+  email: string;
+  ts: number;
+  subject: string;
+  refs: string[];
+}
+
+export interface CommitGraphResult {
+  commits: GraphCommit[];
+  head: string | null;
+}
+
 export interface DiffSummaryResult {
   stats: DiffStats;
   compareBranch: string;
@@ -265,6 +281,71 @@ export class DiffService {
       defaultBranch,
       headBranch: headBranch ?? defaultBranch,
     };
+  }
+
+  /**
+   * Parse `git log --all` into a flat commit list for the Graph panel. The
+   * client lays out the branch tree from each commit's parent SHAs. Returns
+   * an empty history (rather than throwing) for brand-new repos with no
+   * commits yet, so the panel renders "No commits." instead of an error.
+   */
+  async getCommitGraph(
+    workspaceId: string,
+    options: { limit?: number } = {},
+  ): Promise<CommitGraphResult> {
+    const workspace = this.workspaces.resolve(workspaceId);
+    if (!workspace) throw new WorkspaceNotFoundError(workspaceId);
+
+    const cwd = workspace.worktree.path;
+    const limit = options.limit ?? 500;
+
+    // Field separator (US, 0x1f) and record separator (RS, 0x1e) avoid
+    // collisions with subject lines that contain pipes/quotes.
+    const FS = "\x1f";
+    const RS = "\x1e";
+    const fmt = `${["%H", "%P", "%an", "%ae", "%at", "%s", "%D"].join(FS)}${RS}`;
+
+    let stdout = "";
+    try {
+      stdout = await execGit(
+        ["log", "--all", "--date-order", `--max-count=${limit}`, `--pretty=format:${fmt}`],
+        cwd,
+      );
+    } catch {
+      return { commits: [], head: null };
+    }
+
+    const commits: GraphCommit[] = [];
+    for (const raw of stdout.split(RS)) {
+      const rec = raw.replace(/^\n/, "");
+      if (!rec) continue;
+      const parts = rec.split(FS);
+      if (parts.length < 7) continue;
+      const [sha, parentsStr, author, email, tsStr, subject, refsStr] = parts;
+      commits.push({
+        sha,
+        parents: parentsStr ? parentsStr.split(" ").filter(Boolean) : [],
+        author,
+        email,
+        ts: Number.parseInt(tsStr, 10) || 0,
+        subject,
+        refs: refsStr
+          ? refsStr
+              .split(",")
+              .map((r) => r.trim())
+              .filter(Boolean)
+          : [],
+      });
+    }
+
+    let head: string | null = null;
+    try {
+      head = (await execGit(["rev-parse", "HEAD"], cwd)).trim();
+    } catch {
+      // Detached / no commits — leave head null.
+    }
+
+    return { commits, head };
   }
 
   /**

--- a/apps/web/src/server/services/git-graph-service.ts
+++ b/apps/web/src/server/services/git-graph-service.ts
@@ -1,0 +1,150 @@
+// Read + write git operations exposed by the Graph tab's commit-details
+// panel and context menus: inspecting a single commit, diffing one of its
+// files, and the handful of "essentials" actions (checkout branch, create
+// branch, cherry-pick, revert). Every shell-out goes through
+// `infra/git/git-client.ts::execGit` (execFile, no shell), and the workspace
+// is resolved to a worktree path the same way `DiffService` does.
+
+import { WorkspaceNotFoundError } from "../errors";
+import { execGit } from "../infra/git/git-client";
+import {
+  workspaceService as defaultWorkspaceService,
+  type WorkspaceService,
+} from "./workspace-service";
+
+// US (0x1f) field separator — subjects/bodies never contain it, so it is a
+// safe delimiter for the fixed metadata fields.
+const FS = "\x1f";
+
+export interface CommitFileChange {
+  path: string;
+  /** git name-status code: A, M, D, R, C, T. */
+  status: string;
+}
+
+export interface CommitDetails {
+  sha: string;
+  parents: string[];
+  author: string;
+  email: string;
+  authorTs: number;
+  committer: string;
+  committerTs: number;
+  subject: string;
+  body: string;
+  files: CommitFileChange[];
+}
+
+/** Parse `git show --name-status` file lines into a `{path,status}` list. */
+function parseNameStatus(output: string): CommitFileChange[] {
+  const files: CommitFileChange[] = [];
+  for (const line of output.trim().split("\n")) {
+    if (!line) continue;
+    const parts = line.split("\t");
+    const code = parts[0]?.[0];
+    if (!code) continue;
+    // Renames/copies emit "R100\told\tnew" — report the new path.
+    if ((code === "R" || code === "C") && parts[2]) {
+      files.push({ path: parts[2], status: code });
+    } else if (parts[1]) {
+      files.push({ path: parts[1], status: code });
+    }
+  }
+  return files;
+}
+
+export class GitGraphService {
+  constructor(private readonly workspaces: WorkspaceService = defaultWorkspaceService) {}
+
+  private cwd(workspaceId: string): string {
+    const workspace = this.workspaces.resolve(workspaceId);
+    if (!workspace) throw new WorkspaceNotFoundError(workspaceId);
+    return workspace.worktree.path;
+  }
+
+  /** Full metadata + changed-file list for a single commit. */
+  async getCommitDetails(workspaceId: string, sha: string): Promise<CommitDetails> {
+    const cwd = this.cwd(workspaceId);
+
+    // Body (%b) is last so it can safely contain newlines and separators.
+    const fmt = ["%H", "%P", "%an", "%ae", "%at", "%cn", "%ct", "%s", "%b"].join(FS);
+    const raw = await execGit(["show", "-s", `--format=${fmt}`, sha], cwd);
+    const parts = raw.split(FS);
+    const [shaOut, parentsStr, author, email, authorTsStr, committer, committerTsStr, subject] =
+      parts;
+    const body = parts.slice(8).join(FS).replace(/\n$/, "");
+
+    // `--first-parent` diffs a merge against its mainline parent (matches how
+    // the graph shows it). For a root commit diff-tree yields nothing, so
+    // `git show --name-status` naturally lists every file as added.
+    const filesRaw = await execGit(
+      ["show", "--first-parent", "--name-status", "--format=", sha],
+      cwd,
+    );
+
+    return {
+      sha: shaOut,
+      parents: parentsStr ? parentsStr.split(" ").filter(Boolean) : [],
+      author,
+      email,
+      authorTs: Number.parseInt(authorTsStr, 10) || 0,
+      committer,
+      committerTs: Number.parseInt(committerTsStr, 10) || 0,
+      subject,
+      body,
+      files: parseNameStatus(filesRaw),
+    };
+  }
+
+  /** Unified diff for a single file within a commit (vs its first parent). */
+  async getCommitFileDiff(
+    workspaceId: string,
+    sha: string,
+    filePath: string,
+  ): Promise<{ diff: string }> {
+    const cwd = this.cwd(workspaceId);
+    // `--` pins filePath as a pathspec (the router already rejects a leading
+    // dash); `git show` handles the root-commit case where there is no parent.
+    const diff = await execGit(["show", "--first-parent", "--format=", sha, "--", filePath], cwd);
+    return { diff };
+  }
+
+  /** Checkout an existing local branch. Fails (bubbles) if the tree is dirty. */
+  async checkoutBranch(workspaceId: string, branch: string): Promise<{ ok: true }> {
+    const cwd = this.cwd(workspaceId);
+    await execGit(["checkout", branch], cwd);
+    return { ok: true };
+  }
+
+  /** Create a branch at `sha`, optionally checking it out. */
+  async createBranch(
+    workspaceId: string,
+    sha: string,
+    name: string,
+    checkout: boolean,
+  ): Promise<{ ok: true }> {
+    const cwd = this.cwd(workspaceId);
+    if (checkout) {
+      await execGit(["checkout", "-b", name, sha], cwd);
+    } else {
+      await execGit(["branch", name, sha], cwd);
+    }
+    return { ok: true };
+  }
+
+  /** Cherry-pick a commit onto the current branch. Conflicts bubble as errors. */
+  async cherryPick(workspaceId: string, sha: string): Promise<{ ok: true }> {
+    const cwd = this.cwd(workspaceId);
+    await execGit(["cherry-pick", sha], cwd);
+    return { ok: true };
+  }
+
+  /** Revert a commit (creates an inverse commit). Conflicts bubble as errors. */
+  async revert(workspaceId: string, sha: string): Promise<{ ok: true }> {
+    const cwd = this.cwd(workspaceId);
+    await execGit(["revert", "--no-edit", sha], cwd);
+    return { ok: true };
+  }
+}
+
+export const gitGraphService = new GitGraphService();

--- a/apps/web/tests/workspace-commit-graph.test.ts
+++ b/apps/web/tests/workspace-commit-graph.test.ts
@@ -1,0 +1,208 @@
+// Black-box integration test for `workspace.getCommitGraph` — the tRPC
+// query that backs the Graph panel/tab. It parses `git log --all` from
+// the workspace's worktree into a flat commit list the client lays the
+// branch tree out from.
+//
+// Boots the real production server (`dist/start-server.mjs`) against a
+// tmp `$HOME` and drives it over real HTTP. The workspace is backed by a
+// real on-disk git repo with a couple of commits and a side branch so
+// `--all` has more than a single linear history to return. No mocks.
+
+import { execFileSync } from "node:child_process";
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { seedSettings, seedState } from "./helpers/seed-state";
+import {
+  createTmpHome,
+  type ServerHandle,
+  startServer,
+  trpcData,
+  trpcQuery,
+} from "./helpers/server";
+
+const DEFAULT_TOKEN = "workspace-commit-graph-token";
+
+const gitEnv = {
+  ...process.env,
+  GIT_AUTHOR_NAME: "Test",
+  GIT_AUTHOR_EMAIL: "test@test.com",
+  GIT_COMMITTER_NAME: "Test",
+  GIT_COMMITTER_EMAIL: "test@test.com",
+};
+
+function git(cwd: string, args: string[]): string {
+  return execFileSync("git", args, { cwd, env: gitEnv, encoding: "utf-8" });
+}
+
+function seedGitIdentity(tmpHome: string): void {
+  writeFileSync(
+    join(tmpHome, ".gitconfig"),
+    [
+      "[user]",
+      "  name = Test",
+      "  email = test@test.com",
+      "[init]",
+      "  defaultBranch = main",
+      "",
+    ].join("\n"),
+    "utf-8",
+  );
+}
+
+/**
+ * Build a real repo with three commits across two branches:
+ *
+ *   main:    initial ─ second
+ *   feature:         └─ feature-work
+ *
+ * `HEAD` ends on `main` (at `second`). Returns the repo path and the SHAs
+ * so the assertions can pin the exact parent linkage the client relies on.
+ */
+function seedRepo(parent: string): {
+  path: string;
+  initialSha: string;
+  secondSha: string;
+  featureSha: string;
+} {
+  const path = join(parent, "alpha");
+  mkdirSync(path, { recursive: true });
+  git(path, ["init", "-b", "main"]);
+
+  writeFileSync(join(path, "README.md"), "# alpha\n");
+  git(path, ["add", "."]);
+  git(path, ["commit", "-m", "initial"]);
+  const initialSha = git(path, ["rev-parse", "HEAD"]).trim();
+
+  git(path, ["checkout", "-b", "feature"]);
+  writeFileSync(join(path, "feature.md"), "# feature\n");
+  git(path, ["add", "."]);
+  git(path, ["commit", "-m", "feature-work"]);
+  const featureSha = git(path, ["rev-parse", "HEAD"]).trim();
+
+  git(path, ["checkout", "main"]);
+  writeFileSync(join(path, "second.md"), "# second\n");
+  git(path, ["add", "."]);
+  git(path, ["commit", "-m", "second"]);
+  const secondSha = git(path, ["rev-parse", "HEAD"]).trim();
+
+  return { path, initialSha, secondSha, featureSha };
+}
+
+interface GraphCommit {
+  sha: string;
+  parents: string[];
+  author: string;
+  email: string;
+  ts: number;
+  subject: string;
+  refs: string[];
+}
+
+describe("tRPC — workspace.getCommitGraph", () => {
+  let server: ServerHandle;
+  let tmpHome: string;
+  let repo: ReturnType<typeof seedRepo>;
+
+  beforeAll(async () => {
+    tmpHome = createTmpHome("band-workspace-commit-graph-");
+    seedGitIdentity(tmpHome);
+    repo = seedRepo(tmpHome);
+
+    seedState(tmpHome, {
+      projects: [
+        {
+          name: "alpha",
+          path: repo.path,
+          defaultBranch: "main",
+          worktrees: [{ branch: "main", path: repo.path }],
+        },
+      ],
+    });
+    seedSettings(tmpHome, { tokenSecret: DEFAULT_TOKEN });
+
+    server = await startServer({ tmpHome });
+  });
+
+  afterAll(async () => {
+    await server.close();
+    rmSync(tmpHome, { recursive: true, force: true });
+  });
+
+  it("returns 401 without a token", async () => {
+    const res = await fetch(
+      `${server.url}/trpc/workspace.getCommitGraph?input=${encodeURIComponent(
+        JSON.stringify({ workspaceId: "alpha-main" }),
+      )}`,
+    );
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 500 for an unknown workspaceId", async () => {
+    const res = await trpcQuery(
+      server.url,
+      "workspace.getCommitGraph",
+      { workspaceId: "nope-main" },
+      DEFAULT_TOKEN,
+    );
+    expect(res.status).toBe(500);
+  });
+
+  it("returns every branch's commits with parent linkage, author, and HEAD", async () => {
+    const res = await trpcQuery(
+      server.url,
+      "workspace.getCommitGraph",
+      { workspaceId: "alpha-main" },
+      DEFAULT_TOKEN,
+    );
+    expect(res.status).toBe(200);
+
+    const data = await trpcData<{ commits: GraphCommit[]; head: string | null }>(res);
+
+    // HEAD is main's tip (`second`).
+    expect(data.head).toBe(repo.secondSha);
+
+    // `--all` surfaces every branch — all three commits are present.
+    const bySha = new Map(data.commits.map((c) => [c.sha, c]));
+    expect(bySha.size).toBe(3);
+
+    const initial = bySha.get(repo.initialSha);
+    const second = bySha.get(repo.secondSha);
+    const feature = bySha.get(repo.featureSha);
+    expect(initial).toBeDefined();
+    expect(second).toBeDefined();
+    expect(feature).toBeDefined();
+
+    // Parent linkage — the client draws lanes from this.
+    expect(initial?.parents).toEqual([]);
+    expect(second?.parents).toEqual([repo.initialSha]);
+    expect(feature?.parents).toEqual([repo.initialSha]);
+
+    // Seeded author identity round-trips verbatim.
+    expect(second?.author).toBe("Test");
+    expect(second?.email).toBe("test@test.com");
+    expect(typeof second?.ts).toBe("number");
+
+    // Subjects are parsed intact.
+    expect(initial?.subject).toBe("initial");
+    expect(second?.subject).toBe("second");
+    expect(feature?.subject).toBe("feature-work");
+
+    // Ref decorations: main's tip carries the `main` branch ref, the
+    // feature commit carries `feature`.
+    expect(second?.refs.some((r) => r.includes("main"))).toBe(true);
+    expect(feature?.refs.some((r) => r.includes("feature"))).toBe(true);
+  });
+
+  it("honours the limit input", async () => {
+    const res = await trpcQuery(
+      server.url,
+      "workspace.getCommitGraph",
+      { workspaceId: "alpha-main", limit: 1 },
+      DEFAULT_TOKEN,
+    );
+    expect(res.status).toBe(200);
+    const data = await trpcData<{ commits: GraphCommit[]; head: string | null }>(res);
+    expect(data.commits).toHaveLength(1);
+  });
+});

--- a/apps/web/tests/workspace-git-graph-actions.test.ts
+++ b/apps/web/tests/workspace-git-graph-actions.test.ts
@@ -1,0 +1,278 @@
+// Black-box integration tests for the Graph tab's commit-details reads and
+// the four "essentials" write actions on `workspaceRouter`:
+//   - workspace.getCommitDetails / getCommitFileDiff (read)
+//   - workspace.createBranch / checkoutBranch / cherryPick / revertCommit (write)
+//
+// Boots the real production server (`dist/start-server.mjs`) against a tmp
+// `$HOME` and drives it over real HTTP. Each write action operates on its
+// OWN on-disk git repo (one project/workspace per action) so a mutation can
+// never leak into another test's assertions. Every effect is verified by
+// shelling out to real `git` against the repo the server just mutated. No
+// mocks — the same recipe as `workspace-commit-graph.test.ts` /
+// `workspace-git-ops.test.ts`.
+
+import { execFileSync } from "node:child_process";
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { seedSettings, seedState } from "./helpers/seed-state";
+import {
+  createTmpHome,
+  type ServerHandle,
+  startServer,
+  trpcData,
+  trpcMutate,
+  trpcQuery,
+} from "./helpers/server";
+
+const DEFAULT_TOKEN = "workspace-git-graph-actions-token";
+
+const gitEnv = {
+  ...process.env,
+  GIT_AUTHOR_NAME: "Test",
+  GIT_AUTHOR_EMAIL: "test@test.com",
+  GIT_COMMITTER_NAME: "Test",
+  GIT_COMMITTER_EMAIL: "test@test.com",
+};
+
+function git(cwd: string, args: string[]): string {
+  return execFileSync("git", args, { cwd, env: gitEnv, encoding: "utf-8" }).trim();
+}
+
+function seedGitIdentity(tmpHome: string): void {
+  writeFileSync(
+    join(tmpHome, ".gitconfig"),
+    [
+      "[user]",
+      "  name = Test",
+      "  email = test@test.com",
+      "[init]",
+      "  defaultBranch = main",
+      "",
+    ].join("\n"),
+    "utf-8",
+  );
+}
+
+/**
+ * Build a real repo with three commits across two branches:
+ *
+ *   main:    initial ─ second
+ *   feature:         └─ feature-work
+ *
+ * `HEAD` ends on `main` (at `second`). Returns the repo path and the SHAs so
+ * assertions can pin exact object ids.
+ */
+function seedRepo(
+  parent: string,
+  name: string,
+): { path: string; initialSha: string; secondSha: string; featureSha: string } {
+  const path = join(parent, name);
+  mkdirSync(path, { recursive: true });
+  git(path, ["init", "-b", "main"]);
+
+  writeFileSync(join(path, "README.md"), "# repo\n");
+  git(path, ["add", "."]);
+  git(path, ["commit", "-m", "initial"]);
+  const initialSha = git(path, ["rev-parse", "HEAD"]);
+
+  git(path, ["checkout", "-b", "feature"]);
+  writeFileSync(join(path, "feature.md"), "# feature\n");
+  git(path, ["add", "."]);
+  git(path, ["commit", "-m", "feature-work"]);
+  const featureSha = git(path, ["rev-parse", "HEAD"]);
+
+  git(path, ["checkout", "main"]);
+  writeFileSync(join(path, "second.md"), "# second\n");
+  git(path, ["add", "."]);
+  git(path, ["commit", "-m", "second"]);
+  const secondSha = git(path, ["rev-parse", "HEAD"]);
+
+  return { path, initialSha, secondSha, featureSha };
+}
+
+// One repo per action keeps mutations isolated within a single server boot.
+const REPOS = ["reads", "createbranch", "checkout", "cherrypick", "revert"] as const;
+type RepoName = (typeof REPOS)[number];
+
+describe("tRPC — workspace Graph-tab commit details + actions", () => {
+  let server: ServerHandle;
+  let tmpHome: string;
+  const repos = {} as Record<RepoName, ReturnType<typeof seedRepo>>;
+  const wsId = (name: RepoName) => `${name}-main`;
+
+  beforeAll(async () => {
+    tmpHome = createTmpHome("band-git-graph-actions-");
+    seedGitIdentity(tmpHome);
+    for (const name of REPOS) {
+      repos[name] = seedRepo(tmpHome, name);
+    }
+
+    seedState(tmpHome, {
+      projects: REPOS.map((name) => ({
+        name,
+        path: repos[name].path,
+        defaultBranch: "main",
+        worktrees: [{ branch: "main", path: repos[name].path }],
+      })),
+    });
+    seedSettings(tmpHome, { tokenSecret: DEFAULT_TOKEN });
+
+    server = await startServer({ tmpHome });
+  });
+
+  afterAll(async () => {
+    await server.close();
+    rmSync(tmpHome, { recursive: true, force: true });
+  });
+
+  // ── reads ──────────────────────────────────────────────────────────────
+
+  it("getCommitDetails returns metadata + the commit's changed files", async () => {
+    const res = await trpcQuery(
+      server.url,
+      "workspace.getCommitDetails",
+      { workspaceId: wsId("reads"), sha: repos.reads.secondSha },
+      DEFAULT_TOKEN,
+    );
+    expect(res.status).toBe(200);
+
+    const data = await trpcData<{
+      sha: string;
+      parents: string[];
+      author: string;
+      email: string;
+      subject: string;
+      files: { path: string; status: string }[];
+    }>(res);
+
+    expect(data.sha).toBe(repos.reads.secondSha);
+    expect(data.parents).toEqual([repos.reads.initialSha]);
+    expect(data.author).toBe("Test");
+    expect(data.email).toBe("test@test.com");
+    expect(data.subject).toBe("second");
+    // `second` added second.md.
+    expect(data.files.some((f) => f.path === "second.md" && f.status === "A")).toBe(true);
+  });
+
+  it("getCommitFileDiff returns the unified diff for one file in a commit", async () => {
+    const res = await trpcQuery(
+      server.url,
+      "workspace.getCommitFileDiff",
+      { workspaceId: wsId("reads"), sha: repos.reads.secondSha, filePath: "second.md" },
+      DEFAULT_TOKEN,
+    );
+    expect(res.status).toBe(200);
+    const data = await trpcData<{ diff: string }>(res);
+    expect(data.diff).toContain("second.md");
+    expect(data.diff).toContain("+# second");
+  });
+
+  it("getCommitDetails rejects a non-hex sha at the transport boundary", async () => {
+    const res = await trpcQuery(
+      server.url,
+      "workspace.getCommitDetails",
+      { workspaceId: wsId("reads"), sha: "not-a-sha" },
+      DEFAULT_TOKEN,
+    );
+    expect(res.status).toBe(400);
+  });
+
+  // ── createBranch ─────────────────────────────────────────────────────────
+
+  it("createBranch creates a branch at the given sha and checks it out", async () => {
+    const repo = repos.createbranch;
+    const res = await trpcMutate(
+      server.url,
+      "workspace.createBranch",
+      { workspaceId: wsId("createbranch"), sha: repo.initialSha, name: "topic", checkout: true },
+      DEFAULT_TOKEN,
+    );
+    expect(res.status).toBe(200);
+    expect(await trpcData<{ ok: true }>(res)).toEqual({ ok: true });
+
+    // The branch exists, points at `initial`, and is now the checked-out HEAD.
+    expect(git(repo.path, ["rev-parse", "topic"])).toBe(repo.initialSha);
+    expect(git(repo.path, ["symbolic-ref", "--short", "HEAD"])).toBe("topic");
+  });
+
+  it("createBranch rejects a branch name starting with '-'", async () => {
+    const res = await trpcMutate(
+      server.url,
+      "workspace.createBranch",
+      { workspaceId: wsId("createbranch"), sha: repos.createbranch.initialSha, name: "-evil" },
+      DEFAULT_TOKEN,
+    );
+    expect(res.status).toBe(400);
+  });
+
+  // ── checkoutBranch ───────────────────────────────────────────────────────
+
+  it("checkoutBranch switches the worktree to an existing branch", async () => {
+    const repo = repos.checkout;
+    expect(git(repo.path, ["symbolic-ref", "--short", "HEAD"])).toBe("main");
+
+    const res = await trpcMutate(
+      server.url,
+      "workspace.checkoutBranch",
+      { workspaceId: wsId("checkout"), branch: "feature" },
+      DEFAULT_TOKEN,
+    );
+    expect(res.status).toBe(200);
+    expect(await trpcData<{ ok: true }>(res)).toEqual({ ok: true });
+
+    expect(git(repo.path, ["symbolic-ref", "--short", "HEAD"])).toBe("feature");
+    expect(git(repo.path, ["rev-parse", "HEAD"])).toBe(repo.featureSha);
+  });
+
+  it("checkoutBranch bubbles a 500 for a branch that does not exist", async () => {
+    const res = await trpcMutate(
+      server.url,
+      "workspace.checkoutBranch",
+      { workspaceId: wsId("checkout"), branch: "does-not-exist" },
+      DEFAULT_TOKEN,
+    );
+    expect(res.status).toBe(500);
+  });
+
+  // ── cherryPick ─────────────────────────────────────────────────────────
+
+  it("cherryPick replays a commit onto the current branch", async () => {
+    const repo = repos.cherrypick;
+    // HEAD is main@second; feature-work adds feature.md, which main lacks — a
+    // clean, non-conflicting cherry-pick.
+    const res = await trpcMutate(
+      server.url,
+      "workspace.cherryPick",
+      { workspaceId: wsId("cherrypick"), sha: repo.featureSha },
+      DEFAULT_TOKEN,
+    );
+    expect(res.status).toBe(200);
+    expect(await trpcData<{ ok: true }>(res)).toEqual({ ok: true });
+
+    // A new tip commit reproducing feature-work now sits on main.
+    expect(git(repo.path, ["log", "-1", "--format=%s"])).toBe("feature-work");
+    expect(git(repo.path, ["symbolic-ref", "--short", "HEAD"])).toBe("main");
+    // The picked file landed in the working tree.
+    expect(git(repo.path, ["cat-file", "-t", "HEAD:feature.md"])).toBe("blob");
+  });
+
+  // ── revertCommit ─────────────────────────────────────────────────────────
+
+  it("revertCommit creates an inverse commit that undoes the target", async () => {
+    const repo = repos.revert;
+    const res = await trpcMutate(
+      server.url,
+      "workspace.revertCommit",
+      { workspaceId: wsId("revert"), sha: repo.secondSha },
+      DEFAULT_TOKEN,
+    );
+    expect(res.status).toBe(200);
+    expect(await trpcData<{ ok: true }>(res)).toEqual({ ok: true });
+
+    // A "Revert "second"" commit is the new tip, and second.md (added by the
+    // reverted commit) is gone from the tree.
+    expect(git(repo.path, ["log", "-1", "--format=%s"])).toContain('Revert "second"');
+    expect(() => git(repo.path, ["cat-file", "-t", "HEAD:second.md"])).toThrow();
+  });
+});


### PR DESCRIPTION
## PO Summary

Band workspaces now have a **Graph** tab that shows your project's git history as a visual branch tree — every commit, branch, tag, and stash at a glance, the way desktop git apps (GitKraken / GitLens) show it. Click any commit to see who changed what, with a file-by-file diff, without leaving Band. This makes it much easier to understand how a branch evolved and what a given commit touched.

## What's included

- **Graph tab/panel** in every workspace (desktop dockview + mobile tabs), with a ⇧⌘Y shortcut and a "Show Git Graph" command-palette entry.
- **Branch-tree rendering** with stable lanes, merge/branch curves, and pastel HEAD / branch / tag / stash badges (light + dark).
- **Hide-stash toggle** — stashes render as a single node; git's internal index/untracked bookkeeping commits are never surfaced.
- **Commit details panel** — click a commit to see author, date, message body, changed-file list, and a per-file unified diff.
- **Action backend** — `checkout`, `create branch`, `cherry-pick`, `revert` tRPC mutations (validated shas/ref-names), ready to wire to context menus.

## Follow-ups (not in this PR)

- Right-click context menus + confirm dialogs for the checkout/branch/cherry-pick/revert actions.
- ⌘F find-in-graph widget.

## Testing

- Backend: `apps/web/tests/workspace-commit-graph.test.ts` (real server + real git repo).
- Frontend: `apps/web/e2e/commit-graph.spec.ts` (real Chromium, Graph tab renders; stash bookkeeping hidden).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WA79gWTSjxxms4pozR1LfC
