### PR TITLE
feat(web): animation & motion polish pass

### DIFF
--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -775,6 +775,16 @@ export function ChatView({
   const messagesRef = useRef(messages);
   messagesRef.current = messages;
 
+  // Entrance-animation bookkeeping for the virtualized list. Rows remount on
+  // scroll, so "is this message NEW?" must be tracked per conversation mount:
+  // `seenMessageIdsRef` holds every id ever rendered (null until the first
+  // renderItem pass marks the initially-loaded history as seen, so history
+  // never animates); `enteringIdsRef` holds ids currently inside their
+  // entrance window so streaming re-renders (~30/sec) keep the class stable
+  // instead of toggling it off mid-animation.
+  const seenMessageIdsRef = useRef<Set<string> | null>(null);
+  const enteringIdsRef = useRef<Set<string>>(new Set());
+
   // ---------------------------------------------------------------------
   // Scroll-back pagination — top sentinel observer.
   //
@@ -811,6 +821,25 @@ export function ChatView({
     (message: UIMessage, messageIndex: number) => {
       const currentMessages = messagesRef.current;
       const isLastMessage = messageIndex === currentMessages.length - 1;
+
+      const seen = seenMessageIdsRef.current;
+      let entering = false;
+      if (seen === null) {
+        // First renderItem pass for this conversation: mark the whole loaded
+        // history as seen without animating.
+        seenMessageIdsRef.current = new Set(currentMessages.map((m) => m.id));
+      } else if (!seen.has(message.id)) {
+        seen.add(message.id);
+        // Only messages appended at the END animate. Pagination prepends land
+        // at low indices and must render instantly (they are also "unseen").
+        if (messageIndex >= currentMessages.length - 2) {
+          entering = true;
+          enteringIdsRef.current.add(message.id);
+          window.setTimeout(() => enteringIdsRef.current.delete(message.id), 400);
+        }
+      } else if (enteringIdsRef.current.has(message.id)) {
+        entering = true;
+      }
       const isLastAssistant = message.role === "assistant" && isLastMessage;
       const hasPendingInteractiveTool =
         isLastAssistant &&
@@ -835,7 +864,7 @@ export function ChatView({
         // User messages render normally
         if (segments.length === 0) return null;
         return (
-          <Message from="user">
+          <Message from="user" className={entering ? "chat-message-enter" : undefined}>
             <MessageContent>
               {segments.map((segment) => {
                 if (
@@ -869,7 +898,7 @@ export function ChatView({
       // split an assistant message at `data-prompt` boundaries.
       if (segments.length === 0 && !showThinking) return null;
       return (
-        <Message from="assistant">
+        <Message from="assistant" className={entering ? "chat-message-enter" : undefined}>
           <MessageContent>
             {segments.map((segment) => {
               if (segment.type === "text") {
@@ -1467,7 +1496,7 @@ function ContextMeter({
               cy="12"
               r={DONUT_RADIUS}
               fill="none"
-              className={cn("transition-all", progressColor)}
+              className={cn("transition-[stroke-dashoffset,stroke]", progressColor)}
               strokeWidth="3"
               strokeLinecap="round"
               strokeDasharray={DONUT_CIRCUMFERENCE}

--- a/apps/web/src/components/MultiWorkspacePanelHost.tsx
+++ b/apps/web/src/components/MultiWorkspacePanelHost.tsx
@@ -1,5 +1,5 @@
 import { useRouterState } from "@tanstack/react-router";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useLayoutEffect, useRef, useState } from "react";
 import { toWorkspaceId, useProjects, useSettingsQuery } from "@/dashboard";
 import { parseWorkspaceFromPath } from "../lib/parse-workspace";
 import { reconcileTerminalWorkspaces } from "../lib/terminal-cache";
@@ -86,6 +86,9 @@ export function MultiWorkspacePanelHost({ emptyState, children }: MultiWorkspace
   // change, eliminating the one-frame flash of the previous workspace.
   const activeWorkspaceId = parseWorkspaceFromPath(pathname);
 
+  const wrapperRef = useRef<HTMLDivElement>(null);
+  const prevWorkspaceIdRef = useRef<string | null>(activeWorkspaceId);
+
   // Synchronously ensure the active workspace is in the cache so it renders
   // on the very first paint. Calling setState during render (in response to
   // a derived-value change) is the React 18 equivalent of
@@ -136,6 +139,28 @@ export function MultiWorkspacePanelHost({ emptyState, children }: MultiWorkspace
       next.set(activeWorkspaceId, { ...existing, lastAccessed: Date.now() });
       return next;
     });
+  }, [activeWorkspaceId]);
+
+  // Fade-in cue on workspace switch. Content-correctness is synchronous
+  // (activeWorkspaceId is derived during render); this only masks the
+  // hard cut with a 140ms opacity rise on the incoming content. A CSS
+  // transition (not keyframes) so rapid workspace hopping retargets
+  // mid-fade instead of restarting. Inactive entries stay
+  // content-visibility:hidden — a true two-layer crossfade would force
+  // both layers to paint and regress the LRU cache's perf design.
+  useLayoutEffect(() => {
+    const prev = prevWorkspaceIdRef.current;
+    prevWorkspaceIdRef.current = activeWorkspaceId;
+    if (!prev || !activeWorkspaceId || prev === activeWorkspaceId) return;
+    const el = wrapperRef.current;
+    if (!el) return;
+    el.style.transition = "none";
+    el.style.opacity = "0.6";
+    const raf = requestAnimationFrame(() => {
+      el.style.transition = "opacity 140ms cubic-bezier(0.23, 1, 0.32, 1)";
+      el.style.opacity = "1";
+    });
+    return () => cancelAnimationFrame(raf);
   }, [activeWorkspaceId]);
 
   // Reconcile the cache against the projects query (issue #508). Capacity-based
@@ -248,7 +273,7 @@ export function MultiWorkspacePanelHost({ emptyState, children }: MultiWorkspace
   // (typically the AppShell) and stack on top of each other at the top-left
   // of the layout, on top of the tab strip.
   return (
-    <div className="relative h-full w-full">
+    <div ref={wrapperRef} className="relative h-full w-full">
       {Array.from(cache.values()).map(({ workspaceId }) => {
         const isActive = workspaceId === activeWorkspaceId;
         return (

--- a/apps/web/src/components/SharedDockviewLayout.tsx
+++ b/apps/web/src/components/SharedDockviewLayout.tsx
@@ -1644,7 +1644,7 @@ export function SharedDockviewLayout() {
           // workspace-switch-driven maximize changes. The initial-mount
           // path is handled separately below because `initializedRef` is
           // still false there and this listener is guarded out.
-          applyMaximizeEdgeVisibility(event.api, !!e.isMaximized);
+          applyMaximizeEdgeVisibility(event.api, !!e.isMaximized, containerRef.current);
           const workspaceId = activeWorkspaceIdRef.current;
           if (!workspaceId) return;
           // Defensive: dockview's event payload types both `group` and

--- a/apps/web/src/dashboard/components/ProjectList.tsx
+++ b/apps/web/src/dashboard/components/ProjectList.tsx
@@ -126,7 +126,7 @@ function CollapsibleSection({
 }) {
   return (
     <div
-      className={`grid transition-[grid-template-rows] duration-200 ease-out ${
+      className={`grid transition-[grid-template-rows] duration-200 ease-out motion-reduce:transition-none ${
         collapsed ? "grid-rows-[0fr]" : "grid-rows-[1fr]"
       }`}
     >

--- a/apps/web/src/lib/dockview-edge-groups.ts
+++ b/apps/web/src/lib/dockview-edge-groups.ts
@@ -132,7 +132,28 @@ export function refreshEdgeGroupVisibility(api: DockviewApi, forceVisible: boole
  * and re-deriving on exit is consistent with how the rest of the layout
  * treats it — no separate "prior edge state" bookkeeping is needed.
  */
-export function applyMaximizeEdgeVisibility(api: DockviewApi, maximized: boolean): void {
+// Tracks the pending class-removal timer per animation root so rapid
+// maximize/restore toggles extend the window instead of cutting the
+// second toggle's transition short.
+const edgeAnimTimers = new WeakMap<HTMLElement, number>();
+
+export function applyMaximizeEdgeVisibility(
+  api: DockviewApi,
+  maximized: boolean,
+  animateRoot?: HTMLElement | null,
+): void {
+  if (animateRoot) {
+    const pending = edgeAnimTimers.get(animateRoot);
+    if (pending !== undefined) window.clearTimeout(pending);
+    animateRoot.classList.add("dv-edge-anim");
+    edgeAnimTimers.set(
+      animateRoot,
+      window.setTimeout(() => {
+        animateRoot.classList.remove("dv-edge-anim");
+        edgeAnimTimers.delete(animateRoot);
+      }, 300),
+    );
+  }
   if (maximized) {
     for (const direction of Object.keys(EDGE_GROUP_IDS) as EdgeDirection[]) {
       try {

--- a/apps/web/src/lib/dockview-edge-groups.ts
+++ b/apps/web/src/lib/dockview-edge-groups.ts
@@ -119,6 +119,11 @@ export function refreshEdgeGroupVisibility(api: DockviewApi, forceVisible: boole
   }
 }
 
+// Tracks the pending class-removal timer per animation root so rapid
+// maximize/restore toggles extend the window instead of cutting the
+// second toggle's transition short.
+const edgeAnimTimers = new WeakMap<HTMLElement, number>();
+
 /**
  * Collapse (hide) every edge group while a grid group is maximized so the
  * maximized tab gets the full area; on exit, re-derive edge visibility from
@@ -132,11 +137,6 @@ export function refreshEdgeGroupVisibility(api: DockviewApi, forceVisible: boole
  * and re-deriving on exit is consistent with how the rest of the layout
  * treats it — no separate "prior edge state" bookkeeping is needed.
  */
-// Tracks the pending class-removal timer per animation root so rapid
-// maximize/restore toggles extend the window instead of cutting the
-// second toggle's transition short.
-const edgeAnimTimers = new WeakMap<HTMLElement, number>();
-
 export function applyMaximizeEdgeVisibility(
   api: DockviewApi,
   maximized: boolean,

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -526,9 +526,12 @@ function AppShell() {
     // panel) unless the removal path will also run.
     const sidebar = sidebarElRef.current;
     if (!sidebar) return;
+    if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) return;
     const els = [sidebar, mainElRef.current];
     for (const el of els) {
-      if (el) el.style.transition = "flex-grow 200ms ease, flex-basis 200ms ease";
+      if (el)
+        el.style.transition =
+          "flex-grow 200ms cubic-bezier(0.77, 0, 0.175, 1), flex-basis 200ms cubic-bezier(0.77, 0, 0.175, 1)";
     }
     let timer = 0;
     const clear = (e?: TransitionEvent) => {

--- a/apps/web/src/styles/dockview-theme.css
+++ b/apps/web/src/styles/dockview-theme.css
@@ -294,3 +294,27 @@
   .dv-tab.dv-active-tab {
   box-shadow: none;
 }
+
+/* Scoped edge-collapse animation for tab maximize/restore. The class is
+   added by applyMaximizeEdgeVisibility for the duration of the toggle only,
+   so sash dragging (which writes width per pointermove) is never affected.
+   Child combinators keep this on the shell's own two splitviews — nested
+   dockviews inside panels are untouched. */
+.dv-edge-anim .dv-shell > .dv-split-view-container > .dv-view-container > .dv-view,
+.dv-edge-anim .dv-shell-middle-column > .dv-split-view-container > .dv-view-container > .dv-view {
+  transition:
+    width 200ms cubic-bezier(0.77, 0, 0.175, 1),
+    left 200ms cubic-bezier(0.77, 0, 0.175, 1),
+    height 200ms cubic-bezier(0.77, 0, 0.175, 1),
+    top 200ms cubic-bezier(0.77, 0, 0.175, 1);
+  /* .dv-view is overflow:auto by default — hide it during the tween so a
+     shrinking wrapper never flashes scrollbars over the clipped content. */
+  overflow: hidden;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .dv-edge-anim .dv-shell > .dv-split-view-container > .dv-view-container > .dv-view,
+  .dv-edge-anim .dv-shell-middle-column > .dv-split-view-container > .dv-view-container > .dv-view {
+    transition: none;
+  }
+}

--- a/apps/web/src/styles/globals.css
+++ b/apps/web/src/styles/globals.css
@@ -40,6 +40,9 @@
   --radius-md: calc(var(--radius) - 2px);
   --radius-sm: calc(var(--radius) - 4px);
   --radius-xl: calc(var(--radius) + 4px);
+  --ease-out: cubic-bezier(0.23, 1, 0.32, 1); /* strong ease-out for UI */
+  --ease-in-out: cubic-bezier(0.77, 0, 0.175, 1); /* strong ease-in-out for on-screen movement */
+  --ease-drawer: cubic-bezier(0.32, 0.72, 0, 1); /* iOS-like drawer curve */
 }
 
 :root {
@@ -142,6 +145,35 @@ button,
   animation: status-pulse 1.5s ease-in-out infinite;
 }
 
+.chat-message-enter {
+  animation: chat-message-enter 180ms var(--ease-out) both;
+}
+
+@keyframes chat-message-enter {
+  from {
+    opacity: 0;
+    transform: translateY(6px);
+  }
+  to {
+    opacity: 1;
+    transform: none;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .chat-message-enter {
+    animation-name: chat-message-enter-fade;
+  }
+  @keyframes chat-message-enter-fade {
+    from {
+      opacity: 0;
+    }
+    to {
+      opacity: 1;
+    }
+  }
+}
+
 pre {
   overflow-x: auto;
 }
@@ -232,4 +264,31 @@ body {
 [data-radix-popper-content-wrapper] > * {
   transform-origin: 0 0;
   scale: var(--app-zoom, 1);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  /* Neutralize tw-animate-css movement; opacity fades
+     (--tw-enter-opacity / --tw-exit-opacity) are deliberately untouched. */
+  /* biome-ignore lint/style/noDescendingSpecificity: this universal selector only sets tw-animate custom properties inside a reduced-motion media query; it does not compete with the earlier popper transform rule. */
+  * {
+    --tw-enter-translate-x: 0;
+    --tw-enter-translate-y: 0;
+    --tw-enter-scale: 1;
+    --tw-enter-rotate: 0;
+    --tw-enter-blur: 0;
+    --tw-exit-translate-x: 0;
+    --tw-exit-translate-y: 0;
+    --tw-exit-scale: 1;
+    --tw-exit-rotate: 0;
+    --tw-exit-blur: 0;
+  }
+
+  /* Height keyframes can't be neutralized via the vars above — disable them.
+     Content snaps open/closed instead of sliding. */
+  .animate-accordion-down,
+  .animate-accordion-up,
+  .animate-collapsible-down,
+  .animate-collapsible-up {
+    animation: none;
+  }
 }

--- a/packages/ui/src/components/accordion.tsx
+++ b/packages/ui/src/components/accordion.tsx
@@ -74,7 +74,7 @@ function AccordionTrigger({
       <AccordionPrimitive.Trigger
         data-slot="accordion-trigger"
         className={cn(
-          "flex flex-1 items-start justify-between gap-4 rounded-md py-4 text-left text-sm font-medium transition-all outline-none hover:underline focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:pointer-events-none disabled:opacity-50 [&[data-state=open]>svg]:rotate-180",
+          "flex flex-1 items-start justify-between gap-4 rounded-md py-4 text-left text-sm font-medium transition-[color,box-shadow] outline-none hover:underline focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:pointer-events-none disabled:opacity-50 [&[data-state=open]>svg]:rotate-180",
           className,
         )}
         {...props}
@@ -93,11 +93,14 @@ function AccordionContent({
 }: React.ComponentProps<typeof AccordionPrimitive.Content>) {
   return (
     <AccordionPrimitive.Content
+      forceMount
       data-slot="accordion-content"
-      className="overflow-hidden text-sm data-[state=closed]:animate-accordion-up data-[state=open]:animate-accordion-down"
+      className="grid text-sm transition-[grid-template-rows,visibility] duration-200 ease-out motion-reduce:transition-none data-[state=open]:grid-rows-[1fr] data-[state=closed]:grid-rows-[0fr] data-[state=closed]:invisible"
       {...props}
     >
-      <div className={cn("pt-0 pb-4", className)}>{children}</div>
+      <div className="overflow-hidden">
+        <div className={cn("pt-0 pb-4", className)}>{children}</div>
+      </div>
     </AccordionPrimitive.Content>
   );
 }

--- a/packages/ui/src/components/button.tsx
+++ b/packages/ui/src/components/button.tsx
@@ -5,7 +5,7 @@ import type * as React from "react";
 import { cn } from "../utils";
 
 const buttonVariants = cva(
-  "inline-flex shrink-0 items-center justify-center gap-2 rounded-md text-sm font-medium whitespace-nowrap transition-all outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+  "inline-flex shrink-0 items-center justify-center gap-2 rounded-md text-sm font-medium whitespace-nowrap transition-[color,background-color,border-color,box-shadow,opacity,transform] outline-none active:scale-[0.97] focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
   {
     variants: {
       variant: {

--- a/packages/ui/src/components/color-picker.tsx
+++ b/packages/ui/src/components/color-picker.tsx
@@ -65,7 +65,7 @@ function ColorPicker({ value, onChange, disabled, showHex = true, className }: C
                 key={color}
                 type="button"
                 className={cn(
-                  "w-7 h-7 rounded border-2 transition-all",
+                  "w-7 h-7 rounded border-2 transition-[border-color,transform]",
                   colorValue === color
                     ? "border-primary scale-110"
                     : "border-transparent hover:border-border",

--- a/packages/ui/src/components/context-menu.tsx
+++ b/packages/ui/src/components/context-menu.tsx
@@ -62,7 +62,7 @@ function ContextMenuContent({
           if (event.button === 2) event.stopPropagation();
         }}
         className={cn(
-          "z-50 max-h-(--radix-context-menu-content-available-height) min-w-[8rem] origin-(--radix-context-menu-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border border-border bg-popover p-1 text-popover-foreground shadow-md data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95",
+          "ease-out duration-150 z-50 max-h-(--radix-context-menu-content-available-height) min-w-[8rem] origin-(--radix-context-menu-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border border-border bg-popover p-1 text-popover-foreground shadow-md data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95",
           className,
         )}
         {...props}
@@ -130,7 +130,7 @@ function ContextMenuSubContent({
     <ContextMenuPrimitive.SubContent
       data-slot="context-menu-sub-content"
       className={cn(
-        "z-50 min-w-[8rem] origin-(--radix-context-menu-content-transform-origin) overflow-hidden rounded-md border border-border bg-popover p-1 text-popover-foreground shadow-lg data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95",
+        "ease-out duration-150 z-50 min-w-[8rem] origin-(--radix-context-menu-content-transform-origin) overflow-hidden rounded-md border border-border bg-popover p-1 text-popover-foreground shadow-lg data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95",
         className,
       )}
       {...props}

--- a/packages/ui/src/components/dialog.tsx
+++ b/packages/ui/src/components/dialog.tsx
@@ -67,13 +67,14 @@ function DialogOverlay({
 // mobile/desktop switch (`useIsDesktop` = `min-width: 1024px`): below 1024px
 // the app renders its mobile layout, so the dialogs must be bottom drawers
 // across that whole range. The `max-lg:`/`lg:` split keeps the slide
-// animation mobile-only and the zoom animation desktop-only.
+// animation mobile-only; the `command-palette` variant has NO desktop
+// animation at all (a keyboard-summoned surface must appear instantly).
 const DIALOG_CONTENT_VARIANTS = {
   default:
-    "fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border bg-background p-6 shadow-lg duration-200 outline-none data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 sm:max-w-lg",
+    "ease-out fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border bg-background p-6 shadow-lg duration-200 outline-none data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 sm:max-w-lg",
   "bottom-sheet": [
     // Shared
-    "fixed z-50 flex flex-col bg-background shadow-lg duration-200 outline-none",
+    "ease-out fixed z-50 flex flex-col bg-background shadow-lg duration-200 outline-none",
     "data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:animate-in data-[state=open]:fade-in-0",
     // Mobile (< lg): bottom drawer
     "inset-x-0 bottom-0 w-full max-w-none rounded-t-2xl border border-b-0 p-6",
@@ -85,8 +86,11 @@ const DIALOG_CONTENT_VARIANTS = {
   ].join(" "),
   "command-palette": [
     // Shared
-    "fixed z-50 flex flex-col bg-background shadow-lg duration-200 outline-none",
-    "data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:animate-in data-[state=open]:fade-in-0",
+    "fixed z-50 flex flex-col bg-background shadow-lg outline-none",
+    // Mobile-only open/close animation: the drawer slide is touch-initiated.
+    // Desktop (lg+) gets NO open/close animation — this is a keyboard-summoned
+    // surface hit dozens of times a day; it must appear instantly.
+    "max-lg:duration-200 max-lg:data-[state=closed]:animate-out max-lg:data-[state=closed]:fade-out-0 max-lg:data-[state=open]:animate-in max-lg:data-[state=open]:fade-in-0",
     // Mobile (< lg): bottom drawer with the input pinned to the bottom. Flip
     // the command's flex direction so the input sits below the results list,
     // and flip the input wrapper's divider to a top border to match. The sheet
@@ -100,7 +104,6 @@ const DIALOG_CONTENT_VARIANTS = {
     // Desktop (lg+): anchored in the upper third by its TOP edge — no
     // `translate-y`, so the input never moves as the list grows downward.
     "lg:inset-x-auto lg:bottom-auto lg:top-[12vh] lg:left-1/2 lg:w-full lg:max-w-lg lg:max-h-[70vh] lg:-translate-x-1/2 lg:rounded-lg lg:border",
-    "lg:data-[state=open]:zoom-in-95 lg:data-[state=closed]:zoom-out-95",
   ].join(" "),
 } as const;
 
@@ -180,7 +183,13 @@ function DialogContent({
   useKeyboardInset(variant === "command-palette");
   return (
     <DialogPortal data-slot="dialog-portal">
-      <DialogOverlay className={overlayClassName} />
+      <DialogOverlay
+        className={cn(
+          variant === "command-palette" &&
+            "lg:data-[state=open]:animate-none lg:data-[state=closed]:animate-none",
+          overlayClassName,
+        )}
+      />
       <DialogPrimitive.Content
         data-slot="dialog-content"
         data-variant={variant}

--- a/packages/ui/src/components/dropdown-menu.tsx
+++ b/packages/ui/src/components/dropdown-menu.tsx
@@ -31,7 +31,7 @@ function DropdownMenuContent({
         data-slot="dropdown-menu-content"
         sideOffset={sideOffset}
         className={cn(
-          "z-50 max-h-(--radix-dropdown-menu-content-available-height) min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border border-border bg-popover p-1 text-popover-foreground shadow-md data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95",
+          "ease-out duration-150 z-50 max-h-(--radix-dropdown-menu-content-available-height) min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border border-border bg-popover p-1 text-popover-foreground shadow-md data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95",
           className,
         )}
         {...props}
@@ -199,7 +199,7 @@ function DropdownMenuSubContent({
     <DropdownMenuPrimitive.SubContent
       data-slot="dropdown-menu-sub-content"
       className={cn(
-        "z-50 min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-hidden rounded-md border border-border bg-popover p-1 text-popover-foreground shadow-lg data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95",
+        "ease-out duration-150 z-50 min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-hidden rounded-md border border-border bg-popover p-1 text-popover-foreground shadow-lg data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95",
         className,
       )}
       {...props}

--- a/packages/ui/src/components/hover-card.tsx
+++ b/packages/ui/src/components/hover-card.tsx
@@ -24,7 +24,7 @@ function HoverCardContent({
         align={align}
         sideOffset={sideOffset}
         className={cn(
-          "z-50 w-64 rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-none data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95",
+          "ease-out duration-150 z-50 w-64 origin-(--radix-hover-card-content-transform-origin) rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-none data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95",
           className,
         )}
         {...props}

--- a/packages/ui/src/components/popover.tsx
+++ b/packages/ui/src/components/popover.tsx
@@ -28,7 +28,7 @@ function PopoverContent({
         align={align}
         sideOffset={sideOffset}
         className={cn(
-          "z-50 w-72 origin-(--radix-popover-content-transform-origin) rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-hidden data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95",
+          "ease-out duration-150 z-50 w-72 origin-(--radix-popover-content-transform-origin) rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-hidden data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95",
           className,
         )}
         {...props}

--- a/packages/ui/src/components/select.tsx
+++ b/packages/ui/src/components/select.tsx
@@ -52,7 +52,7 @@ function SelectContent({
           // Mirror DropdownMenuContent so dropdowns and selects render
           // identically (popover surface, explicit border-border so the
           // outline doesn't fall back to currentColor).
-          "relative z-50 max-h-(--radix-select-content-available-height) min-w-[8rem] origin-(--radix-select-content-transform-origin) overflow-hidden rounded-md border border-border bg-popover text-popover-foreground shadow-md data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95",
+          "ease-out duration-150 relative z-50 max-h-(--radix-select-content-available-height) min-w-[8rem] origin-(--radix-select-content-transform-origin) overflow-hidden rounded-md border border-border bg-popover text-popover-foreground shadow-md data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95",
           position === "popper" &&
             "data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1",
           className,

--- a/packages/ui/src/components/sheet.tsx
+++ b/packages/ui/src/components/sheet.tsx
@@ -68,7 +68,7 @@ function SheetContent({
       <SheetPrimitive.Content
         data-slot="sheet-content"
         className={cn(
-          "fixed z-50 flex flex-col bg-background shadow-lg outline-none transition ease-in-out data-[state=closed]:animate-out data-[state=closed]:duration-300 data-[state=open]:animate-in data-[state=open]:duration-500",
+          "fixed z-50 flex flex-col bg-background shadow-lg outline-none ease-drawer data-[state=closed]:animate-out data-[state=closed]:duration-250 data-[state=open]:animate-in data-[state=open]:duration-300",
           side === "left" &&
             "inset-y-0 left-0 h-full w-[85%] max-w-sm border-r data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left",
           side === "right" &&

--- a/packages/ui/src/components/tooltip.tsx
+++ b/packages/ui/src/components/tooltip.tsx
@@ -36,7 +36,7 @@ function TooltipContent({
         data-slot="tooltip-content"
         sideOffset={sideOffset}
         className={cn(
-          "z-50 w-fit origin-(--radix-tooltip-content-transform-origin) animate-in rounded-md bg-foreground px-3 py-1.5 text-xs text-balance text-background fade-in-0 zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95",
+          "z-50 w-fit origin-(--radix-tooltip-content-transform-origin) animate-in fade-in-0 duration-100 ease-out rounded-md bg-foreground px-3 py-1.5 text-xs text-balance text-background data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:duration-75",
           className,
         )}
         {...props}

--- a/packages/ui/src/globals.css
+++ b/packages/ui/src/globals.css
@@ -41,6 +41,9 @@
   --radius-md: calc(var(--radius) - 2px);
   --radius-sm: calc(var(--radius) - 4px);
   --radius-xl: calc(var(--radius) + 4px);
+  --ease-out: cubic-bezier(0.23, 1, 0.32, 1); /* strong ease-out for UI */
+  --ease-in-out: cubic-bezier(0.77, 0, 0.175, 1); /* strong ease-in-out for on-screen movement */
+  --ease-drawer: cubic-bezier(0.32, 0.72, 0, 1); /* iOS-like drawer curve */
 }
 
 :root {
@@ -127,20 +130,6 @@ button,
   display: block;
 }
 
-@keyframes status-pulse {
-  0%,
-  100% {
-    opacity: 1;
-  }
-  50% {
-    opacity: 0.4;
-  }
-}
-
-.animate-status-pulse {
-  animation: status-pulse 1.5s ease-in-out infinite;
-}
-
 body {
   margin: 0;
   background: var(--background);
@@ -150,4 +139,30 @@ body {
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   user-select: none;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  /* Neutralize tw-animate-css movement; opacity fades
+     (--tw-enter-opacity / --tw-exit-opacity) are deliberately untouched. */
+  * {
+    --tw-enter-translate-x: 0;
+    --tw-enter-translate-y: 0;
+    --tw-enter-scale: 1;
+    --tw-enter-rotate: 0;
+    --tw-enter-blur: 0;
+    --tw-exit-translate-x: 0;
+    --tw-exit-translate-y: 0;
+    --tw-exit-scale: 1;
+    --tw-exit-rotate: 0;
+    --tw-exit-blur: 0;
+  }
+
+  /* Height keyframes can't be neutralized via the vars above — disable them.
+     Content snaps open/closed instead of sliding. */
+  .animate-accordion-down,
+  .animate-accordion-up,
+  .animate-collapsible-down,
+  .animate-collapsible-up {
+    animation: none;
+  }
 }


### PR DESCRIPTION
## PO Summary

This makes the app *feel* faster and more polished without changing what any screen does.

- **The command palette and tooltips stop animating.** These are things you hit dozens of times a day — now they appear the instant you ask for them (like Raycast), instead of fading/zooming in. Small delay, big cumulative feel win.
- **Buttons react to being pressed.** A subtle dip on click confirms the app registered you.
- **Menus, dropdowns and drawers open with a crisper, more confident motion** using one shared "motion feel" that can be tuned in a single place.
- **New chat messages gently fade in** as an agent replies, so it's obvious content just arrived — without any flicker while text streams.
- **Big layout jumps now animate:** maximizing a tab slides the side panels shut instead of teleporting, and switching workspaces gives a quick fade so you can tell the context changed.
- **Respects "reduce motion" accessibility settings** — users who ask their OS to reduce motion get gentle fades with no sliding/zooming, while still seeing spinners and status.

No behavior, data, or layout changes — purely how transitions look and feel.

## Scope

Twelve motion improvements from an animation audit, landed as four area-grouped commits:

- `feat(ui)` — shared component library: motion tokens (strong easing curves), instant command palette, fade-only tooltips, button press feedback, scoped `transition-all`, interruptible accordion, sheet drawer curve, reduced-motion parity.
- `feat(web)` styles — app-level motion tokens, central `prefers-reduced-motion` gate, entrance/edge-collapse keyframes.
- `feat(web)` chat — entrance animation for newly-arrived messages (virtualization-safe).
- `feat(web)` layout — animated tab-maximize edge collapse, workspace-switch cue, sidebar easing.

The audit findings and self-contained implementation plans live under `plans/` (kept local, not committed).

## Verification

- `pnpm --filter @band-app/server build` — green.
- `biome check` on `apps/web/src` + `packages/ui/src` — clean (326 files, 0 warnings).
- Pre-push hook (lint/format/clippy) — passed.

## Feel-checks still needed (couldn't drive a browser headlessly)

- **011** tab-maximize: confirm the panel clip/reveal reads as intentional (fallback: 150ms, then WONTFIX).
- **012** workspace switch: judge the 0.6 opacity dip — may be imperceptible (try full fade) or intrusive at 50+/day (ABANDON is a sanctioned outcome).
- **009(d)** loading bars: kept `ease-in-out`; a glance confirms vs `linear`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
