### PR TITLE
feat(web): dock the Files explorer left or right, and keep its width fixed

### DIFF
--- a/apps/web/e2e/file-explorer-collapse.spec.ts
+++ b/apps/web/e2e/file-explorer-collapse.spec.ts
@@ -1,0 +1,302 @@
+/**
+ * End-to-end coverage for the Files-tab explorer's COLLAPSED state
+ * (`band-file-tree-collapsed:<workspaceId>`), which had no e2e coverage at all.
+ *
+ * What makes this worth testing is how the restore is done. The explorer is not
+ * mounted at size 0 — it mounts at its persisted pixel `defaultSize` and is then
+ * collapsed imperatively in a `useLayoutEffect`:
+ *
+ *     if (treeCollapsed) treePanelRef.current?.collapse();
+ *
+ * …because `expand()` returns a panel to its last *uncollapsed* size, and a panel
+ * that mounted at 0 has none — it would expand to the group's auto-assigned even
+ * split instead of the width the user dragged. The effect is keyed on the same
+ * things that remount the Group (`treeSide`, `useMobileLayout`), so it has to
+ * re-collapse a freshly-mounted panel too, and it must do so before the browser
+ * paints — otherwise the library's ResizeObserver measures the panel expanded and
+ * reports a blip that would persist `collapsed = false`.
+ *
+ * The three scenarios below are exactly those claims:
+ *   1. collapse survives a reload (the fresh-mount path),
+ *   2. collapse survives a Group REMOUNT, and expanding afterwards returns the
+ *      explorer to the width the user dragged it to (not an even split),
+ *   3. collapse + docking side + width all restore together.
+ *
+ * ── A note on how the remount is driven ──────────────────────────────────────
+ * The review asked for the remount to be driven by `moveExplorerRight()`. That is
+ * not reachable while the explorer is collapsed: the move-explorer context menu's
+ * trigger is the "Files" toolbar, which lives INSIDE the collapsed panel and is
+ * therefore 0px wide and un-right-clickable (verified — the click times out).
+ * `remountGroupViaWindowResize()` drives the other input to the very same
+ * `useLayoutEffect` (`useMobileLayout`) with a real user action — narrowing the
+ * window until the Files tab's container drops under CodeBrowserView's 600px
+ * threshold, then restoring it — which unmounts and remounts the Group while the
+ * explorer is collapsed. Scenario 3 then covers the side-flip half of the
+ * interaction the only way the UI allows: flip while expanded, collapse, reload.
+ *
+ * The collapse itself is driven through BOTH affordances: the separator's chevron
+ * (scenario 1) and the tab bar's tree-toggle (the rest). Expanding always goes
+ * through the tab bar — see `CodeBrowserPage.toggleExplorerCollapsed` for why the
+ * chevron is unusable in that direction.
+ */
+
+import { mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { expect, test } from "@playwright/test";
+import { toWorkspaceId } from "@/dashboard";
+import {
+  cleanupTmpHome,
+  createTmpHome,
+  type ServerHandle,
+  seedSettings,
+  seedState,
+  startServer,
+} from "./helpers/server";
+import { CodeBrowserPage } from "./pages/CodeBrowserPage";
+import { FileTreesPage } from "./pages/FileTreesPage";
+import { WorkspacePage } from "./pages/WorkspacePage";
+
+const TOKEN = "e2e-file-explorer-collapse-token";
+
+const PROJECT = "explorer-collapse";
+const BRANCH = "main";
+const FILE = "notes.txt";
+const WORKSPACE = toWorkspaceId(PROJECT, BRANCH);
+
+// Wide viewport — the Files tab falls back to its mobile single-column layout
+// when its own container is under 600px. Same reasoning as the sibling specs.
+test.use({ viewport: { width: 2400, height: 900 } });
+
+const DEFAULT_TREE_WIDTH_PX = 240;
+const DRAG_DX = 120;
+const WIDTH_TOLERANCE_PX = 2;
+
+let server: ServerHandle;
+let tmpHome: string;
+
+test.beforeAll(async () => {
+  tmpHome = createTmpHome();
+  const dir = join(tmpHome, PROJECT);
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, FILE), "hello\n");
+
+  seedState(tmpHome, {
+    projects: [
+      {
+        name: PROJECT,
+        path: dir,
+        defaultBranch: BRANCH,
+        worktrees: [{ branch: BRANCH, path: dir }],
+      },
+    ],
+  });
+  seedSettings(tmpHome, { tokenSecret: TOKEN });
+  server = await startServer({ tmpHome });
+});
+
+test.afterAll(async () => {
+  await server.close();
+  cleanupTmpHome(tmpHome);
+});
+
+test.describe("Files-tab explorer collapsed state", () => {
+  test("collapsing the explorer survives a reload", async ({ page }) => {
+    const workspace = new WorkspacePage(page, server.url, TOKEN);
+    const codeBrowser = new CodeBrowserPage(page, workspace);
+    const trees = new FileTreesPage(page, workspace);
+
+    await workspace.goto(WORKSPACE);
+    await workspace.waitForReady();
+    await codeBrowser.openFilesTab();
+    // Open a file first: CodeBrowserView deliberately auto-expands the tree when
+    // no editor tabs are open (issue #424 — otherwise a collapsed tree strands
+    // the user with no navigation UI), so a collapse only sticks with a tab open.
+    await trees.openFile(FILE);
+
+    const editorBefore = await codeBrowser.editorWidth();
+
+    await codeBrowser.collapseExplorerViaSeparatorChevron();
+
+    // Positive anchor for the "explorer is gone" assertion: the editor took over
+    // the space the explorer used to occupy.
+    await expect.poll(() => codeBrowser.editorWidth()).toBeGreaterThan(editorBefore + 100);
+    expect(await codeBrowser.isExplorerCollapsed()).toBe(true);
+    await expect.poll(() => codeBrowser.readPersistedCollapsed(WORKSPACE)).toBe("true");
+
+    await workspace.reload();
+    await workspace.waitForReady();
+    await codeBrowser.openFilesTab();
+
+    // Still collapsed after the fresh mount, and still recorded as such.
+    expect(await codeBrowser.isExplorerCollapsed()).toBe(true);
+    expect(await codeBrowser.readPersistedCollapsed(WORKSPACE)).toBe("true");
+
+    // And the user can get it back — with the flag flipped, so the expand is
+    // persisted too.
+    await codeBrowser.toggleExplorerCollapsed();
+    await expect.poll(() => codeBrowser.isExplorerCollapsed()).toBe(false);
+    await expect.poll(() => codeBrowser.readPersistedCollapsed(WORKSPACE)).toBe("false");
+  });
+
+  test("the explorer stays collapsed across a Group remount and expands back to the dragged width", async ({
+    page,
+  }) => {
+    const workspace = new WorkspacePage(page, server.url, TOKEN);
+    const codeBrowser = new CodeBrowserPage(page, workspace);
+    const trees = new FileTreesPage(page, workspace);
+
+    await workspace.goto(WORKSPACE);
+    await workspace.waitForReady();
+    await codeBrowser.openFilesTab();
+    await trees.openFile(FILE);
+
+    // Drag to a width that is clearly neither the 240px default nor an even
+    // split of the group, so "expands back to the dragged width" is falsifiable.
+    await codeBrowser.dragSeparatorBy(DRAG_DX);
+    await expect
+      .poll(() => codeBrowser.explorerWidth())
+      .toBeGreaterThan(DEFAULT_TREE_WIDTH_PX + DRAG_DX / 2);
+    const draggedWidth = await codeBrowser.explorerWidth();
+    // The width write is debounced; let it land before collapsing, so the value
+    // under test is the persisted one and not a leftover in memory.
+    await expect
+      .poll(() => codeBrowser.readPersistedWidthPx(WORKSPACE))
+      .toBe(Math.round(draggedWidth));
+
+    await codeBrowser.toggleExplorerCollapsed();
+    await expect.poll(() => codeBrowser.isExplorerCollapsed()).toBe(true);
+
+    // Remount the Group with the explorer collapsed. If the imperative
+    // `collapse()` lost the race with the library's ResizeObserver, the panel
+    // would come back expanded at its `defaultSize` here.
+    await codeBrowser.remountGroupViaWindowResize();
+
+    expect(await codeBrowser.isExplorerCollapsed()).toBe(true);
+    expect(await codeBrowser.readPersistedCollapsed(WORKSPACE)).toBe("true");
+
+    // Expanding returns it to the DRAGGED width — the whole reason the panel is
+    // mounted at `defaultSize` and collapsed imperatively rather than mounted at
+    // size 0 (which would expand to the group's even split instead).
+    await codeBrowser.toggleExplorerCollapsed();
+    await expect.poll(() => codeBrowser.isExplorerCollapsed()).toBe(false);
+    expect(Math.abs((await codeBrowser.explorerWidth()) - draggedWidth)).toBeLessThanOrEqual(
+      WIDTH_TOLERANCE_PX,
+    );
+  });
+
+  test("collapsing immediately after a drag still persists the dragged width", async ({ page }) => {
+    // Regression guard for the debounce data-loss window.
+    //
+    // The width write is debounced (~200ms). An earlier implementation captured
+    // the width in the Group's `onLayoutChanged` behind a `requestAnimationFrame`;
+    // collapsing inside the debounce window dropped the width the user had just
+    // dragged to and persisted the PREVIOUS one instead. Observed on that build:
+    // drag 240 → 360, collapse at once, reload + expand → the explorer came back
+    // at 240, and `band-file-tree-width-px` still held 240.
+    //
+    // That is a realistic gesture — the collapse chevron sits ON the separator the
+    // user has just been dragging — which is why this test deliberately does NOT
+    // wait for the debounced write to land before collapsing, and why it collapses
+    // via the CHEVRON (where the cursor already is, so the click lands within tens
+    // of ms) rather than via the tab bar (a cursor journey of ~100ms, long enough
+    // for a deferred write to get in first).
+    //
+    // Width capture now lives in the tree Panel's `onResize`, delivered from the
+    // library's own ResizeObserver — i.e. post-layout, so nothing has to be
+    // deferred, and a collapsed `onResize` (which reports 0) is skipped rather
+    // than cancelling anything. The pending debounced write therefore survives the
+    // collapse and lands with the dragged width.
+    const workspace = new WorkspacePage(page, server.url, TOKEN);
+    const codeBrowser = new CodeBrowserPage(page, workspace);
+    const trees = new FileTreesPage(page, workspace);
+
+    await workspace.goto(WORKSPACE);
+    await workspace.waitForReady();
+    await codeBrowser.openFilesTab();
+    await trees.openFile(FILE);
+
+    await codeBrowser.dragSeparatorBy(DRAG_DX);
+    const draggedWidth = await codeBrowser.explorerWidth();
+    expect(draggedWidth).toBeGreaterThan(DEFAULT_TREE_WIDTH_PX + DRAG_DX / 2);
+
+    // Collapse straight away — no poll on the persisted width first. The collapse
+    // goes through the SEPARATOR CHEVRON, not the tab bar: the chevron is where
+    // the cursor already is after a drag, so the click lands within a few tens of
+    // ms. (Driving this through the tab-bar toggle instead takes ~100ms — enough
+    // for the old implementation's rAF to fire first, which is why that variant
+    // does NOT reproduce the bug.)
+    await codeBrowser.collapseExplorerViaSeparatorChevron();
+    await expect.poll(() => codeBrowser.isExplorerCollapsed()).toBe(true);
+
+    // The pending write must still land, carrying the DRAGGED width.
+    await expect
+      .poll(() => codeBrowser.readPersistedWidthPx(WORKSPACE))
+      .toBe(Math.round(draggedWidth));
+
+    // …and the user-visible consequence: reload, expand, and the explorer is the
+    // width the user dragged it to — not the default it would have fallen back to.
+    await workspace.reload();
+    await workspace.waitForReady();
+    await codeBrowser.openFilesTab();
+    expect(await codeBrowser.isExplorerCollapsed()).toBe(true);
+
+    await codeBrowser.toggleExplorerCollapsed();
+    await expect.poll(() => codeBrowser.isExplorerCollapsed()).toBe(false);
+    expect(Math.abs((await codeBrowser.explorerWidth()) - draggedWidth)).toBeLessThanOrEqual(
+      WIDTH_TOLERANCE_PX,
+    );
+    expect(await codeBrowser.readPersistedWidthPx(WORKSPACE)).toBe(Math.round(draggedWidth));
+  });
+
+  test("collapsed + docked right + dragged width all restore together after a reload", async ({
+    page,
+  }) => {
+    const workspace = new WorkspacePage(page, server.url, TOKEN);
+    const codeBrowser = new CodeBrowserPage(page, workspace);
+    const trees = new FileTreesPage(page, workspace);
+
+    await workspace.goto(WORKSPACE);
+    await workspace.waitForReady();
+    await codeBrowser.openFilesTab();
+    await trees.openFile(FILE);
+
+    await codeBrowser.dragSeparatorBy(DRAG_DX);
+    await expect
+      .poll(() => codeBrowser.explorerWidth())
+      .toBeGreaterThan(DEFAULT_TREE_WIDTH_PX + DRAG_DX / 2);
+    const draggedWidth = await codeBrowser.explorerWidth();
+    await expect
+      .poll(() => codeBrowser.readPersistedWidthPx(WORKSPACE))
+      .toBe(Math.round(draggedWidth));
+
+    // Flip the side (only possible while expanded — the context-menu trigger is
+    // inside the panel), THEN collapse. The width must survive the Group remount
+    // the side flip causes.
+    await codeBrowser.moveExplorerRight();
+    await expect.poll(() => codeBrowser.explorerIsRightOfEditor()).toBe(true);
+    expect(Math.abs((await codeBrowser.explorerWidth()) - draggedWidth)).toBeLessThanOrEqual(
+      WIDTH_TOLERANCE_PX,
+    );
+
+    await codeBrowser.toggleExplorerCollapsed();
+    await expect.poll(() => codeBrowser.isExplorerCollapsed()).toBe(true);
+    await expect.poll(() => codeBrowser.readPersistedCollapsed(WORKSPACE)).toBe("true");
+
+    await workspace.reload();
+    await workspace.waitForReady();
+    await codeBrowser.openFilesTab();
+
+    // All three pieces of state come back: collapsed, docked right (the
+    // separator sits right of the editor even at zero explorer width), and — on
+    // expand — the dragged width.
+    expect(await codeBrowser.isExplorerCollapsed()).toBe(true);
+    expect(await codeBrowser.separatorIsRightOfEditor()).toBe(true);
+
+    await codeBrowser.toggleExplorerCollapsed();
+    await expect.poll(() => codeBrowser.isExplorerCollapsed()).toBe(false);
+    expect(await codeBrowser.explorerIsRightOfEditor()).toBe(true);
+    expect(Math.abs((await codeBrowser.explorerWidth()) - draggedWidth)).toBeLessThanOrEqual(
+      WIDTH_TOLERANCE_PX,
+    );
+  });
+});

