### PR TITLE
fix(web): UI stability polish for sidebar toggle and panel animations

### DIFF
--- a/apps/desktop/src/browser/cert-exceptions.ts
+++ b/apps/desktop/src/browser/cert-exceptions.ts
@@ -21,11 +21,12 @@
  *     There is no persistence to disk. Restarting the desktop app
  *     clears every exception (acceptance criterion). Persistence
  *     with a management UI is an explicit follow-up.
- *   - **Partition-aware**. Even though Band's browser tabs currently
- *     all share the default Electron session, keying by partition
- *     keeps the store correct if a future feature introduces named
- *     partitions (e.g. per-workspace storage isolation). The default
- *     session is keyed as `"default"`.
+ *   - **Partition-aware**. Band's browser tabs live in the dedicated
+ *     `persist:band-browser` partition (see `BROWSER_PARTITION` in
+ *     `view-manager.ts`), so their exceptions are keyed by that
+ *     partition's `storagePath`. Keying by partition also keeps the
+ *     store correct if further named partitions are ever introduced
+ *     (e.g. per-workspace storage isolation).
  *   - **No global "ignore all" flag**. Per-host only by design.
  *
  * This module is intentionally pure: no Electron imports, no IPC.

--- a/apps/desktop/src/browser/view-manager.ts
+++ b/apps/desktop/src/browser/view-manager.ts
@@ -65,6 +65,23 @@ const log = createLogger("view-manager");
 
 const MAX_BROWSER_VIEWS = 10;
 
+/**
+ * Session partition for every browser-pane `WebContentsView`.
+ *
+ * Isolating the tabs from `session.defaultSession` (which the dashboard
+ * window uses) matters for zoom: Chromium's zoom is stored per-origin
+ * per-StoragePartition and propagates live to every webContents in the
+ * partition — so with a shared session, zooming a tab pointed at the
+ * dashboard's own origin (localhost:<port>) zoomed the dashboard window
+ * itself and persisted that on disk. A dedicated partition keeps tab
+ * zoom (and cookies/storage) away from the dashboard entirely.
+ *
+ * Anything registered on `session.defaultSession` that tabs rely on must
+ * also be registered on this partition's session — currently the
+ * `band-action://` protocol handler (see `apps/desktop/src/main/index.ts`).
+ */
+export const BROWSER_PARTITION = "persist:band-browser";
+
 // Zoom range + step, intentionally aligned with the dashboard's zoom
 // settings (`apps/web/src/lib/zoom.ts`). Keeping them in sync avoids
 // the dashboard chrome and the tab content drifting to different
