### PR TITLE
fix(web): repaint terminal on every workspace switch, not just once

### DIFF
--- a/apps/web/e2e/terminal-switch-repaint.spec.ts
+++ b/apps/web/e2e/terminal-switch-repaint.spec.ts
@@ -228,11 +228,21 @@ test.describe("Terminal repaint on plain workspace switch", () => {
     // repair stayed "done" (nothing re-armed it), so become-visible only
     // called `fit()` (resizing the SAME canvases at most) and the tags would
     // survive → this poll times out → the test fails before the fix.
+    //
+    // Require `canvasCount > 0` in the same poll: mid-rebuild there is a window
+    // where the old surface has been disposed and the fresh one not yet
+    // attached, during which `survivingTags` is trivially 0 with no canvas
+    // present. Pairing the conditions ensures we only accept a 0 that means "a
+    // real surface exists and none of it is tagged", never a vacuous 0.
     await expect
-      .poll(async () => (await workspacePage.readTerminalSurface(WORKSPACE_A)).survivingTags, {
-        timeout: 20_000,
-      })
-      .toBe(0);
+      .poll(
+        async () => {
+          const s = await workspacePage.readTerminalSurface(WORKSPACE_A);
+          return s.canvasCount > 0 && s.survivingTags === 0;
+        },
+        { timeout: 20_000 },
+      )
+      .toBe(true);
 
     // Positive correctness anchor: the rebuilt surface is sized to the now-
     // visible container — its WebGL backing store matches the `.xterm-screen`

--- a/apps/web/e2e/terminal-switch-repaint.spec.ts
+++ b/apps/web/e2e/terminal-switch-repaint.spec.ts
@@ -1,0 +1,261 @@
+/**
+ * Regression coverage for band-app/band#615 — "terminal renders garbled on a
+ * plain workspace switch; a manual resize fixes it".
+ *
+ * The bug
+ * -------
+ * A terminal that took its FIRST paint while VISIBLE has a known-good WebGL
+ * surface. But once its workspace is switched away, the `MultiWorkspacePanelHost`
+ * LRU keeps it mounted under `content-visibility: hidden` — the browser skips
+ * layout + paint for the subtree, which can drop the WebGL backing store or
+ * leave the rendered glyphs stale. On switching BACK, the old become-visible
+ * effect took the cheap branch (a bare `fitAddon.fit()`), because
+ * `firstVisiblePaintDoneRef` was already `true` from the visible first paint and
+ * no zoom/DPR event had re-armed the one-shot repair. `fit()` early-returns when
+ * the now-visible container resolves to the SAME cols/rows it computed while
+ * hidden — no reflow, no renderer repaint — so the garbled frame stayed on
+ * screen until a manual window resize changed the dimensions.
+ *
+ * The fix (`TerminalPanel.tsx`)
+ * -----------------------------
+ * The one-shot `firstVisiblePaintDoneRef` gate is dropped: become-visible now
+ * ALWAYS re-measures cell geometry and re-attaches the WebGL addon (dispose the
+ * suspect surface, size a fresh <canvas> against the live layout) — the same
+ * recovery the DPR/zoom paths use — then forces an unconditional `refresh()`.
+ *
+ * How this test discriminates old vs new code
+ * -------------------------------------------
+ * The visible garble is a GPU-pixel artifact not reproducible in headless
+ * Chromium (see the sibling `terminal-background-repaint.spec.ts` for the
+ * empirical reasons), so we observe the surface REBUILD instead — the exact
+ * action that repairs the corruption in production. Tag the canvases of A's
+ * visible-first-paint surface while A is hidden, switch back to A, and assert
+ * the tags are gone (a brand-new backing store). Pre-fix code took the bare
+ * `fit()` branch and left the tagged canvases in place, so this fails before the
+ * fix and passes after.
+ *
+ * Crucial precondition vs the sibling specs
+ * -----------------------------------------
+ *  - `terminal-background-repaint.spec.ts`: A's FIRST paint happens while
+ *    hidden, so the (old) first-paint-while-hidden repair applies.
+ *  - `terminal-zoom-hidden-repaint.spec.ts`: A first paints visible, then a
+ *    zoom event while hidden re-arms the (old) one-shot repair.
+ *  - THIS spec: A first paints visible AND there is NO zoom — a plain
+ *    hide→show. Pre-fix, NOTHING re-armed the one-shot repair, so it never
+ *    rebuilt the surface. This is the gap #615 reported and the fix closes.
+ *
+ * Doctrine notes
+ * --------------
+ *  - Real production server (`startServer`), real PTYs (the two projects are
+ *    `git init`-ed real dirs so they classify as "git", which renders the
+ *    sidebar cards `switchWorkspace` needs and gives the PTY a real cwd).
+ *  - No tRPC mocking, no `page.route` on our own routes. The only external-
+ *    boundary control is the Chromium launch flags that turn on SwiftShader
+ *    WebGL so the headless renderer matches production's WebGL default.
+ *  - Driven entirely through `WorkspacePage`.
+ */
+
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, realpathSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { expect, test } from "@playwright/test";
+import { toWorkspaceId } from "@/dashboard";
+import {
+  cleanupTmpHome,
+  createTmpHome,
+  type ServerHandle,
+  seedSettings,
+  seedState,
+  startServer,
+} from "./helpers/server";
+import { WorkspacePage } from "./pages/WorkspacePage";
+
+const TOKEN = "e2e-terminal-switch-repaint-token";
+
+const PROJECT_A = "alpha-switch-repaint";
+const PROJECT_B = "bravo-switch-repaint";
+const WORKSPACE_A = toWorkspaceId(PROJECT_A, "main");
+const WORKSPACE_B = toWorkspaceId(PROJECT_B, "main");
+
+// Wide viewport so `useIsDesktop()` reports true and the shared dockview (which
+// hosts the terminal container) renders. The WebGL flags force the SwiftShader
+// renderer on so xterm attaches a real <canvas> — without them headless
+// Chromium falls back to xterm's DOM renderer and there is no surface to
+// rebuild, which would make this test vacuous.
+test.use({
+  viewport: { width: 1280, height: 800 },
+  launchOptions: {
+    args: [
+      "--use-gl=angle",
+      "--use-angle=swiftshader",
+      "--enable-unsafe-swiftshader",
+      "--ignore-gpu-blocklist",
+      "--enable-webgl",
+    ],
+  },
+});
+
+// Definite-assignment: all four are set in `beforeAll`. The `!` lets `afterAll`
+// reference them while still guarding `server` (the only one that can be left
+// unassigned if `startServer` throws mid-boot).
+let server!: ServerHandle;
+let tmpHome!: string;
+let workdirA!: string;
+let workdirB!: string;
+
+/** Hermetic git environment: an explicit allowlist (no `process.env` spread)
+ *  with `GIT_CONFIG_GLOBAL` / `GIT_CONFIG_SYSTEM` pointed at /dev/null so a
+ *  contributor's host git config can't leak in and hang or skew the setup.
+ *  Mirrors `terminal-zoom-hidden-repaint.spec.ts`. */
+function makeGitEnv(home: string): NodeJS.ProcessEnv {
+  return {
+    PATH: process.env.PATH,
+    HOME: home,
+    GIT_AUTHOR_NAME: "Test",
+    GIT_AUTHOR_EMAIL: "test@example.com",
+    GIT_COMMITTER_NAME: "Test",
+    GIT_COMMITTER_EMAIL: "test@example.com",
+    GIT_CONFIG_GLOBAL: "/dev/null",
+    GIT_CONFIG_SYSTEM: "/dev/null",
+  };
+}
+
+/** A `git init`-ed temp dir: real on disk (so the PTY can spawn with it as
+ *  cwd) and containing a `.git` (so the project classifies as "git" and the
+ *  sidebar renders a clickable workspace card for its default branch).
+ *  `init -b main` forces the initial branch name so a host whose git defaults
+ *  to `master` doesn't make the worktree poller rewrite the seeded `main`. */
+function makeGitWorkdir(prefix: string, home: string): string {
+  const dir = realpathSync(mkdtempSync(join(tmpdir(), prefix)));
+  const env = makeGitEnv(home);
+  execFileSync("git", ["init", "-q", "-b", "main"], { cwd: dir, env });
+  execFileSync("git", ["commit", "-q", "--allow-empty", "-m", "init"], { cwd: dir, env });
+  return dir;
+}
+
+test.beforeAll(async () => {
+  tmpHome = createTmpHome();
+  workdirA = makeGitWorkdir("band-switch-repaint-a-", tmpHome);
+  workdirB = makeGitWorkdir("band-switch-repaint-b-", tmpHome);
+  seedState(tmpHome, {
+    projects: [
+      {
+        name: PROJECT_A,
+        path: workdirA,
+        defaultBranch: "main",
+        worktrees: [{ branch: "main", path: workdirA }],
+      },
+      {
+        name: PROJECT_B,
+        path: workdirB,
+        defaultBranch: "main",
+        worktrees: [{ branch: "main", path: workdirB }],
+      },
+    ],
+  });
+  seedSettings(tmpHome, { tokenSecret: TOKEN });
+  server = await startServer({ tmpHome });
+});
+
+test.afterAll(async () => {
+  // Guard `server`: if `startServer` threw mid-boot it's unassigned, and a
+  // bare `server.close()` would mask the real boot failure with a TypeError.
+  if (server) await server.close();
+  if (tmpHome) cleanupTmpHome(tmpHome);
+  if (workdirA) rmSync(workdirA, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 });
+  if (workdirB) rmSync(workdirB, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 });
+});
+
+test.describe("Terminal repaint on plain workspace switch", () => {
+  test("switching back to a cached workspace rebuilds its terminal's WebGL surface without a manual resize", async ({
+    page,
+  }) => {
+    const workspacePage = new WorkspacePage(page, server.url, TOKEN);
+
+    // Land on A and open its Terminal tab WHILE A IS ACTIVE/VISIBLE. This is
+    // the discriminating precondition: A's terminal takes its first paint
+    // visible, so the (old) first-paint-while-hidden repair does NOT apply.
+    await workspacePage.goto(WORKSPACE_A);
+    await workspacePage.waitForReady();
+    await workspacePage.openTerminalTab();
+    await expect(workspacePage.terminalTabVisibilityMarker(WORKSPACE_A, true)).toBeVisible({
+      timeout: 20_000,
+    });
+
+    // Wait for A's terminal to attach its WebGL surface while visible. This
+    // also asserts the WebGL precondition: without SwiftShader the addon would
+    // fall back to the DOM renderer, no <canvas> would exist, and this poll
+    // would (correctly) fail loudly rather than the test passing vacuously.
+    await expect
+      .poll(async () => (await workspacePage.readTerminalSurface(WORKSPACE_A)).canvasCount, {
+        timeout: 20_000,
+      })
+      .toBeGreaterThan(0);
+
+    // Switch to B via the sidebar. A stays MOUNTED in the LRU cache but
+    // inactive (`wsActive=false`), so A's terminal flips visible → hidden. In-
+    // app navigation (sidebar click), not `goto()`, is what keeps A cached.
+    await workspacePage.switchWorkspace(WORKSPACE_B);
+    // Confirm B is actually active/visible AND A is hidden before we tag — a
+    // sidebar click can land on B's route before B's panels finish rendering,
+    // and we don't want to tag while the layout is still settling.
+    await expect(workspacePage.terminalTabVisibilityMarker(WORKSPACE_B, true)).toBeVisible({
+      timeout: 20_000,
+    });
+    await expect(workspacePage.terminalTabVisibilityMarker(WORKSPACE_A, false)).toBeAttached({
+      timeout: 20_000,
+    });
+
+    // Tag the canvases of A's (visible-first-paint) surface while it's hidden.
+    // NO zoom / DPR event fires in this scenario — that's the whole point: the
+    // pre-fix one-shot repair had nothing to re-arm it.
+    const tagged = await workspacePage.tagTerminalCanvases(WORKSPACE_A);
+    expect(tagged).toBeGreaterThan(0);
+
+    // Bring A back to the foreground and re-activate its Terminal tab so A's
+    // terminal flips hidden → visible — the become-visible transition the fix
+    // hooks. This is a plain workspace switch: no resize, no zoom.
+    await workspacePage.switchWorkspace(WORKSPACE_A);
+    await workspacePage.openTerminalTab();
+    await expect(workspacePage.terminalTabVisibilityMarker(WORKSPACE_A, true)).toBeVisible({
+      timeout: 20_000,
+    });
+
+    // The discriminating assertion: with the fix, become-visible ALWAYS
+    // disposes the surface built/held while hidden and re-attaches a fresh
+    // WebGL addon — none of the tagged canvases survive. Pre-fix, the one-shot
+    // repair stayed "done" (nothing re-armed it), so become-visible only
+    // called `fit()` (resizing the SAME canvases at most) and the tags would
+    // survive → this poll times out → the test fails before the fix.
+    await expect
+      .poll(async () => (await workspacePage.readTerminalSurface(WORKSPACE_A)).survivingTags, {
+        timeout: 20_000,
+      })
+      .toBe(0);
+
+    // Positive correctness anchor: the rebuilt surface is sized to the now-
+    // visible container — its WebGL backing store matches the `.xterm-screen`
+    // rect (× devicePixelRatio). A surface left sized to the hidden layout
+    // would mismatch here. Poll until the screen rect has settled to a non-zero
+    // size before asserting, so a snapshot taken mid-layout can't read 0×0.
+    await expect
+      .poll(
+        async () => {
+          const s = await workspacePage.readTerminalSurface(WORKSPACE_A);
+          return s.canvasCount > 0 && s.screen.w > 0 && s.screen.h > 0;
+        },
+        { timeout: 20_000 },
+      )
+      .toBe(true);
+    const surface = await workspacePage.readTerminalSurface(WORKSPACE_A);
+    // Guard against a vacuous pass: if this snapshot caught the surface
+    // mid-relayout with zero canvases, the `for` loop below would make zero
+    // assertions and pass silently. Assert there's a backing store to check.
+    expect(surface.backing.length).toBeGreaterThan(0);
+    for (const backing of surface.backing) {
+      expect(Math.abs(backing.w - surface.screen.w * surface.dpr)).toBeLessThanOrEqual(2);
+      expect(Math.abs(backing.h - surface.screen.h * surface.dpr)).toBeLessThanOrEqual(2);
+    }
+  });
+});

