### PR TITLE
test(web): harden terminal-parking e2e against CI flake

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,6 +132,18 @@ jobs:
       - name: Test e2e (web)
         run: pnpm --filter @band-app/server test:e2e
 
+      # Playwright writes per-failure error-context.md snapshots (+ any traces)
+      # into test-results/. Without this upload a CI-only e2e flake leaves
+      # nothing to diagnose beyond the assertion message in the log.
+      - name: Upload Playwright failure artifacts
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: playwright-test-results
+          path: apps/web/test-results/
+          if-no-files-found: ignore
+          retention-days: 7
+
       - name: Test (CLI)
         run: cargo test --manifest-path apps/cli/Cargo.toml -- --test-threads=4
 

--- a/apps/web/e2e/pages/WorkspacePage.ts
+++ b/apps/web/e2e/pages/WorkspacePage.ts
@@ -1119,6 +1119,58 @@ export class WorkspacePage {
     });
   }
 
+  /** Wait until the workspace's terminal has rendered ANY text into xterm's
+   *  DOM-renderer rows — i.e. the shell prompt has been drawn. Two failure
+   *  modes collapse into "rendered text is empty forever" without this
+   *  barrier, and it splits them apart: rows that never fill mean the DOM
+   *  renderer isn't active (a WebGL terminal keeps `.xterm-rows` empty), while
+   *  rows that fill but never show a later marker mean the keystrokes were
+   *  lost. Call it after `waitForTerminalReady` and before the first
+   *  `runInTerminal*` a rendered-text assertion depends on. */
+  async waitForTerminalRenderedPrompt(workspaceId: string, timeoutMs = 20_000): Promise<void> {
+    await test.step(`Wait for rendered shell prompt in ${workspaceId}`, async () => {
+      await expect
+        .poll(async () => (await this.readTerminalRenderedText(workspaceId)).trim().length, {
+          timeout: timeoutMs,
+        })
+        .toBeGreaterThan(0);
+    });
+  }
+
+  /** `runInTerminal`, made self-verifying: type `line`, then wait until
+   *  `marker` shows up in the workspace's rendered rows; if it doesn't within
+   *  `renderTimeoutMs`, retype (up to `attempts` total). Keystrokes typed into
+   *  xterm's hidden textarea can be dropped wholesale under parallel CI load
+   *  (a focus steal or a socket hiccup mid-`keyboard.type`), and a plain
+   *  `runInTerminal` has no way to notice — the test then times out on a
+   *  downstream assertion with no clue the command never ran. `runInTerminal`'s
+   *  leading Enter clears any half-typed line a failed attempt left behind, so
+   *  a retype never concatenates onto the previous attempt. Only use with an
+   *  idempotent `line` — a retype after a false-negative render wait would run
+   *  it again. */
+  async runInTerminalUntilRendered(
+    workspaceId: string,
+    line: string,
+    marker: RegExp,
+    { attempts = 3, renderTimeoutMs = 8_000 }: { attempts?: number; renderTimeoutMs?: number } = {},
+  ): Promise<void> {
+    await test.step(`Run in terminal until ${marker} renders: ${line}`, async () => {
+      for (let attempt = 1; attempt <= attempts; attempt++) {
+        await this.runInTerminal(line);
+        try {
+          await expect
+            .poll(async () => marker.test(await this.readTerminalRenderedText(workspaceId)), {
+              timeout: renderTimeoutMs,
+            })
+            .toBe(true);
+          return;
+        } catch (error) {
+          if (attempt === attempts) throw error;
+        }
+      }
+    });
+  }
+
   /** Start counting terminal WebSocket connections the page opens.
    *  Returns a getter for the running count. Call this BEFORE `goto` so
    *  the listener is attached before the first socket opens. A test

--- a/apps/web/e2e/pages/WorkspacePage.ts
+++ b/apps/web/e2e/pages/WorkspacePage.ts
@@ -1143,11 +1143,15 @@ export class WorkspacePage {
    *  xterm's hidden textarea can be dropped wholesale under parallel CI load
    *  (a focus steal or a socket hiccup mid-`keyboard.type`), and a plain
    *  `runInTerminal` has no way to notice — the test then times out on a
-   *  downstream assertion with no clue the command never ran. `runInTerminal`'s
-   *  leading Enter clears any half-typed line a failed attempt left behind, so
-   *  a retype never concatenates onto the previous attempt. Only use with an
-   *  idempotent `line` — a retype after a false-negative render wait would run
-   *  it again. */
+   *  downstream assertion with no clue the command never ran. A retry starts
+   *  with Ctrl+C, which resets both a half-typed line AND a PS2 continuation
+   *  state (a dropped tail like `for … do` without its `done`, or an unclosed
+   *  quote — `runInTerminal`'s leading Enter alone can't escape those), and
+   *  kills a loop a false-negative render wait left running. Only use with an
+   *  idempotent `line` — a retype after a false negative would run it again.
+   *  `marker` must not match the typed line's own echo (quote a fragment,
+   *  e.g. `echo C_OWN_"MARKER"`, so only executed output can match) —
+   *  otherwise a dropped trailing Enter passes verification. */
   async runInTerminalUntilRendered(
     workspaceId: string,
     line: string,
@@ -1156,6 +1160,10 @@ export class WorkspacePage {
   ): Promise<void> {
     await test.step(`Run in terminal until ${marker} renders: ${line}`, async () => {
       for (let attempt = 1; attempt <= attempts; attempt++) {
+        if (attempt > 1) {
+          await this.terminalInput.first().focus();
+          await this.page.keyboard.press("Control+C");
+        }
         await this.runInTerminal(line);
         try {
           await expect

--- a/apps/web/e2e/terminal-parking-output-focus.spec.ts
+++ b/apps/web/e2e/terminal-parking-output-focus.spec.ts
@@ -145,6 +145,10 @@ test.afterAll(async () => {
 
 test.describe("Terminal parking: liveness + focus isolation", () => {
   test("output keeps flowing into a parked terminal over the same socket", async ({ page }) => {
+    // The default 30 s test budget can't absorb this test's stacked 20 s
+    // waits (two workspace loads + three rendered-text polls) on a loaded CI
+    // worker — same override as the other terminal-heavy specs.
+    test.setTimeout(90_000);
     const workspacePage = new WorkspacePage(page, server.url, TOKEN);
     // Count only workspace A's terminal sockets so a reconnect is detectable
     // independent of B opening its own.
@@ -158,16 +162,23 @@ test.describe("Terminal parking: liveness + focus isolation", () => {
     });
     await workspacePage.waitForTerminalReady(20_000);
     await expect.poll(() => socketCount(), { timeout: 20_000 }).toBe(1);
+    // Barrier: the prompt is rendered in `.xterm-rows` before we type. Splits
+    // "DOM renderer never active (rows empty forever)" from "keystrokes lost"
+    // — the two causes a bare TICK poll can't tell apart.
+    await workspacePage.waitForTerminalRenderedPrompt(WORKSPACE_A);
 
-    // Start a long, self-paced stream of incrementing markers.
-    await workspacePage.runInTerminal("for i in $(seq 1 200); do echo TICK_$i; sleep 0.25; done");
-    // Confirm it started rendering while A is active, and record the highest
-    // marker visible just before we switch away.
-    await expect
-      .poll(async () => maxTick(await workspacePage.readTerminalRenderedText(WORKSPACE_A)), {
-        timeout: 20_000,
-      })
-      .toBeGreaterThan(0);
+    // Start a long, self-paced stream of incrementing markers. Self-verifying
+    // typing: retypes if no TICK renders (dropped keystrokes under CI load).
+    // The typed command echo can't satisfy the marker — `TICK_$i` has no
+    // digits — only real loop output matches. A rare double-typed loop is
+    // harmless: the second copy sits buffered in the PTY until the first
+    // finishes (~50 s), long after this test stopped reading.
+    await workspacePage.runInTerminalUntilRendered(
+      WORKSPACE_A,
+      "for i in $(seq 1 200); do echo TICK_$i; sleep 0.25; done",
+      /TICK_\d+/,
+    );
+    // Record the highest marker visible just before we switch away.
     const beforePark = maxTick(await workspacePage.readTerminalRenderedText(WORKSPACE_A));
 
     // Switch away → A parks. In-app nav keeps A cached (maxCachedWorkspaces=3).
@@ -208,6 +219,7 @@ test.describe("Terminal parking: liveness + focus isolation", () => {
   test("keystrokes for the active terminal never leak into a parked one", async ({ page }) => {
     // Own workspace pair (C/D), separate from the output test's (A/B), so this
     // test always starts from fresh, idle shells.
+    test.setTimeout(90_000);
     const workspacePage = new WorkspacePage(page, server.url, TOKEN);
 
     await workspacePage.goto(WORKSPACE_C);
@@ -224,14 +236,12 @@ test.describe("Terminal parking: liveness + focus isolation", () => {
     // check can't pass vacuously against an unrendered buffer, and we never have
     // to type into C after its park→re-attach (that focus race made this test
     // flaky under parallel load).
-    await workspacePage.runInTerminal("echo C_OWN_MARKER");
-    await expect
-      .poll(
-        async () =>
-          (await workspacePage.readTerminalRenderedText(WORKSPACE_C)).includes("C_OWN_MARKER"),
-        { timeout: 20_000 },
-      )
-      .toBe(true);
+    await workspacePage.waitForTerminalRenderedPrompt(WORKSPACE_C);
+    await workspacePage.runInTerminalUntilRendered(
+      WORKSPACE_C,
+      "echo C_OWN_MARKER",
+      /C_OWN_MARKER/,
+    );
 
     // Bring D forward with its own terminal; C parks.
     await workspacePage.switchWorkspace(WORKSPACE_D);
@@ -249,14 +259,12 @@ test.describe("Terminal parking: liveness + focus isolation", () => {
     // Type a unique marker; it must land in the ACTIVE terminal (D), never the
     // parked one (C). `terminalInput` resolves to D only — C's textarea is
     // aria-hidden inside the inert parking container.
-    await workspacePage.runInTerminal("echo LEAKMARKER987");
-    await expect
-      .poll(
-        async () =>
-          (await workspacePage.readTerminalRenderedText(WORKSPACE_D)).includes("LEAKMARKER987"),
-        { timeout: 20_000 },
-      )
-      .toBe(true);
+    await workspacePage.waitForTerminalRenderedPrompt(WORKSPACE_D);
+    await workspacePage.runInTerminalUntilRendered(
+      WORKSPACE_D,
+      "echo LEAKMARKER987",
+      /LEAKMARKER987/,
+    );
 
     // Switch back to C so its buffer is repainted on re-attach (xterm freezes
     // rendering while parked). Wait until C's own marker is rendered again (the

--- a/apps/web/e2e/terminal-parking-output-focus.spec.ts
+++ b/apps/web/e2e/terminal-parking-output-focus.spec.ts
@@ -236,10 +236,13 @@ test.describe("Terminal parking: liveness + focus isolation", () => {
     // check can't pass vacuously against an unrendered buffer, and we never have
     // to type into C after its park→re-attach (that focus race made this test
     // flaky under parallel load).
+    // The quoted fragment keeps the typed echo (`C_OWN_"MARKER"`) from matching
+    // the marker — only executed output (quote removal) can satisfy it, so a
+    // dropped trailing Enter can't pass verification.
     await workspacePage.waitForTerminalRenderedPrompt(WORKSPACE_C);
     await workspacePage.runInTerminalUntilRendered(
       WORKSPACE_C,
-      "echo C_OWN_MARKER",
+      'echo C_OWN_"MARKER"',
       /C_OWN_MARKER/,
     );
 
@@ -259,10 +262,11 @@ test.describe("Terminal parking: liveness + focus isolation", () => {
     // Type a unique marker; it must land in the ACTIVE terminal (D), never the
     // parked one (C). `terminalInput` resolves to D only — C's textarea is
     // aria-hidden inside the inert parking container.
+    // Quoted fragment again: typed echo can't satisfy the marker, only output.
     await workspacePage.waitForTerminalRenderedPrompt(WORKSPACE_D);
     await workspacePage.runInTerminalUntilRendered(
       WORKSPACE_D,
-      "echo LEAKMARKER987",
+      'echo LEAK"MARKER987"',
       /LEAKMARKER987/,
     );
 
@@ -284,8 +288,9 @@ test.describe("Terminal parking: liveness + focus isolation", () => {
         { timeout: 20_000 },
       )
       .toBe(true);
-    expect(await workspacePage.readTerminalRenderedText(WORKSPACE_C)).not.toContain(
-      "LEAKMARKER987",
-    );
+    // "MARKER987" (not the full "LEAKMARKER987") so a leak is caught in BOTH
+    // forms it could render in C: executed output (`LEAKMARKER987`) and the raw
+    // typed echo (`LEAK"MARKER987"`). C's own marker never contains "MARKER987".
+    expect(await workspacePage.readTerminalRenderedText(WORKSPACE_C)).not.toContain("MARKER987");
   });
 });


### PR DESCRIPTION
## PO Summary

A safety test for the terminal feature (the one proving output keeps flowing into a background workspace's terminal) occasionally failed on our build servers even though the product works correctly. Those false alarms block releases and cost investigation time. This change makes the test resistant to the two timing hiccups that caused the false alarm, and makes the build system save diagnostic snapshots whenever a browser test fails, so any future failure can be diagnosed immediately instead of guessed at.

## Notes

Flake, not regression: the same commit passed CI on its PR branch and only failed on the main merge run. The failing poll could not distinguish "typed command never reached the shell" from "terminal rendered nothing at all"; the new prompt-render barrier separates those, and self-verifying typing retries dropped keystrokes. `test.setTimeout(90_000)` matches the other terminal-heavy specs. Verified locally: spec solo 2/2, full e2e suite 143 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)