### PR TITLE
fix(web): scope editor navigation events to owning workspace

### DIFF
--- a/apps/web/e2e/chat-file-link-workspace.spec.ts
+++ b/apps/web/e2e/chat-file-link-workspace.spec.ts
@@ -45,11 +45,11 @@
  * close the dispatcher-side coverage gap.
  */
 
-import { execFileSync } from "node:child_process";
 import { mkdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { expect, test } from "@playwright/test";
 import { toWorkspaceId } from "@/dashboard";
+import { gitInHome as git } from "./helpers/git";
 import {
   cleanupTmpHome,
   createTmpHome,
@@ -76,27 +76,6 @@ const WORKSPACE_B = toWorkspaceId(PROJECT, BRANCH_B);
 // cache. The mobile layout mounts one workspace at a time, so there's no
 // cross-workspace event leak to guard against there in the same way.
 test.use({ viewport: { width: 1280, height: 800 } });
-
-function makeGitEnv(home: string): NodeJS.ProcessEnv {
-  // Hermetic git environment — mirrors `workspace-cache-eviction.spec.ts`.
-  // `GIT_CONFIG_GLOBAL`/`GIT_CONFIG_SYSTEM` pointed at /dev/null block
-  // host config from leaking into commits, which is what makes the
-  // initial-commit hash reproducible across runs.
-  return {
-    PATH: process.env.PATH,
-    HOME: home,
-    GIT_AUTHOR_NAME: "Test",
-    GIT_AUTHOR_EMAIL: "test@test.com",
-    GIT_COMMITTER_NAME: "Test",
-    GIT_COMMITTER_EMAIL: "test@test.com",
-    GIT_CONFIG_GLOBAL: "/dev/null",
-    GIT_CONFIG_SYSTEM: "/dev/null",
-  };
-}
-
-function git(cwd: string, args: string[], home: string): void {
-  execFileSync("git", args, { cwd, env: makeGitEnv(home) });
-}
 
 let server!: ServerHandle;
 let tmpHome: string | undefined;

--- a/apps/web/e2e/editor-go-history-workspace.spec.ts
+++ b/apps/web/e2e/editor-go-history-workspace.spec.ts
@@ -33,11 +33,11 @@
  *     (the palette's real dispatch is a synchronous `window.dispatchEvent`).
  */
 
-import { execFileSync } from "node:child_process";
 import { mkdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { expect, test } from "@playwright/test";
 import { toWorkspaceId } from "@/dashboard";
+import { gitInHome as git } from "./helpers/git";
 import {
   cleanupTmpHome,
   createTmpHome,
@@ -74,23 +74,6 @@ const B_TWO_TEXT = "workspace B file two";
 // renders. The bug only manifests in the desktop layout, where multiple
 // workspaces are alive at once under `MultiWorkspacePanelHost`'s LRU cache.
 test.use({ viewport: { width: 1280, height: 800 } });
-
-function makeGitEnv(home: string): NodeJS.ProcessEnv {
-  return {
-    PATH: process.env.PATH,
-    HOME: home,
-    GIT_AUTHOR_NAME: "Test",
-    GIT_AUTHOR_EMAIL: "test@test.com",
-    GIT_COMMITTER_NAME: "Test",
-    GIT_COMMITTER_EMAIL: "test@test.com",
-    GIT_CONFIG_GLOBAL: "/dev/null",
-    GIT_CONFIG_SYSTEM: "/dev/null",
-  };
-}
-
-function git(cwd: string, args: string[], home: string): void {
-  execFileSync("git", args, { cwd, env: makeGitEnv(home) });
-}
 
 let server!: ServerHandle;
 let tmpHome: string | undefined;

--- a/apps/web/e2e/editor-go-history-workspace.spec.ts
+++ b/apps/web/e2e/editor-go-history-workspace.spec.ts
@@ -1,0 +1,212 @@
+/**
+ * Regression coverage for the cross-workspace editor-history leak —
+ * `band:editor-go-back` / `band:editor-go-forward` events (dispatched by the
+ * command palette's "Go Back" / "Go Forward" commands) must be scoped to the
+ * workspace whose editor owns the history, so a Go Back invoked for workspace
+ * A cannot also step the (different) active workspace B's independent history
+ * stack.
+ *
+ * This is the milder sibling of the `band:lsp-navigate` leak covered by
+ * `lsp-navigate-workspace.spec.ts`: pre-fix, both editor-history events were
+ * dispatched on `window` with NO workspace id, and every mounted
+ * `CodeBrowserView` (the LRU cache in `MultiWorkspacePanelHost` keeps up to
+ * `maxCachedWorkspaces` subtrees alive, hidden with `visibility:hidden`)
+ * handled them with no guard. So a Go Back in A also ran the handler in hidden
+ * workspace B, walking B's own history stack behind the user's back. Unlike
+ * the LSP leak there's no ENOENT (each workspace's stack only holds its own
+ * files), but the active workspace's viewer still silently jumps to a
+ * different file.
+ *
+ * The fix mirrors issue #539: the command palette stamps the active
+ * `workspaceId` onto the event detail, and each `CodeBrowserView` listener
+ * early-returns unless the event is addressed to its own workspace (a missing
+ * id falls through to the active workspace for forward-compat).
+ *
+ * Test architecture:
+ *
+ *   - Boots the real production server against a fresh tmp home.
+ *   - Two real git worktrees. Workspace B gets two files so it has a real
+ *     back-navigable history stack; the bug would surface as B's viewer
+ *     stepping back when a Go Back addressed to A is dispatched.
+ *   - No tRPC mocking, no MSW, no `page.route()` on own routes. The spec
+ *     drives the DOM events directly via `dispatchEditorHistoryEvent(...)`
+ *     (the palette's real dispatch is a synchronous `window.dispatchEvent`).
+ */
+
+import { execFileSync } from "node:child_process";
+import { mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { expect, test } from "@playwright/test";
+import { toWorkspaceId } from "@/dashboard";
+import {
+  cleanupTmpHome,
+  createTmpHome,
+  type ServerHandle,
+  seedSettings,
+  seedState,
+  startServer,
+} from "./helpers/server";
+import { FileTreesPage } from "./pages/FileTreesPage";
+import { FileViewerPage } from "./pages/FileViewerPage";
+import { WorkspacePage } from "./pages/WorkspacePage";
+
+const TOKEN = "e2e-editor-go-history-workspace-token";
+
+const PROJECT = "editor-history-repo";
+const DEFAULT_BRANCH = "main";
+const BRANCH_A = "feature-a";
+const BRANCH_B = "feature-b";
+
+const WORKSPACE_A = toWorkspaceId(PROJECT, BRANCH_A);
+const WORKSPACE_B = toWorkspaceId(PROJECT, BRANCH_B);
+
+// A file unique to A (so A is a real, mounted sibling workspace). Its name
+// can't collide with B's file-tree rows.
+const ONLY_IN_A = "only-in-a.ts";
+// Two files unique to B, opened in order to build B's back-navigable history
+// stack. Distinct content so the viewer assertions can tell them apart.
+const B_ONE = "b-one.ts";
+const B_TWO = "b-two.ts";
+const B_ONE_TEXT = "workspace B file one";
+const B_TWO_TEXT = "workspace B file two";
+
+// Wide viewport so `useIsDesktop()` reports true and the shared dockview
+// renders. The bug only manifests in the desktop layout, where multiple
+// workspaces are alive at once under `MultiWorkspacePanelHost`'s LRU cache.
+test.use({ viewport: { width: 1280, height: 800 } });
+
+function makeGitEnv(home: string): NodeJS.ProcessEnv {
+  return {
+    PATH: process.env.PATH,
+    HOME: home,
+    GIT_AUTHOR_NAME: "Test",
+    GIT_AUTHOR_EMAIL: "test@test.com",
+    GIT_COMMITTER_NAME: "Test",
+    GIT_COMMITTER_EMAIL: "test@test.com",
+    GIT_CONFIG_GLOBAL: "/dev/null",
+    GIT_CONFIG_SYSTEM: "/dev/null",
+  };
+}
+
+function git(cwd: string, args: string[], home: string): void {
+  execFileSync("git", args, { cwd, env: makeGitEnv(home) });
+}
+
+let server!: ServerHandle;
+let tmpHome: string | undefined;
+
+test.beforeAll(async () => {
+  tmpHome = createTmpHome();
+
+  const repoPath = join(tmpHome, PROJECT);
+  mkdirSync(repoPath, { recursive: true });
+  git(repoPath, ["init", "-b", DEFAULT_BRANCH], tmpHome);
+  writeFileSync(join(repoPath, "README.md"), "# Editor history test\n");
+  git(repoPath, ["add", "."], tmpHome);
+  git(repoPath, ["commit", "-m", "initial commit"], tmpHome);
+
+  const worktreeAPath = join(tmpHome, `${PROJECT}-${BRANCH_A}`);
+  const worktreeBPath = join(tmpHome, `${PROJECT}-${BRANCH_B}`);
+  git(repoPath, ["worktree", "add", "-b", BRANCH_A, worktreeAPath], tmpHome);
+  git(repoPath, ["worktree", "add", "-b", BRANCH_B, worktreeBPath], tmpHome);
+
+  writeFileSync(join(worktreeAPath, ONLY_IN_A), "// only in workspace A\n");
+  writeFileSync(join(worktreeBPath, B_ONE), `// ${B_ONE_TEXT}\n`);
+  writeFileSync(join(worktreeBPath, B_TWO), `// ${B_TWO_TEXT}\n`);
+
+  seedState(tmpHome, {
+    projects: [
+      {
+        name: PROJECT,
+        path: repoPath,
+        defaultBranch: DEFAULT_BRANCH,
+        worktrees: [
+          { branch: DEFAULT_BRANCH, path: repoPath },
+          { branch: BRANCH_A, path: worktreeAPath },
+          { branch: BRANCH_B, path: worktreeBPath },
+        ],
+      },
+    ],
+  });
+  // Pin `maxCachedWorkspaces` to 3 so neither A nor B is LRU-evicted — the
+  // bug only manifests when BOTH workspace trees are alive at once.
+  seedSettings(tmpHome, { tokenSecret: TOKEN, maxCachedWorkspaces: 3 });
+  server = await startServer({ tmpHome });
+});
+
+test.afterAll(async () => {
+  if (server) await server.close();
+  if (tmpHome) cleanupTmpHome(tmpHome);
+});
+
+test.describe("Editor-history workspace scoping (cross-workspace history leak)", () => {
+  test("a Go Back addressed to workspace A does NOT step active workspace B's history", async ({
+    page,
+  }) => {
+    const workspacePage = new WorkspacePage(page, server.url, TOKEN);
+    const fileTrees = new FileTreesPage(page, workspacePage);
+    // Scope the viewer to B's subtree: A stays mounted (hidden) in the LRU
+    // cache, so an unscoped `file-viewer__root` could resolve to more than one.
+    const fileViewer = new FileViewerPage(page, workspacePage.cachedPanelEntries(WORKSPACE_B));
+
+    // Land on A and activate its Files tab so A's CodeBrowserView mounts and
+    // its editor-history listener is live — a genuine cross-workspace sibling.
+    await workspacePage.goto(WORKSPACE_A);
+    await workspacePage.waitForReady();
+    await fileTrees.openFilesTab(ONLY_IN_A);
+
+    // Switch to B via the sidebar (client-side nav) so A stays mounted +
+    // cached while B becomes active.
+    await expect(workspacePage.workspaceCard(WORKSPACE_B)).toBeVisible();
+    await workspacePage.switchWorkspace(WORKSPACE_B);
+    await expect(workspacePage.cachedPanelEntries(WORKSPACE_B).first()).toBeVisible();
+    await expect
+      .poll(async () => workspacePage.cachedPanelEntries(WORKSPACE_A).count(), { timeout: 5000 })
+      .toBeGreaterThan(0);
+
+    // Activate B's Files tab so B's CodeBrowserView mounts (its editor-history
+    // + lsp-navigate listeners register and its FileViewer renders).
+    await workspacePage.activateTab("files");
+
+    // Build B's back-navigable history by driving two cross-file navigations
+    // into B — the same `band:lsp-navigate` path go-to-definition uses, which
+    // opens the file AND pushes a departure+arrival onto B's editor-history
+    // stack. Using the event (rather than two file-tree clicks) keeps the
+    // setup deterministic: the second tree click is unreliable because opening
+    // the first file re-lays B's file tree. After both, B shows b-two and a
+    // Go Back lands on b-one.
+    await workspacePage.dispatchLspNavigateEvent({ filePath: B_ONE, workspaceId: WORKSPACE_B });
+    await fileViewer.expectContent(B_ONE_TEXT);
+    await workspacePage.dispatchLspNavigateEvent({ filePath: B_TWO, workspaceId: WORKSPACE_B });
+    await fileViewer.expectContent(B_TWO_TEXT);
+
+    // Guard under test: a Go Back addressed to A must be ignored by B — B's
+    // viewer stays on b-two. Poll for b-one's ARRIVAL within a bounded window
+    // (a plain `expectNotContent` would pass trivially at t=0) and assert it
+    // never came. On bug code B's unguarded handler steps its own stack back
+    // to b-one, which this poll catches.
+    await workspacePage.dispatchEditorHistoryEvent({
+      direction: "back",
+      workspaceId: WORKSPACE_A,
+    });
+    let leaked = false;
+    try {
+      await expect.poll(async () => fileViewer.readText(), { timeout: 2000 }).toContain(B_ONE_TEXT);
+      leaked = true;
+    } catch {
+      // Poll exhausted its budget without B stepping back — the contract.
+    }
+    expect(leaked).toBe(false);
+    // B is still showing b-two (positive anchor that nothing moved).
+    await fileViewer.expectContent(B_TWO_TEXT);
+
+    // Positive control: a Go Back addressed to B itself DOES step B's history
+    // — proving the event mechanism is live, so the negative above is
+    // meaningful rather than a dead event.
+    await workspacePage.dispatchEditorHistoryEvent({
+      direction: "back",
+      workspaceId: WORKSPACE_B,
+    });
+    await fileViewer.expectContent(B_ONE_TEXT);
+  });
+});

--- a/apps/web/e2e/helpers/git.ts
+++ b/apps/web/e2e/helpers/git.ts
@@ -26,3 +26,30 @@ export const gitEnv = {
 export function git(cwd: string, args: string[]): void {
   execFileSync("git", args, { cwd, env: gitEnv });
 }
+
+/**
+ * Fully hermetic git environment rooted at `home`. Unlike `gitEnv` (which
+ * inherits the host `process.env`, including the real `HOME`), this pins
+ * `HOME` to the throwaway tmp home and points `GIT_CONFIG_GLOBAL` /
+ * `GIT_CONFIG_SYSTEM` at `/dev/null` so no host config leaks into the fixture
+ * repo — required by the multi-worktree specs that seed a repo inside the
+ * tmp home and rely on reproducible initial commits.
+ */
+export function makeGitEnv(home: string): NodeJS.ProcessEnv {
+  return {
+    PATH: process.env.PATH,
+    HOME: home,
+    GIT_AUTHOR_NAME: "Test",
+    GIT_AUTHOR_EMAIL: "test@test.com",
+    GIT_COMMITTER_NAME: "Test",
+    GIT_COMMITTER_EMAIL: "test@test.com",
+    GIT_CONFIG_GLOBAL: "/dev/null",
+    GIT_CONFIG_SYSTEM: "/dev/null",
+  };
+}
+
+/** Run `git <args>` in `cwd` under the hermetic environment rooted at `home`
+ *  (see `makeGitEnv`). The home-aware counterpart of `git` above. */
+export function gitInHome(cwd: string, args: string[], home: string): void {
+  execFileSync("git", args, { cwd, env: makeGitEnv(home) });
+}

--- a/apps/web/e2e/lsp-navigate-workspace.spec.ts
+++ b/apps/web/e2e/lsp-navigate-workspace.spec.ts
@@ -38,11 +38,11 @@
  *     `window.dispatchEvent`, so no external stub is needed).
  */
 
-import { execFileSync } from "node:child_process";
 import { mkdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { expect, test } from "@playwright/test";
 import { toWorkspaceId } from "@/dashboard";
+import { gitInHome as git } from "./helpers/git";
 import {
   cleanupTmpHome,
   createTmpHome,
@@ -81,26 +81,6 @@ const ONLY_IN_B = "only-in-b.ts";
 // The mobile layout mounts one workspace at a time, so there's no
 // cross-workspace event leak to guard against there in the same way.
 test.use({ viewport: { width: 1280, height: 800 } });
-
-function makeGitEnv(home: string): NodeJS.ProcessEnv {
-  // Hermetic git environment — mirrors `chat-file-link-workspace.spec.ts`.
-  // `GIT_CONFIG_GLOBAL`/`GIT_CONFIG_SYSTEM` pointed at /dev/null block host
-  // config from leaking into commits.
-  return {
-    PATH: process.env.PATH,
-    HOME: home,
-    GIT_AUTHOR_NAME: "Test",
-    GIT_AUTHOR_EMAIL: "test@test.com",
-    GIT_COMMITTER_NAME: "Test",
-    GIT_COMMITTER_EMAIL: "test@test.com",
-    GIT_CONFIG_GLOBAL: "/dev/null",
-    GIT_CONFIG_SYSTEM: "/dev/null",
-  };
-}
-
-function git(cwd: string, args: string[], home: string): void {
-  execFileSync("git", args, { cwd, env: makeGitEnv(home) });
-}
 
 let server!: ServerHandle;
 let tmpHome: string | undefined;
@@ -271,7 +251,9 @@ test.describe("Files-panel LSP navigate workspace scoping (cross-workspace file 
       })
       .toContain(SHARED);
     // The fall-through opened B's OWN `shared.ts`, which resolves against B's
-    // root — so no error banner.
+    // root — the viewer renders its content (positive anchor) and shows no
+    // error banner.
+    await fileViewer.expectContent("different file in B");
     await expect(fileViewer.errorBanner).not.toBeVisible();
   });
 });

--- a/apps/web/e2e/lsp-navigate-workspace.spec.ts
+++ b/apps/web/e2e/lsp-navigate-workspace.spec.ts
@@ -1,0 +1,273 @@
+/**
+ * Regression coverage for the cross-workspace file leak in the Files panel —
+ * `band:lsp-navigate` events (dispatched by the CodeMirror LSP client on
+ * go-to-definition) must be scoped to the workspace whose editor fired them,
+ * so a go-to-definition in workspace A cannot drive the (different) active
+ * workspace B's Files panel to open A's relative path against B's root.
+ *
+ * Pre-fix, `BandWorkspace.displayFile` in `codemirror-lsp.ts` dispatched
+ * `band:lsp-navigate` with only `{ filePath }`, and every mounted
+ * `CodeBrowserView` (the LRU cache in `MultiWorkspacePanelHost` keeps up to
+ * `maxCachedWorkspaces` workspace subtrees alive, hidden with
+ * `visibility:hidden`) listened with NO workspace guard. So a
+ * go-to-definition in A also ran the handler in hidden workspace B: B's
+ * `FileViewer` stat'd `<B-root>/<A-relative-path>` → `ENOENT`, and
+ * `fileTabs.openTabPinned` persisted the stale path into
+ * `band-open-tabs:<B>` where it survived reloads. This is the same bug class
+ * that issue #539 fixed for `band:open-file`; this spec covers the
+ * sibling `band:lsp-navigate` event.
+ *
+ * The fix mirrors #539:
+ *
+ *   1. `BandWorkspace` threads the owning `workspaceId` through
+ *      `createLspExtension` and stamps it onto the `band:lsp-navigate`
+ *      event detail.
+ *   2. The `CodeBrowserView` `band:lsp-navigate` listener filters on
+ *      `detail.workspaceId`: it ignores the event unless it's addressed to
+ *      this instance's workspace. A missing id falls through to the active
+ *      workspace (forward-compat).
+ *
+ * Test architecture:
+ *
+ *   - Boots the real production server against a fresh tmp home.
+ *   - Two real git worktrees; `only-in-a.ts` exists ONLY in A, so a stat of
+ *     that path against B's root fails with ENOENT — the exact symptom.
+ *   - No tRPC mocking, no MSW, no `page.route()` on own routes. The spec
+ *     drives the DOM event directly via `dispatchLspNavigateEvent(...)`
+ *     (the LSP client's real dispatch is a synchronous
+ *     `window.dispatchEvent`, so no external stub is needed).
+ */
+
+import { execFileSync } from "node:child_process";
+import { mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { expect, test } from "@playwright/test";
+import { toWorkspaceId } from "@/dashboard";
+import {
+  cleanupTmpHome,
+  createTmpHome,
+  type ServerHandle,
+  seedSettings,
+  seedState,
+  startServer,
+} from "./helpers/server";
+import { FileTreesPage } from "./pages/FileTreesPage";
+import { FileViewerPage } from "./pages/FileViewerPage";
+import { WorkspacePage } from "./pages/WorkspacePage";
+
+const TOKEN = "e2e-lsp-navigate-workspace-token";
+
+const PROJECT = "lsp-navigate-repo";
+const DEFAULT_BRANCH = "main";
+const BRANCH_A = "feature-a";
+const BRANCH_B = "feature-b";
+
+const WORKSPACE_A = toWorkspaceId(PROJECT, BRANCH_A);
+const WORKSPACE_B = toWorkspaceId(PROJECT, BRANCH_B);
+
+// A file that exists ONLY in workspace A. When a leaked navigate makes B's
+// FileViewer stat `<B-root>/only-in-a.ts`, the read fails with ENOENT — the
+// bug's observable symptom. Named so it can never collide with a B file.
+const ONLY_IN_A = "only-in-a.ts";
+// A file present in BOTH worktrees (different content) — the healthy file we
+// open in B to establish a clean Files-panel baseline, and the fall-through
+// target for the missing-workspaceId compatibility test.
+const SHARED = "shared.ts";
+const ONLY_IN_B = "only-in-b.ts";
+
+// Wide viewport so `useIsDesktop()` reports true and the shared dockview
+// renders. The bug only manifests in the desktop layout, where multiple
+// workspaces are alive at once under `MultiWorkspacePanelHost`'s LRU cache.
+// The mobile layout mounts one workspace at a time, so there's no
+// cross-workspace event leak to guard against there in the same way.
+test.use({ viewport: { width: 1280, height: 800 } });
+
+function makeGitEnv(home: string): NodeJS.ProcessEnv {
+  // Hermetic git environment — mirrors `chat-file-link-workspace.spec.ts`.
+  // `GIT_CONFIG_GLOBAL`/`GIT_CONFIG_SYSTEM` pointed at /dev/null block host
+  // config from leaking into commits.
+  return {
+    PATH: process.env.PATH,
+    HOME: home,
+    GIT_AUTHOR_NAME: "Test",
+    GIT_AUTHOR_EMAIL: "test@test.com",
+    GIT_COMMITTER_NAME: "Test",
+    GIT_COMMITTER_EMAIL: "test@test.com",
+    GIT_CONFIG_GLOBAL: "/dev/null",
+    GIT_CONFIG_SYSTEM: "/dev/null",
+  };
+}
+
+function git(cwd: string, args: string[], home: string): void {
+  execFileSync("git", args, { cwd, env: makeGitEnv(home) });
+}
+
+let server!: ServerHandle;
+let tmpHome: string | undefined;
+
+test.beforeAll(async () => {
+  tmpHome = createTmpHome();
+
+  // Real git repo with two worktrees. Each worktree has a distinctly named
+  // file plus a `shared.ts` that exists in both (different content).
+  const repoPath = join(tmpHome, PROJECT);
+  mkdirSync(repoPath, { recursive: true });
+  git(repoPath, ["init", "-b", DEFAULT_BRANCH], tmpHome);
+  writeFileSync(join(repoPath, "README.md"), "# LSP navigate test\n");
+  git(repoPath, ["add", "."], tmpHome);
+  git(repoPath, ["commit", "-m", "initial commit"], tmpHome);
+
+  const worktreeAPath = join(tmpHome, `${PROJECT}-${BRANCH_A}`);
+  const worktreeBPath = join(tmpHome, `${PROJECT}-${BRANCH_B}`);
+  git(repoPath, ["worktree", "add", "-b", BRANCH_A, worktreeAPath], tmpHome);
+  git(repoPath, ["worktree", "add", "-b", BRANCH_B, worktreeBPath], tmpHome);
+
+  // `only-in-a.ts` lives only in A: a leaked navigate for it hits B's root
+  // and ENOENTs. `shared.ts` lives in both so B can open a healthy file.
+  writeFileSync(join(worktreeAPath, ONLY_IN_A), "// only in workspace A\n");
+  writeFileSync(join(worktreeAPath, SHARED), "// shared name, different file in A\n");
+  writeFileSync(join(worktreeBPath, ONLY_IN_B), "// only in workspace B\n");
+  writeFileSync(join(worktreeBPath, SHARED), "// shared name, different file in B\n");
+
+  seedState(tmpHome, {
+    projects: [
+      {
+        name: PROJECT,
+        path: repoPath,
+        defaultBranch: DEFAULT_BRANCH,
+        worktrees: [
+          { branch: DEFAULT_BRANCH, path: repoPath },
+          { branch: BRANCH_A, path: worktreeAPath },
+          { branch: BRANCH_B, path: worktreeBPath },
+        ],
+      },
+    ],
+  });
+  // Pin `maxCachedWorkspaces` to 3 — same as the #539 spec — so neither A
+  // nor B is LRU-evicted at the assertion point. The bug only manifests
+  // when BOTH workspace trees are alive simultaneously and the listener has
+  // to decide which one to route to.
+  seedSettings(tmpHome, { tokenSecret: TOKEN, maxCachedWorkspaces: 3 });
+  server = await startServer({ tmpHome });
+});
+
+test.afterAll(async () => {
+  if (server) await server.close();
+  if (tmpHome) cleanupTmpHome(tmpHome);
+});
+
+test.describe("Files-panel LSP navigate workspace scoping (cross-workspace file leak)", () => {
+  test("a go-to-definition addressed to workspace A does NOT leak the file into active workspace B (no ENOENT, no poisoned tabs)", async ({
+    page,
+  }) => {
+    const workspacePage = new WorkspacePage(page, server.url, TOKEN);
+    const fileTrees = new FileTreesPage(page, workspacePage);
+    // Scope the viewer to B's subtree: A's FileViewer stays mounted (hidden)
+    // in the LRU cache, so an unscoped `file-viewer__root` would also resolve
+    // to A's — and after the dispatch A's viewer legitimately shows
+    // `only-in-a.ts`, which would fool a `.first()` content assertion.
+    const fileViewer = new FileViewerPage(page, workspacePage.cachedPanelEntries(WORKSPACE_B));
+
+    // Land on A and activate its Files tab so A's CodeBrowserView mounts and
+    // its `band:lsp-navigate` listener is live. Waiting for the (unclicked)
+    // tree row confirms the tree loaded without opening the file — A's tab
+    // list stays empty until the dispatch, which is what makes the positive
+    // anchor below meaningful.
+    await workspacePage.goto(WORKSPACE_A);
+    await workspacePage.waitForReady();
+    await fileTrees.openFilesTab(ONLY_IN_A);
+
+    // Switch to B via the sidebar (client-side nav) so A stays mounted +
+    // cached (its listener still alive) while B becomes active.
+    await expect(workspacePage.workspaceCard(WORKSPACE_B)).toBeVisible();
+    await workspacePage.switchWorkspace(WORKSPACE_B);
+    await expect(workspacePage.cachedPanelEntries(WORKSPACE_B).first()).toBeVisible();
+    expect(await workspacePage.cachedPanelEntries(WORKSPACE_A).count()).toBeGreaterThan(0);
+
+    // Open a healthy file in B so B's FileViewer is mounted and shows valid
+    // content — the clean baseline the leak would corrupt. We open
+    // `only-in-b.ts` (a name unique to B) rather than `shared.ts`, because A's
+    // hidden-but-mounted file tree also carries a `shared.ts` row, and the
+    // per-path `file-tree__row--*` testid isn't workspace-scoped — a shared
+    // name would resolve to two rows (A's hidden + B's visible).
+    await fileTrees.openFilesTab(ONLY_IN_B);
+    await fileTrees.openFile(ONLY_IN_B);
+    await fileViewer.expectContent("only in workspace B");
+    await expect(fileViewer.errorBanner).not.toBeVisible();
+
+    // Fire the go-to-definition as it belongs to workspace A while B is the
+    // active workspace.
+    await workspacePage.dispatchLspNavigateEvent({
+      filePath: ONLY_IN_A,
+      workspaceId: WORKSPACE_A,
+    });
+
+    // Positive anchor: the event was live and A's listener handled it — A's
+    // persisted tab list gains `only-in-a.ts`. Without this, the negative
+    // assertions on B could pass trivially on a broken build where the event
+    // never reached any listener.
+    await expect
+      .poll(async () => (await workspacePage.readOpenTabsState(WORKSPACE_A))?.tabs ?? [], {
+        timeout: 5000,
+      })
+      .toContain(ONLY_IN_A);
+
+    // Negative — the leak, as a poll-for-appearance. `expect.poll(...).not
+    // .toContain(...)` would pass trivially at t=0 (B's tab list has only
+    // `shared.ts`), so instead poll for the leak's ARRIVAL within a bounded
+    // window and assert it never came. The bug opens `only-in-a.ts` as a
+    // fresh (non-restored) tab, which is NOT covered by the self-heal guard,
+    // so the leak would be persistent — the poll catches it deterministically.
+    let leaked = false;
+    try {
+      await expect
+        .poll(async () => (await workspacePage.readOpenTabsState(WORKSPACE_B))?.tabs ?? [], {
+          timeout: 2000,
+        })
+        .toContain(ONLY_IN_A);
+      leaked = true;
+    } catch {
+      // Poll exhausted its budget without observing the leak — the contract.
+    }
+    expect(leaked).toBe(false);
+
+    // B's Files panel must not have stat'd the A-only path against B's root:
+    // the viewer still shows B's healthy file (positive anchor) and there's no
+    // ENOENT banner. Content-first, then error-absence — same order as the
+    // pre-dispatch baseline above.
+    await fileViewer.expectContent("only in workspace B");
+    await expect(fileViewer.errorBanner).not.toBeVisible();
+  });
+
+  test("a navigate with no workspaceId falls through to the active workspace (backwards-compat)", async ({
+    page,
+  }) => {
+    const workspacePage = new WorkspacePage(page, server.url, TOKEN);
+    const fileTrees = new FileTreesPage(page, workspacePage);
+    // Unscoped viewer is fine here: this test only ever mounts workspace B
+    // (a single `goto`, no switch), so there's no LRU sibling whose
+    // `file-viewer__root` could also match — unlike the first test.
+    const fileViewer = new FileViewerPage(page);
+
+    // A single active workspace B with a healthy file open.
+    await workspacePage.goto(WORKSPACE_B);
+    await workspacePage.waitForReady();
+    await fileTrees.openFilesTab(ONLY_IN_B);
+    await fileTrees.openFile(ONLY_IN_B);
+    await fileViewer.expectContent("only in workspace B");
+
+    // Contract: a navigate with no `workspaceId` (older dispatcher / forward-
+    // compat) must still drive the active workspace's CodeBrowserView. Fire
+    // one for a file that exists in B — it should become a pinned tab there.
+    await workspacePage.dispatchLspNavigateEvent({ filePath: SHARED });
+
+    await expect
+      .poll(async () => (await workspacePage.readOpenTabsState(WORKSPACE_B))?.tabs ?? [], {
+        timeout: 5000,
+      })
+      .toContain(SHARED);
+    // The fall-through opened B's OWN `shared.ts`, which resolves against B's
+    // root — so no error banner.
+    await expect(fileViewer.errorBanner).not.toBeVisible();
+  });
+});

--- a/apps/web/e2e/lsp-navigate-workspace.spec.ts
+++ b/apps/web/e2e/lsp-navigate-workspace.spec.ts
@@ -182,7 +182,11 @@ test.describe("Files-panel LSP navigate workspace scoping (cross-workspace file 
     await expect(workspacePage.workspaceCard(WORKSPACE_B)).toBeVisible();
     await workspacePage.switchWorkspace(WORKSPACE_B);
     await expect(workspacePage.cachedPanelEntries(WORKSPACE_B).first()).toBeVisible();
-    expect(await workspacePage.cachedPanelEntries(WORKSPACE_A).count()).toBeGreaterThan(0);
+    // `.count()` is a one-shot read with no auto-retry — poll so an async LRU
+    // mount of A's cached panels can't lose a race with this assertion.
+    await expect
+      .poll(async () => workspacePage.cachedPanelEntries(WORKSPACE_A).count(), { timeout: 5000 })
+      .toBeGreaterThan(0);
 
     // Open a healthy file in B so B's FileViewer is mounted and shows valid
     // content — the clean baseline the leak would corrupt. We open

--- a/apps/web/e2e/pages/FileViewerPage.ts
+++ b/apps/web/e2e/pages/FileViewerPage.ts
@@ -27,11 +27,38 @@ import { expect, type Locator, type Page, test } from "@playwright/test";
 export const FILE_VIEWER_ROOT_TESTID = "file-viewer__root";
 
 export class FileViewerPage {
-  constructor(private readonly page: Page) {}
+  /**
+   * @param page  The Playwright page.
+   * @param scope Optional locator to scope the viewer lookup to a single
+   *   workspace's subtree. Several workspace subtrees stay mounted at once
+   *   (`MultiWorkspacePanelHost`'s LRU cache), so `file-viewer__root` can
+   *   resolve to more than one element — pass a per-workspace scope (e.g.
+   *   `workspacePage.cachedPanelEntries(id)`) to disambiguate. Defaults to the
+   *   whole page for the common single-workspace case.
+   */
+  constructor(
+    private readonly page: Page,
+    private readonly scope?: Locator,
+  ) {}
+
+  /** The file viewer root, optionally scoped to a single workspace. */
+  private get root(): Locator {
+    return (this.scope ?? this.page).getByTestId(FILE_VIEWER_ROOT_TESTID);
+  }
 
   /** The active file viewer's CodeMirror content element. */
   private get editor(): Locator {
-    return this.page.getByTestId(FILE_VIEWER_ROOT_TESTID).locator(".cm-content").first();
+    return this.root.locator(".cm-content").first();
+  }
+
+  /** The file viewer's load-error banner. Rendered by `FileViewer` when a
+   *  read fails (e.g. an `ENOENT: no such file or directory, stat '<root>/<path>'`
+   *  from the server's `stat`). `data-testid` set on the banner element in
+   *  `FileViewer.tsx` so the assertion doesn't tie to the server error copy.
+   *  Used by the cross-workspace-leak regression to prove a stray file from a
+   *  DIFFERENT workspace never made this viewer attempt a stat that fails. */
+  get errorBanner(): Locator {
+    return this.root.getByTestId("file-viewer__error");
   }
 
   /** Assert (auto-retrying) that the editor's rendered text contains `text`. */

--- a/apps/web/e2e/pages/FileViewerPage.ts
+++ b/apps/web/e2e/pages/FileViewerPage.ts
@@ -61,6 +61,17 @@ export class FileViewerPage {
     return this.root.getByTestId("file-viewer__error");
   }
 
+  /** Read the editor's currently-rendered text. CodeMirror only renders the
+   *  visible viewport, so this is reliable for the small single-line fixtures
+   *  the workspace-scoping specs use. Returns "" when no viewer is mounted.
+   *  Used for poll-for-appearance assertions (poll for a specific file's text
+   *  arriving within a bounded window, then assert it never did). */
+  async readText(): Promise<string> {
+    const el = this.editor;
+    if ((await el.count()) === 0) return "";
+    return (await el.textContent()) ?? "";
+  }
+
   /** Assert (auto-retrying) that the editor's rendered text contains `text`. */
   async expectContent(text: string): Promise<void> {
     await test.step(`Editor shows "${text}"`, async () => {

--- a/apps/web/e2e/pages/WorkspacePage.ts
+++ b/apps/web/e2e/pages/WorkspacePage.ts
@@ -1483,6 +1483,28 @@ export class WorkspacePage {
     });
   }
 
+  /** Dispatch a synthetic `band:lsp-navigate` window event — the same event
+   *  the CodeMirror LSP client fires on go-to-definition (see
+   *  `codemirror-lsp.ts`). Captures the cross-workspace routing contract under
+   *  test: an LSP navigation belongs to the workspace that owns the editor, so
+   *  a navigate addressed to workspace A must NOT drive the (different) active
+   *  workspace B's CodeBrowserView to open A's relative path against B's root
+   *  (ENOENT + poisoned `band-open-tabs:<B>`). Mirrors `dispatchOpenFileEvent`;
+   *  an event with no `workspaceId` falls through to the active workspace
+   *  (forward-compat). See the issue #539 pattern. */
+  async dispatchLspNavigateEvent(opts: { filePath: string; workspaceId?: string }): Promise<void> {
+    const target = opts.workspaceId ? ` for workspace ${opts.workspaceId}` : "";
+    await test.step(`Dispatch band:lsp-navigate for "${opts.filePath}"${target}`, async () => {
+      await this.page.evaluate(({ filePath, workspaceId }) => {
+        window.dispatchEvent(
+          new CustomEvent("band:lsp-navigate", {
+            detail: { filePath, workspaceId },
+          }),
+        );
+      }, opts);
+    });
+  }
+
   /** Write the persisted open-tabs state for a workspace directly into
    *  localStorage under the key `band-open-tabs:<workspaceId>`. Used
    *  by tests that need to seed a "this workspace has a stale tab

--- a/apps/web/e2e/pages/WorkspacePage.ts
+++ b/apps/web/e2e/pages/WorkspacePage.ts
@@ -1505,6 +1505,31 @@ export class WorkspacePage {
     });
   }
 
+  /** Dispatch a synthetic `band:editor-go-back` / `band:editor-go-forward`
+   *  window event — the same events the command palette fires for the editor
+   *  history "Go Back" / "Go Forward" commands (see `command-registry.ts` +
+   *  `SharedDockviewLayout.tsx`). Captures the cross-workspace routing contract
+   *  under test: an editor-history step belongs to the workspace that owns the
+   *  editor, so a step addressed to workspace A must NOT also walk the (hidden)
+   *  active workspace B's independent history stack. Mirrors
+   *  `dispatchLspNavigateEvent`; a missing `workspaceId` falls through to the
+   *  active workspace (forward-compat). See the issue #539 pattern. */
+  async dispatchEditorHistoryEvent(opts: {
+    direction: "back" | "forward";
+    workspaceId?: string;
+  }): Promise<void> {
+    const eventName = opts.direction === "back" ? "band:editor-go-back" : "band:editor-go-forward";
+    const target = opts.workspaceId ? ` for workspace ${opts.workspaceId}` : "";
+    await test.step(`Dispatch ${eventName}${target}`, async () => {
+      await this.page.evaluate(
+        ({ name, workspaceId }) => {
+          window.dispatchEvent(new CustomEvent(name, { detail: { workspaceId } }));
+        },
+        { name: eventName, workspaceId: opts.workspaceId },
+      );
+    });
+  }
+
   /** Write the persisted open-tabs state for a workspace directly into
    *  localStorage under the key `band-open-tabs:<workspaceId>`. Used
    *  by tests that need to seed a "this workspace has a stale tab

--- a/apps/web/src/components/CodeBrowserView.tsx
+++ b/apps/web/src/components/CodeBrowserView.tsx
@@ -687,7 +687,7 @@ export function CodeBrowserView({
     const cmLang = langMap[ext ?? ""];
     const languageId = cmLang ? getLspLanguageId(cmLang) : undefined;
 
-    createLspExtension(lspWsUrl, rootUri, documentUri, languageId)
+    createLspExtension(lspWsUrl, rootUri, documentUri, languageId, workspaceId)
       .then((ext) => {
         if (!cancelled) setLspExtension(ext);
       })
@@ -699,7 +699,7 @@ export function CodeBrowserView({
     return () => {
       cancelled = true;
     };
-  }, [lspWsUrl, workspacePath, viewFilePath]);
+  }, [lspWsUrl, workspacePath, viewFilePath, workspaceId]);
 
   // Clean up LSP client when the WebSocket URL changes or on unmount.
   // Runs the cleanup for the *previous* lspWsUrl on each change.
@@ -1269,10 +1269,25 @@ export function CodeBrowserView({
     if (entry) navigateToEntry(entry);
   }, [editorHistory.goForward, navigateToEntry]);
 
-  // Listen for keyboard shortcut events dispatched from SharedDockviewLayout
+  // Listen for editor history events dispatched from the command palette.
+  //
+  // Scope to the owning workspace: several workspace subtrees stay mounted at
+  // once (MultiWorkspacePanelHost), and each one's CodeBrowserView listens on
+  // `window`. Without the guard a Go Back/Forward in the active workspace would
+  // also step every hidden workspace's independent history stack. A missing
+  // `workspaceId` (older dispatcher) falls through to keep working — same shape
+  // as `band:open-file`, see issue #539.
   useEffect(() => {
-    const handleGoBack = () => handleEditorGoBack();
-    const handleGoForward = () => handleEditorGoForward();
+    const handleGoBack = (e: Event) => {
+      const detail = (e as CustomEvent<{ workspaceId?: string } | undefined>).detail;
+      if (detail?.workspaceId && detail.workspaceId !== workspaceId) return;
+      handleEditorGoBack();
+    };
+    const handleGoForward = (e: Event) => {
+      const detail = (e as CustomEvent<{ workspaceId?: string } | undefined>).detail;
+      if (detail?.workspaceId && detail.workspaceId !== workspaceId) return;
+      handleEditorGoForward();
+    };
 
     window.addEventListener("band:editor-go-back", handleGoBack);
     window.addEventListener("band:editor-go-forward", handleGoForward);
@@ -1280,15 +1295,25 @@ export function CodeBrowserView({
       window.removeEventListener("band:editor-go-back", handleGoBack);
       window.removeEventListener("band:editor-go-forward", handleGoForward);
     };
-  }, [handleEditorGoBack, handleEditorGoForward]);
+  }, [handleEditorGoBack, handleEditorGoForward, workspaceId]);
 
   // Listen for LSP cross-file navigation events (e.g., go-to-definition).
   // Go-to-definition is an explicit user intent to land on the target — pin
   // the destination so the next single-click in the tree doesn't silently
   // replace the file the user just navigated to.
+  //
+  // Scope to the owning workspace: the event is dispatched on `window` and
+  // every mounted (incl. hidden) workspace's CodeBrowserView listens. Without
+  // the guard a go-to-definition in workspace A would also open A's relative
+  // path in hidden workspaces B/C — whose FileViewer stats it against B/C's
+  // own worktree root (→ ENOENT) and persists it into B/C's
+  // `band-open-tabs:` localStorage. A missing `workspaceId` (older dispatcher)
+  // falls through to keep working — same shape as `band:open-file`, issue #539.
   useEffect(() => {
     const handleLspNavigate = (e: Event) => {
-      const detail = (e as CustomEvent).detail;
+      const detail = (e as CustomEvent<{ filePath?: string; workspaceId?: string } | undefined>)
+        .detail;
+      if (detail?.workspaceId && detail.workspaceId !== workspaceId) return;
       if (detail?.filePath) {
         pushDepartureAndArrival({ filePath: detail.filePath });
         // Use skipFileEffectRef to prevent the route change from clobbering nav
@@ -1306,7 +1331,7 @@ export function CodeBrowserView({
 
     window.addEventListener("band:lsp-navigate", handleLspNavigate);
     return () => window.removeEventListener("band:lsp-navigate", handleLspNavigate);
-  }, [pushDepartureAndArrival, fileTabs.openTabPinned, notifySelectFile]);
+  }, [pushDepartureAndArrival, fileTabs.openTabPinned, notifySelectFile, workspaceId]);
 
   // Keyboard shortcuts (capture phase, scoped to this section's focus):
   // - Cmd/Ctrl+W              → close the active file tab

--- a/apps/web/src/components/SharedDockviewLayout.tsx
+++ b/apps/web/src/components/SharedDockviewLayout.tsx
@@ -974,6 +974,18 @@ export function SharedDockviewLayout() {
             }),
           );
         },
+        editorGoBack: () => {
+          const ws = activeWorkspaceIdRef.current;
+          window.dispatchEvent(
+            new CustomEvent("band:editor-go-back", { detail: { workspaceId: ws } }),
+          );
+        },
+        editorGoForward: () => {
+          const ws = activeWorkspaceIdRef.current;
+          window.dispatchEvent(
+            new CustomEvent("band:editor-go-forward", { detail: { workspaceId: ws } }),
+          );
+        },
       }),
     [],
   );

--- a/apps/web/src/components/SharedDockviewLayout.tsx
+++ b/apps/web/src/components/SharedDockviewLayout.tsx
@@ -976,12 +976,19 @@ export function SharedDockviewLayout() {
         },
         editorGoBack: () => {
           const ws = activeWorkspaceIdRef.current;
+          // Bail without a target workspace — a `{ workspaceId: null }` detail
+          // is falsy, so the listener guard would treat it as "fall through to
+          // every mounted workspace" and re-introduce the cross-workspace
+          // history-stepping this fix prevents. Mirrors `formatCurrentFile` /
+          // `changeLanguageMode` above.
+          if (!ws) return;
           window.dispatchEvent(
             new CustomEvent("band:editor-go-back", { detail: { workspaceId: ws } }),
           );
         },
         editorGoForward: () => {
           const ws = activeWorkspaceIdRef.current;
+          if (!ws) return;
           window.dispatchEvent(
             new CustomEvent("band:editor-go-forward", { detail: { workspaceId: ws } }),
           );

--- a/apps/web/src/dashboard/components/FileViewer.tsx
+++ b/apps/web/src/dashboard/components/FileViewer.tsx
@@ -963,7 +963,10 @@ export function FileViewer({
         )}
 
         {error && (
-          <div className="flex h-32 items-center justify-center text-sm text-destructive">
+          <div
+            data-testid="file-viewer__error"
+            className="flex h-32 items-center justify-center text-sm text-destructive"
+          >
             {error}
           </div>
         )}

--- a/apps/web/src/dashboard/lib/codemirror-lsp.ts
+++ b/apps/web/src/dashboard/lib/codemirror-lsp.ts
@@ -119,10 +119,12 @@ class BandWorkspace extends Workspace {
   files: BandWorkspaceFile[] = [];
   private fileVersions: Record<string, number> = Object.create(null);
   private rootUri: string;
+  private workspaceId: string | undefined;
 
-  constructor(client: LSPClient, rootUri: string) {
+  constructor(client: LSPClient, rootUri: string, workspaceId?: string) {
     super(client);
     this.rootUri = rootUri;
+    this.workspaceId = workspaceId;
   }
 
   private nextFileVersion(uri: string): number {
@@ -203,10 +205,22 @@ class BandWorkspace extends Workspace {
 
       pendingNavigation = { resolve, timer };
 
-      // Dispatch navigation event to CodeBrowserView
+      // Dispatch navigation event to CodeBrowserView.
+      //
+      // Scope the event to the owning workspace. Multiple workspace subtrees
+      // stay mounted at once (MultiWorkspacePanelHost keeps up to
+      // `maxCachedWorkspaces` alive, hidden with visibility:hidden), and each
+      // one's CodeBrowserView listens for `band:lsp-navigate` on `window`.
+      // Without a workspace label, a go-to-definition in the active workspace
+      // A would also open the (A-relative) file in hidden workspaces B/C,
+      // whose FileViewer then stats it against B/C's own worktree root →
+      // ENOENT, and poisons B/C's `band-open-tabs:` localStorage. The listener
+      // filters on this id; a missing id falls through to the active
+      // workspace (forward-compat). Same shape as `band:open-file`, see
+      // issue #539.
       window.dispatchEvent(
         new CustomEvent("band:lsp-navigate", {
-          detail: { filePath },
+          detail: { filePath, workspaceId: this.workspaceId },
         }),
       );
     });
@@ -292,7 +306,11 @@ const clientCache = new Map<string, CachedClient>();
  * Get or create an LSP client for the given WebSocket URL.
  * The client is cached per URL (effectively per workspace+language).
  */
-async function getOrCreateClient(wsUrl: string, rootUri: string): Promise<LSPClient> {
+async function getOrCreateClient(
+  wsUrl: string,
+  rootUri: string,
+  workspaceId?: string,
+): Promise<LSPClient> {
   const cached = clientCache.get(wsUrl);
   if (cached) {
     cached.refCount++;
@@ -301,7 +319,7 @@ async function getOrCreateClient(wsUrl: string, rootUri: string): Promise<LSPCli
 
   const client = new LSPClient({
     rootUri,
-    workspace: (c) => new BandWorkspace(c, rootUri),
+    workspace: (c) => new BandWorkspace(c, rootUri, workspaceId),
     extensions: languageServerExtensions(),
     timeout: 10000,
   });
@@ -470,14 +488,18 @@ const cmdClickLinkPlugin = ViewPlugin.fromClass(
  * @param rootUri - Workspace root as file URI (e.g., `file:///path/to/workspace`)
  * @param documentUri - Current file as file URI (e.g., `file:///path/to/workspace/src/index.ts`)
  * @param languageId - LSP language ID (e.g., `typescript`, `typescriptreact`)
+ * @param workspaceId - Owning workspace id, stamped onto `band:lsp-navigate`
+ *   events so hidden sibling workspaces ignore this workspace's
+ *   cross-file navigations (see issue #539 pattern).
  */
 export async function createLspExtension(
   wsUrl: string,
   rootUri: string,
   documentUri: string,
   languageId?: string,
+  workspaceId?: string,
 ): Promise<Extension> {
-  const client = await getOrCreateClient(wsUrl, rootUri);
+  const client = await getOrCreateClient(wsUrl, rootUri, workspaceId);
   return [
     client.plugin(documentUri, languageId),
     // Cmd+Click (Mac) / Ctrl+Click (other) to jump to definition — the

--- a/apps/web/src/dashboard/lib/codemirror-lsp.ts
+++ b/apps/web/src/dashboard/lib/codemirror-lsp.ts
@@ -305,6 +305,13 @@ const clientCache = new Map<string, CachedClient>();
 /**
  * Get or create an LSP client for the given WebSocket URL.
  * The client is cached per URL (effectively per workspace+language).
+ *
+ * `workspaceId` is only consumed on the CREATE path — it's baked into the
+ * `BandWorkspace` at construction. On a cache hit it's intentionally ignored:
+ * `wsUrl` is built from the workspaceId (`buildLspWsUrl`), so the cache key
+ * already partitions clients by workspace and a hit is guaranteed to carry the
+ * same workspaceId the caller passed. (If that URL↔workspace coupling ever
+ * changes, this assumption must be revisited.)
  */
 async function getOrCreateClient(
   wsUrl: string,

--- a/apps/web/src/dashboard/lib/command-registry.ts
+++ b/apps/web/src/dashboard/lib/command-registry.ts
@@ -58,6 +58,16 @@ export interface CommandRegistryDeps {
    * opens the dialog (same pattern as `formatCurrentFile`).
    */
   changeLanguageMode: () => void;
+  /**
+   * Step the active editor's navigation history backward/forward.
+   * Implementations read the active `workspaceId` from a ref and dispatch
+   * `band:editor-go-back` / `band:editor-go-forward` with `{workspaceId}` so
+   * only the active workspace's CodeBrowserView acts — hidden sibling
+   * workspaces stay mounted and would otherwise step their own history
+   * stacks too (same pattern as `formatCurrentFile`, see issue #539).
+   */
+  editorGoBack: () => void;
+  editorGoForward: () => void;
 }
 
 // ---------------------------------------------------------------------------
@@ -223,12 +233,12 @@ export function buildCommands(deps: CommandRegistryDeps): PaletteCommand[] {
       // FileViewer toolbar and via this palette entry.
       id: "editor-go-back",
       label: "Go Back",
-      action: () => window.dispatchEvent(new CustomEvent("band:editor-go-back")),
+      action: () => deps.editorGoBack(),
     },
     {
       id: "editor-go-forward",
       label: "Go Forward",
-      action: () => window.dispatchEvent(new CustomEvent("band:editor-go-forward")),
+      action: () => deps.editorGoForward(),
     },
     {
       // No shortcut advertised: Shift+Tab is wired only inside the chat


### PR DESCRIPTION
## Problem

Open a file in workspace A, switch to workspace B (often a different project), and B's Files panel immediately shows:

```
ENOENT: no such file or directory, stat '<B's worktree root>/<A's relative path>'
```

B tries to open a file that only exists in A. The stale path also gets persisted into B's `band-open-tabs:<B>` localStorage, so it survives reloads.

## Root cause

`MultiWorkspacePanelHost` keeps the last N workspaces mounted at once — inactive ones are hidden with `visibility:hidden` but their subtrees (including each `CodeBrowserView`) stay alive and keep listening to `window` events.

Three editor events were dispatched on `window` **without** a `workspaceId`, and every mounted `CodeBrowserView` listened with **no guard**, so an action in the active workspace A also ran the handler in hidden workspaces B/C:

- **`band:lsp-navigate`** (go-to-definition) — the ENOENT culprit. The handler ran in every instance: `setViewFilePath` → B's FileViewer stats `<B-root>/<A-path>` → ENOENT, and `openTabPinned` poisoned `band-open-tabs:<B>`.
- **`band:editor-go-back` / `band:editor-go-forward`** — same bug class, milder (each instance has its own history stack), but still fired history nav in hidden workspaces.

This is the same bug class issue #539 fixed for `band:open-file`; these three sibling events were never given the same treatment.

## Fix

Scope all three events to the owning workspace, mirroring the #539 pattern:

1. **Dispatchers include the active `workspaceId`** in the event detail:
   - `band:lsp-navigate`: `workspaceId` threaded through `createLspExtension` → `getOrCreateClient` → `BandWorkspace`, which stamps it onto the event.
   - `band:editor-go-back` / `band:editor-go-forward`: the command palette (`command-registry.ts`) dispatches via new `editorGoBack`/`editorGoForward` deps that read the active workspaceId from a ref (same convention as `formatCurrentFile`).
2. **Each `CodeBrowserView` listener early-returns** when `detail.workspaceId` is present and `!==` its own `workspaceId`. A missing id falls through to the active workspace (forward-compat), matching the existing convention.

The persisted-tab self-heal is left in place as a secondary defense for already-poisoned entries.

## Test

New integration test `apps/web/e2e/lsp-navigate-workspace.spec.ts` (real server + real Chromium, per repo doctrine): opens a file in workspace A, switches to B, dispatches the `band:lsp-navigate` event, and asserts B's Files panel shows **no ENOENT** and its `band-open-tabs:<B>` localStorage is **not poisoned** — plus a backwards-compat test for the missing-`workspaceId` fall-through. Confirmed to fail on bug code (guard disabled) and pass with the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)