--- a/apps/web/src/components/TerminalPanel.tsx
+++ b/apps/web/src/components/TerminalPanel.tsx
@@ -1147,12 +1147,25 @@ export function TerminalPanel({
     // Defer past a frame so the just-un-hidden layout has settled before we
     // measure. Cancel on cleanup so a rapid hide→show→hide can't leave a
     // stale callback fitting against a re-hidden (degenerate) layout.
-    const rafId = requestAnimationFrame(() => {
-      // Skip while the container still reports zero size — fitting against a
-      // 0×0 box would compute nonsense cols/rows. The ResizeObserver's own
-      // `fit()` repairs it once layout resolves to a real size.
+    let rafId = 0;
+    // Bound the retry below so a container that stays genuinely zero-sized
+    // (e.g. surfaced then immediately re-hidden) can't spin frame after frame.
+    // A handful of frames is ample for `content-visibility: hidden → visible`
+    // to lay the subtree back out.
+    const MAX_LAYOUT_FRAMES = 5;
+    const repair = (attempt: number) => {
       const container = containerRef.current;
-      if (!container || container.clientWidth === 0 || container.clientHeight === 0) return;
+      if (!container || container.clientWidth === 0 || container.clientHeight === 0) {
+        // Layout hasn't settled yet. `content-visibility: hidden → visible`
+        // preserves the last-rendered size, so it may NOT fire the
+        // ResizeObserver on un-hide — we can't rely on that observer to retry
+        // the repair for us. Re-check on the next frame instead, capped so a
+        // permanently zero-sized container can't loop forever.
+        if (attempt < MAX_LAYOUT_FRAMES) {
+          rafId = requestAnimationFrame(() => repair(attempt + 1));
+        }
+        return;
+      }
       const remeasure = remeasureAndReattachRef.current;
       if (remeasure) {
         // `remeasureAndReattach` fits internally, so we don't call `fit()`
@@ -1172,7 +1185,8 @@ export function TerminalPanel({
       if (term && ws?.readyState === WebSocket.OPEN && term.cols > 0 && term.rows > 0) {
         ws.send(JSON.stringify({ type: "resize", cols: term.cols, rows: term.rows }));
       }
-    });
+    };
+    rafId = requestAnimationFrame(() => repair(0));
     return () => cancelAnimationFrame(rafId);
   }, [visible]);
 

--- a/apps/web/src/components/TerminalPanel.tsx
+++ b/apps/web/src/components/TerminalPanel.tsx
@@ -167,25 +167,13 @@ export function TerminalPanel({
   // separate visibility-change effect below. Same ref-routing pattern as
   // `fitAddonRef` / `terminalRef` — the closure has local context (the
   // live `attachWebGL`, `fitAddon`, etc.) that can't be reconstructed
-  // outside the init effect. Used to force one clean repaint when a
-  // terminal whose first paint happened while hidden becomes visible: such
-  // a terminal renders garbled (its WebGL surface was built against a
-  // hidden/degenerate layout) and a plain `fit()` won't repair it when the
-  // visible layout resolves to the same cols/rows.
+  // outside the init effect. Used to force a clean re-measure + WebGL
+  // re-attach every time this terminal becomes visible, repairing a render
+  // surface whose backing store was dropped or built against a
+  // hidden/degenerate layout while the workspace sat in the background LRU
+  // cache under `content-visibility: hidden` (see the become-visible effect
+  // below and band-app/band#615).
   const remeasureAndReattachRef = useRef<(() => void) | null>(null);
-  // True once this terminal has completed a paint while visible — i.e. its
-  // render surface is known-good. Set when the WebGL addon attaches while
-  // the panel is already visible (the common case), or after the one-shot
-  // hidden-surface repair below. Gates that repair so it fires AT MOST ONCE
-  // per mount: without this gate the `remeasureAndReattach` ref is non-null
-  // forever after init, so every workspace tab-switch back to this terminal
-  // would needlessly dispose + re-attach the WebGL addon.
-  const firstVisiblePaintDoneRef = useRef(false);
-  // Mirrors the latest `visible` prop so the async init effect can read the
-  // panel's visibility at WebGL-attach time (its deps don't include
-  // `visible`, so the closure would otherwise see the stale mount value).
-  const visibleRef = useRef(visible);
-  visibleRef.current = visible;
   const onTitleChangeRef = useRef(onTitleChange);
   onTitleChangeRef.current = onTitleChange;
 
@@ -993,32 +981,13 @@ export function TerminalPanel({
           attachWebGL();
         }
         fitAddon.fit();
-        // App-zoom (and DPR) events fire on EVERY mounted terminal, including
-        // those in cached, hidden background workspaces. When this dance runs
-        // while the panel is hidden, the WebGL surface we just re-attached and
-        // the `fit()` we just computed are sized against a hidden/degenerate
-        // layout — the exact hazard the become-visible repair below was built
-        // for (band-app/band#580). The one-shot repair flag is already `true`
-        // from the initial visible mount, so without this re-arm the next
-        // become-visible would only call a bare `fit()`, which early-returns
-        // when cols/rows are unchanged and leaves a stale frame (notably a
-        // missing scrollbar) until a manual resize. Re-arm so the next
-        // become-visible does a full re-measure + re-attach instead.
-        if (!visibleRef.current) {
-          firstVisiblePaintDoneRef.current = false;
-        }
       };
-      // Expose to the visibility-change effect so a terminal that first
-      // painted while hidden can force a clean re-measure + repaint when
-      // it becomes visible. Bound to the no-arg (re-measure-only) form;
-      // the zoom path keeps calling the local closure directly with its
-      // `{ newFontSize }` argument.
+      // Expose to the visibility-change effect so it can force a clean
+      // re-measure + WebGL re-attach every time this terminal becomes
+      // visible. Bound to the no-arg (re-measure-only) form; the zoom path
+      // keeps calling the local closure directly with its `{ newFontSize }`
+      // argument.
       remeasureAndReattachRef.current = () => remeasureAndReattach();
-      // Record whether the WebGL surface was built against a VISIBLE layout.
-      // If so it's already correct and the become-visible effect must NOT
-      // rebuild it; if the panel is hidden right now, the surface is suspect
-      // and the first become-visible will repair it exactly once.
-      firstVisiblePaintDoneRef.current = visibleRef.current;
       // DPR-only path: bail out if DPR didn't actually change; otherwise
       // run the re-measure dance. DOM renderer is a no-op (CSS sizing
       // handles DPR natively) — `remeasureAndReattach` already handles
@@ -1131,8 +1100,6 @@ export function TerminalPanel({
         searchAddonRef.current = null;
         webglAddonRef.current = null;
         remeasureAndReattachRef.current = null;
-        // Re-arm the one-shot hidden-surface repair for the next mount.
-        firstVisiblePaintDoneRef.current = false;
         wsRef.current = null;
         // Reset toolbar state so a remount (e.g. terminal reconnect) doesn't
         // come back up with selection mode armed against a buffer row that
@@ -1152,45 +1119,61 @@ export function TerminalPanel({
     };
   }, [terminalId, workspaceId, paneMetadata, autoFocus]);
 
-  // Refit when visibility changes and notify server of new size.
+  // Repair the render surface on EVERY hidden→visible transition.
   //
-  // A terminal whose first paint happened while its workspace was a hidden
-  // background tab establishes its WebGL backing store and cell geometry
-  // against a hidden/degenerate layout — the first frames render garbled.
-  // Re-fitting alone does NOT repair that: when the now-visible container
-  // resolves to the SAME cols/rows `fit()` already computed while hidden,
-  // xterm's `resize()` early-returns (no reflow, no renderer repaint) so
-  // the stale garbled frame stays on screen until a manual window resize
-  // changes the dimensions.
+  // While a workspace sits in the background LRU cache its panel host is
+  // `content-visibility: hidden` (see MultiWorkspacePanelHost), so the
+  // browser skips layout + paint for the subtree and may drop the terminal's
+  // WebGL backing store or leave its rendered glyphs stale. Coming back to
+  // the foreground then shows a garbled frame — overlapping text, wrong
+  // wrapping, misaligned glyphs.
   //
-  // So the FIRST time a terminal with a hidden first paint becomes visible
-  // we re-measure cell size and re-attach the WebGL addon (disposing the
-  // corrupted backing store and sizing a fresh canvas against the live
-  // layout) — the same recovery the DPR/zoom paths use — which repaints
-  // every cell from scratch regardless of whether the dimensions changed.
-  // This repair runs at most once per mount (`firstVisiblePaintDoneRef`):
-  // a terminal that first painted while visible never needs it, and every
-  // later visibility flip just re-fits, so we don't pay a full WebGL
-  // dispose + re-attach on every workspace tab-switch back to the terminal.
+  // A bare `fit()` can't repair it: when the now-visible container resolves
+  // to the SAME cols/rows `fit()` already computed while hidden, xterm's
+  // `resize()` early-returns — no reflow, no renderer repaint — so the stale
+  // frame survives until a manual window resize changes the dimensions (the
+  // one case that dodges the early-return, which is why resizing "fixes" it).
+  //
+  // So on become-visible we re-measure cell geometry and re-attach the WebGL
+  // addon (dispose the suspect surface, size a fresh <canvas> against the
+  // live layout) — the same recovery the DPR/zoom paths use — then force an
+  // unconditional `refresh()` so every cell repaints even under the DOM
+  // renderer (no addon to re-attach) regardless of whether cols/rows changed.
+  // Unlike the earlier one-shot repair (band-app/band#580) this runs on
+  // every transition, because a plain hide→show can corrupt the surface just
+  // as a first-paint-while-hidden can. See band-app/band#615.
   useEffect(() => {
-    if (visible && fitAddonRef.current) {
-      requestAnimationFrame(() => {
-        const remeasure = remeasureAndReattachRef.current;
-        if (remeasure && !firstVisiblePaintDoneRef.current) {
-          // `remeasureAndReattach` fits internally, so we don't call
-          // `fit()` again here.
-          remeasure();
-        } else {
-          fitAddonRef.current?.fit();
-        }
-        firstVisiblePaintDoneRef.current = true;
-        const term = terminalRef.current;
-        const ws = wsRef.current;
-        if (term && ws?.readyState === WebSocket.OPEN && term.cols > 0 && term.rows > 0) {
-          ws.send(JSON.stringify({ type: "resize", cols: term.cols, rows: term.rows }));
-        }
-      });
-    }
+    if (!visible) return;
+    // Defer past a frame so the just-un-hidden layout has settled before we
+    // measure. Cancel on cleanup so a rapid hide→show→hide can't leave a
+    // stale callback fitting against a re-hidden (degenerate) layout.
+    const rafId = requestAnimationFrame(() => {
+      // Skip while the container still reports zero size — fitting against a
+      // 0×0 box would compute nonsense cols/rows. The ResizeObserver's own
+      // `fit()` repairs it once layout resolves to a real size.
+      const container = containerRef.current;
+      if (!container || container.clientWidth === 0 || container.clientHeight === 0) return;
+      const remeasure = remeasureAndReattachRef.current;
+      if (remeasure) {
+        // `remeasureAndReattach` fits internally, so we don't call `fit()`
+        // again here.
+        remeasure();
+      } else {
+        fitAddonRef.current?.fit();
+      }
+      const term = terminalRef.current;
+      // Unconditional repaint: `fit()`/`resize()` no-op when the dimensions
+      // are unchanged, so force xterm to redraw every row from scratch. This
+      // is the safety net for the DOM renderer (where `remeasure` has no
+      // WebGL addon to re-attach) and mirrors superset-sh/superset, which
+      // calls `refresh(0, rows-1)` unconditionally on every reattach.
+      if (term && term.rows > 0) term.refresh(0, term.rows - 1);
+      const ws = wsRef.current;
+      if (term && ws?.readyState === WebSocket.OPEN && term.cols > 0 && term.rows > 0) {
+        ws.send(JSON.stringify({ type: "resize", cols: term.cols, rows: term.rows }));
+      }
+    });
+    return () => cancelAnimationFrame(rafId);
   }, [visible]);
 
   // Listen for the workspace-level ⌃` "focus Terminal" event. Many


### PR DESCRIPTION
## Summary

Fixes #615 — switching workspaces left a cached terminal rendered garbled (overlapping text, wrong wrapping, misaligned glyphs); only a manual panel/window resize fixed it.

## Root cause

Inactive cached workspaces are hidden with `content-visibility: hidden` (`MultiWorkspacePanelHost`), which lets the browser skip layout/paint and drop the terminal's WebGL backing store or leave rendered glyphs stale. The become-visible repair in `TerminalPanel.tsx` was **one-shot** (gated on `firstVisiblePaintDoneRef`), so a plain hide→show ran only a bare `fitAddon.fit()` — which no-ops when cols/rows are unchanged (`resize()` early-returns) — leaving the stale frame on screen. A manual resize "fixed" it only because it changed the dimensions, the one case that dodges the early-return.

## Fix (Level 1, minimal)

`apps/web/src/components/TerminalPanel.tsx`:
- Drop the one-shot `firstVisiblePaintDoneRef` gate (and the now-dead `visibleRef` + re-arm block) so the repair runs on **every** hidden→visible transition.
- On become-visible, always `remeasureAndReattach()` (dispose + re-attach the WebGL addon against the live layout), then force an **unconditional `terminal.refresh(0, rows-1)`** so the DOM renderer repaints too (mirrors superset-sh/superset's repaint-on-reattach).
- Guard the fit on a non-zero-size container, defer one `requestAnimationFrame`, and `cancelAnimationFrame` on cleanup for rapid hide→show→hide.

Deliberately scoped to the targeted Level 1 fix — no Level 2 parking-model rewrite, and no overlap with the #613 sibling terminal bug.

## Test

New `apps/web/e2e/terminal-switch-repaint.spec.ts` — boots the real server, drives via `WorkspacePage`, and covers the plain hide→show scenario (visible first paint, **no zoom**) that the two existing repaint specs don't. Verified it **fails on the old code** (tagged canvases survive) and **passes on the fix** (surface rebuilt, backing store sized to the visible container).

## Verification

- `/review-and-apply`: Coding ✅ · Testing ✅ · Security ✅ · Performance ✅ → **approved 👍** (one nit applied).
- `pnpm check` (biome + cargo fmt + clippy): clean.
- All three terminal repaint e2e tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)