### PR TITLE
feat(cron): dispatch cronjobs via terminal (#581)

### DIFF
--- a/apps/cli/skills/band-loop/SKILL.md
+++ b/apps/cli/skills/band-loop/SKILL.md
@@ -3,12 +3,12 @@ name: band-loop
 version: 0.1.0
 description: Schedule a recurring prompt against a Band workspace's coding agent via a cronjob, with an optional self-deleting "stop when criteria is met" wrapper. Use when the user wants to "loop on X every 10m", "keep retrying until Y", "poll the deploy every 5 minutes", "check in every hour until tests pass", "run this prompt on a recurring interval", or otherwise asks for an iterative/repeating agent task. Wraps `band cronjobs create` so the agent re-runs the same prompt on a fixed cadence (default 10m), and optionally appends a stop-condition that makes the agent delete its own cronjob with `band cronjobs delete` when done. Caps loop lifetime at 7 days by default to match the safety horizon Claude Code's built-in `/loop` uses.
 allowed-tools: Bash
-argument-hint: <prompt> [--every <duration>] [--until <stop condition>] [--max-iterations <n>]
+argument-hint: <prompt> [--every <duration>] [--until <stop condition>] [--max-iterations <n>] [--via chat|terminal]
 ---
 
 # Band Loop
 
-Recurring agent tasks via `band cronjobs`. The agent fires on a cron schedule against a target workspace's active chat, optionally checks a stop condition each iteration, and deletes its own cronjob when the condition is met.
+Recurring agent tasks via `band cronjobs`. The agent fires on a cron schedule against a target workspace — dispatching each iteration to the workspace's chat pane (default) or the agent's terminal CLI (`--via terminal`) — optionally checks a stop condition each iteration, and deletes its own cronjob when the condition is met.
 
 This is the **native answer** for users who reach for Claude Code's built-in `/loop`: that command is gated behind `scheduledTasksEnabled`, which is always `false` in SDK / Band sessions. `band cronjobs` runs server-side and survives session restarts.
 
@@ -95,7 +95,14 @@ The `<key>` and `<cronjob_id>` placeholders must be substituted after the cronjo
 
 ### 4. Create the cronjob
 
-`band cronjobs create` requires `--name`, `--prompt`, and `--cron`. For workspace-scoped loops, set `--scope workspace` and pass the workspace ID twice (once positionally as `key`, once as `--workspace-id`):
+`band cronjobs create` requires `--name`, `--prompt`, and `--cron`. For workspace-scoped loops, set `--scope workspace` and pass the workspace ID twice (once positionally as `key`, once as `--workspace-id`).
+
+**Dispatch target (`--via`).** Each iteration dispatches to either the workspace's chat pane (`--via chat`) or the agent's **headless** CLI in a fresh PTY (`--via terminal`). Omit the flag to inherit the caller's context: the CLI resolves it via the same precedence as `band workspaces create` (`--via` flag → `BAND_DISPATCH` env → `.band/config.json`/`~/.band/settings.json` config → `terminal`), while the web UI / server default is `chat`. So a loop set up from a chat agent stays on chat and one set up from a terminal runs in a terminal. Two things to know about `--via terminal` loops:
+
+- The pane runs the agent's **non-interactive one-shot** mode (`claude -p …`, `codex exec …`, etc.), not the interactive REPL — so it runs the task, streams output, and **exits**. The pane is therefore **self-closing** (runs, then closes when the agent finishes), so a frequent loop doesn't pile up panes (≈1 live pane per loop). Its output isn't retained after completion (the outcome is in the cronjob's `lastRunStatus`).
+- An iteration is **skipped** (recorded `skipped`) if the previous run's pane is still active, so an agent that runs longer than the interval is never interrupted mid-work.
+
+For workspace-scoped loops:
 
 ```sh
 job=$(band cronjobs create "$ws_id" \
@@ -236,7 +243,8 @@ band cronjobs delete "$ws_id" cj_1234567890
 ## Invariants
 
 - The cronjob's `--prompt` is what the agent sees on every firing — keep it self-contained (no shell variables, no implicit "previous iteration" context).
-- Workspace-scoped cronjobs (`--scope workspace --workspace-id <ws_id>`) dispatch into the workspace's active chat. Project-scoped ones don't.
+- Workspace-scoped cronjobs (`--scope workspace --workspace-id <ws_id>`) dispatch into the workspace — the cronjob's dedicated chat pane by default, or a fresh terminal pane with `--via terminal`. Project-scoped jobs fire against the project's main-branch workspace.
+- `--via terminal` loops run the agent's headless CLI in a self-closing PTY per iteration and skip a tick while the previous run is still active — the self-deleting stop-condition pattern still works, since the agent runs `band cronjobs delete` from inside the headless run just as it would from a chat.
 - The self-deleting pattern requires the agent itself to run `band cronjobs delete` — the cron engine has no built-in stop condition. The agent needs `band` on its `PATH` (true by default after `band` is installed).
 - Cap loop lifetime at **7 days** unless the user explicitly overrides — same horizon as Claude Code's `/loop`.
 - For an iteration-count cap, the agent must persist a counter to a file inside the worktree (cronjobs are stateless across runs).

--- a/apps/cli/skills/band/SKILL.md
+++ b/apps/cli/skills/band/SKILL.md
@@ -160,8 +160,10 @@ band cronjobs list [--project <string>] [--workspace <string>]
 ### Create a new scheduled cronjob
 
 ```sh
