### PR TITLE
fix: desktop nav-cluster clicks + terminal WebGL repair after sleep/unlock

### DIFF
--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -13,9 +13,10 @@
  *      free port 3456 (release builds only — same gate as Tauri).
  */
 
-import { app, BrowserWindow, protocol, session } from "electron";
+import { app, BrowserWindow, powerMonitor, protocol, session } from "electron";
 import { CertExceptionStore } from "../browser/cert-exceptions.js";
 import { BROWSER_PARTITION, BrowserViewManager } from "../browser/view-manager.js";
+import { Events } from "../shared/ipc-channels.js";
 import { createHiddenBrowserWindow } from "./hidden-browser-window.js";
 import { resolveAppIcon } from "./icon.js";
 import { registerIpc } from "./ipc/register.js";
@@ -62,6 +63,9 @@ interface AppState {
   /** Empty string in dev mode where we don't own the server. */
   webDir: string;
 }
+
+/** powerMonitor listeners survive window close; wire them at most once. */
+let powerEventsWired = false;
 
 const state: AppState = {
   mainWindow: null,
@@ -339,6 +343,19 @@ async function bootstrap(): Promise<void> {
   };
   state.mainWindow.on("enter-full-screen", () => sendFullscreen(true));
   state.mainWindow.on("leave-full-screen", () => sendFullscreen(false));
+
+  // Forward wake-from-sleep / screen-unlock to the renderer (see the
+  // `systemResumed` event doc in shared/ipc-channels.ts). powerMonitor
+  // listeners are process-global, so guard against a macOS dock re-activate
+  // re-running bootstrap and stacking duplicates.
+  if (!powerEventsWired) {
+    powerEventsWired = true;
+    const sendSystemResumed = () => {
+      state.mainWindow?.webContents.send(Events.systemResumed);
+    };
+    powerMonitor.on("resume", sendSystemResumed);
+    powerMonitor.on("unlock-screen", sendSystemResumed);
+  }
 }
 
 app.on("window-all-closed", () => {

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -351,7 +351,11 @@ async function bootstrap(): Promise<void> {
   if (!powerEventsWired) {
     powerEventsWired = true;
     const sendSystemResumed = () => {
-      state.mainWindow?.webContents.send(Events.systemResumed);
+      // These listeners outlive the window: on macOS the app stays alive in
+      // the dock after close, and a destroyed BrowserWindow's webContents
+      // throws (optional chaining only guards null, not destroyed).
+      const win = state.mainWindow;
+      if (win && !win.isDestroyed()) win.webContents.send(Events.systemResumed);
     };
     powerMonitor.on("resume", sendSystemResumed);
     powerMonitor.on("unlock-screen", sendSystemResumed);

--- a/apps/desktop/src/preload/index.cts
+++ b/apps/desktop/src/preload/index.cts
@@ -103,6 +103,9 @@ const ALLOWED_EVENT_NAMES = new Set<string>([
   "browser-open-window",
   "window-fullscreen-changed",
   "updater-status-changed",
+  // Wake from system sleep / screen unlock (powerMonitor resume/unlock-screen);
+  // WebGL surfaces subscribe to repair their glyph atlases.
+  "system-resumed",
 ]);
 
 type Unlisten = () => void;

--- a/apps/desktop/src/shared/ipc-channels.ts
+++ b/apps/desktop/src/shared/ipc-channels.ts
@@ -97,6 +97,13 @@ export const Channels = {
 export type ChannelName = (typeof Channels)[keyof typeof Channels];
 
 export const Events = {
+  /** Pushed when the machine wakes from system sleep or the screen is
+   *  unlocked (powerMonitor `resume` / `unlock-screen`). The window often
+   *  kept OS focus through the nap, so the renderer sees neither `focus`
+   *  nor `visibilitychange` — but the GPU may have discarded texture
+   *  memory in the meantime. WebGL surfaces (terminal glyph atlases)
+   *  subscribe to repair themselves. */
+  systemResumed: "system-resumed",
   browserUrlChanged: "browser-url-changed",
   browserTitleChanged: "browser-title-changed",
   /** Emitted when a `WebContentsView` is destroyed (LRU eviction,

--- a/apps/web/e2e/pages/WorkspacePage.ts
+++ b/apps/web/e2e/pages/WorkspacePage.ts
@@ -501,6 +501,36 @@ export class WorkspacePage {
     return this.page.getByTestId("desktop-title-bar__forward");
   }
 
+  /** The stationary nav-cluster overlay that hosts the sidebar toggle and
+   *  back/forward arrows. `data-testid` set in `__root.tsx` (`AppShell`). */
+  get navOverlay(): Locator {
+    return this.page.getByTestId("app-shell__nav-overlay");
+  }
+
+  /** Whether the nav-cluster overlay renders AFTER every title-bar drag
+   *  surface in DOM order. Load-bearing in the desktop shell: Chromium
+   *  computes the window's draggable region by walking the layout tree in
+   *  document order — unioning `app-region: drag` rects and subtracting
+   *  `no-drag` rects as it goes, z-index irrelevant. If the overlay renders
+   *  before the bars, the bars' drag rects re-cover the buttons and every
+   *  click on them starts a window drag (PR #634). True drag-region
+   *  hit-testing only exists in Electron, so DOM order is the assertable
+   *  projection of the invariant in this browser harness. Throws when either
+   *  side is missing so a renamed testid can't produce a vacuous pass. */
+  async navOverlayFollowsTitleBars(): Promise<boolean> {
+    return await this.navOverlay.evaluate((overlay) => {
+      const bars = document.querySelectorAll(
+        '[data-testid="desktop-title-bar__sidebar-surface"], [data-testid="desktop-title-bar__workspace-surface"]',
+      );
+      if (bars.length === 0) {
+        throw new Error("no title-bar drag surfaces found — testids renamed?");
+      }
+      return Array.from(bars).every(
+        (bar) => (bar.compareDocumentPosition(overlay) & Node.DOCUMENT_POSITION_FOLLOWING) !== 0,
+      );
+    });
+  }
+
   /** The sidebar-toggle button's viewport x-position. The nav cluster lives
    *  in a stationary overlay, so this must not change when the sidebar collapses
    *  or expands — the geometric signal that the toggle neither relocates nor

--- a/apps/web/e2e/sidebar-toggle.spec.ts
+++ b/apps/web/e2e/sidebar-toggle.spec.ts
@@ -168,6 +168,30 @@ test("the toggle and back/forward stay put (no relocation, no jump) when the sid
   await expect.poll(() => wp.sidebarToggleX()).toBe(xBefore);
 });
 
+test("the nav-cluster overlay renders after the title bars in DOM order", async ({ page }) => {
+  const wp = new WorkspacePage(page, server.url, TOKEN);
+  await wp.goto(WORKSPACE);
+  await wp.waitForReady();
+
+  // Positive anchor: the overlay and its toggle actually rendered.
+  await expect(wp.sidebarToggle).toBeVisible();
+
+  // Drag-region invariant (PR #634): in the Electron shell, Chromium builds
+  // the window's draggable region in DOCUMENT order — the overlay's `no-drag`
+  // carve-out only wins if it comes after the title bars' `drag` rects. An
+  // earlier-in-DOM overlay leaves the nav buttons covered by the drag region
+  // (clicks start a window drag instead). Real drag-region hit-testing isn't
+  // reachable from this browser harness, so DOM order is the assertable
+  // projection; the page-object probe throws if either side goes missing.
+  expect(await wp.navOverlayFollowsTitleBars()).toBe(true);
+
+  // The invariant must hold in the collapsed state too — the workspace title
+  // bar is the only drag surface then.
+  await wp.toggleSidebarViaButton();
+  await expect.poll(() => wp.sidebarWidth()).toBeLessThan(5);
+  expect(await wp.navOverlayFollowsTitleBars()).toBe(true);
+});
+
 test("the collapsed state persists across a reload", async ({ page }) => {
   const wp = new WorkspacePage(page, server.url, TOKEN);
   await wp.goto(WORKSPACE);

--- a/apps/web/src/components/DesktopTitleBar.tsx
+++ b/apps/web/src/components/DesktopTitleBar.tsx
@@ -172,6 +172,7 @@ export function NavControls({
 export function SidebarTitleBar() {
   return (
     <div
+      data-testid="desktop-title-bar__sidebar-surface"
       className="h-[38px] shrink-0 flex items-center border-b border-border bg-sidebar"
       style={DRAG_STYLE}
     />
@@ -209,6 +210,7 @@ export function WorkspaceTitleBar({
 
   return (
     <div
+      data-testid="desktop-title-bar__workspace-surface"
       className="relative h-[38px] shrink-0 flex items-center gap-1 border-b border-border bg-background pr-2 pl-2"
       style={DRAG_STYLE}
     >

--- a/apps/web/src/lib/terminal-cache.ts
+++ b/apps/web/src/lib/terminal-cache.ts
@@ -2,6 +2,8 @@ import type { ISearchOptions, SearchAddon } from "@xterm/addon-search";
 import type { WebglAddon } from "@xterm/addon-webgl";
 import type { ITheme, Terminal } from "@xterm/xterm";
 import type { SearchOptions } from "@/dashboard";
+import { listen as desktopListen } from "./desktop-ipc";
+import { isDesktop } from "./is-desktop";
 import { openExternalUrl } from "./open-external-url";
 import { createTerminalFileLinkProvider } from "./terminal-file-links";
 import { getParkingContainer } from "./terminal-parking";
@@ -327,6 +329,15 @@ function createEntry(terminalId: string, opts: CreateOptions): TerminalCacheEntr
   // WebGL "backing store may be stale" flag; a full re-attach is deferred to the
   // next `attach` (e.g. context lost while parked).
   let webglSuspect = false;
+  // WebGL "glyph atlas may be corrupted" flag. A backgrounded/occluded window
+  // can lose GPU texture memory WITHOUT a `webglcontextlost` event; after that,
+  // `term.refresh` alone redraws every row through the same damaged atlas
+  // (backgrounds paint, glyphs come out blank/partial). Set on every return to
+  // the foreground; the next repair drops the atlas so glyphs re-rasterize.
+  // Deliberately NOT set on plain attach (pane switches) — the atlas rebuild
+  // costs a few ms of glyph rasterization and parked terminals keep a healthy
+  // atlas.
+  let atlasSuspect = false;
 
   // Selection (long-press → word-select → arrow-extend) state.
   let selectionAnchor: Cell | null = null;
@@ -764,6 +775,7 @@ function createEntry(terminalId: string, opts: CreateOptions): TerminalCacheEntr
     // and `focus` coalesces into a single repair — same idiom as `attach`.
     const handleForeground = () => {
       handleResume();
+      atlasSuspect = true;
       scheduleRepair();
     };
     const handleVisibility = () => {
@@ -772,6 +784,20 @@ function createEntry(terminalId: string, opts: CreateOptions): TerminalCacheEntr
     window.addEventListener("online", handleResume);
     window.addEventListener("focus", handleForeground);
     document.addEventListener("visibilitychange", handleVisibility);
+    // Desktop shell only: wake from system sleep / screen unlock. The window
+    // often kept OS focus through the nap, so neither `focus` nor
+    // `visibilitychange` fires in the renderer — but the GPU may have
+    // discarded texture memory while the display was down. The main process
+    // forwards powerMonitor's resume/unlock as `system-resumed`.
+    let unlistenSystemResumed: (() => void) | null = null;
+    if (isDesktop) {
+      desktopListen("system-resumed", handleForeground)
+        .then((off) => {
+          if (destroyed) off();
+          else unlistenSystemResumed = off;
+        })
+        .catch(() => {});
+    }
 
     connect();
 
@@ -886,6 +912,15 @@ function createEntry(terminalId: string, opts: CreateOptions): TerminalCacheEntr
         fit.fit();
       }
       webglSuspect = false;
+      // Foreground return: the atlas texture may have been damaged while the
+      // window was backgrounded/occluded, and `refresh` would faithfully
+      // redraw the damage. Drop it so glyphs re-rasterize on the next frame.
+      // (The `webglSuspect` branches above rebuild the whole addon — fresh
+      // atlas — so doing both is harmless.)
+      if (atlasSuspect) {
+        atlasSuspect = false;
+        webglAddon?.clearTextureAtlas();
+      }
       if (term.rows > 0) term.refresh(0, term.rows - 1);
       sendPtyResize();
     };
@@ -905,6 +940,7 @@ function createEntry(terminalId: string, opts: CreateOptions): TerminalCacheEntr
       window.removeEventListener("online", handleResume);
       window.removeEventListener("focus", handleForeground);
       document.removeEventListener("visibilitychange", handleVisibility);
+      unlistenSystemResumed?.();
       themeObserver.disconnect();
       resizeObserver.disconnect();
       searchResultsDisposable.dispose();

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -630,19 +630,6 @@ function AppShell() {
   return (
     <ToolbarOverflowProvider>
       <div className="relative flex flex-col h-full w-full overflow-hidden bg-background text-foreground">
-        {/* The nav cluster (sidebar toggle + back/forward) is hosted ONCE in
-            this stationary overlay pinned over the title-bar row's left edge, floating above
-            both title bars. Hosting it inside either bar means remounting it
-            on every sidebar toggle inside an overflow-clipped, animating
-            panel — the buttons visibly flickered mid-tween. Here the panels
-            slide beneath it and it never moves or remounts. The container is
-            pointer-events-none so the drag regions beneath stay draggable;
-            NavControls re-enables pointer events on itself. */}
-        <div
-          className={`pointer-events-none absolute top-0 left-0 z-10 flex h-[38px] items-center ${titleBarOffset}`}
-        >
-          <NavControls {...navControlProps} />
-        </div>
         <div className="flex-1 min-h-0 overflow-hidden">
           <Group
             orientation="horizontal"
@@ -703,6 +690,26 @@ function AppShell() {
               </div>
             </Panel>
           </Group>
+        </div>
+        {/* The nav cluster (sidebar toggle + back/forward) is hosted ONCE in
+            this stationary overlay pinned over the title-bar row's left edge, floating above
+            both title bars. Hosting it inside either bar means remounting it
+            on every sidebar toggle inside an overflow-clipped, animating
+            panel — the buttons visibly flickered mid-tween. Here the panels
+            slide beneath it and it never moves or remounts. The container is
+            pointer-events-none so the drag regions beneath stay draggable;
+            NavControls re-enables pointer events on itself.
+
+            MUST come after the title bars in DOM order: Chromium computes the
+            window's draggable region by walking the layout tree in document
+            order, unioning `app-region: drag` rects and subtracting `no-drag`
+            rects as it goes — z-index is irrelevant. If this overlay renders
+            before the bars, the bars' drag rects re-cover the buttons and
+            every click on them starts a window drag in the desktop app. */}
+        <div
+          className={`pointer-events-none absolute top-0 left-0 z-10 flex h-[38px] items-center ${titleBarOffset}`}
+        >
+          <NavControls {...navControlProps} />
         </div>
       </div>
     </ToolbarOverflowProvider>

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -707,6 +707,7 @@ function AppShell() {
             before the bars, the bars' drag rects re-cover the buttons and
             every click on them starts a window drag in the desktop app. */}
         <div
+          data-testid="app-shell__nav-overlay"
           className={`pointer-events-none absolute top-0 left-0 z-10 flex h-[38px] items-center ${titleBarOffset}`}
         >
           <NavControls {...navControlProps} />


### PR DESCRIPTION
## PO Summary

Two desktop app fixes:

- **The sidebar toggle and back/forward arrows work again when clicked.** After the recent title-bar polish, clicking these buttons in the desktop app started dragging the window instead of triggering the action (keyboard shortcuts still worked). The buttons now respond to clicks exactly as before.
- **Terminals no longer come back garbled after the screen sleeps or the Mac is locked.** Previously, waking the machine could leave terminal text half-rendered (colored blocks with missing characters) until new output arrived. The terminal now automatically repairs its rendering the moment the system wakes or the screen is unlocked.

## Details

- Nav cluster: Chromium computes the window drag region in DOM order (union `app-region: drag` rects, subtract `no-drag` rects — z-index irrelevant). The stationary overlay rendered before the title bars, so the bars' drag rects re-covered the buttons. Overlay moved after the panels in DOM; same visual position.
- Terminal: GPU texture memory backing the WebGL glyph atlas can be discarded during display/system sleep without a `webglcontextlost` event, and often without any renderer-side focus/visibility event. Foreground repair now drops the atlas (`clearTextureAtlas`) before the full-row refresh, and the main process forwards powerMonitor `resume`/`unlock-screen` as a new `system-resumed` IPC event wired into the same repair path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S4XwwttS5wf6vwCxpRroyB