--- a/apps/web/e2e/file-explorer-fixed-width.spec.ts
+++ b/apps/web/e2e/file-explorer-fixed-width.spec.ts
@@ -1,0 +1,218 @@
+/**
+ * End-to-end coverage for "the Files-tab explorer keeps a FIXED PIXEL width
+ * when the tab is maximized and restored".
+ *
+ * The explorer is a chrome column (VS Code's Primary Side Bar model), not a
+ * proportional pane: whatever width the user drags it to must survive a resize
+ * of the surrounding container. Maximizing the Files tab is exactly such a
+ * resize — the group takes over the whole grid AND
+ * `apps/web/src/lib/dockview-edge-groups.ts` collapses the edge panels, so the
+ * container gets substantially wider.
+ *
+ * Regression: the width used to be persisted as a PERCENTAGE of the group and
+ * the panel used react-resizable-panels' default
+ * `groupResizeBehavior="preserve-relative-size"`, so maximizing scaled the
+ * explorer up with the container. It is now
+ * `groupResizeBehavior="preserve-pixel-size"` with a px-valued `defaultSize`
+ * (`band-file-tree-width-px:<workspaceId>`), and the editor panel — which keeps
+ * `preserve-relative-size` — absorbs the whole delta.
+ *
+ * Each test asserts BOTH halves of that contract:
+ *   - the explorer's pixel width is unchanged across maximize AND restore, and
+ *   - the editor's width really did change, so the test can't pass vacuously
+ *     because the maximize did nothing.
+ *
+ * Architecture: real production server, real browser, no tRPC mocking; all UI
+ * driven through `WorkspacePage` + `CodeBrowserPage`.
+ */
+
+import { mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { expect, test } from "@playwright/test";
+import { toWorkspaceId } from "@/dashboard";
+import {
+  cleanupTmpHome,
+  createTmpHome,
+  type ServerHandle,
+  seedSettings,
+  seedState,
+  startServer,
+} from "./helpers/server";
+import { CodeBrowserPage } from "./pages/CodeBrowserPage";
+import { WorkspacePage } from "./pages/WorkspacePage";
+
+const TOKEN = "e2e-file-explorer-fixed-width-token";
+
+const PROJECT = "explorer-width";
+const BRANCH = "main";
+const WORKSPACE = toWorkspaceId(PROJECT, BRANCH);
+
+// Wide viewport: the Files tab drops to its mobile (toggle) layout when its own
+// container is under 600 px, and with two grid groups side by side that needs a
+// viewport well past 1280. See file-explorer-side.spec.ts for the same note.
+test.use({ viewport: { width: 2400, height: 900 } });
+
+/** Rounding slack: a panel's laid-out width is a fractional CSS px. */
+const WIDTH_TOLERANCE_PX = 2;
+/** How much wider the editor must get on maximize for the event to count as a
+ *  real container resize (the grid roughly doubles the group's width, so this
+ *  is a very loose floor). */
+const MIN_EDITOR_GROWTH_PX = 200;
+const DRAG_DX = 120;
+const DEFAULT_TREE_WIDTH_PX = 240;
+
+let server: ServerHandle;
+let tmpHome: string;
+let repoPath: string;
+
+test.beforeAll(async () => {
+  tmpHome = createTmpHome();
+  repoPath = join(tmpHome, PROJECT);
+  mkdirSync(repoPath, { recursive: true });
+  writeFileSync(join(repoPath, "notes.txt"), "hello\n");
+
+  seedState(tmpHome, {
+    projects: [
+      {
+        name: PROJECT,
+        path: repoPath,
+        defaultBranch: BRANCH,
+        worktrees: [{ branch: BRANCH, path: repoPath }],
+      },
+    ],
+  });
+  seedSettings(tmpHome, { tokenSecret: TOKEN });
+  server = await startServer({ tmpHome });
+});
+
+test.afterAll(async () => {
+  await server.close();
+  cleanupTmpHome(tmpHome);
+});
+
+test.describe("Files-tab explorer keeps its pixel width across maximize", () => {
+  test("maximizing and restoring the Files tab leaves the explorer's width untouched", async ({
+    page,
+  }) => {
+    const workspace = new WorkspacePage(page, server.url, TOKEN);
+    const codeBrowser = new CodeBrowserPage(page, workspace);
+
+    await workspace.goto(WORKSPACE);
+    await workspace.waitForReady();
+    await codeBrowser.openFilesTab();
+
+    const explorerBefore = await codeBrowser.explorerWidth();
+    const editorBefore = await codeBrowser.editorWidth();
+
+    // Maximize the group hosting the Files tab — the container-widening event.
+    await codeBrowser.maximizeFilesGroup();
+    await expect(workspace.restoreButton).toBeVisible();
+
+    // The editor absorbs the delta: polling on ITS growth is both the wait for
+    // the new layout to settle and the proof that the maximize actually
+    // resized the container (without it, an inert maximize would let the
+    // explorer assertion below pass for the wrong reason).
+    await expect
+      .poll(() => codeBrowser.editorWidth())
+      .toBeGreaterThan(editorBefore + MIN_EDITOR_GROWTH_PX);
+
+    expect(Math.abs((await codeBrowser.explorerWidth()) - explorerBefore)).toBeLessThanOrEqual(
+      WIDTH_TOLERANCE_PX,
+    );
+
+    // Restore — the editor shrinks back and the explorer is still untouched.
+    await codeBrowser.restoreFilesGroup();
+    await expect(workspace.maximizeButtons.first()).toBeVisible();
+    await expect
+      .poll(() => codeBrowser.editorWidth())
+      .toBeLessThan(editorBefore + MIN_EDITOR_GROWTH_PX);
+
+    expect(Math.abs((await codeBrowser.explorerWidth()) - explorerBefore)).toBeLessThanOrEqual(
+      WIDTH_TOLERANCE_PX,
+    );
+  });
+
+  // Regression guard: the live layout used to be right while the width
+  // PERSISTED during the maximize/restore layout event was not, so the dragged
+  // width was silently lost on the next reload. See the note at the bottom.
+  test("a width the user dragged to is the width preserved across maximize and reload", async ({
+    page,
+  }) => {
+    const workspace = new WorkspacePage(page, server.url, TOKEN);
+    const codeBrowser = new CodeBrowserPage(page, workspace);
+
+    await workspace.goto(WORKSPACE);
+    await workspace.waitForReady();
+    await codeBrowser.openFilesTab();
+
+    // Drag to a width that is clearly not the default, so "preserved" can't
+    // mean "reset to the default that happened to match".
+    await codeBrowser.dragSeparatorBy(DRAG_DX);
+    await expect
+      .poll(() => codeBrowser.explorerWidth())
+      .toBeGreaterThan(DEFAULT_TREE_WIDTH_PX + DRAG_DX / 2);
+
+    const draggedWidth = await codeBrowser.explorerWidth();
+    const editorBefore = await codeBrowser.editorWidth();
+
+    await codeBrowser.maximizeFilesGroup();
+    await expect(workspace.restoreButton).toBeVisible();
+    await expect
+      .poll(() => codeBrowser.editorWidth())
+      .toBeGreaterThan(editorBefore + MIN_EDITOR_GROWTH_PX);
+
+    expect(Math.abs((await codeBrowser.explorerWidth()) - draggedWidth)).toBeLessThanOrEqual(
+      WIDTH_TOLERANCE_PX,
+    );
+
+    await codeBrowser.restoreFilesGroup();
+    await expect(workspace.maximizeButtons.first()).toBeVisible();
+    await expect
+      .poll(() => codeBrowser.editorWidth())
+      .toBeLessThan(editorBefore + MIN_EDITOR_GROWTH_PX);
+
+    expect(Math.abs((await codeBrowser.explorerWidth()) - draggedWidth)).toBeLessThanOrEqual(
+      WIDTH_TOLERANCE_PX,
+    );
+
+    // The persisted value must still be the dragged pixel width — it is what
+    // seeds the panel's `defaultSize` on the next mount.
+    const persisted = await codeBrowser.readPersistedWidthPx(WORKSPACE);
+    expect(persisted).not.toBeNull();
+    expect(Math.abs((persisted as number) - draggedWidth)).toBeLessThanOrEqual(WIDTH_TOLERANCE_PX);
+
+    // …and the user-visible consequence of getting that wrong: reload and the
+    // explorer must come back at the width the user dragged it to.
+    await workspace.reload();
+    await workspace.waitForReady();
+    await codeBrowser.openFilesTab();
+    expect(Math.abs((await codeBrowser.explorerWidth()) - draggedWidth)).toBeLessThanOrEqual(
+      WIDTH_TOLERANCE_PX,
+    );
+  });
+});
+
+/**
+ * ─────────────────────────────────────────────────────────────────────────────
+ * WHY THE SECOND TEST EXISTS — the bug it caught, so it isn't relaxed later
+ *
+ * The LIVE pixel width always survived maximize/restore. What did not survive
+ * was the PERSISTED width, so the explorer looked correct until the next reload.
+ *
+ * `CodeBrowserView`'s `handleLayoutChanged` used to read the explorer's width
+ * synchronously inside the Group's `onLayoutChanged` callback. But
+ * react-resizable-panels' `getSize()` is a live DOM read (`element.offsetWidth`,
+ * see the library source) and `onLayoutChanged` fires BEFORE the new layout is
+ * written to the DOM — so on a group-size change it measured the panel while it
+ * was still sized by the OLD percentage inside the NEW container:
+ *
+ *     drag explorer to 360px      → live 360   persisted 360   ✅
+ *     maximize the Files tab      → live 360   persisted 721   ❌ (360 × 2160/1080)
+ *     restore                     → live 360   persisted 180   ❌ (360 × 1080/2160)
+ *     reload                      → live 180                   ❌ dragged width lost
+ *
+ * (Real numbers from a 2400px viewport run.) Every maximize/restore cycle halved
+ * the width the user chose, one reload later. The fix defers the `getSize()` read
+ * to the next animation frame, once the settled layout is on screen.
+ * ─────────────────────────────────────────────────────────────────────────────
+ */

--- a/apps/web/e2e/file-explorer-fixed-width.spec.ts
+++ b/apps/web/e2e/file-explorer-fixed-width.spec.ts
@@ -176,10 +176,14 @@ test.describe("Files-tab explorer keeps its pixel width across maximize", () => 
     );
 
     // The persisted value must still be the dragged pixel width — it is what
-    // seeds the panel's `defaultSize` on the next mount.
-    const persisted = await codeBrowser.readPersistedWidthPx(WORKSPACE);
-    expect(persisted).not.toBeNull();
-    expect(Math.abs((persisted as number) - draggedWidth)).toBeLessThanOrEqual(WIDTH_TOLERANCE_PX);
+    // seeds the panel's `defaultSize` on the next mount. The write is debounced
+    // (`WIDTH_PERSIST_DEBOUNCE_MS`), so poll rather than reading once.
+    await expect
+      .poll(async () => {
+        const persisted = await codeBrowser.readPersistedWidthPx(WORKSPACE);
+        return persisted === null ? null : Math.abs(persisted - draggedWidth) <= WIDTH_TOLERANCE_PX;
+      })
+      .toBe(true);
 
     // …and the user-visible consequence of getting that wrong: reload and the
     // explorer must come back at the width the user dragged it to.
@@ -189,6 +193,31 @@ test.describe("Files-tab explorer keeps its pixel width across maximize", () => 
     expect(Math.abs((await codeBrowser.explorerWidth()) - draggedWidth)).toBeLessThanOrEqual(
       WIDTH_TOLERANCE_PX,
     );
+  });
+
+  test("a legacy percentage width is ignored, not restored as a pixel width", async ({ page }) => {
+    const workspace = new WorkspacePage(page, server.url, TOKEN);
+    const codeBrowser = new CodeBrowserPage(page, workspace);
+
+    // Users upgrading from the percentage era have `band-file-tree-width:<ws>`
+    // = "15" (meaning 15% of the group). The key was deliberately renamed to
+    // `-px`, because reusing it would restore that 15 as a 15-PIXEL explorer —
+    // a sliver, below even the 10rem minSize. Seed the legacy key before the app
+    // mounts and assert the explorer falls back to the 240px default.
+    await codeBrowser.seedLegacyWidthValue(WORKSPACE, "15");
+
+    await workspace.goto(WORKSPACE);
+    await workspace.waitForReady();
+    await codeBrowser.openFilesTab();
+
+    expect(
+      Math.abs((await codeBrowser.explorerWidth()) - DEFAULT_TREE_WIDTH_PX),
+    ).toBeLessThanOrEqual(WIDTH_TOLERANCE_PX);
+    // The legacy value is not migrated into the new key either — the explorer
+    // simply starts from the default and re-persists from there.
+    await expect
+      .poll(() => codeBrowser.readPersistedWidthPx(WORKSPACE))
+      .toBe(DEFAULT_TREE_WIDTH_PX);
   });
 });
 

--- a/apps/web/e2e/file-explorer-fixed-width.spec.ts
+++ b/apps/web/e2e/file-explorer-fixed-width.spec.ts
@@ -61,6 +61,16 @@ const MIN_EDITOR_GROWTH_PX = 200;
 const DRAG_DX = 120;
 const DEFAULT_TREE_WIDTH_PX = 240;
 
