### PR TITLE
feat(release): publish Homebrew cask to band-app/homebrew-band tap on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -229,3 +229,41 @@ jobs:
         run: pnpm publish --access public --no-git-checks
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      # Regenerate the Homebrew cask in band-app/homebrew-band so
+      # `brew install --cask band` resolves the release that was just
+      # published. Hashes the local signed DMGs (same files uploaded above)
+      # and pushes over SSH with a write deploy key scoped to the tap repo.
+      # Runs last so a tap-side failure can't block the npm publish of an
+      # already-tagged release.
+      - name: Update Homebrew tap
+        env:
+          HOMEBREW_TAP_DEPLOY_KEY: ${{ secrets.HOMEBREW_TAP_DEPLOY_KEY }}
+          VERSION: ${{ steps.version.outputs.new_version }}
+        run: |
+          ARM_SHA=$(shasum -a 256 "apps/desktop/dist-builder/Band-${VERSION}-apple-silicon.dmg" | awk '{print $1}')
+          INTEL_SHA=$(shasum -a 256 "apps/desktop/dist-builder/Band-${VERSION}-intel.dmg" | awk '{print $1}')
+          KEY_FILE="$RUNNER_TEMP/tap_deploy_key"
+          printf '%s\n' "$HOMEBREW_TAP_DEPLOY_KEY" > "$KEY_FILE"
+          chmod 600 "$KEY_FILE"
+          trap 'rm -f "$KEY_FILE"' EXIT
+          # Pin GitHub's published SSH host key (docs.github.com "GitHub's
+          # SSH key fingerprints") instead of trust-on-first-use.
+          echo "github.com ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOMqqnkVzrm0SdG6UOoqKLsabgH5C9okWi0dh2l9GKJl" > "$RUNNER_TEMP/known_hosts"
+          export GIT_SSH_COMMAND="ssh -i $KEY_FILE -o UserKnownHostsFile=$RUNNER_TEMP/known_hosts -o StrictHostKeyChecking=yes"
+          git clone --depth 1 git@github.com:band-app/homebrew-band.git "$RUNNER_TEMP/homebrew-band"
+          node scripts/generate-homebrew-cask.mjs \
+            --version "$VERSION" \
+            --arm-sha "$ARM_SHA" \
+            --intel-sha "$INTEL_SHA" \
+            > "$RUNNER_TEMP/homebrew-band/Casks/band.rb"
+          cd "$RUNNER_TEMP/homebrew-band"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add Casks/band.rb
+          if git diff --cached --quiet; then
+            echo "Cask already up to date"
+            exit 0
+          fi
+          git commit -m "band ${VERSION}"
+          git push origin HEAD:main

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -250,7 +250,7 @@ jobs:
           # Pin GitHub's published SSH host key (docs.github.com "GitHub's
           # SSH key fingerprints") instead of trust-on-first-use.
           echo "github.com ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOMqqnkVzrm0SdG6UOoqKLsabgH5C9okWi0dh2l9GKJl" > "$RUNNER_TEMP/known_hosts"
-          export GIT_SSH_COMMAND="ssh -i $KEY_FILE -o UserKnownHostsFile=$RUNNER_TEMP/known_hosts -o StrictHostKeyChecking=yes"
+          export GIT_SSH_COMMAND="ssh -i \"$KEY_FILE\" -o UserKnownHostsFile=\"$RUNNER_TEMP/known_hosts\" -o StrictHostKeyChecking=yes"
           git clone --depth 1 git@github.com:band-app/homebrew-band.git "$RUNNER_TEMP/homebrew-band"
           node scripts/generate-homebrew-cask.mjs \
             --version "$VERSION" \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -241,6 +241,12 @@ jobs:
           HOMEBREW_TAP_DEPLOY_KEY: ${{ secrets.HOMEBREW_TAP_DEPLOY_KEY }}
           VERSION: ${{ steps.version.outputs.new_version }}
         run: |
