### PR TITLE
fix(web): strip OSC color queries from terminal scrollback replay (#613)

### DIFF
--- a/apps/web/src/server/api/terminals/router.ts
+++ b/apps/web/src/server/api/terminals/router.ts
@@ -4,6 +4,7 @@ import { z } from "zod";
 import { terminalService } from "../../services/terminal-service";
 import { emit } from "../../services/watcher-service";
 import { publicProcedure, t } from "../trpc";
+import { stripTerminalQueries } from "./strip-queries";
 
 /**
  * Terminal sub-router — migrated into the 3-tier architecture as part of
@@ -105,9 +106,15 @@ const terminalRouter = t.router({
         return;
       }
 
-      // Replay buffered scrollback first
+      // Replay buffered scrollback first. Strip query/report escape
+      // sequences before replay for the same reason the WebSocket path does
+      // (band-app/band#613): a stale color/cursor/DA query replayed into a
+      // fresh terminal emulator gets answered back to the PTY and leaks as
+      // literal text at the prompt. This subscription replays-then-streams,
+      // exactly the reconnect scenario the leak needs, so it needs the same
+      // guard the `/terminal` WebSocket already applies.
       if (replay && session.scrollback.length > 0) {
-        yield { type: "output" as const, data: session.scrollback };
+        yield { type: "output" as const, data: stripTerminalQueries(session.scrollback) };
       }
 
       // Stream live output

--- a/apps/web/src/server/api/terminals/router.ts
+++ b/apps/web/src/server/api/terminals/router.ts
@@ -81,7 +81,13 @@ const terminalRouter = t.router({
           message: `Terminal not found: ${input.terminalId}`,
         });
       }
-      return { output };
+      // Strip query/report escape sequences here too (band-app/band#613):
+      // this scrollback fetch has no live-terminal handshake, so a stale
+      // color/cursor/DA query in it is pure noise, and any client that renders
+      // the result through a terminal emulator would hit the same OSC leak the
+      // replay paths do. Stripping is safe — these sequences carry no display
+      // value in a point-in-time scrollback read.
+      return { output: stripTerminalQueries(output) };
     }),
 
   kill: publicProcedure.input(z.object({ terminalId: z.string() })).mutation(({ input }) => {

--- a/apps/web/src/server/api/terminals/strip-queries.ts
+++ b/apps/web/src/server/api/terminals/strip-queries.ts
@@ -1,0 +1,41 @@
+/**
+ * Strip terminal query/request escape sequences from buffered scrollback so
+ * replaying them on reconnect doesn't cause the client's terminal emulator
+ * (xterm.js) to emit spurious responses.
+ *
+ * Why this matters: when scrollback is replayed, xterm.js parses it just like
+ * live PTY output. Any *query* sequence it sees (a request for cursor
+ * position, device attributes, or the current colors) it answers per spec via
+ * `term.onData()`. The dashboard forwards that answer back to the PTY stdin,
+ * where the shell's line editor inserts the printable remainder as literal
+ * text at the prompt — e.g. `10;rgb:e8e8/e8e8/e8e811;rgb:1e1e/1e1e/1e1e`
+ * appearing out of nowhere (band-app/band#613). Live output never triggers
+ * this because the query response is consumed by whatever tool issued it; the
+ * leak is specific to replaying a stale query with no matching reader.
+ *
+ * Covers:
+ *  CSI (ESC [ …):
+ *   \x1b[6n   — Cursor Position Report (DSR CPR)
+ *   \x1b[?6n  — Extended CPR
+ *   \x1b[5n   — Device Status Report
+ *   \x1b[c    — Primary Device Attributes (DA1)
+ *   \x1b[>c   — Secondary Device Attributes (DA2)
+ *   \x1b[=c   — Tertiary Device Attributes (DA3)
+ *  OSC (ESC ] …), terminated by BEL (\x07) or ST (ESC \):
+ *   \x1b]10;…  — foreground color query/report
+ *   \x1b]11;…  — background color query/report
+ *   \x1b]12;…  — cursor color query/report
+ *  Both the `?` query form (`ESC]11;?BEL`) and any `rgb:` report form that
+ *  may already be sitting in scrollback are removed.
+ */
+export function stripTerminalQueries(data: string): string {
+  return (
+    data
+      // biome-ignore lint/suspicious/noControlCharactersInRegex: intentional — matching real ESC sequences in terminal output
+      .replace(/\x1b\[\??[0-9]*[nc]|\x1b\[>[0-9]*c|\x1b\[=[0-9]*c/g, "")
+      // OSC 10/11/12 color queries/reports. The payload runs until the first
+      // BEL or ST, so `[^\x07\x1b]*` stops at either terminator byte.
+      // biome-ignore lint/suspicious/noControlCharactersInRegex: intentional — matching real OSC sequences in terminal output
+      .replace(/\x1b\]1[012];[^\x07\x1b]*(?:\x07|\x1b\\)/g, "")
+  );
+}

--- a/apps/web/src/server/api/terminals/strip-queries.ts
+++ b/apps/web/src/server/api/terminals/strip-queries.ts
@@ -34,8 +34,16 @@ export function stripTerminalQueries(data: string): string {
       // biome-ignore lint/suspicious/noControlCharactersInRegex: intentional — matching real ESC sequences in terminal output
       .replace(/\x1b\[\??[0-9]*[nc]|\x1b\[>[0-9]*c|\x1b\[=[0-9]*c/g, "")
       // OSC 10/11/12 color queries/reports. The payload runs until the first
-      // BEL or ST, so `[^\x07\x1b]*` stops at either terminator byte.
+      // BEL or ST, so `[^\x07\x1b]*` stops at either terminator byte. The
+      // terminator is OPTIONAL so an *unterminated* opener is stripped too:
+      // PTY output arrives in chunks, so scrollback can end mid-sequence
+      // (`\x1b]11;?` with its BEL not yet appended). Replaying that dangling
+      // query would leave xterm.js waiting for the terminator, which the live
+      // stream then supplies — re-triggering the #613 leak. Because the
+      // negated class stops at any ESC, the optional terminator only ever
+      // consumes a real terminator or nothing; it never eats a following
+      // escape sequence.
       // biome-ignore lint/suspicious/noControlCharactersInRegex: intentional — matching real OSC sequences in terminal output
-      .replace(/\x1b\]1[012];[^\x07\x1b]*(?:\x07|\x1b\\)/g, "")
+      .replace(/\x1b\]1[012];[^\x07\x1b]*(?:\x07|\x1b\\)?/g, "")
   );
 }

--- a/apps/web/src/server/api/terminals/ws.ts
+++ b/apps/web/src/server/api/terminals/ws.ts
@@ -6,6 +6,7 @@ import {
   type TerminalSession,
   terminalService,
 } from "../../services/terminal-service";
+import { stripTerminalQueries } from "./strip-queries";
 
 const log = createLogger("terminal-ws");
 
@@ -285,25 +286,4 @@ function handleMessage(
     }
   }
   session.pty.write(message);
-}
-
-// ---------------------------------------------------------------------------
-// Strip terminal query escape sequences from scrollback
-// ---------------------------------------------------------------------------
-
-/**
- * Strip terminal query/request escape sequences from scrollback so
- * replaying them doesn't cause xterm.js to emit spurious responses.
- *
- * Covers:
- *  \x1b[6n   — Cursor Position Report (DSR CPR)
- *  \x1b[?6n  — Extended CPR
- *  \x1b[5n   — Device Status Report
- *  \x1b[c    — Primary Device Attributes (DA1)
- *  \x1b[>c   — Secondary Device Attributes (DA2)
- *  \x1b[=c   — Tertiary Device Attributes (DA3)
- */
-function stripTerminalQueries(data: string): string {
-  // biome-ignore lint/suspicious/noControlCharactersInRegex: intentional — matching real ESC sequences in terminal output
-  return data.replace(/\x1b\[\??[0-9]*[nc]|\x1b\[>[0-9]*c|\x1b\[=[0-9]*c/g, "");
 }

--- a/apps/web/tests/terminal-ws.test.ts
+++ b/apps/web/tests/terminal-ws.test.ts
@@ -75,7 +75,10 @@ function getRandomPort(): Promise<number> {
   });
 }
 
-async function startServer(home: string): Promise<ServerHandle> {
+async function startServer(
+  home: string,
+  extraEnv: Record<string, string> = {},
+): Promise<ServerHandle> {
   const port = await getRandomPort();
 
   return new Promise((resolve, reject) => {
@@ -86,6 +89,7 @@ async function startServer(home: string): Promise<ServerHandle> {
         HOME: home,
         PORT: String(port),
         NODE_ENV: "production",
+        ...extraEnv,
       },
       stdio: ["pipe", "pipe", "pipe"],
     });
@@ -334,5 +338,141 @@ describe("terminal WebSocket — application-level ping/pong heartbeat", () => {
 
     expect(gotPong).toBe(true);
     ws.close();
+  });
+});
+
+describe("terminal WebSocket — OSC color-query stripping on scrollback replay", () => {
+  let server: ServerHandle;
+  let tmpHome: string;
+
+  beforeAll(async () => {
+    tmpHome = createTmpHome();
+    const projectPath = join(tmpHome, "workspace");
+    mkdirSync(projectPath, { recursive: true });
+    seedState(tmpHome, {
+      projects: [
+        {
+          name: "workspace",
+          path: projectPath,
+          defaultBranch: "main",
+          worktrees: [{ branch: "main", path: projectPath }],
+        },
+      ],
+    });
+    seedSettings(tmpHome, {
+      tokenSecret: DEFAULT_TOKEN,
+      worktreesDir: join(tmpHome, ".band", "worktrees"),
+    });
+    // Pin the shell so `printf`'s octal-escape handling is deterministic
+    // across macOS (defaults to zsh) and Linux CI. bash exists on both.
+    server = await startServer(tmpHome, { SHELL: "/bin/bash" });
+  });
+
+  afterAll(async () => {
+    if (server) await server.close();
+    if (tmpHome) rmSync(tmpHome, { recursive: true, force: true });
+  });
+
+  // Regression for band-app/band#613: a stale OSC 10/11/12 color query sitting
+  // in scrollback used to survive replay (stripTerminalQueries only matched CSI
+  // sequences). The client's xterm.js then answered the replayed query, the
+  // dashboard forwarded the answer to the PTY, and the shell's line editor
+  // inserted the printable remainder (`11;rgb:1e1e/1e1e/1e1e…`) as literal text
+  // at the prompt. This test proves the OSC bytes are stripped from replayed
+  // scrollback while ordinary output survives.
+  it("strips OSC 10/11 sequences from replayed scrollback but keeps normal output", async () => {
+    const workspaceId = "workspace-main";
+    const terminalId = "osc-strip-terminal";
+    const wsUrl = `ws://127.0.0.1:${server.port}/terminal?workspaceId=${workspaceId}&terminalId=${terminalId}`;
+
+    // OSC 11 (background) query + OSC 10 (foreground) rgb: report, plus a
+    // marker whose *source text* (`DONE""MARKER`) differs from its emitted
+    // output (`DONEMARKER`), so the marker we assert on can only come from
+    // executed output — never the shell's echo of the typed command line.
+    // `\\033`/`\\007` are literal backslash-escapes handed to the shell's
+    // printf; only its *execution* produces the raw ESC (0x1b) / BEL (0x07)
+    // bytes that end up in scrollback.
+    const OSC11_QUERY = "\x1b]11;?\x07";
+    const OSC10_REPORT = "\x1b]10;rgb:e8e8/e8e8/e8e8\x07";
+    const MARKER = "DONEMARKER";
+    const command =
+      "printf '\\033]11;?\\007\\033]10;rgb:e8e8/e8e8/e8e8\\007'; echo DONE\"\"MARKER\r";
+
+    // --- Connection 1: spawn the PTY, run the command, wait until the raw
+    //     OSC bytes appear in live output (proving they're now in scrollback).
+    const ws1 = new WebSocket(wsUrl, {
+      headers: { Cookie: `band_token=${DEFAULT_TOKEN}` },
+    });
+
+    let live = Buffer.alloc(0);
+    let sentCommand = false;
+
+    await new Promise<void>((resolve, reject) => {
+      ws1.on("open", () => {
+        ws1.send(JSON.stringify({ type: "init" }));
+      });
+      ws1.on("message", (data: Buffer, isBinary: boolean) => {
+        if (!sentCommand) {
+          // First frame proves the session is attached and the persistent
+          // message listener is live — now send the command.
+          sentCommand = true;
+          ws1.send(command);
+          return;
+        }
+        if (!isBinary) return; // skip JSON control frames (title, etc.)
+        live = Buffer.concat([live, data]);
+        // Live output is NOT stripped, so the raw OSC 11 query round-trips
+        // here. Once we see it, the bytes are guaranteed in scrollback.
+        if (live.includes(Buffer.from(OSC11_QUERY, "binary"))) {
+          resolve();
+        }
+      });
+      ws1.on("error", reject);
+      setTimeout(
+        () => reject(new Error("OSC query never appeared in live output within 10 s")),
+        10_000,
+      );
+    });
+
+    await new Promise<void>((r) => {
+      ws1.on("close", () => r());
+      ws1.close();
+    });
+
+    // --- Connection 2: reconnect to the same terminal. The server replays
+    //     the buffered scrollback through stripTerminalQueries.
+    const ws2 = new WebSocket(wsUrl, {
+      headers: { Cookie: `band_token=${DEFAULT_TOKEN}` },
+    });
+
+    let replay = Buffer.alloc(0);
+
+    await new Promise<void>((resolve, reject) => {
+      ws2.on("message", (data: Buffer, isBinary: boolean) => {
+        if (!isBinary) return;
+        replay = Buffer.concat([replay, data]);
+        // The marker proves scrollback was actually replayed (guards against
+        // a false pass where an empty buffer trivially contains no OSC).
+        if (replay.includes(MARKER)) {
+          resolve();
+        }
+      });
+      ws2.on("error", reject);
+      setTimeout(
+        () => reject(new Error("Marker never appeared in replayed scrollback within 10 s")),
+        10_000,
+      );
+    });
+
+    ws2.close();
+
+    // Ordinary output survived replay.
+    expect(replay.includes(MARKER)).toBe(true);
+    // Both OSC forms — the `?` query and the `rgb:` report — were stripped.
+    expect(replay.includes(Buffer.from(OSC11_QUERY, "binary"))).toBe(false);
+    expect(replay.includes(Buffer.from(OSC10_REPORT, "binary"))).toBe(false);
+    // Nothing starting an OSC 10/11/12 escape (`ESC ] 1x`) should remain.
+    expect(replay.includes(Buffer.from("\x1b]10", "binary"))).toBe(false);
+    expect(replay.includes(Buffer.from("\x1b]11", "binary"))).toBe(false);
   });
 });

--- a/apps/web/tests/terminal-ws.test.ts
+++ b/apps/web/tests/terminal-ws.test.ts
@@ -25,7 +25,7 @@ import { mkdirSync, mkdtempSync, realpathSync, rmSync } from "node:fs";
 import { createServer } from "node:net";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { createTRPCClient, createWSClient, wsLink } from "@trpc/client";
+import { createTRPCClient, createWSClient, httpBatchLink, wsLink } from "@trpc/client";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { WebSocket } from "ws";
 import type { AppRouter } from "../src/server/api/router";
@@ -458,29 +458,25 @@ describe("terminal WebSocket — OSC color-query stripping on scrollback replay"
       headers: { Cookie: `band_token=${DEFAULT_TOKEN}` },
     });
 
+    // The server replays the whole buffered scrollback in a single binary
+    // `ws.send`, so the FIRST binary frame is exactly the replayed scrollback.
+    // Capture only that frame — accumulating later frames could fold in live
+    // PTY output emitted after reconnect and muddy the OSC assertions.
     let replay = Buffer.alloc(0);
 
     await new Promise<void>((resolve, reject) => {
       ws2.on("message", (data: Buffer, isBinary: boolean) => {
-        if (!isBinary) return;
-        replay = Buffer.concat([replay, data]);
-        // The marker proves scrollback was actually replayed (guards against
-        // a false pass where an empty buffer trivially contains no OSC).
-        if (replay.includes(MARKER)) {
-          resolve();
-        }
+        if (!isBinary) return; // skip JSON control frames (title, etc.)
+        replay = data;
+        resolve();
       });
       ws2.on("error", reject);
-      setTimeout(
-        () => reject(new Error("Marker never appeared in replayed scrollback within 10 s")),
-        10_000,
-      );
+      setTimeout(() => reject(new Error("No replayed scrollback frame within 10 s")), 10_000);
     });
 
     ws2.close();
 
-    // Ordinary output survived replay (the promise above only resolves once
-    // MARKER is present, so this is the positive anchor for the negatives).
+    // Ordinary output survived replay — positive anchor for the negatives.
     expect(replay.toString()).toContain(MARKER);
     // Every OSC form — the `?` query (11/12) and the `rgb:` report (10) — was
     // stripped.
@@ -556,12 +552,40 @@ describe("terminal WebSocket — OSC color-query stripping on scrollback replay"
     expect(firstOutput).not.toContain("\x1b]11");
     expect(firstOutput).not.toContain("\x1b]12");
   });
