### PR TITLE
feat(web): recency-ordered workspace switcher + UI polish

### DIFF
--- a/apps/web/e2e/pages/WorkspacePage.ts
+++ b/apps/web/e2e/pages/WorkspacePage.ts
@@ -473,11 +473,10 @@ export class WorkspacePage {
     return this.page.getByTestId("desktop-title-bar__sidebar-toggle");
   }
 
-  /** The hamburger menu trigger (Tasks / Cronjobs / Settings …). Now rendered
-   *  by `NavControls` only in the WorkspaceTitleBar as the fallback for the
-   *  collapsed-sidebar state — while the sidebar is visible those actions live
-   *  in the project-list bottom action bar instead. Targeted by its
-   *  system-controlled ARIA name. */
+  /** The old collapsed-sidebar hamburger menu trigger. The hamburger was
+   *  removed — the overflow actions live solely in the project-list bottom
+   *  action bar now — so this button no longer renders in any state. Retained
+   *  as a locator so specs can assert its absence. */
   get menuTrigger(): Locator {
     return this.page.getByRole("button", { name: "Menu" });
   }
@@ -507,23 +506,6 @@ export class WorkspacePage {
    *  the sidebar is visible. */
   get sidebarToggleWithinSidebar(): Locator {
     return this.sidebar.getByTestId("desktop-title-bar__sidebar-toggle");
-  }
-
-  /** The hamburger menu trigger scoped to the project-list column. The menu no
-   *  longer rides in the SidebarTitleBar (its actions moved to the bottom
-   *  action bar), so this is count 0 while the list is visible; the menu only
-   *  appears in the WorkspaceTitleBar once the sidebar collapses. */
-  get menuTriggerWithinSidebar(): Locator {
-    return this.sidebar.getByRole("button", { name: "Menu" });
-  }
-
-  /** Open the hamburger menu from wherever the cluster currently lives. The
-   *  open dropdown is exposed via the existing `contextMenu` getter (both are
-   *  Radix `role="menu"`). */
-  async openTitleBarMenu(): Promise<void> {
-    await test.step("Open the title-bar hamburger menu", async () => {
-      await this.menuTrigger.click();
-    });
   }
 
   /** Current rendered width of the sidebar in CSS px — ~0 when collapsed.

--- a/apps/web/e2e/pages/WorkspacePicker.ts
+++ b/apps/web/e2e/pages/WorkspacePicker.ts
@@ -45,6 +45,13 @@ export class WorkspacePicker {
     return this.page.getByTestId(`workspace-picker__pin--${workspaceId}`);
   }
 
+  /** The house icon a row shows when its workspace is the project's main
+   *  checkout (default-branch worktree). Feature-branch rows show the branch
+   *  glyph instead and have no such node. */
+  homeIcon(workspaceId: string): Locator {
+    return this.page.getByTestId(`workspace-picker__home-icon--${workspaceId}`);
+  }
+
   /** The search input inside the picker. cmdk's `Command.Input` renders an
    *  `<input role="combobox" aria-autocomplete="list">`; scoping to the dialog
    *  keeps it from resolving any other combobox on the page. Used by the
@@ -64,6 +71,19 @@ export class WorkspacePicker {
    *  object rather than consuming the raw locator. */
   async expectOptionCount(count: number): Promise<void> {
     await expect(this.options).toHaveCount(count);
+  }
+
+  /** The workspace ids of the rows in visual (top-to-bottom) order. Each row
+   *  carries `data-testid="workspace-picker__item--<workspaceId>"`; cmdk keeps
+   *  the rows in the order the component renders them (mount order, preserved
+   *  when the search box is empty), so `evaluateAll` over the DOM reflects the
+   *  switcher's sort. Used to assert the recency ordering. */
+  async orderedWorkspaceIds(): Promise<string[]> {
+    return this.options.evaluateAll((els) =>
+      els.map((el) =>
+        (el.getAttribute("data-testid") ?? "").replace("workspace-picker__item--", ""),
+      ),
+    );
   }
 
   async waitVisible(): Promise<void> {

--- a/apps/web/e2e/pages/WorkspacePicker.ts
+++ b/apps/web/e2e/pages/WorkspacePicker.ts
@@ -80,9 +80,11 @@ export class WorkspacePicker {
    *  switcher's sort. Used to assert the recency ordering. */
   async orderedWorkspaceIds(): Promise<string[]> {
     return this.options.evaluateAll((els) =>
-      els.map((el) =>
-        (el.getAttribute("data-testid") ?? "").replace("workspace-picker__item--", ""),
-      ),
+      els
+        .map((el) => (el.getAttribute("data-testid") ?? "").replace("workspace-picker__item--", ""))
+        // Drop any option that lacked the expected testid rather than letting a
+        // silent "" leak into ordering assertions.
+        .filter((id) => id.length > 0),
     );
   }
 

--- a/apps/web/e2e/sidebar-toggle.spec.ts
+++ b/apps/web/e2e/sidebar-toggle.spec.ts
@@ -128,15 +128,15 @@ test("the nav cluster is hosted in the sidebar title bar while the sidebar is vi
 
   // The split title bar puts the sidebar toggle inside the project-list
   // column (SidebarTitleBar) when the list is shown. The overflow actions
-  // no longer ride in a title-bar hamburger — they live in the project-list
-  // bottom action bar — so the sidebar menu trigger is absent here.
+  // live in the project-list bottom action bar; there is no title-bar
+  // hamburger anywhere, so the Menu button is absent.
   await expect.poll(() => wp.sidebarWidth()).toBeGreaterThan(200);
   await expect(wp.sidebarToggleWithinSidebar).toBeVisible();
   await expect(wp.actionBarWithinSidebar).toBeVisible();
-  await expect(wp.menuTriggerWithinSidebar).toHaveCount(0);
+  await expect(wp.menuTrigger).toHaveCount(0);
 });
 
-test("the menu and back/forward relocate into the workspace bar when the sidebar collapses", async ({
+test("the toggle and back/forward relocate into the workspace bar when the sidebar collapses", async ({
   page,
 }) => {
   const wp = new WorkspacePage(page, server.url, TOKEN);
@@ -144,25 +144,20 @@ test("the menu and back/forward relocate into the workspace bar when the sidebar
   await wp.waitForReady();
 
   // Precondition: while visible, the actions live in the project-list bottom
-  // action bar and no hamburger rides in the sidebar title bar.
+  // action bar and there is no title-bar hamburger.
   await expect(wp.actionBarWithinSidebar).toBeVisible();
-  await expect(wp.menuTriggerWithinSidebar).toHaveCount(0);
+  await expect(wp.menuTrigger).toHaveCount(0);
 
   await wp.toggleSidebarViaButton();
   await expect.poll(() => wp.sidebarWidth()).toBeLessThan(5);
 
-  // Assert the settled new state first — prove the controls rendered in their
-  // new home (the workspace title bar) before asserting the old node is gone...
-  await expect(wp.menuTrigger).toBeVisible();
+  // The nav cluster relocated into the workspace title bar so its controls
+  // stay reachable while the list is collapsed...
+  await expect(wp.sidebarToggle).toBeVisible();
   await expect(wp.backButton).toBeVisible();
   await expect(wp.forwardButton).toBeVisible();
-  // ...and they've left the (now-collapsed) sidebar column.
-  await expect(wp.menuTriggerWithinSidebar).toHaveCount(0);
-
-  // The relocated menu is still wired: clicking it opens the dropdown.
-  await wp.openTitleBarMenu();
-  await expect(wp.contextMenu).toBeVisible();
-  await wp.pressEscape();
+  // ...and no hamburger was resurrected as part of the relocation.
+  await expect(wp.menuTrigger).toHaveCount(0);
 });
 
 test("the collapsed state persists across a reload", async ({ page }) => {

--- a/apps/web/e2e/workspace-picker.spec.ts
+++ b/apps/web/e2e/workspace-picker.spec.ts
@@ -193,10 +193,15 @@ test.describe("Workspace picker — ordering is recency, not pinned", () => {
     // Pin GAMMA — the workspace we never visit, so it stays the LEAST
     // recently accessed. Under the old sort a pinned card floated near the
     // top of the switcher; under the new sort recency wins and pin status is
-    // ignored for ordering. (localStorage recency is per-test-context, so
-    // this test starts with an empty recent list regardless of prior tests;
-    // any DB-persisted pins from earlier tests are irrelevant since pinning
-    // no longer affects order.)
+    // ignored for ordering.
+    //
+    // Recency lives ONLY in localStorage (`lib/recent-workspaces.ts`, key
+    // `band-recent-workspaces`) — there is no server/DB projection — and
+    // Playwright gives every test a fresh browser context, so this test
+    // starts from an empty recent list no matter what earlier tests did.
+    // GAMMA is never selected in this context, so it never enters the recent
+    // list; DB-persisted pins from earlier tests are irrelevant now that
+    // pinning no longer affects order.
     await workspacePage.openWorkspacePickerViaShortcut();
     await picker.waitVisible();
     await picker.togglePin(WS_GAMMA);
@@ -250,8 +255,10 @@ test.describe("Workspace picker — root workspaces show a house icon", () => {
     await picker.waitVisible();
 
     // The default-branch worktree is the project's main checkout — marked with
-    // a house icon, mirroring the project-list root card.
+    // a house icon, mirroring the project-list root card. Assert it for two
+    // different projects so the marker is proven not to be project-specific.
     await expect(picker.homeIcon(WS_ALPHA)).toBeVisible();
+    await expect(picker.homeIcon(WS_BETA)).toBeVisible();
 
     // The feature-branch worktree renders in the list but keeps the branch
     // glyph — no house icon.

--- a/apps/web/e2e/workspace-picker.spec.ts
+++ b/apps/web/e2e/workspace-picker.spec.ts
@@ -42,9 +42,17 @@ const TOKEN = "e2e-workspace-picker-token";
 
 const PROJECT_ALPHA = "alpha-picker";
 const PROJECT_BETA = "beta-picker";
+const PROJECT_GAMMA = "gamma-picker";
 
 const WS_ALPHA = toWorkspaceId(PROJECT_ALPHA, "main");
 const WS_BETA = toWorkspaceId(PROJECT_BETA, "main");
+const WS_GAMMA = toWorkspaceId(PROJECT_GAMMA, "main");
+
+// A feature-branch worktree on alpha (name !== defaultBranch), used to assert
+// the switcher shows the branch glyph — not the house icon — for non-root
+// workspaces.
+const ALPHA_FEATURE_BRANCH = "feat/switcher-home";
+const WS_ALPHA_FEATURE = toWorkspaceId(PROJECT_ALPHA, ALPHA_FEATURE_BRANCH);
 
 // Wide viewport so `useIsDesktop()` reports true and the shared dockview (which
 // owns the ⌘K picker shortcut and the project-list sidebar) mounts, along with
@@ -62,13 +70,22 @@ test.beforeAll(async () => {
         name: PROJECT_ALPHA,
         path: `/tmp/fake/${PROJECT_ALPHA}`,
         defaultBranch: "main",
-        worktrees: [{ branch: "main", path: `/tmp/fake/${PROJECT_ALPHA}` }],
+        worktrees: [
+          { branch: "main", path: `/tmp/fake/${PROJECT_ALPHA}` },
+          { branch: ALPHA_FEATURE_BRANCH, path: `/tmp/fake/${PROJECT_ALPHA}-feature` },
+        ],
       },
       {
         name: PROJECT_BETA,
         path: `/tmp/fake/${PROJECT_BETA}`,
         defaultBranch: "main",
         worktrees: [{ branch: "main", path: `/tmp/fake/${PROJECT_BETA}` }],
+      },
+      {
+        name: PROJECT_GAMMA,
+        path: `/tmp/fake/${PROJECT_GAMMA}`,
+        defaultBranch: "main",
+        worktrees: [{ branch: "main", path: `/tmp/fake/${PROJECT_GAMMA}` }],
       },
     ],
   });
@@ -160,5 +177,85 @@ test.describe("Workspace picker — pin is separate from select", () => {
     await expect(page).toHaveURL(new RegExp(WS_BETA));
     // ...and the dialog closed.
     await expect(picker.dialog).toBeHidden();
+  });
+});
+
+test.describe("Workspace picker — ordering is recency, not pinned", () => {
+  test("a pinned but stale workspace does not float above a recently-used one", async ({
+    page,
+  }) => {
+    const workspacePage = new WorkspacePage(page, server.url, TOKEN);
+    const picker = new WorkspacePicker(page);
+
+    await workspacePage.goto(WS_ALPHA);
+    await workspacePage.waitForReady();
+
+    // Pin GAMMA — the workspace we never visit, so it stays the LEAST
+    // recently accessed. Under the old sort a pinned card floated near the
+    // top of the switcher; under the new sort recency wins and pin status is
+    // ignored for ordering. (localStorage recency is per-test-context, so
+    // this test starts with an empty recent list regardless of prior tests;
+    // any DB-persisted pins from earlier tests are irrelevant since pinning
+    // no longer affects order.)
+    await workspacePage.openWorkspacePickerViaShortcut();
+    await picker.waitVisible();
+    await picker.togglePin(WS_GAMMA);
+    await expect(picker.pinButton(WS_GAMMA)).toHaveAttribute("aria-label", "Unpin workspace");
+    await picker.dismiss();
+    await expect(picker.dialog).toBeHidden();
+
+    // Build the recency trail: visit BETA, then ALPHA. Selecting a row calls
+    // `recordWorkspaceAccess`, so the recent order becomes [ALPHA, BETA];
+    // GAMMA has never been accessed and sorts last.
+    await workspacePage.openWorkspacePickerViaShortcut();
+    await picker.waitVisible();
+    await picker.select(WS_BETA);
+    await expect(page).toHaveURL(new RegExp(WS_BETA));
+    await workspacePage.waitForReady();
+
+    await workspacePage.openWorkspacePickerViaShortcut();
+    await picker.waitVisible();
+    await picker.select(WS_ALPHA);
+    await expect(page).toHaveURL(new RegExp(WS_ALPHA));
+    await workspacePage.waitForReady();
+
+    // Reopen on ALPHA and read the row order. Expected: ALPHA (active) first,
+    // then BETA (recently used), then the pinned-but-stale GAMMA LAST.
+    await workspacePage.openWorkspacePickerViaShortcut();
+    await picker.waitVisible();
+
+    const order = await picker.orderedWorkspaceIds();
+    // The load-bearing assertion: pinned GAMMA must NOT jump ahead of the
+    // more-recently-used BETA (it did under the old pinned-priority sort).
+    expect(order.indexOf(WS_BETA)).toBeLessThan(order.indexOf(WS_GAMMA));
+    // Scoped to the three workspaces this test drives (the seed also has an
+    // untouched feature worktree), the order is strict recency with the active
+    // workspace pinned to top.
+    const scoped = order.filter((id) => [WS_ALPHA, WS_BETA, WS_GAMMA].includes(id));
+    expect(scoped).toEqual([WS_ALPHA, WS_BETA, WS_GAMMA]);
+  });
+});
+
+test.describe("Workspace picker — root workspaces show a house icon", () => {
+  test("the main-branch workspace shows a house icon; a feature branch does not", async ({
+    page,
+  }) => {
+    const workspacePage = new WorkspacePage(page, server.url, TOKEN);
+    const picker = new WorkspacePicker(page);
+
+    await workspacePage.goto(WS_ALPHA);
+    await workspacePage.waitForReady();
+
+    await workspacePage.openWorkspacePickerViaShortcut();
+    await picker.waitVisible();
+
+    // The default-branch worktree is the project's main checkout — marked with
+    // a house icon, mirroring the project-list root card.
+    await expect(picker.homeIcon(WS_ALPHA)).toBeVisible();
+
+    // The feature-branch worktree renders in the list but keeps the branch
+    // glyph — no house icon.
+    await expect(picker.item(WS_ALPHA_FEATURE)).toBeVisible();
+    await expect(picker.homeIcon(WS_ALPHA_FEATURE)).toHaveCount(0);
   });
 });

--- a/apps/web/e2e/workspace-picker.spec.ts
+++ b/apps/web/e2e/workspace-picker.spec.ts
@@ -229,6 +229,11 @@ test.describe("Workspace picker — ordering is recency, not pinned", () => {
     await workspacePage.openWorkspacePickerViaShortcut();
     await picker.waitVisible();
 
+    // Guard against a vacuous pass: `orderedWorkspaceIds` snapshots the DOM
+    // without auto-retry, so wait for all rows (alpha main + alpha feature +
+    // beta + gamma = 4) to render before reading the order.
+    await picker.expectOptionCount(4);
+
     const order = await picker.orderedWorkspaceIds();
     // The load-bearing assertion: pinned GAMMA must NOT jump ahead of the
     // more-recently-used BETA (it did under the old pinned-priority sort).

--- a/apps/web/src/components/DesktopTitleBar.tsx
+++ b/apps/web/src/components/DesktopTitleBar.tsx
@@ -8,8 +8,8 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@band-app/ui";
-import { ChevronLeft, ChevronRight, ChevronsUpDown, Menu, PanelLeft, PanelTop } from "lucide-react";
-import { type ReactNode, useEffect, useState } from "react";
+import { ChevronLeft, ChevronRight, ChevronsUpDown, PanelLeft, PanelTop } from "lucide-react";
+import { useEffect, useState } from "react";
 import { invoke as desktopInvoke } from "../lib/desktop-ipc";
 import { isDesktop } from "../lib/is-desktop";
 import { EditorPicker } from "./EditorPicker";
@@ -29,16 +29,12 @@ export interface PanelItem {
   shortcut?: string;
 }
 
-/** Props for the navigation cluster (sidebar toggle + menu + back/forward).
- *  While the project list is visible the SidebarTitleBar renders only the
- *  toggle + back/forward arrows (its `menuItems` is left undefined — the
- *  overflow actions live in DashboardShell's bottom action bar). When the list
- *  is collapsed the arrows and the fallback hamburger menu render in the
- *  WorkspaceTitleBar instead — so both bars accept the same set of props. */
+/** Props for the navigation cluster (sidebar toggle + back/forward). While the
+ *  project list is visible the SidebarTitleBar renders the cluster; when the
+ *  list is collapsed the same cluster relocates into the WorkspaceTitleBar —
+ *  so both bars accept the same set of props. The overflow actions always live
+ *  in DashboardShell's bottom action bar, so the cluster carries no menu. */
 interface NavControlsProps {
-  /** Items rendered inside the global hamburger dropdown. When undefined, the
-   *  hamburger button is not rendered. */
-  menuItems?: ReactNode;
   /** Toggle the project-list sidebar's visibility (⌘B). When undefined, the
    *  sidebar toggle button is not rendered. */
   onToggleSidebar?: () => void;
@@ -90,10 +86,9 @@ interface WorkspaceTitleBarProps extends NavControlsProps, TitleBarOffsetProps {
   onTogglePanelVisibility?: (panelId: string) => void;
 }
 
-/** Sidebar toggle + hamburger menu + back/forward arrows. Shared by both
- *  title-bar halves; rendered in exactly one of them at a time. */
+/** Sidebar toggle + back/forward arrows. Shared by both title-bar halves;
+ *  rendered in exactly one of them at a time. */
 function NavControls({
-  menuItems,
   onToggleSidebar,
   sidebarVisible,
   onGoBack,
@@ -128,36 +123,6 @@ function NavControls({
             </kbd>
           </TooltipContent>
         </Tooltip>
-      )}
-      {menuItems && (
-        <DropdownMenu>
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <DropdownMenuTrigger asChild>
-                <button
-                  type="button"
-                  className="flex items-center justify-center rounded p-1 text-muted-foreground hover:text-foreground hover:bg-accent/50 transition-colors"
-                  aria-label="Menu"
-                  // This hamburger is the collapsed-sidebar fallback: while
-                  // the project list is visible its actions live in the
-                  // list's bottom action bar (`DashboardShell.tsx`), and
-                  // `AppShell` (`__root.tsx`) only passes `menuItems` to the
-                  // WorkspaceTitleBar — so this renders once the list
-                  // collapses. Retains the historical testid for any direct
-                  // `page.getByTestId` spec use (page objects target the
-                  // bottom-bar buttons now).
-                  data-testid="dashboard__menu-trigger"
-                >
-                  <Menu className="size-5" />
-                </button>
-              </DropdownMenuTrigger>
-            </TooltipTrigger>
-            <TooltipContent side="bottom" className="text-xs">
-              More
-            </TooltipContent>
-          </Tooltip>
-          <DropdownMenuContent align="start">{menuItems}</DropdownMenuContent>
-        </DropdownMenu>
       )}
       {(onGoBack || onGoForward) && (
         <>
@@ -208,7 +173,7 @@ function NavControls({
 }
 
 /** Draggable title bar over the project-list sidebar. Holds the navigation
- *  cluster (sidebar toggle, menu, back/forward) while the list is visible.
+ *  cluster (sidebar toggle, back/forward) while the list is visible.
  *  Painted with the sidebar surface so it reads as one panel with the list
  *  below it, visually separated from the workspace layout to its right. */
 export function SidebarTitleBar({ sidebarVisible, offsetClass, ...nav }: SidebarTitleBarProps) {
@@ -220,10 +185,9 @@ export function SidebarTitleBar({ sidebarVisible, offsetClass, ...nav }: Sidebar
       {/* Gate the cluster on visibility: when the list is collapsed the bar is
           clipped to 0px but stays mounted, so rendering the cluster here would
           duplicate it (the WorkspaceTitleBar shows it while collapsed) and put
-          two `…__sidebar-toggle` nodes in the DOM. `AppShell` passes
-          `menuItems={undefined}` here, so this variant renders only the toggle
-          + back/forward arrows — the overflow menu lives in the WorkspaceTitleBar
-          fallback (collapsed) and the project-list bottom action bar (visible). */}
+          two `…__sidebar-toggle` nodes in the DOM. This variant renders the
+          toggle + back/forward arrows; the overflow actions live in the
+          project-list bottom action bar. */}
       {sidebarVisible && <NavControls sidebarVisible={sidebarVisible} {...nav} />}
     </div>
   );
@@ -232,8 +196,8 @@ export function SidebarTitleBar({ sidebarVisible, offsetClass, ...nav }: Sidebar
 /** Draggable title bar over the workspace layout. Holds the workspace name
  *  (center), the open-in-editor picker, and the panel/layout switcher. When
  *  the project-list sidebar is collapsed, the navigation cluster relocates
- *  here (far left, clearing the traffic lights) so the menu and back/forward
- *  arrows stay reachable. */
+ *  here (far left, clearing the traffic lights) so the back/forward arrows
+ *  stay reachable. */
 export function WorkspaceTitleBar({
   title,
   workspaceName,

--- a/apps/web/src/components/ToolbarButtons.tsx
+++ b/apps/web/src/components/ToolbarButtons.tsx
@@ -12,7 +12,7 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@band-app/ui";
-import { Activity, BarChart3, Globe, ListTodo, MoreHorizontal, Timer } from "lucide-react";
+import { Activity, BarChart3, Globe, ListTodo, MoreVertical, Timer } from "lucide-react";
 import { createContext, type ReactNode, useCallback, useContext, useMemo, useState } from "react";
 import { useTunnel } from "@/hooks/use-tunnel";
 import { CronjobsPageContent } from "./CronjobsPageContent";
@@ -49,8 +49,9 @@ export function useAnyToolbarDialogOpen(): boolean {
  * Owns the dialog state for the toolbar overflow menu (Tasks, Cronjobs, Mobile access).
  *
  * The dialogs are rendered as siblings to `children`, so they remain mounted even when
- * the parent overflow dropdown closes. Menu items live inside the dropdown via
- * <ToolbarOverflowMenuItems /> and call the context handlers to open the dialogs.
+ * the parent overflow dropdown closes. The action buttons live in the project-list
+ * bottom action bar via <ToolbarActionBar /> and call the context handlers to open
+ * the dialogs.
  */
 export function ToolbarOverflowProvider({ children }: { children: ReactNode }) {
   const [showTasksDialog, setShowTasksDialog] = useState(false);
@@ -168,55 +169,6 @@ export function ToolbarOverflowProvider({ children }: { children: ReactNode }) {
 }
 
 /**
- * Menu items for the title-bar hamburger dropdown shown when the project-list
- * sidebar is collapsed (the `WorkspaceTitleBar` fallback). While the sidebar
- * is visible these actions live in the project-list bottom action bar
- * (`ToolbarActionBar`) instead.
- *
- * Must be rendered inside a <ToolbarOverflowProvider>. Returns a fragment of
- * DropdownMenuItem so it can be embedded directly in a DropdownMenuContent.
- */
-export function ToolbarOverflowMenuItems() {
-  const ctx = useContext(ToolbarOverflowContext);
-  if (!ctx) {
-    throw new Error("ToolbarOverflowMenuItems must be used inside ToolbarOverflowProvider");
-  }
-
-  return (
-    <>
-      <DropdownMenuItem onClick={ctx.openTasks}>
-        <ListTodo className="size-4" />
-        Tasks
-      </DropdownMenuItem>
-      <DropdownMenuItem onClick={ctx.openCronjobs}>
-        <Timer className="size-4" />
-        Cronjobs
-      </DropdownMenuItem>
-      <DropdownMenuItem onClick={ctx.openReports} data-testid="menu__reports">
-        <BarChart3 className="size-4" />
-        Usage
-      </DropdownMenuItem>
-      <DropdownMenuItem onClick={ctx.openTunnel}>
-        <Globe
-          className={
-            ctx.tunnelStatus === "error"
-              ? "size-4 text-red-500"
-              : ctx.tunnelStatus === "running"
-                ? "size-4 text-green-500"
-                : "size-4"
-          }
-        />
-        {ctx.tunnelStatus === "running" ? "Mobile access" : "Start tunnel"}
-      </DropdownMenuItem>
-      <DropdownMenuItem onClick={ctx.openResources} data-testid="menu__resources">
-        <Activity className="size-4" />
-        Resources
-      </DropdownMenuItem>
-    </>
-  );
-}
-
-/**
  * Bottom action row cluster for the project list (right-hand side).
  *
  * Surfaces Resources and Usage as standalone icon buttons and tucks the
@@ -233,6 +185,46 @@ export function ToolbarActionBar() {
 
   return (
     <>
+      <DropdownMenu>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <DropdownMenuTrigger asChild>
+              <Button
+                size="icon-sm"
+                variant="ghost"
+                className="text-muted-foreground"
+                aria-label="More actions"
+                data-testid="project-list__overflow-trigger"
+              >
+                <MoreVertical className="size-4" />
+              </Button>
+            </DropdownMenuTrigger>
+          </TooltipTrigger>
+          <TooltipContent side="top">More</TooltipContent>
+        </Tooltip>
+        <DropdownMenuContent align="end">
+          <DropdownMenuItem onClick={ctx.openTasks}>
+            <ListTodo className="size-4" />
+            Tasks
+          </DropdownMenuItem>
+          <DropdownMenuItem onClick={ctx.openCronjobs}>
+            <Timer className="size-4" />
+            Cronjobs
+          </DropdownMenuItem>
+          <DropdownMenuItem onClick={ctx.openTunnel}>
+            <Globe
+              className={
+                ctx.tunnelStatus === "error"
+                  ? "size-4 text-red-500"
+                  : ctx.tunnelStatus === "running"
+                    ? "size-4 text-green-500"
+                    : "size-4"
+              }
+            />
+            {ctx.tunnelStatus === "running" ? "Mobile access" : "Start tunnel"}
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
       <Tooltip>
         <TooltipTrigger asChild>
           <Button
@@ -263,46 +255,6 @@ export function ToolbarActionBar() {
         </TooltipTrigger>
         <TooltipContent side="top">Usage</TooltipContent>
       </Tooltip>
-      <DropdownMenu>
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <DropdownMenuTrigger asChild>
-              <Button
-                size="icon-sm"
-                variant="ghost"
-                className="text-muted-foreground"
-                aria-label="More actions"
-                data-testid="project-list__overflow-trigger"
-              >
-                <MoreHorizontal className="size-4" />
-              </Button>
-            </DropdownMenuTrigger>
-          </TooltipTrigger>
-          <TooltipContent side="top">More</TooltipContent>
-        </Tooltip>
-        <DropdownMenuContent align="end">
-          <DropdownMenuItem onClick={ctx.openTasks}>
-            <ListTodo className="size-4" />
-            Tasks
-          </DropdownMenuItem>
-          <DropdownMenuItem onClick={ctx.openCronjobs}>
-            <Timer className="size-4" />
-            Cronjobs
-          </DropdownMenuItem>
-          <DropdownMenuItem onClick={ctx.openTunnel}>
-            <Globe
-              className={
-                ctx.tunnelStatus === "error"
-                  ? "size-4 text-red-500"
-                  : ctx.tunnelStatus === "running"
-                    ? "size-4 text-green-500"
-                    : "size-4"
-              }
-            />
-            {ctx.tunnelStatus === "running" ? "Mobile access" : "Start tunnel"}
-          </DropdownMenuItem>
-        </DropdownMenuContent>
-      </DropdownMenu>
     </>
   );
 }

--- a/apps/web/src/dashboard/components/DashboardShell.tsx
+++ b/apps/web/src/dashboard/components/DashboardShell.tsx
@@ -246,11 +246,11 @@ export function DashboardShell({ bottomActions, hideTitleBar }: DashboardShellPr
     ],
   );
 
-  // The desktop shell's native menu (Cmd+,) and the in-app DesktopTitleBar
-  // hamburger both call `window.__bandOpenSettings()` to pop this dialog.
-  // The native-menu path goes via webview.eval / executeJavaScript — same
-  // pattern as the zoom menu. Register the global unconditionally so the
-  // hamburger works in the browser too (E2E + web shell).
+  // The desktop shell's native menu (Cmd+,) calls `window.__bandOpenSettings()`
+  // to pop this dialog. The native-menu path goes via webview.eval /
+  // executeJavaScript — same pattern as the zoom menu. Register the global
+  // unconditionally so the handler exists in the browser too (E2E + web shell),
+  // even though only the desktop menu invokes it today.
   //
   // Multiple `DashboardShell` instances can be alive concurrently —
   // DockviewInstanceManager keeps one per cached workspace. They all

--- a/apps/web/src/dashboard/components/ProjectList.tsx
+++ b/apps/web/src/dashboard/components/ProjectList.tsx
@@ -423,13 +423,14 @@ function SortableProject({
                 <TooltipContent side="right">{project.name}</TooltipContent>
               </Tooltip>
             </div>
-            {/* The "+" button is revealed on hover (or keyboard focus) to keep
-                the header uncluttered while scanning the list; the same action
-                lives in the right-click / long-press context menu below.
-                `opacity-0` (not `hidden`) reserves the space so the row doesn't
-                reflow on hover. On touch devices there's no hover, so it stays
-                visible. */}
-            <div className="flex items-center gap-1 opacity-0 transition-opacity group-hover:opacity-100 focus-within:opacity-100 [@media(pointer:coarse)]:opacity-100">
+            {/* The "+" and "⋮" buttons are revealed on hover (or keyboard
+                focus) to keep the header uncluttered while scanning the list;
+                the same actions live in the right-click / long-press context
+                menu below. `opacity-0` (not `hidden`) reserves the space so the
+                row doesn't reflow on hover. On touch devices there's no hover
+                and no room to spare, so the cluster is hidden entirely — the
+                actions are reached via long-press instead. */}
+            <div className="flex items-center gap-0.5 opacity-0 transition-opacity group-hover:opacity-100 focus-within:opacity-100 [@media(pointer:coarse)]:hidden">
               {/* "⋮" opens the same action list as right-click, so the menu is
                   reachable with a plain left click (and on touch, where there's
                   no right-click). Sits to the left of the "+" quick action. */}

--- a/apps/web/src/dashboard/components/WorkspaceCard.tsx
+++ b/apps/web/src/dashboard/components/WorkspaceCard.tsx
@@ -37,6 +37,7 @@ import { AgentStatusIndicator } from "./AgentStatusIndicator";
 import { CIStatusIndicator } from "./CIStatusIndicator";
 import { GitStatusIndicator } from "./GitStatusIndicator";
 import { SetupStatusIndicator } from "./SetupStatusIndicator";
+import { WorkspaceLabel } from "./WorkspaceLabel";
 
 // ---------------------------------------------------------------------------
 // Recent-user-activation marker (used to suppress auto-scroll on in-list nav)
@@ -257,19 +258,13 @@ export const WorkspaceCard = memo(function WorkspaceCard({
                   // Pinned section: stack the branch name over the project name
                   // as a compact two-line block so a mixed list of pinned cards
                   // stays scannable without a long, mid-truncated
-                  // `project/branch` string on one line.
-                  <div className="flex flex-col min-w-0 leading-tight">
-                    <span
-                      className={`text-sm truncate ${isActive ? "font-bold text-foreground" : "font-medium text-muted-foreground"}`}
-                    >
-                      {worktree.name}
-                    </span>
-                    <span
-                      className={`text-xs truncate ${isActive ? "text-foreground/80" : "text-muted-foreground"}`}
-                    >
-                      {projectName}
-                    </span>
-                  </div>
+                  // `project/branch` string on one line. Shared with the ⌘K
+                  // workspace picker via `WorkspaceLabel`.
+                  <WorkspaceLabel
+                    name={worktree.name}
+                    projectName={projectName}
+                    isActive={isActive}
+                  />
                 ) : (
                   <span
                     className={`text-sm truncate ${isActive ? "font-bold text-foreground" : "font-medium text-muted-foreground"}`}

--- a/apps/web/src/dashboard/components/WorkspaceLabel.tsx
+++ b/apps/web/src/dashboard/components/WorkspaceLabel.tsx
@@ -1,3 +1,5 @@
+import { cn } from "@band-app/ui";
+
 /**
  * Two-row workspace label: the workspace name on the first line with the
  * project name stacked beneath it. Shared by the Pinned section cards
@@ -43,8 +45,8 @@ export function WorkspaceLabel({
 
   return (
     <div className="flex flex-col min-w-0 leading-tight">
-      <span className={`text-sm truncate ${nameClass}`}>{name}</span>
-      <span className={`text-xs truncate ${projectClass}`}>{projectName}</span>
+      <span className={cn("text-sm truncate", nameClass)}>{name}</span>
+      <span className={cn("text-xs truncate", projectClass)}>{projectName}</span>
     </div>
   );
 }

--- a/apps/web/src/dashboard/components/WorkspaceLabel.tsx
+++ b/apps/web/src/dashboard/components/WorkspaceLabel.tsx
@@ -1,0 +1,50 @@
+/**
+ * Two-row workspace label: the workspace name on the first line with the
+ * project name stacked beneath it. Shared by the Pinned section cards
+ * (`WorkspaceCard` with `showProjectName`) and the ⌘K workspace picker
+ * (`WorkspacePickerDialog`) so both render the same compact, scannable block
+ * instead of a long, mid-truncated `project/name` string on one line.
+ *
+ * `isActive` bolds the name + brightens the project line to mark the
+ * currently-open workspace, matching the card's active styling.
+ *
+ * `tone` adapts the text colour to the surface:
+ *  - "sidebar" (default): muted text so the label sits quietly inside the dense
+ *    project tree, matching the surrounding cards.
+ *  - "switcher": brighter text for the command-palette overlay, where muted
+ *    grey-on-dark is hard to read.
+ */
+interface WorkspaceLabelProps {
+  /** Stable workspace identity/label (see `WorktreeInfo.name`). */
+  name: string;
+  projectName: string;
+  isActive?: boolean;
+  tone?: "sidebar" | "switcher";
+}
+
+export function WorkspaceLabel({
+  name,
+  projectName,
+  isActive,
+  tone = "sidebar",
+}: WorkspaceLabelProps) {
+  const nameClass =
+    tone === "switcher"
+      ? `text-foreground ${isActive ? "font-semibold" : "font-medium"}`
+      : isActive
+        ? "font-bold text-foreground"
+        : "font-medium text-muted-foreground";
+  const projectClass =
+    tone === "switcher"
+      ? "text-foreground/70"
+      : isActive
+        ? "text-foreground/80"
+        : "text-muted-foreground";
+
+  return (
+    <div className="flex flex-col min-w-0 leading-tight">
+      <span className={`text-sm truncate ${nameClass}`}>{name}</span>
+      <span className={`text-xs truncate ${projectClass}`}>{projectName}</span>
+    </div>
+  );
+}

--- a/apps/web/src/dashboard/components/WorkspacePickerDialog.tsx
+++ b/apps/web/src/dashboard/components/WorkspacePickerDialog.tsx
@@ -18,7 +18,6 @@ import { useProjects } from "../hooks/use-projects";
 import { getRecentWorkspaceOrder, recordWorkspaceAccess } from "../lib/recent-workspaces";
 import { toWorkspaceId } from "../lib/workspace-id";
 import { useDashboardStore } from "../stores/index";
-import type { AgentInfo } from "../types";
 import { AgentStatusIndicator } from "./AgentStatusIndicator";
 import { WorkspaceLabel } from "./WorkspaceLabel";
 
@@ -35,7 +34,6 @@ interface WorkspaceEntry {
    * instead of the branch glyph, mirroring the project-list root card.
    */
   isRoot: boolean;
-  agent?: AgentInfo;
 }
 
 interface WorkspacePickerDialogProps {
@@ -82,7 +80,6 @@ export function WorkspacePickerDialog({ open, onOpenChange }: WorkspacePickerDia
           // A git project's default-branch worktree is its main checkout (the
           // repo root). Plain projects have no root/feature distinction.
           isRoot: project.kind !== "plain" && worktree.name === project.defaultBranch,
-          agent: statuses.get(workspaceId)?.agent,
         });
       }
     }
@@ -97,11 +94,20 @@ export function WorkspacePickerDialog({ open, onOpenChange }: WorkspacePickerDia
     });
 
     return entries;
-  }, [projects, statuses, recentOrder, activeWorkspaceId]);
+    // `statuses` is intentionally NOT a dependency: agent status is read per row
+    // at render time (below), not baked into the sorted entries. Otherwise every
+    // ~1 Hz agent-status tick would re-run this whole flatten + sort while the
+    // picker is open — precisely when agents are busiest.
+  }, [projects, recentOrder, activeWorkspaceId]);
 
   const handleSelect = useCallback(
     (workspaceId: string) => {
       clearNeedsAttention(workspaceId);
+      // Recency is recorded on explicit picker selection. Navigating via URL,
+      // browser back/forward, or the project-list sidebar does NOT currently
+      // update the recency store — those paths keep their existing order until
+      // the workspace is next chosen through the picker. (Broadening recording
+      // to every navigation path is a possible follow-up.)
       recordWorkspaceAccess(workspaceId);
       const href = capabilities.getWorkspaceHref?.(workspaceId);
       if (href && capabilities.navigate) {
@@ -146,6 +152,9 @@ export function WorkspacePickerDialog({ open, onOpenChange }: WorkspacePickerDia
             {sortedWorkspaces.map((entry) => {
               const isActive = activeWorkspaceId === entry.workspaceId;
               const pinnedNow = isPinned(entry.workspaceId);
+              // Read live agent status per row here (not inside the sort memo) so
+              // status ticks repaint only the rows, never re-sort the list.
+              const agent = statuses.get(entry.workspaceId)?.agent;
               return (
                 <CommandItem
                   key={entry.workspaceId}
@@ -162,7 +171,7 @@ export function WorkspacePickerDialog({ open, onOpenChange }: WorkspacePickerDia
                       as the project-list root card); an active agent's status
                       dot replaces it via the fallback slot. */}
                   <AgentStatusIndicator
-                    agent={entry.agent}
+                    agent={agent}
                     isActive={isActive}
                     fallback={
                       entry.isRoot ? (

--- a/apps/web/src/dashboard/components/WorkspacePickerDialog.tsx
+++ b/apps/web/src/dashboard/components/WorkspacePickerDialog.tsx
@@ -10,7 +10,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@band-app/ui";
-import { Pin, PinOff } from "lucide-react";
+import { Home, Pin, PinOff } from "lucide-react";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useCapabilities } from "../context";
 import { usePinnedWorkspaces } from "../hooks/use-pinned-workspaces";
@@ -20,6 +20,7 @@ import { toWorkspaceId } from "../lib/workspace-id";
 import { useDashboardStore } from "../stores/index";
 import type { AgentInfo } from "../types";
 import { AgentStatusIndicator } from "./AgentStatusIndicator";
+import { WorkspaceLabel } from "./WorkspaceLabel";
 
 interface WorkspaceEntry {
   workspaceId: string;
@@ -28,6 +29,12 @@ interface WorkspaceEntry {
   name: string;
   /** Live git branch — kept for search only. */
   branch: string;
+  /**
+   * True when this workspace is the project's main checkout (its default-branch
+   * worktree, and the project is a git project). Marked with a house icon
+   * instead of the branch glyph, mirroring the project-list root card.
+   */
+  isRoot: boolean;
   agent?: AgentInfo;
 }
 
@@ -43,7 +50,7 @@ export function WorkspacePickerDialog({ open, onOpenChange }: WorkspacePickerDia
   const statuses = useDashboardStore((s) => s.statuses);
   const openWorkspace = useDashboardStore((s) => s.openWorkspace);
   const clearNeedsAttention = useDashboardStore((s) => s.clearNeedsAttention);
-  const { isPinned, toggle: togglePinned, pinned } = usePinnedWorkspaces();
+  const { isPinned, toggle: togglePinned } = usePinnedWorkspaces();
 
   const [query, setQuery] = useState("");
 
@@ -57,12 +64,11 @@ export function WorkspacePickerDialog({ open, onOpenChange }: WorkspacePickerDia
     }
   }, [open]);
 
-  // Map workspaceId -> rank in pinnedEntries (order = DB insertion order).
-  // Used to sort pinned entries deterministically near the top of the list.
-  const pinnedRank = useMemo(() => new Map(pinned.map((p, i) => [p.workspaceId, i])), [pinned]);
-
-  // Flatten all workspaces and sort: active first, then pinned (in pin order),
-  // then everything else by recency.
+  // Flatten all workspaces and sort strictly by most-recently-accessed. The
+  // active workspace floats to the top (it's what the user just left / is on),
+  // then everything else follows the recent-access order. Pinned status does
+  // NOT affect ordering here — pinning is a sidebar-grouping affordance, so a
+  // rarely-touched pinned workspace must not jump above one the user just used.
   const sortedWorkspaces = useMemo(() => {
     const entries: WorkspaceEntry[] = [];
     for (const project of projects) {
@@ -73,6 +79,9 @@ export function WorkspacePickerDialog({ open, onOpenChange }: WorkspacePickerDia
           projectName: project.name,
           name: worktree.name,
           branch: worktree.branch,
+          // A git project's default-branch worktree is its main checkout (the
+          // repo root). Plain projects have no root/feature distinction.
+          isRoot: project.kind !== "plain" && worktree.name === project.defaultBranch,
           agent: statuses.get(workspaceId)?.agent,
         });
       }
@@ -82,18 +91,13 @@ export function WorkspacePickerDialog({ open, onOpenChange }: WorkspacePickerDia
     entries.sort((a, b) => {
       if (a.workspaceId === activeWorkspaceId) return -1;
       if (b.workspaceId === activeWorkspaceId) return 1;
-      const ap = pinnedRank.get(a.workspaceId);
-      const bp = pinnedRank.get(b.workspaceId);
-      if (ap !== undefined && bp === undefined) return -1;
-      if (bp !== undefined && ap === undefined) return 1;
-      if (ap !== undefined && bp !== undefined) return ap - bp;
       const ai = orderMap.get(a.workspaceId) ?? Number.MAX_SAFE_INTEGER;
       const bi = orderMap.get(b.workspaceId) ?? Number.MAX_SAFE_INTEGER;
       return ai - bi;
     });
 
     return entries;
-  }, [projects, statuses, recentOrder, activeWorkspaceId, pinnedRank]);
+  }, [projects, statuses, recentOrder, activeWorkspaceId]);
 
   const handleSelect = useCallback(
     (workspaceId: string) => {
@@ -154,13 +158,27 @@ export function WorkspacePickerDialog({ open, onOpenChange }: WorkspacePickerDia
                   // project-list rows.
                   className="group touch-manipulation [@media(pointer:coarse)]:min-h-11 [@media(pointer:coarse)]:gap-3"
                 >
-                  <AgentStatusIndicator agent={entry.agent} />
-                  <span className="text-sm font-medium">
-                    {entry.projectName}/{entry.name}
-                  </span>
-                  {pinnedNow && (
-                    <Pin className="size-3 -rotate-45 text-muted-foreground shrink-0" />
-                  )}
+                  {/* Root workspaces get a house icon (the same identity marker
+                      as the project-list root card); an active agent's status
+                      dot replaces it via the fallback slot. */}
+                  <AgentStatusIndicator
+                    agent={entry.agent}
+                    isActive={isActive}
+                    fallback={
+                      entry.isRoot ? (
+                        <Home
+                          data-testid={`workspace-picker__home-icon--${entry.workspaceId}`}
+                          className={`size-3.5 shrink-0 ${isActive ? "text-primary" : "text-muted-foreground"}`}
+                        />
+                      ) : undefined
+                    }
+                  />
+                  <WorkspaceLabel
+                    name={entry.name}
+                    projectName={entry.projectName}
+                    isActive={isActive}
+                    tone="switcher"
+                  />
                   <div className="ml-auto flex items-center gap-2">
                     {isActive && (
                       <span className="shrink-0 text-xs text-muted-foreground">current</span>

--- a/apps/web/src/dashboard/lib/recent-workspaces.ts
+++ b/apps/web/src/dashboard/lib/recent-workspaces.ts
@@ -25,7 +25,10 @@ export function getRecentWorkspaceOrder(): string[] {
     const raw = localStorage.getItem(STORAGE_KEY);
     if (!raw) return [];
     const parsed = JSON.parse(raw);
-    if (Array.isArray(parsed)) return parsed;
+    // Guard every element, not just the array shape: an older/corrupted schema
+    // (e.g. numeric ids) must fall through to `[]` rather than feed non-string
+    // keys into the switcher's `orderMap` comparison.
+    if (Array.isArray(parsed) && parsed.every((e) => typeof e === "string")) return parsed;
   } catch {
     // Corrupted data — ignore
   }

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -1,4 +1,4 @@
-import { DropdownMenuItem, TooltipProvider } from "@band-app/ui";
+import { TooltipProvider } from "@band-app/ui";
 import {
   createRootRoute,
   HeadContent,
@@ -13,7 +13,6 @@ import {
   GitCompare,
   Globe,
   MessageSquare,
-  Settings as SettingsIcon,
   Terminal as TerminalIcon,
 } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
@@ -30,11 +29,7 @@ import { WebCapabilities, WebDashboardAdapter } from "@/dashboard/adapters/web";
 import { BrowserHostBridge } from "../components/BrowserHostBridge";
 import { type PanelItem, SidebarTitleBar, WorkspaceTitleBar } from "../components/DesktopTitleBar";
 import { crossPanelHandlers, SharedDockviewLayout } from "../components/SharedDockviewLayout";
-import {
-  ToolbarActionBar,
-  ToolbarOverflowMenuItems,
-  ToolbarOverflowProvider,
-} from "../components/ToolbarButtons";
+import { ToolbarActionBar, ToolbarOverflowProvider } from "../components/ToolbarButtons";
 import { useIsDesktop } from "../hooks/useIsDesktop";
 import { useIsFullscreen } from "../hooks/useIsFullscreen";
 import { useNavigationHistory } from "../hooks/useNavigationHistory";
@@ -585,40 +580,20 @@ function AppShell() {
     [],
   );
 
-  // The back/forward arrows (and, when the list is collapsed, the hamburger
-  // menu) belong to the project-list region. While the list is visible the
-  // SidebarTitleBar shows only the sidebar toggle + arrows — the overflow
-  // actions live in DashboardShell's bottom action bar, so `menuItems` is not
-  // passed there. When the list collapses, the arrows + the fallback hamburger
-  // relocate into the WorkspaceTitleBar (far left) so they stay reachable. Both
-  // bars receive the same nav props; each renders the cluster only in the
-  // appropriate state (keyed off `sidebarVisible`).
+  // The back/forward arrows and sidebar toggle belong to the project-list
+  // region. While the list is visible the SidebarTitleBar shows the cluster;
+  // when the list collapses, the same cluster relocates into the
+  // WorkspaceTitleBar (far left) so it stays reachable. The overflow actions
+  // always live in DashboardShell's bottom action bar, so the cluster carries
+  // no menu of its own. Both bars receive the same nav props; each renders the
+  // cluster only in the appropriate state (keyed off `sidebarVisible`).
   //
   // Memoized so both bars get a stable prop reference across the frequent
   // AppShell re-renders (route changes, workspace switches, sidebar toggles).
-  // Hooks must run unconditionally, so these sit above the narrow/mobile early
+  // Hooks must run unconditionally, so this sits above the narrow/mobile early
   // return below.
-  const menuItems = useMemo(
-    () => (
-      <>
-        <ToolbarOverflowMenuItems />
-        <DropdownMenuItem
-          onClick={() => {
-            const fn = (window as unknown as { __bandOpenSettings?: () => void })
-              .__bandOpenSettings;
-            fn?.();
-          }}
-        >
-          <SettingsIcon className="size-4" />
-          Settings
-        </DropdownMenuItem>
-      </>
-    ),
-    [],
-  );
   const navControlProps = useMemo(
     () => ({
-      menuItems,
       onGoBack: navigationHistory.goBack,
       onGoForward: navigationHistory.goForward,
       canGoBack: navigationHistory.canGoBack,
@@ -627,7 +602,6 @@ function AppShell() {
       sidebarVisible,
     }),
     [
-      menuItems,
       navigationHistory.goBack,
       navigationHistory.goForward,
       navigationHistory.canGoBack,
@@ -676,16 +650,10 @@ function AppShell() {
                 className="h-full flex flex-col overflow-hidden border-r border-border bg-sidebar"
                 data-testid="app-shell__sidebar"
               >
-                {/* The hamburger menu is dropped here: while the list is
-                    visible its actions live in DashboardShell's bottom action
-                    bar. Only the sidebar toggle + back/forward arrows ride in
-                    the SidebarTitleBar. The menu stays in the WorkspaceTitleBar
-                    (below) as the fallback for the collapsed-list state. */}
-                <SidebarTitleBar
-                  {...navControlProps}
-                  menuItems={undefined}
-                  offsetClass={titleBarOffset}
-                />
+                {/* The sidebar toggle + back/forward arrows ride in the
+                    SidebarTitleBar; the overflow actions live in
+                    DashboardShell's bottom action bar below. */}
+                <SidebarTitleBar {...navControlProps} offsetClass={titleBarOffset} />
                 <div className="flex-1 min-h-0">
                   <DashboardShell hideTitleBar bottomActions={<ToolbarActionBar />} />
                 </div>


### PR DESCRIPTION
## Workspace switcher (⌘K)
- **Ordering** is now strictly most-recently-accessed. Pinned status no longer floats items to the top of the switcher (the active workspace still leads); recently-used wins.
- **Row layout** mirrors the pinned sidebar cards — a two-row block (workspace name over project name) via a new shared `WorkspaceLabel` component, reused by both surfaces.
- **Readability**: switcher label text is brightened for the dark command-palette overlay (`tone="switcher"`), while the sidebar cards keep their muted styling.
- Removed the small pinned-indicator icon from switcher rows.
- **House icon** for a project's main checkout (default-branch worktree), matching the project-list root card; feature branches keep the branch glyph.

## Toolbar / sidebar polish
- Bottom action bar: the overflow menu is now a vertical 3-dots (`MoreVertical`) moved to the **left** of the Resources/Usage icons.
- Dropped the collapsed-sidebar **hamburger** menu (per request) and the now-dead `menuItems` plumbing; overflow actions live solely in the project-list bottom bar.
- Project-list header: the `+`/`⋮` buttons are **hidden on touch** (reached via long-press context menu) and the gap between them is tightened.

## Tests
- New `workspace-picker.spec.ts` coverage: recency-ordering (a pinned-but-stale workspace does not float above a recently-used one) and the house-icon marker (main vs feature branch). New page-object helpers `orderedWorkspaceIds` / `homeIcon`.
- Updated `sidebar-toggle.spec.ts` + `WorkspacePage` for the removed hamburger (asserts no `Menu` button in any state; toggle + back/forward still relocate on collapse).

All frontend integration tests boot the real server via the e2e helpers and drive real Chromium — no tRPC mocks, no `page.route` on own routes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)