### PR TITLE
fix(web): replace root workspace home icon with status dot

### DIFF
--- a/apps/web/e2e/pages/WorkspacePage.ts
+++ b/apps/web/e2e/pages/WorkspacePage.ts
@@ -67,6 +67,46 @@ export class WorkspacePage {
     return this.page.getByTestId(`project-list__workspace-card--${workspaceId}`);
   }
 
+  /** The root (default-branch) workspace card's house icon — the identity
+   *  marker `AgentStatusIndicator` renders as its idle fallback for the root
+   *  card. `data-testid` set on the lucide `Home` glyph in `WorkspaceCard`.
+   *  Scoped to the card so it never matches another project's root. Present
+   *  only while the root agent is idle; a live status replaces it with the
+   *  status dot — mirroring how the branch glyph is replaced on non-root
+   *  cards. */
+  rootWorkspaceHomeIcon(workspaceId: string): Locator {
+    return this.workspaceCard(workspaceId).getByTestId("workspace-card__home-icon");
+  }
+
+  /** The agent status dot inside a workspace card. `data-testid` set on the
+   *  dot `<span>` in `AgentStatusIndicator`, shown only when the agent status
+   *  is "working" / "needs_attention". Scoped to the card. */
+  agentStatusDot(workspaceId: string): Locator {
+    return this.workspaceCard(workspaceId).getByTestId("workspace-card__agent-status");
+  }
+
+  /** Set a workspace's agent status via the real `statuses.update` tRPC
+   *  mutation (the same procedure the dashboard uses), which emits an SSE
+   *  update the mounted status watcher consumes — so the card re-renders
+   *  live, the way it would in production. Auth via the `band_token` cookie,
+   *  matching the other tRPC HTTP helpers. */
+  async setAgentStatus(workspaceId: string, status: string): Promise<void> {
+    await test.step(`Set agent status of ${workspaceId} to ${status}`, async () => {
+      const res = await this.page.request.post(`${this.baseUrl}/trpc/statuses.update`, {
+        headers: {
+          "Content-Type": "application/json",
+          Cookie: `band_token=${this.token}`,
+        },
+        data: { workspaceId, agent: { status } },
+      });
+      if (!res.ok()) {
+        throw new Error(
+          `setAgentStatus(${workspaceId}, ${status}) failed: ${res.status()} ${await res.text()}`,
+        );
+      }
+    });
+  }
+
   /** Locate the per-panel-host cached entry div for the given workspaceId
    *  (issue #508). `MultiWorkspacePanelHost` renders one of these per
    *  workspace it currently caches; the test asserts on their presence /

--- a/apps/web/e2e/root-workspace-status-icon.spec.ts
+++ b/apps/web/e2e/root-workspace-status-icon.spec.ts
@@ -119,10 +119,16 @@ test.describe("Root workspace status icon", () => {
     // upsert is idempotent and the router re-emits on every call — until the
     // dot renders, so a lost pre-subscription event can't flake the test.
     await expect
-      .poll(async () => {
-        await workspacePage.setAgentStatus(WORKSPACE, "working");
-        return workspacePage.agentStatusDot(WORKSPACE).count();
-      })
+      .poll(
+        async () => {
+          await workspacePage.setAgentStatus(WORKSPACE, "working");
+          return workspacePage.agentStatusDot(WORKSPACE).count();
+        },
+        // Match the `waitForReady` budget: on a slow CI worker the SSE
+        // subscription can take longer than the default 5 s poll window to
+        // come up, and this loop is the barrier that waits for it.
+        { timeout: 15_000 },
+      )
       .toBeGreaterThan(0);
 
     // Positive anchor: the status dot appeared (the swap happened)…

--- a/apps/web/e2e/root-workspace-status-icon.spec.ts
+++ b/apps/web/e2e/root-workspace-status-icon.spec.ts
@@ -1,0 +1,133 @@
+/**
+ * Root workspace status-icon swap.
+ *
+ * The default-branch ("root") workspace card shows a house icon as its
+ * identity marker. When its agent has a live status ("working" /
+ * "needs_attention") the status dot must REPLACE the house — occupying the
+ * same slot — exactly the way the branch glyph is replaced on every other
+ * workspace card. The regression this guards against: the root card showed
+ * the status dot AND the house side by side, instead of swapping.
+ *
+ * Real production binary, real git repo so the default branch reconciles to a
+ * WorkspaceCard, no tRPC mocks. The status is driven live via the real
+ * `statuses.update` mutation (the same procedure the dashboard calls), whose
+ * SSE update the mounted status watcher consumes — so the swap happens the
+ * same way it would in production. Page objects only.
+ */
+
+import { execFileSync } from "node:child_process";
+import { mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { expect, test } from "@playwright/test";
+import { toWorkspaceId } from "@/dashboard";
+import {
+  cleanupTmpHome,
+  createTmpHome,
+  type ServerHandle,
+  seedSettings,
+  seedState,
+  startServer,
+} from "./helpers/server";
+import { WorkspacePage } from "./pages/WorkspacePage";
+
+const TOKEN = "e2e-root-workspace-status-icon-token";
+const PROJECT = "status-icon-repo";
+const DEFAULT_BRANCH = "main";
+const WORKSPACE = toWorkspaceId(PROJECT, DEFAULT_BRANCH);
+
+// Wide viewport so `useIsDesktop()` reports true (threshold 1024px) and the
+// desktop sidebar renders the project list with its workspace cards.
+test.use({ viewport: { width: 1280, height: 800 } });
+
+function makeGitEnv(home: string): NodeJS.ProcessEnv {
+  return {
+    PATH: process.env.PATH,
+    HOME: home,
+    GIT_AUTHOR_NAME: "Test",
+    GIT_AUTHOR_EMAIL: "test@test.com",
+    GIT_COMMITTER_NAME: "Test",
+    GIT_COMMITTER_EMAIL: "test@test.com",
+    GIT_CONFIG_GLOBAL: "/dev/null",
+    GIT_CONFIG_SYSTEM: "/dev/null",
+  };
+}
+
+function git(cwd: string, args: string[], home: string): void {
+  execFileSync("git", args, { cwd, env: makeGitEnv(home) });
+}
+
+let server: ServerHandle;
+let tmpHome: string;
+
+test.beforeAll(async () => {
+  tmpHome = createTmpHome();
+
+  const repoPath = join(tmpHome, PROJECT);
+  mkdirSync(repoPath, { recursive: true });
+  git(repoPath, ["init", "-b", DEFAULT_BRANCH], tmpHome);
+  writeFileSync(join(repoPath, "README.md"), "# Status icon test\n");
+  git(repoPath, ["add", "."], tmpHome);
+  git(repoPath, ["commit", "-m", "init"], tmpHome);
+
+  seedState(tmpHome, {
+    projects: [
+      {
+        name: PROJECT,
+        path: repoPath,
+        defaultBranch: DEFAULT_BRANCH,
+        worktrees: [{ branch: DEFAULT_BRANCH, path: repoPath }],
+      },
+    ],
+  });
+  seedSettings(tmpHome, { tokenSecret: TOKEN });
+  server = await startServer({ tmpHome });
+});
+
+test.afterAll(async () => {
+  await server.close();
+  cleanupTmpHome(tmpHome);
+});
+
+test.describe("Root workspace status icon", () => {
+  test("shows the home icon and no status dot while the agent is idle", async ({ page }) => {
+    const workspacePage = new WorkspacePage(page, server.url, TOKEN);
+
+    await workspacePage.goto(WORKSPACE);
+    await workspacePage.waitForReady();
+
+    // The house is the root card's idle identity marker…
+    await expect(workspacePage.rootWorkspaceHomeIcon(WORKSPACE)).toBeVisible();
+    // …and with no live agent status there is no status dot beside it.
+    await expect(workspacePage.agentStatusDot(WORKSPACE)).toHaveCount(0);
+  });
+
+  test("replaces the home icon with the status dot when the agent is active", async ({ page }) => {
+    const workspacePage = new WorkspacePage(page, server.url, TOKEN);
+
+    await workspacePage.goto(WORKSPACE);
+    await workspacePage.waitForReady();
+
+    // Anchor the starting state: house present, no dot.
+    await expect(workspacePage.rootWorkspaceHomeIcon(WORKSPACE)).toBeVisible();
+    await expect(workspacePage.agentStatusDot(WORKSPACE)).toHaveCount(0);
+
+    // Drive a live "working" status through the real mutation + SSE path.
+    // `statuses.update` emits to currently-subscribed SSE listeners with no
+    // replay, and the browser's status-stream subscription isn't guaranteed
+    // to be live the instant `waitForReady()` returns (it keys on the dockview
+    // Maximize button, not on SSE connectivity). Re-fire the mutation — the
+    // upsert is idempotent and the router re-emits on every call — until the
+    // dot renders, so a lost pre-subscription event can't flake the test.
+    await expect
+      .poll(async () => {
+        await workspacePage.setAgentStatus(WORKSPACE, "working");
+        return workspacePage.agentStatusDot(WORKSPACE).count();
+      })
+      .toBeGreaterThan(0);
+
+    // Positive anchor: the status dot appeared (the swap happened)…
+    await expect(workspacePage.agentStatusDot(WORKSPACE)).toBeVisible();
+    // …and it REPLACED the house rather than sitting beside it.
+    await expect(workspacePage.rootWorkspaceHomeIcon(WORKSPACE)).toHaveCount(0);
+  });
+});

--- a/apps/web/src/dashboard/components/AgentStatusIndicator.tsx
+++ b/apps/web/src/dashboard/components/AgentStatusIndicator.tsx
@@ -1,18 +1,26 @@
 import { Tooltip, TooltipContent, TooltipTrigger } from "@band-app/ui";
 import { GitBranch } from "lucide-react";
+import type { ReactNode } from "react";
 import type { AgentInfo } from "../types";
 
 interface Props {
   agent?: AgentInfo;
   isActive?: boolean;
+  // Icon shown when the agent is idle. Non-root cards fall back to the branch
+  // glyph (the default); the root card passes its house icon so the status dot
+  // occupies the same slot — replacing the identity icon rather than sitting
+  // beside it.
+  fallback?: ReactNode;
 }
 
-export function AgentStatusIndicator({ agent, isActive }: Props) {
+export function AgentStatusIndicator({ agent, isActive, fallback }: Props) {
   if (!agent || (agent.status !== "working" && agent.status !== "needs_attention")) {
     return (
-      <GitBranch
-        className={`size-3 shrink-0 ${isActive ? "text-primary" : "text-muted-foreground"}`}
-      />
+      fallback ?? (
+        <GitBranch
+          className={`size-3 shrink-0 ${isActive ? "text-primary" : "text-muted-foreground"}`}
+        />
+      )
     );
   }
 
@@ -24,7 +32,10 @@ export function AgentStatusIndicator({ agent, isActive }: Props) {
   return (
     <Tooltip>
       <TooltipTrigger asChild>
-        <span className={`inline-block size-2 shrink-0 rounded-full ${color} ${animation}`} />
+        <span
+          data-testid="workspace-card__agent-status"
+          className={`inline-block size-2 shrink-0 rounded-full ${color} ${animation}`}
+        />
       </TooltipTrigger>
       <TooltipContent side="top">{tooltip}</TooltipContent>
     </Tooltip>

--- a/apps/web/src/dashboard/components/WorkspaceCard.tsx
+++ b/apps/web/src/dashboard/components/WorkspaceCard.tsx
@@ -140,11 +140,6 @@ export const WorkspaceCard = memo(function WorkspaceCard({
   // from the added feature worktrees below it. Plain projects have no root
   // worktree distinction (the project header IS the workspace).
   const isRoot = !isPlain && worktree.name === defaultBranch;
-  // AgentStatusIndicator falls back to a branch glyph when idle; on the root
-  // card the house is that identity marker instead, so we only mount the
-  // indicator (a status dot) when an agent is actually active.
-  const agentActive =
-    status?.agent?.status === "working" || status?.agent?.status === "needs_attention";
 
   const workspaceId = toWorkspaceId(projectName, worktree.name);
   const isActive = useDashboardStore((s) => s.activeWorkspaceId === workspaceId);
@@ -241,14 +236,20 @@ export const WorkspaceCard = memo(function WorkspaceCard({
             <TooltipTrigger asChild>
               <div className="flex items-center gap-2 min-w-0 overflow-hidden">
                 {isRoot ? (
-                  <>
-                    {agentActive && (
-                      <AgentStatusIndicator agent={status?.agent} isActive={isActive} />
-                    )}
-                    <Home
-                      className={`size-3.5 shrink-0 ${isActive ? "text-primary" : "text-muted-foreground"}`}
-                    />
-                  </>
+                  // On the root card the house is AgentStatusIndicator's idle
+                  // fallback (the slot other cards use for the branch glyph),
+                  // so an active agent's status dot replaces the house rather
+                  // than sitting beside it.
+                  <AgentStatusIndicator
+                    agent={status?.agent}
+                    isActive={isActive}
+                    fallback={
+                      <Home
+                        data-testid="workspace-card__home-icon"
+                        className={`size-3.5 shrink-0 ${isActive ? "text-primary" : "text-muted-foreground"}`}
+                      />
+                    }
+                  />
                 ) : (
                   <AgentStatusIndicator agent={status?.agent} isActive={isActive} />
                 )}


### PR DESCRIPTION
## Problem

In the projects/workspaces sidebar, the root/main workspace card rendered the agent status dot **and** the home icon side by side (`● 🏠 main`). Every other workspace card has its branch glyph **replaced** by the status dot when there's a live status — the root card should behave the same, with the status dot occupying the home-icon slot.

## Fix

The swap logic already lives in `AgentStatusIndicator` (renders the status dot when active, otherwise a fallback glyph). Made that fallback configurable:

- **`AgentStatusIndicator.tsx`** — added an optional `fallback?: ReactNode` prop; the idle branch now returns `fallback ?? <GitBranch/>`.
- **`WorkspaceCard.tsx`** — the root branch renders a single `<AgentStatusIndicator>` with the `<Home>` icon passed as its `fallback`, so the status dot replaces the house exactly the way it replaces the branch glyph on other cards. Removed the now-dead `agentActive` gate.

This reuses the single swap implementation instead of duplicating it.

## Test

Added `apps/web/e2e/root-workspace-status-icon.spec.ts` following the integration-testing doctrine — boots the real production server against a real git repo (so the default branch reconciles to a `WorkspaceCard`), no tRPC mocks, page objects only. Drives a live status through the real `statuses.update` mutation (whose SSE update the dashboard's status watcher consumes) and asserts:

1. Idle: home icon visible, no status dot.
2. Active: status dot appears **and** the home icon is gone — the swap.

Confirmed the test fails against the old side-by-side rendering (genuine regression guard). Added `data-testid` hooks to the home icon and status dot, plus page-object helpers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)