+/** The viewport `test.use` pins above. */
+const WIDE_VIEWPORT_PX = 2400;
+/** Narrow enough that half the Files group is well under the width the squeeze
+ *  test drags to, but wide enough that the group itself stays over
+ *  CodeBrowserView's 600px mobile threshold — the Group must stay mounted. */
+const NARROW_VIEWPORT_PX = 1700;
+/** Drag target for the squeeze test: comfortably inside `maxSize` (50%) at the
+ *  wide viewport, and comfortably outside it once narrowed. */
+const WIDE_DRAG_DX = 260; // 240 → ~500px
+
 let server: ServerHandle;
 let tmpHome: string;
 let repoPath: string;
@@ -213,11 +223,75 @@ test.describe("Files-tab explorer keeps its pixel width across maximize", () => 
     expect(
       Math.abs((await codeBrowser.explorerWidth()) - DEFAULT_TREE_WIDTH_PX),
     ).toBeLessThanOrEqual(WIDTH_TOLERANCE_PX);
-    // The legacy value is not migrated into the new key either — the explorer
-    // simply starts from the default and re-persists from there.
+
+    // The legacy value is not migrated into the new key — and nothing else is
+    // written there either. Only a width the *user* chose is persisted, so
+    // merely opening the tab leaves the key empty; the explorer falls back to
+    // the default every mount until someone drags it.
+    expect(await codeBrowser.readPersistedWidthPx(WORKSPACE)).toBeNull();
+
+    // Once the user does drag, the new key takes over and the legacy one is
+    // still never consulted.
+    await codeBrowser.dragSeparatorBy(DRAG_DX);
+    const dragged = await codeBrowser.explorerWidth();
+    await expect
+      .poll(async () => {
+        const persisted = await codeBrowser.readPersistedWidthPx(WORKSPACE);
+        return persisted === null ? null : Math.abs(persisted - dragged) <= WIDTH_TOLERANCE_PX;
+      })
+      .toBe(true);
+  });
+
+  test("a width squeezed out by a narrower window is reclaimed when the window widens back", async ({
+    page,
+  }) => {
+    // `preserve-pixel-size` holds the explorer's width through a container
+    // resize — but `maxSize` (50% of the group) still binds. Narrow the window
+    // far enough and the layout engine MUST squeeze the explorer below the width
+    // the user chose. It keeps no memory of the width it took away, so widening
+    // back used to strand the explorer at the squeezed size, and the next persist
+    // would then make that stranded width the user's "chosen" one.
+    //
+    // The fix: a container-driven `onResize` (group width changed) never
+    // overwrites the chosen width — it re-asserts it instead, clamped to whatever
+    // room there is now: `resize(min(chosenWidth, 50% of group))`.
+    const workspace = new WorkspacePage(page, server.url, TOKEN);
+    const codeBrowser = new CodeBrowserPage(page, workspace);
+
+    await workspace.goto(WORKSPACE);
+    await workspace.waitForReady();
+    await codeBrowser.openFilesTab();
+
+    // Drag the explorer wide (~500px) — inside `maxSize` at this viewport, but
+    // well over half the group once the window narrows.
+    await codeBrowser.dragSeparatorBy(WIDE_DRAG_DX);
+    await expect
+      .poll(() => codeBrowser.explorerWidth())
+      .toBeGreaterThan(DEFAULT_TREE_WIDTH_PX + WIDE_DRAG_DX / 2);
+    const chosenWidth = await codeBrowser.explorerWidth();
+
+    // Let the debounced write land, so the persisted value under test is the
+    // user's chosen width before any squeeze happens.
     await expect
       .poll(() => codeBrowser.readPersistedWidthPx(WORKSPACE))
-      .toBe(DEFAULT_TREE_WIDTH_PX);
+      .toBe(Math.round(chosenWidth));
+
+    // Narrow the window. The Group stays mounted (the Files container remains
+    // above the 600px mobile threshold), but 50% of it is now less than the
+    // chosen width, so the explorer is squeezed.
+    await codeBrowser.setWindowWidth(NARROW_VIEWPORT_PX);
+    await expect.poll(() => codeBrowser.explorerWidth()).toBeLessThan(chosenWidth - 20);
+
+    // Widen back: the explorer must RECLAIM the width it chose, not stay stranded
+    // at the squeezed size.
+    await codeBrowser.setWindowWidth(WIDE_VIEWPORT_PX);
+    await expect
+      .poll(async () => Math.abs((await codeBrowser.explorerWidth()) - chosenWidth))
+      .toBeLessThanOrEqual(WIDTH_TOLERANCE_PX);
+
+    // And the squeeze never overwrote the user's chosen width on disk — otherwise
+    // the next reload would come back at the squeezed size.
+    expect(await codeBrowser.readPersistedWidthPx(WORKSPACE)).toBe(Math.round(chosenWidth));
   });
 });
 

--- a/apps/web/e2e/file-explorer-side.spec.ts
+++ b/apps/web/e2e/file-explorer-side.spec.ts
@@ -199,9 +199,13 @@ test.describe("Files-tab explorer docking side", () => {
       WIDTH_TOLERANCE_PX,
     );
 
-    // The dragged width — not the default — is what got persisted.
-    const persisted = await codeBrowser.readPersistedWidthPx(WORKSPACE_A);
-    expect(persisted).not.toBeNull();
-    expect(Math.abs((persisted as number) - draggedWidth)).toBeLessThanOrEqual(WIDTH_TOLERANCE_PX);
+    // The dragged width — not the default — is what got persisted. The width
+    // write is debounced (`WIDTH_PERSIST_DEBOUNCE_MS`), so poll for it.
+    await expect
+      .poll(async () => {
+        const persisted = await codeBrowser.readPersistedWidthPx(WORKSPACE_A);
+        return persisted === null ? null : Math.abs(persisted - draggedWidth) <= WIDTH_TOLERANCE_PX;
+      })
+      .toBe(true);
   });
 });

--- a/apps/web/e2e/file-explorer-side.spec.ts
+++ b/apps/web/e2e/file-explorer-side.spec.ts
@@ -1,0 +1,207 @@
+/**
+ * End-to-end coverage for "the Files-tab explorer can be docked left or right".
+ *
+ * The explorer's header row ("Files") is a Radix context-menu trigger with two
+ * items — "Explorer on Left" / "Explorer on Right". The chosen side is kept per
+ * workspace in `localStorage` under `band-file-tree-side:<workspaceId>` and
+ * re-ordered in the DOM by remounting the resizable Group with the panels in
+ * the opposite order.
+ *
+ * Architecture (mirrors the rest of the e2e suite):
+ *
+ *   - The REAL production `dist/start-server.mjs` boots against a fresh tmp
+ *     `$HOME` with on-disk project directories. No tRPC mocking.
+ *   - Everything is driven through page objects (`WorkspacePage` +
+ *     `CodeBrowserPage`); the test body never touches `page.*`.
+ *
+ * The side is asserted GEOMETRICALLY (explorer's `x` vs the editor's `x`) —
+ * that's what the user sees — with the persisted `localStorage` value asserted
+ * alongside it, so a regression in either the render order or the persistence
+ * fails the test.
+ *
+ * The last scenario guards the invariant that moving sides must not RESIZE the
+ * explorer: `handleSetTreeSide` reads the panel's live pixel width before the
+ * Group remounts and re-seeds the fresh panel's `defaultSize` with it.
+ */
+
+import { mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { expect, test } from "@playwright/test";
+import { toWorkspaceId } from "@/dashboard";
+import {
+  cleanupTmpHome,
+  createTmpHome,
+  type ServerHandle,
+  seedSettings,
+  seedState,
+  startServer,
+} from "./helpers/server";
+import { CodeBrowserPage } from "./pages/CodeBrowserPage";
+import { WorkspacePage } from "./pages/WorkspacePage";
+
+const TOKEN = "e2e-file-explorer-side-token";
+
+const PROJECT_A = "explorer-side-a";
+const PROJECT_B = "explorer-side-b";
+const BRANCH = "main";
+const WORKSPACE_A = toWorkspaceId(PROJECT_A, BRANCH);
+const WORKSPACE_B = toWorkspaceId(PROJECT_B, BRANCH);
+
+// The Files tab falls back to its mobile (toggle) layout whenever its own
+// container is narrower than 600 px — with two grid groups side by side that
+// means the viewport has to be wide enough for the files group to clear 600 px
+// on its own. 2400 px leaves ~1000 px per group (same reasoning as
+// copy-file-path.spec.ts, which needs the Changes tree's container query).
+test.use({ viewport: { width: 2400, height: 900 } });
+
+// `DEFAULT_FILE_TREE_WIDTH_PX` in CodeBrowserView.tsx. Duplicated rather than
+// imported (tests don't import production code) — the drag scenario needs a
+// target width that is unmistakably NOT the default, so a side flip that
+// silently reset the panel to its default width can't pass.
+const DEFAULT_TREE_WIDTH_PX = 240;
+const DRAG_DX = 120;
+/** Rounding slack: the panel's laid-out width is a fractional CSS px. */
+const WIDTH_TOLERANCE_PX = 2;
+
+let server: ServerHandle;
+let tmpHome: string;
+
+test.beforeAll(async () => {
+  tmpHome = createTmpHome();
+  for (const project of [PROJECT_A, PROJECT_B]) {
+    const dir = join(tmpHome, project);
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, "notes.txt"), "hello\n");
+  }
+  seedState(tmpHome, {
+    projects: [PROJECT_A, PROJECT_B].map((name) => ({
+      name,
+      path: join(tmpHome, name),
+      defaultBranch: BRANCH,
+      worktrees: [{ branch: BRANCH, path: join(tmpHome, name) }],
+    })),
+  });
+  seedSettings(tmpHome, { tokenSecret: TOKEN });
+  server = await startServer({ tmpHome });
+});
+
+test.afterAll(async () => {
+  await server.close();
+  cleanupTmpHome(tmpHome);
+});
+
+test.describe("Files-tab explorer docking side", () => {
+  test("defaults to the left edge", async ({ page }) => {
+    const workspace = new WorkspacePage(page, server.url, TOKEN);
+    const codeBrowser = new CodeBrowserPage(page, workspace);
+
+    await workspace.goto(WORKSPACE_A);
+    await workspace.waitForReady();
+    await codeBrowser.openFilesTab();
+
+    const explorer = await codeBrowser.explorerBox();
+    const editor = await codeBrowser.editorBox();
+    expect(explorer.x).toBeLessThan(editor.x);
+
+    // Nothing persisted yet — "left" is the unset fallback, not a stored value.
+    expect(await codeBrowser.readPersistedSide(WORKSPACE_A)).toBeNull();
+  });
+
+  test('"Explorer on Right" moves it to the right edge and persists the choice', async ({
+    page,
+  }) => {
+    const workspace = new WorkspacePage(page, server.url, TOKEN);
+    const codeBrowser = new CodeBrowserPage(page, workspace);
+
+    await workspace.goto(WORKSPACE_A);
+    await workspace.waitForReady();
+    await codeBrowser.openFilesTab();
+    expect(await codeBrowser.explorerIsRightOfEditor()).toBe(false);
+
+    await codeBrowser.moveExplorerRight();
+
+    // The Group remounts with the panels in the opposite order, so poll the
+    // geometry rather than reading it once.
+    await expect.poll(() => codeBrowser.explorerIsRightOfEditor()).toBe(true);
+    expect(await codeBrowser.readPersistedSide(WORKSPACE_A)).toBe("right");
+  });
+
+  test("the chosen side survives a full page reload", async ({ page }) => {
+    const workspace = new WorkspacePage(page, server.url, TOKEN);
+    const codeBrowser = new CodeBrowserPage(page, workspace);
+
+    await workspace.goto(WORKSPACE_A);
+    await workspace.waitForReady();
+    await codeBrowser.openFilesTab();
+    await codeBrowser.moveExplorerRight();
+    await expect.poll(() => codeBrowser.explorerIsRightOfEditor()).toBe(true);
+
+    await workspace.reload();
+    await workspace.waitForReady();
+    await codeBrowser.openFilesTab();
+
+    await expect.poll(() => codeBrowser.explorerIsRightOfEditor()).toBe(true);
+    expect(await codeBrowser.readPersistedSide(WORKSPACE_A)).toBe("right");
+  });
+
+  test("the side is per-workspace — moving it in one workspace leaves the other on the left", async ({
+    page,
+  }) => {
+    const workspace = new WorkspacePage(page, server.url, TOKEN);
+    const codeBrowser = new CodeBrowserPage(page, workspace);
+
+    await workspace.goto(WORKSPACE_A);
+    await workspace.waitForReady();
+    await codeBrowser.openFilesTab();
+    await codeBrowser.moveExplorerRight();
+    await expect.poll(() => codeBrowser.explorerIsRightOfEditor()).toBe(true);
+
+    // Workspace B has never been moved: it renders with the explorer on the
+    // left and has no persisted side of its own.
+    await workspace.goto(WORKSPACE_B);
+    await workspace.waitForReady();
+    await codeBrowser.openFilesTab();
+
+    await expect.poll(() => codeBrowser.explorerIsRightOfEditor()).toBe(false);
+    expect(await codeBrowser.readPersistedSide(WORKSPACE_B)).toBeNull();
+    // …and A's choice was not clobbered by the visit to B.
+    expect(await codeBrowser.readPersistedSide(WORKSPACE_A)).toBe("right");
+  });
+
+  test("moving between sides keeps the explorer's dragged width", async ({ page }) => {
+    const workspace = new WorkspacePage(page, server.url, TOKEN);
+    const codeBrowser = new CodeBrowserPage(page, workspace);
+
+    await workspace.goto(WORKSPACE_A);
+    await workspace.waitForReady();
+    await codeBrowser.openFilesTab();
+
+    // Drag the explorer to a width that is unmistakably not the 240 px default,
+    // so the assertions below can't pass just because both sides happen to fall
+    // back to the same default.
+    await codeBrowser.dragSeparatorBy(DRAG_DX);
+    await expect
+      .poll(() => codeBrowser.explorerWidth())
+      .toBeGreaterThan(DEFAULT_TREE_WIDTH_PX + DRAG_DX / 2);
+    const draggedWidth = await codeBrowser.explorerWidth();
+
+    // Move right: same width, opposite edge.
+    await codeBrowser.moveExplorerRight();
+    await expect.poll(() => codeBrowser.explorerIsRightOfEditor()).toBe(true);
+    expect(Math.abs((await codeBrowser.explorerWidth()) - draggedWidth)).toBeLessThanOrEqual(
+      WIDTH_TOLERANCE_PX,
+    );
+
+    // …and back to the left: still the same width.
+    await codeBrowser.moveExplorerLeft();
+    await expect.poll(() => codeBrowser.explorerIsRightOfEditor()).toBe(false);
+    expect(Math.abs((await codeBrowser.explorerWidth()) - draggedWidth)).toBeLessThanOrEqual(
+      WIDTH_TOLERANCE_PX,
+    );
+
+    // The dragged width — not the default — is what got persisted.
+    const persisted = await codeBrowser.readPersistedWidthPx(WORKSPACE_A);
+    expect(persisted).not.toBeNull();
+    expect(Math.abs((persisted as number) - draggedWidth)).toBeLessThanOrEqual(WIDTH_TOLERANCE_PX);
+  });
+});

