### PR TITLE
feat(web): collapse edge panels when a tab is maximized

### DIFF
--- a/apps/web/e2e/pages/WorkspacePage.ts
+++ b/apps/web/e2e/pages/WorkspacePage.ts
@@ -1260,6 +1260,41 @@ export class WorkspacePage {
     return state?.groups[groupId];
   }
 
+  /** Seed the shared global dockview layout (`band:dockview-layout-v7`)
+   *  before the app mounts. Uses `addInitScript`, so it MUST run BEFORE
+   *  the first `goto` — the value is applied to `localStorage` ahead of
+   *  the page script, exactly like `installTerminalSocketInstrumentation`.
+   *
+   *  The empty default layout leaves all three edge groups collapsed and
+   *  empty (so they render at zero size and there's nothing to observe a
+   *  maximize collapsing). Seeding a layout that docks a panel into an
+   *  edge group is the only non-flaky way to start with a populated,
+   *  visible edge — dockview's edge docking is native HTML5 drag-and-drop,
+   *  which is unreliable to drive through Playwright. */
+  async seedGlobalLayout(layout: unknown): Promise<void> {
+    await this.page.addInitScript((serialized) => {
+      localStorage.setItem("band:dockview-layout-v7", serialized as string);
+    }, JSON.stringify(layout));
+  }
+
+  /** The dockview bottom edge-group container that is currently on-screen.
+   *
+   *  dockview tags every edge-group shell element with a library-provided
+   *  `data-testid` (`dv-edge-group-edge-<direction>`), and renders the
+   *  bottom slot in more than one shell position — only the populated one
+   *  is laid out at a non-zero size. Filtering to `visible` collapses that
+   *  to the single on-screen instance, so the test can assert
+   *  `toHaveCount(1)` (edge shown) vs `toHaveCount(0)` (edge collapsed to
+   *  zero size while a group is maximized).
+   *
+   *  Using dockview's own testid here mirrors how the maximize spec already
+   *  asserts on dockview-owned chrome (e.g. the `dv-active-tab` class on
+   *  `.dv-tab`): the edge shell is third-party markup we don't render, so
+   *  there's no BEM `data-testid` of our own to key off. */
+  bottomEdgeGroup(): Locator {
+    return this.page.getByTestId("dv-edge-group-edge-bottom").filter({ visible: true });
+  }
+
   /** Reset the per-workspace shared-dockview state entry in
    *  `localStorage` and (re-)navigate to the workspace so the next
    *  mount runs against a clean slate. Two-step (matches

--- a/apps/web/e2e/workspace-maximize-collapses-edges.spec.ts
+++ b/apps/web/e2e/workspace-maximize-collapses-edges.spec.ts
@@ -1,0 +1,194 @@
+/**
+ * End-to-end coverage for "maximizing a tab collapses the edge panels".
+ *
+ * A grid group can be maximized (⇧⌘M / the Maximize button), which
+ * overlays it on top of the other grid groups. dockview's edge groups
+ * (`edge-left` / `edge-right` / `edge-bottom` — the side/edge panels
+ * around the central area) sit OUTSIDE the grid, so historically a
+ * maximized tab still shared the screen with any populated edge panel.
+ * The desired behaviour, verified here: maximizing hides the edge panels
+ * so the maximized tab gets the full area, and restoring brings them back.
+ *
+ * Architecture (mirrors `workspace-maximize-state.spec.ts`):
+ *
+ *   - The real production binary runs against a fresh tmp `~/.band/`.
+ *   - No tRPC mocking; the dashboard renders against the real backend.
+ *   - All UI is driven through `WorkspacePage` (no raw `getByRole`,
+ *     `getByTestId`, or `page.goto` in the test body).
+ *
+ * The feature is only observable when an edge group actually holds a
+ * visible panel — an empty edge renders at zero size, so a maximize has
+ * nothing to collapse. There is no reliable way to dock a panel into an
+ * edge through the UI (dockview edge docking is native HTML5
+ * drag-and-drop, flaky under Playwright), so we seed a shared global
+ * layout that starts with the `terminal` panel docked in the bottom edge.
+ *
+ * The seed below was captured from a real app run (load the app, copy
+ * `localStorage["band:dockview-layout-v7"]`) and then edited to move the
+ * `terminal` view out of the central grid group and into the
+ * `edge-bottom` group (visible + expanded). Capturing rather than
+ * hand-authoring keeps the serialized dockview grid shape valid; the
+ * onReady reconciliation only re-adds missing required panels and drops
+ * hidden ones, so it won't move the seeded panel back out of the edge.
+ */
+
+import { expect, test } from "@playwright/test";
+import { toWorkspaceId } from "@/dashboard";
+import {
+  cleanupTmpHome,
+  createTmpHome,
+  type ServerHandle,
+  seedSettings,
+  seedState,
+  startServer,
+} from "./helpers/server";
+import { WorkspacePage } from "./pages/WorkspacePage";
+
+const TOKEN = "e2e-workspace-maximize-collapses-edges-token";
+
+const PROJECT = "alpha-edge";
+const WORKSPACE = toWorkspaceId(PROJECT, "main");
+
+// Wide viewport so `useIsDesktop()` reports true and the shared dockview
+// (and therefore the Maximize button + edge groups) renders — matches
+// >= 1024px in apps/web/src/hooks/useIsDesktop.ts.
+test.use({ viewport: { width: 1280, height: 800 } });
+
+// Global layout with `terminal` docked in the bottom edge group (visible +
+// expanded). Grid leaf "2" keeps changes/files/browser; `edge-bottom`
+// gains the terminal view. Panel definitions for all five stay in the
+// top-level `panels` map. See the file header for how this was captured.
+const LAYOUT_WITH_BOTTOM_EDGE_PANEL = {
+  grid: {
+    root: {
+      type: "branch",
+      data: [
+        { type: "leaf", data: { views: ["chat"], activeView: "chat", id: "1" }, size: 519 },
+        {
+          type: "leaf",
+          data: { views: ["changes", "files", "browser"], activeView: "changes", id: "2" },
+          size: 518,
+        },
+      ],
+      size: 762,
+    },
+    width: 1037,
+    height: 762,
+    orientation: "HORIZONTAL",
+  },
+  panels: {
+    chat: {
+      id: "chat",
+      contentComponent: "chat",
+      tabComponent: "props.defaultTabComponent",
+      title: "Chat",
+      params: {},
+    },
+    changes: {
+      id: "changes",
+      contentComponent: "changes",
+      tabComponent: "badge",
+      params: {},
+      title: "Changes",
+    },
+    files: {
+      id: "files",
+      contentComponent: "files",
+      tabComponent: "props.defaultTabComponent",
+      title: "Files",
+      params: {},
+    },
+    terminal: {
+      id: "terminal",
+      contentComponent: "terminal",
+      tabComponent: "props.defaultTabComponent",
+      title: "Terminal",
+      params: {},
+    },
+    browser: {
+      id: "browser",
+      contentComponent: "browser",
+      tabComponent: "props.defaultTabComponent",
+      title: "Browser",
+      params: {},
+    },
+  },
+  activeGroup: "1",
+  edgeGroups: {
+    left: {
+      size: 200,
+      visible: false,
+      collapsed: true,
+      group: { views: [], id: "edge-left", headerPosition: "left" },
+    },
+    right: {
+      size: 200,
+      visible: false,
+      collapsed: true,
+      group: { views: [], id: "edge-right", headerPosition: "right" },
+    },
+    bottom: {
+      size: 200,
+      visible: true,
+      collapsed: false,
+      group: {
+        views: ["terminal"],
+        activeView: "terminal",
+        id: "edge-bottom",
+        headerPosition: "bottom",
+      },
+    },
+  },
+};
+
+let server: ServerHandle;
+let tmpHome: string;
+
+test.beforeAll(async () => {
+  tmpHome = createTmpHome();
+  seedState(tmpHome, {
+    projects: [
+      {
+        name: PROJECT,
+        path: `/tmp/fake/${PROJECT}`,
+        defaultBranch: "main",
+        worktrees: [{ branch: "main", path: `/tmp/fake/${PROJECT}` }],
+      },
+    ],
+  });
+  seedSettings(tmpHome, { tokenSecret: TOKEN });
+  server = await startServer({ tmpHome });
+});
+
+test.afterAll(async () => {
+  await server.close();
+  cleanupTmpHome(tmpHome);
+});
+
+test.describe("Maximize collapses edge panels", () => {
+  test("maximizing a tab collapses the edge panel; restoring brings it back", async ({ page }) => {
+    const workspacePage = new WorkspacePage(page, server.url, TOKEN);
+
+    // Seed BEFORE navigating so the dockview reads the edge-populated
+    // layout on its onReady (addInitScript runs before the page script).
+    await workspacePage.seedGlobalLayout(LAYOUT_WITH_BOTTOM_EDGE_PANEL);
+
+    await workspacePage.goto(WORKSPACE);
+    await workspacePage.waitForReady();
+
+    // The bottom edge panel is populated (terminal docked there) and
+    // therefore laid out on-screen at a non-zero size.
+    await expect(workspacePage.bottomEdgeGroup()).toHaveCount(1);
+
+    // Maximize a grid group. The edge panel must collapse to zero size so
+    // the maximized tab gets the full area.
+    await workspacePage.maximizePanel(0);
+    await expect(workspacePage.restoreButton).toBeVisible();
+    await expect(workspacePage.bottomEdgeGroup()).toHaveCount(0);
+
+    // Restore (un-maximize). The edge panel must come back.
+    await workspacePage.restorePanel();
+    await expect(workspacePage.maximizeButtons.first()).toBeVisible();
+    await expect(workspacePage.bottomEdgeGroup()).toHaveCount(1);
+  });
+});