-band cronjobs create <key> --name <string> --prompt <string> --cron <string> [--scope <string>] [--workspace-id <string>] [--disabled]
+band cronjobs create <key> --name <string> --prompt <string> --cron <string> [--scope <string>] [--workspace-id <string>] [--via <string>] [--disabled]
 ```
+
+`--via` picks where each fire dispatches the prompt: `chat` (submits a task to the cronjob's dedicated chat pane — the default and backward-compatible behavior) or `terminal` (spawns the agent's vendor CLI in a fresh self-closing PTY pane; if the agent has no vendor CLI it silently falls back to chat). When omitted it resolves via the same precedence as `workspaces create`: `--via` flag → `BAND_DISPATCH` env → `.band/config.json` `workspace.defaultVia` → `~/.band/settings.json` `cli.defaultVia` → `terminal`. A terminal fire is skipped (recorded `skipped`) when the previous run's pane is still active, so an agent that runs longer than the interval is never interrupted.
 
 ### Update an existing cronjob
 

--- a/apps/cli/src/main.rs
+++ b/apps/cli/src/main.rs
@@ -366,6 +366,15 @@ enum CronjobsCmd {
         /// Workspace ID (required when scope is "workspace")
         #[arg(long)]
         workspace_id: Option<String>,
+        /// Where each fire dispatches the prompt: `chat` (chat pane) or
+        /// `terminal` (agent's vendor CLI in a fresh self-closing PTY). When
+        /// omitted, resolved via the same precedence as `workspaces create`:
+        /// `--via` flag → `$BAND_DISPATCH` → `.band/config.json`
+        /// `workspace.defaultVia` → `~/.band/settings.json` `cli.defaultVia`
+        /// → `terminal`. So a cron created from a chat agent defaults to chat,
+        /// one created from a terminal defaults to terminal (issue #581).
+        #[arg(long)]
+        via: Option<String>,
         /// Start disabled
         #[arg(long)]
         disabled: bool,
@@ -577,6 +586,7 @@ fn main() {
                 cron,
                 scope,
                 workspace_id,
+                via,
                 disabled,
             } => cmd_cronjobs_create(
                 &key,
@@ -585,6 +595,7 @@ fn main() {
                 &cron,
                 &scope,
                 workspace_id.as_deref(),
+                via.as_deref(),
                 disabled,
             ),
             CronjobsCmd::Update {
@@ -2104,6 +2115,7 @@ fn cmd_cronjobs_create(
     cron: &str,
     scope: &str,
     workspace_id: Option<&str>,
+    via: Option<&str>,
     disabled: bool,
 ) -> Result<CommandResult, String> {
     if scope != "project" && scope != "workspace" {
@@ -2113,13 +2125,23 @@ fn cmd_cronjobs_create(
         return Err("--workspace-id is required when scope is 'workspace'".to_string());
     }
 
-    let client = api::ApiClient::from_settings()?;
+    // Read settings once and share the snapshot between the API client (port +
+    // auth token) and the dispatch-target resolver — same pattern as
+    // `cmd_workspaces_create`. A cronjob always carries a prompt, so we always
+    // resolve `via` through the precedence chain: a cron created from a chat
+    // agent (BAND_DISPATCH=chat) defaults to chat, one from a terminal
+    // (BAND_DISPATCH=terminal) defaults to terminal (issue #581).
+    let settings = state::load_settings()?;
+    let client = api::ApiClient::from_loaded_settings(settings.clone());
+    let resolved_via = resolve_dispatch_target(via, &settings)?;
+
     let mut input = serde_json::json!({
         "key": key,
         "name": name,
         "prompt": prompt,
         "cronExpression": cron,
         "scope": scope,
+        "via": resolved_via,
         "enabled": !disabled,
     });
     if let Some(ws) = workspace_id {
@@ -2195,15 +2217,39 @@ fn cmd_cronjobs_trigger(key: &str, id: &str) -> Result<CommandResult, String> {
         &serde_json::json!({"key": key, "id": id}),
     )?;
 
-    let task_id = data.get("taskId").and_then(|v| v.as_str()).unwrap_or("");
+    // The server echoes the dispatch it actually used (issue #581). A
+    // via="terminal" job returns a `terminalId` (and no task/chat); a via="chat"
+    // job — including a terminal job whose agent has no vendor CLI and fell back
+    // — returns `taskId`/`chatId`.
     let workspace_id = data
         .get("workspaceId")
         .and_then(|v| v.as_str())
         .unwrap_or("");
+    let via = data.get("via").and_then(|v| v.as_str()).unwrap_or("chat");
 
+    if via == "terminal" {
+        let terminal_id = data
+            .get("terminalId")
+            .and_then(|v| v.as_str())
+            .unwrap_or("");
+        return Ok(CommandResult {
+            text: format!("{terminal_id}\n"),
+            json: serde_json::json!({
+                "via": "terminal",
+                "terminalId": terminal_id,
+                "workspaceId": workspace_id,
+            }),
+        });
+    }
+
+    let task_id = data.get("taskId").and_then(|v| v.as_str()).unwrap_or("");
     Ok(CommandResult {
         text: format!("{task_id}\n"),
-        json: serde_json::json!({"taskId": task_id, "workspaceId": workspace_id}),
+        json: serde_json::json!({
+            "via": "chat",
+            "taskId": task_id,
+            "workspaceId": workspace_id,
+        }),
     })
 }
 
@@ -2738,6 +2784,7 @@ pub(crate) fn build_schema(command: Option<&str>) -> Result<serde_json::Value, S
                 {"name": "--cron", "type": "string", "required": true, "description": "Cron expression (e.g. \"0 */6 * * *\")"},
                 {"name": "--scope", "type": "string", "required": false, "description": "Scope: project (default) or workspace"},
                 {"name": "--workspace-id", "type": "string", "required": false, "description": "Workspace ID (required when scope is workspace)"},
+                {"name": "--via", "type": "string", "required": false, "description": "Where each fire dispatches the prompt: 'chat' (chat pane) or 'terminal' (vendor CLI in a fresh self-closing PTY). Defaults via the same precedence as 'workspaces create' (--via > BAND_DISPATCH > config > settings > terminal)."},
                 {"name": "--disabled", "type": "boolean", "required": false, "description": "Create the job in disabled state"},
             ]
         }),

--- a/apps/web/src/server/api/cronjobs/router.ts
+++ b/apps/web/src/server/api/cronjobs/router.ts
@@ -114,10 +114,11 @@ function throwAsTRPCError(err: unknown): never {
     throw new TRPCError({ code: "BAD_REQUEST", message: err.message });
   }
   if (err instanceof TaskConflictError) {
-    throw new TRPCError({
-      code: "CONFLICT",
-      message: "Task already running for this chat pane",
-    });
+    // Surface the actual conflict reason rather than a hardcoded string: since
+    // #581 a `via="terminal"` fire also throws `TaskConflictError` (previous
+    // terminal run still in progress / being spawned), so a chat-pane-specific
+    // message would misdescribe the terminal case.
+    throw new TRPCError({ code: "CONFLICT", message: err.message });
   }
   throw err;
 }

--- a/apps/web/src/server/api/cronjobs/router.ts
+++ b/apps/web/src/server/api/cronjobs/router.ts
@@ -74,9 +74,12 @@ export const cronjobsRouter = t.router({
     }
   }),
 
-  trigger: publicProcedure.input(cronjobByIdInput).mutation(({ input }) => {
+  trigger: publicProcedure.input(cronjobByIdInput).mutation(async ({ input }) => {
     try {
-      return cronjobService.trigger(input.key, input.id);
+      // `trigger` is async since #581 — the via="terminal" path resolves the
+      // agent adapter and spawns a PTY. `TaskConflictError` (previous terminal
+      // run still active, or a running chat task) still maps to 409 below.
+      return await cronjobService.trigger(input.key, input.id);
     } catch (err) {
       throwAsTRPCError(err);
     }

--- a/apps/web/src/server/infra/db/migrations/20260707132201_moaning_cerebro/migration.sql
+++ b/apps/web/src/server/infra/db/migrations/20260707132201_moaning_cerebro/migration.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `cronjobs` ADD `via` text DEFAULT 'chat' NOT NULL;--> statement-breakpoint
+ALTER TABLE `cronjobs` ADD `last_terminal_id` text;

--- a/apps/web/src/server/infra/db/migrations/20260707132201_moaning_cerebro/snapshot.json
+++ b/apps/web/src/server/infra/db/migrations/20260707132201_moaning_cerebro/snapshot.json
@@ -1,0 +1,1187 @@
+{
+  "version": "7",
+  "dialect": "sqlite",
+  "id": "f0053d67-cc4a-4ed1-baff-9dbf73ccd0a1",
+  "prevIds": [
+    "49dd6291-c6e7-4341-8f22-97c68cf782c9"
+  ],
+  "ddl": [
+    {
+      "name": "branch_statuses",
+      "entityType": "tables"
+    },
+    {
+      "name": "browser_history",
+      "entityType": "tables"
+    },
+    {
+      "name": "cronjobs",
+      "entityType": "tables"
+    },
+    {
+      "name": "panel_states",
+      "entityType": "tables"
+    },
+    {
+      "name": "projects",
+      "entityType": "tables"
+    },
+    {
+      "name": "tasks",
+      "entityType": "tables"
+    },
+    {
+      "name": "usage_events",
+      "entityType": "tables"
+    },
+    {
+      "name": "usage_scan_state",
+      "entityType": "tables"
+    },
+    {
+      "name": "workspace_statuses",
+      "entityType": "tables"
+    },
+    {
+      "name": "worktrees",
+      "entityType": "tables"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "workspace_id",
+      "entityType": "columns",
+      "table": "branch_statuses"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "git_dirty",
+      "entityType": "columns",
+      "table": "branch_statuses"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "git_conflict",
+      "entityType": "columns",
+      "table": "branch_statuses"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "git_ahead",
+      "entityType": "columns",
+      "table": "branch_statuses"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "git_behind",
+      "entityType": "columns",
+      "table": "branch_statuses"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "git_sync_state",
+      "entityType": "columns",
+      "table": "branch_statuses"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "ci_state",
+      "entityType": "columns",
+      "table": "branch_statuses"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "ci_url",
+      "entityType": "columns",
+      "table": "branch_statuses"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "branch_statuses"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": true,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "browser_history"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "workspace_id",
+      "entityType": "columns",
+      "table": "browser_history"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "url",
+      "entityType": "columns",
+      "table": "browser_history"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "title",
+      "entityType": "columns",
+      "table": "browser_history"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "favicon_url",
+      "entityType": "columns",
+      "table": "browser_history"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "last_visited_at",
+      "entityType": "columns",
+      "table": "browser_history"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "1",
+      "generated": null,
+      "name": "visit_count",
+      "entityType": "columns",
+      "table": "browser_history"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "cronjobs"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "file_key",
+      "entityType": "columns",
+      "table": "cronjobs"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "name",
+      "entityType": "columns",
+      "table": "cronjobs"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "prompt",
+      "entityType": "columns",
+      "table": "cronjobs"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "cron_expression",
+      "entityType": "columns",
+      "table": "cronjobs"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "scope",
+      "entityType": "columns",
+      "table": "cronjobs"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "workspace_id",
+      "entityType": "columns",
+      "table": "cronjobs"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'chat'",
+      "generated": null,
+      "name": "via",
+      "entityType": "columns",
+      "table": "cronjobs"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "true",
+      "generated": null,
+      "name": "enabled",
+      "entityType": "columns",
+      "table": "cronjobs"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "cronjobs"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "last_run_at",
+      "entityType": "columns",
+      "table": "cronjobs"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "last_run_status",
+      "entityType": "columns",
+      "table": "cronjobs"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "last_terminal_id",
+      "entityType": "columns",
+      "table": "cronjobs"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "panel_states"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "workspace_id",
+      "entityType": "columns",
+      "table": "panel_states"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "panel_type",
+      "entityType": "columns",
+      "table": "panel_states"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "state",
+      "entityType": "columns",
+      "table": "panel_states"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "labels",
+      "entityType": "columns",
+      "table": "panel_states"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "panel_states"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "panel_states"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "name",
+      "entityType": "columns",
+      "table": "projects"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "path",
+      "entityType": "columns",
+      "table": "projects"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "default_branch",
+      "entityType": "columns",
+      "table": "projects"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "label",
+      "entityType": "columns",
+      "table": "projects"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "sort_order",
+      "entityType": "columns",
+      "table": "projects"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'git'",
+      "generated": null,
+      "name": "kind",
+      "entityType": "columns",
+      "table": "projects"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "true",
+      "generated": null,
+      "name": "has_origin",
+      "entityType": "columns",
+      "table": "projects"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "tasks"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "workspace_id",
+      "entityType": "columns",
+      "table": "tasks"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "project",
+      "entityType": "columns",
+      "table": "tasks"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "branch",
+      "entityType": "columns",
+      "table": "tasks"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "prompt",
+      "entityType": "columns",
+      "table": "tasks"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "status",
+      "entityType": "columns",
+      "table": "tasks"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "session_id",
+      "entityType": "columns",
+      "table": "tasks"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "started_at",
+      "entityType": "columns",
+      "table": "tasks"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "completed_at",
+      "entityType": "columns",
+      "table": "tasks"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "mode",
+      "entityType": "columns",
+      "table": "tasks"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "model",
+      "entityType": "columns",
+      "table": "tasks"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "coding_agent_id",
+      "entityType": "columns",
+      "table": "tasks"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "chat_id",
+      "entityType": "columns",
+      "table": "tasks"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": true,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "usage_events"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "task_id",
+      "entityType": "columns",
+      "table": "usage_events"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "chat_id",
+      "entityType": "columns",
+      "table": "usage_events"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "workspace_id",
+      "entityType": "columns",
+      "table": "usage_events"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "project",
+      "entityType": "columns",
+      "table": "usage_events"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "session_id",
+      "entityType": "columns",
+      "table": "usage_events"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "coding_agent_id",
+      "entityType": "columns",
+      "table": "usage_events"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "provider",
+      "entityType": "columns",
+      "table": "usage_events"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "model",
+      "entityType": "columns",
+      "table": "usage_events"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "0",
+      "generated": null,
+      "name": "input_tokens",
+      "entityType": "columns",
+      "table": "usage_events"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "0",
+      "generated": null,
+      "name": "output_tokens",
+      "entityType": "columns",
+      "table": "usage_events"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "0",
+      "generated": null,
+      "name": "cache_read_tokens",
+      "entityType": "columns",
+      "table": "usage_events"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "0",
+      "generated": null,
+      "name": "cache_creation_tokens",
+      "entityType": "columns",
+      "table": "usage_events"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "0",
+      "generated": null,
+      "name": "reasoning_output_tokens",
+      "entityType": "columns",
+      "table": "usage_events"
+    },
+    {
+      "type": "real",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "0",
+      "generated": null,
+      "name": "cost_usd",
+      "entityType": "columns",
+      "table": "usage_events"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "captured_at",
+      "entityType": "columns",
+      "table": "usage_events"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "external_key",
+      "entityType": "columns",
+      "table": "usage_events"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "workspace_id",
+      "entityType": "columns",
+      "table": "usage_scan_state"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "agent_type",
+      "entityType": "columns",
+      "table": "usage_scan_state"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "last_scanned_updated_at",
+      "entityType": "columns",
+      "table": "usage_scan_state"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "workspace_id",
+      "entityType": "columns",
+      "table": "workspace_statuses"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "project",
+      "entityType": "columns",
+      "table": "workspace_statuses"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "branch",
+      "entityType": "columns",
+      "table": "workspace_statuses"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "worktree_path",
+      "entityType": "columns",
+      "table": "workspace_statuses"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "agent_name",
+      "entityType": "columns",
+      "table": "workspace_statuses"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "agent_status",
+      "entityType": "columns",
+      "table": "workspace_statuses"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "agent_last_activity",
+      "entityType": "columns",
+      "table": "workspace_statuses"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "agent_summary",
+      "entityType": "columns",
+      "table": "workspace_statuses"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "coding_agent_id",
+      "entityType": "columns",
+      "table": "workspace_statuses"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "workspace_statuses"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": true,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "worktrees"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "project_name",
+      "entityType": "columns",
+      "table": "worktrees"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "name",
+      "entityType": "columns",
+      "table": "worktrees"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "branch",
+      "entityType": "columns",
+      "table": "worktrees"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "path",
+      "entityType": "columns",
+      "table": "worktrees"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "head",
+      "entityType": "columns",
+      "table": "worktrees"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "false",
+      "generated": null,
+      "name": "pinned",
+      "entityType": "columns",
+      "table": "worktrees"
+    },
+    {
+      "columns": [
+        "project_name"
+      ],
+      "tableTo": "projects",
+      "columnsTo": [
+        "name"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "worktrees_project_name_projects_name_fk",
+      "entityType": "fks",
+      "table": "worktrees"
+    },
+    {
+      "columns": [
+        "workspace_id"
+      ],
+      "nameExplicit": false,
+      "name": "branch_statuses_pk",
+      "table": "branch_statuses",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "browser_history_pk",
+      "table": "browser_history",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "cronjobs_pk",
+      "table": "cronjobs",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "panel_states_pk",
+      "table": "panel_states",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "name"
+      ],
+      "nameExplicit": false,
+      "name": "projects_pk",
+      "table": "projects",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "tasks_pk",
+      "table": "tasks",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "usage_events_pk",
+      "table": "usage_events",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "workspace_id"
+      ],
+      "nameExplicit": false,
+      "name": "workspace_statuses_pk",
+      "table": "workspace_statuses",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "worktrees_pk",
+      "table": "worktrees",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        {
+          "value": "workspace_id",
+          "isExpression": false
+        },
+        {
+          "value": "url",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "origin": "manual",
+      "name": "browser_history_workspace_url_uq",
+      "entityType": "indexes",
+      "table": "browser_history"
+    },
+    {
+      "columns": [
+        {
+          "value": "workspace_id",
+          "isExpression": false
+        },
+        {
+          "value": "last_visited_at",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "browser_history_workspace_visited_idx",
+      "entityType": "indexes",
+      "table": "browser_history"
+    },
+    {
+      "columns": [
+        {
+          "value": "captured_at",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "usage_events_captured_at_idx",
+      "entityType": "indexes",
+      "table": "usage_events"
+    },
+    {
+      "columns": [
+        {
+          "value": "task_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "usage_events_task_idx",
+      "entityType": "indexes",
+      "table": "usage_events"
+    },
+    {
+      "columns": [
+        {
+          "value": "workspace_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "usage_events_workspace_idx",
+      "entityType": "indexes",
+      "table": "usage_events"
+    },
+    {
+      "columns": [
+        {
+          "value": "external_key",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "origin": "manual",
+      "name": "usage_events_external_key_uq",
+      "entityType": "indexes",
+      "table": "usage_events"
+    },
+    {
+      "columns": [
+        {
+          "value": "workspace_id",
+          "isExpression": false
+        },
+        {
+          "value": "agent_type",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "origin": "manual",
+      "name": "usage_scan_state_pk",
+      "entityType": "indexes",
+      "table": "usage_scan_state"
+    }
+  ],
+  "renames": []
+}

--- a/apps/web/src/server/infra/db/queries/cronjobs.ts
+++ b/apps/web/src/server/infra/db/queries/cronjobs.ts
@@ -14,6 +14,14 @@ import { cronjobs } from "../schema";
  */
 export type CronjobScope = "project" | "workspace";
 
+/**
+ * Where a cronjob fire dispatches its prompt (issue #581). Defined inline here
+ * rather than importing `workspaceVia` from the services tier: Infra must not
+ * depend on `services/`, and the two `via` enums share the same two values by
+ * convention (keep them in sync).
+ */
+export type CronjobVia = "chat" | "terminal";
+
 export interface CronjobDefinition {
   /** Unique identifier, e.g. "cj_1710000000000_a1b2c3d4" */
   id: string;
@@ -27,6 +35,8 @@ export interface CronjobDefinition {
   scope: CronjobScope;
   /** For workspace-scoped jobs, the workspace ID (project-branch) */
   workspaceId?: string;
+  /** Where a fire dispatches the prompt: chat pane (default) or terminal PTY */
+  via: CronjobVia;
   /** Whether the job is enabled */
   enabled: boolean;
   /** ISO timestamp of creation */
@@ -35,6 +45,12 @@ export interface CronjobDefinition {
   lastRunAt?: string;
   /** Status of the last execution */
   lastRunStatus?: "completed" | "failed" | "skipped";
+  /**
+   * For via="terminal" jobs, the id of the terminal spawned by the most recent
+   * fire. The scheduler checks whether this PTY is still alive to decide
+   * whether to skip an overlapping run.
+   */
+  lastTerminalId?: string;
 }
 
 /**
@@ -120,10 +136,12 @@ export class CronjobQueries {
             cronExpression: job.cronExpression,
             scope: job.scope,
             workspaceId: job.workspaceId ?? null,
+            via: job.via ?? "chat",
             enabled: job.enabled,
             createdAt: job.createdAt,
             lastRunAt: job.lastRunAt ?? null,
             lastRunStatus: job.lastRunStatus ?? null,
+            lastTerminalId: job.lastTerminalId ?? null,
           })
           .run();
       }
@@ -164,6 +182,20 @@ export class CronjobQueries {
   }
 
   /**
+   * Record (or clear) the terminal a via="terminal" fire spawned.
+   *
+   * Dedicated targeted UPDATE — same rationale as `updateLastRun`: the fire
+   * path shouldn't load + diff + rewrite the whole file just to stamp one
+   * column. The stored id is the handle the scheduler uses on the next tick to
+   * decide whether the previous run is still in flight (skip) or finished
+   * (spawn a fresh pane). Pass `null` to clear it.
+   */
+  updateLastTerminal(jobId: string, terminalId: string | null): void {
+    const db = getDb();
+    db.update(cronjobs).set({ lastTerminalId: terminalId }).where(eq(cronjobs.id, jobId)).run();
+  }
+
+  /**
    * Convert a Drizzle row into the optional-T-shaped `CronjobDefinition`.
    *
    * Static so the service tier can map listAll-style results without
@@ -177,10 +209,12 @@ export class CronjobQueries {
       cronExpression: row.cronExpression,
       scope: row.scope as CronjobDefinition["scope"],
       workspaceId: row.workspaceId ?? undefined,
+      via: (row.via ?? "chat") as CronjobDefinition["via"],
       enabled: row.enabled,
       createdAt: row.createdAt,
       lastRunAt: row.lastRunAt ?? undefined,
       lastRunStatus: row.lastRunStatus as CronjobDefinition["lastRunStatus"],
+      lastTerminalId: row.lastTerminalId ?? undefined,
     };
   }
 }

--- a/apps/web/src/server/infra/db/queries/cronjobs.ts
+++ b/apps/web/src/server/infra/db/queries/cronjobs.ts
@@ -17,8 +17,8 @@ export type CronjobScope = "project" | "workspace";
 /**
  * Where a cronjob fire dispatches its prompt (issue #581). Defined inline here
  * rather than importing `workspaceVia` from the services tier: Infra must not
- * depend on `services/`, and the two `via` enums share the same two values by
- * convention (keep them in sync).
+ * depend on `services/`. Keep this `CronjobVia` and the `cronjobVia` zod enum in
+ * `cronjob-service.ts` in sync — they intentionally carry the same two values.
  */
 export type CronjobVia = "chat" | "terminal";
 

--- a/apps/web/src/server/infra/db/schema.ts
+++ b/apps/web/src/server/infra/db/schema.ts
@@ -107,10 +107,21 @@ export const cronjobs = sqliteTable("cronjobs", {
   cronExpression: text("cron_expression").notNull(),
   scope: text("scope", { enum: ["project", "workspace"] }).notNull(),
   workspaceId: text("workspace_id"),
+  // Where a fire dispatches the prompt (issue #581): "chat" submits a task to
+  // the workspace's cron chat pane (default, backward-compatible); "terminal"
+  // spawns the agent's vendor CLI in a fresh self-closing PTY pane. Mirrors the
+  // `via` discriminator on `workspaces.create` (#551).
+  via: text("via", { enum: ["chat", "terminal"] })
+    .notNull()
+    .default("chat"),
   enabled: integer("enabled", { mode: "boolean" }).notNull().default(true),
   createdAt: text("created_at").notNull(),
   lastRunAt: text("last_run_at"),
   lastRunStatus: text("last_run_status", { enum: ["completed", "failed", "skipped"] }),
+  // For via="terminal" jobs, the id of the terminal spawned by the most recent
+  // fire. Used as the overlap-check handle: if this PTY is still alive when the
+  // next tick fires, the run is skipped rather than launching a second agent.
+  lastTerminalId: text("last_terminal_id"),
 });
 
 // Persistent record of token usage and cost from coding-agent sessions

--- a/apps/web/src/server/infra/terminals/terminal-pool.ts
+++ b/apps/web/src/server/infra/terminals/terminal-pool.ts
@@ -277,6 +277,11 @@ export class TerminalPool {
 
     ptyProcess.onExit(() => {
       log.debug("Terminal exited: %s (workspace %s)", terminalId, workspaceId);
+      // Distinguish a natural exit from an explicit `kill()`: `kill()` removes
+      // the session from `terminals` synchronously before `pty.kill()`'s async
+      // `onExit` lands here, so a missing entry means the caller already tore
+      // this terminal down. Captured before this handler's own delete below.
+      const explicitlyKilled = !this.terminals.has(terminalId);
       this.terminals.delete(terminalId);
       this.outputListeners.delete(terminalId);
       const set = this.workspaceTerminals.get(workspaceId);
@@ -294,11 +299,14 @@ export class TerminalPool {
           // Already gone / never written — nothing to clean up.
         }
       }
-      // Notify the caller that the PTY exited on its own (e.g. a self-closing
+      // Notify the caller that the PTY exited on its OWN (e.g. a self-closing
       // cron pane whose command ended with `exit`). The pool stays oblivious to
       // layout / event concerns; the service-supplied callback does that
-      // cleanup. Guarded so a throwing callback can't wedge the exit handler.
-      if (onExit) {
+      // cleanup. Skipped on an explicit `kill()` — that path already runs the
+      // same teardown synchronously, so firing here too would double-emit
+      // `terminal-killed`. Guarded so a throwing callback can't wedge the exit
+      // handler.
+      if (onExit && !explicitlyKilled) {
         try {
           onExit();
         } catch (err) {

--- a/apps/web/src/server/infra/terminals/terminal-pool.ts
+++ b/apps/web/src/server/infra/terminals/terminal-pool.ts
@@ -277,10 +277,12 @@ export class TerminalPool {
 
     ptyProcess.onExit(() => {
       log.debug("Terminal exited: %s (workspace %s)", terminalId, workspaceId);
-      // Distinguish a natural exit from an explicit `kill()`: `kill()` removes
-      // the session from `terminals` synchronously before `pty.kill()`'s async
-      // `onExit` lands here, so a missing entry means the caller already tore
-      // this terminal down. Captured before this handler's own delete below.
+      // Distinguish a natural exit from an explicit `kill()`: the `kill()` path
+      // calls `pty.kill()` and then synchronously deletes the session from
+      // `terminals` — both run before node-pty's async `onExit` fires here, so
+      // if the entry is already gone the caller tore this terminal down. On a
+      // natural exit the entry is still present (this handler deletes it just
+      // below). Captured before that delete.
       const explicitlyKilled = !this.terminals.has(terminalId);
       this.terminals.delete(terminalId);
       this.outputListeners.delete(terminalId);

--- a/apps/web/src/server/infra/terminals/terminal-pool.ts
+++ b/apps/web/src/server/infra/terminals/terminal-pool.ts
@@ -109,6 +109,7 @@ export class TerminalPool {
     terminalId: string,
     workspaceRoot: string,
     options?: SpawnOptions,
+    onExit?: () => void,
   ): Promise<TerminalSession> {
     const existing = this.terminals.get(terminalId);
     if (existing) return existing;
@@ -116,7 +117,7 @@ export class TerminalPool {
     if (inflight) return inflight;
     // Store the promise synchronously (before any await) so a concurrent call
     // that arrives while this one is awaiting sees it and reuses it.
-    const promise = this.spawnNew(workspaceId, terminalId, workspaceRoot, options);
+    const promise = this.spawnNew(workspaceId, terminalId, workspaceRoot, options, onExit);
     this.spawning.set(terminalId, promise);
     try {
       return await promise;
@@ -130,6 +131,7 @@ export class TerminalPool {
     terminalId: string,
     workspaceRoot: string,
     options?: SpawnOptions,
+    onExit?: () => void,
   ): Promise<TerminalSession> {
     const shell = defaultShell();
     const resolvedPath = await shellPath();
@@ -290,6 +292,17 @@ export class TerminalPool {
           unlinkSync(session.autoRunFile);
         } catch {
           // Already gone / never written — nothing to clean up.
+        }
+      }
+      // Notify the caller that the PTY exited on its own (e.g. a self-closing
+      // cron pane whose command ended with `exit`). The pool stays oblivious to
+      // layout / event concerns; the service-supplied callback does that
+      // cleanup. Guarded so a throwing callback can't wedge the exit handler.
+      if (onExit) {
+        try {
+          onExit();
+        } catch (err) {
+          log.warn("onExit callback threw for terminal %s: %s", terminalId, err);
         }
       }
     });

--- a/apps/web/src/server/services/cronjob-service.ts
+++ b/apps/web/src/server/services/cronjob-service.ts
@@ -43,6 +43,17 @@ interface SchedulerState {
   jobs: Map<string, Cron>;
   /** Whether the scheduler has been started */
   started: boolean;
+  /**
+   * Job ids with a `via="terminal"` dispatch currently mid-spawn. Held
+   * synchronously across the `await`-heavy body of `spawnCronTerminal`
+   * (resolve adapter → spawn PTY → persist `lastTerminalId`) so two
+   * concurrent fires for the same job — a manual `trigger` racing a
+   * scheduled tick, or a double-click — can't both pass the overlap check
+   * before either commits its new terminal id and orphan a PTY. The
+   * pool's own `spawning` map only dedupes identical `terminalId`s; this
+   * guards the check-then-act at the job level.
+   */
+  spawningTerminals: Set<string>;
 }
 
 const SCHEDULER_KEY = Symbol.for("band.cronjob-scheduler");
@@ -52,6 +63,7 @@ if (!g[SCHEDULER_KEY]) {
   g[SCHEDULER_KEY] = {
     jobs: new Map<string, Cron>(),
     started: false,
+    spawningTerminals: new Set<string>(),
   } satisfies SchedulerState;
 }
 
@@ -321,6 +333,12 @@ export class CronjobService {
     // Best-effort: tear down the terminal a via="terminal" job last spawned so
     // deleting the job doesn't leave a stray pane running the agent. No-op when
     // the id is unset or the PTY already exited.
+    //
+    // If the PTY is still live, `kill()` emits `terminal-killed` synchronously
+    // AND killing the PTY trips its `cleanupOnExit` hook, which emits a second
+    // `terminal-killed` asynchronously. The duplicate is harmless — layout
+    // removal is idempotent and a repeat prune event is a no-op — so we accept
+    // it rather than reaching into the pool to clear the exit hook first.
     if (removed?.lastTerminalId) {
       terminalService.kill(removed.lastTerminalId);
     }
@@ -530,54 +548,71 @@ export class CronjobService {
     workspaceId: string,
     fileKey: string,
   ): Promise<{ terminalId: string | null }> {
-    const workspace = workspaceService.resolve(workspaceId);
-    if (!workspace) {
-      log.warn(
-        { jobId: job.id, workspaceId },
-        "workspace not resolvable for via=terminal cronjob; falling back to chat",
-      );
-      return { terminalId: null };
+    const state = schedulerState();
+    // Close the check-then-act TOCTOU window (PR #627 review): the live-PTY
+    // overlap guard below reads `lastTerminalId`, then this method `await`s an
+    // adapter resolve + PTY spawn before persisting a NEW id. Two concurrent
+    // fires for the same job (a manual `trigger` racing a scheduled tick, a
+    // double-click) could both pass the guard before either commits, spawn two
+    // PTYs, and orphan the first. A synchronous check-and-add BEFORE any await
+    // rejects the second caller with the same `TaskConflictError` the overlap
+    // guard uses (→ scheduled "skipped" / manual 409). Released in `finally`.
+    if (state.spawningTerminals.has(job.id)) {
+      throw new TaskConflictError(`Cronjob ${job.id} terminal run is already being spawned`);
     }
+    state.spawningTerminals.add(job.id);
+    try {
+      const workspace = workspaceService.resolve(workspaceId);
+      if (!workspace) {
+        log.warn(
+          { jobId: job.id, workspaceId },
+          "workspace not resolvable for via=terminal cronjob; falling back to chat",
+        );
+        return { terminalId: null };
+      }
 
-    // Overlap guard: re-read the row (the scheduled path closes over a stale
-    // `job` captured at schedule time) so we check the terminal the LAST fire
-    // actually spawned. A live PTY means the previous headless run is still
-    // working (a finished one has exited and self-closed).
-    const prevTerminalId = this.findJob(fileKey, job.id)?.lastTerminalId;
-    if (prevTerminalId && terminalService.getSession(prevTerminalId)) {
-      throw new TaskConflictError(`Cronjob ${job.id} terminal run is still in progress`);
+      // Overlap guard: re-read the row (the scheduled path closes over a stale
+      // `job` captured at schedule time) so we check the terminal the LAST fire
+      // actually spawned. A live PTY means the previous headless run is still
+      // working (a finished one has exited and self-closed).
+      const prevTerminalId = this.findJob(fileKey, job.id)?.lastTerminalId;
+      if (prevTerminalId && terminalService.getSession(prevTerminalId)) {
+        throw new TaskConflictError(`Cronjob ${job.id} terminal run is still in progress`);
+      }
+
+      // Resolve the agent's HEADLESS CLI invocation on the request thread so we
+      // can fall back to chat synchronously when it's unsupported (e.g.
+      // cursor-cli). No `codingAgentId` on the cron row — use the workspace's
+      // default agent.
+      const adapter = await agentService.createWorkspaceAgent(workspace.worktree.path);
+      const invocation = adapter.cliHeadlessInvocation?.(job.prompt);
+      // Release the short-lived adapter; we only needed the pure-data invocation.
+      adapter.abort?.();
+      if (!invocation || invocation.unsupported) {
+        const reason = invocation?.reason ?? "adapter does not expose cliHeadlessInvocation";
+        log.warn(
+          { jobId: job.id, workspaceId, reason },
+          "via=terminal requested but agent has no headless CLI; falling back to chat",
+        );
+        return { terminalId: null };
+      }
+
+      // `\nexit` makes the pane self-close when the headless CLI returns: the
+      // pool stages `<command>\n` into a temp file and runs it via the POSIX dot
+      // builtin, so a trailing `exit` terminates the shell once the CLI exits.
+      const command = `${formatShellCommand(invocation.command, invocation.args)}\nexit`;
+      const terminalId = randomUUID();
+      await terminalService.spawn(workspaceId, terminalId, { command }, { cleanupOnExit: true });
+      // Persist the id BEFORE emitting so the next tick's overlap check sees it
+      // even if the emit's subscribers race.
+      this.queries.updateLastTerminal(job.id, terminalId);
+      // Broadcast so an open dashboard adds the pane without a reload — same
+      // pattern as `terminal.create` and the `via=terminal` workspace-create path.
+      emit({ kind: "terminal-created", workspaceId, terminalId });
+      return { terminalId };
+    } finally {
+      state.spawningTerminals.delete(job.id);
     }
-
-    // Resolve the agent's HEADLESS CLI invocation on the request thread so we
-    // can fall back to chat synchronously when it's unsupported (e.g.
-    // cursor-cli). No `codingAgentId` on the cron row — use the workspace's
-    // default agent.
-    const adapter = await agentService.createWorkspaceAgent(workspace.worktree.path);
-    const invocation = adapter.cliHeadlessInvocation?.(job.prompt);
-    // Release the short-lived adapter; we only needed the pure-data invocation.
-    adapter.abort?.();
-    if (!invocation || invocation.unsupported) {
-      const reason = invocation?.reason ?? "adapter does not expose cliHeadlessInvocation";
-      log.warn(
-        { jobId: job.id, workspaceId, reason },
-        "via=terminal requested but agent has no headless CLI; falling back to chat",
-      );
-      return { terminalId: null };
-    }
-
-    // `\nexit` makes the pane self-close when the headless CLI returns: the pool
-    // stages `<command>\n` into a temp file and runs it via the POSIX dot
-    // builtin, so a trailing `exit` terminates the shell once the CLI exits.
-    const command = `${formatShellCommand(invocation.command, invocation.args)}\nexit`;
-    const terminalId = randomUUID();
-    await terminalService.spawn(workspaceId, terminalId, { command }, { cleanupOnExit: true });
-    // Persist the id BEFORE emitting so the next tick's overlap check sees it
-    // even if the emit's subscribers race.
-    this.queries.updateLastTerminal(job.id, terminalId);
-    // Broadcast so an open dashboard adds the pane without a reload — same
-    // pattern as `terminal.create` and the `via=terminal` workspace-create path.
-    emit({ kind: "terminal-created", workspaceId, terminalId });
-    return { terminalId };
   }
 
   /**

--- a/apps/web/src/server/services/cronjob-service.ts
+++ b/apps/web/src/server/services/cronjob-service.ts
@@ -332,13 +332,9 @@ export class CronjobService {
     this.queries.saveFile(key, file);
     // Best-effort: tear down the terminal a via="terminal" job last spawned so
     // deleting the job doesn't leave a stray pane running the agent. No-op when
-    // the id is unset or the PTY already exited.
-    //
-    // If the PTY is still live, `kill()` emits `terminal-killed` synchronously
-    // AND killing the PTY trips its `cleanupOnExit` hook, which emits a second
-    // `terminal-killed` asynchronously. The duplicate is harmless — layout
-    // removal is idempotent and a repeat prune event is a no-op — so we accept
-    // it rather than reaching into the pool to clear the exit hook first.
+    // the id is unset or the PTY already exited. `kill()` emits `terminal-killed`
+    // once — the pool suppresses the `cleanupOnExit` hook on an explicit kill
+    // (it detects the session was already removed), so there's no double-emit.
     if (removed?.lastTerminalId) {
       terminalService.kill(removed.lastTerminalId);
     }
@@ -586,7 +582,10 @@ export class CronjobService {
       // default agent.
       const adapter = await agentService.createWorkspaceAgent(workspace.worktree.path);
       const invocation = adapter.cliHeadlessInvocation?.(job.prompt);
-      // Release the short-lived adapter; we only needed the pure-data invocation.
+      // Release the short-lived adapter. `cliHeadlessInvocation` returns pure
+      // data and starts no session/subprocess, so this `abort` is a safe no-op
+      // for every current adapter; it's kept as a belt-and-braces release in
+      // case a future adapter allocates a handle on construction.
       adapter.abort?.();
       if (!invocation || invocation.unsupported) {
         const reason = invocation?.reason ?? "adapter does not expose cliHeadlessInvocation";

--- a/apps/web/src/server/services/cronjob-service.ts
+++ b/apps/web/src/server/services/cronjob-service.ts
@@ -538,6 +538,15 @@ export class CronjobService {
    * Returns `{ terminalId: null }` when the agent exposes no headless CLI (or
    * the workspace can't be resolved), signalling the caller to fall back to
    * chat. Spawn failures propagate (recorded as "failed").
+   *
+   * Edge case: if `terminalService.spawn` throws *after* the PTY is forked but
+   * before `updateLastTerminal` runs, `lastTerminalId` stays unset for this
+   * fire, so the next tick's overlap guard won't see that (now likely dead)
+   * PTY. This is acceptable — a spawn that rejects has almost certainly failed
+   * to produce a usable pane, and the synchronous in-process lock above still
+   * prevents a *concurrent* double-spawn; only a subsequent, well-separated
+   * tick could add a second pane, which is the same at-most-transient
+   * duplication the self-close bound already tolerates.
    */
   private async spawnCronTerminal(
     job: CronjobDefinition,

--- a/apps/web/src/server/services/cronjob-service.ts
+++ b/apps/web/src/server/services/cronjob-service.ts
@@ -588,7 +588,11 @@ export class CronjobService {
       // Resolve the agent's HEADLESS CLI invocation on the request thread so we
       // can fall back to chat synchronously when it's unsupported (e.g.
       // cursor-cli). No `codingAgentId` on the cron row — use the workspace's
-      // default agent.
+      // default agent. `createWorkspaceAgent` deliberately does NOT register in
+      // the chat agent pool (see its doc in `infra/agents/agent-pool.ts`) — it
+      // just constructs a standalone adapter — so this create-then-`abort`
+      // leaves no pool slot behind, the same one-shot pattern
+      // `workspaceService.generateCommitMessage` uses.
       const adapter = await agentService.createWorkspaceAgent(workspace.worktree.path);
       const invocation = adapter.cliHeadlessInvocation?.(job.prompt);
       // Release the short-lived adapter. `cliHeadlessInvocation` returns pure

--- a/apps/web/src/server/services/cronjob-service.ts
+++ b/apps/web/src/server/services/cronjob-service.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 import { createLogger } from "@band-app/logger";
 import { Cron, type CronOptions } from "croner";
 import { z } from "zod";
@@ -7,9 +8,23 @@ import {
   CronjobQueries,
   generateCronjobId,
 } from "../infra/db/queries/cronjobs";
+// FRAGILE: `agentService`, `terminalService`, and `workspaceService` are
+// imported at module load but referenced ONLY inside function bodies
+// (`spawnCronTerminal` and friends). `workspace-service` already imports
+// `cronjobService` from this file, so the two form an ESM cycle — the same
+// live-binding constraint documented on the import block in
+// `workspace-service.ts` applies: never capture these at module load
+// (`const t = terminalService` at the top would get `undefined`), always
+// dereference at call time. The `via` enum below is deliberately NOT imported
+// from `workspace-service` for exactly this reason — see `cronjobVia`.
+import { formatShellCommand } from "./_utils/format-shell-command";
+import { agentService } from "./agent-service";
 import { BAND_CRON_ID_LABEL, type ChatSession, chatService } from "./chat-service";
 import { loadState } from "./state";
 import { TaskConflictError, taskService } from "./task-service";
+import { terminalService } from "./terminal-service";
+import { emit } from "./watcher-service";
+import { workspaceService } from "./workspace-service";
 
 const log = createLogger("cronjob-service");
 
@@ -56,6 +71,20 @@ function schedulerState(): SchedulerState {
 // error at every call site instead of silent drift.
 // ---------------------------------------------------------------------------
 
+/**
+ * Where a cronjob fire dispatches its prompt (issue #581) — the same two
+ * values as `workspaceVia` on `workspaces.create` (#551).
+ *
+ * Deliberately re-declared here rather than imported from
+ * `workspace-service.ts`: that module and this one form an ESM cycle
+ * (`workspace-service` imports `cronjobService`), and `workspaceVia` is a
+ * module-load value — importing it across the cycle risks reading `undefined`
+ * while `workspace-service` is still initialising (see the FRAGILE note on the
+ * import block above). Keep the two enums in sync by convention.
+ */
+export const cronjobVia = z.enum(["chat", "terminal"]);
+export type CronjobVia = z.infer<typeof cronjobVia>;
+
 export const cronjobCreateInput = z.object({
   key: z.string().min(1),
   name: z.string().min(1),
@@ -63,6 +92,9 @@ export const cronjobCreateInput = z.object({
   cronExpression: z.string().min(1),
   scope: z.enum(["project", "workspace"]),
   workspaceId: z.string().optional(),
+  // Dispatch target for scheduled + manual fires. Optional — absent defaults to
+  // "chat" in `create()` so existing callers (the web UI) keep their behavior.
+  via: cronjobVia.optional(),
   enabled: z.boolean().default(true),
 });
 
@@ -102,6 +134,20 @@ export const cronjobByIdInput = z.object({
 export type CronjobCreateInput = z.infer<typeof cronjobCreateInput>;
 export type CronjobUpdateInput = z.infer<typeof cronjobUpdateInput>;
 export type CronjobByIdInput = z.infer<typeof cronjobByIdInput>;
+
+/**
+ * Result of a manual `trigger`, discriminated on the dispatch target.
+ *
+ *   - `chat` — a task was submitted to the cron chat pane (returns the task +
+ *     chat ids, preserving the pre-#581 response fields).
+ *   - `terminal` — a fresh self-closing PTY pane was spawned (returns its id).
+ *
+ * A `via="terminal"` job whose agent has no vendor CLI silently falls back to
+ * the chat shape, so callers can always rely on `via` to know what happened.
+ */
+export type CronjobTriggerResult =
+  | { via: "chat"; taskId: string; workspaceId: string; chatId: string }
+  | { via: "terminal"; terminalId: string; workspaceId: string };
 
 // ---------------------------------------------------------------------------
 // Service-level error types
@@ -223,6 +269,9 @@ export class CronjobService {
       cronExpression: input.cronExpression,
       scope: input.scope,
       workspaceId: input.workspaceId,
+      // Absent `via` means the web UI (or a pre-#581 caller) — default to chat
+      // so existing cronjobs keep dispatching exactly as before.
+      via: input.via ?? "chat",
       enabled: input.enabled,
       createdAt: new Date().toISOString(),
     };
@@ -267,8 +316,14 @@ export class CronjobService {
     const file = this.queries.loadFile(key);
     const index = file.jobs.findIndex((j) => j.id === id);
     if (index === -1) throw new CronjobNotFoundError();
-    file.jobs.splice(index, 1);
+    const [removed] = file.jobs.splice(index, 1);
     this.queries.saveFile(key, file);
+    // Best-effort: tear down the terminal a via="terminal" job last spawned so
+    // deleting the job doesn't leave a stray pane running the agent. No-op when
+    // the id is unset or the PTY already exited.
+    if (removed?.lastTerminalId) {
+      terminalService.kill(removed.lastTerminalId);
+    }
     this.reloadSchedules();
     return { ok: true };
   }
@@ -295,16 +350,27 @@ export class CronjobService {
    * succeeds (which would require buffering the chat name/labels on the
    * task row).
    */
-  trigger(key: string, id: string): { taskId: string; workspaceId: string; chatId: string } {
+  async trigger(key: string, id: string): Promise<CronjobTriggerResult> {
     const job = this.findJob(key, id);
     if (!job) throw new CronjobNotFoundError();
 
     const workspaceId = this.resolveWorkspaceId(job, key);
     if (!workspaceId) throw new CronjobProjectNotFoundError();
 
+    // Terminal dispatch mirrors the scheduled fire. `spawnCronTerminal` throws
+    // `TaskConflictError` when the previous pane is still alive (→ 409, same as
+    // the chat path's running-task conflict) and returns `{ terminalId: null }`
+    // when the agent has no vendor CLI, in which case we fall through to chat.
+    if (job.via === "terminal") {
+      const { terminalId } = await this.spawnCronTerminal(job, workspaceId, key);
+      if (terminalId) {
+        return { via: "terminal", terminalId, workspaceId };
+      }
+    }
+
     const cronChat = this.getOrCreateCronjobChat(workspaceId, job);
     const task = taskService.submitTask({ workspaceId, chatId: cronChat.id, prompt: job.prompt });
-    return { taskId: task.id, workspaceId, chatId: cronChat.id };
+    return { via: "chat", taskId: task.id, workspaceId, chatId: cronChat.id };
   }
 
   // -------------------------------------------------------------------------
@@ -429,6 +495,92 @@ export class CronjobService {
   }
 
   /**
+   * Dispatch a `via="terminal"` fire: spawn the agent's *headless* vendor CLI
+   * in a fresh, self-closing PTY pane. Mirrors the `via=terminal` branch of
+   * `WorkspaceService.create` (#551), but adapted for a recurring cron in two
+   * important ways:
+   *
+   *   - **Headless, not interactive.** We use `adapter.cliHeadlessInvocation`
+   *     (`claude -p`, `codex exec`, …), NOT the interactive `cliInvocation`
+   *     that workspace-create uses. The interactive REPL never exits on its
+   *     own, so the pane would stay parked after the turn — the shell's `exit`
+   *     would never run and the overlap guard below would treat "idle at the
+   *     REPL" as "still running", blocking every subsequent tick (issue #581
+   *     follow-up). The headless form runs the prompt and exits, which is what
+   *     makes both the self-close and the overlap guard actually work.
+   *   - **Overlap guard.** If the terminal spawned by this job's previous fire
+   *     is still alive, throw `TaskConflictError` instead of launching a second
+   *     agent — the caller records "skipped" (scheduled) or surfaces 409
+   *     (manual trigger), exactly like the chat running-task conflict. Because
+   *     the headless process exits when the turn completes, a live PTY reliably
+   *     means the previous run is genuinely still working.
+   *   - **Self-closing pane.** The command is `<headless-cli>\nexit`, staged
+   *     and sourced by the pool via `.`, so the shell exits the moment the
+   *     headless CLI returns. Combined with `cleanupOnExit`, the finished pane
+   *     removes itself from the layout and emits `terminal-killed` — bounding a
+   *     frequent cron to ~1 pane and keeping the next tick's liveness check
+   *     accurate.
+   *
+   * Returns `{ terminalId: null }` when the agent exposes no headless CLI (or
+   * the workspace can't be resolved), signalling the caller to fall back to
+   * chat. Spawn failures propagate (recorded as "failed").
+   */
+  private async spawnCronTerminal(
+    job: CronjobDefinition,
+    workspaceId: string,
+    fileKey: string,
+  ): Promise<{ terminalId: string | null }> {
+    const workspace = workspaceService.resolve(workspaceId);
+    if (!workspace) {
+      log.warn(
+        { jobId: job.id, workspaceId },
+        "workspace not resolvable for via=terminal cronjob; falling back to chat",
+      );
+      return { terminalId: null };
+    }
+
+    // Overlap guard: re-read the row (the scheduled path closes over a stale
+    // `job` captured at schedule time) so we check the terminal the LAST fire
+    // actually spawned. A live PTY means the previous headless run is still
+    // working (a finished one has exited and self-closed).
+    const prevTerminalId = this.findJob(fileKey, job.id)?.lastTerminalId;
+    if (prevTerminalId && terminalService.getSession(prevTerminalId)) {
+      throw new TaskConflictError(`Cronjob ${job.id} terminal run is still in progress`);
+    }
+
+    // Resolve the agent's HEADLESS CLI invocation on the request thread so we
+    // can fall back to chat synchronously when it's unsupported (e.g.
+    // cursor-cli). No `codingAgentId` on the cron row — use the workspace's
+    // default agent.
+    const adapter = await agentService.createWorkspaceAgent(workspace.worktree.path);
+    const invocation = adapter.cliHeadlessInvocation?.(job.prompt);
+    // Release the short-lived adapter; we only needed the pure-data invocation.
+    adapter.abort?.();
+    if (!invocation || invocation.unsupported) {
+      const reason = invocation?.reason ?? "adapter does not expose cliHeadlessInvocation";
+      log.warn(
+        { jobId: job.id, workspaceId, reason },
+        "via=terminal requested but agent has no headless CLI; falling back to chat",
+      );
+      return { terminalId: null };
+    }
+
+    // `\nexit` makes the pane self-close when the headless CLI returns: the pool
+    // stages `<command>\n` into a temp file and runs it via the POSIX dot
+    // builtin, so a trailing `exit` terminates the shell once the CLI exits.
+    const command = `${formatShellCommand(invocation.command, invocation.args)}\nexit`;
+    const terminalId = randomUUID();
+    await terminalService.spawn(workspaceId, terminalId, { command }, { cleanupOnExit: true });
+    // Persist the id BEFORE emitting so the next tick's overlap check sees it
+    // even if the emit's subscribers race.
+    this.queries.updateLastTerminal(job.id, terminalId);
+    // Broadcast so an open dashboard adds the pane without a reload — same
+    // pattern as `terminal.create` and the `via=terminal` workspace-create path.
+    emit({ kind: "terminal-created", workspaceId, terminalId });
+    return { terminalId };
+  }
+
+  /**
    * Resolve the workspace the cronjob fires into.
    *
    * Returns `null` for project-scoped jobs whose project no longer exists
@@ -532,6 +684,38 @@ export class CronjobService {
     }
 
     log.info({ jobId: job.id, name: job.name, workspaceId }, "executing cronjob");
+
+    // Terminal dispatch (issue #581). `spawnCronTerminal` throws
+    // `TaskConflictError` when the job's previous pane is still alive (record
+    // "skipped", identical to the chat running-task conflict below) and returns
+    // `{ terminalId: null }` when the agent has no vendor CLI — in which case we
+    // fall through to the chat path so the fire still does something.
+    if (job.via === "terminal") {
+      try {
+        const { terminalId } = await this.spawnCronTerminal(job, workspaceId, fileKey);
+        if (terminalId) {
+          log.info({ jobId: job.id, terminalId, workspaceId }, "cronjob terminal spawned");
+          this.safeUpdateLastRun(job.id, "completed");
+          return;
+        }
+        log.info(
+          { jobId: job.id, workspaceId },
+          "via=terminal not supported by agent; falling back to chat dispatch",
+        );
+      } catch (err) {
+        if (err instanceof TaskConflictError) {
+          log.info(
+            { jobId: job.id, workspaceId },
+            "previous terminal run still active, skipping cronjob execution",
+          );
+          this.safeUpdateLastRun(job.id, "skipped");
+          return;
+        }
+        log.error({ jobId: job.id, err }, "cronjob terminal dispatch failed");
+        this.safeUpdateLastRun(job.id, "failed");
+        return;
+      }
+    }
 
     try {
       const chat = this.getOrCreateCronjobChat(workspaceId, job);

--- a/apps/web/src/server/services/terminal-service.ts
+++ b/apps/web/src/server/services/terminal-service.ts
@@ -114,6 +114,13 @@ export class TerminalService {
     workspaceId: string,
     terminalId: string,
     options?: SpawnOptions,
+    // `cleanupOnExit` (issue #581): when set, a *natural* PTY exit (e.g. a
+    // self-closing cron pane whose command ended with `exit`) triggers the same
+    // teardown as an explicit `kill` — the tab is dropped from the saved layout
+    // and a `terminal-killed` event is emitted. Off by default so a user's
+    // interactive terminal keeps its "Terminal exited" pane on screen (existing
+    // behavior); only opt-in callers get the auto-prune.
+    opts?: { cleanupOnExit?: boolean },
   ): Promise<TerminalSession> {
     const workspace = workspaceService.resolve(workspaceId);
     if (!workspace) {
@@ -124,6 +131,7 @@ export class TerminalService {
       terminalId,
       workspace.worktree.path,
       options,
+      opts?.cleanupOnExit ? () => this.emitRemoved(workspaceId, terminalId) : undefined,
     );
 
     // Mirror what `createChat` and `createBrowser` do: register the new
@@ -151,9 +159,20 @@ export class TerminalService {
     const workspaceId = session?.workspaceId;
     this.pool.kill(terminalId);
     if (workspaceId) {
-      removeTerminalFromLayout(workspaceId, terminalId);
-      emit({ kind: "terminal-killed", workspaceId, terminalId });
+      this.emitRemoved(workspaceId, terminalId);
     }
+  }
+
+  /**
+   * Drop a terminal from the saved dockview layout and broadcast
+   * `terminal-killed` so an open dashboard prunes the panel. Shared by the
+   * explicit {@link kill} path and the `cleanupOnExit` natural-exit hook wired
+   * up in {@link spawn}. Idempotent: `removeTerminalFromLayout` is a no-op when
+   * the panel is already gone, and a duplicate `terminal-killed` is harmless.
+   */
+  private emitRemoved(workspaceId: string, terminalId: string): void {
+    removeTerminalFromLayout(workspaceId, terminalId);
+    emit({ kind: "terminal-killed", workspaceId, terminalId });
   }
 
   /**

--- a/apps/web/src/server/services/terminal-service.ts
+++ b/apps/web/src/server/services/terminal-service.ts
@@ -119,7 +119,10 @@ export class TerminalService {
     // teardown as an explicit `kill` — the tab is dropped from the saved layout
     // and a `terminal-killed` event is emitted. Off by default so a user's
     // interactive terminal keeps its "Terminal exited" pane on screen (existing
-    // behavior); only opt-in callers get the auto-prune.
+    // behavior); only opt-in callers get the auto-prune. The exit hook closes
+    // over THIS call's `workspaceId`/`terminalId`, so callers must pass the same
+    // `workspaceId` the terminal is registered under in the layout (they match
+    // here — `addTerminalToLayout` below uses the same value).
     opts?: { cleanupOnExit?: boolean },
   ): Promise<TerminalSession> {
     const workspace = workspaceService.resolve(workspaceId);

--- a/apps/web/tests/cronjobs-via.test.ts
+++ b/apps/web/tests/cronjobs-via.test.ts
@@ -1,0 +1,683 @@
+// Integration tests for cronjobs dispatching via terminal (issue #581).
+//
+// A cronjob can dispatch its prompt to the agent's *headless* CLI in a fresh
+// PTY pane (`via: "terminal"`) instead of the chat pane (`via: "chat"`,
+// default), reusing the same `via` model as `workspaces.create` (#551). Unlike
+// workspace-create (which opens the interactive REPL), a cron uses the headless
+// one-shot invocation (`claude -p …`) so the pane runs to completion and exits
+// — see the `-p` regression assertion below. These tests drive the *manual*
+// `cronjobs.trigger` route because it shares the exact dispatch path with the
+// scheduled fire (`executeCronjob` → `spawnCronTerminal`) but is deterministic
+// to invoke from a test.
+//
+// Real production server (`dist/start-server.mjs`), real PTY (node-pty), real
+// git repo, real SQLite. No tRPC mocking, no MSW. Each describe block boots its
+// own server with a tmp `$HOME` so an SDK-adapter wedge in one scenario can't
+// cascade into the next.
+//
+// The cron terminal pane is *self-closing* (its command ends with `exit`), so
+// its scrollback dies with the PTY the instant the command finishes. The
+// happy-path assertion therefore has the stub vendor CLI append its argv to a
+// **log file** rather than reading it back through `terminal.output` (which
+// would race the self-close). The overlap test instead uses a *sleeping* stub
+// so the pane stays alive long enough to observe the skip.
+
+import { execFileSync } from "node:child_process";
+import { chmodSync, existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { toWorkspaceId } from "@/dashboard";
+import { seedSettings, seedState } from "./helpers/seed-state";
+import {
+  createTmpHome,
+  type ServerHandle,
+  startServer,
+  trpcData,
+  trpcMutate,
+  trpcQuery,
+} from "./helpers/server";
+import { listTasksForWorkspace } from "./helpers/tasks";
+import { waitFor } from "./helpers/wait-for";
+
+const FAKE_AGENT_PATH = join(import.meta.dirname, "fake-agent.mjs");
+
+// ---------------------------------------------------------------------------
+// Git + stub helpers
+// ---------------------------------------------------------------------------
+
+const gitEnv = {
+  ...process.env,
+  GIT_AUTHOR_NAME: "Test",
+  GIT_AUTHOR_EMAIL: "test@test.com",
+  GIT_COMMITTER_NAME: "Test",
+  GIT_COMMITTER_EMAIL: "test@test.com",
+};
+
+function git(cwd: string, args: string[]): string {
+  return execFileSync("git", args, { cwd, env: gitEnv, encoding: "utf-8" });
+}
+
+function createGitRepo(parentDir: string, name: string): string {
+  const repoPath = join(parentDir, name);
+  mkdirSync(repoPath, { recursive: true });
+  git(repoPath, ["init", "-b", "main"]);
+  writeFileSync(join(repoPath, "README.md"), "# cron via test\n");
+  git(repoPath, ["add", "."]);
+  git(repoPath, ["commit", "-m", "init"]);
+  return repoPath;
+}
+
+function writeVendorCliScript(tmpHome: string, name: string, body: string): string {
+  const binPath = join(tmpHome, name);
+  writeFileSync(binPath, `#!/bin/sh\n${body}`, "utf-8");
+  chmodSync(binPath, 0o755);
+  return binPath;
+}
+
+/**
+ * Stub vendor CLI for the self-closing happy path: append `ARGV:<arg0>|<arg1>|…`
+ * to `logPath` (baked into the script) and exit immediately. The log file
+ * outlives the PTY, so the test can prove the prompt reached argv even after
+ * the pane self-closes. The `logPath` is single-quoted so a space in the tmp
+ * home can't split the redirect target.
+ *
+ * The same binary is the configured `claude-code` command, so the Claude Code
+ * SDK also spawns it (boot model-refresh / adapter construction) with its own
+ * `-p --output-format stream-json …` arg set into this same log. Two
+ * defenses make the argv assertion robust against that:
+ *   1. The whole argv is composed into one string and written with a SINGLE
+ *      `printf '%s\n'` — one `O_APPEND` write, atomic under PIPE_BUF (our lines
+ *      are <200 bytes) — so concurrent spawns produce distinct, non-interleaved
+ *      lines rather than one byte-mangled line.
+ *   2. The test matches the line bearing the cron prompt and asserts it EXACTLY,
+ *      so an unrelated spawn's line is simply ignored.
+ */
+function writeLoggingVendorCli(tmpHome: string, name: string, logPath: string): string {
+  return writeVendorCliScript(
+    tmpHome,
+    name,
+    `out="ARGV:"\nfor arg in "$@"; do out="$out$arg|"; done\nprintf '%s\\n' "$out" >> '${logPath}'\n`,
+  );
+}
+
+/**
+ * Stub vendor CLI that sleeps so the PTY stays alive long enough for the
+ * overlap / delete tests to observe the running pane and act before the command
+ * finishes. Gated on `BAND_DISPATCH=terminal` so the SDK's boot-time
+ * model-refresh spawn (`BAND_DISPATCH=chat`) exits immediately instead of
+ * spawning a stray multi-second sleeper.
+ */
+function writeSleepingVendorCli(tmpHome: string, name: string, seconds: number): string {
+  return writeVendorCliScript(
+    tmpHome,
+    name,
+    `[ "$BAND_DISPATCH" = terminal ] || exit 0\nsleep ${seconds}\n`,
+  );
+}
+
+/**
+ * Minimal fake-agent scenario for the chat-path dispatch: emit `system.init`
+ * then a terminal `result` so `taskService.submitTask` records a completed task
+ * and tears the agent down cleanly. A bare shell stub would hang the SDK
+ * subprocess on Linux CI.
+ */
+function writeChatScenario(tmpHome: string, name: string): string {
+  const scenarioPath = join(tmpHome, name);
+  writeFileSync(
+    scenarioPath,
+    JSON.stringify([
+      { type: "system", subtype: "init", session_id: "cron-via-chat-session" },
+      { type: "result", subtype: "success", result: "Done" },
+    ]),
+    "utf-8",
+  );
+  return scenarioPath;
+}
+
+interface TerminalListEntry {
+  terminalId: string;
+  workspaceId: string;
+  pid: number;
+}
+
+async function listTerminals(
+  serverUrl: string,
+  workspaceId: string,
+  token: string,
+): Promise<TerminalListEntry[]> {
+  const res = await trpcQuery(serverUrl, "terminal.list", { workspaceId }, token);
+  const body = await res.text();
+  expect(res.status, `terminal.list failed: ${body}`).toBe(200);
+  return (JSON.parse(body) as { result: { data: { terminals: TerminalListEntry[] } } }).result.data
+    .terminals;
+}
+
+interface TriggerResponse {
+  via: "chat" | "terminal";
+  workspaceId: string;
+  terminalId?: string;
+  taskId?: string;
+  chatId?: string;
+}
+
+// ---------------------------------------------------------------------------
+// via=terminal — happy path + self-close
+// ---------------------------------------------------------------------------
+
+describe("cronjobs.trigger via=terminal happy path", () => {
+  const TOKEN = "cron-via-terminal-happy-token";
+  let server: ServerHandle;
+  let tmpHome: string;
+  let logPath: string;
+  let jobId: string;
+
+  beforeAll(async () => {
+    tmpHome = createTmpHome("band-cron-via-happy-");
+    const repoPath = createGitRepo(tmpHome, "viacron");
+    logPath = join(tmpHome, "cron-invocation.log");
+    const stubBin = writeLoggingVendorCli(tmpHome, "stub-claude.sh", logPath);
+    seedState(tmpHome, {
+      projects: [
+        {
+          name: "viacron",
+          path: repoPath,
+          defaultBranch: "main",
+          worktrees: [{ branch: "main", path: repoPath }],
+        },
+      ],
+    });
+    seedSettings(tmpHome, {
+      tokenSecret: TOKEN,
+      codingAgents: [
+        { id: "claude-code", type: "claude-code", label: "Claude Code", command: stubBin },
+      ],
+    });
+    server = await startServer({ tmpHome });
+
+    const res = await trpcMutate(
+      server.url,
+      "cronjobs.create",
+      {
+        key: "viacron",
+        name: "Terminal cron",
+        prompt: "run the terminal check",
+        cronExpression: "0 0 * * *",
+        scope: "project",
+        via: "terminal",
+      },
+      TOKEN,
+    );
+    expect(res.status).toBe(200);
+    const data = await trpcData<{ job: { id: string; via: string } }>(res);
+    expect(data.job.via).toBe("terminal");
+    jobId = data.job.id;
+  });
+
+  afterAll(async () => {
+    await server.close();
+    rmSync(tmpHome, { recursive: true, force: true });
+  });
+
+  it("spawns a self-closing terminal running the prompt, then prunes it", async () => {
+    const res = await trpcMutate(
+      server.url,
+      "cronjobs.trigger",
+      { key: "viacron", id: jobId },
+      TOKEN,
+    );
+    expect(res.status).toBe(200);
+    const data = await trpcData<TriggerResponse>(res);
+
+    // The response reports the actual dispatch: a terminal id, no chat task.
+    expect(data.via).toBe("terminal");
+    expect(typeof data.terminalId).toBe("string");
+    expect(data.terminalId!.length).toBeGreaterThan(0);
+    expect(data.workspaceId).toBe("viacron-main");
+    expect(data.taskId).toBeUndefined();
+
+    // The stub vendor CLI logged its argv (one atomic line per spawn) to a file
+    // so the assertion survives the pane self-closing. Grab the line bearing the
+    // cron prompt — the SDK's own spawns of this same binary write other lines
+    // we ignore.
+    const argvLine = await waitFor(
+      async () => {
+        if (!existsSync(logPath)) return undefined;
+        return readFileSync(logPath, "utf-8")
+          .split("\n")
+          .find((l) => l.includes("run the terminal check|"));
+      },
+      { label: "stub vendor CLI logged the prompt argv" },
+    );
+    // Regression guard for issue #581's follow-up: the cron path must use the
+    // agent's HEADLESS invocation (`claude -p "<prompt>"`), not the interactive
+    // `cliInvocation` (`claude "<prompt>"`). The interactive REPL never exits,
+    // so the pane would stay parked and every later tick would 409. The stub is
+    // a claude-code agent, so headless dispatch logs exactly `-p` then the prompt
+    // (`ARGV:-p|<prompt>|`); interactive dispatch would log only the prompt token
+    // (`ARGV:<prompt>|`). Asserting the whole line rules out both a regression to
+    // the interactive form and any accidental match against an SDK spawn's line.
+    expect(argvLine).toBe("ARGV:-p|run the terminal check|");
+
+    // Self-close: the command ended with `exit`, so the pane closes when the
+    // (fast) stub finishes, and the `cleanupOnExit` hook prunes it from the
+    // pool. No terminal should remain for the workspace.
+    const workspaceId = toWorkspaceId("viacron", "main");
+    const remaining = await waitFor(
+      async () => {
+        const list = await listTerminals(server.url, workspaceId, TOKEN);
+        return list.length === 0 ? list : undefined;
+      },
+      { label: "self-closing cron terminal pruned" },
+    );
+    expect(remaining).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// via=terminal — skip an overlapping run (previous pane still active → 409)
+// ---------------------------------------------------------------------------
+
+describe("cronjobs.trigger via=terminal skips overlapping runs", () => {
+  const TOKEN = "cron-via-terminal-overlap-token";
+  // The stub sleeps this long so the first trigger's pane is still alive when
+  // the second trigger fires. Generous margin over the poll + second-trigger
+  // round-trip below.
+  const STUB_SLEEP_SECONDS = 6;
+  let server: ServerHandle;
+  let tmpHome: string;
+  let jobId: string;
+
+  beforeAll(async () => {
+    tmpHome = createTmpHome("band-cron-via-overlap-");
+    const repoPath = createGitRepo(tmpHome, "overlapcron");
+    const stubBin = writeSleepingVendorCli(tmpHome, "stub-claude.sh", STUB_SLEEP_SECONDS);
+    seedState(tmpHome, {
+      projects: [
+        {
+          name: "overlapcron",
+          path: repoPath,
+          defaultBranch: "main",
+          worktrees: [{ branch: "main", path: repoPath }],
+        },
+      ],
+    });
+    seedSettings(tmpHome, {
+      tokenSecret: TOKEN,
+      codingAgents: [
+        { id: "claude-code", type: "claude-code", label: "Claude Code", command: stubBin },
+      ],
+    });
+    server = await startServer({ tmpHome });
+
+    const res = await trpcMutate(
+      server.url,
+      "cronjobs.create",
+      {
+        key: "overlapcron",
+        name: "Overlapping terminal cron",
+        prompt: "long running work",
+        cronExpression: "0 0 * * *",
+        scope: "project",
+        via: "terminal",
+      },
+      TOKEN,
+    );
+    expect(res.status).toBe(200);
+    const data = await trpcData<{ job: { id: string } }>(res);
+    jobId = data.job.id;
+  });
+
+  afterAll(async () => {
+    await server.close();
+    rmSync(tmpHome, { recursive: true, force: true });
+  });
+
+  it("returns 409 when the previous terminal run is still active", async () => {
+    // First trigger spawns the (sleeping) pane.
+    const first = await trpcMutate(
+      server.url,
+      "cronjobs.trigger",
+      { key: "overlapcron", id: jobId },
+      TOKEN,
+    );
+    expect(first.status).toBe(200);
+    const firstData = await trpcData<TriggerResponse>(first);
+    expect(firstData.via).toBe("terminal");
+
+    // Wait until the PTY is registered so the overlap check has something to
+    // observe, then fire the second trigger while the stub is still sleeping.
+    const workspaceId = toWorkspaceId("overlapcron", "main");
+    await waitFor(
+      async () => {
+        const list = await listTerminals(server.url, workspaceId, TOKEN);
+        return list.some((t) => t.terminalId === firstData.terminalId) ? list : undefined;
+      },
+      { label: "first cron terminal registered" },
+    );
+
+    // Assert the exact status: a [200,409] union would silently pass if the
+    // overlap guard ever stopped firing.
+    const second = await trpcMutate(
+      server.url,
+      "cronjobs.trigger",
+      { key: "overlapcron", id: jobId },
+      TOKEN,
+    );
+    expect(second.status).toBe(409);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// via=chat (default) — no terminal spawned, a chat task is submitted
+//
+// Uses `fake-agent.mjs` (the SDK-protocol stub) because chat dispatch runs
+// `taskService.submitTask`, which spawns the real SDK and reads JSONL events.
+// ---------------------------------------------------------------------------
+
+describe("cronjobs.trigger default dispatches to chat", () => {
+  const TOKEN = "cron-via-chat-token";
+  let server: ServerHandle;
+  let tmpHome: string;
+  let jobId: string;
+
+  beforeAll(async () => {
+    tmpHome = createTmpHome("band-cron-via-chat-");
+    const repoPath = createGitRepo(tmpHome, "chatcron");
+    const scenarioPath = writeChatScenario(tmpHome, "chat-scenario.json");
+    seedState(tmpHome, {
+      projects: [
+        {
+          name: "chatcron",
+          path: repoPath,
+          defaultBranch: "main",
+          worktrees: [{ branch: "main", path: repoPath }],
+        },
+      ],
+    });
+    seedSettings(tmpHome, {
+      tokenSecret: TOKEN,
+      codingAgents: [
+        { id: "claude-code", type: "claude-code", label: "Claude Code", command: FAKE_AGENT_PATH },
+      ],
+    });
+    server = await startServer({ tmpHome, env: { FAKE_AGENT_SCENARIO: scenarioPath } });
+
+    // No `via` field — the server defaults to chat (backward-compatible).
+    const res = await trpcMutate(
+      server.url,
+      "cronjobs.create",
+      {
+        key: "chatcron",
+        name: "Chat cron",
+        prompt: "chat dispatch work",
+        cronExpression: "0 0 * * *",
+        scope: "project",
+      },
+      TOKEN,
+    );
+    expect(res.status).toBe(200);
+    const data = await trpcData<{ job: { id: string; via: string } }>(res);
+    // The persisted job records the default.
+    expect(data.job.via).toBe("chat");
+    jobId = data.job.id;
+  });
+
+  afterAll(async () => {
+    await server.close();
+    rmSync(tmpHome, { recursive: true, force: true });
+  });
+
+  it("returns via=chat with a taskId and spawns no terminal", async () => {
+    const res = await trpcMutate(
+      server.url,
+      "cronjobs.trigger",
+      { key: "chatcron", id: jobId },
+      TOKEN,
+    );
+    expect(res.status).toBe(200);
+    const data = await trpcData<TriggerResponse>(res);
+
+    expect(data.via).toBe("chat");
+    expect(typeof data.taskId).toBe("string");
+    expect(data.terminalId).toBeUndefined();
+
+    const workspaceId = toWorkspaceId("chatcron", "main");
+
+    // Positive anchor: the chat task actually landed.
+    const tasks = await waitFor(
+      async () => {
+        const list = await listTasksForWorkspace(server.url, workspaceId, TOKEN);
+        return list.find((t) => t.prompt === "chat dispatch work") ? list : undefined;
+      },
+      { label: "chat task submitted for default via" },
+    );
+    expect(tasks.some((t) => t.prompt === "chat dispatch work")).toBe(true);
+
+    // No PTY: chat dispatch never touches the terminal pool.
+    const terminals = await listTerminals(server.url, workspaceId, TOKEN);
+    expect(terminals).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// via=terminal + unsupported adapter → silent fallback to chat
+//
+// cursor-cli's `cliInvocation` returns `unsupported: true`; the service warns
+// and downgrades to chat. As in workspace-create-via, the real Cursor SDK isn't
+// safe to run in the test process, so we assert the response shape only.
+// ---------------------------------------------------------------------------
+
+describe("cronjobs.trigger via=terminal falls back to chat when unsupported", () => {
+  const TOKEN = "cron-via-fallback-token";
+  let server: ServerHandle;
+  let tmpHome: string;
+  let jobId: string;
+
+  beforeAll(async () => {
+    tmpHome = createTmpHome("band-cron-via-fallback-");
+    const repoPath = createGitRepo(tmpHome, "fbcron");
+    seedState(tmpHome, {
+      projects: [
+        {
+          name: "fbcron",
+          path: repoPath,
+          defaultBranch: "main",
+          worktrees: [{ branch: "main", path: repoPath }],
+        },
+      ],
+    });
+    seedSettings(tmpHome, {
+      tokenSecret: TOKEN,
+      codingAgents: [{ id: "cursor-cli", type: "cursor-cli", label: "Cursor CLI" }],
+      defaultCodingAgent: "cursor-cli",
+    });
+    server = await startServer({ tmpHome });
+
+    const res = await trpcMutate(
+      server.url,
+      "cronjobs.create",
+      {
+        key: "fbcron",
+        name: "Fallback cron",
+        prompt: "should fall back to chat",
+        cronExpression: "0 0 * * *",
+        scope: "project",
+        via: "terminal",
+      },
+      TOKEN,
+    );
+    expect(res.status).toBe(200);
+    const data = await trpcData<{ job: { id: string } }>(res);
+    jobId = data.job.id;
+  });
+
+  afterAll(async () => {
+    await server.close();
+    rmSync(tmpHome, { recursive: true, force: true });
+  });
+
+  it("reports via=chat and does not return a terminalId", async () => {
+    const res = await trpcMutate(
+      server.url,
+      "cronjobs.trigger",
+      { key: "fbcron", id: jobId },
+      TOKEN,
+    );
+    expect(res.status).toBe(200);
+    const data = await trpcData<TriggerResponse>(res);
+
+    // The response reports the *actual* dispatch the server used, not the value
+    // the caller asked for — so a CLI scripting on `terminalId` can branch on
+    // its absence.
+    expect(data.via).toBe("chat");
+    expect(data.terminalId).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// via=terminal — deleting the job tears down its live terminal
+//
+// `cronjobs.delete` best-effort kills the terminal a via="terminal" job last
+// spawned (cronjob-service `delete()`), so removing a job doesn't leave a stray
+// pane running the agent. Uses a sleeping stub so the pane is still alive when
+// we delete.
+// ---------------------------------------------------------------------------
+
+describe("cronjobs.delete tears down a via=terminal job's terminal", () => {
+  const TOKEN = "cron-via-delete-token";
+  const STUB_SLEEP_SECONDS = 6;
+  let server: ServerHandle;
+  let tmpHome: string;
+  let jobId: string;
+
+  beforeAll(async () => {
+    tmpHome = createTmpHome("band-cron-via-delete-");
+    const repoPath = createGitRepo(tmpHome, "delcron");
+    const stubBin = writeSleepingVendorCli(tmpHome, "stub-claude.sh", STUB_SLEEP_SECONDS);
+    seedState(tmpHome, {
+      projects: [
+        {
+          name: "delcron",
+          path: repoPath,
+          defaultBranch: "main",
+          worktrees: [{ branch: "main", path: repoPath }],
+        },
+      ],
+    });
+    seedSettings(tmpHome, {
+      tokenSecret: TOKEN,
+      codingAgents: [
+        { id: "claude-code", type: "claude-code", label: "Claude Code", command: stubBin },
+      ],
+    });
+    server = await startServer({ tmpHome });
+
+    const res = await trpcMutate(
+      server.url,
+      "cronjobs.create",
+      {
+        key: "delcron",
+        name: "Deletable terminal cron",
+        prompt: "long running work",
+        cronExpression: "0 0 * * *",
+        scope: "project",
+        via: "terminal",
+      },
+      TOKEN,
+    );
+    expect(res.status).toBe(200);
+    const data = await trpcData<{ job: { id: string } }>(res);
+    jobId = data.job.id;
+  });
+
+  afterAll(async () => {
+    await server.close();
+    rmSync(tmpHome, { recursive: true, force: true });
+  });
+
+  it("kills the spawned terminal when the job is deleted", async () => {
+    const trigger = await trpcMutate(
+      server.url,
+      "cronjobs.trigger",
+      { key: "delcron", id: jobId },
+      TOKEN,
+    );
+    expect(trigger.status).toBe(200);
+    const triggerData = await trpcData<TriggerResponse>(trigger);
+    expect(triggerData.via).toBe("terminal");
+
+    const workspaceId = toWorkspaceId("delcron", "main");
+
+    // Positive anchor: the PTY is live (the stub is still sleeping).
+    await waitFor(
+      async () => {
+        const list = await listTerminals(server.url, workspaceId, TOKEN);
+        return list.some((t) => t.terminalId === triggerData.terminalId) ? list : undefined;
+      },
+      { label: "cron terminal registered before delete" },
+    );
+
+    // Deleting the job must tear down its live pane.
+    const del = await trpcMutate(
+      server.url,
+      "cronjobs.delete",
+      { key: "delcron", id: jobId },
+      TOKEN,
+    );
+    expect(del.status).toBe(200);
+
+    const remaining = await waitFor(
+      async () => {
+        const list = await listTerminals(server.url, workspaceId, TOKEN);
+        return list.every((t) => t.terminalId !== triggerData.terminalId) ? list : undefined;
+      },
+      { label: "cron terminal removed after delete" },
+    );
+    expect(remaining.some((t) => t.terminalId === triggerData.terminalId)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Auth — `cronjobs.trigger` is part of this PR's changed contract (now async,
+// returns a chat|terminal union), so this file owns the 401 guard for that
+// surface. Mirrors the auth block in `workspace-create-via.test.ts`.
+// ---------------------------------------------------------------------------
+
+describe("cronjobs.trigger — auth", () => {
+  const TOKEN = "cron-via-auth-token";
+  let server: ServerHandle;
+  let tmpHome: string;
+
+  beforeAll(async () => {
+    tmpHome = createTmpHome("band-cron-via-auth-");
+    const repoPath = createGitRepo(tmpHome, "authcron");
+    seedState(tmpHome, {
+      projects: [
+        {
+          name: "authcron",
+          path: repoPath,
+          defaultBranch: "main",
+          worktrees: [{ branch: "main", path: repoPath }],
+        },
+      ],
+    });
+    seedSettings(tmpHome, { tokenSecret: TOKEN });
+    server = await startServer({ tmpHome });
+  });
+
+  afterAll(async () => {
+    await server.close();
+    rmSync(tmpHome, { recursive: true, force: true });
+  });
+
+  it("rejects cronjobs.trigger without the band_token cookie (401)", async () => {
+    // The shared `trpcMutate` always sends the cookie, so we call `fetch`
+    // directly to omit it — same pattern as the other surface auth guards.
+    const res = await fetch(`${server.url}/trpc/cronjobs.trigger`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ key: "authcron", id: "cj_whatever" }),
+    });
+    expect(res.status).toBe(401);
+  });
+});

--- a/apps/web/tests/cronjobs-via.test.ts
+++ b/apps/web/tests/cronjobs-via.test.ts
@@ -93,10 +93,13 @@ function writeVendorCliScript(tmpHome: string, name: string, body: string): stri
  *      so an unrelated spawn's line is simply ignored.
  */
 function writeLoggingVendorCli(tmpHome: string, name: string, logPath: string): string {
+  // POSIX single-quote escaping so an apostrophe in the tmp path can't break
+  // the `>> '<path>'` redirect (which would fail the test as a silent timeout).
+  const quotedLog = logPath.replace(/'/g, `'\\''`);
   return writeVendorCliScript(
     tmpHome,
     name,
-    `out="ARGV:"\nfor arg in "$@"; do out="$out$arg|"; done\nprintf '%s\\n' "$out" >> '${logPath}'\n`,
+    `out="ARGV:"\nfor arg in "$@"; do out="$out$arg|"; done\nprintf '%s\\n' "$out" >> '${quotedLog}'\n`,
   );
 }
 
@@ -146,9 +149,12 @@ async function listTerminals(
   token: string,
 ): Promise<TerminalListEntry[]> {
   const res = await trpcQuery(serverUrl, "terminal.list", { workspaceId }, token);
-  expect(res.status).toBe(200);
-  const { terminals } = await trpcData<{ terminals: TerminalListEntry[] }>(res);
-  return terminals;
+  // Read the body first so a non-200 surfaces the server's error text, not just
+  // the status — matches the pattern in the sibling terminal specs.
+  const body = await res.text();
+  expect(res.status, `terminal.list failed: ${body}`).toBe(200);
+  return (JSON.parse(body) as { result: { data: { terminals: TerminalListEntry[] } } }).result.data
+    .terminals;
 }
 
 interface TriggerResponse {
@@ -439,7 +445,8 @@ describe("cronjobs.trigger default dispatches to chat", () => {
     expect(data.via).toBe("chat");
     expect(typeof data.taskId).toBe("string");
     expect(data.terminalId).toBeUndefined();
-    // Full chat-response shape (TEST-17): the union also carries workspaceId + chatId.
+    // Assert the full chat-branch shape so a field rename/drop is caught: the
+    // union also carries workspaceId + chatId.
     expect(data.workspaceId).toBe("chatcron-main");
     expect(typeof data.chatId).toBe("string");
 
@@ -538,7 +545,7 @@ describe("cronjobs.trigger via=terminal falls back to chat when unsupported", ()
     // its absence.
     expect(data.via).toBe("chat");
     expect(data.terminalId).toBeUndefined();
-    // Full fallback-response shape (TEST-17): it lands on the chat branch, so
+    // Assert the full fallback shape: it lands on the chat branch, so
     // workspaceId + chatId are present just like a native via=chat trigger.
     expect(data.workspaceId).toBe("fbcron-main");
     expect(typeof data.chatId).toBe("string");
@@ -781,5 +788,103 @@ describe("cronjobs.trigger via=terminal is safe under concurrent fires", () => {
       { label: "one cron terminal registered" },
     );
     expect(terminals).toHaveLength(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// via=terminal — workspace-scoped job resolves to its own workspaceId (not the
+// project's default-branch workspace). All other blocks use scope="project";
+// this exercises `resolveWorkspaceId`'s workspace branch (returns
+// `job.workspaceId` directly) with a terminal dispatch, on a NON-default
+// branch so the two resolutions are distinguishable.
+// ---------------------------------------------------------------------------
+
+describe("cronjobs.trigger via=terminal on a workspace-scoped job", () => {
+  const TOKEN = "cron-via-wsscope-token";
+  const STUB_SLEEP_SECONDS = 6;
+  let server: ServerHandle;
+  let tmpHome: string;
+  let jobId: string;
+  const FEATURE_WS = toWorkspaceId("wsscron", "feature");
+
+  beforeAll(async () => {
+    tmpHome = createTmpHome("band-cron-via-wsscope-");
+    const repoPath = createGitRepo(tmpHome, "wsscron");
+    // A real second worktree on a non-default branch so `workspaceService
+    // .resolve(FEATURE_WS)` finds a path and the resolved id ("wsscron-feature")
+    // differs from the project default ("wsscron-main").
+    const featurePath = join(tmpHome, "wsscron-feature-wt");
+    git(repoPath, ["worktree", "add", featurePath, "-b", "feature"]);
+    const stubBin = writeSleepingVendorCli(tmpHome, "stub-claude.sh", STUB_SLEEP_SECONDS);
+    seedState(tmpHome, {
+      projects: [
+        {
+          name: "wsscron",
+          path: repoPath,
+          defaultBranch: "main",
+          worktrees: [
+            { branch: "main", path: repoPath },
+            { branch: "feature", path: featurePath },
+          ],
+        },
+      ],
+    });
+    seedSettings(tmpHome, {
+      tokenSecret: TOKEN,
+      codingAgents: [
+        { id: "claude-code", type: "claude-code", label: "Claude Code", command: stubBin },
+      ],
+    });
+    server = await startServer({ tmpHome });
+
+    // Storage key for a workspace-scoped cron is the workspace id itself.
+    const res = await trpcMutate(
+      server.url,
+      "cronjobs.create",
+      {
+        key: FEATURE_WS,
+        name: "Workspace-scoped terminal cron",
+        prompt: "workspace scoped work",
+        cronExpression: "0 0 * * *",
+        scope: "workspace",
+        workspaceId: FEATURE_WS,
+        via: "terminal",
+      },
+      TOKEN,
+    );
+    expect(res.status).toBe(200);
+    const data = await trpcData<{ job: { id: string } }>(res);
+    jobId = data.job.id;
+  });
+
+  afterAll(async () => {
+    await server.close();
+    rmSync(tmpHome, { recursive: true, force: true });
+  });
+
+  it("dispatches the terminal into the job's own workspace", async () => {
+    const res = await trpcMutate(
+      server.url,
+      "cronjobs.trigger",
+      { key: FEATURE_WS, id: jobId },
+      TOKEN,
+    );
+    expect(res.status).toBe(200);
+    const data = await trpcData<TriggerResponse>(res);
+    expect(data.via).toBe("terminal");
+    expect(typeof data.terminalId).toBe("string");
+    // The workspace branch returns the job's workspaceId verbatim — the feature
+    // workspace, NOT the project's default "wsscron-main".
+    expect(data.workspaceId).toBe(FEATURE_WS);
+
+    // And the PTY is registered under that same workspace.
+    const terminals = await waitFor(
+      async () => {
+        const list = await listTerminals(server.url, FEATURE_WS, TOKEN);
+        return list.some((t) => t.terminalId === data.terminalId) ? list : undefined;
+      },
+      { label: "terminal registered under the feature workspace" },
+    );
+    expect(terminals.some((t) => t.terminalId === data.terminalId)).toBe(true);
   });
 });

--- a/apps/web/tests/cronjobs-via.test.ts
+++ b/apps/web/tests/cronjobs-via.test.ts
@@ -146,10 +146,9 @@ async function listTerminals(
   token: string,
 ): Promise<TerminalListEntry[]> {
   const res = await trpcQuery(serverUrl, "terminal.list", { workspaceId }, token);
-  const body = await res.text();
-  expect(res.status, `terminal.list failed: ${body}`).toBe(200);
-  return (JSON.parse(body) as { result: { data: { terminals: TerminalListEntry[] } } }).result.data
-    .terminals;
+  expect(res.status).toBe(200);
+  const { terminals } = await trpcData<{ terminals: TerminalListEntry[] }>(res);
+  return terminals;
 }
 
 interface TriggerResponse {
@@ -440,6 +439,9 @@ describe("cronjobs.trigger default dispatches to chat", () => {
     expect(data.via).toBe("chat");
     expect(typeof data.taskId).toBe("string");
     expect(data.terminalId).toBeUndefined();
+    // Full chat-response shape (TEST-17): the union also carries workspaceId + chatId.
+    expect(data.workspaceId).toBe("chatcron-main");
+    expect(typeof data.chatId).toBe("string");
 
     const workspaceId = toWorkspaceId("chatcron", "main");
 
@@ -462,9 +464,14 @@ describe("cronjobs.trigger default dispatches to chat", () => {
 // ---------------------------------------------------------------------------
 // via=terminal + unsupported adapter → silent fallback to chat
 //
-// cursor-cli's `cliInvocation` returns `unsupported: true`; the service warns
-// and downgrades to chat. As in workspace-create-via, the real Cursor SDK isn't
-// safe to run in the test process, so we assert the response shape only.
+// cursor-cli's `cliHeadlessInvocation` returns `unsupported: true`; the service
+// warns and downgrades to chat. As in workspace-create-via, the real Cursor SDK
+// isn't safe to run in the test process, so we assert the response shape only.
+// The chat fallback fires `submitTask`, which spawns the Cursor SDK in the
+// background; with no `cursor` binary in CI that background task fails, but the
+// failure is out-of-band (the response has already returned) and the process is
+// reaped by `server.close()` in afterAll — the only visible effect is benign
+// error-log noise, not a test failure.
 // ---------------------------------------------------------------------------
 
 describe("cronjobs.trigger via=terminal falls back to chat when unsupported", () => {
@@ -531,6 +538,10 @@ describe("cronjobs.trigger via=terminal falls back to chat when unsupported", ()
     // its absence.
     expect(data.via).toBe("chat");
     expect(data.terminalId).toBeUndefined();
+    // Full fallback-response shape (TEST-17): it lands on the chat branch, so
+    // workspaceId + chatId are present just like a native via=chat trigger.
+    expect(data.workspaceId).toBe("fbcron-main");
+    expect(typeof data.chatId).toBe("string");
   });
 });
 
@@ -617,7 +628,11 @@ describe("cronjobs.delete tears down a via=terminal job's terminal", () => {
       { label: "cron terminal registered before delete" },
     );
 
-    // Deleting the job must tear down its live pane.
+    // Deleting the job must tear down its live pane. The stub sleeps
+    // STUB_SLEEP_SECONDS (6s), far longer than the localhost delete +
+    // terminal.list round-trips below, so the pane cannot self-expire within
+    // this window — its removal is attributable to `delete`, not a natural
+    // exit racing the assertion.
     const del = await trpcMutate(
       server.url,
       "cronjobs.delete",

--- a/apps/web/tests/cronjobs-via.test.ts
+++ b/apps/web/tests/cronjobs-via.test.ts
@@ -681,3 +681,90 @@ describe("cronjobs.trigger — auth", () => {
     expect(res.status).toBe(401);
   });
 });
+
+// ---------------------------------------------------------------------------
+// via=terminal — concurrent fires spawn at most one terminal (PR #627 review
+// blocker: TOCTOU race in the overlap guard). Two triggers racing for the same
+// job must NOT both pass the guard and spawn two PTYs (orphaning one). The
+// synchronous per-job spawn lock in `spawnCronTerminal` guarantees exactly one
+// wins and the other conflicts (409). Uses a sleeping stub so the winner's pane
+// stays alive long enough to count.
+// ---------------------------------------------------------------------------
+
+describe("cronjobs.trigger via=terminal is safe under concurrent fires", () => {
+  const TOKEN = "cron-via-race-token";
+  const STUB_SLEEP_SECONDS = 6;
+  let server: ServerHandle;
+  let tmpHome: string;
+  let jobId: string;
+
+  beforeAll(async () => {
+    tmpHome = createTmpHome("band-cron-via-race-");
+    const repoPath = createGitRepo(tmpHome, "racecron");
+    const stubBin = writeSleepingVendorCli(tmpHome, "stub-claude.sh", STUB_SLEEP_SECONDS);
+    seedState(tmpHome, {
+      projects: [
+        {
+          name: "racecron",
+          path: repoPath,
+          defaultBranch: "main",
+          worktrees: [{ branch: "main", path: repoPath }],
+        },
+      ],
+    });
+    seedSettings(tmpHome, {
+      tokenSecret: TOKEN,
+      codingAgents: [
+        { id: "claude-code", type: "claude-code", label: "Claude Code", command: stubBin },
+      ],
+    });
+    server = await startServer({ tmpHome });
+
+    const res = await trpcMutate(
+      server.url,
+      "cronjobs.create",
+      {
+        key: "racecron",
+        name: "Racing terminal cron",
+        prompt: "long running work",
+        cronExpression: "0 0 * * *",
+        scope: "project",
+        via: "terminal",
+      },
+      TOKEN,
+    );
+    expect(res.status).toBe(200);
+    const data = await trpcData<{ job: { id: string } }>(res);
+    jobId = data.job.id;
+  });
+
+  afterAll(async () => {
+    await server.close();
+    rmSync(tmpHome, { recursive: true, force: true });
+  });
+
+  it("two concurrent triggers spawn exactly one terminal; the loser gets 409", async () => {
+    // Fire both at once so their dispatch paths interleave at the `await`
+    // boundaries inside `spawnCronTerminal`.
+    const [a, b] = await Promise.all([
+      trpcMutate(server.url, "cronjobs.trigger", { key: "racecron", id: jobId }, TOKEN),
+      trpcMutate(server.url, "cronjobs.trigger", { key: "racecron", id: jobId }, TOKEN),
+    ]);
+    const statuses = [a.status, b.status].sort();
+
+    // Exactly one winner (200) and one conflict (409) — never two 200s (which
+    // would mean two PTYs raced past the guard).
+    expect(statuses).toEqual([200, 409]);
+
+    // And the workspace holds exactly one terminal — no orphan.
+    const workspaceId = toWorkspaceId("racecron", "main");
+    const terminals = await waitFor(
+      async () => {
+        const list = await listTerminals(server.url, workspaceId, TOKEN);
+        return list.length >= 1 ? list : undefined;
+      },
+      { label: "one cron terminal registered" },
+    );
+    expect(terminals).toHaveLength(1);
+  });
+});

--- a/packages/coding-agent/src/adapters/claude-code.ts
+++ b/packages/coding-agent/src/adapters/claude-code.ts
@@ -789,6 +789,21 @@ export class ClaudeCodeAdapter implements CodingAgent {
   }
 
   /**
+   * Headless one-shot invocation for automated terminal dispatch (cronjobs,
+   * issue #581). `claude -p "<prompt>"` runs the prompt in print
+   * (non-interactive) mode and exits when the turn completes — unlike
+   * `cliInvocation`'s bare `claude "<prompt>"`, which opens the REPL and
+   * stays parked. The prompt is the value of `-p`, so a leading `-` in it is
+   * consumed as the flag's argument rather than parsed as a flag.
+   */
+  cliHeadlessInvocation(prompt: string): CliInvocation {
+    return {
+      command: this.executablePath ?? CLAUDE_CODE_DEFAULT_BINARY,
+      args: ["-p", prompt],
+    };
+  }
+
+  /**
    * Resume CLI invocation for the chat tab's "Continue in terminal" action.
    * `claude --resume <session-id>` reopens the interactive REPL with that
    * exact conversation restored (session-ID lookup is scoped to the

--- a/packages/coding-agent/src/adapters/codex.ts
+++ b/packages/coding-agent/src/adapters/codex.ts
@@ -515,6 +515,19 @@ export class CodexAdapter implements CodingAgent {
   }
 
   /**
+   * Headless one-shot invocation for automated terminal dispatch (cronjobs,
+   * issue #581). `codex exec "<prompt>"` runs the prompt non-interactively
+   * and exits on completion — unlike `cliInvocation`'s bare `codex
+   * "<prompt>"`, which opens the interactive TUI and stays parked.
+   */
+  cliHeadlessInvocation(prompt: string): CliInvocation {
+    return {
+      command: this.executablePath ?? CODEX_DEFAULT_BINARY,
+      args: ["exec", prompt],
+    };
+  }
+
+  /**
    * Resume CLI invocation for the chat tab's "Continue in terminal" action.
    * `codex resume <session-id>` reopens the interactive Codex TUI with that
    * thread restored.

--- a/packages/coding-agent/src/adapters/cursor-cli.ts
+++ b/packages/coding-agent/src/adapters/cursor-cli.ts
@@ -188,6 +188,19 @@ export class CursorCliAdapter implements CodingAgent {
   }
 
   /**
+   * Cursor CLI is SDK-only (JSON over a managed subprocess) with no
+   * non-interactive vendor CLI to run in a pane, so headless terminal
+   * dispatch (cronjobs `via: "terminal"`, issue #581) also returns the
+   * `unsupported` sentinel — the cronjob service then falls back to chat.
+   */
+  cliHeadlessInvocation(_prompt: string): CliInvocation {
+    return {
+      unsupported: true,
+      reason: "Cursor CLI has no non-interactive CLI invocation; falling back to chat.",
+    };
+  }
+
+  /**
    * The chat tab's "Continue in terminal" action has no Cursor equivalent:
    * the agent runs over the SDK's managed JSON subprocess, with no
    * interactive by-id resume CLI. Returning the `unsupported` sentinel

--- a/packages/coding-agent/src/adapters/gemini-cli.ts
+++ b/packages/coding-agent/src/adapters/gemini-cli.ts
@@ -231,6 +231,22 @@ export class GeminiCliAdapter implements CodingAgent {
   }
 
   /**
+   * Headless one-shot invocation for automated terminal dispatch (cronjobs,
+   * issue #581). `gemini --prompt=<prompt>` runs non-interactively and exits
+   * on completion — unlike `cliInvocation`'s `gemini -- "<prompt>"`, which
+   * opens the interactive REPL and stays parked. The `--prompt=<value>`
+   * joined form (rather than `--prompt <value>`) binds the prompt as the
+   * flag's argument even when it starts with `-`, mirroring the leading-dash
+   * safety the interactive `--` guard provides.
+   */
+  cliHeadlessInvocation(prompt: string): CliInvocation {
+    return {
+      command: this.executablePath,
+      args: [`--prompt=${prompt}`],
+    };
+  }
+
+  /**
    * The chat tab's "Continue in terminal" action has no Gemini equivalent:
    * the Gemini CLI has no session model, so there's no session ID to resume
    * by. Returning the `unsupported` sentinel keeps the menu item disabled.

--- a/packages/coding-agent/src/adapters/gemini-cli.ts
+++ b/packages/coding-agent/src/adapters/gemini-cli.ts
@@ -238,6 +238,10 @@ export class GeminiCliAdapter implements CodingAgent {
    * joined form (rather than `--prompt <value>`) binds the prompt as the
    * flag's argument even when it starts with `-`, mirroring the leading-dash
    * safety the interactive `--` guard provides.
+   *
+   * `--output-format` is deliberately omitted (unlike `runSession`, which asks
+   * for NDJSON): a cron terminal shows plain human-readable output in the pane,
+   * not a machine-parsed stream.
    */
   cliHeadlessInvocation(prompt: string): CliInvocation {
     return {

--- a/packages/coding-agent/src/adapters/opencode.ts
+++ b/packages/coding-agent/src/adapters/opencode.ts
@@ -354,6 +354,22 @@ export class OpenCodeAdapter implements CodingAgent {
   }
 
   /**
+   * Headless one-shot invocation for automated terminal dispatch (cronjobs,
+   * issue #581). `opencode run "<prompt>"` executes the prompt
+   * non-interactively and exits on completion — unlike `cliInvocation`'s
+   * `opencode --prompt "<prompt>"`, which opens the interactive TUI and stays
+   * parked. `run` takes the prompt as its trailing positional (same shape as
+   * the SDK `runSession` path above, minus the JSON formatting we only need
+   * when parsing programmatically).
+   */
+  cliHeadlessInvocation(prompt: string): CliInvocation {
+    return {
+      command: this.executablePath,
+      args: ["run", prompt],
+    };
+  }
+
+  /**
    * Resume CLI invocation for the chat tab's "Continue in terminal" action.
    * `opencode --session <id>` launches the interactive TUI on that exact
    * session (the same `--session` flag `runSession` uses for headless

--- a/packages/coding-agent/src/types.ts
+++ b/packages/coding-agent/src/types.ts
@@ -277,6 +277,25 @@ export interface CodingAgent {
    */
   cliInvocation?(prompt: string): CliInvocation;
   /**
+   * Resolve the *headless* (non-interactive) one-shot CLI invocation for
+   * `prompt` — the vendor CLI's "run this and exit" mode (`claude -p
+   * "<prompt>"`, `codex exec "<prompt>"`, `gemini --prompt "<prompt>"`,
+   * `opencode run "<prompt>"`).
+   *
+   * Distinct from {@link cliInvocation}, which opens the *interactive* REPL
+   * and never exits on its own. This variant powers automated, recurring
+   * dispatch — cronjobs with `via: "terminal"` (issue #581) — where the pane
+   * must run to completion, stream its output, and then exit so the terminal
+   * self-closes and the scheduler can tell "still running" from "done".
+   * Using the interactive form there would leave the pane parked at the REPL
+   * forever, blocking every subsequent tick.
+   *
+   * Adapters with no non-interactive CLI (e.g. `cursor-cli`) return
+   * `{ unsupported: true, reason: "..." }`; the caller falls back to the
+   * SDK/chat path.
+   */
+  cliHeadlessInvocation?(prompt: string): CliInvocation;
+  /**
    * Resolve the CLI invocation that *resumes* an existing agent session in
    * an interactive terminal pane (`claude --resume <id>`, `codex resume
    * <id>`, `opencode --session <id>`). Powers the chat tab's "Continue in


### PR DESCRIPTION
Closes #581.

## Summary

Adds a `via: "chat" | "terminal"` discriminator to cronjobs, mirroring the model `workspaces.create` already uses (#551). A `via: "terminal"` fire runs the agent's **headless** CLI (`claude -p`, `codex exec`, `gemini --prompt=`, `opencode run`) in a fresh, self-closing PTY pane instead of submitting a task to the cron chat pane. Default stays `chat` — fully backward-compatible.

## Design decisions

- **Headless, not interactive.** The cron path uses a new `cliHeadlessInvocation` adapter method, NOT the interactive `cliInvocation` (`claude "<prompt>"`) that workspace-create uses. An interactive REPL never exits, so the pane would park forever and every subsequent tick would 409. The headless one-shot runs the prompt and exits, which is what makes the self-close and overlap guard work. Interactive `cliInvocation` is untouched (still used by `workspaces.create --via terminal` and continue-in-terminal).
- **Self-closing pane + skip on overlap.** The pane runs the command and exits; a finished pane is pruned via an opt-in `cleanupOnExit` hook (bounds a frequent cron to ~1 live pane). If the previous run's pane is still alive on the next tick, the dispatch throws the existing `TaskConflictError` → scheduled fire records `skipped`, manual `trigger` returns 409 — identical to the chat conflict path.
- **Overlap handle.** A `last_terminal_id` column on the cronjob row (terminals have no per-pane label store like chats do); it survives restarts.
- **CLI default.** `band cronjobs create --via` reuses the existing `resolve_dispatch_target` precedence chain, so a cron created from a chat agent defaults to chat and one from a terminal defaults to terminal.

## Changes

- schema + migration: `via` (default `chat`) + `last_terminal_id` on `cronjobs`
- service: `spawnCronTerminal`, terminal branch in `executeCronjob`, async `trigger` returning a `chat|terminal` union, best-effort pane teardown on `delete`
- terminal infra: opt-in `cleanupOnExit` prunes a naturally-exited pane
- coding-agent: `cliHeadlessInvocation` on the interface + all adapters (cursor-cli unsupported → falls back to chat)
- CLI: `band cronjobs create --via`; `trigger` reports `terminalId`; `band schema` entry
- skills: `band-loop` + `band` document `--via`

## Testing

New `apps/web/tests/cronjobs-via.test.ts` (real server, real PTY, no mocking): terminal happy-path + self-close, overlap → 409, default → chat, unsupported-adapter fallback, delete-tears-down-terminal, and a 401 auth guard. Existing `cronjobs.test.ts` and the interactive-path suites remain green. Local `pnpm check` (biome + fmt + clippy) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)