### PR TITLE
fix(web): unlock Band's locked git worktrees on workspace removal

### DIFF
--- a/apps/web/src/server/services/workspace-service.ts
+++ b/apps/web/src/server/services/workspace-service.ts
@@ -801,6 +801,27 @@ export class WorkspaceService {
           }
         }
 
+        // Unlock the worktree first. External tooling (e.g. `supacode`)
+        // locks Band's worktrees — visible as a `locked "{...}"` line in
+        // `git worktree list --porcelain` — most likely to stop `git gc` /
+        // auto-prune from reclaiming a worktree while an agent is mid-flight.
+        // A locked worktree is refused by a single `git worktree remove
+        // --force` ("cannot remove a locked working tree") AND is skipped by
+        // `git worktree prune`, so without this unlock the admin record in
+        // `.git/worktrees/<id>/` survives and `syncWorktrees` re-adds the
+        // workspace on the next tick (issue: locked worktrees resurrect
+        // forever). Best-effort: swallow "not locked" and any other error.
+        try {
+          await execFileAsync(command, ["worktree", "unlock", worktreePath], {
+            cwd: projPath,
+            env: gitEnv,
+            encoding: "utf-8",
+          });
+        } catch {
+          // Worktree was not locked, or the path is already gone — either
+          // way there's nothing to unlock. Removal/prune below still runs.
+        }
+
         try {
           await execFileAsync(command, ["worktree", "remove", "--force", worktreePath], {
             cwd: projPath,
@@ -808,8 +829,8 @@ export class WorkspaceService {
             encoding: "utf-8",
           });
         } catch {
-          // Worktree may be corrupted (e.g. missing .git file).
-          // Manually remove the directory and prune stale entries.
+          // Worktree may be corrupted (e.g. missing .git file) or still
+          // refused. Manually remove the directory and prune stale entries.
           try {
             await rm(worktreePath, { recursive: true, force: true });
           } catch (err) {
@@ -818,6 +839,19 @@ export class WorkspaceService {
             // `git worktree prune` to at least clean the index — matches
             // the existing best-effort pattern used for prune/branch -D.
             log.warn({ err, workspaceId, worktreePath }, "manual worktree rm failed");
+          }
+          // Re-run the unlock: `git worktree prune` skips LOCKED entries, so
+          // a still-locked admin record (whose working dir we just `rm`'d)
+          // would otherwise survive the prune and resurrect on sync. Unlock
+          // resolves the entry by its recorded path even when the dir is gone.
+          try {
+            await execFileAsync(command, ["worktree", "unlock", worktreePath], {
+              cwd: projPath,
+              env: gitEnv,
+              encoding: "utf-8",
+            });
+          } catch {
+            // Already unlocked or entry gone — prune below handles the rest.
           }
           try {
             await execFileAsync(command, ["worktree", "prune"], {

--- a/apps/web/tests/helpers/db-read.ts
+++ b/apps/web/tests/helpers/db-read.ts
@@ -1,0 +1,45 @@
+// Shared read helpers for integration tests that need to assert on the
+// server's persisted `worktrees` rows. Reading straight from the same
+// SQLite DB the server writes to keeps the assertion independent of an
+// unrelated tRPC endpoint's behaviour — the same rationale
+// `workspace-remove-detached.test.ts` documented when it first inlined
+// these. Promoted here (issue: third inline copy across the suite) so
+// the removal/reconcile tests share one definition.
+
+import { join } from "node:path";
+import { DatabaseSync } from "node:sqlite";
+
+/**
+ * Persisted `branch` values for a project's worktrees, sorted. The
+ * `branch` column tracks the live git branch (mutated by
+ * `syncWorktrees`).
+ */
+export function listWorktreeBranches(tmpHome: string, projectName: string): string[] {
+  const sqlite = new DatabaseSync(join(tmpHome, ".band", "band.db"));
+  try {
+    const rows = sqlite
+      .prepare("SELECT branch FROM worktrees WHERE project_name = ? ORDER BY branch")
+      .all(projectName) as Array<{ branch: string }>;
+    return rows.map((r) => r.branch);
+  } finally {
+    sqlite.close();
+  }
+}
+
+/**
+ * Persisted `name` (immutable workspace identity) values for a project's
+ * worktrees, sorted. Distinct from `branch`: `name` is frozen at create
+ * time and never mutated by `syncWorktrees`, so it's the key removal
+ * filters on.
+ */
+export function listWorktreeNames(tmpHome: string, projectName: string): string[] {
+  const sqlite = new DatabaseSync(join(tmpHome, ".band", "band.db"));
+  try {
+    const rows = sqlite
+      .prepare("SELECT name FROM worktrees WHERE project_name = ? ORDER BY name")
+      .all(projectName) as Array<{ name: string }>;
+    return rows.map((r) => r.name);
+  } finally {
+    sqlite.close();
+  }
+}

--- a/apps/web/tests/workspace-remove-detached.test.ts
+++ b/apps/web/tests/workspace-remove-detached.test.ts
@@ -22,8 +22,8 @@
 import { execFileSync } from "node:child_process";
 import { mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
-import { DatabaseSync } from "node:sqlite";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { listWorktreeBranches, listWorktreeNames } from "./helpers/db-read";
 import { seedSettings, seedState } from "./helpers/seed-state";
 import { createTmpHome, type ServerHandle, startServer, trpcMutate } from "./helpers/server";
 
@@ -41,38 +41,12 @@ function git(cwd: string, args: string[]): string {
   return execFileSync("git", args, { cwd, env: gitEnv, encoding: "utf-8" });
 }
 
-// Read directly from SQLite rather than going through `projects.list`
-// over tRPC. The mutation's effect on the persisted state is the
-// invariant we're pinning here, and reading via the same DB the server
-// writes to keeps the assertion independent of an unrelated endpoint's
-// behaviour. (Same pattern as `task-cleanup.test.ts`.)
-function listWorktreeBranches(tmpHome: string, projectName: string): string[] {
-  const sqlite = new DatabaseSync(join(tmpHome, ".band", "band.db"));
-  try {
-    const rows = sqlite
-      .prepare("SELECT branch FROM worktrees WHERE project_name = ? ORDER BY branch")
-      .all(projectName) as Array<{ branch: string }>;
-    return rows.map((r) => r.branch);
-  } finally {
-    sqlite.close();
-  }
-}
-
-// Companion to `listWorktreeBranches` that reads the `name` (identity)
-// column. `workspaces.remove` now filters rows by `name`, so asserting the
-// `name` entry is gone — not just the `branch` — pins the actual removal
-// key and guards against a future refactor that removes by branch.
-function listWorktreeNames(tmpHome: string, projectName: string): string[] {
-  const sqlite = new DatabaseSync(join(tmpHome, ".band", "band.db"));
-  try {
-    const rows = sqlite
-      .prepare("SELECT name FROM worktrees WHERE project_name = ? ORDER BY name")
-      .all(projectName) as Array<{ name: string }>;
-    return rows.map((r) => r.name);
-  } finally {
-    sqlite.close();
-  }
-}
+// `listWorktreeBranches` / `listWorktreeNames` read straight from the
+// SQLite DB the server writes to (shared with the locked-remove test) —
+// see `helpers/db-read.ts`. Reading the DB keeps the assertion
+// independent of an unrelated endpoint's behaviour, and asserting BOTH
+// the `branch` and the `name` (identity) columns pins the actual removal
+// key: `workspaces.remove` filters rows by `name`.
 
 describe("workspaces.remove on a detached-HEAD worktree", () => {
   let server: ServerHandle;

--- a/apps/web/tests/workspace-remove-locked.test.ts
+++ b/apps/web/tests/workspace-remove-locked.test.ts
@@ -1,0 +1,203 @@
+// Regression test for the "locked worktrees resurrect forever" bug.
+//
+// Band's worktrees are locked by external tooling (e.g. `supacode`),
+// which shows up as a `locked "{...,\"owner\":\"supacode\",...}"` line in
+// `git worktree list --porcelain` — most likely to stop `git gc` /
+// auto-prune from reclaiming a worktree while an agent is mid-flight.
+// The lock is NOT applied by Band itself: `workspace-service.ts`'s
+// `create` runs a plain `git worktree add` with no `--lock` flag.
+//
+// A locked worktree defeats BOTH branches of the old removal path in
+// `WorkspaceService.remove`'s background cleanup:
+//
+//   1. `git worktree remove --force <path>` is REFUSED for a locked
+//      worktree ("cannot remove a locked working tree") — a single
+//      `--force` does not override a lock.
+//   2. The catch-block fallback `rm -rf` + `git worktree prune` leaves
+//      the admin record in `.git/worktrees/<id>/` behind, because
+//      `git worktree prune` SKIPS locked entries.
+//
+// Net effect: the removed path survives in `git worktree list`, and
+// `syncWorktrees` (`reconcileOneProject`) overwrites the persisted DB
+// list with git's view on the next tick — re-adding the just-deleted
+// workspace so it reappears in the UI forever.
+//
+// The fix unlocks the worktree (`git worktree unlock`) before removal
+// and again before the prune fallback. This test boots the real
+// server, creates a real LOCKED worktree, drives the real
+// `workspaces.remove` mutation, and asserts:
+//
+//   1. `git worktree list --porcelain` no longer lists the removed
+//      path once the background cleanup finishes.
+//   2. The persisted `worktrees` row is gone.
+//   3. A subsequent `syncWorktrees` reconcile does NOT re-add it.
+//
+// Integration-only — no mocks. The removal path runs inside the real
+// production server; the reconcile check runs the real `syncWorktrees`
+// against the same on-disk state, mirroring `sync-service.test.ts`.
+
+import { execFileSync } from "node:child_process";
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { closeDb } from "../src/server/infra/db/connection";
+import { syncWorktrees } from "../src/server/services/sync-service";
+import { seedSettings, seedState } from "./helpers/seed-state";
+import { createTmpHome, type ServerHandle, startServer, trpcMutate } from "./helpers/server";
+
+const DEFAULT_TOKEN = "workspace-remove-locked-token";
+
+const gitEnv = {
+  ...process.env,
+  GIT_AUTHOR_NAME: "Test",
+  GIT_AUTHOR_EMAIL: "test@test.com",
+  GIT_COMMITTER_NAME: "Test",
+  GIT_COMMITTER_EMAIL: "test@test.com",
+};
+
+function git(cwd: string, args: string[]): string {
+  return execFileSync("git", args, { cwd, env: gitEnv, encoding: "utf-8" });
+}
+
+// Read the persisted `worktrees` rows straight from SQLite — the same
+// DB the server writes to — rather than going through an unrelated
+// tRPC endpoint. Matches `workspace-remove-detached.test.ts`.
+function listWorktreeBranches(tmpHome: string, projectName: string): string[] {
+  const sqlite = new DatabaseSync(join(tmpHome, ".band", "band.db"));
+  try {
+    const rows = sqlite
+      .prepare("SELECT branch FROM worktrees WHERE project_name = ? ORDER BY branch")
+      .all(projectName) as Array<{ branch: string }>;
+    return rows.map((r) => r.branch);
+  } finally {
+    sqlite.close();
+  }
+}
+
+// Absolute paths git currently tracks as worktrees, parsed from the
+// porcelain `worktree <path>` lines. This is the invariant the fix is
+// about: the removed path must NOT be here afterwards, even when the
+// worktree was locked.
+function listGitWorktreePaths(repoPath: string): string[] {
+  const out = git(repoPath, ["worktree", "list", "--porcelain"]);
+  return out
+    .split("\n")
+    .filter((line) => line.startsWith("worktree "))
+    .map((line) => line.slice("worktree ".length).trim());
+}
+
+describe("workspaces.remove on a locked worktree", () => {
+  let server: ServerHandle;
+  let tmpHome: string;
+  let repoPath: string;
+  let featurePath: string;
+  // The removal test closes the server early (see below) so the
+  // in-process reconcile is the only DB writer. Guard against a
+  // double-close from `afterAll`.
+  let serverClosed = false;
+  const previousBandHome = process.env.BAND_HOME;
+
+  beforeAll(async () => {
+    tmpHome = createTmpHome("band-locked-remove-");
+
+    repoPath = join(tmpHome, "proj");
+    mkdirSync(repoPath, { recursive: true });
+    git(repoPath, ["init", "-b", "main"]);
+    writeFileSync(join(repoPath, "README.md"), "v1\n");
+    git(repoPath, ["add", "."]);
+    git(repoPath, ["commit", "-m", "v1"]);
+
+    // Create a real worktree on a feature branch, then LOCK it with a
+    // reason that mirrors the `owner` metadata external tooling writes.
+    // The lock is what the old removal path could not clear.
+    featurePath = join(tmpHome, "proj-feature");
+    git(repoPath, ["worktree", "add", "-b", "feature", featurePath]);
+    git(repoPath, ["worktree", "lock", "--reason", '{"owner":"supacode"}', featurePath]);
+
+    seedState(tmpHome, {
+      projects: [
+        {
+          name: "proj",
+          path: repoPath,
+          defaultBranch: "main",
+          worktrees: [
+            { name: "main", branch: "main", path: repoPath },
+            { name: "feature", branch: "feature", path: featurePath },
+          ],
+        },
+      ],
+    });
+    seedSettings(tmpHome, { tokenSecret: DEFAULT_TOKEN });
+
+    server = await startServer({ tmpHome });
+  });
+
+  afterAll(async () => {
+    if (!serverClosed) await server.close();
+    closeDb();
+    if (previousBandHome === undefined) {
+      delete process.env.BAND_HOME;
+    } else {
+      process.env.BAND_HOME = previousBandHome;
+    }
+    rmSync(tmpHome, { recursive: true, force: true });
+  });
+
+  it("rejects an unauthenticated remove and leaves the worktree registered", async () => {
+    // The mutation is auth-gated; an unauthenticated call must not
+    // remove anything. Raw fetch with no `band_token` cookie.
+    const res = await fetch(`${server.url}/trpc/workspaces.remove`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ project: "proj", name: "feature" }),
+    });
+    expect(res.status).toBe(401);
+
+    // Positive anchor: the worktree is still registered, so the 401
+    // short-circuited before any removal ran.
+    expect(listWorktreeBranches(tmpHome, "proj").sort()).toEqual(["feature", "main"]);
+    expect(listGitWorktreePaths(repoPath)).toContain(featurePath);
+  });
+
+  it("fully deregisters a locked worktree so a later sync can't resurrect it", async () => {
+    // Sanity: the locked worktree exists in git and is registered.
+    expect(listGitWorktreePaths(repoPath)).toContain(featurePath);
+    expect(git(repoPath, ["worktree", "list", "--porcelain"])).toContain("locked");
+    expect(listWorktreeBranches(tmpHome, "proj").sort()).toEqual(["feature", "main"]);
+
+    const res = await trpcMutate(
+      server.url,
+      "workspaces.remove",
+      { project: "proj", name: "feature" },
+      DEFAULT_TOKEN,
+    );
+    const body = await res.text();
+    expect(res.status, `unexpected status; body=${body}`).toBe(200);
+    expect(JSON.parse(body)).toEqual({ result: { data: { ok: true } } });
+
+    // The persisted row is dropped synchronously by the fast path.
+    expect(listWorktreeBranches(tmpHome, "proj")).toEqual(["main"]);
+
+    // The git deregistration is the crux — and it runs in a background
+    // `setImmediate` task in the server process, so poll until the
+    // locked path is gone from `git worktree list --porcelain`. Without
+    // the unlock fix this never happens: the entry survives locked.
+    await expect
+      .poll(() => listGitWorktreePaths(repoPath), { timeout: 10_000, interval: 100 })
+      .not.toContain(featurePath);
+
+    // Prove the resurrection path is closed: run the real reconcile
+    // against the now-clean git state and confirm it does not re-add
+    // the removed workspace. Close the server first so the in-process
+    // `syncWorktrees` is the sole writer to the SQLite DB — otherwise
+    // the server's own periodic reconcile could contend on the WAL.
+    // `syncWorktrees` reads `$BAND_HOME`.
+    await server.close();
+    serverClosed = true;
+    process.env.BAND_HOME = join(tmpHome, ".band");
+    await syncWorktrees();
+    closeDb();
+    expect(listWorktreeBranches(tmpHome, "proj")).toEqual(["main"]);
+  });
+});

--- a/apps/web/tests/workspace-remove-locked.test.ts
+++ b/apps/web/tests/workspace-remove-locked.test.ts
@@ -30,19 +30,20 @@
 //   1. `git worktree list --porcelain` no longer lists the removed
 //      path once the background cleanup finishes.
 //   2. The persisted `worktrees` row is gone.
-//   3. A subsequent `syncWorktrees` reconcile does NOT re-add it.
+//   3. A subsequent reconcile does NOT re-add it — exercised by booting
+//      a FRESH server against the same home, whose boot-time
+//      `syncWorktrees` (awaited before it listens) runs the real
+//      reconcile against the cleaned git state, all over the real
+//      process boundary.
 //
-// Integration-only — no mocks. The removal path runs inside the real
-// production server; the reconcile check runs the real `syncWorktrees`
-// against the same on-disk state, mirroring `sync-service.test.ts`.
+// Integration-only — no mocks, no in-process calls to the system under
+// test. Mirrors `workspace-remove-detached.test.ts`.
 
 import { execFileSync } from "node:child_process";
 import { mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
-import { DatabaseSync } from "node:sqlite";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { closeDb } from "../src/server/infra/db/connection";
-import { syncWorktrees } from "../src/server/services/sync-service";
+import { listWorktreeBranches } from "./helpers/db-read";
 import { seedSettings, seedState } from "./helpers/seed-state";
 import { createTmpHome, type ServerHandle, startServer, trpcMutate } from "./helpers/server";
 
@@ -58,21 +59,6 @@ const gitEnv = {
 
 function git(cwd: string, args: string[]): string {
   return execFileSync("git", args, { cwd, env: gitEnv, encoding: "utf-8" });
-}
-
-// Read the persisted `worktrees` rows straight from SQLite — the same
-// DB the server writes to — rather than going through an unrelated
-// tRPC endpoint. Matches `workspace-remove-detached.test.ts`.
-function listWorktreeBranches(tmpHome: string, projectName: string): string[] {
-  const sqlite = new DatabaseSync(join(tmpHome, ".band", "band.db"));
-  try {
-    const rows = sqlite
-      .prepare("SELECT branch FROM worktrees WHERE project_name = ? ORDER BY branch")
-      .all(projectName) as Array<{ branch: string }>;
-    return rows.map((r) => r.branch);
-  } finally {
-    sqlite.close();
-  }
 }
 
 // Absolute paths git currently tracks as worktrees, parsed from the
@@ -92,11 +78,6 @@ describe("workspaces.remove on a locked worktree", () => {
   let tmpHome: string;
   let repoPath: string;
   let featurePath: string;
-  // The removal test closes the server early (see below) so the
-  // in-process reconcile is the only DB writer. Guard against a
-  // double-close from `afterAll`.
-  let serverClosed = false;
-  const previousBandHome = process.env.BAND_HOME;
 
   beforeAll(async () => {
     tmpHome = createTmpHome("band-locked-remove-");
@@ -134,13 +115,7 @@ describe("workspaces.remove on a locked worktree", () => {
   });
 
   afterAll(async () => {
-    if (!serverClosed) await server.close();
-    closeDb();
-    if (previousBandHome === undefined) {
-      delete process.env.BAND_HOME;
-    } else {
-      process.env.BAND_HOME = previousBandHome;
-    }
+    await server.close();
     rmSync(tmpHome, { recursive: true, force: true });
   });
 
@@ -187,17 +162,14 @@ describe("workspaces.remove on a locked worktree", () => {
       .poll(() => listGitWorktreePaths(repoPath), { timeout: 10_000, interval: 100 })
       .not.toContain(featurePath);
 
-    // Prove the resurrection path is closed: run the real reconcile
-    // against the now-clean git state and confirm it does not re-add
-    // the removed workspace. Close the server first so the in-process
-    // `syncWorktrees` is the sole writer to the SQLite DB — otherwise
-    // the server's own periodic reconcile could contend on the WAL.
-    // `syncWorktrees` reads `$BAND_HOME`.
+    // Prove the resurrection path is closed through the real boundary:
+    // boot a FRESH server against the same home. Its boot-time
+    // `runFirstTimeSetup` → `syncWorktrees` is awaited before the server
+    // listens, so once `startServer` resolves the production reconcile
+    // has already run against the cleaned git state. If the entry had
+    // survived locked, reconcile would re-add `feature` here.
     await server.close();
-    serverClosed = true;
-    process.env.BAND_HOME = join(tmpHome, ".band");
-    await syncWorktrees();
-    closeDb();
+    server = await startServer({ tmpHome });
     expect(listWorktreeBranches(tmpHome, "proj")).toEqual(["main"]);
   });
 });

--- a/apps/web/tests/workspace-remove-locked.test.ts
+++ b/apps/web/tests/workspace-remove-locked.test.ts
@@ -43,7 +43,7 @@ import { execFileSync } from "node:child_process";
 import { mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { listWorktreeBranches } from "./helpers/db-read";
+import { listWorktreeBranches, listWorktreeNames } from "./helpers/db-read";
 import { seedSettings, seedState } from "./helpers/seed-state";
 import { createTmpHome, type ServerHandle, startServer, trpcMutate } from "./helpers/server";
 
@@ -152,7 +152,11 @@ describe("workspaces.remove on a locked worktree", () => {
     expect(JSON.parse(body)).toEqual({ result: { data: { ok: true } } });
 
     // The persisted row is dropped synchronously by the fast path.
+    // Assert on both `branch` and the `name` (identity) column —
+    // `workspaces.remove` filters by `name`, so pinning it guards
+    // against a regression that leaves the identity row behind.
     expect(listWorktreeBranches(tmpHome, "proj")).toEqual(["main"]);
+    expect(listWorktreeNames(tmpHome, "proj")).toEqual(["main"]);
 
     // The git deregistration is the crux — and it runs in a background
     // `setImmediate` task in the server process, so poll until the
@@ -171,5 +175,6 @@ describe("workspaces.remove on a locked worktree", () => {
     await server.close();
     server = await startServer({ tmpHome });
     expect(listWorktreeBranches(tmpHome, "proj")).toEqual(["main"]);
+    expect(listWorktreeNames(tmpHome, "proj")).toEqual(["main"]);
   });
 });


### PR DESCRIPTION
## Problem

Band's worktrees are locked by external tooling (`supacode`) — visible as a `locked "{...,\"owner\":\"supacode\",...}"` line in `git worktree list --porcelain`, most likely to stop `git gc` / auto-prune from reclaiming a worktree while an agent is mid-flight. Band itself does **not** set the lock: `WorkspaceService.create` runs a plain `git worktree add` with no `--lock` flag.

That lock defeated **both** branches of `WorkspaceService.remove()`'s background cleanup:

1. `git worktree remove --force <path>` is *refused* for a locked worktree (`cannot remove a locked working tree`) — a single `--force` does not override a lock.
2. The `rm -rf` + `git worktree prune` fallback leaves the admin record in `.git/worktrees/<id>/` behind, because **`git worktree prune` skips locked entries**.

Net effect: the removed path survived in `git worktree list`, and `syncWorktrees()` (`reconcileOneProject`) overwrote the persisted DB list with git's view on the next sync tick — re-adding the just-deleted workspace so it reappeared in the UI forever.

## Fix

In `WorkspaceService.remove()`'s background cleanup (`apps/web/src/server/services/workspace-service.ts`):

- Run `git worktree unlock <path>` before `git worktree remove --force`.
- Re-run `git worktree unlock <path>` before the `git worktree prune` fallback (unlock resolves the entry by its recorded path even after the working dir is `rm`'d).

All git/fs calls stay best-effort (log + swallow), so removal never throws from the background `setImmediate` task.

## Tests

`apps/web/tests/workspace-remove-locked.test.ts` — real-git-in-a-tempdir integration test (no mocks) following the `workspace-remove-detached.test.ts` pattern:

- Creates a real repo + worktree, **locks it**, boots the real production server, and drives the real `workspaces.remove` mutation.
- Asserts the path is gone from `git worktree list --porcelain`, the persisted DB row is dropped, and a subsequent real `syncWorktrees()` reconcile does **not** re-add it.
- Includes a 401 negative test for the auth-gated mutation.
- Verified it **fails on the pre-fix code** (locked path survives) and passes with the fix.

## Verification

- `biome check` clean; no Rust changed.
- `pnpm --filter @band-app/server test` — locked test passes alone and alongside the sibling sync/remove tests.
- Ran `/review-and-apply` locally: Coding ✅ · Testing ✅ · Security ✅ · Performance ✅, verdict approved 👍.

🤖 Generated with [Claude Code](https://claude.com/claude-code)