+
+  // Third scrollback surface (band-app/band#613): the `terminal.output` tRPC
+  // query returns the buffered scrollback on demand. A client rendering that
+  // into a terminal emulator would hit the same OSC leak, so it strips too.
+  // Driven over the real HTTP tRPC transport.
+  it("strips OSC 10/11/12 sequences from the terminal.output query response", async () => {
+    const terminalId = "osc-strip-output";
+    await seedOscScrollback(terminalId);
+
+    const client = createTRPCClient<AppRouter>({
+      links: [
+        httpBatchLink({
+          url: `${server.url}/trpc`,
+          headers: { Cookie: `band_token=${DEFAULT_TOKEN}` },
+        }),
+      ],
+    });
+
+    const { output } = await client.terminal.output.query({ terminalId });
+
+    expect(output).toContain(MARKER);
+    expect(output).not.toContain(OSC11_QUERY);
+    expect(output).not.toContain(OSC10_REPORT);
+    expect(output).not.toContain(OSC12_QUERY);
+    expect(output).not.toContain("\x1b]10");
+    expect(output).not.toContain("\x1b]11");
+    expect(output).not.toContain("\x1b]12");
+  });
 });
 
-// Negative-auth coverage (TEST-13): the WebSocket upgrade and every HTTP
-// request are gated on the `band_token` cookie (see the start-server.ts
-// upgrade handler and auth.ts). A seeded `tokenSecret` makes the server
-// enforce the token, so a request without it must be rejected.
+// Negative-auth coverage: the WebSocket upgrade and every HTTP request are
+// gated on the `band_token` cookie (see the start-server.ts upgrade handler
+// and auth.ts). A seeded `tokenSecret` makes the server enforce the token, so
+// a request without it must be rejected.
 describe("terminal WebSocket — authentication", () => {
   let server: ServerHandle;
   let tmpHome: string;

--- a/apps/web/tests/terminal-ws.test.ts
+++ b/apps/web/tests/terminal-ws.test.ts
@@ -479,8 +479,9 @@ describe("terminal WebSocket — OSC color-query stripping on scrollback replay"
 
     ws2.close();
 
-    // Ordinary output survived replay.
-    expect(replay.includes(MARKER)).toBe(true);
+    // Ordinary output survived replay (the promise above only resolves once
+    // MARKER is present, so this is the positive anchor for the negatives).
+    expect(replay.toString()).toContain(MARKER);
     // Every OSC form — the `?` query (11/12) and the `rgb:` report (10) — was
     // stripped.
     expect(replay.includes(Buffer.from(OSC11_QUERY))).toBe(false);
@@ -555,19 +556,40 @@ describe("terminal WebSocket — OSC color-query stripping on scrollback replay"
     expect(firstOutput).not.toContain("\x1b]11");
     expect(firstOutput).not.toContain("\x1b]12");
   });
+});
 
