### PR TITLE
refactor(web): replace hand-rolled keyboard shortcuts with react-hotkeys-hook

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,18 @@
+# Band
+
+IDE-agnostic agent orchestrator: a workspace dashboard that hosts coding-agent chats, terminals, browsers, and file editors in dockable panels.
+
+## Language
+
+### Shortcuts
+
+**Dock**:
+A focusable panel container in the workspace (chat, terminal, browser, files), each hosting its own tabs.
+_Avoid_: Doc, pane, container (ambiguous)
+
+**Global shortcut**:
+A shortcut that fires anywhere in the workspace regardless of which dock has focus.
+
+**Dock-scoped shortcut**:
+A shortcut that fires only while its dock has focus. The same key combo may perform a different action in a different dock.
+_Avoid_: Per-docs keys, local shortcut

--- a/apps/web/e2e/pages/WorkspacePage.ts
+++ b/apps/web/e2e/pages/WorkspacePage.ts
@@ -589,20 +589,307 @@ export class WorkspacePage {
     });
   }
 
-  /** Drive the ⌘1..9 / Ctrl+1..9 label shortcut as a real user keypress.
-   *  Uses `projectListRoot.press(...)` so Playwright moves focus there
-   *  before dispatching the key, bypassing the chat textarea autofocus
-   *  on the workspace route. The keydown bubbles to the window listener
-   *  in `DashboardShell` where the shortcut is wired up. `index` is
-   *  0-based; 0 picks "All" (⌘0), 1..9 pick the Nth label (⌘1..9). */
+  // ──────────────────────────────────────────────────────────────────────
+  // Keyboard-shortcut matrix (see `shortcut-matrix.spec.ts`).
+  //
+  // The global handler lives on a CAPTURE-phase window keydown listener in
+  // `SharedDockviewLayout.tsx`, so it sees the keystroke before whatever
+  // element happens to own focus. That's the property the migration to
+  // `react-hotkeys-hook` most easily breaks (the library scopes to a
+  // subtree / bails inside form fields by default), which is why every
+  // method below deliberately drives the key from a NON-default focus
+  // anchor deep inside an inner dockview instead of `document.body`.
+  //
+  // The methods split into "focus, then press" (terminal anchor — the page
+  // object owns the terminal locator) and bare "press at current focus"
+  // (chat anchor — `ChatPanePage` owns the prompt locator, so the spec
+  // focuses through that page object first and then presses here). Both
+  // shapes keep raw `page.keyboard` out of test bodies.
+  // ──────────────────────────────────────────────────────────────────────
+
+  /** Outer-tab shortcut for each panel the global bindings can activate with a
+   *  ⌘⇧ chord. Mirrors `GLOBAL_SHORTCUTS.showFiles` / `showChanges` /
+   *  `showBrowser` in `lib/shortcuts.ts`. Kept as a lookup rather than three
+   *  near-identical methods so a renamed chord is a one-line change. */
+  private static readonly PANEL_SHORTCUTS = {
+    files: "Meta+Shift+e",
+    changes: "Meta+Shift+g",
+    browser: "Meta+Shift+b",
+  } as const;
+
+  /** Move keyboard focus into the terminal's xterm input.
+   *
+   *  `focus()` rather than `click()`: xterm keeps its input as an offscreen
+   *  "helper" textarea that Playwright never reports as visible, so it isn't
+   *  click-targetable. The terminal tab must already be active and xterm
+   *  mounted — call `openTerminalTab()` + `waitForTerminalReady()` first,
+   *  otherwise the wrapper is parked in the `inert` parking container and
+   *  refuses focus. */
+  private async focusTerminalInput(): Promise<void> {
+    await this.terminalInput.first().focus();
+  }
+
+  /** Activate an outer panel via its ⌘⇧ shortcut, fired from inside the
+   *  focused terminal.
+   *
+   *  The terminal is the worst-case anchor on purpose: it's an editable
+   *  textarea owned by a third-party widget, nested two dockviews deep, and
+   *  the handler has an explicit `terminalFocused && !e.metaKey` bail — so a
+   *  regression that makes these chords focus-scoped (or that widens the
+   *  terminal bail to cover ⌘ chords) shows up here and nowhere else. */
+  async activatePanelViaShortcutFromTerminal(
+    panel: keyof typeof WorkspacePage.PANEL_SHORTCUTS,
+  ): Promise<void> {
+    const chord = WorkspacePage.PANEL_SHORTCUTS[panel];
+    await test.step(`Activate the ${panel} tab via ${chord} from the focused terminal`, async () => {
+      await this.focusTerminalInput();
+      await this.page.keyboard.press(chord);
+    });
+  }
+
+  /** Press Ctrl+` (activate the Terminal tab) at whatever currently holds
+   *  focus, without moving it first.
+   *
+   *  Unlike the ⌘⇧ chords above this one canNOT be driven from the terminal:
+   *  the assertion ("the Terminal tab became active") is only meaningful when
+   *  the terminal tab starts INACTIVE, and an inactive terminal's wrapper is
+   *  parked in the `inert` parking container where its input can't take
+   *  focus. The spec therefore focuses the chat prompt through `ChatPanePage`
+   *  — an editable textarea inside the chat inner dockview, equally
+   *  non-default — and calls this to fire the key there. */
+  async pressActivateTerminalShortcut(): Promise<void> {
+    await test.step("Press Ctrl+` at the current focus", async () => {
+      await this.page.keyboard.press("Control+`");
+    });
+  }
+
+  /** Press ⌘B at whatever currently holds focus, without moving it first.
+   *
+   *  Deliberately anchor-free: the whole point of the ⌘B coverage is WHICH
+   *  target the handler picks for a given focus, so the spec establishes the
+   *  focus it wants (chat prompt via `ChatPanePage`) and this method only
+   *  fires the key. Compare `toggleSidebarViaShortcut()`, which anchors on
+   *  the sidebar toggle button and therefore always exercises the
+   *  no-inner-dockview-focused path. */
+  async pressToggleSidebarShortcut(): Promise<void> {
+    await test.step("Press ⌘B at the current focus", async () => {
+      await this.page.keyboard.press("Meta+b");
+    });
+  }
+
+  /** Press ⌘J at whatever currently holds focus, without moving it first.
+   *
+   *  Anchor-free for the same reason as `pressToggleSidebarShortcut()`: the
+   *  property under test is WHICH bottom edge the handler picks for a given
+   *  focus, so the spec establishes the focus it wants (the chat prompt, via
+   *  `ChatPanePage.focusPromptAt`) and this method only fires the key.
+   *
+   *  ⌘J used to be focus-aware — `findFocusedInnerDockview()` first, and a
+   *  focused inner dock with a populated `edge-bottom` claimed the chord. It
+   *  now always toggles the outermost layout's bottom edge, so firing it from
+   *  inside an inner dock is exactly the case that distinguishes the two. */
+  async pressToggleBottomEdgeShortcut(): Promise<void> {
+    await test.step("Press ⌘J at the current focus", async () => {
+      await this.page.keyboard.press("Meta+j");
+    });
+  }
+
+  // ──────────────────────────────────────────────────────────────────────
+  // DOCK-SCOPED shortcuts (see `shortcut-matrix.spec.ts`, group C).
+  //
+  // Unlike the global chords above, these are registered by EACH inner
+  // container (`DockviewChatContainer` / `DockviewTerminalContainer`) on its
+  // own capture-phase window listener, gated by
+  // `containerRef.current?.contains(document.activeElement)`. Both listeners
+  // are live at the same time whenever both docks are visible, so the SAME
+  // combo (⌘T) resolves to a different action purely by where focus sits.
+  //
+  // That containment check is exactly what the `react-hotkeys-hook`
+  // migration replaces with the hook's returned ref. The failure mode is one
+  // dock's binding winning globally while the other's goes dead — which is
+  // only observable if the key is fired from a focus anchor INSIDE the dock
+  // under test while the rival dock is also mounted and listening. Every
+  // method below therefore names its anchor explicitly.
+  // ──────────────────────────────────────────────────────────────────────
+
+  /** Press ⌘T at whatever currently holds focus, without moving it first.
+   *
+   *  Anchor-free on purpose, mirroring `pressToggleSidebarShortcut()`: the
+   *  whole point of the dock-scoped coverage is WHICH dock claims the combo
+   *  for a given focus, so the spec establishes the focus it wants (the chat
+   *  prompt, via `ChatPanePage.focusPromptAt`) and this method only fires the
+   *  key. The terminal-anchored counterpart is
+   *  `newTabViaShortcutFromTerminal()`. */
+  async pressNewTabShortcut(): Promise<void> {
+    await test.step("Press ⌘T at the current focus", async () => {
+      await this.page.keyboard.press("Meta+t");
+    });
+  }
+
+  /** Fire ⌘T (new tab) from inside the focused terminal.
+   *
+   *  Anchored on the xterm helper textarea rather than the pane's render
+   *  surface: `focus()` is the only way in (xterm parks its input offscreen,
+   *  so Playwright never reports it as click-targetable) and it is a
+   *  descendant of the terminal container's ref — which is precisely what
+   *  `containerRef.contains(document.activeElement)` tests. The terminal tab
+   *  must already be active and xterm mounted (`openTerminalTab()` +
+   *  `waitForTerminalReady()`), otherwise the wrapper sits in the `inert`
+   *  parking container and refuses focus. */
+  async newTabViaShortcutFromTerminal(): Promise<void> {
+    await test.step("Press ⌘T from the focused terminal", async () => {
+      await this.focusTerminalInput();
+      await this.page.keyboard.press("Meta+t");
+    });
+  }
+
+  /** Fire ⌘D (split right) from inside the focused terminal.
+   *
+   *  ⌘D and Ctrl+D are NOT interchangeable in `DockviewTerminalContainer`,
+   *  unlike every other chord in that handler: the `key === "d"` branch
+   *  splits on `e.metaKey && !e.ctrlKey`, closes the active tab on
+   *  `e.ctrlKey && !e.metaKey && !e.shiftKey`, and swallows anything else so
+   *  no stray `^D` reaches xterm. So this method must press Meta+d
+   *  specifically — Control+d would exercise the close path instead.
+   *
+   *  Same xterm-helper-textarea anchor as `newTabViaShortcutFromTerminal()`;
+   *  see that method's comment. */
+  async splitRightViaShortcutFromTerminal(): Promise<void> {
+    await test.step("Press ⌘D (split right) from the focused terminal", async () => {
+      await this.focusTerminalInput();
+      await this.page.keyboard.press("Meta+d");
+    });
+  }
+
+  /** Fire ⌘B from inside the focused terminal — the inner dockview whose
+   *  `edge-left` group is empty on a default layout.
+   *
+   *  `toggleEdgeGroup` returns `false` for an empty edge, so the handler
+   *  falls through to the `band:toggle-sidebar` window event and the
+   *  project-list sidebar toggles. This is the fallback path that works
+   *  today and must survive the migration unchanged. */
+  async toggleSidebarViaShortcutFromTerminal(): Promise<void> {
+    await test.step("Toggle the sidebar via ⌘B from the focused terminal", async () => {
+      await this.focusTerminalInput();
+      await this.page.keyboard.press("Meta+b");
+    });
+  }
+
+  // ──────────────────────────────────────────────────────────────────────
+  // Server-side inner-layout seeding.
+  //
+  // The inner chat/terminal/browser dockviews persist their layout tree
+  // server-side (`chatLayout.save`), NOT in localStorage like the outer
+  // shared layout — so `seedGlobalLayout`'s `addInitScript` trick doesn't
+  // reach them. These helpers POST the real tRPC mutations before `goto`,
+  // which is the same wire shape the app itself writes.
+  // ──────────────────────────────────────────────────────────────────────
+
+  /** Create a chat pane record server-side via the real `chats.create`
+   *  mutation, pinning its id so a seeded layout can reference it.
+   *
+   *  Pinning the id is load-bearing: `DockviewChatContainer`'s `onReady`
+   *  prunes every restored panel whose id isn't in `chats.list`, so a layout
+   *  referencing invented ids would be silently emptied and replaced with a
+   *  fresh default tab — a vacuous test. Auth via the `band_token` cookie,
+   *  matching the other tRPC HTTP helpers here. */
+  async createChat(workspaceId: string, chatId: string, name: string): Promise<void> {
+    await test.step(`Create chat ${chatId} in ${workspaceId}`, async () => {
+      const res = await this.page.request.post(`${this.baseUrl}/trpc/chats.create`, {
+        headers: { "Content-Type": "application/json", Cookie: `band_token=${this.token}` },
+        data: { workspaceId, id: chatId, name },
+      });
+      if (!res.ok()) {
+        throw new Error(`createChat(${chatId}) failed: ${res.status()} ${await res.text()}`);
+      }
+    });
+  }
+
+  /** Persist an inner dockview layout tree server-side via the real
+   *  `<container>Layout.save` mutation — the counterpart of
+   *  `readInnerLayout`.
+   *
+   *  MUST run AFTER any `createChat` calls: `chats.create` itself appends the
+   *  new pane to the saved layout row, so creating a chat after seeding would
+   *  overwrite the hand-built tree. And MUST run BEFORE `goto`, since the
+   *  container fetches its layout once on mount. */
+  async seedInnerLayout(
+    container: "chat" | "terminal" | "browser",
+    workspaceId: string,
+    tree: unknown,
+  ): Promise<void> {
+    const procedure =
+      container === "chat"
+        ? "chatLayout.save"
+        : container === "terminal"
+          ? "terminalLayout.save"
+          : "browserLayout.save";
+    await test.step(`Seed ${container} layout for ${workspaceId}`, async () => {
+      const res = await this.page.request.post(`${this.baseUrl}/trpc/${procedure}`, {
+        headers: { "Content-Type": "application/json", Cookie: `band_token=${this.token}` },
+        data: { workspaceId, tree },
+      });
+      if (!res.ok()) {
+        throw new Error(
+          `seedInnerLayout(${container}) failed: ${res.status()} ${await res.text()}`,
+        );
+      }
+    });
+  }
+
+  /** The view (panel) ids docked in an inner container's `edge-left` group,
+   *  read back from the SERVER-persisted layout.
+   *
+   *  Used as the round-trip check on a seeded tree: if dockview rejected the
+   *  seed, `onReady` falls back to a default single-panel layout and
+   *  re-persists it, so the left edge reads back empty and the ⌘B focus-aware
+   *  branch under test would have had nothing to act on. Returns `[]` when no
+   *  layout, no edge group, or an empty edge. */
+  async innerEdgeLeftViews(
+    container: "chat" | "terminal" | "browser",
+    workspaceId: string,
+  ): Promise<string[]> {
+    const tree = await this.readInnerLayout(container, workspaceId);
+    return tree?.edgeGroups?.left?.group?.views ?? [];
+  }
+
+  /** The view (panel) ids docked in an inner container's `edge-bottom` group,
+   *  read back from the SERVER-persisted layout. Bottom-edge counterpart of
+   *  `innerEdgeLeftViews` — see that method for the round-trip rationale.
+   *
+   *  Used by the ⌘J coverage, where a populated INNER bottom edge is what makes
+   *  the test able to tell the always-outer handler apart from the focus-aware
+   *  one it replaced. An empty read means the seed didn't take and the test
+   *  would no longer distinguish them. */
+  async innerEdgeBottomViews(
+    container: "chat" | "terminal" | "browser",
+    workspaceId: string,
+  ): Promise<string[]> {
+    const tree = await this.readInnerLayout(container, workspaceId);
+    return tree?.edgeGroups?.bottom?.group?.views ?? [];
+  }
+
+  /** Drive the label-filter shortcut as a real user keypress. `index` is
+   *  0-based: 0 picks "All", 1..9 pick the Nth label.
+   *
+   *  Uses `projectListRoot.press(...)` so Playwright moves focus there before
+   *  dispatching the key, bypassing the chat textarea autofocus on the
+   *  workspace route — the shortcut deliberately does not fire from inside a
+   *  text field.
+   *
+   *  Digit 0 is pressed with ⌘, digits 1..9 with Ctrl, because the two halves
+   *  are bound differently: Ctrl+0 belongs to the global "Focus Projects"
+   *  shortcut, so the label filter binds ⌘0 alone for "All" while 1..9 accept
+   *  either modifier. See `LABEL_FILTER_SHORTCUT` in `lib/shortcuts.ts`. */
   async pressLabelShortcut(index: number): Promise<void> {
     if (index < 0 || index > 9) {
       throw new Error(`pressLabelShortcut: index must be 0..9, got ${index}`);
     }
-    await test.step(`Press Control+${index} (label shortcut)`, async () => {
+    const combo = index === 0 ? "Meta+0" : `Control+${index}`;
+    await test.step(`Press ${combo} (label shortcut)`, async () => {
       const root = this.projectListRoot();
       await root.waitFor({ state: "visible" });
-      await root.press(`Control+${index}`);
+      await root.press(combo);
     });
   }
 
@@ -1441,6 +1728,44 @@ export class WorkspacePage {
     return this.page.getByTestId("dv-edge-group-edge-bottom").filter({ visible: true });
   }
 
+  /** Rendered height in CSS px of the OUTERMOST shared-dockview layout's
+   *  bottom edge group — the projection the ⌘J coverage keys off.
+   *
+   *  Why height and not `bottomEdgeGroup().toHaveCount(0/1)`, which is how
+   *  `workspace-maximize-collapses-edges.spec.ts` asserts on the same edge:
+   *  the two features hide the edge by DIFFERENT dockview mechanisms.
+   *  Maximizing calls `setEdgeGroupVisible(false)`, which unmounts the shell
+   *  from layout entirely (count 1 → 0). ⌘J calls `group.api.collapse()`,
+   *  which keeps the shell mounted and merely shrinks it to its header strip
+   *  (~200px → ~35px) — so the count probe reads 1 in BOTH states and cannot
+   *  see the toggle at all. Height is the signal that actually moves, and it
+   *  mirrors how `sidebarWidth()` reports the sibling ⌘B collapse.
+   *
+   *  "Outermost" is resolved structurally: every INNER dockview (chat /
+   *  terminal / browser) is rendered inside a `MultiWorkspacePanelHost`
+   *  cached entry, so the one edge shell with no such ancestor belongs to
+   *  `SharedDockviewLayout` itself. That distinction is load-bearing here —
+   *  a test that seeds a populated inner bottom edge puts three
+   *  `dv-edge-group-edge-bottom` elements on the page, and the whole point of
+   *  the ⌘J assertion is WHICH of them moved.
+   *
+   *  Throws when the outer shell isn't uniquely resolvable, so a renamed
+   *  dockview testid or a structural change fails loudly instead of
+   *  reporting a vacuous 0. */
+  async outerBottomEdgeHeight(): Promise<number> {
+    return await this.page.evaluate(() => {
+      const outer = Array.from(
+        document.querySelectorAll<HTMLElement>('[data-testid="dv-edge-group-edge-bottom"]'),
+      ).filter((el) => el.closest('[data-testid^="workspace-panel-host__cached-entry"]') === null);
+      if (outer.length !== 1) {
+        throw new Error(
+          `expected exactly 1 outer bottom edge group, found ${outer.length} — dockview testid renamed or panel-host nesting changed?`,
+        );
+      }
+      return outer[0].getBoundingClientRect().height;
+    });
+  }
+
   /** Reset the per-workspace shared-dockview state entry in
    *  `localStorage` and (re-)navigate to the workspace so the next
    *  mount runs against a clean slate. Two-step (matches
@@ -2275,6 +2600,158 @@ export class WorkspacePage {
     });
   }
 
+  // ──────────────────────────────────────────────────────────────────────
+  // Shortcut matrix, group D (see `shortcut-matrix.spec.ts`).
+  //
+  // Three bindings whose CORRECTNESS is invisible in the DOM chrome the
+  // groups above key off:
+  //
+  //   - ⌘0 vs Ctrl+0. The two used to be the same chord, and Focus Projects
+  //     won only because it ran in capture phase and called
+  //     `stopPropagation()` before the label filter's bubble-phase listener
+  //     saw it. They're separate bindings now (`LABEL_FILTER_SHORTCUT` binds
+  //     ⌘0 only; `GLOBAL_SHORTCUTS.focusProjects` binds Ctrl+0), so the
+  //     observable is the label filter's localStorage entry plus where focus
+  //     landed — not anything the dockview renders.
+  //   - ⌘⇧] / ⌘⇧[. Tab cycling within the focused dock's active group. The
+  //     panel COUNT is unchanged by a cycle, so the persisted layout's
+  //     `activeView` is the only server-side projection that moves.
+  //   - ⌘= / ⌘⇧= / ⌘-. Zoom is applied to `<html>` and mirrored onto the
+  //     `--app-zoom` custom property by `applyZoomLevelToDom` (lib/zoom.ts);
+  //     that variable is the rendered state, so it's what we read.
+  // ──────────────────────────────────────────────────────────────────────
+
+  /** Read the active project-list label filter from localStorage — `null`
+   *  for "All". `useLabelFilter` writes this key on every change (and
+   *  `removeItem`s it for All), so it is the persisted projection of the
+   *  filter the sidebar is showing.
+   *
+   *  Used by the ⌘0 / Ctrl+0 split coverage in both directions: as the
+   *  positive anchor that a filter really was applied, and as the assertion
+   *  that Ctrl+0 left it alone. */
+  async readLabelFilter(): Promise<string | null> {
+    return await this.page.evaluate((key) => localStorage.getItem(key), LABEL_FILTER_KEY);
+  }
+
+  /** Index of the active tab within the multi-tab group of an inner
+   *  container's SERVER-persisted layout.
+   *
+   *  Tab cycling (⌘⇧] / ⌘⇧[) moves the active view inside one group without
+   *  changing the panel count, so `countTerminalPanels` can't see it. Dockview
+   *  serializes each grid leaf as `{ views, activeView }`, and the position of
+   *  `activeView` within `views` is exactly what `cycleTabs(±1)` advances —
+   *  and it's stable across runs, unlike the server-generated terminal ids.
+   *
+   *  Picks the leaf holding more than one view (the group the test stacked its
+   *  tabs into), falling back to the first leaf so a layout that never grew a
+   *  second tab reports index 0 rather than throwing — the caller's positive
+   *  anchor is what catches that case. Returns -1 when there is no layout or
+   *  no active view, so a missing projection can't read as "index 0". */
+  async innerActiveTabIndex(
+    container: "chat" | "terminal" | "browser",
+    workspaceId: string,
+  ): Promise<number> {
+    const tree = await this.readInnerLayout(container, workspaceId);
+    const root = tree?.grid?.root;
+    if (!root) return -1;
+    const leaves: { id: string; views: string[]; activeView?: string }[] = [];
+    const walk = (node: DockviewGridNode): void => {
+      if (node.type === "leaf") {
+        leaves.push(node.data);
+        return;
+      }
+      for (const child of node.data) walk(child);
+    };
+    walk(root);
+    const group = leaves.find((leaf) => leaf.views.length > 1) ?? leaves[0];
+    if (!group?.activeView) return -1;
+    return group.views.indexOf(group.activeView);
+  }
+
+  /** The tab-cycling chords each dock binds through `DOCK_SHORTCUTS.nextTab`
+   *  / `previousTab`. Spelled with the PHYSICAL key (`BracketRight` /
+   *  `BracketLeft`) because that's how the bindings are spelled and it's the
+   *  whole point of the fix: Shift turns `]` into `}` on a US layout, so the
+   *  character form these used to carry could never match and both chords were
+   *  dead despite being advertised in the command palette. */
+  private static readonly TAB_CYCLE_CHORDS = {
+    next: "Meta+Shift+BracketRight",
+    previous: "Meta+Shift+BracketLeft",
+  } as const;
+
+  /** Cycle the terminal dock's active tab, firing the chord from inside that
+   *  dock.
+   *
+   *  Anchored on the dock's own visible "New terminal" header button rather
+   *  than on the xterm helper textarea the other dock-scoped helpers use.
+   *  Both sit inside the element the container hands to `useAppShortcut`'s
+   *  ref — which is what scopes the binding — but only the header button is
+   *  unambiguous once a SECOND tab exists: `terminalInput.first()` resolves in
+   *  DOM order across every mounted terminal, including the inactive one
+   *  parked in the `inert` parking container, and focusing an inert element
+   *  silently no-ops. That would fire the chord from `document.body` and
+   *  quietly test nothing. The button is non-editable, always rendered while
+   *  the dock is visible, and `centralToolbar` already scopes it to this
+   *  workspace's central group. */
+  async cycleTabViaShortcutFromTerminalDock(
+    workspaceId: string,
+    direction: keyof typeof WorkspacePage.TAB_CYCLE_CHORDS,
+  ): Promise<void> {
+    const chord = WorkspacePage.TAB_CYCLE_CHORDS[direction];
+    await test.step(`Press ${chord} (${direction} tab) from the terminal dock`, async () => {
+      await this.terminalAddTabButton(workspaceId).first().focus();
+      await this.page.keyboard.press(chord);
+    });
+  }
+
+  /** The zoom chords `useZoom` binds in browser mode, mirroring
+   *  `ZOOM_SHORTCUTS` in `lib/shortcuts.ts`. All three are spelled with the
+   *  PHYSICAL key (`Equal` / `Minus`) rather than the produced character,
+   *  matching the bindings: the library splits combos on `"+"` (so a literal
+   *  `meta++` parses to nothing) and compares modifiers for exact equality
+   *  (so a `meta+=` binding can't fire while Shift is held). `inShifted` is
+   *  ⌘+ — the same physical key with Shift, and the half that was silently
+   *  dead before the binding was corrected. */
+  private static readonly ZOOM_CHORDS = {
+    in: "Meta+Equal",
+    inShifted: "Meta+Shift+Equal",
+    out: "Meta+Minus",
+  } as const;
+
+  /** Fire a zoom chord from inside the focused terminal.
+   *
+   *  Same worst-case anchor as `activatePanelViaShortcutFromTerminal`: an
+   *  editable textarea owned by xterm, nested two dockviews deep. `useZoom`
+   *  binds these globally with no terminal bail, so they must fire there —
+   *  and a regression that makes them focus-scoped shows up nowhere else.
+   *  The terminal tab must already be active and xterm mounted
+   *  (`openTerminalTab()` + `waitForTerminalReady()`). */
+  async zoomViaShortcutFromTerminal(
+    direction: keyof typeof WorkspacePage.ZOOM_CHORDS,
+  ): Promise<void> {
+    const chord = WorkspacePage.ZOOM_CHORDS[direction];
+    await test.step(`Press ${chord} (zoom ${direction}) from the focused terminal`, async () => {
+      await this.focusTerminalInput();
+      await this.page.keyboard.press(chord);
+    });
+  }
+
+  /** The zoom factor currently APPLIED to the document — read from the
+   *  `--app-zoom` custom property `applyZoomLevelToDom` mirrors onto `<html>`
+   *  alongside the CSS `zoom` itself (`ZOOM_CSS_VAR` in lib/zoom.ts).
+   *
+   *  Read the applied value rather than any rendered copy: zoom has no UI
+   *  chrome of its own, and the pre-paint init script in `__root.tsx` seeds
+   *  the property on first boot, so this is defined from mount onward and can
+   *  serve as a test's positive anchor. Returns NaN when the property is
+   *  missing, which fails an equality assertion loudly instead of defaulting
+   *  to 1 and passing vacuously. */
+  async appliedZoomLevel(): Promise<number> {
+    return await this.page.evaluate(() =>
+      Number.parseFloat(document.documentElement.style.getPropertyValue("--app-zoom")),
+    );
+  }
+
   /** Poll the DOM-renderer rows until one whose trimmed text equals `text`
    *  is painted, returning its viewport rectangle. */
   private async waitForTerminalRowRect(
@@ -2311,6 +2788,13 @@ export interface DockviewLayoutSnapshot {
     root?: DockviewGridNode;
   };
   panels: Record<string, unknown>;
+  /** dockview serializes its three cardinal edge groups alongside the grid.
+   *  Only the `views` list is modelled — that's the single bit the shortcut
+   *  matrix needs (is the left edge populated?), and `toggleEdgeGroup` keys
+   *  off exactly that (`group.panels.length === 0`). */
+  edgeGroups?: Partial<
+    Record<"left" | "right" | "bottom", { group?: { views?: string[] } } | undefined>
+  >;
 }
 
 export type DockviewGridNode =

--- a/apps/web/e2e/shortcut-matrix.spec.ts
+++ b/apps/web/e2e/shortcut-matrix.spec.ts
@@ -1,0 +1,929 @@
+/**
+ * Keyboard-shortcut matrix — the safety net for the `react-hotkeys-hook`
+ * migration.
+ *
+ * Shortcuts are bound through `useAppShortcut` (`hooks/useAppShortcut.ts`), a
+ * wrapper over `react-hotkeys-hook` whose defaults exist to preserve what the
+ * previous hand-rolled `window` keydown handlers did: capture-phase listening,
+ * firing inside form fields, `preventDefault`, and character-vs-physical key
+ * matching. Combos live in `lib/shortcuts.ts` (`GLOBAL_SHORTCUTS` /
+ * `DOCK_SHORTCUTS`); dock-scoped chords scope via the hook's returned ref.
+ *
+ * Each of those defaults is one the library does NOT give you: it binds on
+ * `document` in bubble phase, skips events originating in form fields
+ * (`<textarea>` — i.e. xterm's helper input and the chat prompt) unless
+ * `enableOnFormTags` is set, and scopes to a subtree when bound to a ref. So
+ * the realistic failure mode here is not "the shortcut stops working" — it is
+ * "the shortcut silently becomes focus-scoped and only works when nothing
+ * interesting is focused". Every test below therefore drives its key from a
+ * NON-default focus anchor deep inside an inner dockview, never from
+ * `document.body`.
+ *
+ * Architecture (matches the repo's integration doctrine):
+ *   - The real production binary runs against a fresh tmp `~/.band/`.
+ *   - No tRPC mocking, no `page.route()` — the dashboard renders against the
+ *     real backend, and the seeded chat layout is written through the real
+ *     `chats.create` / `chatLayout.save` mutations over HTTP.
+ *   - All UI is driven through `WorkspacePage` / `ChatPanePage`; no raw
+ *     `page.goto` / `page.getByRole` / `page.getByTestId` / `page.keyboard`
+ *     appears in a test body.
+ *
+ * Four groups:
+ *
+ *   A. "Global shortcuts fire regardless of focus" — the tab-activation
+ *      chords. Behaviour is unchanged from before the migration.
+ *
+ *   B. "⌘B always toggles the project sidebar" — an intentional behaviour
+ *      change. ⌘B used to be focus-aware: `findFocusedInnerDockview()`
+ *      resolved the inner dockview owning `document.activeElement`, and if
+ *      that dockview's `edge-left` group held panels, `toggleEdgeGroup`
+ *      collapsed THAT edge and the project sidebar was never touched. It now
+ *      toggles the project-list sidebar unconditionally. ⌘J has since moved
+ *      to the same rule (group D covers it), leaving ⌥⌘B as the only edge
+ *      chord that still resolves its target by focus.
+ *
+ *   C. "Dock-scoped shortcuts act on the focused dock" — the chords owned
+ *      by the INNER containers rather than by `SharedDockviewLayout`. Each
+ *      container binds them through the ref `useAppShortcut` returns, so a
+ *      chord only fires while that container (or a descendant) holds focus
+ *      and the same combo means different things per dock: ⌘T in the chat
+ *      dock opens a chat pane, ⌘T in the terminal dock opens a terminal.
+ *      Ref scoping replaced hand-written `contains(document.activeElement)`
+ *      checks, and its realistic failure mode is one dock's binding winning
+ *      GLOBALLY while the other's goes dead. Catching that needs both halves
+ *      asserted — the dock that should have reacted did, and the rival dock
+ *      did not — which
+ *      is why every test in the group boots BOTH docks and pins both counts.
+ *
+ *   D. "Split, physical-key and zoom bindings" — chords whose correctness is
+ *      invisible in the chrome groups A–C key off, and each of which was
+ *      silently broken (or silently order-dependent) before.
+ *      ⌘0 and Ctrl+0 used to be the SAME chord, with "Focus Projects"
+ *      winning only because it listened in capture phase and called
+ *      `stopPropagation()` ahead of the label filter's bubble-phase
+ *      listener; they are separate bindings now, so both halves are pinned
+ *      — ⌘0 resets the filter, Ctrl+0 focuses the list and leaves the
+ *      filter alone. ⌘⇧] / ⌘⇧[ were dead bindings (Shift turns `]` into
+ *      `}`, so a character match never fired) and now match the physical
+ *      `BracketRight` / `BracketLeft`. ⌘= / ⌘⇧= / ⌘- bind the physical
+ *      `Equal` / `Minus` because the library splits combos on `"+"` (so
+ *      `meta++` parsed to nothing) and compares modifiers for exact
+ *      equality (so a `meta+=` binding could not fire with Shift held) —
+ *      ⌘⇧= is the half that was silently dead. ⌘J is the group's other
+ *      intentional behaviour change: it used to resolve its target by
+ *      focus (a focused inner dock with a populated `edge-bottom` claimed
+ *      the chord and the outer layout was never touched) and now always
+ *      toggles the outermost layout's bottom edge, same rule as ⌘B with
+ *      the sidebar — leaving ⌥⌘B as the only edge chord still focus-aware.
+ *
+ * Why group C asserts on the SERVER-persisted layout (`countChatPanels` /
+ * `countTerminalPanels`, which hit the real `chatLayout.get` /
+ * `terminalLayout.get` procedures) rather than on the DOM: a pane count in
+ * the rendered tree can't distinguish "the chat dockview grew a panel" from
+ * "the terminal dockview grew one" without re-encoding dockview's internals
+ * in a selector, whereas the two layouts are separate rows keyed by
+ * container. Reading them back proves WHICH dockview actually mutated, which
+ * is the entire property under test. They're read over HTTP and written
+ * asynchronously by the layout-change listener, so every such assertion is an
+ * `expect.poll`, never a bare `expect`.
+ *
+ * Why tab-activation is asserted via dockview's `dv-active-tab` class: it's
+ * the library's own state marker on the `.dv-tab` wrapper, flipped
+ * synchronously by `panel.api.setActive()`. Waiting on panel CONTENT instead
+ * (xterm booting, the file tree fetching) would conflate "the shortcut fired"
+ * with "the panel finished loading". Same rationale as
+ * `workspace-maximize-state.spec.ts`.
+ */
+
+import { expect, test } from "@playwright/test";
+import { toWorkspaceId } from "@/dashboard";
+import {
+  cleanupTmpHome,
+  createTmpHome,
+  type ServerHandle,
+  seedSettings,
+  seedState,
+  startServer,
+} from "./helpers/server";
+import { ChatPanePage } from "./pages/ChatPanePage";
+import { WorkspacePage } from "./pages/WorkspacePage";
+
+const TOKEN = "e2e-shortcut-matrix-token";
+const PROJECT = "alpha-shortcuts";
+const WORKSPACE = toWorkspaceId(PROJECT, "main");
+
+// The ⌘B focus-aware test seeds a two-pane chat layout with one pane docked in
+// `edge-left`. That seed is workspace-scoped server state, so it gets its OWN
+// project/workspace — otherwise every other test in this file would suddenly
+// see two chat prompts (and `ChatPanePage`'s single-prompt locators would trip
+// strict mode) depending on execution order.
+const PROJECT_EDGE = "alpha-shortcuts-edge";
+const WORKSPACE_EDGE = toWorkspaceId(PROJECT_EDGE, "main");
+
+// The dock-scoped tests each MUTATE an inner dockview's persisted layout (⌘T
+// adds a pane, ⌘D splits), and they assert on absolute panel counts read back
+// from the server. Sharing one workspace between them would make every test
+// depend on the execution order of its siblings — and on whether the groups
+// above happened to open a terminal in the same workspace first. So each gets
+// its own project/workspace, following the `PROJECT_EDGE` precedent: extra
+// entries in the single `seedState` call, no extra server boot.
+const PROJECT_DOCK_CHAT = "alpha-shortcuts-dock-chat";
+const WORKSPACE_DOCK_CHAT = toWorkspaceId(PROJECT_DOCK_CHAT, "main");
+const PROJECT_DOCK_TERM = "alpha-shortcuts-dock-term";
+const WORKSPACE_DOCK_TERM = toWorkspaceId(PROJECT_DOCK_TERM, "main");
+const PROJECT_DOCK_SPLIT = "alpha-shortcuts-dock-split";
+const WORKSPACE_DOCK_SPLIT = toWorkspaceId(PROJECT_DOCK_SPLIT, "main");
+
+// Group D, same rationale as the group-C workspaces above.
+//
+// The ⌘0 / Ctrl+0 pair needs a project that actually carries a label:
+// `LABEL_FILTER_SHORTCUT`'s digit-0 arm resolves to "All", and proving it
+// RESET something requires a filter to have been applied first, which the
+// dropdown only offers for labels that exist in settings. The label is
+// therefore added to the single `seedSettings` call and hung on its own
+// project — the existing projects stay unlabelled, so the sections the other
+// tests' sidebars render are unchanged (none of them reads the project list).
+//
+// The tab-cycling test MUTATES the terminal dock's persisted layout (it adds a
+// second tab) and asserts on the active tab's index within that group, so it
+// gets its own workspace exactly like the group-C tests. Zoom mutates nothing
+// server-side, but it boots its own terminal as a focus anchor and would
+// otherwise inherit whatever tab count a sibling left behind.
+const LABEL_D = "lbl_shortcuts";
+const PROJECT_LABELLED = "alpha-shortcuts-labelled";
+const WORKSPACE_LABELLED = toWorkspaceId(PROJECT_LABELLED, "main");
+const PROJECT_TAB_CYCLE = "alpha-shortcuts-tab-cycle";
+const WORKSPACE_TAB_CYCLE = toWorkspaceId(PROJECT_TAB_CYCLE, "main");
+const PROJECT_ZOOM = "alpha-shortcuts-zoom";
+const WORKSPACE_ZOOM = toWorkspaceId(PROJECT_ZOOM, "main");
+
+// The ⌘J test seeds a two-pane chat layout with one pane docked in the inner
+// dock's `edge-bottom` — the same kind of workspace-scoped server state as the
+// ⌘B `PROJECT_EDGE` seed above, and it needs its own project for the same
+// reason: any sibling test landing in this workspace would suddenly see two
+// chat prompts and trip `ChatPanePage`'s single-prompt locators depending on
+// execution order.
+const PROJECT_BOTTOM = "alpha-shortcuts-bottom";
+const WORKSPACE_BOTTOM = toWorkspaceId(PROJECT_BOTTOM, "main");
+
+// Chat pane ids are pinned (rather than server-generated) so the seeded
+// layout below can reference them — `DockviewChatContainer` prunes restored
+// panels whose id isn't in `chats.list`.
+const CHAT_CENTER = "chat_e2e_center";
+const CHAT_EDGE = "chat_e2e_edge";
+
+// The ⌘J seed's own pair. Chat pane ids are GLOBALLY unique server-side
+// (`panel_states.id` is the primary key), not scoped per workspace, so reusing
+// the two ids above in a second workspace fails `chats.create` with a UNIQUE
+// constraint violation rather than creating a parallel pane.
+const CHAT_BOTTOM_CENTER = "chat_e2e_bottom_center";
+const CHAT_BOTTOM_EDGE = "chat_e2e_bottom_edge";
+
+// Wide viewport so `useIsDesktop()` reports true and the desktop layout
+// (title bar + sidebar + shared dockview) renders (>= 1024px in
+// useIsDesktop.ts).
+test.use({ viewport: { width: 1280, height: 800 } });
+
+/**
+ * Inner CHAT dockview layout with one pane in the central grid and one docked
+ * in `edge-left` (visible + expanded, so it actually renders and
+ * `toggleEdgeGroup` has something to collapse).
+ *
+ * Shape mirrors the real serialized dockview snapshot captured in
+ * `workspace-maximize-collapses-edges.spec.ts` — grid + flat `panels` map +
+ * `edgeGroups` with per-direction `{ size, visible, collapsed, group }`. The
+ * panel entries use the `chatTab` content/tab component and the
+ * `{ workspaceId, chatId }` params `createDefaultPanel` writes, so the
+ * restored panes mount real `ChatPane`s.
+ *
+ * The three edge groups are all present because `ensureEdgeGroups` expects
+ * them; only `left` is populated.
+ */
+function chatLayoutWithLeftEdgePanel(workspaceId: string) {
+  const panel = (id: string, title: string) => ({
+    id,
+    contentComponent: "chatTab",
+    tabComponent: "chatTab",
+    title,
+    params: { workspaceId, chatId: id },
+  });
+  return {
+    grid: {
+      root: {
+        type: "branch",
+        data: [
+          {
+            type: "leaf",
+            data: { views: [CHAT_CENTER], activeView: CHAT_CENTER, id: "1" },
+            size: 500,
+          },
+        ],
+        size: 700,
+      },
+      width: 500,
+      height: 700,
+      orientation: "HORIZONTAL",
+    },
+    panels: {
+      [CHAT_CENTER]: panel(CHAT_CENTER, "Center"),
+      [CHAT_EDGE]: panel(CHAT_EDGE, "Edge"),
+    },
+    activeGroup: "1",
+    edgeGroups: {
+      left: {
+        size: 200,
+        visible: true,
+        collapsed: false,
+        group: {
+          views: [CHAT_EDGE],
+          activeView: CHAT_EDGE,
+          id: "edge-left",
+          headerPosition: "left",
+        },
+      },
+      right: {
+        size: 200,
+        visible: false,
+        collapsed: true,
+        group: { views: [], id: "edge-right", headerPosition: "right" },
+      },
+      bottom: {
+        size: 200,
+        visible: false,
+        collapsed: true,
+        group: { views: [], id: "edge-bottom", headerPosition: "bottom" },
+      },
+    },
+  };
+}
+
+/**
+ * Same shape as `chatLayoutWithLeftEdgePanel`, but with the second pane docked
+ * in `edge-bottom` (left and right left empty) and referencing the ⌘J test's
+ * own chat ids.
+ *
+ * Written out rather than derived from the left-edge factory: the two differ in
+ * their panel ids as well as their edge slots — chat ids are globally unique
+ * server-side (see `CHAT_BOTTOM_CENTER`) — so a derivation would have to rewrite
+ * the grid tree and the `panels` map anyway, which is the whole body.
+ *
+ * This seed is what makes the ⌘J test non-vacuous. The chord under test now
+ * targets the OUTER layout unconditionally; under the old focus-aware handler,
+ * a focused inner dock whose `edge-bottom` held panels claimed the chord and
+ * the outer edge was never touched. With an EMPTY inner bottom edge (what the
+ * default layout gives you) the old code would have fallen straight through to
+ * the outer layout and this test would have passed against both
+ * implementations — proving nothing. Populating the inner edge separates them.
+ */
+function chatLayoutWithBottomEdgePanel(workspaceId: string) {
+  const panel = (id: string, title: string) => ({
+    id,
+    contentComponent: "chatTab",
+    tabComponent: "chatTab",
+    title,
+    params: { workspaceId, chatId: id },
+  });
+  return {
+    grid: {
+      root: {
+        type: "branch",
+        data: [
+          {
+            type: "leaf",
+            data: { views: [CHAT_BOTTOM_CENTER], activeView: CHAT_BOTTOM_CENTER, id: "1" },
+            size: 500,
+          },
+        ],
+        size: 700,
+      },
+      width: 500,
+      height: 700,
+      orientation: "HORIZONTAL",
+    },
+    panels: {
+      [CHAT_BOTTOM_CENTER]: panel(CHAT_BOTTOM_CENTER, "Center"),
+      [CHAT_BOTTOM_EDGE]: panel(CHAT_BOTTOM_EDGE, "Edge"),
+    },
+    activeGroup: "1",
+    edgeGroups: {
+      left: {
+        size: 200,
+        visible: false,
+        collapsed: true,
+        group: { views: [], id: "edge-left", headerPosition: "left" },
+      },
+      right: {
+        size: 200,
+        visible: false,
+        collapsed: true,
+        group: { views: [], id: "edge-right", headerPosition: "right" },
+      },
+      bottom: {
+        size: 200,
+        visible: true,
+        collapsed: false,
+        group: {
+          views: [CHAT_BOTTOM_EDGE],
+          activeView: CHAT_BOTTOM_EDGE,
+          id: "edge-bottom",
+          headerPosition: "bottom",
+        },
+      },
+    },
+  };
+}
+
+/**
+ * OUTER (shared) dockview layout with the `terminal` panel docked in
+ * `edge-bottom`, visible and expanded — so ⌘J has a populated outer edge to
+ * collapse and the collapse is observable as a height change.
+ *
+ * Captured shape reused verbatim from
+ * `workspace-maximize-collapses-edges.spec.ts` (`LAYOUT_WITH_BOTTOM_EDGE_PANEL`
+ * — see that file's header for how it was captured off a real app run). Seeding
+ * is the only non-flaky way to start with a populated edge: dockview's edge
+ * docking is native HTML5 drag-and-drop, which is unreliable to drive through
+ * Playwright. Unlike the inner chat layout above this one lives in
+ * `localStorage`, so it is installed with `seedGlobalLayout` before the first
+ * `goto` rather than through a tRPC mutation.
+ */
+const OUTER_LAYOUT_WITH_BOTTOM_EDGE_PANEL = {
+  grid: {
+    root: {
+      type: "branch",
+      data: [
+        { type: "leaf", data: { views: ["chat"], activeView: "chat", id: "1" }, size: 519 },
+        {
+          type: "leaf",
+          data: { views: ["changes", "files", "browser"], activeView: "changes", id: "2" },
+          size: 518,
+        },
+      ],
+      size: 762,
+    },
+    width: 1037,
+    height: 762,
+    orientation: "HORIZONTAL",
+  },
+  panels: {
+    chat: {
+      id: "chat",
+      contentComponent: "chat",
+      tabComponent: "props.defaultTabComponent",
+      title: "Chat",
+      params: {},
+    },
+    changes: {
+      id: "changes",
+      contentComponent: "changes",
+      tabComponent: "badge",
+      params: {},
+      title: "Changes",
+    },
+    files: {
+      id: "files",
+      contentComponent: "files",
+      tabComponent: "props.defaultTabComponent",
+      title: "Files",
+      params: {},
+    },
+    terminal: {
+      id: "terminal",
+      contentComponent: "terminal",
+      tabComponent: "props.defaultTabComponent",
+      title: "Terminal",
+      params: {},
+    },
+    browser: {
+      id: "browser",
+      contentComponent: "browser",
+      tabComponent: "props.defaultTabComponent",
+      title: "Browser",
+      params: {},
+    },
+  },
+  activeGroup: "1",
+  edgeGroups: {
+    left: {
+      size: 200,
+      visible: false,
+      collapsed: true,
+      group: { views: [], id: "edge-left", headerPosition: "left" },
+    },
+    right: {
+      size: 200,
+      visible: false,
+      collapsed: true,
+      group: { views: [], id: "edge-right", headerPosition: "right" },
+    },
+    bottom: {
+      size: 200,
+      visible: true,
+      collapsed: false,
+      group: {
+        views: ["terminal"],
+        activeView: "terminal",
+        id: "edge-bottom",
+        headerPosition: "bottom",
+      },
+    },
+  },
+};
+
+let server: ServerHandle;
+let tmpHome: string;
+
+test.beforeAll(async () => {
+  tmpHome = createTmpHome();
+  seedState(tmpHome, {
+    projects: [
+      {
+        name: PROJECT,
+        path: `/tmp/fake/${PROJECT}`,
+        defaultBranch: "main",
+        worktrees: [{ branch: "main", path: `/tmp/fake/${PROJECT}` }],
+      },
+      {
+        name: PROJECT_EDGE,
+        path: `/tmp/fake/${PROJECT_EDGE}`,
+        defaultBranch: "main",
+        worktrees: [{ branch: "main", path: `/tmp/fake/${PROJECT_EDGE}` }],
+      },
+      ...[
+        PROJECT_DOCK_CHAT,
+        PROJECT_DOCK_TERM,
+        PROJECT_DOCK_SPLIT,
+        PROJECT_TAB_CYCLE,
+        PROJECT_ZOOM,
+        PROJECT_BOTTOM,
+      ].map((name) => ({
+        name,
+        path: `/tmp/fake/${name}`,
+        defaultBranch: "main",
+        worktrees: [{ branch: "main", path: `/tmp/fake/${name}` }],
+      })),
+      // The only labelled project — see the group-D constants above.
+      {
+        name: PROJECT_LABELLED,
+        path: `/tmp/fake/${PROJECT_LABELLED}`,
+        defaultBranch: "main",
+        label: LABEL_D,
+        worktrees: [{ branch: "main", path: `/tmp/fake/${PROJECT_LABELLED}` }],
+      },
+    ],
+  });
+  // One label so the sidebar renders the filter dropdown and ⌘1 / ⌘0 have
+  // something to select and reset. Purely additive for the other groups: no
+  // test above reads the project list or the dropdown.
+  seedSettings(tmpHome, {
+    tokenSecret: TOKEN,
+    labels: [{ id: LABEL_D, name: "Shortcuts", color: "#8b5cf6" }],
+  });
+  server = await startServer({ tmpHome });
+});
+
+test.afterAll(async () => {
+  await server.close();
+  cleanupTmpHome(tmpHome);
+});
+
+test.describe("Global shortcuts fire regardless of focus", () => {
+  test("Ctrl+` activates the Terminal tab from a focused chat prompt", async ({ page }) => {
+    const wp = new WorkspacePage(page, server.url, TOKEN);
+    const chat = new ChatPanePage(page, server.url, TOKEN);
+    await wp.goto(WORKSPACE);
+    await wp.waitForReady();
+    await chat.waitForReady();
+
+    // Anchor: the chat prompt (an editable textarea inside the chat inner
+    // dockview), NOT the terminal. The assertion below only means anything
+    // while the Terminal tab starts inactive, and an inactive terminal is
+    // parked in an `inert` container where its input can't take focus — so
+    // the terminal is unusable as the anchor for its own shortcut. See
+    // `pressActivateTerminalShortcut`'s doc comment.
+    await chat.focusPromptAt(0);
+    await wp.pressActivateTerminalShortcut();
+
+    await expect(wp.tabContainer("terminal")).toHaveClass(/dv-active-tab/);
+  });
+
+  test("⌘⇧E activates the Files tab from a focused terminal", async ({ page }) => {
+    const wp = new WorkspacePage(page, server.url, TOKEN);
+    await wp.goto(WORKSPACE);
+    await wp.waitForReady();
+    await wp.openTerminalTab();
+    await wp.waitForTerminalReady();
+    // Positive anchor for the starting state: the Terminal tab really is the
+    // active view in its group, so the post-shortcut assertion is a genuine
+    // transition rather than a coincidence.
+    await expect(wp.tabContainer("terminal")).toHaveClass(/dv-active-tab/);
+
+    await wp.activatePanelViaShortcutFromTerminal("files");
+
+    await expect(wp.tabContainer("files")).toHaveClass(/dv-active-tab/);
+  });
+
+  test("⌘⇧G activates the Changes tab from a focused terminal", async ({ page }) => {
+    const wp = new WorkspacePage(page, server.url, TOKEN);
+    await wp.goto(WORKSPACE);
+    await wp.waitForReady();
+    await wp.openTerminalTab();
+    await wp.waitForTerminalReady();
+    await expect(wp.tabContainer("terminal")).toHaveClass(/dv-active-tab/);
+
+    await wp.activatePanelViaShortcutFromTerminal("changes");
+
+    await expect(wp.tabContainer("changes")).toHaveClass(/dv-active-tab/);
+  });
+
+  test("⌘⇧B activates the Browser tab from a focused terminal", async ({ page }) => {
+    const wp = new WorkspacePage(page, server.url, TOKEN);
+    await wp.goto(WORKSPACE);
+    await wp.waitForReady();
+    await wp.openTerminalTab();
+    await wp.waitForTerminalReady();
+    await expect(wp.tabContainer("terminal")).toHaveClass(/dv-active-tab/);
+
+    await wp.activatePanelViaShortcutFromTerminal("browser");
+
+    await expect(wp.tabContainer("browser")).toHaveClass(/dv-active-tab/);
+  });
+});
+
+test.describe("⌘B always toggles the project sidebar", () => {
+  test("⌘B from a focused terminal (empty inner left edge) toggles the sidebar", async ({
+    page,
+  }) => {
+    const wp = new WorkspacePage(page, server.url, TOKEN);
+    await wp.goto(WORKSPACE);
+    await wp.waitForReady();
+    await wp.openTerminalTab();
+    await wp.waitForTerminalReady();
+
+    // Starting state: sidebar shown.
+    await expect.poll(() => wp.sidebarWidth()).toBeGreaterThan(200);
+    await expect(wp.sidebarToggle).toHaveAttribute("aria-pressed", "true");
+
+    // The terminal inner dockview's `edge-left` is empty on a default layout,
+    // so `toggleEdgeGroup` reports `false` and the handler falls through to
+    // the `band:toggle-sidebar` window event. This is the fallback path that
+    // works TODAY and must keep working after the migration.
+    await wp.toggleSidebarViaShortcutFromTerminal();
+    await expect.poll(() => wp.sidebarWidth()).toBeLessThan(5);
+    await expect(wp.sidebarToggle).toHaveAttribute("aria-pressed", "false");
+
+    // Round trip — the same anchor must bring it back.
+    await wp.toggleSidebarViaShortcutFromTerminal();
+    await expect.poll(() => wp.sidebarWidth()).toBeGreaterThan(200);
+    await expect(wp.sidebarToggle).toHaveAttribute("aria-pressed", "true");
+  });
+
+  // The intentional behaviour change that shipped with the `react-hotkeys-hook`
+  // migration. ⌘B used to be focus-aware: the handler asked
+  // `findFocusedInnerDockview()` first, and because the focused chat dockview
+  // has a populated `edge-left`, `toggleEdgeGroup` collapsed THAT inner edge and
+  // returned `true` — `band:toggle-sidebar` was never dispatched and the sidebar
+  // kept its full width. It now toggles the project-list sidebar unconditionally.
+  //
+  // This test was authored as a `test.fail()` against the old behaviour and
+  // flipped to a normal test when the migration landed; the assertions are
+  // unchanged from that original form.
+  //
+  // ⌘J (bottom) has since followed ⌘B to the same unconditional rule — group D
+  // pins it — so ⌥⌘B (right) is now the only edge chord still resolving its
+  // target by focus. See the ⌘B / ⌘J comments in `SharedDockviewLayout.tsx`.
+  test("⌘B from a focused chat pane collapses the sidebar, not the inner left edge", async ({
+    page,
+  }) => {
+    const wp = new WorkspacePage(page, server.url, TOKEN);
+    const chat = new ChatPanePage(page, server.url, TOKEN);
+
+    // Seed BEFORE `goto`: the inner chat dockview fetches its layout once on
+    // mount. Chats first (their ids must exist in `chats.list` or the restored
+    // panels get pruned as orphans), layout second (`chats.create` appends to
+    // the layout row, so seeding first would be overwritten).
+    await wp.createChat(WORKSPACE_EDGE, CHAT_CENTER, "Center");
+    await wp.createChat(WORKSPACE_EDGE, CHAT_EDGE, "Edge");
+    await wp.seedInnerLayout("chat", WORKSPACE_EDGE, chatLayoutWithLeftEdgePanel(WORKSPACE_EDGE));
+
+    await wp.goto(WORKSPACE_EDGE);
+    await wp.waitForReady();
+
+    // Round-trip the seed. Both checks guard against a vacuous test: a tree
+    // dockview silently rejects makes `onReady` fall back to a single default
+    // pane, which would leave `edge-left` empty and turn the ⌘B branch under
+    // test into the (already-covered) sidebar fallback path. Polling the pane
+    // count also stands in for `ChatPanePage.waitForReady()`, whose
+    // single-prompt locator can't be used once two panes are mounted.
+    await expect.poll(() => chat.promptCount()).toBe(2);
+    // Polled, not read once: the container re-persists its layout asynchronously
+    // on mount, so a single-shot read can observe the value we seeded moments
+    // earlier and pass even though dockview rejected the tree and `onReady` fell
+    // back to a single default pane — leaving `edge-left` empty and silently
+    // degrading this test into the sidebar-fallback path group B already covers.
+    await expect.poll(() => wp.innerEdgeLeftViews("chat", WORKSPACE_EDGE)).toEqual([CHAT_EDGE]);
+
+    // Starting state: sidebar shown.
+    await expect.poll(() => wp.sidebarWidth()).toBeGreaterThan(200);
+    await expect(wp.sidebarToggle).toHaveAttribute("aria-pressed", "true");
+
+    // Focus INSIDE the chat inner dockview — the focus that makes
+    // `findFocusedInnerDockview()` return the chat api today.
+    await chat.focusPromptAt(0);
+    await wp.pressToggleSidebarShortcut();
+
+    // The sidebar collapse is a CSS tween that settles in well under a
+    // second; the tightened poll budget keeps the expected-failure fast
+    // instead of burning the full 30 s test timeout on every run.
+    await expect.poll(() => wp.sidebarWidth(), { timeout: 5_000 }).toBeLessThan(5);
+    await expect(wp.sidebarToggle).toHaveAttribute("aria-pressed", "false");
+  });
+});
+
+test.describe("Dock-scoped shortcuts act on the focused dock", () => {
+  // Every test here boots a real PTY (`openTerminalTab` + `waitForTerminalReady`)
+  // on top of the normal multi-stage app boot, and then waits on a server
+  // round-trip for the layout write. The 30 s file default leaves no headroom
+  // for that under parallel CI load, so the group opts into a longer budget.
+  test.slow();
+
+  /**
+   * Bring a workspace up with BOTH inner docks mounted, visible, and their
+   * layouts persisted — the precondition for every test in this group.
+   *
+   * Both docks must be live simultaneously for the negative half of each
+   * assertion to mean anything: a container only registers its keydown
+   * listener while `visible` is true, so if the terminal dock were never
+   * opened, "⌘T did not add a terminal" would pass trivially (nothing was
+   * listening) instead of proving the chat binding stayed scoped. The default
+   * outer layout puts Chat in its own group and Terminal in the other, so
+   * activating the Terminal tab leaves both on screen at once.
+   *
+   * Returns the settled starting panel counts, polled rather than assumed —
+   * they're written asynchronously on mount, and each test uses them as its
+   * positive anchor before asserting the transition.
+   */
+  async function openBothDocks(
+    wp: WorkspacePage,
+    workspaceId: string,
+  ): Promise<{ chat: number; terminal: number }> {
+    await wp.goto(workspaceId);
+    await wp.waitForReady();
+    await wp.openTerminalTab();
+    await wp.waitForTerminalReady();
+
+    // Positive anchor: both docks have persisted exactly their one default
+    // pane. Polling (not a bare read) because the layout row is written by the
+    // container's layout-change listener after mount.
+    await expect.poll(() => wp.countChatPanels(workspaceId)).toBe(1);
+    await expect.poll(() => wp.countTerminalPanels(workspaceId)).toBe(1);
+    return { chat: 1, terminal: 1 };
+  }
+
+  test("⌘T with the chat dock focused adds a chat pane and no terminal", async ({ page }) => {
+    const wp = new WorkspacePage(page, server.url, TOKEN);
+    const chat = new ChatPanePage(page, server.url, TOKEN);
+    const start = await openBothDocks(wp, WORKSPACE_DOCK_CHAT);
+
+    // Anchor inside the CHAT dock. `focusPromptAt` clicks (rather than
+    // `focus()`es) the prompt so dockview's focusin tracking runs and the chat
+    // container's `containerRef.contains(document.activeElement)` guard passes
+    // — while the terminal container's identical guard fails.
+    await chat.focusPromptAt(0);
+    await wp.pressNewTabShortcut();
+
+    // Positive half: the chat dockview grew a pane.
+    await expect.poll(() => wp.countChatPanels(WORKSPACE_DOCK_CHAT)).toBe(start.chat + 1);
+    // Negative half — the one that catches a binding that leaked global. Both
+    // containers' handlers were mounted and listening; only the focused one
+    // may act. Polled over the same HTTP surface so a late terminal write
+    // can't sneak in after a single-shot read.
+    await expect.poll(() => wp.countTerminalPanels(WORKSPACE_DOCK_CHAT)).toBe(start.terminal);
+    // NOT asserted here: the number of rendered chat prompts. ⌘T adds the new
+    // pane as a TAB in the active group, and dockview only renders the active
+    // tab's content — so `ChatPanePage.promptCount()` stays at 1 even though
+    // the dockview really did grow a panel. (The ⌘B test above sees 2 prompts
+    // because its seeded layout puts the panes in two different groups.) The
+    // persisted-layout count is the projection that distinguishes the docks.
+  });
+
+  test("⌘T with the terminal dock focused adds a terminal and no chat pane", async ({ page }) => {
+    const wp = new WorkspacePage(page, server.url, TOKEN);
+    const start = await openBothDocks(wp, WORKSPACE_DOCK_TERM);
+
+    // Anchor inside the TERMINAL dock — the mirror image of the test above,
+    // same combo, same two live listeners, opposite outcome.
+    await wp.newTabViaShortcutFromTerminal();
+
+    await expect.poll(() => wp.countTerminalPanels(WORKSPACE_DOCK_TERM)).toBe(start.terminal + 1);
+    await expect.poll(() => wp.countChatPanels(WORKSPACE_DOCK_TERM)).toBe(start.chat);
+  });
+
+  test("⌘D with the terminal dock focused splits the terminal dock", async ({ page }) => {
+    const wp = new WorkspacePage(page, server.url, TOKEN);
+    const start = await openBothDocks(wp, WORKSPACE_DOCK_SPLIT);
+
+    // ⌘D is the SPLIT branch, not close: `DockviewTerminalContainer`'s
+    // `key === "d"` arm splits on `e.metaKey && !e.ctrlKey` and only closes
+    // the active tab on `e.ctrlKey && !e.metaKey && !e.shiftKey`. The two are
+    // deliberately NOT interchangeable here, unlike every other chord in that
+    // handler where `mod = e.metaKey || e.ctrlKey`. Pinning the real
+    // behaviour: ⌘D grows the terminal dock.
+    await wp.splitRightViaShortcutFromTerminal();
+
+    await expect.poll(() => wp.countTerminalPanels(WORKSPACE_DOCK_SPLIT)).toBe(start.terminal + 1);
+    // The chat dock owns ⌘D too (its own handler splits on the same key), so
+    // the unchanged chat count is again the half that proves the binding
+    // stayed scoped to the focused dock.
+    await expect.poll(() => wp.countChatPanels(WORKSPACE_DOCK_SPLIT)).toBe(start.chat);
+  });
+});
+
+test.describe("Split, physical-key and zoom bindings", () => {
+  // Two of the three tests boot a real PTY on top of the multi-stage app boot
+  // and then wait on a server round-trip for the layout write, same as group C.
+  test.slow();
+
+  test("⌘0 resets the label filter to All", async ({ page }) => {
+    const wp = new WorkspacePage(page, server.url, TOKEN);
+    await wp.goto(WORKSPACE_LABELLED);
+    await wp.waitForReady();
+
+    // Positive anchor: a filter really is applied before the reset. Selected
+    // through the dropdown (the click path) rather than a digit shortcut, so
+    // this test's subject is ⌘0 alone and not ⌘1's half of the same binding.
+    // Polled because `useLabelFilter` writes the key from a React state
+    // update, one micro-task after the click.
+    await wp.selectLabelFilter(LABEL_D);
+    await expect.poll(() => wp.readLabelFilter()).toBe(LABEL_D);
+
+    await wp.pressLabelShortcut(0);
+
+    // "All" is represented by the ABSENCE of the key — `useLabelFilter`
+    // `removeItem`s it rather than storing a sentinel.
+    await expect.poll(() => wp.readLabelFilter()).toBeNull();
+  });
+
+  test("Ctrl+0 focuses the project list and leaves the label filter alone", async ({ page }) => {
+    const wp = new WorkspacePage(page, server.url, TOKEN);
+    await wp.goto(WORKSPACE_LABELLED);
+    await wp.waitForReady();
+
+    await wp.selectLabelFilter(LABEL_D);
+    await expect.poll(() => wp.readLabelFilter()).toBe(LABEL_D);
+    // Second half of the starting state: focus is NOT yet on the project list
+    // (the workspace route autofocuses the chat prompt), so the assertion
+    // below is a genuine transition rather than a coincidence.
+    await expect(wp.projectListRoot()).not.toBeFocused();
+
+    // `focusProjectsViaShortcut` anchors the keypress on the sidebar toggle
+    // button — deliberately NOT the project list itself, which would make the
+    // focus assertion vacuous.
+    await wp.focusProjectsViaShortcut();
+
+    // The half that pins the split. Both used to be one chord, and Focus
+    // Projects only won by capture-phase `stopPropagation()` ordering; if
+    // Ctrl+0 ever rejoins `LABEL_FILTER_SHORTCUT` this filter reads back null.
+    await expect(wp.projectListRoot()).toBeFocused();
+    // Read AFTER the focus assertion has settled, so the Ctrl+0 handlers have
+    // demonstrably run — a filter reset would already be in localStorage by
+    // now and this poll would fail on its first iteration rather than pass
+    // before the damage lands.
+    await expect.poll(() => wp.readLabelFilter()).toBe(LABEL_D);
+  });
+
+  test("⌘⇧] and ⌘⇧[ cycle the focused dock's active tab", async ({ page }) => {
+    const wp = new WorkspacePage(page, server.url, TOKEN);
+    await wp.goto(WORKSPACE_TAB_CYCLE);
+    await wp.waitForReady();
+    await wp.openTerminalTab();
+    await wp.waitForTerminalReady();
+
+    // Stack a SECOND tab into the same group via the dock's own "+" button.
+    // Cycling only means anything with more than one tab in the active group,
+    // and the button path keeps the setup independent of ⌘T (which group C
+    // already covers).
+    await expect.poll(() => wp.countTerminalPanels(WORKSPACE_TAB_CYCLE)).toBe(1);
+    await wp.clickTerminalAddTab(WORKSPACE_TAB_CYCLE);
+    await expect.poll(() => wp.countTerminalPanels(WORKSPACE_TAB_CYCLE)).toBe(2);
+
+    // Positive anchor: dockview activates a newly added tab, so the active
+    // view is the SECOND entry in the group's `views` list. Asserting on the
+    // index rather than the panel count is the point — a cycle leaves the
+    // count at 2 either way, so the count can't tell a working binding from a
+    // dead one.
+    await expect.poll(() => wp.innerActiveTabIndex("terminal", WORKSPACE_TAB_CYCLE)).toBe(1);
+
+    // Forward from the last tab wraps to the first — `cycleTabs(1)` is modular.
+    await wp.cycleTabViaShortcutFromTerminalDock(WORKSPACE_TAB_CYCLE, "next");
+    await expect.poll(() => wp.innerActiveTabIndex("terminal", WORKSPACE_TAB_CYCLE)).toBe(0);
+
+    // …and back. Both directions are asserted because they are separate
+    // bindings (`nextTab` / `previousTab`) that were separately dead.
+    await wp.cycleTabViaShortcutFromTerminalDock(WORKSPACE_TAB_CYCLE, "previous");
+    await expect.poll(() => wp.innerActiveTabIndex("terminal", WORKSPACE_TAB_CYCLE)).toBe(1);
+  });
+
+  test("⌘=, ⌘⇧= and ⌘- drive the applied zoom level", async ({ page }) => {
+    const wp = new WorkspacePage(page, server.url, TOKEN);
+    await wp.goto(WORKSPACE_ZOOM);
+    await wp.waitForReady();
+    await wp.openTerminalTab();
+    await wp.waitForTerminalReady();
+
+    // Positive anchor: the pre-paint init script in `__root.tsx` seeds
+    // `--app-zoom` at 1 on a fresh origin, so every step below is a measured
+    // delta from a known start rather than an absolute guess.
+    await expect.poll(() => wp.appliedZoomLevel()).toBe(1);
+
+    // ⌘= — the unshifted spelling. `ZOOM_STEP` is 0.1 and `applyZoomLevel`
+    // rounds to two decimals, so the levels are exact, not floating-point
+    // approximations.
+    await wp.zoomViaShortcutFromTerminal("in");
+    await expect.poll(() => wp.appliedZoomLevel()).toBe(1.1);
+
+    // ⌘⇧= (i.e. ⌘+) — the half that was silently dead. `+` and `=` share one
+    // physical key, the old handler accepted both characters, and a `meta+=`
+    // binding cannot fire while Shift is held because the library compares
+    // modifiers for exact equality. Binding the physical `Equal` with AND
+    // without Shift is what makes this line pass.
+    await wp.zoomViaShortcutFromTerminal("inShifted");
+    await expect.poll(() => wp.appliedZoomLevel()).toBe(1.2);
+
+    // ⌘- — the opposite direction, so a binding that fired on any modifier
+    // combination (rather than the one it declares) can't pass the whole test.
+    await wp.zoomViaShortcutFromTerminal("out");
+    await expect.poll(() => wp.appliedZoomLevel()).toBe(1.1);
+  });
+
+  // The group's other intentional behaviour change. ⌘J used to be focus-aware
+  // exactly like ⌥⌘B still is: the handler asked `findFocusedInnerDockview()`
+  // first, and if that dockview's `edge-bottom` held panels, `toggleEdgeGroup`
+  // collapsed THAT inner edge and returned `true` — the outer layout was never
+  // touched. It now always toggles the outermost shared-dockview layout's
+  // bottom edge, the same rule ⌘B follows with the sidebar, which leaves ⌥⌘B
+  // as the only edge chord that still resolves its target by focus.
+  //
+  // Both edges are seeded populated so the two implementations are actually
+  // distinguishable: with an empty inner bottom edge the old handler would
+  // have fallen through to the outer layout and this test would pass against
+  // it too. See `chatLayoutWithBottomEdgePanel`.
+  test("⌘J from a focused chat pane toggles the outer bottom edge, not the inner one", async ({
+    page,
+  }) => {
+    const wp = new WorkspacePage(page, server.url, TOKEN);
+    const chat = new ChatPanePage(page, server.url, TOKEN);
+
+    // Seed BEFORE `goto`, in this order, for two different reasons. The inner
+    // chat layout is SERVER state fetched once on mount, and chats must exist
+    // in `chats.list` first or the restored panels are pruned as orphans (same
+    // ordering constraint the ⌘B test documents). The outer layout is CLIENT
+    // state installed via `addInitScript`, which only applies to navigations
+    // that happen after it is registered.
+    await wp.createChat(WORKSPACE_BOTTOM, CHAT_BOTTOM_CENTER, "Center");
+    await wp.createChat(WORKSPACE_BOTTOM, CHAT_BOTTOM_EDGE, "Edge");
+    await wp.seedInnerLayout(
+      "chat",
+      WORKSPACE_BOTTOM,
+      chatLayoutWithBottomEdgePanel(WORKSPACE_BOTTOM),
+    );
+    await wp.seedGlobalLayout(OUTER_LAYOUT_WITH_BOTTOM_EDGE_PANEL);
+
+    await wp.goto(WORKSPACE_BOTTOM);
+    await wp.waitForReady();
+
+    // Round-trip the INNER seed, polled for the same reason the ⌘B test polls
+    // its own: the container re-persists asynchronously on mount, so a
+    // single-shot read can observe what we seeded moments earlier even though
+    // dockview rejected the tree and `onReady` fell back to one default pane —
+    // which would empty the inner bottom edge and silently turn this into a
+    // test that can't tell the two implementations apart.
+    await expect.poll(() => chat.promptCount()).toBe(2);
+    await expect
+      .poll(() => wp.innerEdgeBottomViews("chat", WORKSPACE_BOTTOM))
+      .toEqual([CHAT_BOTTOM_EDGE]);
+
+    // Positive anchor: the OUTER bottom edge really is populated and expanded,
+    // so there is something observable for the chord to collapse. Expanded is
+    // the seeded 200px; a collapsed edge keeps its ~35px header strip (dockview
+    // collapses rather than hides here — see `outerBottomEdgeHeight`), so the
+    // thresholds sit either side of that gap with room for the tween.
+    await expect.poll(() => wp.outerBottomEdgeHeight()).toBeGreaterThan(100);
+
+    // Focus INSIDE the chat inner dockview, whose own `edge-bottom` is
+    // populated — the focus that used to retarget this chord away from the
+    // outer layout.
+    await chat.focusPromptAt(0);
+    await wp.pressToggleBottomEdgeShortcut();
+
+    // The outer edge collapsed despite the inner dock holding focus.
+    await expect.poll(() => wp.outerBottomEdgeHeight(), { timeout: 5_000 }).toBeLessThan(60);
+
+    // Round trip from the same anchor — proves the binding is a toggle rather
+    // than a one-way collapse, and that the second press didn't get retargeted
+    // either.
+    await chat.focusPromptAt(0);
+    await wp.pressToggleBottomEdgeShortcut();
+    await expect.poll(() => wp.outerBottomEdgeHeight(), { timeout: 5_000 }).toBeGreaterThan(100);
+  });
+});

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -40,6 +40,7 @@
     "fzf": "0.5.2",
     "node-pty": "^1.1.0",
     "prettier": "^3.8.3",
+    "react-hotkeys-hook": "^5.3.3",
     "react-resizable-panels": "^4.9.0",
     "typescript-language-server": "^5.1.3",
     "vscode-jsonrpc": "8.2.0"

--- a/apps/web/src/components/CodeBrowserView.tsx
+++ b/apps/web/src/components/CodeBrowserView.tsx
@@ -64,12 +64,14 @@ import {
   useSettingsQuery,
   useWorkspacePath,
 } from "@/dashboard";
+import { useAppShortcut } from "../hooks/useAppShortcut";
 import { isUntitledPath, useFileTabs } from "../hooks/useFileTabs";
 import { useIsDesktop } from "../hooks/useIsDesktop";
 import { useTabState } from "../hooks/useTabState";
 import { pathInside } from "../lib/path-inside";
 import { consumeExternalOpen, subscribeExternalOpens } from "../lib/pending-external-open";
 import { shouldDropPersistedTab } from "../lib/persisted-tab-self-heal";
+import { DOCK_SHORTCUTS } from "../lib/shortcuts";
 import { FileTabBar } from "./FileTabBar";
 import type { MarkdownPreviewHandle, MarkdownPreviewMatchInfo } from "./MarkdownPreview";
 import { MarkdownPreview } from "./MarkdownPreview";
@@ -1427,16 +1429,26 @@ export function CodeBrowserView({
     return () => window.removeEventListener("band:lsp-navigate", handleLspNavigate);
   }, [pushDepartureAndArrival, fileTabs.openTabPinned, notifySelectFile, workspaceId]);
 
-  // Keyboard shortcuts (capture phase, scoped to this section's focus):
-  // - Cmd/Ctrl+W              → close the active file tab
-  // - Ctrl+(Shift)+Tab        → cycle file tabs
-  // - Cmd/Ctrl+Shift+[/]      → cycle file tabs (matches the per-section
-  //                             convention used by Terminal/Chats/Browser).
-  // - Ctrl+-                  → editor history: go back (VSCode parity)
-  // - Ctrl+Shift+-            → editor history: go forward (VSCode parity)
+  // Keyboard shortcuts, scoped to this section's focus:
+  // - Cmd+W              → close the active file tab
+  // - Ctrl+(Shift)+Tab   → cycle file tabs
+  // - Cmd+Shift+[/]      → cycle file tabs (matches the per-section
+  //                        convention used by Terminal/Chats/Browser).
+  // - Ctrl+-             → editor history: go back (VSCode parity)
+  // - Ctrl+Shift+-       → editor history: go forward (VSCode parity)
   //
-  // The Code section has no sub-dockview groups, so Cmd/Ctrl+[/] is a no-op
-  // here — we still swallow it so it doesn't bubble up to anything else.
+  // The Code section has no sub-dockview groups, so `DOCK_SHORTCUTS.nextGroup`
+  // / `previousGroup` (Cmd+[ / Cmd+]) are deliberately left unbound here.
+  //
+  // The shared combos come from `DOCK_SHORTCUTS`, and the scoping that used to
+  // be a hand-written `containerRef.contains(document.activeElement)` check
+  // inside a window-level capture listener is now `react-hotkeys-hook`'s
+  // returned ref: each binding listens on this view's root element, so it only
+  // fires while that element or a descendant holds focus. `useAppShortcut`
+  // supplies capture-phase listening, form-tag / contentEditable enablement
+  // (the editor is the usual focus target here) and `preventDefault`;
+  // `stopPropagation` is still called by hand wherever the old handler called
+  // it, so the chord never also reaches the editor.
   //
   // The editor-history shortcuts deliberately use **Ctrl** (not Cmd) to
   // mirror VSCode on macOS and — more importantly — to dodge the desktop
@@ -1446,8 +1458,13 @@ export function CodeBrowserView({
   // Windows/Linux the same accelerator binds `Ctrl+-`, so the shortcut
   // will be intercepted by the menu before reaching this handler; that's
   // a known limitation to revisit when we ship outside macOS.
-  useEffect(() => {
-    const cycleFileTabs = (direction: 1 | -1) => {
+  //
+  // They bind the PHYSICAL `Minus` key (`useKey` left unset, the library
+  // default) rather than the produced character, so the Shift-modified `e.key`
+  // — `"_"` on US layouts — doesn't have to be juggled. That is the same test
+  // the old handler's `e.code === "Minus"` performed.
+  const cycleFileTabs = useCallback(
+    (direction: 1 | -1) => {
       const tabs = fileTabs.openTabs;
       if (tabs.length <= 1) return;
       const currentIndex = tabs.findIndex((t) => t.filePath === fileTabs.activeTabPath);
@@ -1464,65 +1481,110 @@ export function CodeBrowserView({
             : tabs.length - 1
           : (currentIndex + direction + tabs.length) % tabs.length;
       handleTabSelect(tabs[nextIndex].filePath);
-    };
+    },
+    [fileTabs.openTabs, fileTabs.activeTabPath, handleTabSelect],
+  );
 
-    const handler = (e: KeyboardEvent) => {
-      if (!containerRef.current?.contains(document.activeElement)) return;
+  const cycleForwardRef = useAppShortcut(
+    DOCK_SHORTCUTS.cycleTabForward,
+    (e) => {
+      e.stopPropagation();
+      cycleFileTabs(1);
+    },
+    {},
+    [cycleFileTabs],
+  );
+  const cycleBackwardRef = useAppShortcut(
+    DOCK_SHORTCUTS.cycleTabBackward,
+    (e) => {
+      e.stopPropagation();
+      cycleFileTabs(-1);
+    },
+    {},
+    [cycleFileTabs],
+  );
+  const nextTabRef = useAppShortcut(
+    DOCK_SHORTCUTS.nextTab,
+    (e) => {
+      e.stopPropagation();
+      cycleFileTabs(1);
+    },
+    {},
+    [cycleFileTabs],
+  );
+  const previousTabRef = useAppShortcut(
+    DOCK_SHORTCUTS.previousTab,
+    (e) => {
+      e.stopPropagation();
+      cycleFileTabs(-1);
+    },
+    {},
+    [cycleFileTabs],
+  );
 
-      const key = e.key.toLowerCase();
+  const historyBackRef = useAppShortcut(
+    { binding: "ctrl+minus", display: "Ctrl+-" },
+    (e) => {
+      e.stopPropagation();
+      handleEditorGoBack();
+    },
+    {},
+    [handleEditorGoBack],
+  );
+  const historyForwardRef = useAppShortcut(
+    { binding: "ctrl+shift+minus", display: "Ctrl+Shift+-" },
+    (e) => {
+      e.stopPropagation();
+      handleEditorGoForward();
+    },
+    {},
+    [handleEditorGoForward],
+  );
 
-      // Ctrl+(Shift)+Tab → cycle file tabs
-      if (e.ctrlKey && !e.metaKey && key === "tab") {
-        e.preventDefault();
-        e.stopPropagation();
-        cycleFileTabs(e.shiftKey ? -1 : 1);
-        return;
+  // ⌘W only acts — and only suppresses the browser's own ⌘W — when there is an
+  // active tab to close, so `preventDefault` stays conditional.
+  const closeTabRef = useAppShortcut(
+    DOCK_SHORTCUTS.closeTab,
+    (e) => {
+      if (!fileTabs.activeTabPath) return;
+      e.preventDefault();
+      e.stopPropagation();
+      handleTabClose(fileTabs.activeTabPath);
+    },
+    { preventDefault: false },
+    [fileTabs.activeTabPath, handleTabClose],
+  );
+
+  // All bindings scope to the same root element, so their ref callbacks are
+  // fanned out through one composed callback. The library's setters are stable,
+  // so listing them as deps keeps this callback stable too — an unstable ref
+  // callback would detach and re-attach (and re-register every listener) on
+  // every render.
+  const setContainerRef = useCallback(
+    (element: HTMLDivElement | null) => {
+      containerRef.current = element;
+      for (const attach of [
+        cycleForwardRef,
+        cycleBackwardRef,
+        nextTabRef,
+        previousTabRef,
+        historyBackRef,
+        historyForwardRef,
+        closeTabRef,
+      ]) {
+        attach(element);
       }
-
-      // Ctrl+- / Ctrl+Shift+- → editor history back/forward.
-      // Match on `e.code === "Minus"` so we don't have to juggle the
-      // Shift-modified `e.key` (which becomes `"_"` on US layouts).
-      // Require Ctrl exclusively (no Cmd, no Alt) to keep it distinct
-      // from the desktop Zoom Out accelerator.
-      if (e.ctrlKey && !e.metaKey && !e.altKey && e.code === "Minus") {
-        e.preventDefault();
-        e.stopPropagation();
-        if (e.shiftKey) {
-          handleEditorGoForward();
-        } else {
-          handleEditorGoBack();
-        }
-        return;
-      }
-
-      const mod = e.metaKey || e.ctrlKey;
-      if (!mod) return;
-
-      // Cmd/Ctrl+Shift+[ / Cmd/Ctrl+Shift+] → cycle file tabs
-      if (e.shiftKey && (key === "[" || key === "]")) {
-        e.preventDefault();
-        e.stopPropagation();
-        cycleFileTabs(key === "]" ? 1 : -1);
-        return;
-      }
-
-      // Cmd/Ctrl+W → close the active file tab
-      if (key === "w" && !e.shiftKey && fileTabs.activeTabPath) {
-        e.preventDefault();
-        e.stopPropagation();
-        handleTabClose(fileTabs.activeTabPath);
-      }
-    };
-    window.addEventListener("keydown", handler, { capture: true });
-    return () => window.removeEventListener("keydown", handler, { capture: true });
-  }, [
-    fileTabs.openTabs,
-    fileTabs.activeTabPath,
-    handleTabSelect,
-    handleTabClose,
-    handleEditorGoBack,
-    handleEditorGoForward,
-  ]);
+    },
+    [
+      cycleForwardRef,
+      cycleBackwardRef,
+      nextTabRef,
+      previousTabRef,
+      historyBackRef,
+      historyForwardRef,
+      closeTabRef,
+    ],
+  );
 
   // -------------------------------------------------------------------------
   // File tree imperative handle (drives "new file" / "new folder" from toolbar)
@@ -2234,7 +2296,7 @@ export function CodeBrowserView({
     // dockview's content container, which has min-height:0 but not
     // min-width:0 and would otherwise be pushed wider than its allocated
     // group slot — visibly shoving the right-edge tab strip off-screen.
-    <div ref={containerRef} className="h-full w-full min-w-0 overflow-hidden">
+    <div ref={setContainerRef} className="h-full w-full min-w-0 overflow-hidden">
       {useMobileLayout ? (
         // Mobile / narrow container: toggle between file browser and viewer
         viewFilePath ? (

--- a/apps/web/src/components/DockviewBrowserContainer.tsx
+++ b/apps/web/src/components/DockviewBrowserContainer.tsx
@@ -11,6 +11,7 @@ import {
 import { Columns2, Globe, Plus, Rows2, X } from "lucide-react";
 import React, { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { useAdapter } from "@/dashboard";
+import { useAppShortcut } from "../hooks/useAppShortcut";
 import { injectInitialUrls } from "../lib/browser-layout";
 import { invoke as desktopInvoke, listen as desktopListen } from "../lib/desktop-ipc";
 import {
@@ -25,6 +26,7 @@ import {
   selectNeighbourBeforeRemove,
 } from "../lib/dockview-section-actions";
 import { isDesktop } from "../lib/is-desktop";
+import { DOCK_SHORTCUTS } from "../lib/shortcuts";
 import { trpc } from "../lib/trpc-client";
 import { BrowserPaneComponent, type BrowserPaneParams, useFavicon } from "./BrowserPanel";
 import { PanelVisibilityContext, usePanelVisibility } from "./panel-visibility-context";
@@ -611,7 +613,7 @@ export function DockviewBrowserContainer({
       }
 
       // After closing, focus the address bar in the newly active panel so the
-      // section-scoped keydown handler still sees Cmd+W on the next press.
+      // section-scoped shortcuts still see Cmd+W on the next press.
       requestAnimationFrame(() => {
         const activePanel = api.activePanel;
         if (!activePanel) return;
@@ -629,121 +631,229 @@ export function DockviewBrowserContainer({
     [workspaceId],
   );
 
-  // Keyboard shortcuts (capture phase, scoped to this section's focus):
-  // - Cmd/Ctrl+T              → open a new browser tab
-  // - Cmd/Ctrl+W              → close the active browser tab
-  // - Cmd/Ctrl+D              → split right (vertical split)
-  // - Cmd/Ctrl+Shift+D        → split down (horizontal split)
-  // - Cmd/Ctrl+R              → reload the active browser tab (desktop only)
-  // - Ctrl+(Shift)+Tab        → cycle tabs in the active group
-  // - Cmd/Ctrl+[ / Cmd/Ctrl+] → cycle between split browser groups (panels)
-  // - Cmd/Ctrl+Shift+[/]      → cycle tabs in the active group
-  useEffect(() => {
-    if (!visible) return;
+  // Keyboard shortcuts, scoped to this section's focus:
+  // - Cmd+T              → open a new browser tab
+  // - Cmd+W              → close the active browser tab
+  // - Cmd+D              → split right (vertical split)
+  // - Cmd+Shift+D        → split down (horizontal split)
+  // - Cmd+R              → reload the active browser tab (desktop only)
+  // - Ctrl+(Shift)+Tab   → cycle tabs in the active group
+  // - Cmd+[ / Cmd+]      → cycle between split browser groups (panels)
+  // - Cmd+Shift+[/]      → cycle tabs in the active group
+  //
+  // Combos come from `DOCK_SHORTCUTS`, shared with the chat, terminal and
+  // file-tab docks. Scoping is `react-hotkeys-hook`'s returned ref rather than
+  // the hand-written `containerRef.contains(document.activeElement)` check that
+  // used to guard a window-level capture listener: each binding listens on this
+  // container's root, so it only fires while that element or a descendant holds
+  // focus. `useAppShortcut` supplies capture-phase listening, form-tag
+  // enablement (the address bar is the usual focus target here) and
+  // `preventDefault`. `stopPropagation` is called by hand wherever the old
+  // handler called it, so the chord never also reaches the focused input.
+  //
+  // `data-band-address-input` is set on the address-bar input in
+  // BrowserPanel.tsx — using the data attribute (rather than
+  // `input[type='text']`) avoids matching the find-bar input.
+  const refocusAddressBar = useCallback(() => {
+    const panel = apiRef.current?.activePanel;
+    if (!panel) return;
+    panel.view.content.element
+      .querySelector<HTMLInputElement>("[data-band-address-input]")
+      ?.focus();
+  }, []);
 
-    // `data-band-address-input` is set on the address-bar input in
-    // BrowserPanel.tsx — using the data attribute (rather than
-    // `input[type='text']`) avoids matching the find-bar input.
-    const refocusAddressBar = () => {
-      const panel = apiRef.current?.activePanel;
-      if (!panel) return;
-      panel.view.content.element
-        .querySelector<HTMLInputElement>("[data-band-address-input]")
-        ?.focus();
-    };
-
-    const cycleTabs = (direction: 1 | -1) => {
+  const cycleTabs = useCallback(
+    (direction: 1 | -1) => {
       cycleTabsInActiveGroup(apiRef.current, direction, () => {
         requestAnimationFrame(refocusAddressBar);
       });
-    };
+    },
+    [refocusAddressBar],
+  );
 
-    const cycleGroups = (direction: 1 | -1) => {
+  const cycleGroups = useCallback(
+    (direction: 1 | -1) => {
       cycleGridGroups(apiRef.current, direction, () => {
         requestAnimationFrame(refocusAddressBar);
       });
-    };
+    },
+    [refocusAddressBar],
+  );
 
-    const handler = (e: KeyboardEvent) => {
-      // Only handle shortcut if this container (or a descendant) has focus
-      if (!containerRef.current?.contains(document.activeElement)) return;
+  // Bindings are only live while the section is visible — same gate the
+  // effect-based handler applied before registering its listener.
+  const shortcutOptions = { enabled: visible };
 
-      const key = e.key.toLowerCase();
+  const cycleForwardRef = useAppShortcut(
+    DOCK_SHORTCUTS.cycleTabForward,
+    (e) => {
+      e.stopPropagation();
+      cycleTabs(1);
+    },
+    shortcutOptions,
+    [cycleTabs, visible],
+  );
+  const cycleBackwardRef = useAppShortcut(
+    DOCK_SHORTCUTS.cycleTabBackward,
+    (e) => {
+      e.stopPropagation();
+      cycleTabs(-1);
+    },
+    shortcutOptions,
+    [cycleTabs, visible],
+  );
+  const nextTabRef = useAppShortcut(
+    DOCK_SHORTCUTS.nextTab,
+    (e) => {
+      e.stopPropagation();
+      cycleTabs(1);
+    },
+    shortcutOptions,
+    [cycleTabs, visible],
+  );
+  const previousTabRef = useAppShortcut(
+    DOCK_SHORTCUTS.previousTab,
+    (e) => {
+      e.stopPropagation();
+      cycleTabs(-1);
+    },
+    shortcutOptions,
+    [cycleTabs, visible],
+  );
+  const nextGroupRef = useAppShortcut(
+    DOCK_SHORTCUTS.nextGroup,
+    (e) => {
+      e.stopPropagation();
+      cycleGroups(1);
+    },
+    shortcutOptions,
+    [cycleGroups, visible],
+  );
+  const previousGroupRef = useAppShortcut(
+    DOCK_SHORTCUTS.previousGroup,
+    (e) => {
+      e.stopPropagation();
+      cycleGroups(-1);
+    },
+    shortcutOptions,
+    [cycleGroups, visible],
+  );
 
-      // Ctrl+(Shift)+Tab → cycle tabs within the active group
-      if (e.ctrlKey && !e.metaKey && key === "tab") {
-        e.preventDefault();
-        e.stopPropagation();
-        cycleTabs(e.shiftKey ? -1 : 1);
-        return;
+  const newTabRef = useAppShortcut(
+    DOCK_SHORTCUTS.newTab,
+    (e) => {
+      e.stopPropagation();
+      handleAddTab().then(() => {
+        // Focus the address bar in the newly created panel.
+        requestAnimationFrame(refocusAddressBar);
+      });
+    },
+    shortcutOptions,
+    [handleAddTab, refocusAddressBar, visible],
+  );
+
+  const closeTabRef = useAppShortcut(
+    DOCK_SHORTCUTS.closeTab,
+    (e) => {
+      const api = apiRef.current;
+      if (!api) return;
+      e.preventDefault();
+      e.stopPropagation();
+      const active = api.activePanel;
+      if (active) {
+        closeTab(active.id);
       }
+    },
+    { ...shortcutOptions, preventDefault: false },
+    [closeTab, visible],
+  );
 
-      const mod = e.metaKey || e.ctrlKey;
-      if (!mod) return;
+  const splitRightRef = useAppShortcut(
+    DOCK_SHORTCUTS.splitRight,
+    (e) => {
+      e.stopPropagation();
+      const activeGroup = apiRef.current?.activeGroup;
+      if (!activeGroup) return;
+      handleSplit(activeGroup.id, "right");
+    },
+    shortcutOptions,
+    [handleSplit, visible],
+  );
+  const splitDownRef = useAppShortcut(
+    DOCK_SHORTCUTS.splitDown,
+    (e) => {
+      e.stopPropagation();
+      const activeGroup = apiRef.current?.activeGroup;
+      if (!activeGroup) return;
+      handleSplit(activeGroup.id, "below");
+    },
+    shortcutOptions,
+    [handleSplit, visible],
+  );
 
-      // Cmd/Ctrl+Shift+[ / Cmd/Ctrl+Shift+] → cycle tabs in active group
-      if (e.shiftKey && (key === "[" || key === "]")) {
-        e.preventDefault();
-        e.stopPropagation();
-        cycleTabs(key === "]" ? 1 : -1);
-        return;
+  // ⌘R reloads the embedded WebContentsView — desktop only, since the plain web
+  // build has no such view to reload, and unbound there so the browser's own
+  // page reload keeps working. No `DOCK_SHORTCUTS` entry: it is this dock's
+  // alone. `preventDefault` stays conditional on there being a browser id to
+  // reload, matching the old handler's ordering.
+  //
+  // Both modifier spellings are bound rather than `mod+r`: the old handler gated
+  // on `e.metaKey || e.ctrlKey`, so Ctrl+R reloaded on macOS too, and `mod`
+  // would collapse that to ⌘ alone there.
+  const reloadRef = useAppShortcut(
+    { binding: "meta+r, ctrl+r", display: "Cmd+R" },
+    (e) => {
+      const active = apiRef.current?.activePanel;
+      const browserId = (active?.params as BrowserTabParams | undefined)?.browserId;
+      if (!browserId) return;
+      e.preventDefault();
+      e.stopPropagation();
+      desktopInvoke("browser_reload", { browserId }).catch((err) => {
+        console.error("[DockviewBrowserContainer] browser_reload failed:", err);
+      });
+    },
+    { enabled: visible && isDesktop, preventDefault: false },
+    [visible],
+  );
+
+  // All bindings scope to the same root element, so their ref callbacks are
+  // fanned out through one composed callback. The library's setters are stable,
+  // so listing them as deps keeps this callback stable too — an unstable ref
+  // callback would detach and re-attach (and re-register every listener) on
+  // every render.
+  const setContainerRef = useCallback(
+    (element: HTMLDivElement | null) => {
+      containerRef.current = element;
+      for (const attach of [
+        cycleForwardRef,
+        cycleBackwardRef,
+        nextTabRef,
+        previousTabRef,
+        nextGroupRef,
+        previousGroupRef,
+        newTabRef,
+        closeTabRef,
+        splitRightRef,
+        splitDownRef,
+        reloadRef,
+      ]) {
+        attach(element);
       }
-
-      // Cmd/Ctrl+[ / Cmd/Ctrl+] → cycle between split groups (panels)
-      if (!e.shiftKey && (key === "[" || key === "]")) {
-        e.preventDefault();
-        e.stopPropagation();
-        cycleGroups(key === "]" ? 1 : -1);
-        return;
-      }
-
-      if (key === "t" && !e.shiftKey) {
-        e.preventDefault();
-        e.stopPropagation();
-        handleAddTab().then(() => {
-          // Focus the address bar in the newly created panel.
-          requestAnimationFrame(() => {
-            const panel = apiRef.current?.activePanel;
-            if (!panel) return;
-            panel.view.content.element
-              .querySelector<HTMLInputElement>("[data-band-address-input]")
-              ?.focus();
-          });
-        });
-      } else if (key === "w" && !e.shiftKey) {
-        const api = apiRef.current;
-        if (!api) return;
-        e.preventDefault();
-        e.stopPropagation();
-        const active = api.activePanel;
-        if (active) {
-          closeTab(active.id);
-        }
-      } else if (key === "d") {
-        e.preventDefault();
-        e.stopPropagation();
-        const api = apiRef.current;
-        if (!api) return;
-        const activeGroup = api.activeGroup;
-        if (!activeGroup) return;
-        const direction = e.shiftKey ? "below" : "right";
-        handleSplit(activeGroup.id, direction);
-      } else if (key === "r" && !e.shiftKey && isDesktop) {
-        const api = apiRef.current;
-        if (!api) return;
-        const active = api.activePanel;
-        const browserId = (active?.params as BrowserTabParams | undefined)?.browserId;
-        if (!browserId) return;
-        e.preventDefault();
-        e.stopPropagation();
-        desktopInvoke("browser_reload", { browserId }).catch((err) => {
-          console.error("[DockviewBrowserContainer] browser_reload failed:", err);
-        });
-      }
-    };
-    window.addEventListener("keydown", handler, true);
-    return () => window.removeEventListener("keydown", handler, true);
-  }, [visible, closeTab, handleSplit, handleAddTab]);
+    },
+    [
+      cycleForwardRef,
+      cycleBackwardRef,
+      nextTabRef,
+      previousTabRef,
+      nextGroupRef,
+      previousGroupRef,
+      newTabRef,
+      closeTabRef,
+      splitRightRef,
+      splitDownRef,
+      reloadRef,
+    ],
+  );
 
   // Force a synchronous re-layout of the inner dockview when the outer
   // Browser panel becomes visible. See the matching effect (and its
@@ -1244,7 +1354,7 @@ export function DockviewBrowserContainer({
   }
 
   return (
-    <div ref={containerRef} className="flex h-full w-full flex-col overflow-hidden">
+    <div ref={setContainerRef} className="flex h-full w-full flex-col overflow-hidden">
       <PanelVisibilityContext.Provider value={visibilityValue}>
         <DockviewReact
           theme={browserTabTheme}

--- a/apps/web/src/components/DockviewChatContainer.tsx
+++ b/apps/web/src/components/DockviewChatContainer.tsx
@@ -12,6 +12,7 @@ import {
 import { Columns2, Plus, Rows2, X } from "lucide-react";
 import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { AgentIcon, type ChatInsertDetail, useAdapter } from "@/dashboard";
+import { useAppShortcut } from "../hooks/useAppShortcut";
 import { writeClipboardText } from "../lib/clipboard";
 import {
   attachEdgeGroupDragVisibility,
@@ -24,6 +25,7 @@ import {
   cycleTabsInActiveGroup,
   selectNeighbourBeforeRemove,
 } from "../lib/dockview-section-actions";
+import { DOCK_SHORTCUTS } from "../lib/shortcuts";
 import { trpc } from "../lib/trpc-client";
 import { ChatPane, type CodingAgentDef, useChatPaneState } from "./ChatPane";
 import { PanelVisibilityContext, usePanelVisibility } from "./panel-visibility-context";
@@ -800,8 +802,8 @@ export function DockviewChatContainer({
       api.removePanel(panel);
     }
 
-    // Re-focus the panel content so the section-scoped keydown handler keeps
-    // seeing events on the next press.
+    // Re-focus the panel content so focus stays inside this container and the
+    // section-scoped shortcuts keep firing on the next press.
     requestAnimationFrame(() => {
       apiRef.current?.activeGroup?.model.focusContent();
     });
@@ -816,94 +818,197 @@ export function DockviewChatContainer({
     // Layout change listeners will auto-persist
   }, []);
 
-  // Keyboard shortcuts (capture phase, scoped to this section's focus):
-  // - Cmd/Ctrl+T              → open a new chat tab (default coding agent)
-  // - Cmd/Ctrl+W              → close the active chat tab
-  // - Cmd/Ctrl+D              → split right (vertical split)
-  // - Cmd/Ctrl+Shift+D        → split down (horizontal split)
-  // - Ctrl+(Shift)+Tab        → cycle tabs in the active group
-  // - Cmd/Ctrl+[ / Cmd/Ctrl+] → cycle between split chat groups (panels)
-  // - Cmd/Ctrl+Shift+[/]      → cycle tabs in the active group
-  useEffect(() => {
-    if (!visible) return;
+  // Keyboard shortcuts, scoped to this section's focus:
+  // - Cmd+T              → open a new chat tab (default coding agent)
+  // - Cmd+W              → close the active chat tab
+  // - Cmd+D              → split right (vertical split)
+  // - Cmd+Shift+D        → split down (horizontal split)
+  // - Ctrl+(Shift)+Tab   → cycle tabs in the active group
+  // - Cmd+[ / Cmd+]      → cycle between split chat groups (panels)
+  // - Cmd+Shift+[/]      → cycle tabs in the active group
+  //
+  // Combos come from `DOCK_SHORTCUTS` (the chat, terminal, browser and file-tab
+  // docks all bind the same set), and the scoping that used to be a hand-written
+  // `containerRef.contains(document.activeElement)` check inside a window-level
+  // capture listener is now `react-hotkeys-hook`'s returned ref: each binding
+  // listens on this container's root element, so it only fires while that
+  // element or a descendant holds focus and the innermost focused dock wins.
+  // `useAppShortcut` supplies capture-phase listening, form-tag /
+  // contentEditable enablement and `preventDefault`.
+  //
+  // `stopPropagation` is still called by hand in every branch that acts: the
+  // listener sits above the chat prompt in the capture path, and swallowing the
+  // event there is what keeps the chord out of the focused input.
+  const focusActiveGroupContent = useCallback(() => {
+    apiRef.current?.activeGroup?.model.focusContent();
+  }, []);
 
-    const cycleTabs = (direction: 1 | -1) => {
-      cycleTabsInActiveGroup(apiRef.current, direction, () => {
-        apiRef.current?.activeGroup?.model.focusContent();
-      });
-    };
+  const cycleTabs = useCallback(
+    (direction: 1 | -1) => {
+      cycleTabsInActiveGroup(apiRef.current, direction, focusActiveGroupContent);
+    },
+    [focusActiveGroupContent],
+  );
 
-    const cycleGroups = (direction: 1 | -1) => {
-      cycleGridGroups(apiRef.current, direction, () => {
-        apiRef.current?.activeGroup?.model.focusContent();
-      });
-    };
+  const cycleGroups = useCallback(
+    (direction: 1 | -1) => {
+      cycleGridGroups(apiRef.current, direction, focusActiveGroupContent);
+    },
+    [focusActiveGroupContent],
+  );
 
-    const handler = (e: KeyboardEvent) => {
-      // Only handle shortcut if this container (or a descendant) has focus
-      if (!containerRef.current?.contains(document.activeElement)) return;
+  // Bindings are only live while the section is visible — same gate the
+  // effect-based handler applied before registering its listener.
+  const shortcutOptions = { enabled: visible };
 
-      const key = e.key.toLowerCase();
+  const cycleForwardRef = useAppShortcut(
+    DOCK_SHORTCUTS.cycleTabForward,
+    (e) => {
+      e.stopPropagation();
+      cycleTabs(1);
+    },
+    shortcutOptions,
+    [cycleTabs, visible],
+  );
+  const cycleBackwardRef = useAppShortcut(
+    DOCK_SHORTCUTS.cycleTabBackward,
+    (e) => {
+      e.stopPropagation();
+      cycleTabs(-1);
+    },
+    shortcutOptions,
+    [cycleTabs, visible],
+  );
+  const nextTabRef = useAppShortcut(
+    DOCK_SHORTCUTS.nextTab,
+    (e) => {
+      e.stopPropagation();
+      cycleTabs(1);
+    },
+    shortcutOptions,
+    [cycleTabs, visible],
+  );
+  const previousTabRef = useAppShortcut(
+    DOCK_SHORTCUTS.previousTab,
+    (e) => {
+      e.stopPropagation();
+      cycleTabs(-1);
+    },
+    shortcutOptions,
+    [cycleTabs, visible],
+  );
+  const nextGroupRef = useAppShortcut(
+    DOCK_SHORTCUTS.nextGroup,
+    (e) => {
+      e.stopPropagation();
+      cycleGroups(1);
+    },
+    shortcutOptions,
+    [cycleGroups, visible],
+  );
+  const previousGroupRef = useAppShortcut(
+    DOCK_SHORTCUTS.previousGroup,
+    (e) => {
+      e.stopPropagation();
+      cycleGroups(-1);
+    },
+    shortcutOptions,
+    [cycleGroups, visible],
+  );
 
-      // Ctrl+(Shift)+Tab → cycle tabs within the active group
-      if (e.ctrlKey && !e.metaKey && key === "tab") {
-        e.preventDefault();
-        e.stopPropagation();
-        cycleTabs(e.shiftKey ? -1 : 1);
-        return;
+  const newTabRef = useAppShortcut(
+    DOCK_SHORTCUTS.newTab,
+    (e) => {
+      e.stopPropagation();
+      handleAddTab();
+    },
+    shortcutOptions,
+    [handleAddTab, visible],
+  );
+
+  // ⌘W closes only while more than one tab is open, and `preventDefault` is
+  // deliberately conditional on that: on the last tab the keystroke has to stay
+  // untouched so Electron's menu can still close the window.
+  const closeTabRef = useAppShortcut(
+    DOCK_SHORTCUTS.closeTab,
+    (e) => {
+      const api = apiRef.current;
+      if (!api || api.panels.length <= 1) return;
+      e.preventDefault();
+      e.stopPropagation();
+      const active = api.activePanel;
+      if (active) {
+        closeTab(active.id);
       }
+    },
+    { ...shortcutOptions, preventDefault: false },
+    [closeTab, visible],
+  );
 
-      const mod = e.metaKey || e.ctrlKey;
-      if (!mod) return;
+  const splitRightRef = useAppShortcut(
+    DOCK_SHORTCUTS.splitRight,
+    (e) => {
+      e.stopPropagation();
+      const activeGroup = apiRef.current?.activeGroup;
+      if (!activeGroup) return;
+      handleSplit(activeGroup.id, "right");
+    },
+    shortcutOptions,
+    [handleSplit, visible],
+  );
+  const splitDownRef = useAppShortcut(
+    DOCK_SHORTCUTS.splitDown,
+    (e) => {
+      e.stopPropagation();
+      const activeGroup = apiRef.current?.activeGroup;
+      if (!activeGroup) return;
+      handleSplit(activeGroup.id, "below");
+    },
+    shortcutOptions,
+    [handleSplit, visible],
+  );
 
-      // Cmd/Ctrl+Shift+[ / Cmd/Ctrl+Shift+] → cycle tabs in active group
-      if (e.shiftKey && (key === "[" || key === "]")) {
-        e.preventDefault();
-        e.stopPropagation();
-        cycleTabs(key === "]" ? 1 : -1);
-        return;
+  // All ten bindings scope to the same root element, so their ref callbacks are
+  // fanned out through one composed callback. The library's setters are stable,
+  // so listing them as deps keeps this callback stable too — an unstable ref
+  // callback would detach and re-attach (and re-register every listener) on
+  // every render.
+  const setContainerRef = useCallback(
+    (element: HTMLDivElement | null) => {
+      containerRef.current = element;
+      for (const attach of [
+        cycleForwardRef,
+        cycleBackwardRef,
+        nextTabRef,
+        previousTabRef,
+        nextGroupRef,
+        previousGroupRef,
+        newTabRef,
+        closeTabRef,
+        splitRightRef,
+        splitDownRef,
+      ]) {
+        attach(element);
       }
-
-      // Cmd/Ctrl+[ / Cmd/Ctrl+] → cycle between split groups (panels)
-      if (!e.shiftKey && (key === "[" || key === "]")) {
-        e.preventDefault();
-        e.stopPropagation();
-        cycleGroups(key === "]" ? 1 : -1);
-        return;
-      }
-
-      if (key === "t" && !e.shiftKey) {
-        e.preventDefault();
-        e.stopPropagation();
-        handleAddTab();
-      } else if (key === "w" && !e.shiftKey) {
-        const api = apiRef.current;
-        if (!api || api.panels.length <= 1) return;
-        e.preventDefault();
-        e.stopPropagation();
-        const active = api.activePanel;
-        if (active) {
-          closeTab(active.id);
-        }
-      } else if (key === "d") {
-        e.preventDefault();
-        e.stopPropagation();
-        const api = apiRef.current;
-        if (!api) return;
-        const activeGroup = api.activeGroup;
-        if (!activeGroup) return;
-        const direction = e.shiftKey ? "below" : "right";
-        handleSplit(activeGroup.id, direction);
-      }
-    };
-    window.addEventListener("keydown", handler, true);
-    return () => window.removeEventListener("keydown", handler, true);
-  }, [visible, closeTab, handleSplit, handleAddTab]);
+    },
+    [
+      cycleForwardRef,
+      cycleBackwardRef,
+      nextTabRef,
+      previousTabRef,
+      nextGroupRef,
+      previousGroupRef,
+      newTabRef,
+      closeTabRef,
+      splitRightRef,
+      splitDownRef,
+    ],
+  );
 
   // Auto-focus the active chat panel whenever the section becomes visible
   // (e.g. user clicked the outer "Chat" panel tab) so the section-scoped
-  // keydown handler above starts seeing events without the user having to
-  // click into a tab first.
+  // shortcuts above start firing without the user having to click into a tab
+  // first.
   useEffect(() => {
     if (!visible) return;
     const id = requestAnimationFrame(() => {
@@ -1128,7 +1233,7 @@ export function DockviewChatContainer({
   }
 
   return (
-    <div ref={containerRef} className="flex h-full w-full flex-col overflow-hidden">
+    <div ref={setContainerRef} className="flex h-full w-full flex-col overflow-hidden">
       <PanelVisibilityContext.Provider value={visibilityValue}>
         <DockviewReact
           theme={chatTabTheme}

--- a/apps/web/src/components/DockviewTerminalContainer.tsx
+++ b/apps/web/src/components/DockviewTerminalContainer.tsx
@@ -20,6 +20,7 @@ import React, {
   useState,
 } from "react";
 import { type TerminalInsertDetail, useAdapter } from "@/dashboard";
+import { useAppShortcut } from "../hooks/useAppShortcut";
 import {
   attachEdgeGroupDragVisibility,
   centralPanelPosition,
@@ -31,6 +32,7 @@ import {
   cycleTabsInActiveGroup,
   selectNeighbourBeforeRemove,
 } from "../lib/dockview-section-actions";
+import { DOCK_SHORTCUTS } from "../lib/shortcuts";
 import { disposeTerminal } from "../lib/terminal-cache";
 import { trpc } from "../lib/trpc-client";
 import { PanelVisibilityContext, usePanelVisibility } from "./panel-visibility-context";
@@ -540,135 +542,254 @@ export function DockviewTerminalContainer({
     });
   }, []);
 
-  // Keyboard shortcuts (capture phase, scoped to this section's focus).
-  // The outer modifier guard uses `mod = e.metaKey || e.ctrlKey`, so every
-  // shortcut that names `Cmd+X` below also fires for `Ctrl+X` — that's
-  // intentional for cross-platform support; readers should not assume
-  // platform-specific dispatch.
-  // - Cmd/Ctrl+T              → open a new terminal tab
-  // - Cmd/Ctrl+W              → close the active terminal tab
-  // - Ctrl+D                  → close the active terminal tab (Cmd owns split)
-  // - Cmd/Ctrl+D              → split right (vertical split)
-  // - Cmd/Ctrl+Shift+D        → split down (horizontal split)
-  // - Ctrl+(Shift)+Tab        → cycle tabs in the active group
-  // - Cmd/Ctrl+[ / Cmd/Ctrl+] → cycle between split terminal groups (panels)
-  // - Cmd/Ctrl+Shift+[/]      → cycle tabs in the active group
-  useEffect(() => {
-    if (!visible) return;
+  // Keyboard shortcuts, scoped to this section's focus:
+  // - Cmd+T              → open a new terminal tab
+  // - Cmd+W              → close the active terminal tab
+  // - Ctrl+D             → close the active terminal tab (Cmd owns split)
+  // - Cmd+D              → split right (vertical split)
+  // - Cmd+Shift+D        → split down (horizontal split)
+  // - Ctrl+(Shift)+Tab   → cycle tabs in the active group
+  // - Cmd+[ / Cmd+]      → cycle between split terminal groups (panels)
+  // - Cmd+Shift+[/]      → cycle tabs in the active group
+  //
+  // Combos come from `DOCK_SHORTCUTS`, shared with the chat, browser and
+  // file-tab docks. Scoping is `react-hotkeys-hook`'s returned ref rather than
+  // the hand-written `containerRef.contains(document.activeElement)` check that
+  // used to guard a window-level capture listener: each binding listens on this
+  // container's root, so it only fires while that element or a descendant holds
+  // focus. `useAppShortcut` supplies capture-phase listening, form-tag
+  // enablement (xterm's helper `<textarea>` is the usual focus target here) and
+  // `preventDefault`.
+  //
+  // `stopPropagation` is called by hand wherever the old handler called it: the
+  // listener sits above xterm in the capture path, and swallowing the event
+  // there is what keeps the chord from also reaching the shell.
+  const refocusActivePanel = useCallback(() => {
+    const panel = apiRef.current?.activePanel;
+    if (!panel) return;
+    panel.view.content.element
+      .querySelector<HTMLTextAreaElement>(".xterm-helper-textarea")
+      ?.focus();
+  }, []);
 
-    const refocusActivePanel = () => {
-      const panel = apiRef.current?.activePanel;
-      if (!panel) return;
-      panel.view.content.element
-        .querySelector<HTMLTextAreaElement>(".xterm-helper-textarea")
-        ?.focus();
-    };
-
-    const cycleTabs = (direction: 1 | -1) => {
+  const cycleTabs = useCallback(
+    (direction: 1 | -1) => {
       cycleTabsInActiveGroup(apiRef.current, direction, () => {
         requestAnimationFrame(refocusActivePanel);
       });
-    };
+    },
+    [refocusActivePanel],
+  );
 
-    const cycleGroups = (direction: 1 | -1) => {
+  const cycleGroups = useCallback(
+    (direction: 1 | -1) => {
       cycleGridGroups(apiRef.current, direction, () => {
         requestAnimationFrame(refocusActivePanel);
       });
-    };
+    },
+    [refocusActivePanel],
+  );
 
-    const handler = (e: KeyboardEvent) => {
-      // Only handle shortcut if this container (or a descendant) has focus
-      if (!containerRef.current?.contains(document.activeElement)) return;
+  // Try to close the active tab; returns whether the close path actually ran.
+  // Callers use the return value to decide whether to swallow the keystroke.
+  // When `false` (no tab to close), the caller must leave the event alone —
+  // Cmd+W on the last tab needs to reach Electron's menu so the window can
+  // close, and Ctrl+D on the last tab needs to reach xterm so the user's shell
+  // can receive EOF.
+  const tryCloseActiveTab = useCallback((): boolean => {
+    const api = apiRef.current;
+    if (!api || api.panels.length <= 1) return false;
+    const active = api.activePanel;
+    if (!active) return false;
+    closeTab(active.id);
+    return true;
+  }, [closeTab]);
 
-      const key = e.key.toLowerCase();
+  // Bindings are only live while the section is visible — same gate the
+  // effect-based handler applied before registering its listener.
+  const shortcutOptions = { enabled: visible };
 
-      // Ctrl+(Shift)+Tab → cycle tabs within the active group
-      if (e.ctrlKey && !e.metaKey && key === "tab") {
+  // ⌘ owns split here, Ctrl owns close, and the two are deliberately NOT
+  // interchangeable — unlike every other chord in this container. The guard
+  // reproduces the old `e.metaKey && !e.ctrlKey` test: `mod` alone would let
+  // Cmd+Ctrl+D split (react-hotkeys-hook stops checking Ctrl once `mod` is in
+  // the combo), and on Windows/Linux, where `mod` IS Ctrl, it would fire the
+  // split and the Ctrl+D close on the very same keystroke.
+  const SPLIT_IS_CMD_ONLY = {
+    ignoreEventWhen: (e: KeyboardEvent) => !e.metaKey || e.ctrlKey,
+  };
+
+  const cycleForwardRef = useAppShortcut(
+    DOCK_SHORTCUTS.cycleTabForward,
+    (e) => {
+      e.stopPropagation();
+      cycleTabs(1);
+    },
+    shortcutOptions,
+    [cycleTabs, visible],
+  );
+  const cycleBackwardRef = useAppShortcut(
+    DOCK_SHORTCUTS.cycleTabBackward,
+    (e) => {
+      e.stopPropagation();
+      cycleTabs(-1);
+    },
+    shortcutOptions,
+    [cycleTabs, visible],
+  );
+  const nextTabRef = useAppShortcut(
+    DOCK_SHORTCUTS.nextTab,
+    (e) => {
+      e.stopPropagation();
+      cycleTabs(1);
+    },
+    shortcutOptions,
+    [cycleTabs, visible],
+  );
+  const previousTabRef = useAppShortcut(
+    DOCK_SHORTCUTS.previousTab,
+    (e) => {
+      e.stopPropagation();
+      cycleTabs(-1);
+    },
+    shortcutOptions,
+    [cycleTabs, visible],
+  );
+  const nextGroupRef = useAppShortcut(
+    DOCK_SHORTCUTS.nextGroup,
+    (e) => {
+      e.stopPropagation();
+      cycleGroups(1);
+    },
+    shortcutOptions,
+    [cycleGroups, visible],
+  );
+  const previousGroupRef = useAppShortcut(
+    DOCK_SHORTCUTS.previousGroup,
+    (e) => {
+      e.stopPropagation();
+      cycleGroups(-1);
+    },
+    shortcutOptions,
+    [cycleGroups, visible],
+  );
+
+  const newTabRef = useAppShortcut(
+    DOCK_SHORTCUTS.newTab,
+    (e) => {
+      e.stopPropagation();
+      handleAddTab();
+    },
+    shortcutOptions,
+    [handleAddTab, visible],
+  );
+
+  // Conditional `preventDefault`: nothing to close → the keystroke is left
+  // untouched so the OS / Electron menu can handle Cmd+W (close window).
+  const closeTabRef = useAppShortcut(
+    DOCK_SHORTCUTS.closeTab,
+    (e) => {
+      if (tryCloseActiveTab()) {
         e.preventDefault();
         e.stopPropagation();
-        cycleTabs(e.shiftKey ? -1 : 1);
-        return;
       }
+    },
+    { ...shortcutOptions, preventDefault: false },
+    [tryCloseActiveTab, visible],
+  );
 
-      const mod = e.metaKey || e.ctrlKey;
-      if (!mod) return;
+  const splitRightRef = useAppShortcut(
+    DOCK_SHORTCUTS.splitRight,
+    (e) => {
+      e.stopPropagation();
+      const activeGroup = apiRef.current?.activeGroup;
+      if (!activeGroup) return;
+      handleSplit(activeGroup.id, "right");
+    },
+    { ...shortcutOptions, ...SPLIT_IS_CMD_ONLY },
+    [handleSplit, visible],
+  );
+  const splitDownRef = useAppShortcut(
+    DOCK_SHORTCUTS.splitDown,
+    (e) => {
+      e.stopPropagation();
+      const activeGroup = apiRef.current?.activeGroup;
+      if (!activeGroup) return;
+      handleSplit(activeGroup.id, "below");
+    },
+    { ...shortcutOptions, ...SPLIT_IS_CMD_ONLY },
+    [handleSplit, visible],
+  );
 
-      // Cmd/Ctrl+Shift+[ / Cmd/Ctrl+Shift+] → cycle tabs in active group
-      if (e.shiftKey && (key === "[" || key === "]")) {
+  // Ctrl+D closes the active tab, but only while more than one is open — on a
+  // lone terminal `tryCloseActiveTab` returns false and the conditional
+  // `preventDefault` lets the keystroke through to xterm so the user can exit
+  // their shell with EOF. No entry in `DOCK_SHORTCUTS` covers this: it is the
+  // one chord that is this dock's alone, because it exists to work around ⌘D
+  // already meaning split.
+  const closeTabCtrlDRef = useAppShortcut(
+    { binding: "ctrl+d", display: "Ctrl+D" },
+    (e) => {
+      if (tryCloseActiveTab()) {
         e.preventDefault();
         e.stopPropagation();
-        cycleTabs(key === "]" ? 1 : -1);
-        return;
       }
+    },
+    { ...shortcutOptions, preventDefault: false },
+    [tryCloseActiveTab, visible],
+  );
 
-      // Cmd/Ctrl+[ / Cmd/Ctrl+] → cycle between split groups (panels)
-      if (!e.shiftKey && (key === "[" || key === "]")) {
-        e.preventDefault();
-        e.stopPropagation();
-        cycleGroups(key === "]" ? 1 : -1);
-        return;
+  // The modifier-d combos that neither split nor close (Ctrl+Shift+D,
+  // Cmd+Ctrl+D, Cmd+Ctrl+Shift+D) are swallowed rather than ignored: xterm
+  // turns every Ctrl+D spelling into a `^D`, and letting one leak would kill
+  // the user's shell on a chord that visibly did nothing.
+  const swallowStrayDRef = useAppShortcut(
+    { binding: "ctrl+shift+d, meta+ctrl+d, meta+ctrl+shift+d", display: "Ctrl+Shift+D" },
+    (e) => e.stopPropagation(),
+    shortcutOptions,
+    [visible],
+  );
+
+  // All bindings scope to the same root element, so their ref callbacks are
+  // fanned out through one composed callback. The library's setters are stable,
+  // so listing them as deps keeps this callback stable too — an unstable ref
+  // callback would detach and re-attach (and re-register every listener) on
+  // every render.
+  const setContainerRef = useCallback(
+    (element: HTMLDivElement | null) => {
+      containerRef.current = element;
+      for (const attach of [
+        cycleForwardRef,
+        cycleBackwardRef,
+        nextTabRef,
+        previousTabRef,
+        nextGroupRef,
+        previousGroupRef,
+        newTabRef,
+        closeTabRef,
+        splitRightRef,
+        splitDownRef,
+        closeTabCtrlDRef,
+        swallowStrayDRef,
+      ]) {
+        attach(element);
       }
-
-      // Try to close the active tab; returns whether the close path actually
-      // ran. Callers use the return value to decide whether to swallow the
-      // keystroke. When `false` (no tab to close), the caller should let the
-      // event bubble — Cmd+W on the last tab needs to reach Electron's menu
-      // so the window can close, and Ctrl+D on the last tab needs to reach
-      // xterm so the user's shell can receive EOF.
-      const tryCloseActiveTab = (): boolean => {
-        const api = apiRef.current;
-        if (!api || api.panels.length <= 1) return false;
-        const active = api.activePanel;
-        if (!active) return false;
-        closeTab(active.id);
-        return true;
-      };
-
-      if (key === "t" && !e.shiftKey) {
-        e.preventDefault();
-        e.stopPropagation();
-        handleAddTab();
-      } else if (key === "w" && !e.shiftKey) {
-        // Don't preventDefault when there's nothing to close — let the OS /
-        // Electron menu handle Cmd+W (close window) and let plain Ctrl+W
-        // bubble up.
-        if (tryCloseActiveTab()) {
-          e.preventDefault();
-          e.stopPropagation();
-        }
-      } else if (key === "d") {
-        // Cmd+D / Cmd+Shift+D → split. Ctrl+D → close active tab (Cmd already
-        // owns split, so reuse Ctrl+D for close).
-        //
-        // For the SPLIT branch we always `preventDefault` so unhandled
-        // modifier-d combos that fall through (e.g. Ctrl+Shift+D, Cmd+Ctrl+D)
-        // don't leak a stray `^D` to xterm.
-        //
-        // For the CLOSE branch we conditionally preventDefault — on the last
-        // terminal tab `tryCloseActiveTab` returns false and we let Ctrl+D
-        // through to xterm so the user can exit their shell with EOF.
-        if (e.metaKey && !e.ctrlKey) {
-          e.preventDefault();
-          e.stopPropagation();
-          const activeGroup = apiRef.current?.activeGroup;
-          if (!activeGroup) return;
-          handleSplit(activeGroup.id, e.shiftKey ? "below" : "right");
-        } else if (e.ctrlKey && !e.metaKey && !e.shiftKey) {
-          if (tryCloseActiveTab()) {
-            e.preventDefault();
-            e.stopPropagation();
-          }
-        } else {
-          // Any other modifier-d combo (e.g. Ctrl+Shift+D, Cmd+Ctrl+D):
-          // swallow so xterm doesn't see a stray `^D`. No close, no split.
-          e.preventDefault();
-          e.stopPropagation();
-        }
-      }
-    };
-    window.addEventListener("keydown", handler, true);
-    return () => window.removeEventListener("keydown", handler, true);
-  }, [visible, closeTab, handleSplit, handleAddTab]);
+    },
+    [
+      cycleForwardRef,
+      cycleBackwardRef,
+      nextTabRef,
+      previousTabRef,
+      nextGroupRef,
+      previousGroupRef,
+      newTabRef,
+      closeTabRef,
+      splitRightRef,
+      splitDownRef,
+      closeTabCtrlDRef,
+      swallowStrayDRef,
+    ],
+  );
 
   // Force a synchronous re-layout of the inner dockview when the outer
   // Terminal panel becomes visible. Background: dockview-core's
@@ -746,8 +867,8 @@ export function DockviewTerminalContainer({
 
   // Auto-focus the active terminal's xterm textarea whenever the section
   // becomes visible (e.g. user clicked the outer "Terminal" panel tab).
-  // Without this, the section-scoped keydown handler above bails out because
-  // document.activeElement is outside containerRef — meaning shortcuts only
+  // Without this, the section-scoped shortcuts above never fire because
+  // document.activeElement is outside this container — meaning they only
   // worked after the user manually clicked into a tab.
   useEffect(() => {
     if (!visible) return;
@@ -984,7 +1105,7 @@ export function DockviewTerminalContainer({
   }
 
   return (
-    <div ref={containerRef} className="flex h-full w-full flex-col overflow-hidden">
+    <div ref={setContainerRef} className="flex h-full w-full flex-col overflow-hidden">
       <PanelVisibilityContext.Provider value={visibilityValue}>
         <DockviewReact
           theme={terminalTabTheme}

--- a/apps/web/src/components/SharedDockviewLayout.tsx
+++ b/apps/web/src/components/SharedDockviewLayout.tsx
@@ -34,6 +34,7 @@ import {
   useSettingsQuery,
   WorkspacePickerDialog,
 } from "@/dashboard";
+import { isTerminalOriginatedEvent, useAppShortcut } from "../hooks/useAppShortcut";
 import { useRecentFiles } from "../hooks/useRecentFiles";
 import { invoke as desktopInvoke } from "../lib/desktop-ipc";
 import {
@@ -54,6 +55,7 @@ import {
 } from "../lib/dockview-edge-groups";
 import { isDesktop } from "../lib/is-desktop";
 import { parseWorkspaceFromPath } from "../lib/parse-workspace";
+import { GLOBAL_SHORTCUTS } from "../lib/shortcuts";
 import { trpc } from "../lib/trpc-client";
 import { CodeBrowserView } from "./CodeBrowserView";
 import { DockviewChatContainer } from "./DockviewChatContainer";
@@ -1011,219 +1013,236 @@ export function SharedDockviewLayout() {
   // Global keyboard shortcuts
   // ---------------------------------------------------------------------
 
-  useEffect(() => {
-    const handler = (e: KeyboardEvent) => {
+  // Every global shortcut below is bound through `useAppShortcut`, which
+  // supplies the defaults the old hand-rolled handler implemented inline:
+  // capture-phase listening (so a focused xterm can't swallow the chord),
+  // firing inside form fields / contentEditable, `preventDefault`, and
+  // character-vs-physical key matching per the combo's `useKey`. Combos come
+  // from `GLOBAL_SHORTCUTS` so the command palette advertises exactly what is
+  // bound here. See `apps/web/src/hooks/useAppShortcut.ts`.
+  //
+  // What the wrapper does NOT supply is `stopPropagation` — the library never
+  // calls it. The three chords below stop propagation by hand because they can
+  // fire while a terminal is focused, and without it the keystroke goes on to
+  // reach xterm's own keydown listener and leaks into the shell.
+  //
+  // `TERMINAL_YIELDS` is the shell-key bail: a chord reached via Ctrl defers to
+  // a focused terminal (Ctrl+K is kill-to-end-of-line, Ctrl+D is EOF), while the
+  // same chord reached via ⌘ still fires. On Windows/Linux, where `mod` IS Ctrl,
+  // that means these deliberately yield to the shell — preserved from the
+  // `terminalFocused && !e.metaKey` gate this replaces.
+  const TERMINAL_YIELDS = {
+    ignoreEventWhen: (e: KeyboardEvent) => isTerminalOriginatedEvent(e) && !e.metaKey,
+  };
+
+  // ⌘K → workspace picker. Fires even while a terminal is focused (a
+  // long-standing request); the Ctrl+K spelling on other platforms still yields
+  // to xterm via `TERMINAL_YIELDS`.
+  useAppShortcut(
+    GLOBAL_SHORTCUTS.workspacePicker,
+    (e) => {
+      e.stopPropagation();
+      setWorkspacePickerOpen(true);
+    },
+    { ...TERMINAL_YIELDS },
+  );
+
+  // Ctrl+` → Terminal panel.
+  useAppShortcut(GLOBAL_SHORTCUTS.showTerminal, (e) => {
+    e.stopPropagation();
+    if (hiddenPanelsRef.current.includes("terminal")) return;
+    apiRef.current?.getPanel("terminal")?.api.setActive();
+    queueMicrotask(() => {
+      window.dispatchEvent(new CustomEvent("band:focus-terminal"));
+    });
+  });
+
+  // Ctrl+0 → reveal the project-list sidebar and focus it. The sidebar lives
+  // outside the dockview, so we reveal it via the `band:show-sidebar` window
+  // event and let the sidebar's `band:focus-projects` listener move keyboard
+  // focus into the list.
+  useAppShortcut(GLOBAL_SHORTCUTS.focusProjects, (e) => {
+    e.stopPropagation();
+    window.dispatchEvent(new CustomEvent("band:show-sidebar"));
+    queueMicrotask(() => {
+      window.dispatchEvent(new CustomEvent("band:focus-projects"));
+    });
+  });
+
+  // ⇧⌥F → Format Current File (VS Code parity). The only binding with no mod
+  // key in the chord. `useKey: false` matches on the physical key so the macOS
+  // Option-layer dead-key (⌥F → "ƒ") doesn't swallow it — the reason the old
+  // branch tested `e.code` rather than `e.key`.
+  useAppShortcut(
+    GLOBAL_SHORTCUTS.formatCurrentFile,
+    () => {
       const ws = activeWorkspaceIdRef.current;
-      const terminalFocused = document.activeElement?.closest(".xterm") != null;
+      if (!ws) return;
+      window.dispatchEvent(
+        new CustomEvent("band:format-current-file", {
+          detail: { workspaceId: ws, filePath: currentFileRef.current },
+        }),
+      );
+    },
+    { useKey: false, ignoreEventWhen: isTerminalOriginatedEvent },
+  );
 
-      // ⌘K → workspace picker. We deliberately omit the `terminalFocused`
-      // guard here so the picker opens even while a terminal is focused
-      // (long-standing complaint) — preventDefault/stopPropagation keep the
-      // keystroke from leaking into xterm. (The Ctrl+K branch below DOES bail
-      // on a focused terminal, since Ctrl+K is a terminal editing key.)
-      if (e.metaKey && !e.ctrlKey && !e.shiftKey && e.key.toLowerCase() === "k") {
-        e.preventDefault();
-        e.stopPropagation();
-        setWorkspacePickerOpen(true);
-        return;
-      }
+  useAppShortcut(
+    GLOBAL_SHORTCUTS.newChatSession,
+    () => window.dispatchEvent(new CustomEvent("band:new-chat-session")),
+    { ...TERMINAL_YIELDS },
+  );
 
-      // Ctrl+K → workspace picker on non-macOS. `SharedDockviewLayout` also
-      // mounts for wide-viewport web users on Windows/Linux, where ⌘ doesn't
-      // exist and Ctrl is the platform-native modifier. Unlike the ⌘ branch we
-      // DO bail when the terminal is focused: Ctrl+K is "kill to end of line"
-      // in most shells, so hijacking it inside xterm would break a common
-      // editing keystroke.
-      if (e.ctrlKey && !e.metaKey && !e.shiftKey && e.key.toLowerCase() === "k") {
-        if (terminalFocused) return;
-        e.preventDefault();
-        e.stopPropagation();
-        setWorkspacePickerOpen(true);
-        return;
-      }
+  useAppShortcut(
+    GLOBAL_SHORTCUTS.newUntitledTab,
+    () => window.dispatchEvent(new CustomEvent("band:new-untitled-tab")),
+    { ...TERMINAL_YIELDS },
+  );
 
-      // Ctrl+` → Terminal panel
-      if (e.ctrlKey && !e.metaKey && e.key === "`") {
-        e.preventDefault();
-        e.stopPropagation();
-        if (!hiddenPanelsRef.current.includes("terminal")) {
-          apiRef.current?.getPanel("terminal")?.api.setActive();
-          queueMicrotask(() => {
-            window.dispatchEvent(new CustomEvent("band:focus-terminal"));
-          });
-        }
-        return;
-      }
+  useAppShortcut(GLOBAL_SHORTCUTS.commandPalette, () => setCommandPaletteOpen(true), {
+    ...TERMINAL_YIELDS,
+  });
 
-      // Ctrl+0 → reveal the project-list sidebar and focus it. The sidebar
-      // lives outside the dockview now, so we reveal it via the
-      // `band:show-sidebar` window event and let the sidebar's
-      // `band:focus-projects` listener move keyboard focus into the list.
-      if (e.ctrlKey && !e.metaKey && e.key === "0") {
-        e.preventDefault();
-        e.stopPropagation();
-        window.dispatchEvent(new CustomEvent("band:show-sidebar"));
-        queueMicrotask(() => {
-          window.dispatchEvent(new CustomEvent("band:focus-projects"));
-        });
-        return;
-      }
+  useAppShortcut(GLOBAL_SHORTCUTS.quickOpen, () => setQuickOpenOpen(true), { ...TERMINAL_YIELDS });
 
-      // ⇧⌥F → Format Current File (matches VS Code; uses e.code so the
-      // macOS Option-layer dead-key doesn't swallow the keystroke).
-      if (e.code === "KeyF" && e.altKey && e.shiftKey && !e.metaKey && !e.ctrlKey) {
-        if (terminalFocused) return;
-        e.preventDefault();
-        if (!ws) return;
-        const filePath = currentFileRef.current;
-        window.dispatchEvent(
-          new CustomEvent("band:format-current-file", {
-            detail: { workspaceId: ws, filePath },
-          }),
-        );
-        return;
-      }
+  useAppShortcut(GLOBAL_SHORTCUTS.searchFiles, () => setSearchFilesOpen(true), {
+    ...TERMINAL_YIELDS,
+  });
 
-      const mod = e.metaKey || e.ctrlKey;
-      if (!mod) return;
-      if (terminalFocused && !e.metaKey) return;
+  // ⌘F → Find in File. Prefers the active editor's registered handler; falls
+  // back to the broadcast event when no editor has registered one.
+  useAppShortcut(
+    GLOBAL_SHORTCUTS.findInFile,
+    () => {
+      const ws = activeWorkspaceIdRef.current;
+      const fn = ws ? findInFileRegistry.current.get(ws) : undefined;
+      if (fn) fn();
+      else window.dispatchEvent(new CustomEvent("band:find-in-file"));
+    },
+    { ...TERMINAL_YIELDS },
+  );
 
+  // ⌘O → Open File… The actual picker invocation lives in CodeBrowserView and
+  // is gated by `capabilities.pickFile`, so the event is a no-op in the plain
+  // web build — `preventDefault` still suppresses the browser's own ⌘O.
+  //
+  // Addressed to the active workspace: the per-panel content cache keeps
+  // multiple CodeBrowserView instances alive at once, and an undelimited
+  // broadcast would race every cached instance into opening its own picker (the
+  // file landed in the wrong workspace). Same shape as
+  // `band:format-current-file`.
+  useAppShortcut(
+    GLOBAL_SHORTCUTS.openFile,
+    () => {
+      const ws = activeWorkspaceIdRef.current;
+      if (!ws) return;
+      window.dispatchEvent(
+        new CustomEvent("band:open-file-external", { detail: { workspaceId: ws } }),
+      );
+    },
+    { ...TERMINAL_YIELDS },
+  );
+
+  // Panel activation. Each one no-ops when its panel is hidden, then hands
+  // focus to the panel via a `band:focus-*` event on the next microtask (after
+  // dockview has committed the activation).
+  const activatePanel = (panelId: string, focusEvent: string) => () => {
+    if (hiddenPanelsRef.current.includes(panelId)) return;
+    apiRef.current?.getPanel(panelId)?.api.setActive();
+    queueMicrotask(() => {
+      window.dispatchEvent(new CustomEvent(focusEvent));
+    });
+  };
+
+  useAppShortcut(GLOBAL_SHORTCUTS.showChat, activatePanel("chat", "band:focus-chat"), {
+    ...TERMINAL_YIELDS,
+  });
+  useAppShortcut(GLOBAL_SHORTCUTS.showChanges, activatePanel("changes", "band:focus-changes"), {
+    ...TERMINAL_YIELDS,
+  });
+  useAppShortcut(GLOBAL_SHORTCUTS.showFiles, activatePanel("files", "band:focus-files"), {
+    ...TERMINAL_YIELDS,
+  });
+  useAppShortcut(GLOBAL_SHORTCUTS.showBrowser, activatePanel("browser", "band:focus-browser"), {
+    ...TERMINAL_YIELDS,
+  });
+
+  // ⌘B → toggle the project-list sidebar. Unconditional: unlike its two
+  // siblings below it does NOT resolve its target by focus. A shortcut that
+  // means different things depending on invisible focus state is hard to trust,
+  // and the sidebar is overwhelmingly the intended target. The cost is that an
+  // inner dockview's LEFT edge has no keyboard toggle — if that turns out to
+  // matter it gets its own combo rather than focus-dependence here.
+  useAppShortcut(
+    GLOBAL_SHORTCUTS.toggleSidebar,
+    () => window.dispatchEvent(new CustomEvent("band:toggle-sidebar")),
+    { ...TERMINAL_YIELDS },
+  );
+
+  // ⌥⌘B → toggle the RIGHT edge, focus-aware: when an inner dockview (terminal /
+  // chat / browser) holds focus and has panels on that edge, toggle its edge;
+  // otherwise fall through to the main layout's. The fallthrough is driven by
+  // `toggleEdgeGroup`'s return value (`true` when it acted on a non-empty edge),
+  // so empty inner edges delegate transparently. See `dockview-edge-groups.ts`
+  // for the registry behind the focus lookup.
+  //
+  // `useKey: false` matches the physical key: macOS substitutes Alt-layer
+  // characters into `e.key` (⌥B → "∫"), which is why the handler this replaces
+  // tested `e.code`.
+  useAppShortcut(
+    GLOBAL_SHORTCUTS.toggleRightEdge,
+    () => {
       const api = apiRef.current;
-      const key = e.key.toLowerCase();
+      if (!api) return;
+      const inner = findFocusedInnerDockview();
+      if (inner && toggleEdgeGroup(inner, "right")) return;
+      toggleEdgeGroup(api, "right");
+    },
+    { ...TERMINAL_YIELDS, useKey: false },
+  );
 
-      if (key === "n" && e.shiftKey) {
-        e.preventDefault();
-        window.dispatchEvent(new CustomEvent("band:new-chat-session"));
-      } else if (key === "n" && !e.shiftKey && !e.altKey) {
-        // ⌘N → New Untitled File
-        e.preventDefault();
-        window.dispatchEvent(new CustomEvent("band:new-untitled-tab"));
-      } else if (key === "p" && e.shiftKey) {
-        e.preventDefault();
-        setCommandPaletteOpen(true);
-      } else if (key === "p" && !e.shiftKey) {
-        e.preventDefault();
-        setQuickOpenOpen(true);
-      } else if (key === "f" && e.shiftKey && !e.altKey) {
-        e.preventDefault();
-        setSearchFilesOpen(true);
-      } else if (key === "f" && !e.shiftKey && !e.altKey) {
-        e.preventDefault();
-        const fn = ws ? findInFileRegistry.current.get(ws) : undefined;
-        if (fn) {
-          fn();
-        } else {
-          window.dispatchEvent(new CustomEvent("band:find-in-file"));
-        }
-      } else if (key === "o" && !e.shiftKey && !e.altKey) {
-        // ⌘O → Open File… The actual picker invocation lives in
-        // CodeBrowserView and is gated by `capabilities.pickFile`, so
-        // the event is a no-op in the plain web build — preventDefault
-        // here still suppresses the browser's own Cmd+O.
-        //
-        // Address the event to the active workspace: the per-panel
-        // content cache keeps multiple CodeBrowserView instances alive
-        // at once, and an undelimited broadcast would race every
-        // cached instance to open its own picker (the file landed in
-        // the wrong workspace). Same shape as `band:format-current-file`.
-        e.preventDefault();
-        if (!ws) return;
-        window.dispatchEvent(
-          new CustomEvent("band:open-file-external", {
-            detail: { workspaceId: ws },
-          }),
-        );
-      } else if (key === "i" && e.ctrlKey && e.metaKey && api) {
-        e.preventDefault();
-        if (!hiddenPanelsRef.current.includes("chat")) {
-          api.getPanel("chat")?.api.setActive();
-          queueMicrotask(() => {
-            window.dispatchEvent(new CustomEvent("band:focus-chat"));
-          });
-        }
-      } else if (key === "g" && e.shiftKey && api) {
-        e.preventDefault();
-        if (!hiddenPanelsRef.current.includes("changes")) {
-          api.getPanel("changes")?.api.setActive();
-          queueMicrotask(() => {
-            window.dispatchEvent(new CustomEvent("band:focus-changes"));
-          });
-        }
-      } else if (key === "e" && e.shiftKey && api) {
-        e.preventDefault();
-        if (!hiddenPanelsRef.current.includes("files")) {
-          api.getPanel("files")?.api.setActive();
-          queueMicrotask(() => {
-            window.dispatchEvent(new CustomEvent("band:focus-files"));
-          });
-        }
-      } else if (key === "b" && e.shiftKey && api) {
-        e.preventDefault();
-        if (!hiddenPanelsRef.current.includes("browser")) {
-          api.getPanel("browser")?.api.setActive();
-          queueMicrotask(() => {
-            window.dispatchEvent(new CustomEvent("band:focus-browser"));
-          });
-        }
-      } else if (key === "b" && !e.shiftKey && !e.altKey && api) {
-        // ⌘B → toggle the project-list sidebar. Focus-aware: if an inner
-        // dockview (terminal / chat / browser) is focused AND has panels on
-        // its left edge, toggle that inner edge; otherwise toggle the
-        // sidebar that lives outside the dockview, reached via the
-        // `band:toggle-sidebar` window event.
-        //
-        // The inner branch is driven by `toggleEdgeGroup`'s return value
-        // (`true` when it acted on a non-empty edge, `false` when there was
-        // nothing to act on) — so empty inner edges transparently delegate
-        // to the sidebar. See `dockview-edge-groups.ts` for the registry
-        // that makes the focus lookup possible.
-        e.preventDefault();
-        const inner = findFocusedInnerDockview();
-        if (inner && toggleEdgeGroup(inner, "left")) return;
-        window.dispatchEvent(new CustomEvent("band:toggle-sidebar"));
-      } else if (e.code === "KeyB" && e.altKey && !e.shiftKey && api) {
-        // ⌥⌘B → toggle RIGHT edge. Uses `e.code === "KeyB"` instead
-        // of `key === "b"` because macOS substitutes Alt-layer
-        // characters into `e.key` (Alt+B → "∫"), making the letter
-        // check unreliable when Alt is held. `e.code` is keyboard-
-        // layout independent and matches the pattern used by the
-        // ⇧⌥F format-current-file shortcut above.
-        e.preventDefault();
-        const inner = findFocusedInnerDockview();
-        if (inner && toggleEdgeGroup(inner, "right")) return;
-        toggleEdgeGroup(api, "right");
-      } else if (key === "j" && !e.shiftKey && !e.altKey && api) {
-        // ⌘J → toggle BOTTOM edge. Same focus-aware fallback as ⌘B.
-        // Unlike the ⌥⌘B branch above, this branch uses `key` instead
-        // of `e.code` — there's no Alt variant to disambiguate (⌥⌘J
-        // would produce "∆" in `e.key`, but the `!e.altKey` guard
-        // already excludes that case before the letter check runs).
-        e.preventDefault();
-        const inner = findFocusedInnerDockview();
-        if (inner && toggleEdgeGroup(inner, "bottom")) return;
-        toggleEdgeGroup(api, "bottom");
-      } else if (key === "m" && e.shiftKey && api) {
-        e.preventDefault();
-        const active = api.activeGroup;
-        if (!active) return;
-        if (active.api.location.type !== "grid") {
-          if (api.hasMaximizedGroup()) {
-            prepareMaximizeRestoreAnimation(containerRef.current);
-            api.exitMaximizedGroup();
-          }
-          return;
-        }
-        if (active.api.isMaximized()) {
+  // ⌘J → toggle the OUTERMOST layout's bottom edge, always. Like ⌘B (and unlike
+  // its ⌥⌘B sibling above) it does not consult focus: the bottom panel is a
+  // single shared surface in the user's mental model, so the chord that shows
+  // and hides it should mean one thing everywhere rather than retargeting to
+  // whichever inner dock happens to hold focus.
+  //
+  // `toggleEdgeGroup` already no-ops when that edge is absent or holds no
+  // panels, so "toggle it if there is one" needs no extra guard here.
+  useAppShortcut(
+    GLOBAL_SHORTCUTS.toggleBottomEdge,
+    () => {
+      const api = apiRef.current;
+      if (!api) return;
+      toggleEdgeGroup(api, "bottom");
+    },
+    { ...TERMINAL_YIELDS },
+  );
+
+  // ⇧⌘M → maximize / restore the active grid group. A non-grid (edge) group
+  // can't be maximized, so the shortcut only exits an existing maximize there.
+  useAppShortcut(
+    GLOBAL_SHORTCUTS.maximizePanel,
+    () => {
+      const api = apiRef.current;
+      const active = api?.activeGroup;
+      if (!api || !active) return;
+      if (active.api.location.type !== "grid") {
+        if (api.hasMaximizedGroup()) {
           prepareMaximizeRestoreAnimation(containerRef.current);
-          active.api.exitMaximized();
-        } else {
-          active.api.maximize();
+          api.exitMaximizedGroup();
         }
+        return;
       }
-    };
-    window.addEventListener("keydown", handler, true);
-    return () => window.removeEventListener("keydown", handler, true);
-  }, []);
+      if (active.api.isMaximized()) {
+        prepareMaximizeRestoreAnimation(containerRef.current);
+        active.api.exitMaximized();
+      } else {
+        active.api.maximize();
+      }
+    },
+    { ...TERMINAL_YIELDS },
+  );
 
   // Listen for file link clicks from chat messages → open Quick Open with query.
   //

--- a/apps/web/src/dashboard/components/DashboardShell.tsx
+++ b/apps/web/src/dashboard/components/DashboardShell.tsx
@@ -19,6 +19,8 @@ import {
 } from "@band-app/ui";
 import { Check, ChevronsDownUp, FolderPlus, Plus, Settings, Tag, X } from "lucide-react";
 import { type ReactNode, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useAppShortcut } from "@/hooks/useAppShortcut";
+import { LABEL_FILTER_SHORTCUT } from "@/lib/shortcuts";
 import { useCapabilities } from "../context";
 import { useAppUpdate } from "../hooks/use-app-update";
 import { useCliSetup } from "../hooks/use-cli-setup";
@@ -288,36 +290,41 @@ export function DashboardShell({ bottomActions, hideTitleBar }: DashboardShellPr
     return () => window.removeEventListener("band:focus-projects", handler);
   }, []);
 
-  // Keyboard shortcuts: Cmd+0 → all projects, Cmd+1..9 → nth label.
-  // Skips when focus is in an editable element so it doesn't hijack typing.
-  useEffect(() => {
-    const handler = (e: KeyboardEvent) => {
-      if (!(e.metaKey || e.ctrlKey) || e.altKey || e.shiftKey) return;
-      if (e.key < "0" || e.key > "9") return;
-
-      const target = e.target as HTMLElement | null;
-      if (target) {
-        const tag = target.tagName;
-        if (tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT" || target.isContentEditable) {
-          return;
-        }
-      }
-
-      const digit = Number(e.key);
+  // Label filter: ⌘0 → all projects, ⌘1..9 / Ctrl+1..9 → nth label.
+  //
+  // Unlike the global shortcuts in `SharedDockviewLayout`, these deliberately
+  // do NOT fire from inside a text field — ⌘1 while typing should stay a
+  // no-op — hence `enableOnFormTags: false`.
+  //
+  // ⌘0 is bound to ⌘ ONLY, while 1..9 accept either modifier. Ctrl+0 belongs to
+  // the global "Focus Projects" shortcut. That split is the existing behaviour,
+  // but it used to be an accident of listener ordering: Focus Projects ran in
+  // capture phase and called `stopPropagation()`, so this bubble-phase listener
+  // simply never saw Ctrl+0. Both are `useHotkeys` on `document` now, where
+  // registration order decides — far too fragile a thing to leave implicit, so
+  // the two shortcuts no longer contend for the same chord at all.
+  //
+  // `preventDefault: false` because the original only suppressed the browser's
+  // default when it actually applied a filter; a ⌘7 with only three labels
+  // defined must fall through untouched.
+  useAppShortcut(
+    LABEL_FILTER_SHORTCUT,
+    (event) => {
+      const digit = Number(event.key);
+      if (!Number.isInteger(digit)) return;
       if (digit === 0) {
-        e.preventDefault();
+        event.preventDefault();
         setLabelFilter(null);
         return;
       }
       const lbl = labels[digit - 1];
-      if (lbl) {
-        e.preventDefault();
-        setLabelFilter(lbl.id);
-      }
-    };
-    window.addEventListener("keydown", handler);
-    return () => window.removeEventListener("keydown", handler);
-  }, [labels, setLabelFilter]);
+      if (!lbl) return;
+      event.preventDefault();
+      setLabelFilter(lbl.id);
+    },
+    { enableOnFormTags: false, enableOnContentEditable: false, preventDefault: false },
+    [labels, setLabelFilter],
+  );
 
   return (
     <div

--- a/apps/web/src/dashboard/hooks/use-search.ts
+++ b/apps/web/src/dashboard/hooks/use-search.ts
@@ -1,5 +1,7 @@
 import type { EditorView } from "@codemirror/view";
 import { useCallback, useEffect, useRef, useState } from "react";
+import { useAppShortcut } from "@/hooks/useAppShortcut";
+import { GLOBAL_SHORTCUTS } from "@/lib/shortcuts";
 import type { SearchBarHandle, SearchOptions } from "../components/SearchBar";
 import {
   clearSearch,
@@ -171,19 +173,12 @@ export function useSearch({
     return () => onFindInFile?.(null);
   }, [onFindInFile, handleOpenSearch]);
 
-  // Direct Cmd+F / Ctrl+F handler so the search works even when
-  // the parent layout does not provide a FindInFileContext (e.g. desktop / mobile).
-  useEffect(() => {
-    const handler = (e: KeyboardEvent) => {
-      const mod = e.metaKey || e.ctrlKey;
-      if (mod && e.key.toLowerCase() === "f" && !e.shiftKey) {
-        e.preventDefault();
-        handleOpenSearch();
-      }
-    };
-    window.addEventListener("keydown", handler);
-    return () => window.removeEventListener("keydown", handler);
-  }, [handleOpenSearch]);
+  // Direct Cmd+F / Ctrl+F binding so the search works even when the parent
+  // layout does not provide a FindInFileContext (e.g. desktop / mobile). Shares
+  // the `findInFile` combo with the global binding in `SharedDockviewLayout`;
+  // that one prefers a registered per-workspace handler and only broadcasts as
+  // a fallback, so the two don't fight over the same keystroke.
+  useAppShortcut(GLOBAL_SHORTCUTS.findInFile, () => handleOpenSearch(), {}, [handleOpenSearch]);
 
   return {
     searchOpen,

--- a/apps/web/src/dashboard/lib/command-registry.ts
+++ b/apps/web/src/dashboard/lib/command-registry.ts
@@ -3,7 +3,14 @@
  *
  * All palette-visible commands are defined here so they can be referenced by
  * both the CommandPaletteDialog component and the keyboard shortcut handler.
+ *
+ * The `shortcut` strings are read from `GLOBAL_SHORTCUTS` rather than written
+ * out here. They used to be independent copies, so a rebinding could leave the
+ * palette advertising a combo that no longer did anything — the display string
+ * and the `useHotkeys` binding now come from the same record.
  */
+
+import { GLOBAL_SHORTCUTS } from "@/lib/shortcuts";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -130,13 +137,13 @@ export function buildCommands(deps: CommandRegistryDeps): PaletteCommand[] {
       // is one of the most discoverable in the app.
       id: "new-untitled-tab",
       label: "New Untitled File",
-      shortcut: "Cmd+N",
+      shortcut: GLOBAL_SHORTCUTS.newUntitledTab.display,
       action: () => deps.newUntitledTab(),
     },
     {
       id: "quick-open",
       label: "Quick Open",
-      shortcut: "Cmd+P",
+      shortcut: GLOBAL_SHORTCUTS.quickOpen.display,
       action: () => deps.openQuickOpen(),
     },
     {
@@ -146,13 +153,13 @@ export function buildCommands(deps: CommandRegistryDeps): PaletteCommand[] {
       // Current File lives at ⇧⌥F (also VS Code parity, see below).
       id: "search-files",
       label: "Search in Files",
-      shortcut: "Cmd+Shift+F",
+      shortcut: GLOBAL_SHORTCUTS.searchFiles.display,
       action: () => deps.openSearchFiles(),
     },
     {
       id: "find-in-file",
       label: "Find in File",
-      shortcut: "Cmd+F",
+      shortcut: GLOBAL_SHORTCUTS.findInFile.display,
       action: () => deps.findInFile(),
     },
     {
@@ -169,7 +176,7 @@ export function buildCommands(deps: CommandRegistryDeps): PaletteCommand[] {
       // gate so the keystroke reaches us in the first place.
       id: "format-current-file",
       label: "Format Current File",
-      shortcut: "Shift+Alt+F",
+      shortcut: GLOBAL_SHORTCUTS.formatCurrentFile.display,
       action: () => deps.formatCurrentFile(),
     },
     {
@@ -185,31 +192,31 @@ export function buildCommands(deps: CommandRegistryDeps): PaletteCommand[] {
     {
       id: "show-chat",
       label: "Show Chat",
-      shortcut: "Ctrl+Cmd+I",
+      shortcut: GLOBAL_SHORTCUTS.showChat.display,
       action: () => activatePanel(deps, "chat"),
     },
     {
       id: "show-changes",
       label: "Show Changes",
-      shortcut: "Cmd+Shift+G",
+      shortcut: GLOBAL_SHORTCUTS.showChanges.display,
       action: () => activatePanel(deps, "changes"),
     },
     {
       id: "show-terminal",
       label: "Show Terminal",
-      shortcut: "Ctrl+`",
+      shortcut: GLOBAL_SHORTCUTS.showTerminal.display,
       action: () => activatePanel(deps, "terminal"),
     },
     {
       id: "show-files",
       label: "Show Files",
-      shortcut: "Cmd+Shift+E",
+      shortcut: GLOBAL_SHORTCUTS.showFiles.display,
       action: () => activatePanel(deps, "files"),
     },
     {
       id: "show-browser",
       label: "Show Browser",
-      shortcut: "Cmd+Shift+B",
+      shortcut: GLOBAL_SHORTCUTS.showBrowser.display,
       action: () => activatePanel(deps, "browser"),
     },
     {
@@ -219,7 +226,7 @@ export function buildCommands(deps: CommandRegistryDeps): PaletteCommand[] {
       // `band:focus-projects` listener then focuses the list.
       id: "focus-projects",
       label: "Focus Projects",
-      shortcut: "Ctrl+0",
+      shortcut: GLOBAL_SHORTCUTS.focusProjects.display,
       action: () => {
         window.dispatchEvent(new CustomEvent("band:show-sidebar"));
         queueMicrotask(() => {

--- a/apps/web/src/hooks/useAppShortcut.ts
+++ b/apps/web/src/hooks/useAppShortcut.ts
@@ -1,0 +1,79 @@
+import { useHotkeys } from "react-hotkeys-hook";
+import type { ShortcutSpec } from "@/lib/shortcuts";
+
+/**
+ * Thin wrapper over `useHotkeys` carrying the defaults every Band shortcut
+ * needs. Four of them are load-bearing and easy to get wrong individually,
+ * which is why they live here rather than at each call site:
+ *
+ * 1. `enableOnFormTags` / `enableOnContentEditable` — the library skips events
+ *    originating in form fields by default. Band's two most common focus
+ *    targets are xterm's offscreen helper `<textarea>` and the chat prompt, so
+ *    the default would make every global shortcut dead exactly when the user is
+ *    doing something. The hand-rolled handler this replaces had no such
+ *    exclusion.
+ *
+ * 2. `capture: true` — the old handler bound on `window` in capture phase.
+ *    xterm calls `stopPropagation()` on the keys it consumes, so a bubble-phase
+ *    listener (the library's default) would never see them. Capture keeps the
+ *    app's chords winning over the terminal's, which is the current behaviour.
+ *
+ * 3. `preventDefault: true` — every branch of the old handler called
+ *    `e.preventDefault()`, suppressing the browser's own ⌘P / ⌘O / ⌘F.
+ *
+ * 4. `useKey` from the combo — the library matches the physical `event.code` by
+ *    default, so a punctuation binding written as its character (`` ` ``, `[`,
+ *    `=`) silently never fires. Carrying the choice on the spec means a call
+ *    site can't get it wrong. See `ShortcutSpec.useKey`.
+ *
+ * NOT supplied: `stopPropagation`. The library never calls it, so a chord that
+ * must not also reach xterm or an input has to call it in its own callback.
+ *
+ * Pass `enabled: false` to bind conditionally (desktop-only shortcuts), or
+ * `ignoreEventWhen` to add a bail on top — see `useGlobalShortcut` in
+ * `SharedDockviewLayout` for the terminal-focus case.
+ */
+export function useAppShortcut(
+  spec: ShortcutSpec,
+  callback: (event: KeyboardEvent) => void,
+  options: Parameters<typeof useHotkeys>[2] = {},
+  // Defaults to `undefined`, NOT `[]`. `useHotkeys` treats a present array like
+  // `useCallback(cb, deps)`, and an empty array is still present — so defaulting
+  // to `[]` would freeze every callback at its first render. Omitting the
+  // argument entirely keeps the handler current, which is the safe default;
+  // pass `[]` explicitly to opt into freezing.
+  deps?: unknown[],
+): ReturnType<typeof useHotkeys> {
+  return useHotkeys(
+    spec.binding,
+    callback,
+    {
+      enableOnFormTags: true,
+      enableOnContentEditable: true,
+      eventListenerOptions: { capture: true },
+      preventDefault: true,
+      // Character- vs physical-key matching travels with the combo (see
+      // `ShortcutSpec.useKey`) so a call site can't bind `Ctrl+\`` and have it
+      // silently never fire. An explicit `options.useKey` still wins.
+      useKey: spec.useKey ?? false,
+      ...options,
+    },
+    deps,
+  );
+}
+
+/**
+ * True when the event originated inside an xterm instance.
+ *
+ * The shell owns most Ctrl chords (Ctrl+K is kill-to-end-of-line, Ctrl+D is
+ * EOF), so shortcuts spelled with Ctrl yield to a focused terminal. Chords the
+ * user reached via ⌘ do not — ⌘ isn't a shell modifier on macOS. This mirrors
+ * the `terminalFocused && !e.metaKey` gate in the handler being replaced.
+ *
+ * Note the platform asymmetry this preserves: on Windows and Linux `mod` IS
+ * Ctrl, so these shortcuts deliberately defer to the shell there.
+ */
+export function isTerminalOriginatedEvent(event: KeyboardEvent): boolean {
+  const target = event.target as Element | null;
+  return target?.closest?.(".xterm") != null;
+}

--- a/apps/web/src/hooks/useZoom.ts
+++ b/apps/web/src/hooks/useZoom.ts
@@ -1,6 +1,7 @@
-import { useEffect } from "react";
 import { isDesktop } from "../lib/is-desktop";
+import { ZOOM_SHORTCUTS } from "../lib/shortcuts";
 import { zoomIn, zoomOut, zoomReset } from "../lib/zoom";
+import { useAppShortcut } from "./useAppShortcut";
 
 /**
  * Browser-mode keyboard shortcut handler for zoom.
@@ -13,45 +14,14 @@ import { zoomIn, zoomOut, zoomReset } from "../lib/zoom";
  *
  * Only active outside the desktop shell — when running inside Electron the
  * native View menu accelerators intercept these keys before they reach the
- * webview (see `apps/desktop/src/main/menu.ts`).
+ * webview (see `apps/desktop/src/main/menu.ts`). `enabled: !isDesktop` is the
+ * hook-friendly form of the early `return` this replaces: the bindings are
+ * declared unconditionally (hooks must be) but stay inert in a desktop shell.
  */
 export function useZoom(): void {
-  useEffect(() => {
-    // In a desktop shell, the View menu accelerators handle Cmd+= / Cmd+-
-    // before they reach the webview, so skip the JS listener.
-    if (isDesktop) return;
+  const enabled = !isDesktop;
 
-    const handler = (e: KeyboardEvent) => {
-      if (!(e.metaKey || e.ctrlKey)) return;
-
-      // Cmd+= or Cmd++ → zoom in
-      // On US keyboards, Shift is needed for +, but = and + share a key.
-      if (e.key === "=" || e.key === "+") {
-        e.preventDefault();
-        e.stopPropagation();
-        zoomIn();
-        return;
-      }
-
-      // Cmd+- → zoom out
-      if (e.key === "-") {
-        e.preventDefault();
-        e.stopPropagation();
-        zoomOut();
-        return;
-      }
-
-      // Cmd+Shift+0 → reset. Match on `e.code`: with Shift held, `e.key`
-      // is layout-dependent (")" on US keyboards), but the physical digit
-      // key is always Digit0.
-      if (e.shiftKey && e.code === "Digit0") {
-        e.preventDefault();
-        e.stopPropagation();
-        zoomReset();
-      }
-    };
-
-    window.addEventListener("keydown", handler, true);
-    return () => window.removeEventListener("keydown", handler, true);
-  }, []);
+  useAppShortcut(ZOOM_SHORTCUTS.zoomIn, () => zoomIn(), { enabled });
+  useAppShortcut(ZOOM_SHORTCUTS.zoomOut, () => zoomOut(), { enabled });
+  useAppShortcut(ZOOM_SHORTCUTS.resetZoom, () => zoomReset(), { enabled });
 }

--- a/apps/web/src/lib/shortcuts.ts
+++ b/apps/web/src/lib/shortcuts.ts
@@ -1,0 +1,212 @@
+/**
+ * The single source of truth for Band's keyboard shortcut combos.
+ *
+ * Every DOM-delivered shortcut is declared here once, as a pair:
+ *
+ *   - `binding` — the combo in `react-hotkeys-hook` syntax, passed straight
+ *     to `useHotkeys`. `mod` resolves to ⌘ on macOS and Ctrl elsewhere.
+ *   - `display` — the same combo in the canonical `Cmd+X` notation that
+ *     `formatShortcut` (command-registry.ts) turns into platform symbols for
+ *     the command palette and the UI hints.
+ *
+ * Keeping both on one record is the point: the palette used to carry its own
+ * copy of every combo string, so a rebinding could silently leave the
+ * advertised shortcut pointing at nothing.
+ *
+ * NOT declared here — these reach the app through their own delivery
+ * mechanisms and never touch the DOM keydown path:
+ *
+ *   - CodeMirror editing keys (⌘S, Tab, undo/redo) — `codemirror-setup.ts`
+ *     registers them as a `keymap` extension on the editor state.
+ *   - The Electron menu accelerators (⌘R, ⌘=, ⌘,, ⌥⌘I) — `apps/desktop/
+ *     src/main/menu.ts`. The native menu consumes the keystroke before the
+ *     renderer sees it.
+ *   - Browser find-in-page (⌘F inside a WebContentsView) — the embedded view
+ *     swallows keydown, so the main process forwards a `browser-find-shortcut`
+ *     IPC event instead (`useBrowserFindInPage.ts`).
+ */
+
+/** A shortcut's binding (react-hotkeys-hook syntax) plus its display form. */
+export interface ShortcutSpec {
+  /** Passed to `useHotkeys`. `mod` = ⌘ on macOS, Ctrl elsewhere. */
+  binding: string;
+  /** Canonical `Cmd+X` notation for `formatShortcut`. */
+  display: string;
+  /**
+   * Match the produced CHARACTER rather than the physical key.
+   *
+   * react-hotkeys-hook v5 defaults to `useKey: false`, which matches on
+   * `KeyboardEvent.code` — so a punctuation binding written as the literal
+   * character (`` ` ``, `[`, `=`) silently never fires; it would have to be
+   * spelled `Backquote` / `BracketLeft` / `Equal` instead. Every punctuation
+   * binding below therefore sets this, which also preserves the `e.key`
+   * (character-based) matching the hand-rolled handlers used.
+   *
+   * The inverse case — deliberately matching the physical key — is why ⇧⌥F and
+   * ⌥⌘B leave this unset: macOS substitutes Alt-layer characters into `e.key`
+   * (⌥B → "∫", ⌥F → "ƒ"), so those must match on `code`.
+   */
+  useKey?: boolean;
+}
+
+/**
+ * Expand a mod-key combo into BOTH the ⌘ and the Ctrl spelling.
+ *
+ * `react-hotkeys-hook`'s `mod` alias resolves to ONE modifier per platform (⌘
+ * on macOS, Ctrl elsewhere). The handler this replaces gated on
+ * `e.metaKey || e.ctrlKey`, so every one of these chords fired from EITHER
+ * modifier on EVERY platform — ⌘N and Ctrl+N both opened a new file on a Mac.
+ * Using `mod` would silently drop half of each binding, so the combos are
+ * spelled out instead.
+ *
+ * Narrowing these to one modifier per platform may well be an improvement
+ * (Ctrl+N is "next line" in readline), but it's a user-visible change and
+ * belongs in its own decision, not smuggled in by a refactor.
+ */
+function eitherMod(suffix: string): string {
+  return `meta+${suffix}, ctrl+${suffix}`;
+}
+
+/**
+ * Shortcuts that fire from anywhere in the workspace.
+ *
+ * Terminal caveat: xterm owns most Ctrl chords (Ctrl+K is kill-to-end-of-line,
+ * Ctrl+D is EOF), so the handlers for the `mod`-based entries below bail while
+ * a terminal is focused *unless* the user actually pressed ⌘. On Windows and
+ * Linux, where `mod` IS Ctrl, that means these shortcuts deliberately yield to
+ * the shell. The two entries called out individually below are the exceptions.
+ */
+export const GLOBAL_SHORTCUTS = {
+  /**
+   * Workspace picker. BOTH spellings are bound on every platform, not `mod+k`:
+   * the Ctrl+K spelling has to keep working on a Mac too (it predates the ⌘
+   * binding and users have it in muscle memory), and `mod` would collapse to ⌘
+   * alone there. Collapsing these two was a real regression caught by
+   * `workspace-picker.spec.ts`'s "non-macOS path" test.
+   *
+   * The two spellings differ in one respect, handled by the shared terminal
+   * bail rather than here: ⌘K fires even from a focused terminal (⌘ isn't a
+   * shell modifier, and opening the picker from a terminal was a long-standing
+   * request), while Ctrl+K yields to xterm since it's kill-to-end-of-line.
+   */
+  workspacePicker: { binding: "meta+k, ctrl+k", display: "Cmd+K" },
+  /** Reveal the project-list sidebar and focus the list. */
+  focusProjects: { binding: "ctrl+0", display: "Ctrl+0" },
+
+  // Dialogs and editor actions.
+  newUntitledTab: { binding: eitherMod("n"), display: "Cmd+N" },
+  newChatSession: { binding: eitherMod("shift+n"), display: "Cmd+Shift+N" },
+  quickOpen: { binding: eitherMod("p"), display: "Cmd+P" },
+  commandPalette: { binding: eitherMod("shift+p"), display: "Cmd+Shift+P" },
+  searchFiles: { binding: eitherMod("shift+f"), display: "Cmd+Shift+F" },
+  findInFile: { binding: eitherMod("f"), display: "Cmd+F" },
+  /** Desktop only — the plain web build has no file picker to invoke. */
+  openFile: { binding: eitherMod("o"), display: "Cmd+O" },
+  /** The one binding with no mod key in the chord, so it needs its own
+   *  handler rather than riding the shared mod gate. */
+  formatCurrentFile: { binding: "shift+alt+f", display: "Shift+Alt+F" },
+
+  // Panel activation.
+  showChat: { binding: "ctrl+meta+i", display: "Ctrl+Cmd+I" },
+  showChanges: { binding: eitherMod("shift+g"), display: "Cmd+Shift+G" },
+  showFiles: { binding: eitherMod("shift+e"), display: "Cmd+Shift+E" },
+  showBrowser: { binding: eitherMod("shift+b"), display: "Cmd+Shift+B" },
+  /** Ctrl+` on every platform (VS Code parity) — not a `mod` binding. */
+  showTerminal: { binding: "ctrl+`", display: "Ctrl+`", useKey: true },
+
+  // Layout.
+  /** Toggles the project-list sidebar, always — it does not resolve its target
+   *  by focus. A shortcut that means different things depending on invisible
+   *  focus state is hard to trust, and the sidebar is overwhelmingly the
+   *  intended target. The cost is that an inner dockview's LEFT edge has no
+   *  keyboard toggle; if that turns out to matter it gets its own combo rather
+   *  than focus-dependence here. */
+  toggleSidebar: { binding: eitherMod("b"), display: "Cmd+B" },
+  /** Focus-aware: toggles the focused inner dockview's right edge when it has
+   *  panels, else the main layout's. The last of the three edge chords to
+   *  resolve its target by focus. */
+  toggleRightEdge: { binding: eitherMod("alt+b"), display: "Cmd+Alt+B" },
+  /** Toggles the OUTERMOST layout's bottom edge, always — same rule as
+   *  `toggleSidebar`, not `toggleRightEdge`. The bottom panel reads as one
+   *  shared surface, so the chord that shows and hides it means one thing
+   *  everywhere instead of retargeting to the focused inner dock. No-ops when
+   *  that edge is absent or empty. */
+  toggleBottomEdge: { binding: eitherMod("j"), display: "Cmd+J" },
+  maximizePanel: { binding: eitherMod("shift+m"), display: "Cmd+Shift+M" },
+} as const satisfies Record<string, ShortcutSpec>;
+
+/**
+ * Shortcuts scoped to a dock — the chat, terminal, browser, and file-tab
+ * containers. Each dock binds these against its own element, so the same
+ * combo performs the dock's own version of the action and only while that
+ * dock (or a descendant) holds focus. Innermost focused dock wins.
+ */
+export const DOCK_SHORTCUTS = {
+  newTab: { binding: eitherMod("t"), display: "Cmd+T" },
+  closeTab: { binding: eitherMod("w"), display: "Cmd+W" },
+  /** The terminal dock additionally requires ⌘ (Ctrl+D is EOF there) and
+   *  enforces that with its own `ignoreEventWhen`; chat and browser accept
+   *  either modifier, as they did before. */
+  splitRight: { binding: eitherMod("d"), display: "Cmd+D" },
+  splitDown: { binding: eitherMod("shift+d"), display: "Cmd+Shift+D" },
+  /**
+   * Matched on the PHYSICAL key (no `useKey`), unlike their unshifted
+   * `nextGroup` / `previousGroup` siblings. Holding Shift changes the produced
+   * character — `]` becomes `}` on a US layout — so a character match against
+   * `]` can never fire. The hand-rolled handlers had exactly that bug
+   * (`e.key.toLowerCase() === "]"` behind a `e.shiftKey` test), which made both
+   * of these dead bindings despite being advertised in the palette. Physical
+   * matching fixes them and is layout-independent besides.
+   */
+  nextTab: { binding: eitherMod("shift+BracketRight"), display: "Cmd+Shift+]" },
+  previousTab: { binding: eitherMod("shift+BracketLeft"), display: "Cmd+Shift+[" },
+  /** Ctrl-only by design, and must NOT fire with ⌘ held — matches the
+   *  `e.ctrlKey && !e.metaKey` test in the handlers this replaces. */
+  cycleTabForward: { binding: "ctrl+tab", display: "Ctrl+Tab" },
+  cycleTabBackward: { binding: "ctrl+shift+tab", display: "Ctrl+Shift+Tab" },
+  nextGroup: { binding: eitherMod("]"), display: "Cmd+]", useKey: true },
+  previousGroup: { binding: eitherMod("["), display: "Cmd+[", useKey: true },
+} as const satisfies Record<string, ShortcutSpec>;
+
+/**
+ * Label filter in the dashboard sidebar: ⌘0 = All, ⌘1..9 / Ctrl+1..9 = Nth
+ * label. One binding covering all ten digits, since the handler has to resolve
+ * the digit against the label list at call time anyway.
+ *
+ * ⌘0 is ⌘-only on purpose: Ctrl+0 is the global "Focus Projects" shortcut, so
+ * the two must not both claim that chord. Digits 1..9 have no such conflict and
+ * accept either modifier, matching the `e.metaKey || e.ctrlKey` gate this
+ * replaces. See the call site in `DashboardShell.tsx`.
+ */
+export const LABEL_FILTER_SHORTCUT: ShortcutSpec = {
+  binding: ["meta+0", ...Array.from({ length: 9 }, (_, i) => eitherMod(String(i + 1)))].join(", "),
+  display: "Cmd+0",
+  // Character-based so the match and the handler agree: the callback resolves
+  // which label to select with `Number(event.key)`. Matching on the physical key
+  // instead would fire on a layout whose digit row is shifted (AZERTY `Digit1` →
+  // "&") and then silently no-op inside the handler. The handler this replaces
+  // was character-based on both halves too (`e.key < "0" || e.key > "9"`).
+  useKey: true,
+};
+
+/** Zoom shortcuts. Browser build only — in the desktop shell the native View
+ *  menu owns these accelerators and the renderer never sees the keydown. */
+export const ZOOM_SHORTCUTS = {
+  /**
+   * `=` and `+` share one physical key (`+` needs Shift on a US layout) and the
+   * old handler accepted either character, so both spellings must fire.
+   *
+   * Matched on the PHYSICAL key rather than the character. Two reasons the
+   * obvious character form is wrong: the library splits a combo on `"+"`, so
+   * `"meta++"` parses to empty key names and can never match; and it compares
+   * modifiers for exact equality, so a `meta+=` binding would not fire while
+   * Shift is held. Binding `Equal` with and without Shift covers both.
+   */
+  zoomIn: { binding: `${eitherMod("Equal")}, ${eitherMod("shift+Equal")}`, display: "Cmd+=" },
+  /** Physical key for the same reason as `zoomIn`. */
+  zoomOut: { binding: eitherMod("Minus"), display: "Cmd+-" },
+  /** Shift is deliberate: plain ⌘0 is the "All labels" filter. Matched on the
+   *  PHYSICAL key (no `useKey`) because with Shift held `e.key` is
+   *  layout-dependent — ")" on US layouts — while the code is always Digit0. */
+  resetZoom: { binding: eitherMod("shift+0"), display: "Cmd+Shift+0" },
+} as const satisfies Record<string, ShortcutSpec>;

--- a/docs/adr/0001-react-hotkeys-hook-for-shortcuts.md
+++ b/docs/adr/0001-react-hotkeys-hook-for-shortcuts.md
@@ -1,0 +1,88 @@
+# 1. Use react-hotkeys-hook for keyboard shortcuts
+
+Date: 2026-07-20
+
+## Status
+
+Accepted
+
+## Context
+
+Band's keyboard shortcuts were implemented as six independent raw `keydown` listeners:
+`SharedDockviewLayout` (global, window-level, capture phase), plus near-duplicate
+container handlers in the chat, terminal, browser, and file-tab docks, plus the dashboard
+label filter and the zoom hook. Roughly 40 shortcuts total.
+
+Each container handler re-implemented the same two things by hand: platform branching
+(`isMac ? metaKey : ctrlKey`) and scoping (`document.activeElement?.contains(...)` or
+`closest(".xterm")`). The same combos (`⌘T`, `⌘W`, `⌘D`, `⌘[`/`⌘]`, `Ctrl+Tab`) mean
+different things in different docks, so scoping is load-bearing, not incidental.
+
+Two systems deliver keys through their own mechanisms and are out of scope: CodeMirror
+(its own `keymap` extension) and the Electron native menu / find-in-page IPC (keys never
+reach the DOM because `WebContentsView` swallows them).
+
+## Decision
+
+Adopt `react-hotkeys-hook` (v5) as the single shortcut mechanism for all DOM-delivered
+shortcuts.
+
+- **Dock scoping via the hook's returned ref**, not named scopes. The ref only fires while
+  that element or a descendant has focus, and innermost-focused wins — the exact semantics
+  the hand-rolled `contains()` checks were approximating. No provider bookkeeping and no
+  focus/scope state to keep in sync.
+- **Combos live in one central constants module** (action id → combo string). Handlers stay
+  in their components. The command palette and UI hints read the same constants, so the
+  displayed shortcut can't drift from the bound one.
+- **Both modifier spellings are bound, not `mod+`.** The handler this replaces gated on
+  `e.metaKey || e.ctrlKey`, so every chord fired from either modifier on every platform —
+  `⌘N` and `Ctrl+N` both opened a new file on a Mac. `mod` resolves to one modifier per
+  platform and would have silently dropped half of each binding, so `eitherMod()` spells
+  both out. Narrowing them is a user-visible change that belongs in its own decision.
+- **Character- vs physical-key matching travels with the combo** (`ShortcutSpec.useKey`).
+  The library matches `KeyboardEvent.code` by default, so a punctuation binding written as
+  its character (`` ` ``, `[`, `=`) silently never fires. Putting the choice on the spec
+  means a call site cannot get it wrong.
+- **Terminal behaviour is preserved exactly**: `enableOnFormTags` for globals plus
+  `ignoreEventWhen` for the shell-owned combos that must reach xterm, and the existing
+  "`Ctrl+D` only closes when more than one tab" rule.
+- **The `band:*` custom-event dispatch layer stays.** Only key detection changes.
+
+Four deliberate behaviour changes ride along with the refactor.
+
+**`⌘B` and `⌘J` become true globals.** Both used to resolve their target by focus: a focused
+inner dockview with a non-empty edge on that side won, and only otherwise did the chord fall
+through to the outer layout. `⌘B` now always toggles the project sidebar and `⌘J` always
+toggles the outermost layout's bottom edge. The sidebar and the bottom panel each read as a
+single shared surface, and a shortcut that means different things depending on invisible
+focus state is hard to trust. `⌥⌘B` (right edge) is now the only edge chord that still
+resolves by focus — knowingly inconsistent, kept because nothing has argued for changing it.
+Inner-dockview *left* and *bottom* edges consequently lose their keyboard toggle; if that
+matters, each gets its own combo rather than a return to focus-dependence.
+
+**`⌘0` and `Ctrl+0` no longer contend.** "Focus Projects" (`Ctrl+0`) previously beat the label
+filter's "All" only because it listened in capture phase and called `stopPropagation()` ahead
+of the filter's bubble-phase listener. Once both are `useHotkeys` on `document`, registration
+order decides — too fragile to leave implicit — so the label filter binds `⌘0` alone and
+digits 1–9 still take either modifier. Net user-facing behaviour is unchanged; it is now
+explicit rather than accidental.
+
+**`⌘⇧[` / `⌘⇧]` start working.** They were advertised in the palette but dead: Shift turns `]`
+into `}`, so the character match never fired. They now match the physical key. This fixes a
+pre-existing bug rather than preserving it — a single source of truth that ships a
+documented-but-dead shortcut is worse than the drift it replaced.
+
+## Consequences
+
+- One dependency added (~5 kB, peer range `react >=16.8`; the web app is on React 19).
+- Most `isMac` branching and every hand-written focus-containment check disappear.
+- CodeMirror, the Electron menu, and find-in-page IPC remain separate delivery paths. A
+  reader looking for "all shortcuts" must still check those three places — the central
+  constants module documents them as out of scope.
+- No user-rebindable shortcuts. The constants are plain literals, not an overridable map;
+  adding persistence later is a contained change.
+- Migration is guarded by an end-to-end shortcut matrix spec written against the current
+  behaviour first and kept green throughout. Each intended difference has a case written to
+  the NEW behaviour, so it fails until the change lands and pins it afterwards.
+- Inner-dockview left and bottom edges are no longer reachable from the keyboard. If that turns out to
+  matter, the fix is a dedicated combo rather than restoring focus-dependence on `⌘B`.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -87,6 +87,9 @@ importers:
       prettier:
         specifier: ^3.8.3
         version: 3.8.3
+      react-hotkeys-hook:
+        specifier: ^5.3.3
+        version: 5.3.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       react-resizable-panels:
         specifier: ^4.9.0
         version: 4.9.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -6249,6 +6252,12 @@ packages:
     resolution: {integrity: sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==}
     peerDependencies:
       react: ^19.2.4
+
+  react-hotkeys-hook@5.3.3:
+    resolution: {integrity: sha512-aswgyWUnE25hmhzHTfKDmKzsaSE5DJ4LKaU/o6rQSXkDd/1Bh9TfAFQbHkf6fLy11HvlYkp+cDDarGdhmCDhoQ==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
 
   react-is@19.2.6:
     resolution: {integrity: sha512-XjBR15BhXuylgWGuslhDKqlSayuqvqBX91BP8pauG8kd1zY8kotkNWbXksTCNRarse4kuGbe2kIY05ARtwNIvw==}
@@ -14127,6 +14136,11 @@ snapshots:
     dependencies:
       react: 19.2.4
       scheduler: 0.27.0
+
+  react-hotkeys-hook@5.3.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+    dependencies:
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
 
   react-is@19.2.6: {}
 


### PR DESCRIPTION
## PO Summary

Band's keyboard shortcuts now run on a well-maintained open-source library instead of custom code we wrote and maintain ourselves. For most people nothing changes — every shortcut keeps working exactly as before.

Four things do change, and three of them are fixes:

- **⌘B and ⌘J are predictable now.** Both used to do different things depending on which panel you'd last clicked — sometimes collapsing a small inner panel edge instead of the thing you meant. ⌘B now always shows/hides the project sidebar, and ⌘J always shows/hides the bottom panel, no matter where you're working.
- **⌘⇧[ and ⌘⇧] work.** These were listed in the command palette but did nothing at all. They now cycle tabs as advertised.
- **⌘+ zooms in again.** Zooming in while holding Shift had silently stopped working.
- **⌘0 and Ctrl+0 no longer collide.** ⌘0 clears the label filter, Ctrl+0 jumps focus to the project list. Same as before in practice, but it was previously working by accident and could have broken at any time.

Why it matters: the shortcut code was ~215 lines of hand-written keyboard handling duplicated across six places, which is where the dead and colliding shortcuts came from. Consolidating it means the command palette can no longer advertise a shortcut that isn't real, and future shortcut work is a one-line change instead of an archaeology exercise.

## Behaviour changes

| Chord | Before | After |
|---|---|---|
| `⌘B` | Retargeted to a focused inner dock's left edge | Always toggles the project sidebar |
| `⌘J` | Retargeted to a focused inner dock's bottom edge | Always toggles the outermost bottom edge |
| `⌘⇧[` / `⌘⇧]` | Dead (Shift turns `]` into `}`) | Cycle tabs in the focused dock |
| `⌘⇧=` (`⌘+`) | Dead | Zooms in |
| `⌘0` / `Ctrl+0` | Same chord; winner decided by listener ordering | Separate bindings |

`⌥⌘B` (right edge) is now the only edge chord that still resolves its target by focus.

Inner-dockview left and bottom edges lose their keyboard toggle as a consequence. If that turns out to matter, the fix is a dedicated combo rather than restoring focus-dependence.

## Design

- **Dock scoping via the hook's returned ref**, not named scopes — fires only while that dock or a descendant has focus, innermost wins. Replaces every hand-written `contains(document.activeElement)` check.
- **`lib/shortcuts.ts`** holds each combo once, carrying both its binding and its display string, so the palette can't drift from what's bound.
- **`useAppShortcut`** supplies the four defaults the old handlers implemented inline. Each is load-bearing: capture-phase listening (xterm calls `stopPropagation()` on keys it consumes), firing inside form fields (the library skips them by default, and xterm's helper textarea plus the chat prompt are our two commonest focus targets), `preventDefault`, and character-vs-physical key matching.
- **Both modifier spellings are bound**, not `mod+`. The old gate was `e.metaKey || e.ctrlKey`, so every chord fired from either modifier on every platform; `mod` resolves to one per platform and would have silently halved each binding.

Out of scope, each with its own delivery path: the CodeMirror keymap, Electron menu accelerators, and find-in-page IPC. `lib/shortcuts.ts` documents them so a reader auditing "all shortcuts" knows where else to look.

## Testing

New `shortcut-matrix.spec.ts` — 14 cases, real server boot, no tRPC mocking, all driven through page objects.

Every behaviour change has a case **written to the new behaviour and verified to fail against the old implementation**, so none of them can pass vacuously. The matrix was written first and caught two regressions mid-migration: `Ctrl+`` ` `` going dead (the library matches physical keys by default) and `Ctrl+K` no longer opening the workspace picker on macOS.

`165/165` e2e, `pnpm check` clean (biome + `cargo fmt` + clippy `-D warnings`), `tsc --noEmit` clean.

## Notes for review

- `docs/adr/0001-react-hotkeys-hook-for-shortcuts.md` records the decisions and the trade-offs behind them.
- Pre-existing and untouched: `Ctrl+-` fires both zoom-out and editor-history-back. Both old handlers were window-capture listeners that already did this. Worth its own issue.
- Also pre-existing: terminal split (`⌘D`) is keyboard-unreachable on Windows/Linux — the handler requires `metaKey`. Preserved verbatim; worth its own issue.
- Backend vitest has an intermittent `ENOTEMPTY` teardown flake in `trpc.test.ts` (1 in 3 runs on identical code, all 1176 assertions passing). Unrelated to this change — it's the race `cleanupTmpHome` documents and retries around, which that file doesn't use.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EJXsGhcvLz1nLAEMP77QEv