@@ -542,10 +559,12 @@ export class BrowserViewManager {
 
   /**
    * Per-tab zoom. Adjusts `webContents.zoomFactor` on the targeted view
-   * by ±`ZOOM_STEP`, or sets it back to `ZOOM_DEFAULT`. The zoom is
-   * stored on the WebContents (Electron preserves it across reloads on
-   * the same origin, same as Chrome), and is independent of every
-   * other tab and of the dashboard's `document.documentElement.style.zoom`.
+   * by ±`ZOOM_STEP`, or sets it back to `ZOOM_DEFAULT`. Chromium stores
+   * the zoom per-origin within `BROWSER_PARTITION` (preserved across
+   * reloads, shared between tabs on the same origin — same as Chrome),
+   * and — because the tabs live in their own partition — it can never
+   * leak into the dashboard window's session or its CSS
+   * `document.documentElement.style.zoom`.
    *
    * The `direct` overload, taking a view rather than an args bag, lets
    * the menu handler reuse this logic for the
@@ -731,13 +750,17 @@ export class BrowserViewManager {
       return;
     }
 
-    // Create the DevTools-host sibling. Same security flags as the
-    // page view — DevTools is just a webpage from Chromium's POV.
+    // Create the DevTools-host sibling. Same security flags and partition
+    // as the page view — DevTools is just a webpage from Chromium's POV,
+    // and keeping it in BROWSER_PARTITION means its network activity
+    // (e.g. source-map fetches declared by the inspected page) and any
+    // per-origin zoom writes stay out of the dashboard's default session.
     const dt = new WebContentsView({
       webPreferences: {
         contextIsolation: true,
         sandbox: true,
         nodeIntegration: false,
+        partition: BROWSER_PARTITION,
       },
     });
     const parent = this.parentByKey.get(key) ?? "main";
@@ -936,6 +959,7 @@ export class BrowserViewManager {
         contextIsolation: true,
         sandbox: true,
         nodeIntegration: false,
+        partition: BROWSER_PARTITION,
       },
     });
     this.wireEvents(key, view);

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -15,7 +15,7 @@
 
 import { app, BrowserWindow, protocol, session } from "electron";
 import { CertExceptionStore } from "../browser/cert-exceptions.js";
-import { BrowserViewManager } from "../browser/view-manager.js";
+import { BROWSER_PARTITION, BrowserViewManager } from "../browser/view-manager.js";
 import { createHiddenBrowserWindow } from "./hidden-browser-window.js";
 import { resolveAppIcon } from "./icon.js";
 import { registerIpc } from "./ipc/register.js";
@@ -276,19 +276,17 @@ async function bootstrap(): Promise<void> {
   // setImmediate, so we just return an empty no-content response
   // and Chromium quietly throws away the result.
   //
-  // **Default session only.** `BrowserViewManager.createView()`
-  // constructs every `WebContentsView` without `webPreferences.
-  // partition` or `webPreferences.session`, so they all share
-  // `session.defaultSession`. If a future feature introduces named
-  // partitions (e.g. `persist:workspace-<id>`), each new partition's
-  // `Session` is a separate object and would need this handler
-  // re-registered on it — otherwise band-action navigations in
-  // those tabs would still pop the macOS "no application set to
-  // open this URL" dialog before our setImmediate fires. Add the
-  // call to whatever code creates the partition.
-  session.defaultSession.protocol.handle("band-action", () => {
-    return new Response(null, { status: 204 });
-  });
+  // Registered on BOTH sessions in play: `session.defaultSession`
+  // (the dashboard window) and the browser panes' dedicated
+  // `BROWSER_PARTITION` (each partition's `Session` is a separate
+  // object with its own protocol registry — without the second
+  // registration, band-action navigations in tabs would pop the
+  // macOS "no application set to open this URL" dialog before our
+  // setImmediate fires). If another partition is ever introduced,
+  // register the handler on it too.
+  const bandActionHandler = () => new Response(null, { status: 204 });
+  session.defaultSession.protocol.handle("band-action", bandActionHandler);
+  session.fromPartition(BROWSER_PARTITION).protocol.handle("band-action", bandActionHandler);
 
   state.unregisterIpc = registerIpc({
     mainWindow: state.mainWindow,

--- a/apps/desktop/src/main/menu.ts
+++ b/apps/desktop/src/main/menu.ts
@@ -214,11 +214,12 @@ export function buildAppMenu(deps: MenuDeps): Menu {
       accelerator: "CmdOrCtrl+-",
       click: () => zoomFocused(deps, "out"),
     },
-    // Zoom-reset deliberately has no accelerator: CmdOrCtrl+0 is owned by
-    // the dashboard's "All projects" label filter (see DashboardShell).
-    // Reset is still reachable here via menu click.
+    // CmdOrCtrl+0 is owned by the dashboard's "All projects" label filter
+    // (see DashboardShell), so zoom-reset uses the shifted variant instead
+    // of the conventional plain Cmd+0.
     {
       label: "Actual Size",
+      accelerator: "CmdOrCtrl+Shift+0",
       click: () => zoomFocused(deps, "reset"),
     },
     { type: "separator" },

--- a/apps/desktop/src/main/window.ts
+++ b/apps/desktop/src/main/window.ts
@@ -80,6 +80,18 @@ export function createMainWindow(opts: CreateMainWindowOptions): BrowserWindow {
   const { width, height } = primary.workAreaSize;
   win.setBounds({ x: 0, y: 0, width, height });
 
+  // The dashboard's zoom is CSS-based (`<html> zoom`, see
+  // apps/web/src/lib/zoom.ts) — its Chromium-level zoom must always stay
+  // at 1. Chromium persists per-origin zoom in the default partition's
+  // Preferences, so a stray zoom on the dashboard's origin (historically:
+  // zooming a browser tab pointed at localhost:<port> back when tabs
+  // shared the default session) would silently rescale the whole window
+  // on every boot, misaligning the native WebContentsView overlays.
+  // Force it back on every load; this also rewrites the persisted entry.
+  win.webContents.on("did-finish-load", () => {
+    win.webContents.setZoomLevel(0);
+  });
+
   win.once("ready-to-show", () => {
     win.show();
     // Auto-open DevTools in dev so the renderer is inspectable from the

--- a/apps/web/e2e/pages/WorkspacePage.ts
+++ b/apps/web/e2e/pages/WorkspacePage.ts
@@ -465,10 +465,10 @@ export class WorkspacePage {
   }
 
   /** The header button that toggles the sidebar (⌘B). Rendered by
-   *  `NavControls` in `DesktopTitleBar.tsx`, hosted by `SidebarTitleBar` while
-   *  the sidebar is visible and by `WorkspaceTitleBar` while it's collapsed
-   *  (the cluster relocates so the controls stay reachable). Its `aria-pressed`
-   *  reflects current visibility. */
+   *  `NavControls` in `DesktopTitleBar.tsx`, hosted once in `AppShell`'s
+   *  stationary overlay pinned over the title-bar row's left edge — it stays put in both
+   *  sidebar states rather than relocating between the title bars. Its
+   *  `aria-pressed` reflects current visibility. */
   get sidebarToggle(): Locator {
     return this.page.getByTestId("desktop-title-bar__sidebar-toggle");
   }
@@ -487,25 +487,31 @@ export class WorkspacePage {
     return this.sidebar.getByTestId("project-list__action-bar");
   }
 
-  /** The workspace-history back arrow (⌘[). Part of the relocating
+  /** The workspace-history back arrow (⌘[). Part of the stationary-overlay
    *  `NavControls` cluster. Targeted by testid: the "Back"/"Forward" ARIA
    *  names aren't unique app-wide (ScreencastPanel's address bar reuses them). */
   get backButton(): Locator {
     return this.page.getByTestId("desktop-title-bar__back");
   }
 
-  /** The workspace-history forward arrow (⌘]). Part of the relocating
+  /** The workspace-history forward arrow (⌘]). Part of the stationary-overlay
    *  `NavControls` cluster. Targeted by testid for the same uniqueness reason
    *  as `backButton`. */
   get forwardButton(): Locator {
     return this.page.getByTestId("desktop-title-bar__forward");
   }
 
-  /** The sidebar-toggle button scoped to the project-list column — proves the
-   *  nav cluster is hosted in `SidebarTitleBar` (not the workspace bar) while
-   *  the sidebar is visible. */
-  get sidebarToggleWithinSidebar(): Locator {
-    return this.sidebar.getByTestId("desktop-title-bar__sidebar-toggle");
+  /** The sidebar-toggle button's viewport x-position. The nav cluster lives
+   *  in a stationary overlay, so this must not change when the sidebar collapses
+   *  or expands — the geometric signal that the toggle neither relocates nor
+   *  jumps during the tween. */
+  async sidebarToggleX(): Promise<number> {
+    const box = await this.sidebarToggle.boundingBox();
+    // Throw rather than return NaN: `expect(NaN).toBe(NaN)` passes
+    // (Object.is), so a hidden toggle would make two compared reads
+    // vacuously equal instead of failing loudly.
+    if (!box) throw new Error("sidebar toggle has no bounding box — not visible");
+    return box.x;
   }
 
   /** Current rendered width of the sidebar in CSS px — ~0 when collapsed.

--- a/apps/web/e2e/sidebar-toggle.spec.ts
+++ b/apps/web/e2e/sidebar-toggle.spec.ts
@@ -119,24 +119,21 @@ test("⌃0 (Focus Projects) reveals a collapsed sidebar", async ({ page }) => {
   await expect(wp.sidebarToggle).toHaveAttribute("aria-pressed", "true");
 });
 
-test("the nav cluster is hosted in the sidebar title bar while the sidebar is visible", async ({
-  page,
-}) => {
+test("the nav cluster renders once alongside the sidebar's own action bar", async ({ page }) => {
   const wp = new WorkspacePage(page, server.url, TOKEN);
   await wp.goto(WORKSPACE);
   await wp.waitForReady();
 
-  // The split title bar puts the sidebar toggle inside the project-list
-  // column (SidebarTitleBar) when the list is shown. The overflow actions
-  // live in the project-list bottom action bar; there is no title-bar
-  // hamburger anywhere, so the Menu button is absent.
+  // The nav cluster is a single stationary overlay over the title-bar row. The
+  // overflow actions live in the project-list bottom action bar; there is
+  // no title-bar hamburger anywhere, so the Menu button is absent.
   await expect.poll(() => wp.sidebarWidth()).toBeGreaterThan(200);
-  await expect(wp.sidebarToggleWithinSidebar).toBeVisible();
+  await expect(wp.sidebarToggle).toHaveCount(1);
   await expect(wp.actionBarWithinSidebar).toBeVisible();
   await expect(wp.menuTrigger).toHaveCount(0);
 });
 
-test("the toggle and back/forward relocate into the workspace bar when the sidebar collapses", async ({
+test("the toggle and back/forward stay put (no relocation, no jump) when the sidebar collapses", async ({
   page,
 }) => {
   const wp = new WorkspacePage(page, server.url, TOKEN);
@@ -147,17 +144,28 @@ test("the toggle and back/forward relocate into the workspace bar when the sideb
   // action bar and there is no title-bar hamburger.
   await expect(wp.actionBarWithinSidebar).toBeVisible();
   await expect(wp.menuTrigger).toHaveCount(0);
+  await expect(wp.sidebarToggle).toBeVisible();
+  const xBefore = await wp.sidebarToggleX();
 
   await wp.toggleSidebarViaButton();
   await expect.poll(() => wp.sidebarWidth()).toBeLessThan(5);
 
-  // The nav cluster relocated into the workspace title bar so its controls
-  // stay reachable while the list is collapsed...
+  // The cluster is hosted in a stationary overlay, so its controls stay reachable
+  // while the list is collapsed — at the exact same position (the flicker
+  // regression was the cluster remounting 3px off between the two bars)...
   await expect(wp.sidebarToggle).toBeVisible();
   await expect(wp.backButton).toBeVisible();
   await expect(wp.forwardButton).toBeVisible();
-  // ...and no hamburger was resurrected as part of the relocation.
+  await expect.poll(() => wp.sidebarToggleX()).toBe(xBefore);
+  // ...and no hamburger appears in the collapsed state either.
   await expect(wp.menuTrigger).toHaveCount(0);
+
+  // Round trip: re-expanding was the other half of the flicker regression
+  // (the cluster used to remount into the sidebar bar) — the toggle must
+  // hold the same position through the expand too.
+  await wp.toggleSidebarViaButton();
+  await expect.poll(() => wp.sidebarWidth()).toBeGreaterThan(200);
+  await expect.poll(() => wp.sidebarToggleX()).toBe(xBefore);
 });
 
 test("the collapsed state persists across a reload", async ({ page }) => {

--- a/apps/web/src/components/DesktopTitleBar.tsx
+++ b/apps/web/src/components/DesktopTitleBar.tsx
@@ -29,12 +29,16 @@ export interface PanelItem {
   shortcut?: string;
 }
 
-/** Props for the navigation cluster (sidebar toggle + back/forward). While the
- *  project list is visible the SidebarTitleBar renders the cluster; when the
- *  list is collapsed the same cluster relocates into the WorkspaceTitleBar —
- *  so both bars accept the same set of props. The overflow actions always live
- *  in DashboardShell's bottom action bar, so the cluster carries no menu. */
-interface NavControlsProps {
+/** Props for the navigation cluster (sidebar toggle + back/forward). The
+ *  cluster is hosted ONCE, in `AppShell`'s stationary overlay pinned over the
+ *  title-bar row's left edge (absolutely positioned on the app root, which
+ *  spans the window) — never inside either title bar. Earlier revisions
+ *  relocated it between the two bars on sidebar toggle, but the handoff
+ *  remounted the buttons inside an overflow-clipped, animating panel, so
+ *  they visibly flickered mid-tween. A stationary overlay can't flicker:
+ *  the panels slide beneath it. The overflow actions always live in
+ *  DashboardShell's bottom action bar, so the cluster carries no menu. */
+export interface NavControlsProps {
   /** Toggle the project-list sidebar's visibility (⌘B). When undefined, the
    *  sidebar toggle button is not rendered. */
   onToggleSidebar?: () => void;
@@ -51,20 +55,7 @@ interface NavControlsProps {
   canGoForward?: boolean;
 }
 
-/** The traffic-light gutter class: on macOS desktop (outside fullscreen) the
- *  window controls occupy the top-left ~80px, so whichever title-bar half sits
- *  at the window's left edge must clear that space. Computed once in `AppShell`
- *  (a single `useIsFullscreen` subscription) and passed to both halves. */
-interface TitleBarOffsetProps {
-  /** Left-padding class to apply when the bar is at the window's left edge. */
-  offsetClass: string;
-}
-
-/** The sidebar half takes the shared nav-control props verbatim;
- *  `sidebarVisible` (inherited from NavControlsProps) gates the cluster. */
-type SidebarTitleBarProps = NavControlsProps & TitleBarOffsetProps;
-
-interface WorkspaceTitleBarProps extends NavControlsProps, TitleBarOffsetProps {
+interface WorkspaceTitleBarProps {
   /** Static title. If omitted, fetches the app title from the desktop shell. */
   title?: string;
   /** Active workspace name to display prominently. */
@@ -86,9 +77,9 @@ interface WorkspaceTitleBarProps extends NavControlsProps, TitleBarOffsetProps {
   onTogglePanelVisibility?: (panelId: string) => void;
 }
 
-/** Sidebar toggle + back/forward arrows. Shared by both title-bar halves;
- *  rendered in exactly one of them at a time. */
-function NavControls({
+/** Sidebar toggle + back/forward arrows. Rendered once by `AppShell` in a
+ *  stationary overlay pinned over the title-bar row's left edge. */
+export function NavControls({
   onToggleSidebar,
   sidebarVisible,
   onGoBack,
@@ -172,32 +163,25 @@ function NavControls({
   );
 }
 
-/** Draggable title bar over the project-list sidebar. Holds the navigation
- *  cluster (sidebar toggle, back/forward) while the list is visible.
- *  Painted with the sidebar surface so it reads as one panel with the list
- *  below it, visually separated from the workspace layout to its right. */
-export function SidebarTitleBar({ sidebarVisible, offsetClass, ...nav }: SidebarTitleBarProps) {
+/** Draggable title bar over the project-list sidebar. A pure drag/paint
+ *  surface: the navigation cluster that used to live here is now hosted in
+ *  `AppShell`'s stationary overlay (see NavControlsProps), which sits on top of
+ *  this bar while the list is visible. Painted with the sidebar surface so
+ *  it reads as one panel with the list below it, visually separated from
+ *  the workspace layout to its right. */
+export function SidebarTitleBar() {
   return (
     <div
-      className={`h-[38px] shrink-0 flex items-center gap-0.5 border-b border-border bg-sidebar pr-2 ${offsetClass}`}
+      className="h-[38px] shrink-0 flex items-center border-b border-border bg-sidebar"
       style={DRAG_STYLE}
-    >
-      {/* Gate the cluster on visibility: when the list is collapsed the bar is
-          clipped to 0px but stays mounted, so rendering the cluster here would
-          duplicate it (the WorkspaceTitleBar shows it while collapsed) and put
-          two `…__sidebar-toggle` nodes in the DOM. This variant renders the
-          toggle + back/forward arrows; the overflow actions live in the
-          project-list bottom action bar. */}
-      {sidebarVisible && <NavControls sidebarVisible={sidebarVisible} {...nav} />}
-    </div>
+    />
   );
 }
 
 /** Draggable title bar over the workspace layout. Holds the workspace name
- *  (center), the open-in-editor picker, and the panel/layout switcher. When
- *  the project-list sidebar is collapsed, the navigation cluster relocates
- *  here (far left, clearing the traffic lights) so the back/forward arrows
- *  stay reachable. */
+ *  (centered on the bar) and the open-in-editor / panel-switcher controls
+ *  (right). The navigation cluster lives in `AppShell`'s stationary overlay, not
+ *  here — see NavControlsProps. */
 export function WorkspaceTitleBar({
   title,
   workspaceName,
@@ -207,9 +191,6 @@ export function WorkspaceTitleBar({
   panelItems,
   hiddenPanels,
   onTogglePanelVisibility,
-  sidebarVisible,
-  offsetClass,
-  ...nav
 }: WorkspaceTitleBarProps) {
   const [appTitle, setAppTitle] = useState(title ?? "Band");
 
@@ -228,30 +209,16 @@ export function WorkspaceTitleBar({
 
   return (
     <div
-      // Left padding clears the macOS traffic lights only when this bar sits at
-      // the window's left edge — i.e. while the sidebar is collapsed and the
-      // nav cluster lives here. When the sidebar is visible it owns that gutter.
-      className={`relative h-[38px] shrink-0 flex items-center gap-1 border-b border-border bg-background pr-2 ${sidebarVisible ? "pl-2" : offsetClass}`}
+      className="relative h-[38px] shrink-0 flex items-center gap-1 border-b border-border bg-background pr-2 pl-2"
       style={DRAG_STYLE}
     >
-      {/* Nav cluster relocates here (left-aligned, in normal flow) while the
-          project list is collapsed. The collapsed sidebar's 3px Separator
-          still sits at the window edge, so this bar starts 3px right of
-          where the SidebarTitleBar starts — pull the cluster back by that
-          much so the toggle lands on the exact same pixel in both hosts and
-          the handoff between the two bars is invisible. */}
-      {!sidebarVisible && (
-        <div className="-ml-[3px]">
-          <NavControls sidebarVisible={sidebarVisible} {...nav} />
-        </div>
-      )}
-
       {/* The title is centered on the BAR (absolute overlay), not on the
-          leftover flex space — flex-centering would re-center it the instant
-          the nav cluster mounts/unmounts on a sidebar toggle, a ±44px jump
-          layered on top of the bar's own smooth 200ms slide. Anchored to the
-          bar, it only ever moves with the bar. pointer-events pass through
-          the overlay; the picker button re-enables them for itself. */}
+          leftover flex space — flex-centering re-centers it whenever the
+          bar's other flex children change (an instant jump layered on top
+          of the bar's own smooth 200ms slide during a sidebar toggle).
+          Anchored to the bar, it only ever moves with the bar.
+          pointer-events pass through the overlay; the picker button
+          re-enables them for itself. */}
       <div className="absolute inset-x-0 top-0 flex h-full items-center justify-center min-w-0 px-1 pointer-events-none">
         {workspaceName ? (
           onWorkspaceNameClick ? (
@@ -296,9 +263,13 @@ export function WorkspaceTitleBar({
         )}
       </div>
 
+      {/* `relative` lifts the controls above the absolutely-positioned title
+          overlay (positioned siblings later in the DOM paint on top) so a
+          long workspace name can never sit over these buttons and steal
+          their clicks on a narrow bar. */}
       {(hasEditorPicker || hasPanels) && (
         <div
-          className="ml-auto flex shrink-0 items-center gap-1 pointer-events-auto"
+          className="relative ml-auto flex shrink-0 items-center gap-1 pointer-events-auto"
           style={NO_DRAG_STYLE}
         >
           {hasEditorPicker && (

--- a/apps/web/src/components/DesktopTitleBar.tsx
+++ b/apps/web/src/components/DesktopTitleBar.tsx
@@ -231,14 +231,28 @@ export function WorkspaceTitleBar({
       // Left padding clears the macOS traffic lights only when this bar sits at
       // the window's left edge — i.e. while the sidebar is collapsed and the
       // nav cluster lives here. When the sidebar is visible it owns that gutter.
-      className={`h-[38px] shrink-0 flex items-center gap-1 border-b border-border bg-background pr-2 ${sidebarVisible ? "pl-2" : offsetClass}`}
+      className={`relative h-[38px] shrink-0 flex items-center gap-1 border-b border-border bg-background pr-2 ${sidebarVisible ? "pl-2" : offsetClass}`}
       style={DRAG_STYLE}
     >
       {/* Nav cluster relocates here (left-aligned, in normal flow) while the
-          project list is collapsed, so it never overlaps the centered title. */}
-      {!sidebarVisible && <NavControls sidebarVisible={sidebarVisible} {...nav} />}
+          project list is collapsed. The collapsed sidebar's 3px Separator
+          still sits at the window edge, so this bar starts 3px right of
+          where the SidebarTitleBar starts — pull the cluster back by that
+          much so the toggle lands on the exact same pixel in both hosts and
+          the handoff between the two bars is invisible. */}
+      {!sidebarVisible && (
+        <div className="-ml-[3px]">
+          <NavControls sidebarVisible={sidebarVisible} {...nav} />
+        </div>
+      )}
 
-      <div className="flex flex-1 items-center justify-center min-w-0 px-1">
+      {/* The title is centered on the BAR (absolute overlay), not on the
+          leftover flex space — flex-centering would re-center it the instant
+          the nav cluster mounts/unmounts on a sidebar toggle, a ±44px jump
+          layered on top of the bar's own smooth 200ms slide. Anchored to the
+          bar, it only ever moves with the bar. pointer-events pass through
+          the overlay; the picker button re-enables them for itself. */}
+      <div className="absolute inset-x-0 top-0 flex h-full items-center justify-center min-w-0 px-1 pointer-events-none">
         {workspaceName ? (
           onWorkspaceNameClick ? (
             // Interactive: clicking opens the workspace picker (mirrors the
@@ -283,7 +297,10 @@ export function WorkspaceTitleBar({
       </div>
 
       {(hasEditorPicker || hasPanels) && (
-        <div className="flex shrink-0 items-center gap-1 pointer-events-auto" style={NO_DRAG_STYLE}>
+        <div
+          className="ml-auto flex shrink-0 items-center gap-1 pointer-events-auto"
+          style={NO_DRAG_STYLE}
+        >
           {hasEditorPicker && (
             <EditorPicker workspacePath={workspacePath} onCopyPath={onCopyPath} />
           )}

--- a/apps/web/src/components/SharedDockviewLayout.tsx
+++ b/apps/web/src/components/SharedDockviewLayout.tsx
@@ -47,6 +47,7 @@ import {
 import {
   anchorHiddenGridViews,
   applyMaximizeEdgeVisibility,
+  attachSyncLayout,
   findFocusedInnerDockview,
   prepareMaximizeRestoreAnimation,
   toggleEdgeGroup,
@@ -1695,6 +1696,22 @@ export function SharedDockviewLayout() {
     },
     [buildDefaultLayout, addMissingPanel],
   );
+
+  // ---------------------------------------------------------------------
+  // Synchronous layout on container resize
+  // ---------------------------------------------------------------------
+
+  // dockview's built-in resize handling is deferred by one animation frame,
+  // which makes the grid visibly trail the panel edge during the sidebar
+  // toggle tween and sash drags — see attachSyncLayout. `apiRef` is set by
+  // `onReady` during DockviewReact's mount, which runs before this parent
+  // effect, so the api is available on first pass.
+  useEffect(() => {
+    const el = containerRef.current;
+    const api = apiRef.current;
+    if (!el || !api) return;
+    return attachSyncLayout(el, api);
+  }, []);
 
   // ---------------------------------------------------------------------
   // Reactive: badge update on diff count change

--- a/apps/web/src/components/SharedDockviewLayout.tsx
+++ b/apps/web/src/components/SharedDockviewLayout.tsx
@@ -45,8 +45,10 @@ import {
   walkGridNode,
 } from "../lib/dockview-active-state";
 import {
+  anchorHiddenGridViews,
   applyMaximizeEdgeVisibility,
   findFocusedInnerDockview,
+  prepareMaximizeRestoreAnimation,
   toggleEdgeGroup,
 } from "../lib/dockview-edge-groups";
 import { isDesktop } from "../lib/is-desktop";
@@ -475,9 +477,16 @@ const MainGroupRightActions = memo(function MainGroupRightActions(
           <button
             type="button"
             aria-label={label}
-            onClick={() => {
-              if (props.api.isMaximized()) props.api.exitMaximized();
-              else props.api.maximize();
+            onClick={(e) => {
+              if (props.api.isMaximized()) {
+                // Re-commit the hidden views' parked positions before the
+                // restore writes land, so the tween starts from the right
+                // edge (see prepareMaximizeRestoreAnimation).
+                prepareMaximizeRestoreAnimation(e.currentTarget.closest<HTMLElement>(".dv-shell"));
+                props.api.exitMaximized();
+              } else {
+                props.api.maximize();
+              }
             }}
             className="inline-flex size-7 items-center justify-center rounded text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
           >
@@ -1197,11 +1206,18 @@ export function SharedDockviewLayout() {
         const active = api.activeGroup;
         if (!active) return;
         if (active.api.location.type !== "grid") {
-          if (api.hasMaximizedGroup()) api.exitMaximizedGroup();
+          if (api.hasMaximizedGroup()) {
+            prepareMaximizeRestoreAnimation(containerRef.current);
+            api.exitMaximizedGroup();
+          }
           return;
         }
-        if (active.api.isMaximized()) active.api.exitMaximized();
-        else active.api.maximize();
+        if (active.api.isMaximized()) {
+          prepareMaximizeRestoreAnimation(containerRef.current);
+          active.api.exitMaximized();
+        } else {
+          active.api.maximize();
+        }
       }
     };
     window.addEventListener("keydown", handler, true);
@@ -1645,6 +1661,13 @@ export function SharedDockviewLayout() {
           // path is handled separately below because `initializedRef` is
           // still false there and this listener is guarded out.
           applyMaximizeEdgeVisibility(event.api, !!e.isMaximized, containerRef.current);
+          // Synchronously (same task, same style recalc as dockview's own
+          // hide writes) re-anchor the views the maximize just hid, so the
+          // in-flight tween collapses them in place instead of sweeping
+          // them across the maximized group. See anchorHiddenGridViews.
+          if (e.isMaximized && containerRef.current) {
+            anchorHiddenGridViews(containerRef.current);
+          }
           const workspaceId = activeWorkspaceIdRef.current;
           if (!workspaceId) return;
           // Defensive: dockview's event payload types both `group` and
@@ -1738,6 +1761,14 @@ export function SharedDockviewLayout() {
     // from the workspace we just left — otherwise switching A
     // (maximized) → B (no state) would leave B rendered under A's
     // maximize overlay.
+    //
+    // When this is about to EXIT a maximize (switching out of a maximized
+    // workspace), the exit animates via the onDidMaximizedGroupChange
+    // listener — commit the hidden views' parked positions first so the
+    // tween starts from the correct edge.
+    if (api.hasMaximizedGroup()) {
+      prepareMaximizeRestoreAnimation(containerRef.current);
+    }
     applyMaximizedGroupToApi(api, activeState?.maximizedGroup);
     // Keep the edge panels in sync with the incoming workspace's maximize
     // state deterministically. When `applyMaximizedGroupToApi` actually

--- a/apps/web/src/components/SharedDockviewLayout.tsx
+++ b/apps/web/src/components/SharedDockviewLayout.tsx
@@ -1705,7 +1705,9 @@ export function SharedDockviewLayout() {
   // which makes the grid visibly trail the panel edge during the sidebar
   // toggle tween and sash drags — see attachSyncLayout. `apiRef` is set by
   // `onReady` during DockviewReact's mount, which runs before this parent
-  // effect, so the api is available on first pass.
+  // effect, so the api is available on first pass. The observer's initial
+  // notification also reconciles any mount-time container/api size mismatch
+  // (this replaced a one-shot rAF layout-sync effect that did only that).
   useEffect(() => {
     const el = containerRef.current;
     const api = apiRef.current;
@@ -1822,22 +1824,6 @@ export function SharedDockviewLayout() {
       }
     }
   }, [hiddenPanels, addMissingPanel]);
-
-  // ---------------------------------------------------------------------
-  // Recalculate dockview layout on container resize
-  // ---------------------------------------------------------------------
-
-  useEffect(() => {
-    if (!apiRef.current || !containerRef.current) return;
-    const api = apiRef.current;
-    const el = containerRef.current;
-    requestAnimationFrame(() => {
-      const { clientWidth, clientHeight } = el;
-      if (clientWidth !== api.width || clientHeight !== api.height) {
-        api.layout(clientWidth, clientHeight);
-      }
-    });
-  }, []);
 
   // ---------------------------------------------------------------------
   // Edge group drag visibility

--- a/apps/web/src/hooks/useZoom.ts
+++ b/apps/web/src/hooks/useZoom.ts
@@ -1,14 +1,15 @@
 import { useEffect } from "react";
 import { isDesktop } from "../lib/is-desktop";
-import { zoomIn, zoomOut } from "../lib/zoom";
+import { zoomIn, zoomOut, zoomReset } from "../lib/zoom";
 
 /**
  * Browser-mode keyboard shortcut handler for zoom.
  *
- * Registers Cmd+= (zoom in) and Cmd+- (zoom out). Cmd+0 is intentionally
- * NOT bound — that combo is owned by the dashboard's "All projects" label
- * filter (see DashboardShell). Reset is still reachable via the desktop
- * View menu's "Actual Size" item.
+ * Registers Cmd+= (zoom in), Cmd+- (zoom out) and Cmd+Shift+0 (reset).
+ * Plain Cmd+0 is intentionally NOT bound — that combo is owned by the
+ * dashboard's "All projects" label filter (see DashboardShell), which is
+ * also why reset uses the shifted variant (mirrored by the desktop View
+ * menu's "Actual Size" accelerator in `apps/desktop/src/main/menu.ts`).
  *
  * Only active outside the desktop shell — when running inside Electron the
  * native View menu accelerators intercept these keys before they reach the
@@ -37,6 +38,16 @@ export function useZoom(): void {
         e.preventDefault();
         e.stopPropagation();
         zoomOut();
+        return;
+      }
+
+      // Cmd+Shift+0 → reset. Match on `e.code`: with Shift held, `e.key`
+      // is layout-dependent (")" on US keyboards), but the physical digit
+      // key is always Digit0.
+      if (e.shiftKey && e.code === "Digit0") {
+        e.preventDefault();
+        e.stopPropagation();
+        zoomReset();
       }
     };
 

--- a/apps/web/src/lib/dockview-edge-groups.ts
+++ b/apps/web/src/lib/dockview-edge-groups.ts
@@ -125,6 +125,78 @@ export function refreshEdgeGroupVisibility(api: DockviewApi, forceVisible: boole
 const edgeAnimTimers = new WeakMap<HTMLElement, number>();
 
 /**
+ * Call IMMEDIATELY BEFORE exiting a maximized group. Any relayout while
+ * maximized (panel mounts after a reload, a window resize) re-parks the
+ * hidden views at offset 0, so the restore tween would start from the
+ * wrong edge. Re-anchor and force a synchronous style flush so the
+ * corrected positions are committed as the transition START values before
+ * the restore's own style writes land in the same task.
+ */
+export function prepareMaximizeRestoreAnimation(root: HTMLElement | null): void {
+  if (!root) return;
+  anchorHiddenGridViews(root);
+  void root.offsetWidth;
+}
+
+/**
+ * dockview's splitview parks a hidden view at offset 0 regardless of which
+ * side of the visible (maximized) view it came from. For a view that sits
+ * AFTER the maximized group the maximize tween then sweeps its box across
+ * the maximized group — and since it is a later DOM sibling it paints on
+ * top, so the old panel visibly slides "through" the maximizing one (and
+ * back out from under it on restore). Views BEFORE the maximized group are
+ * unaffected: offset 0 is already their natural collapse anchor, which is
+ * why maximizing the right panel tweens with a clean seam while maximizing
+ * the left one ghosted.
+ *
+ * Re-anchor every hidden view that has a visible sibling before it to the
+ * container's far edge so its box collapses (and later re-expands) in
+ * place, exactly mirroring the before-side behaviour.
+ *
+ * Must run synchronously in the same task as the maximize toggle so the new
+ * anchor lands in the same style recalc as dockview's own inline-style
+ * writes. The far edge is derived from the visible siblings' inline styles
+ * rather than clientWidth so the patch never forces a layout flush.
+ *
+ * The anchor persists as an inline style until dockview's next relayout of
+ * that splitview. A relayout while maximized (e.g. a window resize) re-parks
+ * hidden views at 0, so the following restore can still ghost for one
+ * 200ms tween — accepted; the next maximize re-anchors.
+ */
+export function anchorHiddenGridViews(root: HTMLElement): void {
+  for (const sv of Array.from(
+    root.querySelectorAll<HTMLElement>(".dv-branch-node > .dv-split-view-container"),
+  )) {
+    // Only the outer grid's splitviews participate in the maximize tween —
+    // splitviews inside panel content (inner chat/terminal/browser
+    // dockviews) are exempted from the animation by the CSS override, so
+    // skip them here too rather than writing dead inline styles.
+    if (sv.closest(".dv-content-container")) continue;
+    const horizontal = sv.classList.contains("dv-horizontal");
+    const views = Array.from(
+      sv.querySelectorAll<HTMLElement>(":scope > .dv-view-container > .dv-view"),
+    );
+    let farEdge = 0;
+    for (const v of views) {
+      if (!v.classList.contains("visible")) continue;
+      const start = Number.parseFloat(horizontal ? v.style.left : v.style.top) || 0;
+      const size = Number.parseFloat(horizontal ? v.style.width : v.style.height) || 0;
+      farEdge = Math.max(farEdge, start + size);
+    }
+    let seenVisible = false;
+    for (const v of views) {
+      if (v.classList.contains("visible")) {
+        seenVisible = true;
+        continue;
+      }
+      if (!seenVisible) continue;
+      if (horizontal) v.style.left = `${farEdge}px`;
+      else v.style.top = `${farEdge}px`;
+    }
+  }
+}
+
+/**
  * Collapse (hide) every edge group while a grid group is maximized so the
  * maximized tab gets the full area; on exit, re-derive edge visibility from
  * panel presence.

--- a/apps/web/src/lib/dockview-edge-groups.ts
+++ b/apps/web/src/lib/dockview-edge-groups.ts
@@ -137,13 +137,20 @@ const edgeAnimTimers = new WeakMap<HTMLElement, number>();
  * a frame, so this observer always gets the last word while the size is
  * changing.
  *
+ * Cost: while the container is actively resizing (toggle tween, sash drag,
+ * window resize) dockview lays out twice per frame — its stale deferred
+ * pass plus this corrective one, ~0.5-2ms each on the default 5-panel
+ * layout. Sizes are rounded to whole px to match dockview's own rounded
+ * bookkeeping, so the settle frame doesn't trigger a final
+ * fractional-vs-rounded extra relayout.
+ *
  * Returns a disposer — call it from the owning effect's cleanup.
  */
 export function attachSyncLayout(el: HTMLElement, api: DockviewApi): () => void {
   const observer = new ResizeObserver((entries) => {
     const rect = entries[entries.length - 1]?.contentRect;
     if (!rect) return;
-    api.layout(rect.width, rect.height);
+    api.layout(Math.round(rect.width), Math.round(rect.height));
   });
   observer.observe(el);
   return () => observer.disconnect();

--- a/apps/web/src/lib/dockview-edge-groups.ts
+++ b/apps/web/src/lib/dockview-edge-groups.ts
@@ -125,6 +125,31 @@ export function refreshEdgeGroupVisibility(api: DockviewApi, forceVisible: boole
 const edgeAnimTimers = new WeakMap<HTMLElement, number>();
 
 /**
+ * dockview-core defers its ResizeObserver callback by one
+ * requestAnimationFrame (`watchElementResize` in its dom.ts), so while the
+ * container is animating — the project-sidebar toggle tween, a sash drag —
+ * dockview lays out against the PREVIOUS frame's size and the grid content
+ * visibly trails the panel edge (up to ~80px at the tween's velocity peak:
+ * a hole on collapse, clipped overshoot on expand). Observe the container
+ * ourselves WITHOUT the deferral and lay out synchronously in the same
+ * frame. dockview's own deferred pass still runs a frame later with the
+ * stale size, but rAF callbacks run before resize-observer callbacks within
+ * a frame, so this observer always gets the last word while the size is
+ * changing.
+ *
+ * Returns a disposer — call it from the owning effect's cleanup.
+ */
+export function attachSyncLayout(el: HTMLElement, api: DockviewApi): () => void {
+  const observer = new ResizeObserver((entries) => {
+    const rect = entries[entries.length - 1]?.contentRect;
+    if (!rect) return;
+    api.layout(rect.width, rect.height);
+  });
+  observer.observe(el);
+  return () => observer.disconnect();
+}
+
+/**
  * Call IMMEDIATELY BEFORE exiting a maximized group. Any relayout while
  * maximized (panel mounts after a reload, a window resize) re-parks the
  * hidden views at offset 0, so the restore tween would start from the

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -322,7 +322,7 @@ function AppShell() {
   const routerNavigate = useCallback((href: string) => router.navigate({ to: href }), [router]);
   const navigationHistory = useNavigationHistory(routerNavigate, capabilities);
 
-  // Cmd+= / Cmd+- / Cmd+0 — zoom in/out/reset (browser mode only;
+  // Cmd+= / Cmd+- / Cmd+Shift+0 — zoom in/out/reset (browser mode only;
   // in the desktop shell the View menu accelerators handle these keys)
   useZoom();
 
@@ -616,10 +616,10 @@ function AppShell() {
     ],
   );
 
-  // Single source for the macOS traffic-light gutter: compute it once here (one
-  // `useIsFullscreen` subscription) and pass to both title-bar halves, rather
-  // than each bar instantiating its own hook. The offset applies to whichever
-  // bar sits at the window's left edge.
+  // Single source for the macOS traffic-light gutter: the offset is applied
+  // to the stationary nav-cluster overlay below so the sidebar-toggle /
+  // back-forward buttons clear the traffic lights; the title bars themselves
+  // no longer take an offset prop.
   const isFullscreen = useIsFullscreen();
   const titleBarOffset = isDesktop && !isFullscreen ? "pl-[80px]" : "pl-2";
 

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -27,7 +27,12 @@ import {
 import { DesktopDashboardAdapter, NativeShellCapabilities } from "@/dashboard/adapters/desktop";
 import { WebCapabilities, WebDashboardAdapter } from "@/dashboard/adapters/web";
 import { BrowserHostBridge } from "../components/BrowserHostBridge";
-import { type PanelItem, SidebarTitleBar, WorkspaceTitleBar } from "../components/DesktopTitleBar";
+import {
+  NavControls,
+  type PanelItem,
+  SidebarTitleBar,
+  WorkspaceTitleBar,
+} from "../components/DesktopTitleBar";
 import { crossPanelHandlers, SharedDockviewLayout } from "../components/SharedDockviewLayout";
 import { ToolbarActionBar, ToolbarOverflowProvider } from "../components/ToolbarButtons";
 import { useIsDesktop } from "../hooks/useIsDesktop";
@@ -583,17 +588,14 @@ function AppShell() {
     [],
   );
 
-  // The back/forward arrows and sidebar toggle belong to the project-list
-  // region. While the list is visible the SidebarTitleBar shows the cluster;
-  // when the list collapses, the same cluster relocates into the
-  // WorkspaceTitleBar (far left) so it stays reachable. The overflow actions
-  // always live in DashboardShell's bottom action bar, so the cluster carries
-  // no menu of its own. Both bars receive the same nav props; each renders the
-  // cluster only in the appropriate state (keyed off `sidebarVisible`).
+  // Props for the nav cluster (sidebar toggle + back/forward) hosted in the
+  // stationary overlay in the render below. The overflow actions always live in
+  // DashboardShell's bottom action bar, so the cluster carries no menu of
+  // its own.
   //
-  // Memoized so both bars get a stable prop reference across the frequent
-  // AppShell re-renders (route changes, workspace switches, sidebar toggles).
-  // Hooks must run unconditionally, so this sits above the narrow/mobile early
+  // Memoized for a stable prop reference across the frequent AppShell
+  // re-renders (route changes, workspace switches, sidebar toggles). Hooks
+  // must run unconditionally, so this sits above the narrow/mobile early
   // return below.
   const navControlProps = useMemo(
     () => ({
@@ -627,7 +629,20 @@ function AppShell() {
 
   return (
     <ToolbarOverflowProvider>
-      <div className="flex flex-col h-full w-full overflow-hidden bg-background text-foreground">
+      <div className="relative flex flex-col h-full w-full overflow-hidden bg-background text-foreground">
+        {/* The nav cluster (sidebar toggle + back/forward) is hosted ONCE in
+            this stationary overlay pinned over the title-bar row's left edge, floating above
+            both title bars. Hosting it inside either bar means remounting it
+            on every sidebar toggle inside an overflow-clipped, animating
+            panel — the buttons visibly flickered mid-tween. Here the panels
+            slide beneath it and it never moves or remounts. The container is
+            pointer-events-none so the drag regions beneath stay draggable;
+            NavControls re-enables pointer events on itself. */}
+        <div
+          className={`pointer-events-none absolute top-0 left-0 z-10 flex h-[38px] items-center ${titleBarOffset}`}
+        >
+          <NavControls {...navControlProps} />
+        </div>
         <div className="flex-1 min-h-0 overflow-hidden">
           <Group
             orientation="horizontal"
@@ -653,10 +668,10 @@ function AppShell() {
                 className="h-full flex flex-col overflow-hidden border-r border-border bg-sidebar"
                 data-testid="app-shell__sidebar"
               >
-                {/* The sidebar toggle + back/forward arrows ride in the
-                    SidebarTitleBar; the overflow actions live in
-                    DashboardShell's bottom action bar below. */}
-                <SidebarTitleBar {...navControlProps} offsetClass={titleBarOffset} />
+                {/* Pure drag/paint surface — the sidebar toggle + back/forward
+                    arrows live in the stationary overlay above; the overflow
+                    actions live in DashboardShell's bottom action bar below. */}
+                <SidebarTitleBar />
                 <div className="flex-1 min-h-0">
                   <DashboardShell hideTitleBar bottomActions={<ToolbarActionBar />} />
                 </div>
@@ -668,8 +683,6 @@ function AppShell() {
                   subtree or the dockview tears down all cached workspaces. */}
               <div className="h-full flex flex-col min-w-0 overflow-hidden">
                 <WorkspaceTitleBar
-                  {...navControlProps}
-                  offsetClass={titleBarOffset}
                   workspaceName={activeWorkspaceId ?? undefined}
                   workspacePath={activeWorkspaceId ? workspacePath : undefined}
                   onCopyPath={activeWorkspaceId ? handleCopyPath : undefined}

--- a/apps/web/src/styles/dockview-theme.css
+++ b/apps/web/src/styles/dockview-theme.css
@@ -298,10 +298,17 @@
 /* Scoped edge-collapse animation for tab maximize/restore. The class is
    added by applyMaximizeEdgeVisibility for the duration of the toggle only,
    so sash dragging (which writes width per pointermove) is never affected.
-   Child combinators keep this on the shell's own two splitviews — nested
-   dockviews inside panels are untouched. */
+   Three splitview layers move during a maximize toggle and all must tween
+   with the same curve or the layout tears (issue: maximizing the right
+   group snapped while maximizing the left felt smooth):
+   - the shell's outer splitview (edge panels sliding away),
+   - the shell's middle column (bottom edge),
+   - the gridview branch splitviews (the maximized group swallowing its
+     siblings — dockview resizes them via inline width/left, so without a
+     transition the grid part of the movement is an instant jump). */
 .dv-edge-anim .dv-shell > .dv-split-view-container > .dv-view-container > .dv-view,
-.dv-edge-anim .dv-shell-middle-column > .dv-split-view-container > .dv-view-container > .dv-view {
+.dv-edge-anim .dv-shell-middle-column > .dv-split-view-container > .dv-view-container > .dv-view,
+.dv-edge-anim .dv-branch-node > .dv-split-view-container > .dv-view-container > .dv-view {
   transition:
     width 200ms cubic-bezier(0.77, 0, 0.175, 1),
     left 200ms cubic-bezier(0.77, 0, 0.175, 1),
@@ -312,9 +319,21 @@
   overflow: hidden;
 }
 
+/* Inner dockviews nested inside panel content (chat tabs, terminal
+   sections, browser tabs) are full shells + grids, so the rules above
+   match their splitviews too. They re-layout via a ResizeObserver while
+   the OUTER tween runs, and each of those per-frame inline-style writes
+   would start its own 200ms transition — the inner content then visibly
+   chases its wrapper and settles a beat late. Let them track instantly
+   instead; same order in the cascade wins over the grant above. */
+.dv-edge-anim .dv-content-container .dv-split-view-container > .dv-view-container > .dv-view {
+  transition: none;
+}
+
 @media (prefers-reduced-motion: reduce) {
   .dv-edge-anim .dv-shell > .dv-split-view-container > .dv-view-container > .dv-view,
-  .dv-edge-anim .dv-shell-middle-column > .dv-split-view-container > .dv-view-container > .dv-view {
+  .dv-edge-anim .dv-shell-middle-column > .dv-split-view-container > .dv-view-container > .dv-view,
+  .dv-edge-anim .dv-branch-node > .dv-split-view-container > .dv-view-container > .dv-view {
     transition: none;
   }
 }


### PR DESCRIPTION
## PO Summary

This change removes several visual glitches that made the app feel unpolished, and fixes a bug where zooming inside the built-in browser could permanently distort the whole app:

- Toggling the sidebar no longer makes the title bar jump or the panel grid bounce — the layout stays steady while the sidebar slides.
- The navigation buttons at the top no longer flicker when the sidebar opens or closes.
- Maximizing and restoring a panel now animates the same way in both directions, without a ghost trail sweeping across the screen.
- Terminals no longer show stale or garbled bottom rows after returning to the app window.
- Zooming a page inside the built-in browser can no longer "infect" the app itself: browser tabs now live in their own isolated browsing context, and the app repairs any previously stuck zoom automatically on startup. A one-time side effect: sites open in browser tabs will ask you to log in again.
- New shortcut: Cmd+Shift+0 resets the app zoom (Cmd+0 remains "show all projects").

---

Intentional deviation from TEST-6: no e2e specs for the maximize/restore anchor fix and the Cmd+Shift+0 reset shortcut — waived by the author to keep this PR scoped; the Electron main-process session/zoom changes have no e2e harness in this repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dtx2SXpsa2sSfcxeR4rR72