+          # Defence-in-depth: fail fast if the release version isn't a plain
+          # semver before interpolating it into any command below. (new_version
+          # comes from the trusted bump-version step, and bash does not
+          # re-evaluate $() inside an expanded variable, but a malformed value
+          # would otherwise build a wrong DMG path and fail shasum silently.)
+          [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || { echo "VERSION is not a plain semver: $VERSION" >&2; exit 1; }
           ARM_SHA=$(shasum -a 256 "apps/desktop/dist-builder/Band-${VERSION}-apple-silicon.dmg" | awk '{print $1}')
           INTEL_SHA=$(shasum -a 256 "apps/desktop/dist-builder/Band-${VERSION}-intel.dmg" | awk '{print $1}')
           KEY_FILE="$RUNNER_TEMP/tap_deploy_key"

--- a/apps/desktop/tests/generate-homebrew-cask.test.mjs
+++ b/apps/desktop/tests/generate-homebrew-cask.test.mjs
@@ -1,0 +1,117 @@
+/**
+ * Integration tests for scripts/generate-homebrew-cask.mjs.
+ *
+ * Black-box: the script is a CLI that validates its args and prints a
+ * Homebrew cask definition to stdout (the release workflow redirects that
+ * into a clone of band-app/homebrew-band and pushes it). We exercise it as
+ * a child process — the same way the workflow invokes it — and assert on
+ * exit code, stdout, and stderr. A regression in argument validation or the
+ * Ruby template would otherwise silently push a malformed cask to the tap.
+ *
+ * The script lives in the repo-root scripts/ dir; its test lives here
+ * because apps/desktop is the workspace package whose `test` script globs
+ * tests/**\/*.test.mjs and runs under CI's `pnpm test`.
+ */
+
+import { strict as assert } from "node:assert";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { describe, test } from "node:test";
+
+const SCRIPT = fileURLToPath(
+  new URL("../../../scripts/generate-homebrew-cask.mjs", import.meta.url),
+);
+
+const ARM_SHA = "a".repeat(64);
+const INTEL_SHA = "b".repeat(64);
+
+/** Run the generator with the given argv array; return { status, stdout, stderr }. */
+function run(args) {
+  const result = spawnSync(process.execPath, [SCRIPT, ...args], {
+    encoding: "utf8",
+  });
+  assert.equal(result.error, undefined, `spawn failed: ${result.error}`);
+  return result;
+}
+
+const VALID_ARGS = [
+  "--version",
+  "0.26.1",
+  "--arm-sha",
+  ARM_SHA,
+  "--intel-sha",
+  INTEL_SHA,
+];
+
+describe("generate-homebrew-cask", () => {
+  test("valid args render a cask containing version, shas, and urls", () => {
+    const { status, stdout } = run(VALID_ARGS);
+    assert.equal(status, 0);
+
+    // Version, both arch shas, and both download URLs are interpolated.
+    assert.match(stdout, /cask "band" do/);
+    assert.match(stdout, /version "0\.26\.1"/);
+    assert.ok(stdout.includes(`sha256 "${ARM_SHA}"`), "arm sha present");
+    assert.ok(stdout.includes(`sha256 "${INTEL_SHA}"`), "intel sha present");
+    assert.ok(
+      stdout.includes("Band-#{version}-apple-silicon.dmg"),
+      "arm url present",
+    );
+    assert.ok(stdout.includes("Band-#{version}-intel.dmg"), "intel url present");
+
+    // Fix [1]: the app self-updates via Squirrel, so `auto_updates true` owns
+    // upgrades and there is no (redundant, contradictory) livecheck block.
+    assert.ok(stdout.includes("auto_updates true"), "auto_updates retained");
+    assert.ok(!stdout.includes("livecheck do"), "livecheck block removed");
+  });
+
+  test("missing --version exits 1 with a meaningful message", () => {
+    const { status, stderr } = run([
+      "--arm-sha",
+      ARM_SHA,
+      "--intel-sha",
+      INTEL_SHA,
+    ]);
+    assert.equal(status, 1);
+    assert.match(stderr, /version/i);
+  });
+
+  test("malformed --version exits 1", () => {
+    const { status, stderr } = run([
+      "--version",
+      "not-semver",
+      "--arm-sha",
+      ARM_SHA,
+      "--intel-sha",
+      INTEL_SHA,
+    ]);
+    assert.equal(status, 1);
+    assert.match(stderr, /version/i);
+  });
+
+  test("a sha that is not 64 lowercase hex chars exits 1", () => {
+    for (const bad of [
+      "abc", // too short
+      "A".repeat(64), // uppercase
+      `${"a".repeat(63)}g`, // non-hex char
+      `${"a".repeat(65)}`, // too long
+    ]) {
+      const { status, stderr } = run([
+        "--version",
+        "0.26.1",
+        "--arm-sha",
+        bad,
+        "--intel-sha",
+        INTEL_SHA,
+      ]);
+      assert.equal(status, 1, `expected exit 1 for arm-sha "${bad}"`);
+      assert.match(stderr, /sha/i);
+    }
+  });
+
+  test("an unknown argument exits 1", () => {
+    const { status, stderr } = run([...VALID_ARGS, "--bogus"]);
+    assert.equal(status, 1);
+    assert.match(stderr, /unknown argument/i);
+  });
+});

--- a/apps/desktop/tests/generate-homebrew-cask.test.mjs
+++ b/apps/desktop/tests/generate-homebrew-cask.test.mjs
@@ -62,7 +62,11 @@ describe("generate-homebrew-cask", () => {
     // Fix [1]: the app self-updates via Squirrel, so `auto_updates true` owns
     // upgrades and there is no (redundant, contradictory) livecheck block.
     assert.ok(stdout.includes("auto_updates true"), "auto_updates retained");
-    assert.ok(!stdout.includes("livecheck do"), "livecheck block removed");
+    assert.equal(
+      stdout.includes("livecheck do"),
+      false,
+      "unexpected livecheck block in output",
+    );
   });
 
   test("missing --version exits 1 with a meaningful message", () => {
@@ -128,6 +132,18 @@ describe("generate-homebrew-cask", () => {
       });
     }
   }
+
+  test("a flag with no following value exits 1 with a requires-a-value message", () => {
+    const { status, stderr } = run([
+      "--arm-sha",
+      ARM_SHA,
+      "--intel-sha",
+      INTEL_SHA,
+      "--version",
+    ]);
+    assert.equal(status, 1);
+    assert.match(stderr, /--version requires a value/);
+  });
 
   test("an unknown argument exits 1", () => {
     const { status, stderr } = run([...VALID_ARGS, "--bogus"]);

--- a/apps/desktop/tests/generate-homebrew-cask.test.mjs
+++ b/apps/desktop/tests/generate-homebrew-cask.test.mjs
@@ -89,25 +89,45 @@ describe("generate-homebrew-cask", () => {
     assert.match(stderr, /version/i);
   });
 
-  test("a sha that is not 64 lowercase hex chars exits 1", () => {
-    for (const bad of [
-      "abc", // too short
-      "A".repeat(64), // uppercase
-      `${"a".repeat(63)}g`, // non-hex char
-      `${"a".repeat(65)}`, // too long
-    ]) {
-      const { status, stderr } = run([
-        "--version",
-        "0.26.1",
-        "--arm-sha",
-        bad,
-        "--intel-sha",
-        INTEL_SHA,
-      ]);
-      assert.equal(status, 1, `expected exit 1 for arm-sha "${bad}"`);
-      assert.match(stderr, /sha/i);
-    }
+  test("missing --arm-sha exits 1", () => {
+    const { status, stderr } = run(["--version", "0.26.1", "--intel-sha", INTEL_SHA]);
+    assert.equal(status, 1);
+    assert.match(stderr, /sha/i);
   });
+
+  test("missing --intel-sha exits 1", () => {
+    const { status, stderr } = run(["--version", "0.26.1", "--arm-sha", ARM_SHA]);
+    assert.equal(status, 1);
+    assert.match(stderr, /sha/i);
+  });
+
+  // Both sha flags share one validation path, but exercise each independently
+  // so a regression touching only one branch can't hide behind the other.
+  // One test() per bad shape so the first failure doesn't mask the rest.
+  const BAD_SHAS = {
+    "too short": "abc",
+    uppercase: "A".repeat(64),
+    "non-hex char": `${"a".repeat(63)}g`,
+    "too long": "a".repeat(65),
+  };
+  for (const flag of ["--arm-sha", "--intel-sha"]) {
+    for (const [shape, bad] of Object.entries(BAD_SHAS)) {
+      test(`${flag} that is ${shape} exits 1`, () => {
+        const otherFlag = flag === "--arm-sha" ? "--intel-sha" : "--arm-sha";
+        const good = flag === "--arm-sha" ? INTEL_SHA : ARM_SHA;
+        const { status, stderr } = run([
+          "--version",
+          "0.26.1",
+          flag,
+          bad,
+          otherFlag,
+          good,
+        ]);
+        assert.equal(status, 1);
+        assert.match(stderr, /sha/i);
+      });
+    }
+  }
 
   test("an unknown argument exits 1", () => {
     const { status, stderr } = run([...VALID_ARGS, "--bogus"]);

--- a/scripts/generate-homebrew-cask.mjs
+++ b/scripts/generate-homebrew-cask.mjs
@@ -74,11 +74,10 @@ process.stdout.write(`cask "band" do
   desc "IDE-agnostic agent orchestrator"
   homepage "https://github.com/band-app/band"
 
-  livecheck do
-    url :url
-    strategy :github_latest
-  end
-
+  # Band ships a Squirrel.Mac auto-updater (see the ShipIt entry in the zap
+  # trash list below), so the app upgrades itself in place. auto_updates true
+  # tells Homebrew not to manage upgrades -- hence no livecheck block, which
+  # would only matter if brew upgrade owned the upgrade path.
   auto_updates true
   depends_on macos: :big_sur
 

--- a/scripts/generate-homebrew-cask.mjs
+++ b/scripts/generate-homebrew-cask.mjs
@@ -16,16 +16,27 @@ function parseArgs() {
   const args = process.argv.slice(2);
   const opts = { version: null, armSha: null, intelSha: null };
 
+  // Read the value that follows a flag, failing with a flag-specific message
+  // if it was the last token (so an omitted value isn't misreported later as
+  // a malformed one).
+  const takeValue = (flag, i) => {
+    if (i >= args.length) {
+      console.error(`${flag} requires a value`);
+      process.exit(1);
+    }
+    return args[i];
+  };
+
   for (let i = 0; i < args.length; i++) {
     switch (args[i]) {
       case "--version":
-        opts.version = args[++i];
+        opts.version = takeValue("--version", ++i);
         break;
       case "--arm-sha":
-        opts.armSha = args[++i];
+        opts.armSha = takeValue("--arm-sha", ++i);
         break;
       case "--intel-sha":
-        opts.intelSha = args[++i];
+        opts.intelSha = takeValue("--intel-sha", ++i);
         break;
       default:
         console.error(`Unknown argument: ${args[i]}`);
@@ -53,9 +64,10 @@ function parseArgs() {
 const { version, armSha, intelSha } = parseArgs();
 
 // The `binary` stanza symlinks the CLI sidecar bundled inside the app
-// (electron-builder `extraResources`, see apps/desktop/electron-builder.yml)
-// into Homebrew's bin, so `brew install --cask band` also provides the
-// `band` command without the in-app admin-privileged symlink flow.
+// (placed in Contents/Resources/binaries/ by electron-builder's
+// extraResources config) into Homebrew's bin, so `brew install --cask band`
+// also provides the `band` command without the in-app admin-privileged
+// symlink flow.
 process.stdout.write(`cask "band" do
   version "${version}"
 

--- a/scripts/generate-homebrew-cask.mjs
+++ b/scripts/generate-homebrew-cask.mjs
@@ -1,0 +1,98 @@
+#!/usr/bin/env node
+
+// Generates the Homebrew cask definition for the Band desktop app and
+// prints it to stdout. The release workflow runs this after building the
+// signed DMGs, redirects the output into a clone of band-app/homebrew-band
+// (Casks/band.rb), and pushes — keeping the tap in lockstep with every
+// release without a manual bump.
+//
+// Usage:
+//   node scripts/generate-homebrew-cask.mjs \
+//     --version 0.26.0 \
+//     --arm-sha <sha256 of Band-<v>-apple-silicon.dmg> \
+//     --intel-sha <sha256 of Band-<v>-intel.dmg>
+
+function parseArgs() {
+  const args = process.argv.slice(2);
+  const opts = { version: null, armSha: null, intelSha: null };
+
+  for (let i = 0; i < args.length; i++) {
+    switch (args[i]) {
+      case "--version":
+        opts.version = args[++i];
+        break;
+      case "--arm-sha":
+        opts.armSha = args[++i];
+        break;
+      case "--intel-sha":
+        opts.intelSha = args[++i];
+        break;
+      default:
+        console.error(`Unknown argument: ${args[i]}`);
+        process.exit(1);
+    }
+  }
+
+  if (!/^\d+\.\d+\.\d+$/.test(opts.version ?? "")) {
+    console.error("--version must be a semver like 0.26.0");
+    process.exit(1);
+  }
+  for (const [flag, value] of [
+    ["--arm-sha", opts.armSha],
+    ["--intel-sha", opts.intelSha],
+  ]) {
+    if (!/^[0-9a-f]{64}$/.test(value ?? "")) {
+      console.error(`${flag} must be a lowercase hex sha256`);
+      process.exit(1);
+    }
+  }
+
+  return opts;
+}
+
+const { version, armSha, intelSha } = parseArgs();
+
+// The `binary` stanza symlinks the CLI sidecar bundled inside the app
+// (electron-builder `extraResources`, see apps/desktop/electron-builder.yml)
+// into Homebrew's bin, so `brew install --cask band` also provides the
+// `band` command without the in-app admin-privileged symlink flow.
+process.stdout.write(`cask "band" do
+  version "${version}"
+
+  on_arm do
+    sha256 "${armSha}"
+
+    url "https://github.com/band-app/band/releases/download/v#{version}/Band-#{version}-apple-silicon.dmg"
+  end
+  on_intel do
+    sha256 "${intelSha}"
+
+    url "https://github.com/band-app/band/releases/download/v#{version}/Band-#{version}-intel.dmg"
+  end
+
+  name "Band"
+  desc "IDE-agnostic agent orchestrator"
+  homepage "https://github.com/band-app/band"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  auto_updates true
+  depends_on macos: :big_sur
+
+  app "Band.app"
+  binary "#{appdir}/Band.app/Contents/Resources/binaries/band"
+
+  zap trash: [
+    "~/.band",
+    "~/Library/Application Support/Band",
+    "~/Library/Caches/app.getband.agent",
+    "~/Library/Caches/app.getband.agent.ShipIt",
+    "~/Library/Logs/Band",
+    "~/Library/Preferences/app.getband.agent.plist",
+    "~/Library/Saved Application State/app.getband.agent.savedState",
+  ]
+end
+`);


### PR DESCRIPTION
## PO Summary

Band can now be installed with Homebrew, the standard way Mac developers install tools. After this change (plus a one-time tap repo setup), anyone can run `brew install --cask band` to get the Band app and the `band` command-line tool in one step — no downloading DMGs from GitHub by hand. Every future release automatically updates the Homebrew listing, so users always get the latest version.

## Notes

- `scripts/generate-homebrew-cask.mjs` emits `Casks/band.rb`; output validated with `brew style --cask` (no offenses) and `brew audit --cask --online` (passes) against the v0.26.1 assets.
- New release step hashes the signed DMGs and pushes the regenerated cask to `band-app/homebrew-band` over SSH with a write deploy key (`HOMEBREW_TAP_DEPLOY_KEY` secret). Host key pinned, key file removed on exit, step runs after npm publish so a tap failure can't block the release.
- Requires one-time setup: create `band-app/homebrew-band`, add deploy key, set the secret.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WhgqiMe32FE83FXjmZ71cQ