-  // TEST-13: negative auth. The WebSocket upgrade and every HTTP request are
-  // gated on the `band_token` cookie (see start-server.ts upgrade handler and
-  // auth.ts). Assert both surfaces reject a request with no token.
-  it("rejects unauthenticated access: WS upgrade dropped and HTTP returns 401", async () => {
-    // HTTP: no cookie → 401 from the auth middleware.
+// Negative-auth coverage (TEST-13): the WebSocket upgrade and every HTTP
+// request are gated on the `band_token` cookie (see the start-server.ts
+// upgrade handler and auth.ts). A seeded `tokenSecret` makes the server
+// enforce the token, so a request without it must be rejected.
+describe("terminal WebSocket — authentication", () => {
+  let server: ServerHandle;
+  let tmpHome: string;
+
+  beforeAll(async () => {
+    tmpHome = createTmpHome();
+    seedSettings(tmpHome, {
+      tokenSecret: DEFAULT_TOKEN,
+      worktreesDir: join(tmpHome, ".band", "worktrees"),
+    });
+    server = await startServer(tmpHome);
+  });
+
+  afterAll(async () => {
+    if (server) await server.close();
+    if (tmpHome) rmSync(tmpHome, { recursive: true, force: true });
+  });
+
+  it("returns 401 for an HTTP request without the band_token cookie", async () => {
     const res = await fetch(`${server.url}/api/health`);
     expect(res.status).toBe(401);
+  });
 
-    // WebSocket: no cookie → the upgrade handler destroys the socket before
-    // the 101 handshake, so the client never opens. Assert we observe a
-    // failure (error / unexpected-response / close) and never an `open`.
-    const wsUrl = `ws://127.0.0.1:${server.port}/terminal?workspaceId=${WORKSPACE_ID}&terminalId=noauth`;
+  it("rejects a /terminal WebSocket upgrade without the band_token cookie", async () => {
+    // No cookie → the upgrade handler destroys the socket before the 101
+    // handshake, so the client never opens. Assert we observe a failure
+    // (error / unexpected-response / close) and never an `open`.
+    const wsUrl = `ws://127.0.0.1:${server.port}/terminal?workspaceId=workspace-main&terminalId=noauth`;
     const ws = new WebSocket(wsUrl); // deliberately no Cookie header
 
     const opened = await new Promise<boolean>((resolve, reject) => {

--- a/apps/web/tests/terminal-ws.test.ts
+++ b/apps/web/tests/terminal-ws.test.ts
@@ -384,14 +384,20 @@ describe("terminal WebSocket — OSC color-query stripping on scrollback replay"
   // bytes that end up in scrollback.
   const OSC11_QUERY = "\x1b]11;?\x07";
   const OSC10_REPORT = "\x1b]10;rgb:e8e8/e8e8/e8e8\x07";
+  const OSC12_QUERY = "\x1b]12;?\x07";
   const MARKER = "DONEMARKER";
-  const COMMAND = "printf '\\033]11;?\\007\\033]10;rgb:e8e8/e8e8/e8e8\\007'; echo DONE\"\"MARKER\r";
+  const COMMAND =
+    "printf '\\033]11;?\\007\\033]10;rgb:e8e8/e8e8/e8e8\\007\\033]12;?\\007'; echo DONE\"\"MARKER\r";
 
   const WORKSPACE_ID = "workspace-main";
 
   // Spawn a PTY over the `/terminal` WebSocket, run the OSC-emitting command,
-  // and resolve only once the raw OSC bytes have appeared in live output —
-  // which guarantees they are now buffered in the server-side scrollback.
+  // and resolve only once BOTH the raw OSC bytes AND the trailing marker have
+  // appeared in live output — which guarantees the whole command's output
+  // (queries + marker) is buffered in the server-side scrollback. Waiting for
+  // the marker too matters: the PTY can deliver the OSC bytes and `DONEMARKER`
+  // in separate chunks, so resolving on the OSC alone could close the socket
+  // before the marker reaches scrollback and make the replay assertions flake.
   // Then close the socket; the pool keeps the PTY alive for reconnect/replay.
   async function seedOscScrollback(terminalId: string): Promise<void> {
     const wsUrl = `ws://127.0.0.1:${server.port}/terminal?workspaceId=${WORKSPACE_ID}&terminalId=${terminalId}`;
@@ -414,15 +420,16 @@ describe("terminal WebSocket — OSC color-query stripping on scrollback replay"
         }
         if (!isBinary) return; // skip JSON control frames (title, etc.)
         live = Buffer.concat([live, data]);
-        // Live output is NOT stripped, so the raw OSC 11 query round-trips
-        // here. Once we see it, the bytes are guaranteed in scrollback.
-        if (live.includes(Buffer.from(OSC11_QUERY))) {
+        // Live output is NOT stripped, so the raw OSC query round-trips here.
+        // Wait for the OSC bytes and the marker so the full command output is
+        // guaranteed in scrollback before we close.
+        if (live.includes(Buffer.from(OSC11_QUERY)) && live.includes(Buffer.from(MARKER))) {
           resolve();
         }
       });
       ws.on("error", reject);
       setTimeout(
-        () => reject(new Error("OSC query never appeared in live output within 10 s")),
+        () => reject(new Error("OSC query + marker never appeared in live output within 10 s")),
         10_000,
       );
     });
@@ -474,12 +481,15 @@ describe("terminal WebSocket — OSC color-query stripping on scrollback replay"
 
     // Ordinary output survived replay.
     expect(replay.includes(MARKER)).toBe(true);
-    // Both OSC forms — the `?` query and the `rgb:` report — were stripped.
+    // Every OSC form — the `?` query (11/12) and the `rgb:` report (10) — was
+    // stripped.
     expect(replay.includes(Buffer.from(OSC11_QUERY))).toBe(false);
     expect(replay.includes(Buffer.from(OSC10_REPORT))).toBe(false);
+    expect(replay.includes(Buffer.from(OSC12_QUERY))).toBe(false);
     // Nothing starting an OSC 10/11/12 escape (`ESC ] 1x`) should remain.
     expect(replay.includes(Buffer.from("\x1b]10"))).toBe(false);
     expect(replay.includes(Buffer.from("\x1b]11"))).toBe(false);
+    expect(replay.includes(Buffer.from("\x1b]12"))).toBe(false);
   });
 
   // The second replay path (band-app/band#613): the tRPC `terminal.stream`
@@ -540,7 +550,35 @@ describe("terminal WebSocket — OSC color-query stripping on scrollback replay"
     expect(firstOutput).toContain(MARKER);
     expect(firstOutput).not.toContain(OSC11_QUERY);
     expect(firstOutput).not.toContain(OSC10_REPORT);
+    expect(firstOutput).not.toContain(OSC12_QUERY);
     expect(firstOutput).not.toContain("\x1b]10");
     expect(firstOutput).not.toContain("\x1b]11");
+    expect(firstOutput).not.toContain("\x1b]12");
+  });
+
+  // TEST-13: negative auth. The WebSocket upgrade and every HTTP request are
+  // gated on the `band_token` cookie (see start-server.ts upgrade handler and
+  // auth.ts). Assert both surfaces reject a request with no token.
+  it("rejects unauthenticated access: WS upgrade dropped and HTTP returns 401", async () => {
+    // HTTP: no cookie → 401 from the auth middleware.
+    const res = await fetch(`${server.url}/api/health`);
+    expect(res.status).toBe(401);
+
+    // WebSocket: no cookie → the upgrade handler destroys the socket before
+    // the 101 handshake, so the client never opens. Assert we observe a
+    // failure (error / unexpected-response / close) and never an `open`.
+    const wsUrl = `ws://127.0.0.1:${server.port}/terminal?workspaceId=${WORKSPACE_ID}&terminalId=noauth`;
+    const ws = new WebSocket(wsUrl); // deliberately no Cookie header
+
+    const opened = await new Promise<boolean>((resolve, reject) => {
+      ws.on("open", () => resolve(true));
+      ws.on("error", () => resolve(false));
+      ws.on("unexpected-response", () => resolve(false));
+      ws.on("close", () => resolve(false));
+      setTimeout(() => reject(new Error("No open/error/close within 10 s")), 10_000);
+    });
+
+    expect(opened).toBe(false);
+    ws.close();
   });
 });

--- a/apps/web/tests/terminal-ws.test.ts
+++ b/apps/web/tests/terminal-ws.test.ts
@@ -25,8 +25,10 @@ import { mkdirSync, mkdtempSync, realpathSync, rmSync } from "node:fs";
 import { createServer } from "node:net";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { createTRPCClient, createWSClient, wsLink } from "@trpc/client";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { WebSocket } from "ws";
+import type { AppRouter } from "../src/server/api/router";
 import { seedSettings, seedState } from "./helpers/seed-state";
 import { SERVER_RUNTIME, SERVER_SCRIPT } from "./helpers/server-runtime";
 
@@ -373,61 +375,52 @@ describe("terminal WebSocket — OSC color-query stripping on scrollback replay"
     if (tmpHome) rmSync(tmpHome, { recursive: true, force: true });
   });
 
-  // Regression for band-app/band#613: a stale OSC 10/11/12 color query sitting
-  // in scrollback used to survive replay (stripTerminalQueries only matched CSI
-  // sequences). The client's xterm.js then answered the replayed query, the
-  // dashboard forwarded the answer to the PTY, and the shell's line editor
-  // inserted the printable remainder (`11;rgb:1e1e/1e1e/1e1e…`) as literal text
-  // at the prompt. This test proves the OSC bytes are stripped from replayed
-  // scrollback while ordinary output survives.
-  it("strips OSC 10/11 sequences from replayed scrollback but keeps normal output", async () => {
-    const workspaceId = "workspace-main";
-    const terminalId = "osc-strip-terminal";
-    const wsUrl = `ws://127.0.0.1:${server.port}/terminal?workspaceId=${workspaceId}&terminalId=${terminalId}`;
+  // OSC 11 (background) query + OSC 10 (foreground) rgb: report, plus a
+  // marker whose *source text* (`DONE""MARKER`) differs from its emitted
+  // output (`DONEMARKER`), so the marker we assert on can only come from
+  // executed output — never the shell's echo of the typed command line.
+  // `\\033`/`\\007` are literal backslash-escapes handed to the shell's
+  // printf; only its *execution* produces the raw ESC (0x1b) / BEL (0x07)
+  // bytes that end up in scrollback.
+  const OSC11_QUERY = "\x1b]11;?\x07";
+  const OSC10_REPORT = "\x1b]10;rgb:e8e8/e8e8/e8e8\x07";
+  const MARKER = "DONEMARKER";
+  const COMMAND = "printf '\\033]11;?\\007\\033]10;rgb:e8e8/e8e8/e8e8\\007'; echo DONE\"\"MARKER\r";
 
-    // OSC 11 (background) query + OSC 10 (foreground) rgb: report, plus a
-    // marker whose *source text* (`DONE""MARKER`) differs from its emitted
-    // output (`DONEMARKER`), so the marker we assert on can only come from
-    // executed output — never the shell's echo of the typed command line.
-    // `\\033`/`\\007` are literal backslash-escapes handed to the shell's
-    // printf; only its *execution* produces the raw ESC (0x1b) / BEL (0x07)
-    // bytes that end up in scrollback.
-    const OSC11_QUERY = "\x1b]11;?\x07";
-    const OSC10_REPORT = "\x1b]10;rgb:e8e8/e8e8/e8e8\x07";
-    const MARKER = "DONEMARKER";
-    const command =
-      "printf '\\033]11;?\\007\\033]10;rgb:e8e8/e8e8/e8e8\\007'; echo DONE\"\"MARKER\r";
+  const WORKSPACE_ID = "workspace-main";
 
-    // --- Connection 1: spawn the PTY, run the command, wait until the raw
-    //     OSC bytes appear in live output (proving they're now in scrollback).
-    const ws1 = new WebSocket(wsUrl, {
-      headers: { Cookie: `band_token=${DEFAULT_TOKEN}` },
-    });
+  // Spawn a PTY over the `/terminal` WebSocket, run the OSC-emitting command,
+  // and resolve only once the raw OSC bytes have appeared in live output —
+  // which guarantees they are now buffered in the server-side scrollback.
+  // Then close the socket; the pool keeps the PTY alive for reconnect/replay.
+  async function seedOscScrollback(terminalId: string): Promise<void> {
+    const wsUrl = `ws://127.0.0.1:${server.port}/terminal?workspaceId=${WORKSPACE_ID}&terminalId=${terminalId}`;
+    const ws = new WebSocket(wsUrl, { headers: { Cookie: `band_token=${DEFAULT_TOKEN}` } });
 
     let live = Buffer.alloc(0);
     let sentCommand = false;
 
     await new Promise<void>((resolve, reject) => {
-      ws1.on("open", () => {
-        ws1.send(JSON.stringify({ type: "init" }));
+      ws.on("open", () => {
+        ws.send(JSON.stringify({ type: "init" }));
       });
-      ws1.on("message", (data: Buffer, isBinary: boolean) => {
+      ws.on("message", (data: Buffer, isBinary: boolean) => {
         if (!sentCommand) {
           // First frame proves the session is attached and the persistent
           // message listener is live — now send the command.
           sentCommand = true;
-          ws1.send(command);
+          ws.send(COMMAND);
           return;
         }
         if (!isBinary) return; // skip JSON control frames (title, etc.)
         live = Buffer.concat([live, data]);
         // Live output is NOT stripped, so the raw OSC 11 query round-trips
         // here. Once we see it, the bytes are guaranteed in scrollback.
-        if (live.includes(Buffer.from(OSC11_QUERY, "binary"))) {
+        if (live.includes(Buffer.from(OSC11_QUERY))) {
           resolve();
         }
       });
-      ws1.on("error", reject);
+      ws.on("error", reject);
       setTimeout(
         () => reject(new Error("OSC query never appeared in live output within 10 s")),
         10_000,
@@ -435,12 +428,25 @@ describe("terminal WebSocket — OSC color-query stripping on scrollback replay"
     });
 
     await new Promise<void>((r) => {
-      ws1.on("close", () => r());
-      ws1.close();
+      ws.on("close", () => r());
+      ws.close();
     });
+  }
 
-    // --- Connection 2: reconnect to the same terminal. The server replays
-    //     the buffered scrollback through stripTerminalQueries.
+  // Regression for band-app/band#613: a stale OSC 10/11/12 color query sitting
+  // in scrollback used to survive replay (stripTerminalQueries only matched CSI
+  // sequences). The client's xterm.js then answered the replayed query, the
+  // dashboard forwarded the answer to the PTY, and the shell's line editor
+  // inserted the printable remainder (`11;rgb:1e1e/1e1e/1e1e…`) as literal text
+  // at the prompt. This test proves the OSC bytes are stripped from replayed
+  // scrollback while ordinary output survives.
+  it("strips OSC 10/11 sequences from WebSocket scrollback replay but keeps normal output", async () => {
+    const terminalId = "osc-strip-ws";
+    await seedOscScrollback(terminalId);
+
+    // Reconnect to the same terminal. The server replays the buffered
+    // scrollback through stripTerminalQueries on the `/terminal` WS path.
+    const wsUrl = `ws://127.0.0.1:${server.port}/terminal?workspaceId=${WORKSPACE_ID}&terminalId=${terminalId}`;
     const ws2 = new WebSocket(wsUrl, {
       headers: { Cookie: `band_token=${DEFAULT_TOKEN}` },
     });
@@ -469,10 +475,72 @@ describe("terminal WebSocket — OSC color-query stripping on scrollback replay"
     // Ordinary output survived replay.
     expect(replay.includes(MARKER)).toBe(true);
     // Both OSC forms — the `?` query and the `rgb:` report — were stripped.
-    expect(replay.includes(Buffer.from(OSC11_QUERY, "binary"))).toBe(false);
-    expect(replay.includes(Buffer.from(OSC10_REPORT, "binary"))).toBe(false);
+    expect(replay.includes(Buffer.from(OSC11_QUERY))).toBe(false);
+    expect(replay.includes(Buffer.from(OSC10_REPORT))).toBe(false);
     // Nothing starting an OSC 10/11/12 escape (`ESC ] 1x`) should remain.
-    expect(replay.includes(Buffer.from("\x1b]10", "binary"))).toBe(false);
-    expect(replay.includes(Buffer.from("\x1b]11", "binary"))).toBe(false);
+    expect(replay.includes(Buffer.from("\x1b]10"))).toBe(false);
+    expect(replay.includes(Buffer.from("\x1b]11"))).toBe(false);
+  });
+
+  // The second replay path (band-app/band#613): the tRPC `terminal.stream`
+  // subscription replays scrollback before streaming live output. It
+  // previously replayed raw scrollback with no stripping at all, so the same
+  // OSC leak applied. This drives the real tRPC client over the production WS
+  // transport and asserts the first replayed `output` frame is stripped.
+  it("strips OSC 10/11 sequences from the tRPC terminal.stream scrollback replay", async () => {
+    const terminalId = "osc-strip-trpc";
+    await seedOscScrollback(terminalId);
+
+    // The tRPC WS transport authenticates via the same `band_token` cookie the
+    // HTTP upgrade handler checks. `createWSClient` constructs its socket as
+    // `new WebSocket(url, protocols)` with no way to set headers, so wrap the
+    // `ws` implementation to always attach the cookie.
+    class CookieWebSocket extends WebSocket {
+      constructor(address: string, protocols?: string | string[]) {
+        super(address, protocols, {
+          headers: { Cookie: `band_token=${DEFAULT_TOKEN}` },
+        });
+      }
+    }
+
+    const wsClient = createWSClient({
+      url: `ws://127.0.0.1:${server.port}/trpc`,
+      WebSocket: CookieWebSocket as unknown as typeof globalThis.WebSocket,
+    });
+    const client = createTRPCClient<AppRouter>({ links: [wsLink({ client: wsClient })] });
+
+    // The subscription replays scrollback as its first `output` event.
+    const firstOutput = await new Promise<string>((resolve, reject) => {
+      const timer = setTimeout(
+        () => reject(new Error("No output event from terminal.stream within 10 s")),
+        10_000,
+      );
+      const sub = client.terminal.stream.subscribe(
+        { terminalId, replay: true },
+        {
+          onData: (evt) => {
+            if (evt.type === "output") {
+              clearTimeout(timer);
+              sub.unsubscribe();
+              resolve(evt.data);
+            }
+          },
+          onError: (err) => {
+            clearTimeout(timer);
+            reject(err);
+          },
+        },
+      );
+    });
+
+    wsClient.close();
+
+    // The replayed scrollback (a plain string on this path) kept normal
+    // output but had every OSC sequence stripped.
+    expect(firstOutput).toContain(MARKER);
+    expect(firstOutput).not.toContain(OSC11_QUERY);
+    expect(firstOutput).not.toContain(OSC10_REPORT);
+    expect(firstOutput).not.toContain("\x1b]10");
+    expect(firstOutput).not.toContain("\x1b]11");
   });
 });


### PR DESCRIPTION
## Summary

Fixes #613 — OSC 10/11/12 color-query responses leaked into the shell prompt as literal text (e.g. `10;rgb:e8e8/e8e8/e8e811;rgb:1e1e/1e1e/1e1e`) on terminal reconnect.

**Root cause:** `stripTerminalQueries` only matched CSI sequences (`ESC [ … n/c`), so OSC color queries (`ESC ] 1x ; …`) sitting in replayed scrollback survived. On reconnect the server replays scrollback, xterm.js answers the replayed query per spec via `onData()`, the frontend forwards the answer to the PTY stdin, and the shell's line editor inserts the printable remainder as literal text at the prompt. Live output never triggers this — the leak is specific to replaying a stale query with no matching reader.

## Changes

- **Extract** `stripTerminalQueries` from `ws.ts` into a shared module `apps/web/src/server/api/terminals/strip-queries.ts`.
- **Extend** it to also strip OSC 10/11/12 color queries/reports — `ESC ] 1[012] ; …` terminated by BEL (`\x07`) or ST (`ESC \`), covering both the `?` query form and any `rgb:` report form. The terminator is **optional** so an *unterminated* opener (scrollback ending mid-sequence at a PTY chunk boundary) is also stripped; because the negated payload class stops at any ESC, the optional terminator never eats a following escape sequence. Linear-time, no ReDoS.
- **Apply the strip to all three scrollback surfaces** that can feed a terminal emulator:
  1. the `/terminal` **WebSocket** replay (the live UI path),
  2. the tRPC **`terminal.stream`** subscription replay (previously replayed raw scrollback with no stripping at all — it also missed CSI queries),
  3. the tRPC **`terminal.output`** query (point-in-time scrollback fetch — stripped as defense-in-depth; query/report escapes carry no display value in a scrollback read).

## Testing

New integration tests in `terminal-ws.test.ts`, all black-box through the real production server bundle (no mocking of own routes):

- WebSocket scrollback replay strips OSC 10/11/12 while ordinary output survives (asserts on the single replay frame).
- tRPC `terminal.stream` replay strips OSC — driven by the real tRPC client over the production WS transport.
- tRPC `terminal.output` query strips OSC — driven by the real tRPC HTTP client.
- Negative-auth coverage (TEST-13): HTTP without the `band_token` cookie returns 401; a `/terminal` WS upgrade without it is rejected.

Each stripping test was verified to fail without its corresponding production fix.

- `pnpm check` (biome + cargo fmt --check + clippy): ✅
- `pnpm --filter @band-app/server test`: ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)