### PR TITLE
feat(web): add "Copy terminal ID" to terminal tab right-click menu

### DIFF
--- a/apps/web/e2e/pages/WorkspacePage.ts
+++ b/apps/web/e2e/pages/WorkspacePage.ts
@@ -2055,6 +2055,56 @@ export class WorkspacePage {
     });
   }
 
+  // ──────────────────────────────────────────────────────────────────────
+  // Terminal tab header context menu ("Copy terminal ID"). Mirrors the
+  // chat-tab surface above: the tab header carries a
+  // `terminal-tab__trigger--<terminalId>` testid whose suffix is generated
+  // at runtime, so we match the stable PREFIX with a regex and take
+  // `.first()` — the workspaces these tests seed have a single terminal tab.
+  // ──────────────────────────────────────────────────────────────────────
+
+  /** The terminal tab header (right-click target). */
+  terminalTabTrigger(): Locator {
+    return this.page.getByTestId(/^terminal-tab__trigger--/).first();
+  }
+
+  /** The opened terminal-tab context menu content (portalled to body). */
+  get terminalTabContextMenu(): Locator {
+    return this.page.getByTestId("terminal-tab__context-menu");
+  }
+
+  /** "Copy terminal ID" item. */
+  get copyTerminalIdItem(): Locator {
+    return this.page.getByTestId("terminal-tab__context-menu-item--copy-terminal-id");
+  }
+
+  /** Read the terminal id the app assigned to the (single) terminal in the
+   *  given workspace, straight from the persistent terminal wrapper's
+   *  `data-terminal-id`. Lets a test assert the copied value equals the id
+   *  the app actually rendered, rather than one the test guessed. */
+  async readActiveTerminalId(workspaceId: string): Promise<string> {
+    return await this.page.evaluate((id) => {
+      const wrapper = document.querySelector(`[data-workspace-id="${id}"][data-terminal-id]`);
+      const terminalId = wrapper?.getAttribute("data-terminal-id");
+      if (!terminalId) throw new Error(`no terminal wrapper found for workspace ${id}`);
+      return terminalId;
+    }, workspaceId);
+  }
+
+  /** Right-click the terminal tab header to open its context menu. */
+  async openTerminalTabContextMenu(): Promise<void> {
+    await test.step("Right-click the terminal tab to open its context menu", async () => {
+      await this.terminalTabTrigger().click({ button: "right" });
+    });
+  }
+
+  /** Click the "Copy terminal ID" context-menu item. */
+  async clickCopyTerminalId(): Promise<void> {
+    await test.step("Click Copy terminal ID", async () => {
+      await this.copyTerminalIdItem.click();
+    });
+  }
+
   /** Simulate a NON-secure context (`navigator.clipboard === undefined`,
    *  the LAN-IP / non-HTTPS-tunnel case) and capture the `execCommand("copy")`
    *  fallback's payload into `window.__copied`. Must run BEFORE `goto` (uses

--- a/apps/web/e2e/terminal-tab-copy-id.spec.ts
+++ b/apps/web/e2e/terminal-tab-copy-id.spec.ts
@@ -1,0 +1,106 @@
+/**
+ * End-to-end coverage for the terminal tab's right-click "Copy terminal ID"
+ * context-menu action.
+ *
+ * Architecture (mirrors the rest of the e2e suite):
+ *   - REAL production `dist/start-server.mjs` boots against a fresh tmp
+ *     `$HOME` with an on-disk project worktree. No tRPC mocking — the
+ *     terminal is created through the same pipeline production uses, so its
+ *     id is server-assigned rather than test-fabricated.
+ *   - Clipboard writes are captured via `WorkspacePage.installClipboardCapture`,
+ *     which removes `navigator.clipboard` (the non-secure / LAN-IP case) and
+ *     records the `execCommand("copy")` fallback payload. That doubles as a
+ *     regression guard: code that bypassed the shared `writeClipboardText`
+ *     helper and called `navigator.clipboard` directly would copy nothing
+ *     here and fail the assertion.
+ *
+ * The asserted value is the id the app actually rendered — read back from the
+ * terminal wrapper's `data-terminal-id` — so the test proves the menu copies
+ * THIS terminal's id, not a guessed constant.
+ */
+
+import { mkdtempSync, realpathSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { expect, test } from "@playwright/test";
+import { toWorkspaceId } from "@/dashboard";
+import {
+  cleanupTmpHome,
+  createTmpHome,
+  type ServerHandle,
+  seedSettings,
+  seedState,
+  startServer,
+} from "./helpers/server";
+import { WorkspacePage } from "./pages/WorkspacePage";
+
+const TOKEN = "e2e-terminal-copy-id-token";
+const PROJECT = "alpha-terminal-copy-id";
+const WORKSPACE = toWorkspaceId(PROJECT, "main");
+
+// Wide viewport so `useIsDesktop()` reports true and the shared dockview
+// (which hosts the terminal container) renders.
+test.use({ viewport: { width: 1280, height: 800 } });
+
+let server: ServerHandle;
+let tmpHome: string;
+/** A real directory used as the project path — the PTY spawns with cwd =
+ *  the project path and `terminal-pool` throws if it doesn't exist, so a
+ *  fake `/tmp/...` path (fine for layout-only tests) won't work here. */
+let workdir: string;
+
+test.beforeAll(async () => {
+  tmpHome = createTmpHome();
+  workdir = realpathSync(mkdtempSync(join(tmpdir(), "band-term-copyid-workdir-")));
+  seedState(tmpHome, {
+    projects: [
+      {
+        name: PROJECT,
+        path: workdir,
+        defaultBranch: "main",
+        worktrees: [{ branch: "main", path: workdir }],
+      },
+    ],
+  });
+  seedSettings(tmpHome, { tokenSecret: TOKEN });
+  server = await startServer({ tmpHome });
+});
+
+test.afterAll(async () => {
+  await server.close();
+  cleanupTmpHome(tmpHome);
+  rmSync(workdir, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 });
+});
+
+test.describe("Terminal tab: Copy terminal ID", () => {
+  test("right-click → Copy terminal ID copies this terminal's id to the clipboard", async ({
+    page,
+  }) => {
+    const workspacePage = new WorkspacePage(page, server.url, TOKEN);
+
+    // Must run before `goto` (installs an init script that removes
+    // `navigator.clipboard` and records the execCommand fallback).
+    await workspacePage.installClipboardCapture();
+
+    await workspacePage.goto(WORKSPACE);
+    await workspacePage.waitForReady();
+    await workspacePage.openTerminalTab();
+    await workspacePage.waitForTerminalReady();
+
+    // The id the app assigned to the terminal it just booted.
+    const terminalId = await workspacePage.readActiveTerminalId(WORKSPACE);
+    expect(terminalId).not.toBe("");
+
+    await workspacePage.openTerminalTabContextMenu();
+    await expect(workspacePage.copyTerminalIdItem).toBeVisible();
+    await workspacePage.clickCopyTerminalId();
+
+    // The copied payload is exactly the rendered terminal id.
+    await expect
+      .poll(async () => (await workspacePage.readCopied()).at(-1), {
+        message: "terminal id copied to clipboard",
+        timeout: 15_000,
+      })
+      .toBe(terminalId);
+  });
+});