--- a/apps/web/src/components/SharedDockviewLayout.tsx
+++ b/apps/web/src/components/SharedDockviewLayout.tsx
@@ -44,7 +44,11 @@ import {
   extractActiveState,
   walkGridNode,
 } from "../lib/dockview-active-state";
-import { findFocusedInnerDockview, toggleEdgeGroup } from "../lib/dockview-edge-groups";
+import {
+  applyMaximizeEdgeVisibility,
+  findFocusedInnerDockview,
+  toggleEdgeGroup,
+} from "../lib/dockview-edge-groups";
 import { isDesktop } from "../lib/is-desktop";
 import { parseWorkspaceFromPath } from "../lib/parse-workspace";
 import { trpc } from "../lib/trpc-client";
@@ -1569,6 +1573,12 @@ export function SharedDockviewLayout() {
       }
       if (initialActiveState?.maximizedGroup) {
         applyMaximizedGroupToApi(event.api, initialActiveState.maximizedGroup);
+        // The `onDidMaximizedGroupChange` listener is guarded out here
+        // (`initializedRef.current` is still false), so hide the edge
+        // panels explicitly for a reload that lands on a maximized tab.
+        // The edge-visibility reconciliation above already ran (edges
+        // visible from panel count); this hides them over the top.
+        applyMaximizeEdgeVisibility(event.api, true);
       }
 
       // Persist layout on changes. With a single dockview instance shared by