--- a/apps/web/e2e/pages/CodeBrowserPage.ts
+++ b/apps/web/e2e/pages/CodeBrowserPage.ts
@@ -234,6 +234,22 @@ export class CodeBrowserPage {
     });
   }
 
+  /** Resize the browser window to `width` (keeping the current height) — a real
+   *  window resize, which is what drives a container-driven `onResize` of the
+   *  explorer panel (as opposed to a user-driven separator drag).
+   *
+   *  Callers that need the Group to stay mounted must keep the Files tab's own
+   *  container above CodeBrowserView's 600px mobile threshold; that container is
+   *  roughly half the width left over after the project sidebar, so a viewport
+   *  around 1700px still leaves it comfortably desktop. */
+  async setWindowWidth(width: number): Promise<void> {
+    await test.step(`Resize the window to ${width}px wide`, async () => {
+      const size = this.page.viewportSize();
+      if (!size) throw new Error("No viewport size — cannot resize");
+      await this.page.setViewportSize({ width, height: size.height });
+    });
+  }
+
   /** Force the `key={treeSide}` Group to REMOUNT without changing the docking
    *  side: narrow the window until the Files tab's own container drops under
    *  `CodeBrowserView`'s 600px threshold (the desktop Group unmounts in favour

--- a/apps/web/e2e/pages/CodeBrowserPage.ts
+++ b/apps/web/e2e/pages/CodeBrowserPage.ts
@@ -1,0 +1,192 @@
+/**
+ * Page object for the Files tab's two-panel code browser (`CodeBrowserView`):
+ * the explorer (file tree) column, the editor column, and the separator
+ * between them.
+ *
+ * It owns the two behaviours the specs drive:
+ *
+ *   - **Docking side** — the "Files" toolbar's right-click context menu moves
+ *     the explorer to the left or right edge of the tab
+ *     (`band-file-tree-side:<workspaceId>`).
+ *   - **Width** — the explorer is a fixed-*pixel* column
+ *     (`band-file-tree-width-px:<workspaceId>`), so it must survive container
+ *     resizes (maximize / restore) and side flips unchanged.
+ *
+ * Locators:
+ *
+ *   - `file-tree__toolbar`, `file-tree__move-left`, `file-tree__move-right` are
+ *     BEM `data-testid`s we set in `CodeBrowserView.tsx`.
+ *   - `file-tree`, `file-viewer` and `file-tree-separator` are the panel /
+ *     separator elements. react-resizable-panels renders each element's `id`
+ *     prop onto BOTH `id` and `data-testid`, so those testids come straight
+ *     from the `<Panel id="file-tree">` / `<Panel id="file-viewer">` /
+ *     `<Separator id="file-tree-separator">` declarations in the same file —
+ *     a library-provided test hook, addressed by testid rather than by a CSS
+ *     or `#id` selector.
+ *
+ * This is a SECONDARY page object (same shape as `FileTreesPage`): it owns no
+ * routes and constructs no URLs, so it takes a `WorkspacePage` and delegates
+ * navigation, tab activation and maximize/restore to it.
+ */
+
+import { type Locator, type Page, test } from "@playwright/test";
+import type { WorkspacePage } from "./WorkspacePage";
+
+/** localStorage keys written by `CodeBrowserView` (mirrors `fileTreeSideKey` /
+ *  `fileTreeWidthKey` in the source — duplicated here rather than imported, so
+ *  a rename in production has to be a conscious change on both sides). */
+const SIDE_KEY_PREFIX = "band-file-tree-side:";
+const WIDTH_PX_KEY_PREFIX = "band-file-tree-width-px:";
+
+export class CodeBrowserPage {
+  constructor(
+    private readonly page: Page,
+    private readonly workspace: WorkspacePage,
+  ) {}
+
+  /** The "Files" header row of the explorer — the context-menu trigger for the
+   *  move-explorer actions. */
+  get toolbar(): Locator {
+    return this.page.getByTestId("file-tree__toolbar");
+  }
+
+  get moveLeftMenuItem(): Locator {
+    return this.page.getByTestId("file-tree__move-left");
+  }
+
+  get moveRightMenuItem(): Locator {
+    return this.page.getByTestId("file-tree__move-right");
+  }
+
+  /** The explorer panel (`<Panel id="file-tree">`). */
+  get explorerPanel(): Locator {
+    return this.page.getByTestId("file-tree");
+  }
+
+  /** The editor panel (`<Panel id="file-viewer">`). */
+  get editorPanel(): Locator {
+    return this.page.getByTestId("file-viewer");
+  }
+
+  /** The drag handle between them (`<Separator id="file-tree-separator">`). */
+  get separator(): Locator {
+    return this.page.getByTestId("file-tree-separator");
+  }
+
+  /** Activate the outer Files tab and wait for the desktop side-by-side layout
+   *  to mount. Anchors on the explorer's toolbar rather than a tree row so the
+   *  helper doesn't depend on the seeded project's contents. */
+  async openFilesTab(): Promise<void> {
+    await test.step("Open the Files tab", async () => {
+      await this.workspace.activateTab("files");
+      await this.toolbar.waitFor({ state: "visible", timeout: 15_000 });
+      await this.explorerPanel.waitFor({ state: "visible", timeout: 15_000 });
+    });
+  }
+
+  /** Bounding box of the explorer panel. Throws rather than returning null so
+   *  callers get a useful failure instead of a confusing `undefined` compare. */
+  async explorerBox(): Promise<{ x: number; width: number }> {
+    const box = await this.explorerPanel.boundingBox();
+    if (!box) throw new Error("Explorer panel has no bounding box (not rendered?)");
+    return { x: box.x, width: box.width };
+  }
+
+  /** Bounding box of the editor panel. */
+  async editorBox(): Promise<{ x: number; width: number }> {
+    const box = await this.editorPanel.boundingBox();
+    if (!box) throw new Error("Editor panel has no bounding box (not rendered?)");
+    return { x: box.x, width: box.width };
+  }
+
+  async explorerWidth(): Promise<number> {
+    return (await this.explorerBox()).width;
+  }
+
+  async editorWidth(): Promise<number> {
+    return (await this.editorBox()).width;
+  }
+
+  /** Whether the explorer currently sits to the RIGHT of the editor. The
+   *  geometric, user-observable signal for the docking side: the Group renders
+   *  its children in DOM order (tree, separator, viewer — or the reverse), so
+   *  the panels' `x` offsets are what the user actually sees. */
+  async explorerIsRightOfEditor(): Promise<boolean> {
+    const [explorer, editor] = await Promise.all([this.explorerBox(), this.editorBox()]);
+    return explorer.x > editor.x;
+  }
+
+  /** Right-click the "Files" toolbar and dock the explorer to `side`. Drives
+   *  the exact surface the user does: the Radix context menu on the toolbar. */
+  async moveExplorer(side: "left" | "right"): Promise<void> {
+    await test.step(`Move the explorer to the ${side}`, async () => {
+      await this.toolbar.click({ button: "right" });
+      const item = side === "left" ? this.moveLeftMenuItem : this.moveRightMenuItem;
+      await item.waitFor({ state: "visible" });
+      await item.click();
+      // The Group is keyed on the side, so it fully remounts. Waiting for the
+      // menu to leave the DOM keeps a back-to-back move from clicking a portal
+      // that is still fading out.
+      await item.waitFor({ state: "hidden" });
+      await this.explorerPanel.waitFor({ state: "visible" });
+    });
+  }
+
+  async moveExplorerRight(): Promise<void> {
+    await this.moveExplorer("right");
+  }
+
+  async moveExplorerLeft(): Promise<void> {
+    await this.moveExplorer("left");
+  }
+
+  /** Drag the separator horizontally by `dx` CSS px — a real mouse press /
+   *  move / release, so it goes through react-resizable-panels' pointer
+   *  resize path exactly as a user's drag does. */
+  async dragSeparatorBy(dx: number): Promise<void> {
+    await test.step(`Drag the explorer separator by ${dx}px`, async () => {
+      const box = await this.separator.boundingBox();
+      if (!box) throw new Error("Separator has no bounding box (not rendered?)");
+      const y = box.y + box.height / 2;
+      const startX = box.x + box.width / 2;
+      await this.page.mouse.move(startX, y);
+      await this.page.mouse.down();
+      // Intermediate steps: the resize handler tracks pointermove, and a single
+      // jump can be coalesced or land outside the drag threshold.
+      await this.page.mouse.move(startX + dx / 2, y, { steps: 5 });
+      await this.page.mouse.move(startX + dx, y, { steps: 5 });
+      await this.page.mouse.up();
+    });
+  }
+
+  /** Maximize the outer dockview group that hosts the Files tab — the
+   *  container-widening event the fixed-pixel width has to survive. */
+  async maximizeFilesGroup(): Promise<void> {
+    await this.workspace.maximizeGroupContaining("files");
+  }
+
+  /** Exit maximize (delegates to the shared header Restore button). */
+  async restoreFilesGroup(): Promise<void> {
+    await this.workspace.restorePanel();
+  }
+
+  /** The persisted docking side. `null` when nothing has been written yet
+   *  (production then defaults to "left"). */
+  async readPersistedSide(workspaceId: string): Promise<string | null> {
+    return await this.page.evaluate(([prefix, id]) => localStorage.getItem(`${prefix}${id}`), [
+      SIDE_KEY_PREFIX,
+      workspaceId,
+    ] as const);
+  }
+
+  /** The persisted explorer width in px. `null` when nothing has been written
+   *  yet. Returned as a number so specs can compare it against a measured
+   *  bounding box. */
+  async readPersistedWidthPx(workspaceId: string): Promise<number | null> {
+    const raw = await this.page.evaluate(([prefix, id]) => localStorage.getItem(`${prefix}${id}`), [
+      WIDTH_PX_KEY_PREFIX,
+      workspaceId,
+    ] as const);
+    return raw === null ? null : Number(raw);
+  }
+}

--- a/apps/web/e2e/pages/CodeBrowserPage.ts
+++ b/apps/web/e2e/pages/CodeBrowserPage.ts
@@ -37,6 +37,11 @@ import type { WorkspacePage } from "./WorkspacePage";
  *  a rename in production has to be a conscious change on both sides). */
 const SIDE_KEY_PREFIX = "band-file-tree-side:";
 const WIDTH_PX_KEY_PREFIX = "band-file-tree-width-px:";