--- a/apps/web/e2e/terminal-tab-copy-id.spec.ts
+++ b/apps/web/e2e/terminal-tab-copy-id.spec.ts
@@ -92,6 +92,9 @@ test.describe("Terminal tab: Copy terminal ID", () => {
     expect(terminalId).not.toBe("");
 
     await workspacePage.openTerminalTabContextMenu();
+    // Positive anchor: the menu content actually opened before we assert on
+    // (and click) an individual item — mirrors the chat-tab spec.
+    await expect(workspacePage.terminalTabContextMenu).toBeVisible();
     await expect(workspacePage.copyTerminalIdItem).toBeVisible();
     await workspacePage.clickCopyTerminalId();
 

--- a/apps/web/src/components/DockviewTerminalContainer.tsx
+++ b/apps/web/src/components/DockviewTerminalContainer.tsx
@@ -1,3 +1,4 @@
+import { ContextMenu, ContextMenuContent, ContextMenuItem, ContextMenuTrigger } from "@band-app/ui";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import {
   type DockviewApi,
@@ -8,7 +9,7 @@ import {
   type IDockviewPanelHeaderProps,
   type IDockviewPanelProps,
 } from "dockview";
-import { Columns2, Plus, Rows2, TerminalSquare, X } from "lucide-react";
+import { ClipboardCopy, Columns2, Plus, Rows2, TerminalSquare, X } from "lucide-react";
 import React, {
   lazy,
   Suspense,
@@ -20,6 +21,7 @@ import React, {
   useState,
 } from "react";
 import { type TerminalInsertDetail, useAdapter } from "@/dashboard";
+import { writeClipboardText } from "../lib/clipboard";
 import {
   attachEdgeGroupDragVisibility,
   centralPanelPosition,
@@ -238,25 +240,47 @@ function TerminalTab(props: IDockviewPanelHeaderProps<TerminalTabParams>) {
     [containerApi, terminalId],
   );
 
+  const handleCopyTerminalId = useCallback(() => {
+    // Use the shared helper, not `navigator.clipboard` directly:
+    // `navigator.clipboard` is undefined in a non-secure context (Band
+    // served over plain HTTP on a LAN IP / non-HTTPS tunnel), so the raw
+    // API silently no-ops there. `writeClipboardText` falls back to the
+    // legacy execCommand path that works without a secure context.
+    void writeClipboardText(terminalId);
+  }, [terminalId]);
+
   const showClose = panelCount > 1;
 
   return (
-    <div className="dv-default-tab">
-      <div className="flex items-center gap-1.5 min-w-0">
-        <TerminalSquare className="size-3.5 shrink-0 text-muted-foreground" />
-        <span className="truncate">{title}</span>
-      </div>
-      {showClose && (
-        <button
-          type="button"
-          className="ml-1 inline-flex size-4 items-center justify-center rounded-sm opacity-60 hover:opacity-100 hover:bg-accent transition-colors"
-          onClick={handleClose}
-          title="Close terminal"
+    <ContextMenu>
+      <ContextMenuTrigger asChild>
+        <div className="dv-default-tab" data-testid={`terminal-tab__trigger--${terminalId}`}>
+          <div className="flex items-center gap-1.5 min-w-0">
+            <TerminalSquare className="size-3.5 shrink-0 text-muted-foreground" />
+            <span className="truncate">{title}</span>
+          </div>
+          {showClose && (
+            <button
+              type="button"
+              className="ml-1 inline-flex size-4 items-center justify-center rounded-sm opacity-60 hover:opacity-100 hover:bg-accent transition-colors"
+              onClick={handleClose}
+              title="Close terminal"
+            >
+              <X className="size-3" />
+            </button>
+          )}
+        </div>
+      </ContextMenuTrigger>
+      <ContextMenuContent data-testid="terminal-tab__context-menu">
+        <ContextMenuItem
+          onClick={handleCopyTerminalId}
+          data-testid="terminal-tab__context-menu-item--copy-terminal-id"
         >
-          <X className="size-3" />
-        </button>
-      )}
-    </div>
+          <ClipboardCopy className="size-4" />
+          Copy terminal ID
+        </ContextMenuItem>
+      </ContextMenuContent>
+    </ContextMenu>
   );
 }
 


### PR DESCRIPTION
## Summary

Adds a right-click context menu option on the terminal tab to copy the terminal ID, mirroring the existing chat-tab "Copy session ID" pattern.

- Wraps the terminal tab header (`TerminalTab`) in a Radix `ContextMenu` offering a single **"Copy terminal ID"** item.
- Copies `props.params.terminalId` via the shared `writeClipboardText` helper (not `navigator.clipboard` directly), so it also works in a non-secure context — Band served over plain HTTP on a LAN IP / non-HTTPS tunnel — where `navigator.clipboard` is `undefined`.
- Adds BEM `data-testid` hooks (`terminal-tab__trigger--<id>`, `terminal-tab__context-menu`, `terminal-tab__context-menu-item--copy-terminal-id`) consistent with the chat tab.

## Testing

- New e2e spec `apps/web/e2e/terminal-tab-copy-id.spec.ts` follows the repo integration-test doctrine: boots the real `dist/start-server.mjs` against a fresh tmp home + on-disk workdir, no tRPC mocking, opens a terminal, right-clicks the tab, clicks "Copy terminal ID", and asserts the captured clipboard payload equals the app-assigned terminal id (read back from the terminal wrapper's `data-terminal-id`). Uses `installClipboardCapture` so a regression to the raw `navigator.clipboard` API would fail the test.
- New page-object methods on `WorkspacePage` for the terminal-tab context menu.

Local `pnpm check` (biome + cargo fmt + clippy) clean; e2e spec passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)