@@ -1608,6 +1618,14 @@ export function SharedDockviewLayout() {
           // flag is set by `saveLayout` for the synchronous duration of
           // its `toJSON()` call.
           if (inSaveLayoutToJSON) return;
+          // Collapse the edge panels while a group is maximized so the
+          // maximized tab gets the full area; re-derive them on exit. This
+          // is the hook for the Maximize/Restore button (which calls
+          // `api.maximize()` / `api.exitMaximized()` directly) and for
+          // workspace-switch-driven maximize changes. The initial-mount
+          // path is handled separately below because `initializedRef` is
+          // still false there and this listener is guarded out.
+          applyMaximizeEdgeVisibility(event.api, !!e.isMaximized);
           const workspaceId = activeWorkspaceIdRef.current;
           if (!workspaceId) return;
           // Defensive: dockview's event payload types both `group` and
@@ -1702,6 +1720,12 @@ export function SharedDockviewLayout() {
     // (maximized) → B (no state) would leave B rendered under A's
     // maximize overlay.
     applyMaximizedGroupToApi(api, activeState?.maximizedGroup);
+    // Keep the edge panels in sync with the incoming workspace's maximize
+    // state deterministically. When `applyMaximizedGroupToApi` actually
+    // changes the maximize the listener above also fires, but it's a no-op
+    // when the state is unchanged — and `applyMaximizeEdgeVisibility` is
+    // idempotent, so calling it here is safe either way.
+    applyMaximizeEdgeVisibility(api, !!activeState?.maximizedGroup);
   }, [activeWorkspaceId]);
 
   // ---------------------------------------------------------------------

