### PR TITLE
fix(web): repaint terminal on foreground to clear stale WebGL rows

### DIFF
--- a/apps/web/src/lib/terminal-cache.ts
+++ b/apps/web/src/lib/terminal-cache.ts
@@ -754,10 +754,23 @@ function createEntry(terminalId: string, opts: CreateOptions): TerminalCacheEntr
         probeConnection();
       }
     };
+    // Coming back to the foreground (tab re-shown, or — in the Electron app —
+    // the window regaining OS focus, which does NOT fire `visibilitychange`).
+    // Besides re-checking the socket, force a full repaint: a WebGL terminal
+    // that was backgrounded/throttled can drop the rAF frames carrying a TUI's
+    // in-place statusline redraws, leaving the bottom rows stale/garbled until
+    // the next byte arrives. `scheduleRepair` is rAF-debounced (self-guards on
+    // attached+visible), so a switch-back that fires both `visibilitychange`
+    // and `focus` coalesces into a single repair — same idiom as `attach`.
+    const handleForeground = () => {
+      handleResume();
+      scheduleRepair();
+    };
     const handleVisibility = () => {
-      if (!document.hidden) handleResume();
+      if (!document.hidden) handleForeground();
     };
     window.addEventListener("online", handleResume);
+    window.addEventListener("focus", handleForeground);
     document.addEventListener("visibilitychange", handleVisibility);
 
     connect();
@@ -890,6 +903,7 @@ function createEntry(terminalId: string, opts: CreateOptions): TerminalCacheEntr
       clearReconnectTimer();
       stopHeartbeat();
       window.removeEventListener("online", handleResume);
+      window.removeEventListener("focus", handleForeground);
       document.removeEventListener("visibilitychange", handleVisibility);
       themeObserver.disconnect();
       resizeObserver.disconnect();


### PR DESCRIPTION
## PO Summary

Sometimes when you switch away from Band and come back — or a running tool (like Claude Code) is busy in the terminal — the bottom of the terminal (the status bar and footer) shows up blank or garbled, with stray coloured blocks, until you resize the panel or type something. This makes it look like part of the screen is missing.

This fixes that: whenever the Band window comes back to the foreground, the terminal now forces a clean repaint automatically, so the status bar and footer are always intact. No action needed from the user — it just stops happening.

## Details

The embedded terminal uses the WebGL renderer, which paints on animation frames. While the tab/window is backgrounded or throttled, those frames get dropped, so a TUI's in-place statusline redraws never present — the bottom rows are left showing a stale/garbled frame until the next byte arrives.

Previously, returning to the foreground only re-checked the WebSocket (`handleResume`) and never repainted. Window focus — the signal the Electron desktop app gets when it regains OS focus — doesn't fire `visibilitychange` at all, so that path was fully uncovered.

- New `handleForeground` = `handleResume()` + `scheduleRepair()`, wired to `window` `focus` and visibility un-hide.
- `scheduleRepair()` is the existing rAF-debounced repair path (fit + full-row `term.refresh` + PTY resize). It self-guards on attached+visible and coalesces a `visibilitychange`+`focus` double-fire into one repair — same idiom `attach()` already uses.
- Listener removed symmetrically in cleanup.

## Testing

Verified `tsc --noEmit` (exit 0) and biome clean; pre-push hook (lint/format/clippy) passed.

The garbled-frame condition depends on the WebGL context being throttled/backgrounded and is not deterministically reproducible in headless Chromium; asserting the repaint fired would require reaching into xterm internals (against this repo's black-box test doctrine). No automated test added — consistent with the already-untested `online`/`visibilitychange` resume triggers in the same module. Best exercised by hand: run a TUI, background the window, return, confirm the statusline repaints without a resize.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JNa6jnVcBjLj6jagrWffNy