+const COLLAPSED_KEY_PREFIX = "band-file-tree-collapsed:";
+/** The key the width used to live under, holding PERCENTAGES. Production
+ *  deliberately moved to the `-px` key so an old "15" (15%) can't be restored as
+ *  a 15px explorer; the legacy-key scenario seeds this one. */
+const LEGACY_WIDTH_KEY_PREFIX = "band-file-tree-width:";
 
 export class CodeBrowserPage {
   constructor(
@@ -73,23 +78,46 @@ export class CodeBrowserPage {
     return this.page.getByTestId("file-tree-separator");
   }
 
+  /** The collapse/expand chevron that sits on the separator. It carries no
+   *  text — it's the only button inside the separator, so a name-less
+   *  `getByRole` scoped to that container resolves it (and is immune to the
+   *  chevron flipping direction with the docking side). */
+  get collapseToggle(): Locator {
+    return this.separator.getByRole("button");
+  }
+
   /** Activate the outer Files tab and wait for the desktop side-by-side layout
-   *  to mount. Anchors on the explorer's toolbar rather than a tree row so the
-   *  helper doesn't depend on the seeded project's contents. */
+   *  to mount. Anchors on the EDITOR panel, which is present whether or not the
+   *  explorer is collapsed — a collapsed explorer is laid out at 0px, i.e.
+   *  "hidden" as far as Playwright is concerned, so anchoring on it would hang
+   *  exactly in the tests that reload with the explorer collapsed. */
   async openFilesTab(): Promise<void> {
     await test.step("Open the Files tab", async () => {
       await this.workspace.activateTab("files");
-      await this.toolbar.waitFor({ state: "visible", timeout: 15_000 });
-      await this.explorerPanel.waitFor({ state: "visible", timeout: 15_000 });
+      await this.editorPanel.waitFor({ state: "visible", timeout: 15_000 });
     });
   }
 
-  /** Bounding box of the explorer panel. Throws rather than returning null so
-   *  callers get a useful failure instead of a confusing `undefined` compare. */
+  /** Bounding box of the explorer panel. Waits for it to be laid out first, so
+   *  callers measuring right after a mount / remount don't race the layout. */
   async explorerBox(): Promise<{ x: number; width: number }> {
+    await this.explorerPanel.waitFor({ state: "visible", timeout: 15_000 });
     const box = await this.explorerPanel.boundingBox();
     if (!box) throw new Error("Explorer panel has no bounding box (not rendered?)");
     return { x: box.x, width: box.width };
+  }
+
+  /** The explorer's width WITHOUT waiting for it to be visible — 0 when the
+   *  panel is collapsed (`collapsedSize="0%"`, so it stays in the DOM at zero
+   *  width). The counterpart of `explorerBox()` for collapse assertions. */
+  async explorerWidthOrZero(): Promise<number> {
+    const box = await this.explorerPanel.boundingBox();
+    return box?.width ?? 0;
+  }
+
+  /** Whether the explorer is currently collapsed (laid out at zero width). */
+  async isExplorerCollapsed(): Promise<boolean> {
+    return (await this.explorerWidthOrZero()) < 1;
   }
 
   /** Bounding box of the editor panel. */
@@ -116,6 +144,17 @@ export class CodeBrowserPage {
     return explorer.x > editor.x;
   }
 
+  /** Where the SEPARATOR sits relative to the editor. Same signal as
+   *  `explorerIsRightOfEditor`, but it still works when the explorer is
+   *  collapsed to 0px and therefore has no bounding box at all — which is the
+   *  only way to prove the `key={treeSide}` remount re-ordered the panels while
+   *  the explorer stays collapsed. */
+  async separatorIsRightOfEditor(): Promise<boolean> {
+    const sep = await this.separator.boundingBox();
+    if (!sep) throw new Error("Separator has no bounding box (not rendered?)");
+    return sep.x > (await this.editorBox()).x;
+  }
+
   /** Right-click the "Files" toolbar and dock the explorer to `side`. Drives
    *  the exact surface the user does: the Radix context menu on the toolbar. */
   async moveExplorer(side: "left" | "right"): Promise<void> {
@@ -126,9 +165,10 @@ export class CodeBrowserPage {
       await item.click();
       // The Group is keyed on the side, so it fully remounts. Waiting for the
       // menu to leave the DOM keeps a back-to-back move from clicking a portal
-      // that is still fading out.
+      // that is still fading out. Anchor the remount on the editor panel, not
+      // the explorer — the explorer has no box while collapsed.
       await item.waitFor({ state: "hidden" });
-      await this.explorerPanel.waitFor({ state: "visible" });
+      await this.editorPanel.waitFor({ state: "visible" });
     });
   }
 
@@ -147,7 +187,11 @@ export class CodeBrowserPage {
     await test.step(`Drag the explorer separator by ${dx}px`, async () => {
       const box = await this.separator.boundingBox();
       if (!box) throw new Error("Separator has no bounding box (not rendered?)");
-      const y = box.y + box.height / 2;
+      // Grab the separator BELOW its midpoint: the 28px collapse chevron is
+      // absolutely positioned at the centre with `z-10` and is revealed by the
+      // hover that `mouse.move` itself triggers, so pressing at the exact centre
+      // presses the button, not the handle.
+      const y = box.y + box.height * 0.85;
       const startX = box.x + box.width / 2;
       await this.page.mouse.move(startX, y);
       await this.page.mouse.down();
@@ -156,6 +200,63 @@ export class CodeBrowserPage {
       await this.page.mouse.move(startX + dx / 2, y, { steps: 5 });
       await this.page.mouse.move(startX + dx, y, { steps: 5 });
       await this.page.mouse.up();
+    });
+  }
+
+  /** The FileTabBar's "Show / Hide File Explorer" button (`data-testid` set in
+   *  `FileTabBar.tsx`). Rendered whenever at least one editor tab is open — it
+   *  is the affordance the user has for RE-opening a collapsed explorer, which
+   *  is why `CodeBrowserView` auto-expands the tree when the last tab closes. */
+  get tabBarTreeToggle(): Locator {
+    return this.page.getByTestId("file-tab-bar__tree-toggle");
+  }
+
+  /** Collapse / expand the explorer through the tab bar's tree-toggle button.
+   *
+   *  This — not the separator chevron — is the toggle the specs drive, because
+   *  the chevron is unreachable once the explorer IS collapsed: the panel
+   *  shrinks to 0px, the chevron lands on the Files group's outer edge, and
+   *  dockview's own `.dv-sash` (the handle between the two dockview groups)
+   *  sits on top of it and swallows the click. Verified in Chromium — Playwright
+   *  reports `<div class="dv-sash dv-enabled"> … intercepts pointer events`. */
+  async toggleExplorerCollapsed(): Promise<void> {
+    await test.step("Toggle the explorer via the tab bar's tree-toggle button", async () => {
+      await this.tabBarTreeToggle.click();
+    });
+  }
+
+  /** Collapse the explorer via the separator's chevron — the OTHER affordance,
+   *  covered so the chevron's collapse direction doesn't rot. Only valid while
+   *  the explorer is expanded (see `toggleExplorerCollapsed`). */
+  async collapseExplorerViaSeparatorChevron(): Promise<void> {
+    await test.step("Collapse the explorer via the separator chevron", async () => {
+      await this.collapseToggle.click();
+    });
+  }
+
+  /** Force the `key={treeSide}` Group to REMOUNT without changing the docking
+   *  side: narrow the window until the Files tab's own container drops under
+   *  `CodeBrowserView`'s 600px threshold (the desktop Group unmounts in favour
+   *  of the mobile single-column layout), then restore it.
+   *
+   *  This is the remount path the specs can actually drive while the explorer is
+   *  COLLAPSED. The other one — flipping the docking side — is unreachable in
+   *  that state: its context-menu trigger is the "Files" toolbar, which lives
+   *  *inside* the 0px-wide collapsed panel and can't be right-clicked.
+   *
+   *  1100px keeps the workspace in its desktop layout (`useIsDesktop()` is
+   *  ≥1024) while squeezing the Files group itself below 600px, so only the
+   *  CodeBrowserView Group remounts — the dockview around it stays put. */
+  async remountGroupViaWindowResize(): Promise<void> {
+    await test.step("Remount the explorer Group by narrowing and restoring the window", async () => {
+      const size = this.page.viewportSize();
+      if (!size) throw new Error("No viewport size — cannot resize");
+      await this.page.setViewportSize({ width: 1100, height: size.height });
+      // The mobile branch renders no `Panel`s at all: the editor panel leaving
+      // the DOM is the proof the Group actually unmounted.
+      await this.editorPanel.waitFor({ state: "detached", timeout: 15_000 });
+      await this.page.setViewportSize(size);
+      await this.editorPanel.waitFor({ state: "visible", timeout: 15_000 });
     });
   }
 
@@ -188,5 +289,27 @@ export class CodeBrowserPage {
       workspaceId,
     ] as const);
     return raw === null ? null : Number(raw);
+  }
+
+  /** The persisted collapsed flag. `null` when nothing has been written yet
+   *  (production then defaults to expanded). */
+  async readPersistedCollapsed(workspaceId: string): Promise<string | null> {
+    return await this.page.evaluate(([prefix, id]) => localStorage.getItem(`${prefix}${id}`), [
+      COLLAPSED_KEY_PREFIX,
+      workspaceId,
+    ] as const);
+  }
+
+  /** Seed the LEGACY width key (`band-file-tree-width:<wsId>`, whose values were
+   *  PERCENTAGES) before the app mounts. Uses `addInitScript`, so it MUST be
+   *  called before `goto`. Exists to prove the deliberate key rename: a stored
+   *  "15" (meaning 15%) must not come back as a 15px explorer. */
+  async seedLegacyWidthValue(workspaceId: string, value: string): Promise<void> {
+    await this.page.addInitScript(
+      ([prefix, id, v]) => {
+        localStorage.setItem(`${prefix}${id}`, v);
+      },
+      [LEGACY_WIDTH_KEY_PREFIX, workspaceId, value] as const,
+    );
   }
 }

--- a/apps/web/e2e/pages/WorkspacePage.ts
+++ b/apps/web/e2e/pages/WorkspacePage.ts
@@ -1176,6 +1176,31 @@ export class WorkspacePage {
     });
   }
 
+  /** The outer dockview group shell (`.dv-groupview`) that currently hosts the
+   *  named outer tab. dockview owns this markup — we don't render it — so, as
+   *  with `tabContainer`'s `.dv-tab` wrapper, anchoring on our own
+   *  `workspace__tab--*` testid and walking up to the library's shell via
+   *  `:has(...)` is the only way to address a specific group. Nested (inner)
+   *  dockviews render their own `.dv-groupview`s but never carry
+   *  `workspace__tab--*` testids, so this stays scoped to the outer layout. */
+  groupContaining(panelComponent: "chat" | "changes" | "files" | "terminal" | "browser"): Locator {
+    return this.page.locator(
+      `.dv-groupview:has([data-testid="workspace__tab--${panelComponent}"])`,
+    );
+  }
+
+  /** Maximize the outer group that hosts the named tab (rather than the Nth
+   *  group, which depends on the default layout's ordering). Each center group
+   *  renders exactly one Maximize/Restore toggle in its right header actions
+   *  (`MainGroupRightActions` in `SharedDockviewLayout.tsx`). */
+  async maximizeGroupContaining(
+    panelComponent: "chat" | "changes" | "files" | "terminal" | "browser",
+  ): Promise<void> {
+    await test.step(`Maximize the group hosting the ${panelComponent} tab`, async () => {
+      await this.groupContaining(panelComponent).getByRole("button", { name: "Maximize" }).click();
+    });
+  }
+
   /** Click the Nth Maximize button (0-indexed). Useful when the layout
    *  has multiple groups and the test wants to target a specific one. */
   async maximizePanel(index = 0): Promise<void> {

--- a/apps/web/src/components/CodeBrowserView.tsx
+++ b/apps/web/src/components/CodeBrowserView.tsx
@@ -103,6 +103,15 @@ export type FileTreeSide = "left" | "right";
 /** Fallback when nothing is persisted — also the `defaultSize` for a fresh workspace. */
 const DEFAULT_FILE_TREE_WIDTH_PX = 240; // 15rem
 
+/**
+ * The explorer's size constraints. These back the Panel's `minSize` / `maxSize`
+ * props *and* the clamp arithmetic in the resize handler, which has to know the
+ * bounds the layout engine is enforcing in order to tell "the user chose this
+ * width" apart from "the container squeezed us to this width".
+ */
+const MIN_FILE_TREE_WIDTH_PX = 160; // 10rem
+const MAX_FILE_TREE_WIDTH_RATIO = 0.5; // half the group
+
 /** Trailing debounce on the width write — see the tree Panel's `onResize`. */
 const WIDTH_PERSIST_DEBOUNCE_MS = 200;
 
@@ -2023,6 +2032,66 @@ export function CodeBrowserView({
     };
   }, [workspaceId]);
 