--- a/apps/web/src/lib/dockview-edge-groups.ts
+++ b/apps/web/src/lib/dockview-edge-groups.ts
@@ -119,6 +119,31 @@ export function refreshEdgeGroupVisibility(api: DockviewApi, forceVisible: boole
   }
 }
 
+/**
+ * Collapse (hide) every edge group while a grid group is maximized so the
+ * maximized tab gets the full area; on exit, re-derive edge visibility from
+ * panel presence.
+ *
+ * Restore is deliberately state-free: we only ever toggle *visibility* here,
+ * never `collapse()`/`expand()`, so each edge's collapsed-vs-expanded strip
+ * state is left untouched and comes back exactly as the user left it. Edge
+ * visibility is already an ephemeral, derived property (see
+ * `refreshEdgeGroupVisibility`), so hiding it for the duration of a maximize
+ * and re-deriving on exit is consistent with how the rest of the layout
+ * treats it — no separate "prior edge state" bookkeeping is needed.
+ */
+export function applyMaximizeEdgeVisibility(api: DockviewApi, maximized: boolean): void {
+  if (maximized) {
+    for (const direction of Object.keys(EDGE_GROUP_IDS) as EdgeDirection[]) {
+      try {
+        api.setEdgeGroupVisible(direction, false);
+      } catch {}
+    }
+  } else {
+    refreshEdgeGroupVisibility(api, false);
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Collapse/expand toggle + inner-dockview registry
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

Maximizing a dockview grid group (⇧⌘M / the Maximize button) now also hides the surrounding **edge panels** (`edge-left` / `edge-right` / `edge-bottom`) so the maximized tab gets the full area. Un-maximizing brings the edge panels back to exactly the state they were in before — their per-edge collapsed/expanded strip state is preserved.

Previously the edge groups sit *outside* the grid, so a maximized tab still shared the screen with any populated edge panel.

## How

- New `applyMaximizeEdgeVisibility(api, maximized)` in `dockview-edge-groups.ts`: hides all edge groups via `setEdgeGroupVisible(dir, false)` while maximized, and re-derives visibility from panel presence (`refreshEdgeGroupVisibility`) on exit.
- Wired at the three points maximize is applied in `SharedDockviewLayout.tsx`:
  - the `onDidMaximizedGroupChange` listener (covers the Maximize/Restore button + workspace-switch toggles), placed after the `inSaveLayoutToJSON` guard;
  - the initial-mount restore (the listener is guarded out while `initializedRef` is still false, so reload-while-maximized still hides edges);
  - the workspace-switch effect (idempotent, deterministic).
- **Restore is state-free** — only *visibility* is toggled, never `collapse()`/`expand()`, so each edge's collapsed/expanded strip state comes back untouched. This is consistent with how edge visibility is already treated as an ephemeral, derived property, and is self-healing w.r.t. the shared global layout.

## Testing

- New e2e spec `workspace-maximize-collapses-edges.spec.ts`: boots the real server, seeds a layout with `terminal` docked in the bottom edge, and asserts the edge collapses on maximize (`toHaveCount(0)`) and returns on restore (`toHaveCount(1)`), using dockview's own `dv-edge-group-edge-bottom` testid.
- All 6 existing `workspace-maximize-state` regressions pass; verified on top of current `main` (incl. #622).

🤖 Generated with [Claude Code](https://claude.com/claude-code)