### PR TITLE
fix(web): reset Quick Open selection to first result on query change

### DIFF
--- a/apps/web/e2e/pages/WorkspacePage.ts
+++ b/apps/web/e2e/pages/WorkspacePage.ts
@@ -1626,8 +1626,13 @@ export class WorkspacePage {
    *  re-renders a new result set, then snap the highlight back to a stale
    *  surviving row; a one-shot poll for "selection is first" would pass on that
    *  transient and miss the regression. The post-fix selection is first AND
-   *  stays first, so the settled value is the honest signal for both. */
-  private async waitForStableSelection(read: () => Promise<string | null>): Promise<string | null> {
+   *  stays first, so the settled value is the honest signal for both.
+   *
+   *  The canonical stability-polling primitive for any cmdk dialog's selection;
+   *  `protected` so a future dialog page object can reuse it. */
+  protected async waitForStableSelection(
+    read: () => Promise<string | null>,
+  ): Promise<string | null> {
     let previous: string | null | undefined;
     await expect
       .poll(

--- a/apps/web/e2e/pages/WorkspacePage.ts
+++ b/apps/web/e2e/pages/WorkspacePage.ts
@@ -1565,11 +1565,32 @@ export class WorkspacePage {
   }
 
   /** Press a key while the Quick Open input is focused — the real path for
-   *  keyboard navigation (ArrowDown / ArrowUp / Home / End / Enter). */
+   *  keyboard navigation (ArrowDown / ArrowUp / Enter). */
   async pressQuickOpenKey(key: string): Promise<void> {
     await test.step(`Press "${key}" in Quick Open`, async () => {
       await this.quickOpenInput.focus();
       await this.page.keyboard.press(key);
+    });
+  }
+
+  /** Move the Quick Open selection onto the row whose `data-value` is `value`
+   *  by stepping `ArrowDown` from the current position. Deterministic where
+   *  cmdk's `End` binding is not: with focus in the search input, `End` is
+   *  ambiguous with a caret-to-end-of-text move, so it can't be relied on to
+   *  jump the list selection. `ArrowDown` is unambiguous and walks every row in
+   *  DOM order until it wraps, so a bounded loop reaches any rendered row.
+   *  Throws (rather than looping forever) if `value` is never selected. */
+  async navigateQuickOpenTo(value: string): Promise<void> {
+    await test.step(`Navigate Quick Open selection to "${value}"`, async () => {
+      // One press per row is always enough to reach any row from any start
+      // position; +2 leaves slack for the initial (already-selected) row and a
+      // possible trailing action row without risking a wrap past the target.
+      const maxPresses = (await this.quickOpenItems.count()) + 2;
+      for (let i = 0; i < maxPresses; i++) {
+        if ((await this.selectedQuickOpenValue()) === value) return;
+        await this.pressQuickOpenKey("ArrowDown");
+      }
+      throw new Error(`Quick Open never selected "${value}" after ${maxPresses} ArrowDown presses`);
     });
   }
 

--- a/apps/web/e2e/pages/WorkspacePage.ts
+++ b/apps/web/e2e/pages/WorkspacePage.ts
@@ -1636,9 +1636,11 @@ export class WorkspacePage {
           return isStable;
         },
         {
-          intervals: [150, 150, 150, 150, 150, 150],
-          timeout: 6000,
-          message: "Quick Open / Search-in-Files selection never stabilized within 6s",
+          // Sample ~10 times at 200ms so a sub-render transient on slow CI
+          // can't be mistaken for a settled value by two adjacent samples.
+          intervals: [200, 200, 200, 200, 200, 200, 200, 200, 200, 200],
+          timeout: 8000,
+          message: "Quick Open / Search-in-Files selection never stabilized within 8s",
         },
       )
       .toBe(true);

--- a/apps/web/e2e/pages/WorkspacePage.ts
+++ b/apps/web/e2e/pages/WorkspacePage.ts
@@ -1584,7 +1584,7 @@ export class WorkspacePage {
   /** The `data-value` of the single row cmdk currently marks
    *  `aria-selected="true"`, or `null` when nothing is selected. */
   async selectedQuickOpenValue(): Promise<string | null> {
-    const selected = this.quickOpenItems.and(this.page.locator('[aria-selected="true"]'));
+    const selected = this.quickOpenDialog().getByRole("option", { selected: true });
     if ((await selected.count()) === 0) return null;
     return await selected.first().getAttribute("data-value");
   }

--- a/apps/web/e2e/pages/WorkspacePage.ts
+++ b/apps/web/e2e/pages/WorkspacePage.ts
@@ -1437,8 +1437,9 @@ export class WorkspacePage {
 
   /** Dispatch the `band:open-quick-open` window event — the same event the
    *  file-tree toolbar's "Quick Open" action fires (see `CodeBrowserView.tsx`).
-   *  MobileWorkspaceLayout listens for it and opens the QuickOpenDialog with an
-   *  empty query (unlike `band:open-file`, which pre-fills a query and can
+   *  On desktop `SharedDockviewLayout` listens for it; on mobile
+   *  `MobileWorkspaceLayout` does. Either way it opens the QuickOpenDialog with
+   *  an empty query (unlike `band:open-file`, which pre-fills a query and can
    *  auto-open a single match without ever showing the dialog). */
   async dispatchOpenQuickOpen(): Promise<void> {
     await test.step("Dispatch band:open-quick-open", async () => {
@@ -1487,6 +1488,110 @@ export class WorkspacePage {
    *  real user would take. */
   async closeQuickOpenDialog(): Promise<void> {
     await this.pressEscape();
+  }
+
+  // ──────────────────────────────────────────────────────────────────────
+  // Quick Open selection / scroll probes (fix/quick-open-select-first).
+  //
+  // The dialog is a cmdk `Command`; its input, list, and item rows carry the
+  // `data-slot` attributes set by the `@band-app/ui` command wrappers plus the
+  // `aria-selected` / `data-value` attributes cmdk owns. All locators below are
+  // scoped to the QuickOpenDialog root so they never collide with the other
+  // command palettes (workspace picker, command palette) mounted in the tree.
+  // ──────────────────────────────────────────────────────────────────────
+
+  /** The Quick Open search input. ARIA role is system-controlled (cmdk sets
+   *  `role="combobox"`); scoped to the dialog root. */
+  get quickOpenInput(): Locator {
+    return this.quickOpenDialog().getByRole("combobox");
+  }
+
+  /** The scrollable results list — cmdk renders `role="listbox"` on
+   *  `Command.List` (system-controlled), the element whose `scrollTop` the fix
+   *  must reset to 0. `getByRole` matches the sibling cmdk page objects and the
+   *  locator-priority doctrine. */
+  get quickOpenList(): Locator {
+    return this.quickOpenDialog().getByRole("listbox");
+  }
+
+  /** All rendered result rows — cmdk renders `role="option"` on every
+   *  `Command.Item` (matching `WorkspacePicker.options`). Covers the
+   *  file/recent rows plus any action row; the test reads each row's
+   *  `data-value` (the file path) to reason about order and selection. */
+  get quickOpenItems(): Locator {
+    return this.quickOpenDialog().getByRole("option");
+  }
+
+  /** Open Quick Open via the same `band:open-quick-open` window event the file
+   *  tree toolbar fires, then wait for the dialog to render. */
+  async openQuickOpen(): Promise<void> {
+    await test.step("Open Quick Open", async () => {
+      await this.dispatchOpenQuickOpen();
+      await this.quickOpenDialog().waitFor({ state: "visible" });
+    });
+  }
+
+  /** Type a query into the Quick Open input (replacing any existing text), the
+   *  way a user editing the search field would. Focuses first, selects all so
+   *  the new text replaces a restored `lastQuery`, then types. */
+  async typeQuickOpen(text: string): Promise<void> {
+    await test.step(`Type Quick Open query "${text}"`, async () => {
+      await this.quickOpenInput.focus();
+      await this.page.keyboard.press("ControlOrMeta+a");
+      await this.page.keyboard.type(text);
+    });
+  }
+
+  /** Append text to the Quick Open query without clearing it — the way a user
+   *  refining an existing search types the next character. Distinct from
+   *  `typeQuickOpen`, which replaces the field: appending keeps the previously
+   *  matched files continuously mounted, which is the exact condition under
+   *  which the stale-selection bug reproduced. */
+  async appendQuickOpen(text: string): Promise<void> {
+    await test.step(`Append "${text}" to Quick Open query`, async () => {
+      await this.quickOpenInput.focus();
+      await this.page.keyboard.type(text);
+    });
+  }
+
+  /** Clear the Quick Open input entirely (select-all + delete) so the empty-
+   *  query recent-files view is shown. */
+  async clearQuickOpenQuery(): Promise<void> {
+    await test.step("Clear Quick Open query", async () => {
+      await this.quickOpenInput.focus();
+      await this.page.keyboard.press("ControlOrMeta+a");
+      await this.page.keyboard.press("Delete");
+    });
+  }
+
+  /** Press a key while the Quick Open input is focused — the real path for
+   *  keyboard navigation (ArrowDown / ArrowUp / Home / End / Enter). */
+  async pressQuickOpenKey(key: string): Promise<void> {
+    await test.step(`Press "${key}" in Quick Open`, async () => {
+      await this.quickOpenInput.focus();
+      await this.page.keyboard.press(key);
+    });
+  }
+
+  /** The `data-value` (file path) of every rendered result row, in DOM order.
+   *  cmdk mirrors each item's `value` prop onto its `data-value` attribute. */
+  async quickOpenItemValues(): Promise<string[]> {
+    return await this.quickOpenItems.evaluateAll((els) =>
+      els.map((el) => el.getAttribute("data-value") ?? ""),
+    );
+  }
+
+  /** The `data-value` of the single row cmdk currently marks
+   *  `aria-selected="true"`, or `null` when nothing is selected. */
+  async selectedQuickOpenValue(): Promise<string | null> {
+    const selected = this.quickOpenItems.and(this.page.locator('[aria-selected="true"]'));
+    if ((await selected.count()) === 0) return null;
+    return await selected.first().getAttribute("data-value");
+  }
+
+  /** Current `scrollTop` of the Quick Open results list. 0 ⇔ scrolled to top. */
+  async quickOpenListScrollTop(): Promise<number> {
+    return await this.quickOpenList.evaluate((el) => el.scrollTop);
   }
 
   /** Dispatch a synthetic `band:open-file` window event into the page

--- a/apps/web/e2e/pages/WorkspacePage.ts
+++ b/apps/web/e2e/pages/WorkspacePage.ts
@@ -1492,7 +1492,7 @@ export class WorkspacePage {
   }
 
   // ──────────────────────────────────────────────────────────────────────
-  // Quick Open selection / scroll probes (fix/quick-open-select-first).
+  // Quick Open selection / scroll probes.
   //
   // The dialog is a cmdk `Command`; its input, list, and item rows carry the
   // `data-slot` attributes set by the `@band-app/ui` command wrappers plus the
@@ -1516,9 +1516,10 @@ export class WorkspacePage {
   }
 
   /** All rendered result rows — cmdk renders `role="option"` on every
-   *  `Command.Item` (matching `WorkspacePicker.options`). Covers the
-   *  file/recent rows plus any action row; the test reads each row's
-   *  `data-value` (the file path) to reason about order and selection. */
+   *  `Command.Item` (a system-controlled ARIA role), so `getByRole("option")`
+   *  is the correct locator. Covers the file/recent rows plus any action row;
+   *  the test reads each row's `data-value` (the file path) to reason about
+   *  order and selection. */
   get quickOpenItems(): Locator {
     return this.quickOpenDialog().getByRole("option");
   }
@@ -1580,7 +1581,10 @@ export class WorkspacePage {
    *  ambiguous with a caret-to-end-of-text move, so it can't be relied on to
    *  jump the list selection. `ArrowDown` is unambiguous and walks every row in
    *  DOM order until it wraps, so a bounded loop reaches any rendered row.
-   *  Throws (rather than looping forever) if `value` is never selected. */
+   *  Throws (rather than looping forever) if `value` is never selected.
+   *  Precondition: the caller must have waited for the result count to settle
+   *  (e.g. `expect.poll(() => quickOpenItems.count())`) — the press bound is
+   *  snapshotted once, so a still-growing list could make it give up early. */
   async navigateQuickOpenTo(value: string): Promise<void> {
     await test.step(`Navigate Quick Open selection to "${value}"`, async () => {
       // One press per row is always enough to reach any row from any start
@@ -1625,14 +1629,12 @@ export class WorkspacePage {
    *  stays first, so the settled value is the honest signal for both. */
   private async waitForStableSelection(read: () => Promise<string | null>): Promise<string | null> {
     let previous: string | null | undefined;
-    let stable: string | null = null;
     await expect
       .poll(
         async () => {
           const current = await read();
           const isStable = previous !== undefined && current === previous;
           previous = current;
-          if (isStable) stable = current;
           return isStable;
         },
         {
@@ -1644,7 +1646,9 @@ export class WorkspacePage {
         },
       )
       .toBe(true);
-    return stable;
+    // The poll resolved on two consecutive equal samples, so `previous` holds
+    // the settled value.
+    return previous ?? null;
   }
 
   /** The Quick Open selection once it has settled — see `waitForStableSelection`. */
@@ -1653,7 +1657,7 @@ export class WorkspacePage {
   }
 
   // ──────────────────────────────────────────────────────────────────────
-  // Search-in-Files selection / scroll probes (fix/quick-open-select-first).
+  // Search-in-Files selection / scroll probes.
   //
   // SearchFilesDialog is the sibling cmdk `Command` with `shouldFilter={false}`
   // — the same manual-filtering pattern as QuickOpen, so it carries the same
@@ -1750,7 +1754,9 @@ export class WorkspacePage {
 
   /** Move the Search-in-Files selection onto the row whose `data-value` is
    *  `value` by stepping ArrowDown (deterministic where cmdk's `End` is not —
-   *  see `navigateQuickOpenTo`). Throws if `value` is never selected. */
+   *  see `navigateQuickOpenTo`). Throws if `value` is never selected.
+   *  Precondition: the caller must have waited for the result count to settle
+   *  (the press bound is snapshotted once, as in `navigateQuickOpenTo`). */
   async navigateSearchFilesTo(value: string): Promise<void> {
     await test.step(`Navigate Search-in-Files selection to "${value}"`, async () => {
       const maxPresses = (await this.searchFilesItems.count()) + 2;

--- a/apps/web/e2e/pages/WorkspacePage.ts
+++ b/apps/web/e2e/pages/WorkspacePage.ts
@@ -1615,6 +1615,148 @@ export class WorkspacePage {
     return await this.quickOpenList.evaluate((el) => el.scrollTop);
   }
 
+  /** Poll `read` until it returns the same value on two consecutive samples —
+   *  i.e. the selection has settled — and return that stable value. Needed
+   *  because the *pre-fix* palettes briefly highlight the first row while React
+   *  re-renders a new result set, then snap the highlight back to a stale
+   *  surviving row; a one-shot poll for "selection is first" would pass on that
+   *  transient and miss the regression. The post-fix selection is first AND
+   *  stays first, so the settled value is the honest signal for both. */
+  private async waitForStableSelection(read: () => Promise<string | null>): Promise<string | null> {
+    let previous: string | null | undefined;
+    let stable: string | null = null;
+    await expect
+      .poll(
+        async () => {
+          const current = await read();
+          const isStable = previous !== undefined && current === previous;
+          previous = current;
+          if (isStable) stable = current;
+          return isStable;
+        },
+        { intervals: [150, 150, 150, 150, 150, 150], timeout: 6000 },
+      )
+      .toBe(true);
+    return stable;
+  }
+
+  /** The Quick Open selection once it has settled — see `waitForStableSelection`. */
+  async settledSelectedQuickOpenValue(): Promise<string | null> {
+    return await this.waitForStableSelection(() => this.selectedQuickOpenValue());
+  }
+
+  // ──────────────────────────────────────────────────────────────────────
+  // Search-in-Files selection / scroll probes (fix/quick-open-select-first).
+  //
+  // SearchFilesDialog is the sibling cmdk `Command` with `shouldFilter={false}`
+  // — the same manual-filtering pattern as QuickOpen, so it carries the same
+  // stale-selection contract: a new result set must snap the highlight to the
+  // first row and scroll the list to the top. Its input is a custom `SearchBar`
+  // textbox (not cmdk's `CommandInput`), but the rows are still cmdk items, so
+  // the list/option/selected probes match the QuickOpen ones. All locators are
+  // scoped to the SearchFilesDialog root.
+  // ──────────────────────────────────────────────────────────────────────
+
+  /** The Search-in-Files query input — the `SearchBar`'s plain `<input>`
+   *  (role `textbox`), the only textbox inside the dialog. */
+  get searchFilesInput(): Locator {
+    return this.searchFilesDialog().getByRole("textbox");
+  }
+
+  /** The scrollable results list — cmdk renders `role="listbox"` on
+   *  `Command.List`, the element whose `scrollTop` the fix resets to 0. */
+  get searchFilesList(): Locator {
+    return this.searchFilesDialog().getByRole("listbox");
+  }
+
+  /** All rendered content-match rows — cmdk renders `role="option"` on every
+   *  `Command.Item`. Each row's `data-value` is `file:line:content`. */
+  get searchFilesItems(): Locator {
+    return this.searchFilesDialog().getByRole("option");
+  }
+
+  /** Open Search-in-Files via the same `band:open-search-files` window event
+   *  the file-tree toolbar fires, then wait for the dialog to render. */
+  async openSearchFiles(): Promise<void> {
+    await test.step("Open Search in Files", async () => {
+      await this.dispatchOpenSearchFiles();
+      await this.searchFilesDialog().waitFor({ state: "visible" });
+    });
+  }
+
+  /** Type a query into the Search-in-Files input, replacing any existing text
+   *  (focus, select-all, type) the way a user editing the field would. */
+  async typeSearchFiles(text: string): Promise<void> {
+    await test.step(`Type Search-in-Files query "${text}"`, async () => {
+      await this.searchFilesInput.focus();
+      await this.page.keyboard.press("ControlOrMeta+a");
+      await this.page.keyboard.type(text);
+    });
+  }
+
+  /** Append text to the Search-in-Files query without clearing it — the way a
+   *  user refining an existing search types the next character. Keeps the
+   *  previously matched rows continuously mounted, the exact condition under
+   *  which the stale-selection bug reproduces. */
+  async appendSearchFiles(text: string): Promise<void> {
+    await test.step(`Append "${text}" to Search-in-Files query`, async () => {
+      await this.searchFilesInput.focus();
+      await this.page.keyboard.type(text);
+    });
+  }
+
+  /** Press a key while the Search-in-Files input is focused — ArrowDown /
+   *  ArrowUp / Enter. */
+  async pressSearchFilesKey(key: string): Promise<void> {
+    await test.step(`Press "${key}" in Search in Files`, async () => {
+      await this.searchFilesInput.focus();
+      await this.page.keyboard.press(key);
+    });
+  }
+
+  /** The `data-value` (`file:line:content`) of every rendered row, in DOM
+   *  order. */
+  async searchFilesItemValues(): Promise<string[]> {
+    return await this.searchFilesItems.evaluateAll((els) =>
+      els.map((el) => el.getAttribute("data-value") ?? ""),
+    );
+  }
+
+  /** The `data-value` of the single row cmdk currently marks
+   *  `aria-selected="true"`, or `null` when nothing is selected. */
+  async selectedSearchFilesValue(): Promise<string | null> {
+    const selected = this.searchFilesDialog().getByRole("option", { selected: true });
+    if ((await selected.count()) === 0) return null;
+    return await selected.first().getAttribute("data-value");
+  }
+
+  /** Current `scrollTop` of the Search-in-Files results list. */
+  async searchFilesListScrollTop(): Promise<number> {
+    return await this.searchFilesList.evaluate((el) => el.scrollTop);
+  }
+
+  /** The Search-in-Files selection once it has settled — see
+   *  `waitForStableSelection`. */
+  async settledSelectedSearchFilesValue(): Promise<string | null> {
+    return await this.waitForStableSelection(() => this.selectedSearchFilesValue());
+  }
+
+  /** Move the Search-in-Files selection onto the row whose `data-value` is
+   *  `value` by stepping ArrowDown (deterministic where cmdk's `End` is not —
+   *  see `navigateQuickOpenTo`). Throws if `value` is never selected. */
+  async navigateSearchFilesTo(value: string): Promise<void> {
+    await test.step(`Navigate Search-in-Files selection to "${value}"`, async () => {
+      const maxPresses = (await this.searchFilesItems.count()) + 2;
+      for (let i = 0; i < maxPresses; i++) {
+        if ((await this.selectedSearchFilesValue()) === value) return;
+        await this.pressSearchFilesKey("ArrowDown");
+      }
+      throw new Error(
+        `Search in Files never selected "${value}" after ${maxPresses} ArrowDown presses`,
+      );
+    });
+  }
+
   /** Dispatch a synthetic `band:open-file` window event into the page
    *  context. Captures the cross-workspace routing contract under test:
    *  events addressed to a specific workspace must reach only THAT

--- a/apps/web/e2e/pages/WorkspacePage.ts
+++ b/apps/web/e2e/pages/WorkspacePage.ts
@@ -1451,8 +1451,9 @@ export class WorkspacePage {
 
   /** Dispatch the `band:open-search-files` window event — the same event the
    *  file-tree toolbar's "Search in Files" action fires (see
-   *  `CodeBrowserView.tsx`). MobileWorkspaceLayout listens for it and opens
-   *  the SearchFilesDialog. Mirrors `dispatchOpenFileEvent`. */
+   *  `CodeBrowserView.tsx`). On desktop `SharedDockviewLayout` listens for it;
+   *  on mobile `MobileWorkspaceLayout` does. Either way it opens the
+   *  SearchFilesDialog. Mirrors `dispatchOpenFileEvent`. */
   async dispatchOpenSearchFiles(): Promise<void> {
     await test.step("Dispatch band:open-search-files", async () => {
       await this.page.evaluate(() => {
@@ -1507,9 +1508,9 @@ export class WorkspacePage {
   }
 
   /** The scrollable results list — cmdk renders `role="listbox"` on
-   *  `Command.List` (system-controlled), the element whose `scrollTop` the fix
-   *  must reset to 0. `getByRole` matches the sibling cmdk page objects and the
-   *  locator-priority doctrine. */
+   *  `Command.List` (a system-controlled ARIA role), the element whose
+   *  `scrollTop` the fix must reset to 0, so `getByRole("listbox")` is the
+   *  correct locator. */
   get quickOpenList(): Locator {
     return this.quickOpenDialog().getByRole("listbox");
   }
@@ -1634,7 +1635,11 @@ export class WorkspacePage {
           if (isStable) stable = current;
           return isStable;
         },
-        { intervals: [150, 150, 150, 150, 150, 150], timeout: 6000 },
+        {
+          intervals: [150, 150, 150, 150, 150, 150],
+          timeout: 6000,
+          message: "Quick Open / Search-in-Files selection never stabilized within 6s",
+        },
       )
       .toBe(true);
     return stable;

--- a/apps/web/e2e/quick-open-select-first.spec.ts
+++ b/apps/web/e2e/quick-open-select-first.spec.ts
@@ -14,8 +14,9 @@
  * now controls cmdk's selection and, whenever the result *contents* change,
  * forces the selection back to the first row and scrolls the list to the top.
  *
- * Test architecture (per CLAUDE.md + write-integration-test doctrine):
- *   - Boots the real production server against a fresh tmp home.
+ * Test architecture:
+ *   - Boots the real production server (via `startServer`) against a fresh tmp
+ *     home — no in-process React mounting.
  *   - A real git worktree seeded with a deterministic corpus so the real
  *     `searchWorkspaceFiles` fuzzy ranking is predictable: the two queries
  *     under test return different result *sets*, and a distinctly long-named
@@ -137,7 +138,7 @@ test.describe("Quick Open selection reset on query change", () => {
     const itemsBefore = await workspacePage.quickOpenItemValues();
     expect(itemsBefore[itemsBefore.length - 1]).toBe(TARGET);
     expect(itemsBefore[0]).not.toBe(TARGET);
-    expect(await workspacePage.quickOpenListScrollTop()).toBeGreaterThan(0);
+    await expect.poll(() => workspacePage.quickOpenListScrollTop()).toBeGreaterThan(0);
 
     // Query 2: refine to "reports" by APPENDING "s" (not retyping) so TARGET
     // stays continuously mounted — the 6 ".md" decoys drop out (21 results),

--- a/apps/web/e2e/quick-open-select-first.spec.ts
+++ b/apps/web/e2e/quick-open-select-first.spec.ts
@@ -148,16 +148,17 @@ test.describe("Quick Open selection reset on query change", () => {
     await workspacePage.appendQuickOpen("s");
     await expect.poll(() => workspacePage.quickOpenItems.count()).toBe(21);
 
-    // Post-fix: selection snaps to the first row and the list is at the top.
-    await expect
-      .poll(async () => {
-        const items = await workspacePage.quickOpenItemValues();
-        const selected = await workspacePage.selectedQuickOpenValue();
-        return selected !== null && selected === items[0];
-      })
-      .toBe(true);
-    expect(await workspacePage.selectedQuickOpenValue()).not.toBe(TARGET);
-    await expect.poll(() => workspacePage.quickOpenListScrollTop()).toBe(0);
+    // Post-fix: once the new result set settles, the selection is on the FIRST
+    // row and the list is scrolled to the top. We wait for the *settled*
+    // selection rather than a transient one — the pre-fix dialog briefly
+    // highlights the first row while React re-renders, then snaps the highlight
+    // back to the stale surviving row (TARGET), so a plain `expect.poll` for
+    // "selection is first" would pass on that transient and miss the bug.
+    const settled = await workspacePage.settledSelectedQuickOpenValue();
+    const items = await workspacePage.quickOpenItemValues();
+    expect(settled).toBe(items[0]);
+    expect(settled).not.toBe(TARGET);
+    expect(await workspacePage.quickOpenListScrollTop()).toBe(0);
   });
 
   test("arrow keys move the selection and Enter opens the highlighted (first) result", async ({

--- a/apps/web/e2e/quick-open-select-first.spec.ts
+++ b/apps/web/e2e/quick-open-select-first.spec.ts
@@ -1,0 +1,224 @@
+/**
+ * Regression coverage for the Quick Open (Cmd+P file finder) selection reset.
+ *
+ * Expected behaviour (matching VS Code): every time the search query changes
+ * and a new result set arrives, the highlighted item snaps back to the first
+ * result and the list scrolls to the top. Pre-fix, the dialog let cmdk keep a
+ * stale selection — when the previously highlighted file was still present in
+ * the new results (just not first), it stayed selected and the list never
+ * scrolled back up, so pressing Enter opened the wrong file.
+ *
+ * The dialog is a cmdk `Command` with `shouldFilter={false}`; cmdk only
+ * re-selects the first item when the currently selected item unmounts, so a
+ * file that survives a query refinement keeps the highlight. `QuickOpenDialog`
+ * now controls cmdk's selection and, whenever the result *contents* change,
+ * forces the selection back to the first row and scrolls the list to the top.
+ *
+ * Test architecture (per CLAUDE.md + write-integration-test doctrine):
+ *   - Boots the real production server against a fresh tmp home.
+ *   - A real git worktree seeded with a deterministic corpus so the real
+ *     `searchWorkspaceFiles` fuzzy ranking is predictable: the two queries
+ *     under test return different result *sets*, and a distinctly long-named
+ *     "target" file is deterministically LAST (worst length tiebreaker) in
+ *     both — so it is never the first row, which is exactly the stale-
+ *     selection trap.
+ *   - No tRPC mocking, no MSW, no page.route() on own routes — the dialog is
+ *     driven through real keyboard input and the real search endpoint.
+ *   - All locators/actions go through the WorkspacePage page object.
+ */
+
+import { mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { expect, test } from "@playwright/test";
+import { toWorkspaceId } from "@/dashboard";
+import { gitInHome as git } from "./helpers/git";
+import {
+  cleanupTmpHome,
+  createTmpHome,
+  type ServerHandle,
+  seedSettings,
+  seedState,
+  startServer,
+} from "./helpers/server";
+import { WorkspacePage } from "./pages/WorkspacePage";
+
+const TOKEN = "e2e-quick-open-select-first-token";
+
+const PROJECT = "quick-open-repo";
+const DEFAULT_BRANCH = "main";
+const BRANCH = "feature";
+const WORKSPACE = toWorkspaceId(PROJECT, BRANCH);
+
+// Distinctly long name → worst length tiebreaker → deterministically LAST in
+// both `report` and `reports` rankings, regardless of the on-disk file order
+// that `rg --files` happens to return. It matches both queries, so it survives
+// the "report" → "reports" refinement without unmounting — the precise
+// condition under which cmdk would otherwise keep it selected.
+const TARGET = "reports-really-long-target-name-file.ts";
+
+// Desktop viewport so `useIsDesktop()` is true and `SharedDockviewLayout`
+// (which mounts QuickOpenDialog and listens for `band:open-quick-open`) renders.
+test.use({ viewport: { width: 1280, height: 800 } });
+
+let server!: ServerHandle;
+let tmpHome: string | undefined;
+
+test.beforeAll(async () => {
+  tmpHome = createTmpHome();
+
+  const repoPath = join(tmpHome, PROJECT);
+  mkdirSync(repoPath, { recursive: true });
+  git(repoPath, ["init", "-b", DEFAULT_BRANCH], tmpHome);
+
+  // 20 files that match BOTH "report" and "reports" (literal substring).
+  for (let i = 0; i < 20; i++) {
+    const name = `reports-${String(i).padStart(2, "0")}.ts`;
+    writeFileSync(join(repoPath, name), `// ${name}\n`);
+  }
+  // 6 decoy files that match "report" but NOT "reports": the ".md" extension
+  // carries no trailing "s", so refining the query from "report" to "reports"
+  // drops them — the two queries therefore return different result SETS, which
+  // is what makes the selection-reset observable rather than a no-op.
+  for (let i = 0; i < 6; i++) {
+    const name = `report-decoy-${String(i).padStart(2, "0")}.md`;
+    writeFileSync(join(repoPath, name), `<!-- ${name} -->\n`);
+  }
+  writeFileSync(join(repoPath, TARGET), `// ${TARGET}\n`);
+
+  git(repoPath, ["add", "."], tmpHome);
+  git(repoPath, ["commit", "-m", "seed quick-open corpus"], tmpHome);
+
+  const worktreePath = join(tmpHome, `${PROJECT}-${BRANCH}`);
+  git(repoPath, ["worktree", "add", "-b", BRANCH, worktreePath], tmpHome);
+
+  seedState(tmpHome, {
+    projects: [
+      {
+        name: PROJECT,
+        path: repoPath,
+        defaultBranch: DEFAULT_BRANCH,
+        worktrees: [
+          { branch: DEFAULT_BRANCH, path: repoPath },
+          { branch: BRANCH, path: worktreePath },
+        ],
+      },
+    ],
+  });
+  seedSettings(tmpHome, { tokenSecret: TOKEN });
+  server = await startServer({ tmpHome });
+});
+
+test.afterAll(async () => {
+  if (server) await server.close();
+  if (tmpHome) cleanupTmpHome(tmpHome);
+});
+
+test.describe("Quick Open selection reset on query change", () => {
+  test("changing the query snaps selection to the first result and scrolls the list to the top", async ({
+    page,
+  }) => {
+    const workspacePage = new WorkspacePage(page, server.url, TOKEN);
+    await workspacePage.goto(WORKSPACE);
+    await workspacePage.waitForReady();
+
+    await workspacePage.openQuickOpen();
+
+    // Query 1: "report" — matches all 27 seeded files. TARGET ranks last.
+    await workspacePage.typeQuickOpen("report");
+    await expect.poll(() => workspacePage.quickOpenItems.count()).toBe(27);
+
+    // Drive the selection to the LAST row (TARGET) with the keyboard. cmdk's
+    // "End" binding selects the last item and scrolls it into view — the
+    // stale-selection precondition: a non-first item selected, list scrolled
+    // off the top.
+    await workspacePage.pressQuickOpenKey("End");
+    await expect.poll(() => workspacePage.selectedQuickOpenValue()).toBe(TARGET);
+
+    const itemsBefore = await workspacePage.quickOpenItemValues();
+    expect(itemsBefore[itemsBefore.length - 1]).toBe(TARGET);
+    expect(itemsBefore[0]).not.toBe(TARGET);
+    expect(await workspacePage.quickOpenListScrollTop()).toBeGreaterThan(0);
+
+    // Query 2: refine to "reports" by APPENDING "s" (not retyping) so TARGET
+    // stays continuously mounted — the 6 ".md" decoys drop out (21 results),
+    // but TARGET survives and is still ranked last. Pre-fix, cmdk would keep
+    // TARGET highlighted (it never unmounted) and leave the list scrolled down.
+    await workspacePage.appendQuickOpen("s");
+    await expect.poll(() => workspacePage.quickOpenItems.count()).toBe(21);
+
+    // Post-fix: selection snaps to the first row and the list is at the top.
+    await expect
+      .poll(async () => {
+        const items = await workspacePage.quickOpenItemValues();
+        const selected = await workspacePage.selectedQuickOpenValue();
+        return selected !== null && selected === items[0];
+      })
+      .toBe(true);
+    expect(await workspacePage.selectedQuickOpenValue()).not.toBe(TARGET);
+    await expect.poll(() => workspacePage.quickOpenListScrollTop()).toBe(0);
+  });
+
+  test("arrow keys move the selection and Enter opens the highlighted (first) result", async ({
+    page,
+  }) => {
+    const workspacePage = new WorkspacePage(page, server.url, TOKEN);
+    await workspacePage.goto(WORKSPACE);
+    await workspacePage.waitForReady();
+
+    await workspacePage.openQuickOpen();
+    await workspacePage.typeQuickOpen("reports");
+    await expect.poll(() => workspacePage.quickOpenItems.count()).toBe(21);
+
+    // Fresh results → first row selected.
+    const items = await workspacePage.quickOpenItemValues();
+    const firstFile = items[0];
+    await expect.poll(() => workspacePage.selectedQuickOpenValue()).toBe(firstFile);
+
+    // Down then up returns to the first row — keyboard navigation still works.
+    await workspacePage.pressQuickOpenKey("ArrowDown");
+    await expect.poll(() => workspacePage.selectedQuickOpenValue()).toBe(items[1]);
+    await workspacePage.pressQuickOpenKey("ArrowUp");
+    await expect.poll(() => workspacePage.selectedQuickOpenValue()).toBe(firstFile);
+
+    // Enter opens the highlighted (first) file. The open is observable through
+    // the persisted open-tabs state the Files panel writes for this workspace.
+    await workspacePage.pressQuickOpenKey("Enter");
+    await expect(workspacePage.quickOpenDialog()).toBeHidden();
+    await expect
+      .poll(async () => (await workspacePage.readOpenTabsState(WORKSPACE))?.active, {
+        timeout: 15_000,
+      })
+      .toBe(firstFile);
+  });
+
+  test("empty-query recent-files view selects its first item", async ({ page }) => {
+    const workspacePage = new WorkspacePage(page, server.url, TOKEN);
+    await workspacePage.goto(WORKSPACE);
+    await workspacePage.waitForReady();
+
+    // Open a file so it is tracked as a recent file.
+    await workspacePage.openQuickOpen();
+    await workspacePage.typeQuickOpen("reports");
+    await expect.poll(() => workspacePage.quickOpenItems.count()).toBe(21);
+    const openedFile = (await workspacePage.quickOpenItemValues())[0];
+    await workspacePage.pressQuickOpenKey("Enter");
+    await expect(workspacePage.quickOpenDialog()).toBeHidden();
+    await expect
+      .poll(async () => (await workspacePage.readOpenTabsState(WORKSPACE))?.active, {
+        timeout: 15_000,
+      })
+      .toBe(openedFile);
+
+    // Reopen and clear the query so the recent-files view shows. Its first
+    // (and only) entry — the file just opened — must be selected.
+    await workspacePage.openQuickOpen();
+    await workspacePage.clearQuickOpenQuery();
+    await expect
+      .poll(async () => {
+        const items = await workspacePage.quickOpenItemValues();
+        return items[0];
+      })
+      .toBe(openedFile);
+    await expect.poll(() => workspacePage.selectedQuickOpenValue()).toBe(openedFile);
+  });
+});

--- a/apps/web/e2e/quick-open-select-first.spec.ts
+++ b/apps/web/e2e/quick-open-select-first.spec.ts
@@ -128,11 +128,12 @@ test.describe("Quick Open selection reset on query change", () => {
     await workspacePage.typeQuickOpen("report");
     await expect.poll(() => workspacePage.quickOpenItems.count()).toBe(27);
 
-    // Drive the selection to the LAST row (TARGET) with the keyboard. cmdk's
-    // "End" binding selects the last item and scrolls it into view — the
+    // Drive the selection down to the LAST row (TARGET) with ArrowDown — the
     // stale-selection precondition: a non-first item selected, list scrolled
-    // off the top.
-    await workspacePage.pressQuickOpenKey("End");
+    // off the top. (ArrowDown, not End: with focus in the search input End is
+    // ambiguous with a caret move and can't be relied on to move the list
+    // selection — see `navigateQuickOpenTo`.)
+    await workspacePage.navigateQuickOpenTo(TARGET);
     await expect.poll(() => workspacePage.selectedQuickOpenValue()).toBe(TARGET);
 
     const itemsBefore = await workspacePage.quickOpenItemValues();

--- a/apps/web/e2e/quick-open-select-first.spec.ts
+++ b/apps/web/e2e/quick-open-select-first.spec.ts
@@ -159,7 +159,7 @@ test.describe("Quick Open selection reset on query change", () => {
     const items = await workspacePage.quickOpenItemValues();
     expect(settled).toBe(items[0]);
     expect(settled).not.toBe(TARGET);
-    expect(await workspacePage.quickOpenListScrollTop()).toBe(0);
+    await expect.poll(() => workspacePage.quickOpenListScrollTop()).toBe(0);
   });
 
   test("arrow keys move the selection and Enter opens the highlighted (first) result", async ({

--- a/apps/web/e2e/quick-open-select-first.spec.ts
+++ b/apps/web/e2e/quick-open-select-first.spec.ts
@@ -185,13 +185,15 @@ test.describe("Quick Open selection reset on query change", () => {
 
     // Enter opens the highlighted (first) file. The open is observable through
     // the persisted open-tabs state the Files panel writes for this workspace.
+    // Assert the positive new state (the tab opened) first, then that the
+    // dialog closed.
     await workspacePage.pressQuickOpenKey("Enter");
-    await expect(workspacePage.quickOpenDialog()).toBeHidden();
     await expect
       .poll(async () => (await workspacePage.readOpenTabsState(WORKSPACE))?.active, {
         timeout: 15_000,
       })
       .toBe(firstFile);
+    await expect(workspacePage.quickOpenDialog()).toBeHidden();
   });
 
   test("empty-query recent-files view selects its first item", async ({ page }) => {

--- a/apps/web/e2e/quick-open-select-first.spec.ts
+++ b/apps/web/e2e/quick-open-select-first.spec.ts
@@ -213,7 +213,7 @@ test.describe("Quick Open selection reset on query change", () => {
       .toBe(openedFile);
 
     // Reopen and clear the query so the recent-files view shows. Its first
-    // (and only) entry — the file just opened — must be selected.
+    // entry — the file just opened — must be selected.
     await workspacePage.openQuickOpen();
     await workspacePage.clearQuickOpenQuery();
     await expect

--- a/apps/web/e2e/quick-open-select-first.spec.ts
+++ b/apps/web/e2e/quick-open-select-first.spec.ts
@@ -124,7 +124,8 @@ test.describe("Quick Open selection reset on query change", () => {
 
     await workspacePage.openQuickOpen();
 
-    // Query 1: "report" — matches all 27 seeded files. TARGET ranks last.
+    // Query 1: "report" — matches all 27 seeded files
+    // (20 reports-NN.ts + 6 report-decoy-NN.md + 1 TARGET). TARGET ranks last.
     await workspacePage.typeQuickOpen("report");
     await expect.poll(() => workspacePage.quickOpenItems.count()).toBe(27);
 

--- a/apps/web/e2e/search-files-select-first.spec.ts
+++ b/apps/web/e2e/search-files-select-first.spec.ts
@@ -1,0 +1,185 @@
+/**
+ * Regression coverage for the Search-in-Files dialog selection reset — the
+ * sibling of the Quick Open fix in `quick-open-select-first.spec.ts`.
+ *
+ * SearchFilesDialog is a cmdk `Command` with `shouldFilter={false}` (manual
+ * filtering via the real content-search endpoint), so it carries the same
+ * stale-selection contract as Quick Open: every time the query changes and a
+ * new result set arrives, the highlighted row must snap back to the first
+ * result and the list must scroll to the top. Pre-fix it only reset the
+ * selection when the highlighted match *unmounted*; a match that survived a
+ * query refinement (still present, just not first) stayed selected and the
+ * list never scrolled back up, so pressing Enter opened the wrong match — and,
+ * unlike Quick Open, the scroll position was never reset at all.
+ *
+ * Test architecture:
+ *   - Boots the real production server (via `startServer`) against a fresh tmp
+ *     home — no in-process React mounting, no mocking.
+ *   - A real git worktree seeded with ONE file of 40 matching lines. ripgrep
+ *     returns matches within a single file in line-number order, so the row
+ *     order is deterministic (cross-file order is not — hence a single file).
+ *     Odd lines contain only "alpha"; even lines contain "alpha beta". The
+ *     query "alpha" matches all 40; refining to "alpha beta" drops the odd
+ *     lines (20 survive) — a genuine result-set change — while the last row
+ *     (an even line) survives without unmounting: the exact stale-selection
+ *     trap.
+ *   - All interactions go through the WorkspacePage page object.
+ */
+
+import { mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { expect, test } from "@playwright/test";
+import { toWorkspaceId } from "@/dashboard";
+import { gitInHome as git } from "./helpers/git";
+import {
+  cleanupTmpHome,
+  createTmpHome,
+  type ServerHandle,
+  seedSettings,
+  seedState,
+  startServer,
+} from "./helpers/server";
+import { WorkspacePage } from "./pages/WorkspacePage";
+
+const TOKEN = "e2e-search-files-select-first-token";
+
+const PROJECT = "search-files-repo";
+const DEFAULT_BRANCH = "main";
+const BRANCH = "feature";
+const WORKSPACE = toWorkspaceId(PROJECT, BRANCH);
+
+const HAYSTACK = "haystack.txt";
+const LINE_COUNT = 40;
+
+// Desktop viewport so `SharedDockviewLayout` (which mounts SearchFilesDialog
+// and listens for `band:open-search-files`) renders.
+test.use({ viewport: { width: 1280, height: 800 } });
+
+let server!: ServerHandle;
+let tmpHome: string | undefined;
+
+test.beforeAll(async () => {
+  tmpHome = createTmpHome();
+
+  const repoPath = join(tmpHome, PROJECT);
+  mkdirSync(repoPath, { recursive: true });
+  git(repoPath, ["init", "-b", DEFAULT_BRANCH], tmpHome);
+
+  // One file, 40 lines. Odd lines match only "alpha"; even lines also match
+  // "alpha beta". Within a single file ripgrep emits matches in line order, so
+  // row 1..40 order is deterministic regardless of directory-walk order.
+  let content = "";
+  for (let i = 1; i <= LINE_COUNT; i++) {
+    content += i % 2 === 0 ? `alpha beta marker row ${i}\n` : `alpha marker row ${i}\n`;
+  }
+  writeFileSync(join(repoPath, HAYSTACK), content);
+
+  git(repoPath, ["add", "."], tmpHome);
+  git(repoPath, ["commit", "-m", "seed search-files corpus"], tmpHome);
+
+  const worktreePath = join(tmpHome, `${PROJECT}-${BRANCH}`);
+  git(repoPath, ["worktree", "add", "-b", BRANCH, worktreePath], tmpHome);
+
+  seedState(tmpHome, {
+    projects: [
+      {
+        name: PROJECT,
+        path: repoPath,
+        defaultBranch: DEFAULT_BRANCH,
+        worktrees: [
+          { branch: DEFAULT_BRANCH, path: repoPath },
+          { branch: BRANCH, path: worktreePath },
+        ],
+      },
+    ],
+  });
+  seedSettings(tmpHome, { tokenSecret: TOKEN });
+  server = await startServer({ tmpHome });
+});
+
+test.afterAll(async () => {
+  if (server) await server.close();
+  if (tmpHome) cleanupTmpHome(tmpHome);
+});
+
+test.describe("Search in Files selection reset on query change", () => {
+  test("changing the query snaps selection to the first result and scrolls the list to the top", async ({
+    page,
+  }) => {
+    const workspacePage = new WorkspacePage(page, server.url, TOKEN);
+    await workspacePage.goto(WORKSPACE);
+    await workspacePage.waitForReady();
+
+    await workspacePage.openSearchFiles();
+
+    // Query 1: "alpha" — matches every line (40 rows).
+    await workspacePage.typeSearchFiles("alpha");
+    await expect.poll(() => workspacePage.searchFilesItems.count()).toBe(LINE_COUNT);
+
+    // The deepest row (the last even line) is a survivor of the "alpha beta"
+    // refinement. Grab it dynamically and drive the selection down to it, so a
+    // non-first row is selected with the list scrolled off the top.
+    const itemsBefore = await workspacePage.searchFilesItemValues();
+    const target = itemsBefore[itemsBefore.length - 1];
+    expect(target).toContain("beta"); // survives the refinement (still mounts)
+    expect(target).not.toBe(itemsBefore[0]); // not already the first row
+
+    await workspacePage.navigateSearchFilesTo(target);
+    await expect.poll(() => workspacePage.selectedSearchFilesValue()).toBe(target);
+    await expect.poll(() => workspacePage.searchFilesListScrollTop()).toBeGreaterThan(0);
+
+    // Query 2: refine to "alpha beta" by APPENDING " beta" so `target` stays
+    // continuously mounted — the 20 odd-line matches drop out (20 survive), but
+    // `target` survives and is no longer first. Pre-fix, the highlight would
+    // stay on `target` (it never unmounted) and the list stay scrolled down.
+    await workspacePage.appendSearchFiles(" beta");
+    await expect.poll(() => workspacePage.searchFilesItems.count()).toBe(LINE_COUNT / 2);
+
+    // Post-fix: once the new result set settles, the selection is on the FIRST
+    // row and the list is scrolled to the top. We wait for the *settled*
+    // selection rather than a transient one — the pre-fix dialog briefly
+    // highlights the first row while React re-renders, then snaps the highlight
+    // back to the stale surviving row (`target`), so a plain `expect.poll` for
+    // "selection is first" would pass on that transient and miss the bug.
+    const settled = await workspacePage.settledSelectedSearchFilesValue();
+    const items = await workspacePage.searchFilesItemValues();
+    expect(settled).toBe(items[0]);
+    expect(settled).not.toBe(target);
+    expect(await workspacePage.searchFilesListScrollTop()).toBe(0);
+  });
+
+  test("arrow keys move the selection and Enter opens the highlighted (first) result", async ({
+    page,
+  }) => {
+    const workspacePage = new WorkspacePage(page, server.url, TOKEN);
+    await workspacePage.goto(WORKSPACE);
+    await workspacePage.waitForReady();
+
+    await workspacePage.openSearchFiles();
+    await workspacePage.typeSearchFiles("alpha beta");
+    await expect.poll(() => workspacePage.searchFilesItems.count()).toBe(LINE_COUNT / 2);
+
+    // Fresh results → first row selected.
+    const items = await workspacePage.searchFilesItemValues();
+    const firstValue = items[0];
+    await expect.poll(() => workspacePage.selectedSearchFilesValue()).toBe(firstValue);
+
+    // Down then up returns to the first row — keyboard navigation still works.
+    await workspacePage.pressSearchFilesKey("ArrowDown");
+    await expect.poll(() => workspacePage.selectedSearchFilesValue()).toBe(items[1]);
+    await workspacePage.pressSearchFilesKey("ArrowUp");
+    await expect.poll(() => workspacePage.selectedSearchFilesValue()).toBe(firstValue);
+
+    // Enter opens the highlighted (first) match. The value is `file:line:content`;
+    // the open is observable through the persisted open-tabs state, whose active
+    // entry carries the opened file path (a `path:line` location).
+    const firstFile = firstValue.split(":")[0];
+    await workspacePage.pressSearchFilesKey("Enter");
+    await expect(workspacePage.searchFilesDialog()).toBeHidden();
+    await expect
+      .poll(async () => (await workspacePage.readOpenTabsState(WORKSPACE))?.active, {
+        timeout: 15_000,
+      })
+      .toContain(firstFile);
+  });
+});

--- a/apps/web/e2e/search-files-select-first.spec.ts
+++ b/apps/web/e2e/search-files-select-first.spec.ts
@@ -106,6 +106,9 @@ test.describe("Search in Files selection reset on query change", () => {
   test("changing the query snaps selection to the first result and scrolls the list to the top", async ({
     page,
   }) => {
+    // Navigating to the last of 40 rows is ~40 sequential ArrowDown round-trips
+    // plus an up-to-8s stability poll; give slow CI headroom over the 30s default.
+    test.setTimeout(90_000);
     const workspacePage = new WorkspacePage(page, server.url, TOKEN);
     await workspacePage.goto(WORKSPACE);
     await workspacePage.waitForReady();
@@ -145,7 +148,7 @@ test.describe("Search in Files selection reset on query change", () => {
     const items = await workspacePage.searchFilesItemValues();
     expect(settled).toBe(items[0]);
     expect(settled).not.toBe(target);
-    expect(await workspacePage.searchFilesListScrollTop()).toBe(0);
+    await expect.poll(() => workspacePage.searchFilesListScrollTop()).toBe(0);
   });
 
   test("arrow keys move the selection and Enter opens the highlighted (first) result", async ({

--- a/apps/web/e2e/search-files-select-first.spec.ts
+++ b/apps/web/e2e/search-files-select-first.spec.ts
@@ -173,13 +173,15 @@ test.describe("Search in Files selection reset on query change", () => {
     // Enter opens the highlighted (first) match. The value is `file:line:content`;
     // the open is observable through the persisted open-tabs state, whose active
     // entry carries the opened file path (a `path:line` location).
+    // Assert the positive new state (the tab opened) first, then that the
+    // dialog closed.
     const firstFile = firstValue.split(":")[0];
     await workspacePage.pressSearchFilesKey("Enter");
-    await expect(workspacePage.searchFilesDialog()).toBeHidden();
     await expect
       .poll(async () => (await workspacePage.readOpenTabsState(WORKSPACE))?.active, {
         timeout: 15_000,
       })
       .toContain(firstFile);
+    await expect(workspacePage.searchFilesDialog()).toBeHidden();
   });
 });

--- a/apps/web/src/dashboard/components/QuickOpenDialog.tsx
+++ b/apps/web/src/dashboard/components/QuickOpenDialog.tsx
@@ -56,6 +56,12 @@ export function QuickOpenDialog({
   const [files, setFiles] = useState<string[]>([]);
   const [loading, setLoading] = useState(false);
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // Controlled cmdk selection. We drive the highlighted item ourselves so we
+  // can snap it back to the first result whenever the query changes (see the
+  // reset effect near the render). The scrollable results list is scrolled to
+  // the top at the same time.
+  const [selectedValue, setSelectedValue] = useState("");
+  const listRef = useRef<HTMLDivElement>(null);
 
   // Track whether a search has resolved at least once since the dialog opened.
   // This prevents the auto-open effect from firing before the search starts
@@ -296,6 +302,28 @@ export function QuickOpenDialog({
   const displayFiles = showRecent ? recentFiles : files;
   const groupHeading = showRecent ? "Recent files" : undefined;
 
+  // Whenever a new result set is applied — the query changed and fresh search
+  // results arrived, or we toggled between the recent-files view and a search —
+  // snap the highlighted item back to the first result and scroll the list to
+  // the top, matching VS Code's Quick Open. Without this, cmdk keeps a stale
+  // selection: when the previously highlighted file is still present in the new
+  // results (just not first) it stays selected, and the list never scrolls back
+  // up on its own — so pressing Enter would open the wrong file.
+  //
+  // Keyed on the result *contents* (not the array reference) so that repeated
+  // clears to an empty list — e.g. the go-to-line path calls `setFiles([])` on
+  // every keystroke — don't re-fire and fight cmdk's own single-item selection.
+  // Keyboard up/down and hover still update `selectedValue` via `onValueChange`,
+  // so this only overrides selection on an actual result change, never
+  // mid-navigation.
+  const firstFile = displayFiles[0] ?? "";
+  const resultKey = displayFiles.join("\n");
+  // biome-ignore lint/correctness/useExhaustiveDependencies: resultKey is an intentional trigger dependency (fires on any content change, incl. when firstFile is unchanged) — it isn't read in the body
+  useEffect(() => {
+    setSelectedValue(firstFile);
+    if (listRef.current) listRef.current.scrollTop = 0;
+  }, [resultKey, firstFile]);
+
   return (
     <Dialog open={open && dialogVisible} onOpenChange={onOpenChange}>
       <DialogContent
@@ -311,7 +339,7 @@ export function QuickOpenDialog({
           <DialogTitle>Quick Open</DialogTitle>
           <DialogDescription>Search for files by name</DialogDescription>
         </DialogHeader>
-        <Command shouldFilter={false}>
+        <Command shouldFilter={false} value={selectedValue} onValueChange={setSelectedValue}>
           <CommandInput
             placeholder="Search files by name..."
             value={query}
@@ -327,7 +355,7 @@ export function QuickOpenDialog({
               )}
             </div>
           )}
-          <CommandList className="max-h-[360px]">
+          <CommandList ref={listRef} className="max-h-[360px]">
             {isGoToLine && currentFile ? (
               <CommandGroup>
                 <CommandItem onSelect={handleGoToLine}>

--- a/apps/web/src/dashboard/components/QuickOpenDialog.tsx
+++ b/apps/web/src/dashboard/components/QuickOpenDialog.tsx
@@ -320,6 +320,13 @@ export function QuickOpenDialog({
   // O(N) string allocation — memoised on `displayFiles` so it only recomputes
   // when the result set changes, not on every `selectedValue` / hover render.
   const resultKey = useMemo(() => displayFiles.join("\n"), [displayFiles]);
+  // Basename per row, memoised on `displayFiles` so the `split`/`pop` only runs
+  // when the result set changes — not on every `selectedValue` render caused by
+  // keyboard navigation or hover. Indexed by row position in the map below.
+  const fileNames = useMemo(
+    () => displayFiles.map((file) => file.split("/").pop() || file),
+    [displayFiles],
+  );
   // biome-ignore lint/correctness/useExhaustiveDependencies: resultKey is an intentional trigger dependency (fires on any content change, incl. when firstFile is unchanged) — it isn't read in the body
   useEffect(() => {
     setSelectedValue(firstFile);
@@ -371,8 +378,8 @@ export function QuickOpenDialog({
               <>
                 <CommandEmpty>{loading ? "Searching..." : "No files found."}</CommandEmpty>
                 <CommandGroup heading={groupHeading}>
-                  {displayFiles.map((file) => {
-                    const fileName = file.split("/").pop() || file;
+                  {displayFiles.map((file, index) => {
+                    const fileName = fileNames[index];
                     const Icon = getFileIcon(fileName);
                     return (
                       <CommandItem key={file} value={file} onSelect={() => handleSelect(file)}>

--- a/apps/web/src/dashboard/components/QuickOpenDialog.tsx
+++ b/apps/web/src/dashboard/components/QuickOpenDialog.tsx
@@ -316,8 +316,10 @@ export function QuickOpenDialog({
   // Keyboard up/down and hover still update `selectedValue` via `onValueChange`,
   // so this only overrides selection on an actual result change, never
   // mid-navigation.
-  const firstFile = displayFiles[0] ?? "";
-  const resultKey = displayFiles.join("\n");
+  const firstFile = useMemo(() => displayFiles[0] ?? "", [displayFiles]);
+  // O(N) string allocation — memoised on `displayFiles` so it only recomputes
+  // when the result set changes, not on every `selectedValue` / hover render.
+  const resultKey = useMemo(() => displayFiles.join("\n"), [displayFiles]);
   // biome-ignore lint/correctness/useExhaustiveDependencies: resultKey is an intentional trigger dependency (fires on any content change, incl. when firstFile is unchanged) — it isn't read in the body
   useEffect(() => {
     setSelectedValue(firstFile);

--- a/apps/web/src/dashboard/components/SearchFilesDialog.tsx
+++ b/apps/web/src/dashboard/components/SearchFilesDialog.tsx
@@ -42,6 +42,7 @@ export function SearchFilesDialog({
   const [loading, setLoading] = useState(false);
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const searchBarRef = useRef<SearchBarHandle>(null);
+  const listRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     if (!open || !adapter.searchWorkspaceContent || query.length < 2) {
@@ -99,27 +100,31 @@ export function SearchFilesDialog({
     return Array.from(map.entries());
   }, [results]);
 
-  // Auto-select the first result only when the current selection is no longer valid
-  const selectedValueRef = useRef(selectedValue);
-  selectedValueRef.current = selectedValue;
-
+  // Whenever a new result set is applied, snap the highlighted item back to the
+  // first result and scroll the list to the top, matching VS Code and the Quick
+  // Open dialog. cmdk runs with `shouldFilter={false}` here, so it never re-runs
+  // its own select-first logic on a query change: a match that survives a query
+  // refinement (its `file:line:content` value still present in the new results,
+  // just not first) would otherwise stay selected with the list scrolled down,
+  // and pressing Enter would open the wrong match.
+  //
+  // Keyed on the result *contents* (not the array reference) so repeated clears
+  // to an empty list — a query under 2 chars sets `results` to [] — don't
+  // re-fire and fight cmdk's own single-item selection. Keyboard up/down and
+  // hover still update `selectedValue` via `onValueChange`, so this only
+  // overrides selection on an actual result change, never mid-navigation.
+  const itemValues = useMemo(
+    () =>
+      grouped.flatMap(([file, matches]) => matches.map((m) => `${file}:${m.line}:${m.content}`)),
+    [grouped],
+  );
+  const firstValue = itemValues[0] ?? "";
+  const resultKey = itemValues.join("\n");
+  // biome-ignore lint/correctness/useExhaustiveDependencies: resultKey is an intentional trigger dependency (fires on any content change, incl. when firstValue is unchanged) — it isn't read in the body
   useEffect(() => {
-    if (grouped.length > 0) {
-      const current = selectedValueRef.current;
-      const stillValid =
-        current &&
-        grouped.some(([file, matches]) =>
-          matches.some((m) => `${file}:${m.line}:${m.content}` === current),
-        );
-      if (!stillValid) {
-        const [file, matches] = grouped[0];
-        const first = matches[0];
-        setSelectedValue(`${file}:${first.line}:${first.content}`);
-      }
-    } else {
-      setSelectedValue("");
-    }
-  }, [grouped]);
+    setSelectedValue(firstValue);
+    if (listRef.current) listRef.current.scrollTop = 0;
+  }, [resultKey, firstValue]);
 
   const handleSelect = useCallback(
     (filePath: string, line: number) => {
@@ -158,7 +163,7 @@ export function SearchFilesDialog({
             // the list), so its divider flips to a top border.
             className="max-lg:border-t max-lg:border-b-0"
           />
-          <CommandList className="max-h-[400px]">
+          <CommandList ref={listRef} className="max-h-[400px]">
             <CommandEmpty>
               {loading
                 ? "Searching..."

--- a/apps/web/src/dashboard/components/SearchFilesDialog.tsx
+++ b/apps/web/src/dashboard/components/SearchFilesDialog.tsx
@@ -185,18 +185,24 @@ export function SearchFilesDialog({
                     </span>
                   }
                 >
-                  {matches.map((match) => (
-                    <CommandItem
-                      key={`${file}:${match.line}:${match.content}`}
-                      value={`${file}:${match.line}:${match.content}`}
-                      onSelect={() => handleSelect(file, match.line)}
-                    >
-                      <span className="w-8 shrink-0 text-right font-mono text-xs text-muted-foreground">
-                        {match.line}
-                      </span>
-                      <span className="min-w-0 truncate font-mono text-xs">{match.content}</span>
-                    </CommandItem>
-                  ))}
+                  {matches.map((match) => {
+                    // Compute the `file:line:content` row value once and reuse
+                    // it for both `key` and `value` instead of allocating the
+                    // template literal twice per row on every render.
+                    const value = `${file}:${match.line}:${match.content}`;
+                    return (
+                      <CommandItem
+                        key={value}
+                        value={value}
+                        onSelect={() => handleSelect(file, match.line)}
+                      >
+                        <span className="w-8 shrink-0 text-right font-mono text-xs text-muted-foreground">
+                          {match.line}
+                        </span>
+                        <span className="min-w-0 truncate font-mono text-xs">{match.content}</span>
+                      </CommandItem>
+                    );
+                  })}
                 </CommandGroup>
               );
             })}

--- a/apps/web/src/dashboard/components/SearchFilesDialog.tsx
+++ b/apps/web/src/dashboard/components/SearchFilesDialog.tsx
@@ -138,6 +138,13 @@ export function SearchFilesDialog({
 
   const totalMatches = results.length;
 
+  // Running row index into the memoised `itemValues`, advanced once per rendered
+  // match below. `grouped.flatMap(...)` (which builds `itemValues`) and the
+  // `grouped.map(...).matches.map(...)` render walk `grouped` in the same order,
+  // so `itemValues[rowIndex]` is that row's `file:line:content` — reused for both
+  // `key` and `value` instead of re-allocating the string on every render.
+  let rowIndex = 0;
+
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent
@@ -186,10 +193,8 @@ export function SearchFilesDialog({
                   }
                 >
                   {matches.map((match) => {
-                    // Compute the `file:line:content` row value once and reuse
-                    // it for both `key` and `value` instead of allocating the
-                    // template literal twice per row on every render.
-                    const value = `${file}:${match.line}:${match.content}`;
+                    // Reuse the pre-computed `file:line:content` for key + value.
+                    const value = itemValues[rowIndex++];
                     return (
                       <CommandItem
                         key={value}

--- a/apps/web/src/dashboard/components/SearchFilesDialog.tsx
+++ b/apps/web/src/dashboard/components/SearchFilesDialog.tsx
@@ -119,7 +119,9 @@ export function SearchFilesDialog({
     [grouped],
   );
   const firstValue = itemValues[0] ?? "";
-  const resultKey = itemValues.join("\n");
+  // O(N) string allocation — memoised so it only recomputes when the result set
+  // changes, not on every `selectedValue` / hover render.
+  const resultKey = useMemo(() => itemValues.join("\n"), [itemValues]);
   // biome-ignore lint/correctness/useExhaustiveDependencies: resultKey is an intentional trigger dependency (fires on any content change, incl. when firstValue is unchanged) — it isn't read in the body
   useEffect(() => {
     setSelectedValue(firstValue);

--- a/packages/ui/src/components/command.tsx
+++ b/packages/ui/src/components/command.tsx
@@ -1,6 +1,6 @@
 import { Command as CommandPrimitive } from "cmdk";
 import { SearchIcon } from "lucide-react";
-import type * as React from "react";
+import * as React from "react";
 
 import { cn } from "../utils";
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from "./dialog";
@@ -61,15 +61,20 @@ function CommandInput({
   );
 }
 
-function CommandList({ className, ...props }: React.ComponentProps<typeof CommandPrimitive.List>) {
+const CommandList = React.forwardRef<
+  React.ElementRef<typeof CommandPrimitive.List>,
+  React.ComponentProps<typeof CommandPrimitive.List>
+>(({ className, ...props }, ref) => {
   return (
     <CommandPrimitive.List
+      ref={ref}
       data-slot="command-list"
       className={cn("max-h-[300px] overflow-y-auto overflow-x-hidden", className)}
       {...props}
     />
   );
-}
+});
+CommandList.displayName = "CommandList";
 
 function CommandEmpty({ ...props }: React.ComponentProps<typeof CommandPrimitive.Empty>) {
   return (


### PR DESCRIPTION
## Summary

Quick Open (Cmd+P file finder) let cmdk keep a **stale selection**: when the previously highlighted file survived a query refinement (still present in the new results, just not first), it stayed selected and the list never scrolled back to the top — so pressing Enter opened the **wrong file**.

cmdk only re-selects the first item when the currently selected item *unmounts*. A file that survives a query change (e.g. `report` → `reports`) keeps the highlight. This fix controls cmdk's selection in `QuickOpenDialog` and, whenever the result *contents* change, snaps the highlight back to the first row and scrolls the list to the top — matching VS Code's Quick Open.

## Changes

- **`QuickOpenDialog.tsx`** — control cmdk's `value`/`onValueChange`; on any result-content change, reset selection to the first row and `scrollTop` to 0. Keyed on result contents (not array reference) so repeated `setFiles([])` clears don't fight cmdk's own selection.
- **`packages/ui/src/components/command.tsx`** — forward a ref through `CommandList` so the dialog can reset the scroll position.
- **`quick-open-select-first.spec.ts`** — real-server e2e regression coverage: boots the production server against a fresh tmp home + real git worktree with a deterministic corpus, drives the dialog through real keyboard input and the real search endpoint (no tRPC mocking, no `page.route()`). Covers selection reset on query change, arrow-key navigation + Enter opening the first result, and the empty-query recent-files view.
- **`WorkspacePage.ts`** — page-object locators/actions for the Quick Open dialog.

## Test plan

- [x] `pnpm --filter @band-app/server test:e2e` (new spec)
- [x] Pre-push hooks (lint/fmt/clippy) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)