+  // Width of the group at the last `onResize`, used to tell the two kinds of
+  // resize apart, and a flag marking the resizes we asked for ourselves.
+  const groupWidthRef = useRef(0);
+  const selfResizeRef = useRef(false);
+
+  const handleTreeResize = useCallback(
+    (size: { asPercentage: number; inPixels: number }) => {
+      const collapsed = size.asPercentage === 0;
+
+      // `onResize` fires on every pointermove of a drag, so only touch React and
+      // localStorage when collapsed-ness actually flipped.
+      if (collapsed !== collapsedRef.current) {
+        collapsedRef.current = collapsed;
+        setTreeCollapsed(collapsed);
+        saveFileTreeCollapsed(workspaceId, collapsed);
+      }
+
+      // A collapsed panel reports 0, which is not a width the user chose.
+      // Skipping it — rather than clearing anything — is what lets a
+      // drag-then-collapse keep the width the drag just set.
+      if (collapsed) return;
+
+      const groupWidth = size.inPixels / (size.asPercentage / 100);
+      const groupResized = Math.abs(groupWidth - groupWidthRef.current) > 1;
+      groupWidthRef.current = groupWidth;
+
+      // A resize we requested below. Its result tells us nothing about what the
+      // user wants — swallow it, or a clamped restore would overwrite the very
+      // width it was trying to restore.
+      if (selfResizeRef.current) {
+        selfResizeRef.current = false;
+        return;
+      }
+
+      if (!groupResized) {
+        // The group is the same size, so nothing but the user can have moved the
+        // panel (separator drag, or keyboard resize). This is a chosen width.
+        treeWidthRef.current = size.inPixels;
+        scheduleWidthPersist();
+        return;
+      }
+
+      // The group changed size. `preserve-pixel-size` normally holds the
+      // explorer's width through that — but `maxSize` still binds, so narrowing
+      // the tab far enough squeezes the explorer below the chosen width. Left
+      // alone, the layout engine has no memory of the width it took away, so
+      // widening back would strand the explorer at the squeezed size and the
+      // next persist would make that the user's width. Take it back instead,
+      // as far as there is now room for.
+      const maxWidth = groupWidth * MAX_FILE_TREE_WIDTH_RATIO;
+      if (maxWidth < MIN_FILE_TREE_WIDTH_PX) return; // no room to honour either bound
+      const target = Math.min(treeWidthRef.current, maxWidth);
+      if (Math.abs(size.inPixels - target) > 1) {
+        selfResizeRef.current = true;
+        treePanelRef.current?.resize(`${target}px`);
+      }
+    },
+    [workspaceId, treePanelRef, scheduleWidthPersist],
+  );
+
   const handleSetTreeSide = useCallback(
     (side: FileTreeSide) => {
       // The Group remount tears down CodeMirror, and the editor's state is only
@@ -2088,8 +2157,8 @@ export function CodeBrowserView({
       key="file-tree"
       id="file-tree"
       defaultSize={`${treeWidthRef.current}px`}
-      minSize="10rem"
-      maxSize="50%"
+      minSize={`${MIN_FILE_TREE_WIDTH_PX}px`}
+      maxSize={`${MAX_FILE_TREE_WIDTH_RATIO * 100}%`}
       // Hold the explorer's pixel width when the Files tab itself is resized —
       // maximize/restore, window resize, project-sidebar collapse. The editor
       // panel keeps the default `preserve-relative-size` and absorbs the delta;
@@ -2098,26 +2167,7 @@ export function CodeBrowserView({
       collapsible
       collapsedSize="0%"
       panelRef={treePanelRef}
-      onResize={(size) => {
-        const collapsed = size.asPercentage === 0;
-
-        // Remember the width the explorer expands *back* to. A collapsed panel
-        // reports 0, which is not a width the user chose — skipping it (rather
-        // than clearing anything) is what lets a drag-then-collapse keep the
-        // width the drag just set.
-        if (!collapsed && size.inPixels > 0) {
-          treeWidthRef.current = size.inPixels;
-          scheduleWidthPersist();
-        }
-
-        // `onResize` fires on every pointermove of a drag, so only touch React
-        // and localStorage when collapsed-ness actually flipped.
-        if (collapsed !== collapsedRef.current) {
-          collapsedRef.current = collapsed;
-          setTreeCollapsed(collapsed);
-          saveFileTreeCollapsed(workspaceId, collapsed);
-        }
-      }}
+      onResize={handleTreeResize}
     >
       <div
         className={`flex h-full flex-col overflow-hidden border-border ${

--- a/apps/web/src/components/CodeBrowserView.tsx
+++ b/apps/web/src/components/CodeBrowserView.tsx
@@ -1,4 +1,8 @@
 import {
+  ContextMenu,
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuTrigger,
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
@@ -10,6 +14,7 @@ import {
 } from "@band-app/ui";
 import type { Extension } from "@codemirror/state";
 import {
+  Check,
   ChevronLeft,
   ChevronRight,
   Code,
@@ -19,6 +24,8 @@ import {
   FilePlus,
   FolderPlus,
   MoreVertical,
+  PanelLeft,
+  PanelRight,
   Search,
   TextSearch,
 } from "lucide-react";
@@ -68,7 +75,7 @@ import type { MarkdownPreviewHandle, MarkdownPreviewMatchInfo } from "./Markdown
 import { MarkdownPreview } from "./MarkdownPreview";
 
 // ---------------------------------------------------------------------------
-// File tree width persistence
+// File tree width / side persistence
 // ---------------------------------------------------------------------------
 // The width is stored in **pixels**, not as a percentage of the group. The
 // explorer is a fixed-width chrome column (VS Code's Primary Side Bar model):
@@ -86,6 +93,12 @@ function fileTreeWidthKey(wsId: string): string {
 function fileTreeCollapsedKey(wsId: string): string {
   return `band-file-tree-collapsed:${wsId}`;
 }
+
+function fileTreeSideKey(wsId: string): string {
+  return `band-file-tree-side:${wsId}`;
+}
+
+export type FileTreeSide = "left" | "right";
 
 /** Fallback when nothing is persisted — also the `defaultSize` for a fresh workspace. */
 const DEFAULT_FILE_TREE_WIDTH_PX = 240; // 15rem
@@ -120,6 +133,22 @@ function loadFileTreeCollapsed(wsId: string): boolean {
 function saveFileTreeCollapsed(wsId: string, collapsed: boolean): void {
   try {
     localStorage.setItem(fileTreeCollapsedKey(wsId), String(collapsed));
+  } catch {
+    // storage unavailable
+  }
+}
+
+function loadFileTreeSide(wsId: string): FileTreeSide {
+  try {
+    return localStorage.getItem(fileTreeSideKey(wsId)) === "right" ? "right" : "left";
+  } catch {
+    return "left";
+  }
+}
+
+function saveFileTreeSide(wsId: string, side: FileTreeSide): void {
+  try {
+    localStorage.setItem(fileTreeSideKey(wsId), side);
   } catch {
     // storage unavailable
   }
@@ -169,6 +198,15 @@ interface FileTreeToolbarProps {
    * the user actually saves (`capabilities.pickSaveFile`).
    */
   onNewUntitled?: () => void;
+  /**
+   * Which edge of the Files tab the explorer is docked to. Undefined on the
+   * mobile layout, where the tree and the editor are separate full-width
+   * views and "side" is meaningless — the toolbar then omits the
+   * move-explorer context menu entirely.
+   */
+  side?: FileTreeSide;
+  /** Dock the explorer to the given edge. Paired with `side`. */
+  onSetSide?: (side: FileTreeSide) => void;
 }
 
 // Below this width (px), the toolbar collapses its action buttons into a
@@ -208,6 +246,8 @@ function FileTreeToolbar({
   onNewFolder,
   onOpenFile,
   onNewUntitled,
+  side,
+  onSetSide,
 }: FileTreeToolbarProps) {
   const rootRef = useRef<HTMLDivElement>(null);
   const [compact, setCompact] = useState(false);
@@ -254,7 +294,7 @@ function FileTreeToolbar({
     fn?.();
   }, []);
 
-  return (
+  const header = (
     <div
       ref={rootRef}
       data-testid="file-tree__toolbar"
@@ -428,6 +468,26 @@ function FileTreeToolbar({
         </>
       )}
     </div>
+  );
+
+  if (!side || !onSetSide) return header;
+
+  return (
+    <ContextMenu>
+      <ContextMenuTrigger asChild>{header}</ContextMenuTrigger>
+      <ContextMenuContent className="min-w-[12rem]">
+        <ContextMenuItem data-testid="file-tree__move-left" onSelect={() => onSetSide("left")}>
+          <PanelLeft className="size-4" />
+          Explorer on Left
+          {side === "left" && <Check className="ml-auto size-4" />}
+        </ContextMenuItem>
+        <ContextMenuItem data-testid="file-tree__move-right" onSelect={() => onSetSide("right")}>
+          <PanelRight className="size-4" />
+          Explorer on Right
+          {side === "right" && <Check className="ml-auto size-4" />}
+        </ContextMenuItem>
+      </ContextMenuContent>
+    </ContextMenu>
   );
 }
 
@@ -1884,20 +1944,24 @@ export function CodeBrowserView({
   // -------------------------------------------------------------------------
   const treePanelRef = usePanelRef();
   const [treeCollapsed, setTreeCollapsed] = useState(() => loadFileTreeCollapsed(workspaceId));
+  const [treeSide, setTreeSide] = useState<FileTreeSide>(() => loadFileTreeSide(workspaceId));
   const [treeWidthPx, setTreeWidthPx] = useState(
     () => loadFileTreeWidth(workspaceId) ?? DEFAULT_FILE_TREE_WIDTH_PX,
   );
 
-  // The Group remounts whenever the layout crosses the mobile/desktop
-  // threshold, so `defaultSize` and the collapsed state are re-seeded from live
-  // state rather than read once at first mount.
+  // Switching sides remounts the Group (see `key={treeSide}` below), because
+  // react-resizable-panels orders its panels by `offsetLeft` at *registration*
+  // time — reordering the children in place would leave it with a stale order.
+  // A remount means `defaultSize` / collapsed have to be re-seeded from live
+  // state rather than read once at first mount, which is what the two hooks
+  // below do.
   //
   // `hydratedTreeRef` guards the persistence writes in `onResize` against the
-  // panel's own mount-time callback, which always reports the panel expanded at
-  // its `defaultSize` — without the guard, remounting a collapsed explorer would
-  // immediately persist `collapsed = false`.
+  // panel's own mount-time callback, which always reports the panel expanded
+  // at its `defaultSize` — without the guard, remounting a collapsed explorer
+  // would immediately persist `collapsed = false`.
   const hydratedTreeRef = useRef(false);
-  // biome-ignore lint/correctness/useExhaustiveDependencies: `useMobileLayout` is a trigger, not an input — it is what mounts or remounts the Group, and this effect re-seeds the fresh panel. `treeCollapsed` is read but deliberately not a dependency: this is a re-seed, not a controlled-collapse effect.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: `treeSide` and `useMobileLayout` are triggers, not inputs — they are what mount or remount the Group, and this effect re-seeds the fresh panel. `treeCollapsed` is read but deliberately not a dependency: this is a re-seed, not a controlled-collapse effect.
   useLayoutEffect(() => {
     hydratedTreeRef.current = false;
     // Restore collapsed imperatively rather than mounting the panel at size 0:
@@ -1906,7 +1970,7 @@ export function CodeBrowserView({
     // even split instead of the width the user dragged.
     if (treeCollapsed) treePanelRef.current?.collapse();
     hydratedTreeRef.current = true;
-  }, [useMobileLayout, treePanelRef]);
+  }, [treeSide, useMobileLayout, treePanelRef]);
 
   // `onLayoutChanged` fires *before* the browser applies the new layout, and
   // `getSize()` is a live `offsetWidth` read. Measuring synchronously here
@@ -1940,6 +2004,24 @@ export function CodeBrowserView({
     };
   }, []);
 
+  const handleSetTreeSide = useCallback(
+    (side: FileTreeSide) => {
+      // Capture the explorer's live width before the Group remounts. Moving
+      // sides must not resize the explorer, and `treeWidthPx` — which seeds the
+      // remounted panel's `defaultSize` — otherwise only refreshes on
+      // `onLayoutChanged`. Reading the panel directly means the width the user
+      // is looking at is exactly the width that comes back on the other side.
+      const size = treePanelRef.current?.getSize();
+      if (size && size.inPixels > 0) {
+        setTreeWidthPx(size.inPixels);
+        saveFileTreeWidth(workspaceId, size.inPixels);
+      }
+      setTreeSide(side);
+      saveFileTreeSide(workspaceId, side);
+    },
+    [workspaceId, treePanelRef],
+  );
+
   const toggleTree = useCallback(() => {
     const panel = treePanelRef.current;
     if (!panel) return;
@@ -1972,6 +2054,84 @@ export function CodeBrowserView({
       treePanelRef.current?.expand();
     }
   }, [fileTabs.openTabs.length, treeCollapsed, treePanelRef]);
+
+  // The explorer panel and its separator are hoisted out of the JSX below so
+  // they can be rendered on either side of the editor panel without
+  // duplicating them.
+  const treePanelEl = (
+    <Panel
+      key="file-tree"
+      id="file-tree"
+      defaultSize={`${treeWidthPx}px`}
+      minSize="10rem"
+      maxSize="50%"
+      // Hold the explorer's pixel width when the Files tab itself is resized —
+      // maximize/restore, window resize, project-sidebar collapse. The editor
+      // panel keeps the default `preserve-relative-size` and absorbs the delta;
+      // a group needs at least one relative-size panel.
+      groupResizeBehavior="preserve-pixel-size"
+      collapsible
+      collapsedSize="0%"
+      panelRef={treePanelRef}
+      onResize={(size) => {
+        const collapsed = size.asPercentage === 0;
+        setTreeCollapsed(collapsed);
+        if (hydratedTreeRef.current) saveFileTreeCollapsed(workspaceId, collapsed);
+      }}
+    >
+      <div
+        className={`flex h-full flex-col overflow-hidden border-border ${
+          treeSide === "left" ? "border-r" : "border-l"
+        }`}
+      >
+        <FileTreeToolbar
+          onNewFile={handleNewFile}
+          onNewFolder={handleNewFolder}
+          onOpenFile={pickFile ? handleOpenExternalFile : undefined}
+          onNewUntitled={handleNewUntitled}
+          side={treeSide}
+          onSetSide={handleSetTreeSide}
+        />
+        <div className="min-h-0 flex-1 overflow-hidden">
+          <FileBrowser
+            ref={fileBrowserRef}
+            workspaceId={workspaceId}
+            workspacePath={workspacePath}
+            onOpenFile={handleSelectFile}
+            onOpenFilePinned={handleSelectFilePinned}
+            compact
+            selectedFile={viewFilePath}
+            onPathRenamed={handlePathRenamed}
+            onPathDeleted={handlePathDeleted}
+          />
+        </div>
+      </div>
+    </Panel>
+  );
+
+  // The chevron points the way the explorer would travel: toward its own edge
+  // to collapse, back toward the editor to expand.
+  const pointsLeft = treeSide === "left" ? !treeCollapsed : treeCollapsed;
+  const separatorEl = (
+    <Separator
+      key="file-tree-separator"
+      // react-resizable-panels renders `id` onto BOTH the element's `id` and
+      // its `data-testid` (same as the `file-tree` / `file-viewer` panels
+      // above), which is the only stable hook e2e tests have for grabbing this
+      // separator — the workspace shell renders other `role="separator"`
+      // elements (the project sidebar's), so role alone is ambiguous.
+      id="file-tree-separator"
+      className="group relative w-[3px] bg-transparent hover:bg-accent-foreground/20 active:bg-accent-foreground/30 transition-colors cursor-col-resize"
+    >
+      <button
+        type="button"
+        onClick={toggleTree}
+        className="absolute top-1/2 left-1/2 z-10 flex size-7 -translate-x-1/2 -translate-y-1/2 items-center justify-center rounded-full border-2 border-accent-foreground/30 bg-background text-muted-foreground opacity-0 shadow-md transition-opacity hover:border-accent-foreground/50 hover:text-foreground group-hover:opacity-100"
+      >
+        {pointsLeft ? <ChevronLeft className="size-4" /> : <ChevronRight className="size-4" />}
+      </button>
+    </Separator>
+  );
 
   // -------------------------------------------------------------------------
   // Render — mobile toggle layout or desktop side-by-side layout
@@ -2080,71 +2240,17 @@ export function CodeBrowserView({
           </div>
         )
       ) : (
-        // Desktop: side-by-side layout with resizable file tree
-        <Group orientation="horizontal" onLayoutChanged={handleLayoutChanged}>
-          {/* Left panel — file tree */}
-          <Panel
-            id="file-tree"
-            defaultSize={`${treeWidthPx}px`}
-            minSize="10rem"
-            maxSize="50%"
-            // Hold the explorer's pixel width when the Files tab itself is
-            // resized — maximize/restore, window resize, project-sidebar
-            // collapse. The editor panel keeps the default
-            // `preserve-relative-size` and absorbs the delta; a group needs at
-            // least one relative-size panel.
-            groupResizeBehavior="preserve-pixel-size"
-            collapsible
-            collapsedSize="0%"
-            panelRef={treePanelRef}
-            onResize={(size) => {
-              const collapsed = size.asPercentage === 0;
-              setTreeCollapsed(collapsed);
-              if (hydratedTreeRef.current) saveFileTreeCollapsed(workspaceId, collapsed);
-            }}
-          >
-            <div className="flex h-full flex-col overflow-hidden border-r border-border">
-              <FileTreeToolbar
-                onNewFile={handleNewFile}
-                onNewFolder={handleNewFolder}
-                onOpenFile={pickFile ? handleOpenExternalFile : undefined}
-                onNewUntitled={handleNewUntitled}
-              />
-              <div className="min-h-0 flex-1 overflow-hidden">
-                <FileBrowser
-                  ref={fileBrowserRef}
-                  workspaceId={workspaceId}
-                  workspacePath={workspacePath}
-                  onOpenFile={handleSelectFile}
-                  onOpenFilePinned={handleSelectFilePinned}
-                  compact
-                  selectedFile={viewFilePath}
-                  onPathRenamed={handlePathRenamed}
-                  onPathDeleted={handlePathDeleted}
-                />
-              </div>
-            </div>
-          </Panel>
+        // Desktop: side-by-side layout with resizable file tree. The Group is
+        // keyed on the side so it fully remounts when the explorer moves —
+        // react-resizable-panels sorts its panels by `offsetLeft` when they
+        // register, so reordering the children in place would leave it holding
+        // a stale order.
+        <Group key={treeSide} orientation="horizontal" onLayoutChanged={handleLayoutChanged}>
+          {treeSide === "left" && treePanelEl}
+          {treeSide === "left" && separatorEl}
 
-          <Separator
-            id="file-tree-separator"
-            className="group relative w-[3px] bg-transparent hover:bg-accent-foreground/20 active:bg-accent-foreground/30 transition-colors cursor-col-resize"
-          >
-            <button
-              type="button"
-              onClick={toggleTree}
-              className="absolute top-1/2 left-1/2 z-10 flex size-7 -translate-x-1/2 -translate-y-1/2 items-center justify-center rounded-full border-2 border-accent-foreground/30 bg-background text-muted-foreground opacity-0 shadow-md transition-opacity hover:border-accent-foreground/50 hover:text-foreground group-hover:opacity-100"
-            >
-              {treeCollapsed ? (
-                <ChevronRight className="size-4" />
-              ) : (
-                <ChevronLeft className="size-4" />
-              )}
-            </button>
-          </Separator>
-
-          {/* Right panel — file tabs + content */}
-          <Panel id="file-viewer" minSize="20%">
+          {/* Editor panel — file tabs + content */}
+          <Panel key="file-viewer" id="file-viewer" minSize="20%">
             <div className="relative flex h-full min-w-0 flex-col overflow-hidden">
               {/* Tab bar — owns the file-tree toggle now (auto-hides when narrow) */}
               <FileTabBar
@@ -2161,6 +2267,7 @@ export function CodeBrowserView({
                 isDirty={tabState.isDirty}
                 onSaveUntitled={pickSaveFile ? handleSaveUntitledForClose : undefined}
                 treeCollapsed={treeCollapsed}
+                treeSide={treeSide}
                 onToggleTree={toggleTree}
                 actions={
                   isMarkdown ? (
@@ -2287,6 +2394,9 @@ export function CodeBrowserView({
               </div>
             </div>
           </Panel>
+
+          {treeSide === "right" && separatorEl}
+          {treeSide === "right" && treePanelEl}
         </Group>
       )}
     </div>

--- a/apps/web/src/components/CodeBrowserView.tsx
+++ b/apps/web/src/components/CodeBrowserView.tsx
@@ -70,28 +70,40 @@ import { MarkdownPreview } from "./MarkdownPreview";
 // ---------------------------------------------------------------------------
 // File tree width persistence
 // ---------------------------------------------------------------------------
+// The width is stored in **pixels**, not as a percentage of the group. The
+// explorer is a fixed-width chrome column (VS Code's Primary Side Bar model):
+// it must keep the width the user dragged it to when the surrounding container
+// changes size — maximizing/restoring the Files tab, collapsing the project
+// sidebar, resizing the window. The editor panel absorbs the delta instead.
+// A percentage would rescale the explorer on every one of those events.
+// The `-px` suffix on the key is a deliberate break from the old
+// `band-file-tree-width:` key, whose values were percentages: reusing the key
+// would restore "15" (15%) as 15px.
 function fileTreeWidthKey(wsId: string): string {
-  return `band-file-tree-width:${wsId}`;
+  return `band-file-tree-width-px:${wsId}`;
 }
 
 function fileTreeCollapsedKey(wsId: string): string {
   return `band-file-tree-collapsed:${wsId}`;
 }
 
+/** Fallback when nothing is persisted — also the `defaultSize` for a fresh workspace. */
+const DEFAULT_FILE_TREE_WIDTH_PX = 240; // 15rem
+
 function loadFileTreeWidth(wsId: string): number | null {
   try {
     const raw = localStorage.getItem(fileTreeWidthKey(wsId));
     if (raw == null) return null;
     const val = Number(raw);
-    return Number.isFinite(val) ? val : null;
+    return Number.isFinite(val) && val > 0 ? val : null;
   } catch {
     return null;
   }
 }
 
-function saveFileTreeWidth(wsId: string, width: number): void {
+function saveFileTreeWidth(wsId: string, widthPx: number): void {
   try {
-    localStorage.setItem(fileTreeWidthKey(wsId), String(width));
+    localStorage.setItem(fileTreeWidthKey(wsId), String(Math.round(widthPx)));
   } catch {
     // storage unavailable
   }
@@ -245,6 +257,7 @@ function FileTreeToolbar({
   return (
     <div
       ref={rootRef}
+      data-testid="file-tree__toolbar"
       className="flex h-9 shrink-0 items-center gap-0.5 border-b border-border/50 pl-3 pr-1.5"
     >
       <span className="text-xs font-medium text-muted-foreground">Files</span>
@@ -1871,28 +1884,61 @@ export function CodeBrowserView({
   // -------------------------------------------------------------------------
   const treePanelRef = usePanelRef();
   const [treeCollapsed, setTreeCollapsed] = useState(() => loadFileTreeCollapsed(workspaceId));
-  const skipFirstLayoutCallback = useRef(true);
-
-  const savedCollapsed = loadFileTreeCollapsed(workspaceId);
-  const savedWidth = loadFileTreeWidth(workspaceId);
-  const defaultLayout = savedCollapsed
-    ? { "file-tree": 0, "file-viewer": 100 }
-    : savedWidth
-      ? { "file-tree": savedWidth, "file-viewer": 100 - savedWidth }
-      : undefined;
-
-  const handleLayoutChanged = useCallback(
-    (layout: Record<string, number>) => {
-      if (skipFirstLayoutCallback.current) {
-        skipFirstLayoutCallback.current = false;
-        return;
-      }
-      if (layout["file-tree"] != null) {
-        saveFileTreeWidth(workspaceId, layout["file-tree"]);
-      }
-    },
-    [workspaceId],
+  const [treeWidthPx, setTreeWidthPx] = useState(
+    () => loadFileTreeWidth(workspaceId) ?? DEFAULT_FILE_TREE_WIDTH_PX,
   );
+
+  // The Group remounts whenever the layout crosses the mobile/desktop
+  // threshold, so `defaultSize` and the collapsed state are re-seeded from live
+  // state rather than read once at first mount.
+  //
+  // `hydratedTreeRef` guards the persistence writes in `onResize` against the
+  // panel's own mount-time callback, which always reports the panel expanded at
+  // its `defaultSize` — without the guard, remounting a collapsed explorer would
+  // immediately persist `collapsed = false`.
+  const hydratedTreeRef = useRef(false);
+  // biome-ignore lint/correctness/useExhaustiveDependencies: `useMobileLayout` is a trigger, not an input — it is what mounts or remounts the Group, and this effect re-seeds the fresh panel. `treeCollapsed` is read but deliberately not a dependency: this is a re-seed, not a controlled-collapse effect.
+  useLayoutEffect(() => {
+    hydratedTreeRef.current = false;
+    // Restore collapsed imperatively rather than mounting the panel at size 0:
+    // `expand()` returns a panel to its last uncollapsed size, and one that
+    // mounted at 0 has none — it would expand to the group's auto-assigned
+    // even split instead of the width the user dragged.
+    if (treeCollapsed) treePanelRef.current?.collapse();
+    hydratedTreeRef.current = true;
+  }, [useMobileLayout, treePanelRef]);
+
+  // `onLayoutChanged` fires *before* the browser applies the new layout, and
+  // `getSize()` is a live `offsetWidth` read. Measuring synchronously here
+  // catches the explorer still sized by the old percentage inside the already-
+  // resized container: maximizing the tab persisted 721px for a 360px explorer,
+  // and restoring persisted 180px — so every maximize/restore cycle halved the
+  // user's width on the next reload, even though the on-screen width never
+  // moved. Defer the read to the next frame, once the settled width is real.
+  const widthWriteFrameRef = useRef<number | null>(null);
+  const handleLayoutChanged = useCallback(() => {
+    if (widthWriteFrameRef.current !== null) {
+      cancelAnimationFrame(widthWriteFrameRef.current);
+    }
+    widthWriteFrameRef.current = requestAnimationFrame(() => {
+      widthWriteFrameRef.current = null;
+      const size = treePanelRef.current?.getSize();
+      // Skip the collapsed layout: the width we persist is the one the explorer
+      // expands *back* to. Collapsed-ness is tracked separately, in `onResize`.
+      if (size && size.inPixels > 0) {
+        setTreeWidthPx(size.inPixels);
+        saveFileTreeWidth(workspaceId, size.inPixels);
+      }
+    });
+  }, [workspaceId, treePanelRef]);
+
+  useEffect(() => {
+    return () => {
+      if (widthWriteFrameRef.current !== null) {
+        cancelAnimationFrame(widthWriteFrameRef.current);
+      }
+    };
+  }, []);
 
   const toggleTree = useCallback(() => {
     const panel = treePanelRef.current;
@@ -2035,24 +2081,26 @@ export function CodeBrowserView({
         )
       ) : (
         // Desktop: side-by-side layout with resizable file tree
-        <Group
-          orientation="horizontal"
-          defaultLayout={defaultLayout}
-          onLayoutChanged={handleLayoutChanged}
-        >
+        <Group orientation="horizontal" onLayoutChanged={handleLayoutChanged}>
           {/* Left panel — file tree */}
           <Panel
             id="file-tree"
-            defaultSize="15rem"
+            defaultSize={`${treeWidthPx}px`}
             minSize="10rem"
             maxSize="50%"
+            // Hold the explorer's pixel width when the Files tab itself is
+            // resized — maximize/restore, window resize, project-sidebar
+            // collapse. The editor panel keeps the default
+            // `preserve-relative-size` and absorbs the delta; a group needs at
+            // least one relative-size panel.
+            groupResizeBehavior="preserve-pixel-size"
             collapsible
             collapsedSize="0%"
             panelRef={treePanelRef}
             onResize={(size) => {
               const collapsed = size.asPercentage === 0;
               setTreeCollapsed(collapsed);
-              saveFileTreeCollapsed(workspaceId, collapsed);
+              if (hydratedTreeRef.current) saveFileTreeCollapsed(workspaceId, collapsed);
             }}
           >
             <div className="flex h-full flex-col overflow-hidden border-r border-border">
@@ -2078,7 +2126,10 @@ export function CodeBrowserView({
             </div>
           </Panel>
 
-          <Separator className="group relative w-[3px] bg-transparent hover:bg-accent-foreground/20 active:bg-accent-foreground/30 transition-colors cursor-col-resize">
+          <Separator
+            id="file-tree-separator"
+            className="group relative w-[3px] bg-transparent hover:bg-accent-foreground/20 active:bg-accent-foreground/30 transition-colors cursor-col-resize"
+          >
             <button
               type="button"
               onClick={toggleTree}

--- a/apps/web/src/components/CodeBrowserView.tsx
+++ b/apps/web/src/components/CodeBrowserView.tsx
@@ -103,6 +103,9 @@ export type FileTreeSide = "left" | "right";
 /** Fallback when nothing is persisted — also the `defaultSize` for a fresh workspace. */
 const DEFAULT_FILE_TREE_WIDTH_PX = 240; // 15rem
 
+/** Trailing debounce on the width write — see the tree Panel's `onResize`. */
+const WIDTH_PERSIST_DEBOUNCE_MS = 200;
+
 function loadFileTreeWidth(wsId: string): number | null {
   try {
     const raw = localStorage.getItem(fileTreeWidthKey(wsId));
@@ -1231,23 +1234,32 @@ export function CodeBrowserView({
     notifySelectFile(null);
   }, [viewFilePath, handleTabClose, notifySelectFile]);
 
+  // Save full editor state for the current file (doc, selection, undo history,
+  // scroll) into both the in-memory cache and localStorage. Call this before
+  // anything that tears the CodeMirror view down — switching tabs, or
+  // remounting the panel Group to move the explorer to the other side.
+  //
+  // Distinct from `flushActiveEditorState` below, which *returns* the state so
+  // a rename/delete caller can re-file it under a different path.
+  const persistActiveEditorState = useCallback(() => {
+    const view = editorViewRef.current;
+    if (!view || !viewFilePath) return;
+    try {
+      const state = serializeEditorState(view);
+      savedEditorStatesRef.current[viewFilePath] = state;
+      // Persist to localStorage so undo history survives workspace switches
+      tabState.update(viewFilePath, {
+        editorState: state.editorState,
+        scrollTop: state.scrollTop,
+      });
+    } catch {
+      // CM view not ready
+    }
+  }, [viewFilePath, tabState.update]);
+
   const handleTabSelect = useCallback(
     (filePath: string) => {
-      // Save full editor state for the departing file (doc, selection, undo history, scroll)
-      const view = editorViewRef.current;
-      if (view && viewFilePath) {
-        try {
-          const state = serializeEditorState(view);
-          savedEditorStatesRef.current[viewFilePath] = state;
-          // Persist to localStorage so undo history survives workspace switches
-          tabState.update(viewFilePath, {
-            editorState: state.editorState,
-            scrollTop: state.scrollTop,
-          });
-        } catch {
-          // CM view not ready
-        }
-      }
+      persistActiveEditorState();
 
       // Prevent the file prop effect from overwriting state.
       // The route round-trip (via onSelectFile) only carries the file path.
@@ -1261,7 +1273,7 @@ export function CodeBrowserView({
       setViewColumn(undefined);
       notifySelectFile(filePath);
     },
-    [fileTabs.setActiveTab, notifySelectFile, viewFilePath, tabState.update],
+    [fileTabs.setActiveTab, notifySelectFile, viewFilePath, persistActiveEditorState],
   );
 
   // Sync viewFilePath when active tab changes due to a close.
@@ -1945,81 +1957,94 @@ export function CodeBrowserView({
   const treePanelRef = usePanelRef();
   const [treeCollapsed, setTreeCollapsed] = useState(() => loadFileTreeCollapsed(workspaceId));
   const [treeSide, setTreeSide] = useState<FileTreeSide>(() => loadFileTreeSide(workspaceId));
-  const [treeWidthPx, setTreeWidthPx] = useState(
-    () => loadFileTreeWidth(workspaceId) ?? DEFAULT_FILE_TREE_WIDTH_PX,
-  );
+  // Mirrors `treeCollapsed` so `onResize` — which fires per pointermove — can
+  // detect an actual flip without reading through React state.
+  const collapsedRef = useRef(treeCollapsed);
+
+  // The explorer's width lives in a ref, not state. It is only ever *consumed*
+  // as the panel's `defaultSize` — i.e. at mount — so re-rendering when it
+  // changes buys nothing and costs a lot: `defaultSize` sits in the library's
+  // Panel registration effect dependencies, so a new value unregisters and
+  // re-registers the panel (two `sortPanels` passes, each reading `offsetLeft`
+  // on every panel — a forced reflow) without moving anything on screen. The
+  // panel's `onResize` fires on every ResizeObserver tick, so as state this
+  // fired that whole cascade ~60×/sec for the length of any window or splitter
+  // drag.
+  const treeWidthRef = useRef(loadFileTreeWidth(workspaceId) ?? DEFAULT_FILE_TREE_WIDTH_PX);
 
   // Switching sides remounts the Group (see `key={treeSide}` below), because
   // react-resizable-panels orders its panels by `offsetLeft` at *registration*
   // time — reordering the children in place would leave it with a stale order.
-  // A remount means `defaultSize` / collapsed have to be re-seeded from live
-  // state rather than read once at first mount, which is what the two hooks
-  // below do.
-  //
-  // `hydratedTreeRef` guards the persistence writes in `onResize` against the
-  // panel's own mount-time callback, which always reports the panel expanded
-  // at its `defaultSize` — without the guard, remounting a collapsed explorer
-  // would immediately persist `collapsed = false`.
-  const hydratedTreeRef = useRef(false);
+  // Crossing the mobile/desktop threshold remounts it too. Either way the fresh
+  // panel has to be re-seeded from live state rather than from a value read once
+  // at first mount.
   // biome-ignore lint/correctness/useExhaustiveDependencies: `treeSide` and `useMobileLayout` are triggers, not inputs — they are what mount or remount the Group, and this effect re-seeds the fresh panel. `treeCollapsed` is read but deliberately not a dependency: this is a re-seed, not a controlled-collapse effect.
   useLayoutEffect(() => {
-    hydratedTreeRef.current = false;
     // Restore collapsed imperatively rather than mounting the panel at size 0:
     // `expand()` returns a panel to its last uncollapsed size, and one that
     // mounted at 0 has none — it would expand to the group's auto-assigned
-    // even split instead of the width the user dragged.
+    // even split instead of the width the user dragged. Running before the
+    // browser lays out means the library's ResizeObserver measures the panel
+    // already collapsed, so this never round-trips through a 0 → expanded blip.
     if (treeCollapsed) treePanelRef.current?.collapse();
-    hydratedTreeRef.current = true;
   }, [treeSide, useMobileLayout, treePanelRef]);
 
-  // `onLayoutChanged` fires *before* the browser applies the new layout, and
-  // `getSize()` is a live `offsetWidth` read. Measuring synchronously here
-  // catches the explorer still sized by the old percentage inside the already-
-  // resized container: maximizing the tab persisted 721px for a 360px explorer,
-  // and restoring persisted 180px — so every maximize/restore cycle halved the
-  // user's width on the next reload, even though the on-screen width never
-  // moved. Defer the read to the next frame, once the settled width is real.
-  const widthWriteFrameRef = useRef<number | null>(null);
-  const handleLayoutChanged = useCallback(() => {
-    if (widthWriteFrameRef.current !== null) {
-      cancelAnimationFrame(widthWriteFrameRef.current);
+  // Width is measured in the Panel's `onResize`, NOT in the Group's
+  // `onLayoutChanged`. `onLayoutChanged` fires *before* the browser applies the
+  // new layout, so reading the panel there caught it still sized by its old
+  // proportion inside the already-resized container: maximizing the tab reported
+  // 721px for a 360px explorer, restoring reported 180px, and every
+  // maximize/restore cycle halved the user's width on the next reload even
+  // though the on-screen width never moved. `onResize` is delivered from the
+  // library's ResizeObserver — i.e. after layout — so the size it hands us is
+  // the settled one.
+  //
+  // The localStorage write is debounced because `onResize` fires on every
+  // pointermove of a drag and `setItem` is synchronous and disk-backed:
+  // persisting on each one would write ~60×/sec and throw all but the last away.
+  const widthPersistTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const scheduleWidthPersist = useCallback(() => {
+    if (widthPersistTimerRef.current !== null) {
+      clearTimeout(widthPersistTimerRef.current);
     }
-    widthWriteFrameRef.current = requestAnimationFrame(() => {
-      widthWriteFrameRef.current = null;
-      const size = treePanelRef.current?.getSize();
-      // Skip the collapsed layout: the width we persist is the one the explorer
-      // expands *back* to. Collapsed-ness is tracked separately, in `onResize`.
-      if (size && size.inPixels > 0) {
-        setTreeWidthPx(size.inPixels);
-        saveFileTreeWidth(workspaceId, size.inPixels);
-      }
-    });
-  }, [workspaceId, treePanelRef]);
+    widthPersistTimerRef.current = setTimeout(() => {
+      widthPersistTimerRef.current = null;
+      saveFileTreeWidth(workspaceId, treeWidthRef.current);
+    }, WIDTH_PERSIST_DEBOUNCE_MS);
+  }, [workspaceId]);
 
   useEffect(() => {
     return () => {
-      if (widthWriteFrameRef.current !== null) {
-        cancelAnimationFrame(widthWriteFrameRef.current);
+      if (widthPersistTimerRef.current !== null) {
+        clearTimeout(widthPersistTimerRef.current);
+        // Don't drop a width the user set moments before unmounting.
+        saveFileTreeWidth(workspaceId, treeWidthRef.current);
       }
     };
-  }, []);
+  }, [workspaceId]);
 
   const handleSetTreeSide = useCallback(
     (side: FileTreeSide) => {
-      // Capture the explorer's live width before the Group remounts. Moving
-      // sides must not resize the explorer, and `treeWidthPx` — which seeds the
-      // remounted panel's `defaultSize` — otherwise only refreshes on
-      // `onLayoutChanged`. Reading the panel directly means the width the user
-      // is looking at is exactly the width that comes back on the other side.
+      // The Group remount tears down CodeMirror, and the editor's state is only
+      // written on tab switch or on CodeBrowserView unmount — neither of which
+      // happens here. Without this, moving the explorer silently drops the open
+      // file's undo history, cursor and scroll position.
+      persistActiveEditorState();
+
+      // Capture the explorer's live width before the remount. Moving sides must
+      // not resize the explorer, and `treeWidthRef` — which seeds the remounted
+      // panel's `defaultSize` — otherwise only refreshes on `onResize`. Reading
+      // the panel directly means the width the user is looking at is exactly the
+      // width that comes back on the other side.
       const size = treePanelRef.current?.getSize();
       if (size && size.inPixels > 0) {
-        setTreeWidthPx(size.inPixels);
+        treeWidthRef.current = size.inPixels;
         saveFileTreeWidth(workspaceId, size.inPixels);
       }
       setTreeSide(side);
       saveFileTreeSide(workspaceId, side);
     },
-    [workspaceId, treePanelRef],
+    [workspaceId, treePanelRef, persistActiveEditorState],
   );
 
   const toggleTree = useCallback(() => {
@@ -2062,7 +2087,7 @@ export function CodeBrowserView({
     <Panel
       key="file-tree"
       id="file-tree"
-      defaultSize={`${treeWidthPx}px`}
+      defaultSize={`${treeWidthRef.current}px`}
       minSize="10rem"
       maxSize="50%"
       // Hold the explorer's pixel width when the Files tab itself is resized —
@@ -2075,8 +2100,23 @@ export function CodeBrowserView({
       panelRef={treePanelRef}
       onResize={(size) => {
         const collapsed = size.asPercentage === 0;
-        setTreeCollapsed(collapsed);
-        if (hydratedTreeRef.current) saveFileTreeCollapsed(workspaceId, collapsed);
+
+        // Remember the width the explorer expands *back* to. A collapsed panel
+        // reports 0, which is not a width the user chose — skipping it (rather
+        // than clearing anything) is what lets a drag-then-collapse keep the
+        // width the drag just set.
+        if (!collapsed && size.inPixels > 0) {
+          treeWidthRef.current = size.inPixels;
+          scheduleWidthPersist();
+        }
+
+        // `onResize` fires on every pointermove of a drag, so only touch React
+        // and localStorage when collapsed-ness actually flipped.
+        if (collapsed !== collapsedRef.current) {
+          collapsedRef.current = collapsed;
+          setTreeCollapsed(collapsed);
+          saveFileTreeCollapsed(workspaceId, collapsed);
+        }
       }}
     >
       <div
@@ -2245,7 +2285,7 @@ export function CodeBrowserView({
         // react-resizable-panels sorts its panels by `offsetLeft` when they
         // register, so reordering the children in place would leave it holding
         // a stale order.
-        <Group key={treeSide} orientation="horizontal" onLayoutChanged={handleLayoutChanged}>
+        <Group key={treeSide} orientation="horizontal">
           {treeSide === "left" && treePanelEl}
           {treeSide === "left" && separatorEl}
 

--- a/apps/web/src/components/FileTabBar.tsx
+++ b/apps/web/src/components/FileTabBar.tsx
@@ -250,6 +250,7 @@ export function FileTabBar({
             <TooltipTrigger asChild>
               <button
                 type="button"
+                data-testid="file-tab-bar__tree-toggle"
                 onClick={onToggleTree}
                 className="ml-1 hidden size-7 shrink-0 items-center justify-center rounded-md text-muted-foreground hover:bg-accent hover:text-foreground transition-colors @[16rem]:inline-flex"
               >

--- a/apps/web/src/components/FileTabBar.tsx
+++ b/apps/web/src/components/FileTabBar.tsx
@@ -24,6 +24,7 @@ import {
   ExternalLink,
   FileText,
   PanelLeft,
+  PanelRight,
   Pin,
   X,
 } from "lucide-react";
@@ -78,6 +79,8 @@ interface FileTabBarProps {
   actions?: React.ReactNode;
   /** Whether the file-tree sidebar is collapsed (used to flip the toggle icon's tooltip). */
   treeCollapsed?: boolean;
+  /** Which edge the file-tree sidebar is docked to (used to mirror the toggle icon). */
+  treeSide?: "left" | "right";
   /** When provided, renders a leading button that toggles the file-tree sidebar.
    *  The button auto-hides when the tab bar's container becomes too narrow. */
   onToggleTree?: () => void;
@@ -102,6 +105,7 @@ export function FileTabBar({
   onSaveUntitled,
   actions,
   treeCollapsed,
+  treeSide = "left",
   onToggleTree,
 }: FileTabBarProps) {
   const activeRef = useRef<HTMLButtonElement>(null);
@@ -249,7 +253,11 @@ export function FileTabBar({
                 onClick={onToggleTree}
                 className="ml-1 hidden size-7 shrink-0 items-center justify-center rounded-md text-muted-foreground hover:bg-accent hover:text-foreground transition-colors @[16rem]:inline-flex"
               >
-                <PanelLeft className="size-3.5" />
+                {treeSide === "right" ? (
+                  <PanelRight className="size-3.5" />
+                ) : (
+                  <PanelLeft className="size-3.5" />
+                )}
               </button>
             </TooltipTrigger>
             <TooltipContent side="bottom" className="text-xs">


### PR DESCRIPTION
## PO Summary

Two changes to the **Files** tab.

**You can now put the file explorer on either side.** Right-click the "Files" header and choose "Explorer on Left" or "Explorer on Right" — the same option VS Code offers for its sidebar. Each workspace remembers where you put it.

**The explorer no longer changes size on its own.** Previously it was sized as a *proportion* of the tab, so anything that resized the tab resized the explorer with it — maximizing the tab made it grow, restoring made it shrink. Now it's a fixed column: whatever width you drag it to is the width it stays, and the editor takes up the slack. Moving it between sides doesn't resize it either.

Along the way this fixed a bug that was quietly losing people's settings: because the width was saved as a proportion, every maximize-and-restore cycle **halved the width you had chosen** — but only after your next reload, so it looked fine at the time. A 360px explorer came back at 180px, then 90px, and so on.

## Notes for reviewers

- The width now persists in **pixels**, under a new key (`band-file-tree-width-px:`). The old key held percentages, so it is deliberately not reused — a stale "15" must not come back as a 15px explorer. Covered by a test.
- The panel uses `groupResizeBehavior="preserve-pixel-size"`; the editor keeps `preserve-relative-size` and absorbs the delta.
- The width is measured in the Panel's `onResize`, which the library delivers from its ResizeObserver (after layout). The Group's `onLayoutChanged` fires *before* layout is applied and `getSize()` is a live `offsetWidth` read — measuring there is what produced the halving bug.
- Moving sides remounts the panel `Group` (`key={treeSide}`): react-resizable-panels sorts panels by `offsetLeft` at registration, so reordering children in place leaves a stale order. The remount means the width, the collapsed state, and the CodeMirror editor state all have to be carried across it explicitly.

## Testing

13 new Playwright e2e tests (real server, real browser, no mocking) covering docking side, fixed width across maximize/restore, the collapsed state, and the legacy-key break. Full web e2e suite: **142 passed**. `pnpm check` clean.

Reviewed locally with the four-specialist review before pushing; the resulting fixes are in `853f329`.