### PR TITLE
feat(web): Windows compatibility for @band-app/server runtime (#150)

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -18,7 +18,8 @@
   },
   "os": [
     "darwin",
-    "linux"
+    "linux",
+    "win32"
   ],
   "scripts": {
     "dev": "NODE_ENV=development tsx watch start-server.ts",
@@ -28,7 +29,7 @@
     "test": "NODE_OPTIONS='--no-warnings=ExperimentalWarning' vitest run",
     "test:e2e": "NODE_OPTIONS='--no-warnings=ExperimentalWarning' playwright test",
     "test:e2e:ui": "NODE_OPTIONS='--no-warnings=ExperimentalWarning' playwright test --ui",
-    "postinstall": "chmod +x node_modules/node-pty/prebuilds/*/spawn-helper 2>/dev/null || true"
+    "postinstall": "node -e \"process.platform!=='win32'&&require('child_process').execSync('chmod +x node_modules/node-pty/prebuilds/*/spawn-helper 2>/dev/null || true',{stdio:'ignore'})\""
   },
   "dependencies": {
     "@vscode/ripgrep": "^1.18.0",

--- a/apps/web/src/server/infra/process/du.ts
+++ b/apps/web/src/server/infra/process/du.ts
@@ -34,14 +34,17 @@ const DU_TIMEOUT_MS = 30_000;
  * followed — avoiding both double-counting a file reachable two ways and
  * infinite loops on a symlink cycle.
  *
- * Bounded like the POSIX path: a `DU_TIMEOUT_MS` deadline (checked once per
- * directory) caps the wall-clock so a pathological tree or a stalled
- * network mount can't pin the caller's `du` semaphore slot indefinitely —
- * the partial total is returned, mirroring `du`'s partial-output-on-timeout
- * behaviour. Per-directory `stat`s are batched with `Promise.all` so the
- * libuv threadpool services several at once rather than one round-trip at a
- * time.
+ * Bounded like the POSIX path: a `DU_TIMEOUT_MS` deadline caps the
+ * wall-clock so a pathological tree or a stalled network mount can't pin
+ * the caller's `du` semaphore slot indefinitely — the partial total is
+ * returned, mirroring `du`'s partial-output-on-timeout behaviour. Per-file
+ * `stat`s run concurrently but in bounded chunks (`STAT_CHUNK`) so a single
+ * huge directory (a big `node_modules`) can't queue tens of thousands of
+ * pending stats against the small libuv threadpool at once; the deadline is
+ * re-checked between chunks.
  */
+const STAT_CHUNK = 256;
+
 async function duBytesNodeWalk(path: string): Promise<number> {
   const deadline = Date.now() + DU_TIMEOUT_MS;
   let total = 0;
@@ -60,15 +63,18 @@ async function duBytesNodeWalk(path: string): Promise<number> {
         }
         // Symlinks (and other special entries) are not followed or counted.
       }
-      const sizes = await Promise.all(
-        filePaths.map((p) =>
-          stat(p).then(
-            (s) => s.size,
-            () => 0, // vanished between readdir and stat — count as 0
+      for (let i = 0; i < filePaths.length; i += STAT_CHUNK) {
+        if (Date.now() > deadline) break;
+        const sizes = await Promise.all(
+          filePaths.slice(i, i + STAT_CHUNK).map((p) =>
+            stat(p).then(
+              (s) => s.size,
+              () => 0, // vanished between readdir and stat — count as 0
+            ),
           ),
-        ),
-      );
-      for (const size of sizes) total += size;
+        );
+        for (const size of sizes) total += size;
+      }
     } catch {
       // Unreadable directory — skip, like `du` does on EACCES.
     }

--- a/apps/web/src/server/infra/process/du.ts
+++ b/apps/web/src/server/infra/process/du.ts
@@ -11,12 +11,70 @@
  */
 
 import { execFile } from "node:child_process";
+import { readdir, stat } from "node:fs/promises";
+import { join } from "node:path";
 
 /** Maximum buffer size for `du` stdout. `du -sk` prints a single summary line; 10 MB is overkill but defensible. */
 const MAX_DU_BUFFER = 10 * 1024 * 1024;
 
 /** Hard wall-clock cap on a single `du` invocation. Prevents stalled NFS/CIFS mounts hanging the tRPC handler. */
 const DU_TIMEOUT_MS = 30_000;
+
+/**
+ * Windows has no `du`. Walk the tree with Node and sum apparent file
+ * sizes — the same "close enough" contract as `du` (BSD/GNU `du` reports
+ * *allocated* size, which differs from apparent by < 5% for typical
+ * content; see the `duBytes` docstring).
+ *
+ * Mirrors `du`'s tolerance for unreadable descendants: a directory that
+ * can't be read (permission denied, a symlink loop, a vanished entry) is
+ * skipped rather than aborting the whole measurement, so the caller sees a
+ * possibly-truncated total instead of a hard failure. `readdir` with
+ * `withFileTypes` reports symlinks as their own kind, so they are never
+ * followed — avoiding both double-counting a file reachable two ways and
+ * infinite loops on a symlink cycle.
+ *
+ * Bounded like the POSIX path: a `DU_TIMEOUT_MS` deadline (checked once per
+ * directory) caps the wall-clock so a pathological tree or a stalled
+ * network mount can't pin the caller's `du` semaphore slot indefinitely —
+ * the partial total is returned, mirroring `du`'s partial-output-on-timeout
+ * behaviour. Per-directory `stat`s are batched with `Promise.all` so the
+ * libuv threadpool services several at once rather than one round-trip at a
+ * time.
+ */
+async function duBytesNodeWalk(path: string): Promise<number> {
+  const deadline = Date.now() + DU_TIMEOUT_MS;
+  let total = 0;
+  const stack: string[] = [path];
+  while (stack.length > 0) {
+    if (Date.now() > deadline) break; // return the partial total, like `du` on timeout
+    const dir = stack.pop() as string;
+    try {
+      const entries = await readdir(dir, { withFileTypes: true });
+      const filePaths: string[] = [];
+      for (const entry of entries) {
+        if (entry.isDirectory()) {
+          stack.push(join(dir, entry.name));
+        } else if (entry.isFile()) {
+          filePaths.push(join(dir, entry.name));
+        }
+        // Symlinks (and other special entries) are not followed or counted.
+      }
+      const sizes = await Promise.all(
+        filePaths.map((p) =>
+          stat(p).then(
+            (s) => s.size,
+            () => 0, // vanished between readdir and stat — count as 0
+          ),
+        ),
+      );
+      for (const size of sizes) total += size;
+    } catch {
+      // Unreadable directory — skip, like `du` does on EACCES.
+    }
+  }
+  return total;
+}
 
 /**
  * Run `du -sk PATH` and return the allocated byte total.
@@ -35,6 +93,11 @@ const DU_TIMEOUT_MS = 30_000;
  * use the callback form and parse stdout regardless of exit status.
  */
 export async function duBytes(path: string): Promise<number> {
+  // Windows has no `du` — fall back to a Node walk. POSIX keeps the fast
+  // single-fork `du` path below.
+  if (process.platform === "win32") {
+    return duBytesNodeWalk(path);
+  }
   const stdout = await new Promise<string>((resolve, reject) => {
     execFile(
       "du",

--- a/apps/web/src/server/infra/process/path.ts
+++ b/apps/web/src/server/infra/process/path.ts
@@ -84,10 +84,53 @@ export function prependBinDirs(path: string | undefined): string {
   return [...extraBinDirs(), ...(path ? [path] : [])].join(delimiter);
 }
 
+/**
+ * Build the argv to run a shell *command string* (the `sh -c "<command>"`
+ * shape used by the `.band` setup/teardown hooks) cross-platform.
+ *
+ * POSIX keeps the historical `bash -c <command>` so user-authored setup
+ * commands (which are written as bash) behave exactly as before. Windows
+ * has no bash on a stock host, so route the command through the command
+ * interpreter (`%ComSpec%`, i.e. cmd.exe) with `/d /s /c` — `/d` skips
+ * AutoRun, `/s` fixes quote handling, `/c` runs the string and exits.
+ */
+export function shellCommandInvocation(command: string): { file: string; args: string[] } {
+  if (process.platform === "win32") {
+    return { file: process.env.ComSpec || "cmd.exe", args: ["/d", "/s", "/c", command] };
+  }
+  return { file: "bash", args: ["-c", command] };
+}
+
+/**
+ * Build the argv to execute a script *file* by path cross-platform.
+ *
+ * POSIX runs it via `bash <scriptPath>` (the file is interpreted as a bash
+ * script regardless of its executable bit). Windows has no bash on a stock
+ * host, so hand the path to the command interpreter — a `.cmd`/`.bat`
+ * runs directly; a bash-shaped script won't execute correctly, but the
+ * interpreter always exists so the call never ENOENTs on a missing `bash`.
+ */
+export function scriptInvocation(scriptPath: string): { file: string; args: string[] } {
+  if (process.platform === "win32") {
+    return { file: process.env.ComSpec || "cmd.exe", args: ["/d", "/s", "/c", scriptPath] };
+  }
+  return { file: "bash", args: [scriptPath] };
+}
+
 let cachedShellPath: string | null = null;
 
 export async function shellPath(): Promise<string> {
   if (cachedShellPath) return cachedShellPath;
+
+  // Windows has no POSIX login shell to interrogate — cmd.exe/PowerShell
+  // don't understand `-li -c 'echo $PATH'`. The process already inherits
+  // the user's `PATH` from the environment, so use it directly.
+  // `extraBinDirs()` is empty on Windows, so `prependBinDirs` is a
+  // passthrough that just normalises an undefined `PATH` to "".
+  if (process.platform === "win32") {
+    cachedShellPath = prependBinDirs(process.env.PATH);
+    return cachedShellPath;
+  }
 
   const shell = defaultShell();
   try {
@@ -116,9 +159,13 @@ export async function shellPath(): Promise<string> {
 /** Resolve a binary against the user's interactive `$PATH`, or `null` when absent. */
 export async function whichBinary(name: string): Promise<string | null> {
   const resolvedPath = await shellPath();
+  // `which` is POSIX-only; Windows ships `where.exe`, which prints one
+  // absolute match per line (resolving against `PATHEXT`, so a bare name
+  // like `claude` finds `claude.cmd`/`claude.exe`).
+  const locator = process.platform === "win32" ? "where" : "which";
   try {
     const result = await new Promise<string>((resolve, reject) => {
-      execFile("which", [name], { env: { ...process.env, PATH: resolvedPath } }, (err, stdout) => {
+      execFile(locator, [name], { env: { ...process.env, PATH: resolvedPath } }, (err, stdout) => {
         if (err) {
           reject(err);
           return;
@@ -126,7 +173,9 @@ export async function whichBinary(name: string): Promise<string | null> {
         resolve(stdout.trim());
       });
     });
-    return result || null;
+    // `where` can return several lines (one per match); take the first.
+    const first = result.split(/\r?\n/)[0]?.trim();
+    return first || null;
   } catch {
     return null;
   }

--- a/apps/web/src/server/infra/setup/setup-runner.ts
+++ b/apps/web/src/server/infra/setup/setup-runner.ts
@@ -1,6 +1,6 @@
 import { type ChildProcess, spawn } from "node:child_process";
 import { emit } from "../events/status-event-bus";
-import { prependBinDirs } from "../process/path";
+import { prependBinDirs, shellCommandInvocation } from "../process/path";
 import { loadProjectConfig } from "./project-config";
 
 /**
@@ -46,7 +46,11 @@ export function runSetup(
   }
 
   const { PORT: _port, ...parentEnv } = process.env;
-  const child = spawn("bash", ["-c", setupCommand], {
+  // `bash -c <cmd>` on POSIX, `cmd.exe /d /s /c <cmd>` on Windows — a
+  // stock Windows host has no bash, so route the command through the
+  // platform shell rather than ENOENT on a missing `bash`.
+  const { file, args } = shellCommandInvocation(setupCommand);
+  const child = spawn(file, args, {
     cwd: worktreePath,
     env: {
       ...parentEnv,

--- a/apps/web/src/server/infra/tunnels/tunnel-client.ts
+++ b/apps/web/src/server/infra/tunnels/tunnel-client.ts
@@ -42,7 +42,10 @@ export class TunnelClient {
   }
 
   private spawnTunnel(options: { port: number }, resolvedPath: string): Promise<void> {
-    const args = ["tunnel", "--config", "/dev/null", "--url", `http://localhost:${options.port}`];
+    // Point cloudflared at the platform's null device so it never picks up
+    // a stray config file: `/dev/null` on POSIX, `NUL` on Windows.
+    const nullDevice = process.platform === "win32" ? "NUL" : "/dev/null";
+    const args = ["tunnel", "--config", nullDevice, "--url", `http://localhost:${options.port}`];
 
     log.debug("spawning cloudflared %s", args.join(" "));
 

--- a/apps/web/src/server/services/cli-service.ts
+++ b/apps/web/src/server/services/cli-service.ts
@@ -317,6 +317,10 @@ async function installCliWindows(binaryPath: string): Promise<void> {
   mkdirSync(binDir, { recursive: true });
   // `%*` forwards every argument; the binary path is quoted so a space in
   // the install location (e.g. under a profile dir) is handled correctly.
+  // `binaryPath` comes from `findCliBinary()` (a resolved on-disk path) and
+  // the Windows filesystem forbids `"` in paths, so the double-quote wrapping
+  // can't be broken by the interpolated value — the same assumption
+  // `checkCliWindows` relies on when it parses the quoted target back out.
   const shim = `@echo off\r\n"${binaryPath}" %*\r\n`;
   writeFileSync(SYMLINK_PATH, shim, "utf-8");
   await addBinDirToUserPath(binDir);

--- a/apps/web/src/server/services/cli-service.ts
+++ b/apps/web/src/server/services/cli-service.ts
@@ -1,6 +1,18 @@
-import { accessSync, constants, lstatSync, realpathSync, symlinkSync, unlinkSync } from "node:fs";
-import { platform } from "node:os";
-import { dirname, join, resolve } from "node:path";
+import { execFile } from "node:child_process";
+import {
+  accessSync,
+  constants,
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  readFileSync,
+  realpathSync,
+  symlinkSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { homedir, platform } from "node:os";
+import { basename, dirname, join, resolve } from "node:path";
 
 export type CliStatus =
   | "Installed"
@@ -9,7 +21,26 @@ export type CliStatus =
   | "DirNotFound"
   | "NotWritable";
 
-export const SYMLINK_PATH = "/usr/local/bin/band";
+/**
+ * Directory that holds the Windows `band.cmd` shim. Kept under
+ * `%LOCALAPPDATA%\band\bin` (a per-user, no-elevation-required location);
+ * falls back to the conventional `AppData\Local` path when the env var is
+ * somehow unset.
+ */
+function windowsBinDir(): string {
+  const localAppData = process.env.LOCALAPPDATA || join(homedir(), "AppData", "Local");
+  return join(localAppData, "band", "bin");
+}
+
+/**
+ * Install target for the `band` CLI entry point.
+ *
+ * - POSIX: a `/usr/local/bin/band` symlink to the resolved binary.
+ * - Windows: a `band.cmd` shim under `%LOCALAPPDATA%\band\bin` (symlinks
+ *   need Developer Mode / admin, a shim doesn't — see `installCliWindows`).
+ */
+export const SYMLINK_PATH =
+  platform() === "win32" ? join(windowsBinDir(), "band.cmd") : "/usr/local/bin/band";
 
 /**
  * Pure resolver for the band CLI binary. Takes the cwd and the calling
@@ -22,6 +53,9 @@ export const SYMLINK_PATH = "/usr/local/bin/band";
  */
 export function findCliBinaryAt(opts: { cwd: string; dirname: string }): string | null {
   const { cwd, dirname } = opts;
+
+  // Cargo/Electron emit `band.exe` on Windows, `band` elsewhere.
+  const exe = platform() === "win32" ? "band.exe" : "band";
 
   // --- Strategy A: cargo build output (dev & source builds) ---
   const appsStrategies = [
@@ -43,7 +77,7 @@ export function findCliBinaryAt(opts: { cwd: string; dirname: string }): string 
 
   for (const appsDir of appsStrategies) {
     for (const profile of ["release", "debug"]) {
-      const p = join(appsDir, "cli", "target", profile, "band");
+      const p = join(appsDir, "cli", "target", profile, exe);
       try {
         lstatSync(p);
         return p;
@@ -62,7 +96,6 @@ export function findCliBinaryAt(opts: { cwd: string; dirname: string }): string 
   // paths so the resolution survives a future change to the spawn cwd (the
   // dirname path matches the bundled file's installed location at
   // `<Resources>/web/dist/start-server.mjs`).
-  const exe = platform() === "win32" ? "band.exe" : "band";
   const electronCandidates = [
     // From cwd (<Resources>/web) → <Resources>/binaries/band
     resolve(cwd, "..", "binaries", exe),
@@ -87,7 +120,41 @@ export function findCliBinary(): string | null {
   return findCliBinaryAt({ cwd: process.cwd(), dirname: import.meta.dirname });
 }
 
+/**
+ * Windows install-status check. The shim is a plain `band.cmd` file (not a
+ * symlink), so we read it and confirm it still points at an existing
+ * `band.exe`. A shim referencing a moved/removed binary reports
+ * `NotInstalled` so first-time setup rewrites it; a `band.cmd` we don't
+ * recognise (foreign or hand-edited — its quoted target isn't `band.exe`)
+ * reports `ConflictingBinary`, mirroring the POSIX branch rather than
+ * silently trusting and later overwriting it.
+ */
+function checkCliWindows(): CliStatus {
+  let contents: string;
+  try {
+    contents = readFileSync(SYMLINK_PATH, "utf-8");
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code === "EACCES") return "NotWritable";
+    // ENOENT (no shim yet) or anything else — the bin dir is ours to
+    // create in installCli, so treat as a clean "not installed".
+    return "NotInstalled";
+  }
+  // Our shim invokes a quoted absolute path: `"C:\...\band.exe" %*`.
+  const match = contents.match(/"([^"]+)"/);
+  if (!match) return "ConflictingBinary";
+  const target = match[1];
+  // A quoted target that isn't `band.exe` is someone else's `band.cmd`.
+  if (basename(target).toLowerCase() !== "band.exe") return "ConflictingBinary";
+  return existsSync(target) ? "Installed" : "NotInstalled";
+}
+
 export async function checkCli(): Promise<CliStatus> {
+  // Windows uses a `.cmd` shim, not a symlink — different install/verify
+  // shape entirely.
+  if (platform() === "win32") {
+    return checkCliWindows();
+  }
   try {
     const stat = lstatSync(SYMLINK_PATH);
     if (!stat.isSymbolicLink()) {
@@ -190,10 +257,80 @@ export function noBinaryError(env: NodeJS.ProcessEnv = process.env): Error {
   );
 }
 
+/**
+ * Run `reg` and resolve with its stdout, never rejecting — callers treat
+ * every registry operation as best-effort.
+ */
+function runReg(args: string[]): Promise<string> {
+  return new Promise((resolve) => {
+    execFile("reg", args, { windowsHide: true }, (err, stdout) => {
+      resolve(err ? "" : (stdout ?? ""));
+    });
+  });
+}
+
+/**
+ * Best-effort: add `binDir` to the *user* `PATH` (HKCU\Environment) so
+ * `band` resolves in newly opened shells. Reads the raw (unexpanded) value
+ * and rewrites it as `REG_EXPAND_SZ` via `reg add` — deliberately NOT
+ * `setx`, which truncates values over 1024 chars and would corrupt a long
+ * PATH. A no-op when the dir is already present. Any failure is swallowed:
+ * the shim itself is already installed, so the worst case is the user
+ * adding the directory to PATH manually. Note that already-running shells
+ * won't see the change until they're restarted.
+ */
+async function addBinDirToUserPath(binDir: string): Promise<void> {
+  try {
+    const stdout = await runReg(["query", "HKCU\\Environment", "/v", "Path"]);
+    // Output line shape: `    Path    REG_EXPAND_SZ    C:\a;C:\b`
+    const match = stdout.match(/\bPath\s+REG(?:_EXPAND)?_SZ\s+(.*)/i);
+    const current = match ? match[1].trim() : "";
+    const parts = current ? current.split(";").filter(Boolean) : [];
+    if (parts.some((p) => p.toLowerCase() === binDir.toLowerCase())) {
+      return;
+    }
+    const next = current ? `${current};${binDir}` : binDir;
+    await runReg([
+      "add",
+      "HKCU\\Environment",
+      "/v",
+      "Path",
+      "/t",
+      "REG_EXPAND_SZ",
+      "/d",
+      next,
+      "/f",
+    ]);
+  } catch {
+    // Best-effort — the shim works from an absolute path regardless.
+  }
+}
+
+/**
+ * Install the Windows `band.cmd` shim under `%LOCALAPPDATA%\band\bin` and
+ * put that directory on the user PATH. A shim (rather than a symlink)
+ * avoids the Developer-Mode/admin requirement Windows imposes on symlink
+ * creation, and works from cmd, PowerShell, and Git Bash alike.
+ */
+async function installCliWindows(binaryPath: string): Promise<void> {
+  const binDir = windowsBinDir();
+  mkdirSync(binDir, { recursive: true });
+  // `%*` forwards every argument; the binary path is quoted so a space in
+  // the install location (e.g. under a profile dir) is handled correctly.
+  const shim = `@echo off\r\n"${binaryPath}" %*\r\n`;
+  writeFileSync(SYMLINK_PATH, shim, "utf-8");
+  await addBinDirToUserPath(binDir);
+}
+
 export async function installCli(_opts: InstallCliOptions = {}): Promise<void> {
   const binaryPath = findCliBinary();
   if (!binaryPath) {
     throw noBinaryError();
+  }
+
+  if (platform() === "win32") {
+    await installCliWindows(binaryPath);
+    return;
   }
 
   const dir = dirname(SYMLINK_PATH);

--- a/apps/web/src/server/services/cli-skills-service.ts
+++ b/apps/web/src/server/services/cli-skills-service.ts
@@ -69,11 +69,18 @@ const SKILL_FILE = "SKILL.md";
  * idempotent setup pipeline).
  */
 export async function findBandBinary(): Promise<string | null> {
-  try {
-    const stat = statSync("/usr/local/bin/band");
-    if (stat) return "/usr/local/bin/band";
-  } catch {
-    // Fall through to `which`.
+  // The `/usr/local/bin/band` symlink is POSIX-only. On Windows the CLI
+  // install is a `band.cmd` shim (which `execFile` can't invoke directly
+  // anyway), so skip this shortcut and rely on `where band` / the bundled
+  // sidecar resolver below, both of which return a directly-executable
+  // path.
+  if (process.platform !== "win32") {
+    try {
+      const stat = statSync("/usr/local/bin/band");
+      if (stat) return "/usr/local/bin/band";
+    } catch {
+      // Fall through to `which`.
+    }
   }
 
   const onPath = await systemService.whichBinary("band");

--- a/apps/web/src/server/services/cli-skills-service.ts
+++ b/apps/web/src/server/services/cli-skills-service.ts
@@ -76,8 +76,10 @@ export async function findBandBinary(): Promise<string | null> {
   // path.
   if (process.platform !== "win32") {
     try {
-      const stat = statSync("/usr/local/bin/band");
-      if (stat) return "/usr/local/bin/band";
+      // `statSync` throws when the symlink is absent (caught below); a
+      // successful return means it exists, so no truthiness check is needed.
+      statSync("/usr/local/bin/band");
+      return "/usr/local/bin/band";
     } catch {
       // Fall through to `which`.
     }

--- a/apps/web/src/server/services/hooks-service.ts
+++ b/apps/web/src/server/services/hooks-service.ts
@@ -67,8 +67,10 @@ export async function installHooks(): Promise<void> {
   let bandPath: string | null = null;
   if (process.platform !== "win32") {
     try {
-      const stat = await import("node:fs/promises").then((m) => m.stat("/usr/local/bin/band"));
-      if (stat) bandPath = "/usr/local/bin/band";
+      // `stat` rejects when the symlink is absent (caught below); resolving
+      // means it exists, so no truthiness check on the Stats object is needed.
+      await import("node:fs/promises").then((m) => m.stat("/usr/local/bin/band"));
+      bandPath = "/usr/local/bin/band";
     } catch {
       // Try which
     }

--- a/apps/web/src/server/services/hooks-service.ts
+++ b/apps/web/src/server/services/hooks-service.ts
@@ -60,13 +60,18 @@ export async function checkHooks(): Promise<{
 }
 
 export async function installHooks(): Promise<void> {
-  // Find band binary
+  // Find band binary. The `/usr/local/bin/band` symlink is POSIX-only;
+  // on Windows resolve it off PATH (`where band`) instead — the hook
+  // command is executed by the coding agent's own shell, so a `band.cmd`
+  // shim path works there.
   let bandPath: string | null = null;
-  try {
-    const stat = await import("node:fs/promises").then((m) => m.stat("/usr/local/bin/band"));
-    if (stat) bandPath = "/usr/local/bin/band";
-  } catch {
-    // Try which
+  if (process.platform !== "win32") {
+    try {
+      const stat = await import("node:fs/promises").then((m) => m.stat("/usr/local/bin/band"));
+      if (stat) bandPath = "/usr/local/bin/band";
+    } catch {
+      // Try which
+    }
   }
   if (!bandPath) {
     bandPath = await systemService.whichBinary("band");

--- a/apps/web/src/server/services/setup-service.ts
+++ b/apps/web/src/server/services/setup-service.ts
@@ -1,5 +1,5 @@
 import { createLogger } from "@band-app/logger";
-import { checkCli, installCli } from "./cli-service";
+import { checkCli, installCli, SYMLINK_PATH } from "./cli-service";
 import { installSkills } from "./cli-skills-service";
 import { checkHooks, installHooks } from "./hooks-service";
 import { modelRefreshService } from "./model-refresh-service";
@@ -210,7 +210,7 @@ async function ensureCliInstalled(): Promise<void> {
   log.info("Installing band CLI...");
   try {
     await installCli();
-    log.info("CLI installed to /usr/local/bin/band");
+    log.info("CLI installed to %s", SYMLINK_PATH);
   } catch (err) {
     log.warn("CLI installation failed: %s", err instanceof Error ? err.message : String(err));
   }

--- a/apps/web/src/server/services/system-service.ts
+++ b/apps/web/src/server/services/system-service.ts
@@ -84,18 +84,23 @@ export class SystemService {
    * even when the Node process inherited a stripped-down PATH from
    * launchd / Electron.
    *
-   * Homebrew is macOS-only here: a stock Linux host has no `brew`, so
-   * shelling out to it would fail with an opaque ENOENT. Guard on
-   * `darwin` and surface a distro-appropriate hint on every other
-   * platform — the message bubbles up to the dashboard's install flow as
-   * a normal error instead of a crash.
+   * Homebrew is macOS-only here: a stock Linux or Windows host has no
+   * `brew`, so shelling out to it would fail with an opaque ENOENT. Guard
+   * on `darwin` and surface a platform-appropriate hint everywhere else —
+   * the message bubbles up to the dashboard's install flow as a normal
+   * error instead of a crash.
    */
   async installCloudflared(resolvedPath: string): Promise<void> {
     if (process.platform !== "darwin") {
+      const hint =
+        process.platform === "win32"
+          ? "On Windows, install it with `winget install --id Cloudflare.cloudflared` " +
+            "(or `choco install cloudflared`)"
+          : "On Linux, install it with your package manager " +
+            "(e.g. `sudo apt install cloudflared` or `sudo dnf install cloudflared`)";
       throw new Error(
         "Automatic cloudflared install is only supported on macOS (via Homebrew). " +
-          "On Linux, install it with your package manager " +
-          "(e.g. `sudo apt install cloudflared` or `sudo dnf install cloudflared`) " +
+          `${hint} ` +
           "or download it from " +
           "https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/downloads/ " +
           "and re-open the tunnel.",

--- a/apps/web/src/server/services/workspace-service.ts
+++ b/apps/web/src/server/services/workspace-service.ts
@@ -1274,11 +1274,12 @@ export class WorkspaceService {
    * (e.g. `on-create`, `on-open`). Returns once the script exits 0;
    * rejects on a non-zero exit. On POSIX the script is run via
    * `bash <scriptPath>` — execFile with a fixed argv, not a shell-spawned
-   * command string, so no shell interpretation of `input.path` /
-   * `input.scriptType` is possible. On Windows it runs through the command
-   * interpreter (`cmd.exe /d /s /c <scriptPath>`); `scriptPath` is composed
-   * from a server-controlled workspace path plus a constrained
-   * `scriptType`, so it is not attacker-controlled.
+   * command string. On Windows it runs through the command interpreter
+   * (`cmd.exe /d /s /c <scriptPath>`), where cmd metacharacters in the path
+   * WOULD be interpreted — so `scriptType` (an unconstrained `z.string()` at
+   * the tRPC edge) is validated to a safe filename charset before it becomes
+   * a path segment, closing both a Windows shell-injection vector and a
+   * cross-platform `..` path-traversal vector.
    *
    * Missing-script case throws a generic `Error` (not a domain class) so
    * tRPC surfaces it as `INTERNAL_SERVER_ERROR` (500). The wire-level
@@ -1288,6 +1289,15 @@ export class WorkspaceService {
    * pattern-matching on status.
    */
   async runScript(input: WorkspaceRunScriptInput): Promise<{ ok: true }> {
+    // Harden `scriptType` before it becomes a path segment / command token.
+    // Real callers only ever send `"setup"` / `"teardown"` (see WorkspaceCard),
+    // but the tRPC input is an unconstrained `z.string()`. Restrict to a safe
+    // filename charset — no path separators, no `..` segment, no cmd.exe
+    // metacharacters — so the Windows `cmd /c <scriptPath>` path can't be
+    // steered into shell injection or traversal outside `.band/`.
+    if (!/^[a-zA-Z0-9._-]+$/.test(input.scriptType) || input.scriptType.includes("..")) {
+      throw new Error(`Invalid script type "${input.scriptType}"`);
+    }
     const scriptPath = join(input.path, ".band", input.scriptType);
     if (!existsSync(scriptPath)) {
       throw new Error(`Script "${input.scriptType}" not found`);

--- a/apps/web/src/server/services/workspace-service.ts
+++ b/apps/web/src/server/services/workspace-service.ts
@@ -15,7 +15,7 @@ import { UsageScanStateQueries } from "../infra/db/queries/usage-scan-state";
 import { WorkspaceQueries } from "../infra/db/queries/workspaces";
 import { DETACHED_BRANCH_PREFIX, execGit, gitCmd, listWorktrees } from "../infra/git/git-client";
 import { killWorkspaceServers } from "../infra/lsp/lsp-manager";
-import { prependBinDirs } from "../infra/process/path";
+import { prependBinDirs, scriptInvocation, shellCommandInvocation } from "../infra/process/path";
 import { loadProjectConfig } from "../infra/setup/project-config";
 import { runSetup } from "../infra/setup/setup-runner";
 import { copyWorkspaceFiles } from "../infra/setup/workspace-files";
@@ -787,7 +787,9 @@ export class WorkspaceService {
         // project files.
         if (teardownCmd) {
           try {
-            await execFileAsync("bash", ["-c", teardownCmd], {
+            // `bash -c <cmd>` on POSIX, `cmd.exe /d /s /c <cmd>` on Windows.
+            const { file, args } = shellCommandInvocation(teardownCmd);
+            await execFileAsync(file, args, {
               cwd: worktreePath,
               env: {
                 ...process.env,
@@ -1270,10 +1272,13 @@ export class WorkspaceService {
    *
    * Used by the dashboard's "Run script" actions on a workspace
    * (e.g. `on-create`, `on-open`). Returns once the script exits 0;
-   * rejects on a non-zero exit. The script is run via
-   * `bash <scriptPath>` — execFile, not a shell-spawned command, so no
-   * shell interpretation of `input.path` / `input.scriptType` is
-   * possible.
+   * rejects on a non-zero exit. On POSIX the script is run via
+   * `bash <scriptPath>` — execFile with a fixed argv, not a shell-spawned
+   * command string, so no shell interpretation of `input.path` /
+   * `input.scriptType` is possible. On Windows it runs through the command
+   * interpreter (`cmd.exe /d /s /c <scriptPath>`); `scriptPath` is composed
+   * from a server-controlled workspace path plus a constrained
+   * `scriptType`, so it is not attacker-controlled.
    *
    * Missing-script case throws a generic `Error` (not a domain class) so
    * tRPC surfaces it as `INTERNAL_SERVER_ERROR` (500). The wire-level
@@ -1289,7 +1294,10 @@ export class WorkspaceService {
     }
 
     try {
-      await execFileAsync("bash", [scriptPath], { cwd: input.path });
+      // `bash <scriptPath>` on POSIX; on Windows the script runs through
+      // the command interpreter (see `scriptInvocation`).
+      const { file, args } = scriptInvocation(scriptPath);
+      await execFileAsync(file, args, { cwd: input.path });
     } catch (err) {
       // Rewrap as a plain `Error` carrying just the message — preserves the
       // legacy router's behaviour, where the callback-style failure path

--- a/apps/web/start-server.ts
+++ b/apps/web/start-server.ts
@@ -1185,6 +1185,12 @@ async function main() {
     process.exit(0);
   };
 
+  // SIGINT (Ctrl-C) is delivered on every platform. SIGTERM is a POSIX
+  // signal that Node never raises on Windows — a Windows host relies on
+  // SIGINT for interactive stops, and graceful shutdown when launched by
+  // the Electron desktop parent will be wired through parent-process IPC
+  // as part of the desktop-integration work (#518). Registering the
+  // SIGTERM handler here is harmless on Windows (it simply never fires).
   process.on("SIGTERM", shutdown);
   process.on("SIGINT", shutdown);
 }

--- a/apps/web/tests/cli-sidecar-path.test.ts
+++ b/apps/web/tests/cli-sidecar-path.test.ts
@@ -57,9 +57,11 @@ describe("findCliBinaryAt in packaged Electron layout", () => {
     mkdirSync(distDir, { recursive: true });
     mkdirSync(binDir, { recursive: true });
     writeFileSync(join(distDir, "start-server.mjs"), "// stub bundled server\n", "utf-8");
-    const sidecar = join(binDir, "band");
+    // On Windows the resolver looks for `band.exe`; elsewhere `band`. The
+    // executable bit is meaningless on Windows, so chmod only off-win32.
+    const sidecar = join(binDir, process.platform === "win32" ? "band.exe" : "band");
     writeFileSync(sidecar, "#!/bin/sh\nexit 0\n", "utf-8");
-    chmodSync(sidecar, 0o755);
+    if (process.platform !== "win32") chmodSync(sidecar, 0o755);
 
     // cwd is <Resources>/web (matches the real spawn cwd) and dirname is
     // <Resources>/web/dist (matches `import.meta.dirname` of the bundled
@@ -95,9 +97,11 @@ describe("findCliBinaryAt in packaged Electron layout", () => {
     const binDir = join(resources, "binaries");
     mkdirSync(distDir, { recursive: true });
     mkdirSync(binDir, { recursive: true });
-    const sidecar = join(binDir, "band");
+    // On Windows the resolver looks for `band.exe`; elsewhere `band`. The
+    // executable bit is meaningless on Windows, so chmod only off-win32.
+    const sidecar = join(binDir, process.platform === "win32" ? "band.exe" : "band");
     writeFileSync(sidecar, "#!/bin/sh\nexit 0\n", "utf-8");
-    chmodSync(sidecar, 0o755);
+    if (process.platform !== "win32") chmodSync(sidecar, 0o755);
 
     // cwd points at an unrelated subtree with no binaries/ sibling, so the
     // cwd-based candidate misses. dirname is the real bundled location.

--- a/apps/web/tests/tunnel-install-platform.test.ts
+++ b/apps/web/tests/tunnel-install-platform.test.ts
@@ -36,9 +36,11 @@ describe("prereqs.installTunnel", () => {
     if (tmpHome) rmSync(tmpHome, { recursive: true, force: true });
   });
 
-  // Skipped on darwin only — the assertion body reaches the brew shell-out on
-  // macOS. Everywhere else it exercises the non-darwin platform hint.
-  it.skipIf(process.platform === "darwin")(
+  // Linux-only: the hint text asserted here is the Linux package-manager
+  // branch. On darwin the procedure would reach the brew shell-out (must
+  // never run from a test); on win32 the hint is the winget/choco branch
+  // (asserted separately below), so this runs only on Linux.
+  it.skipIf(process.platform !== "linux")(
     "fails with a package-manager hint instead of shelling out to brew",
     async () => {
       const res = await trpcMutate(server.url, "prereqs.installTunnel", undefined, TOKEN);
@@ -48,6 +50,24 @@ describe("prereqs.installTunnel", () => {
       const body = (await res.json()) as { error: { message: string } };
       expect(body.error.message).toContain("only supported on macOS");
       expect(body.error.message).toMatch(/apt install cloudflared|dnf install cloudflared/);
+      expect(body.error.message).toContain(
+        "developers.cloudflare.com/cloudflare-one/connections/connect-networks/downloads",
+      );
+    },
+  );
+
+  // Windows-only counterpart: `package.json` now declares `win32` supported,
+  // so a Windows CI runner is a valid target. There the non-darwin guard
+  // surfaces the winget/choco hint rather than the Linux one.
+  it.skipIf(process.platform !== "win32")(
+    "fails with a winget/choco hint on Windows instead of shelling out to brew",
+    async () => {
+      const res = await trpcMutate(server.url, "prereqs.installTunnel", undefined, TOKEN);
+
+      expect(res.status).toBe(500);
+      const body = (await res.json()) as { error: { message: string } };
+      expect(body.error.message).toContain("only supported on macOS");
+      expect(body.error.message).toMatch(/winget install|choco install/);
       expect(body.error.message).toContain(
         "developers.cloudflare.com/cloudflare-one/connections/connect-networks/downloads",
       );


### PR DESCRIPTION
## Summary

Makes the published `@band-app/server` package install and run on Windows so `npx @band-app/server` boots a working Band server. Scope is **runtime-only** for `apps/web/` source — desktop packaging (#518) and the dev build pipeline (#519) are tracked separately and untouched here.

Much of the cross-platform groundwork already existed (`path.delimiter`, `sep`-based traversal guards, `defaultShell()`, `extraBinDirs()`). This PR fills the remaining gaps.

## Changes

**Install blockers** (`package.json`)
- Add `win32` to the `os` array.
- Gate the node-pty `chmod` postinstall behind a `node -e` platform check so cmd.exe doesn't fail the install.

**Shell + PATH** (`infra/process/path.ts`)
- `shellPath()` reads env `PATH` directly on Windows (no POSIX login shell).
- `whichBinary()` uses `where` instead of `which` (first match) — this is what makes external `claude`/`codex` detection work.
- New `shellCommandInvocation()` / `scriptInvocation()` helpers: `bash -c` / `bash <file>` on POSIX, `cmd.exe /d /s /c` on Windows.

**Bash invocations** — routed through the helpers: `setup-runner` (setup command), `workspace-service` (teardown + `runScript`).

**POSIX utilities**
- `du.ts`: Node fs-walk fallback where `du` is absent (batched `stat`s, `DU_TIMEOUT_MS` deadline, skips unreadable dirs/symlinks like `du`).
- `tunnel-client.ts`: `NUL` instead of `/dev/null` for cloudflared `--config`.
- `system-service.ts`: Windows-specific cloudflared install hint.

**CLI bootstrap** (`cli-service.ts`)
- Platform-aware `SYMLINK_PATH`: a `band.cmd` shim under `%LOCALAPPDATA%\band\bin` on Windows (shims avoid the Developer-Mode/admin symlink requirement).
- `findCliBinaryAt` resolves `band.exe` on Windows.
- Windows `checkCli`/`installCli`: write the shim, best-effort add its dir to the **user** PATH via `reg` (not `setx`, which truncates long PATHs); `ConflictingBinary` for a foreign `band.cmd`.
- `cli-skills` + `hooks`: skip the POSIX `/usr/local/bin/band` shortcut on Windows.

**Signals** (`start-server.ts`): document that SIGTERM never fires on Windows (SIGINT covers interactive stops; desktop graceful-shutdown is #518).

## POSIX safety

Every change is a `process.platform === "win32"` branch or a helper that returns **identical argv on POSIX** — macOS/Linux behavior is unchanged. The two shared-path touches (postinstall rewrite, reworded cloudflared hint) were verified: the postinstall still exits 0 and performs the `chmod` on POSIX, and the Linux cloudflared message still satisfies `tunnel-install-platform.test.ts`.

## Testing

`tsc --noEmit` clean, biome clean. The win32 branches only execute on Windows, so they can't run through the macOS/Linux integration harness without stubbing `process.platform` (against the repo's testing doctrine) — they're cross-platform by construction, guided by the pattern files. Existing macOS/Linux suites cover the unchanged POSIX paths. A Windows CI runner (for #150 acceptance) belongs with the build-pipeline work (#519).

**Known limitation (not a regression):** `terminal-pool`'s auto-run command feature still uses POSIX `. '<file>'` sourcing, so agent-in-terminal auto-launch won't work under cmd.exe. Plain terminal spawning (the smoke-flow requirement) works.

Closes #150

🤖 Generated with [Claude Code](https://claude.com/claude-code)