### PR TITLE
feat(web): open files by absolute path from Quick Open and terminal links

### DIFF
--- a/apps/web/e2e/pages/FileViewerPage.ts
+++ b/apps/web/e2e/pages/FileViewerPage.ts
@@ -72,6 +72,15 @@ export class FileViewerPage {
     return (await el.textContent()) ?? "";
   }
 
+  /** Assert (auto-retrying) that the file viewer is mounted and visible.
+   *  Used for previews (e.g. markdown) that render outside the CodeMirror
+   *  `.cm-content` surface, where `expectContent` doesn't apply. */
+  async expectVisible(): Promise<void> {
+    await test.step("File viewer is visible", async () => {
+      await expect(this.root).toBeVisible({ timeout: 15_000 });
+    });
+  }
+
   /** Assert (auto-retrying) that the editor's rendered text contains `text`. */
   async expectContent(text: string): Promise<void> {
     await test.step(`Editor shows "${text}"`, async () => {

--- a/apps/web/e2e/pages/WorkspacePage.ts
+++ b/apps/web/e2e/pages/WorkspacePage.ts
@@ -1645,6 +1645,22 @@ export class WorkspacePage {
     return this.quickOpenDialog().getByRole("option");
   }
 
+  /** The "Open file" / "Open external file" row shown when the Quick Open
+   *  query is an absolute path that resolves to a real file (inside or
+   *  outside the worktree). `data-testid` set on the `CommandItem` in
+   *  `QuickOpenDialog.tsx` (BEM convention). */
+  get quickOpenPathItem(): Locator {
+    return this.quickOpenDialog().getByTestId("quick-open__path-result");
+  }
+
+  /** Click the offered path row — the way a user accepts the offer to open an
+   *  absolute path that resolves to a real file. */
+  async openQuickOpenPathItem(): Promise<void> {
+    await test.step("Open the offered path", async () => {
+      await this.quickOpenPathItem.click();
+    });
+  }
+
   /** Open Quick Open via the same `band:open-quick-open` window event the file
    *  tree toolbar fires, then wait for the dialog to render. */
   async openQuickOpen(): Promise<void> {
@@ -1662,6 +1678,18 @@ export class WorkspacePage {
       await this.quickOpenInput.focus();
       await this.page.keyboard.press("ControlOrMeta+a");
       await this.page.keyboard.type(text);
+    });
+  }
+
+  /** Set the Quick Open query atomically (like a paste), replacing any
+   *  existing text. Prefer this over `typeQuickOpen` for long strings such as
+   *  absolute paths: character-by-character typing into the controlled cmdk
+   *  input can drop leading characters under the per-keystroke re-render
+   *  churn, and "paste a path" is the real gesture for the external-open
+   *  flow anyway. */
+  async fillQuickOpen(text: string): Promise<void> {
+    await test.step(`Fill Quick Open query "${text}"`, async () => {
+      await this.quickOpenInput.fill(text);
     });
   }
 

--- a/apps/web/e2e/quick-open-external-file.spec.ts
+++ b/apps/web/e2e/quick-open-external-file.spec.ts
@@ -132,6 +132,9 @@ test.describe("Quick Open — open a file outside the worktree by absolute path"
     await expect(workspacePage.quickOpenPathItem).toBeVisible({ timeout: 15_000 });
     await expect(workspacePage.quickOpenPathItem).toContainText(externalTsPath);
 
+    // Positive anchor: the dialog is open before we accept + assert dismissal.
+    await expect(workspacePage.quickOpenDialog()).toBeVisible();
+
     // Accept the offer.
     await workspacePage.openQuickOpenPathItem();
 
@@ -175,8 +178,9 @@ test.describe("Quick Open — open a file outside the worktree by absolute path"
         timeout: 15_000,
       })
       .toBe(externalMdPath);
-    await expect(workspacePage.quickOpenDialog()).toBeHidden();
+    // Positive DOM anchor (viewer mounted) before the negative dismissal check.
     await new FileViewerPage(page).expectVisible();
+    await expect(workspacePage.quickOpenDialog()).toBeHidden();
   });
 
   test("a band:open-file event for a non-existent absolute path reveals the dialog with no match", async ({

--- a/apps/web/e2e/quick-open-external-file.spec.ts
+++ b/apps/web/e2e/quick-open-external-file.spec.ts
@@ -176,7 +176,7 @@ test.describe("Quick Open — open a file outside the worktree by absolute path"
       })
       .toBe(externalMdPath);
     await expect(workspacePage.quickOpenDialog()).toBeHidden();
-    await expect(page.getByTestId("file-viewer__root")).toBeVisible({ timeout: 15_000 });
+    await new FileViewerPage(page).expectVisible();
   });
 
   test("a band:open-file event for a non-existent absolute path reveals the dialog with no match", async ({

--- a/apps/web/e2e/quick-open-external-file.spec.ts
+++ b/apps/web/e2e/quick-open-external-file.spec.ts
@@ -189,9 +189,13 @@ test.describe("Quick Open — open a file outside the worktree by absolute path"
     const missing = join(tmpHome!, "does-not-exist.md");
     await workspacePage.dispatchOpenFileEvent({ filename: missing, workspaceId: WORKSPACE });
 
-    // No file to auto-open → the dialog is revealed for the user, and offers
-    // no external-open row (the path isn't a real file).
+    // Positive anchor: the dialog is revealed AND settled with the query set
+    // (the missing path is seeded into the input) — so the subsequent
+    // "no offer" assertion proves the resolver found nothing, not that the
+    // query never arrived.
     await expect(workspacePage.quickOpenDialog()).toBeVisible({ timeout: 15_000 });
+    await expect(workspacePage.quickOpenInput).toHaveValue(missing);
+    // No file to auto-open → no external-open row (the path isn't a real file).
     await expect(workspacePage.quickOpenPathItem).toBeHidden();
     expect(await workspacePage.readOpenTabPaths(WORKSPACE)).not.toContain(missing);
   });

--- a/apps/web/e2e/quick-open-external-file.spec.ts
+++ b/apps/web/e2e/quick-open-external-file.spec.ts
@@ -1,0 +1,232 @@
+/**
+ * End-to-end coverage for opening a file that lives OUTSIDE the workspace
+ * worktree from Quick Open (Cmd+P).
+ *
+ * Feature: when the Quick Open query is an absolute path to a file that
+ * exists — e.g. `/tmp/notes.md` pasted in, or the absolute path a terminal /
+ * chat link dispatches via `band:open-file` — the dialog resolves it against
+ * the workspace (`workspace.resolvePath`) and offers to open it. A path
+ * INSIDE the worktree opens as a normal workspace-relative tab; a path
+ * OUTSIDE opens as an *external* tab (contents read via `host.readFile`,
+ * same pipeline the CLI's `band open <abs>` uses). See `QuickOpenDialog.tsx`,
+ * `workspace.resolvePath` / `editorService.resolvePath`, and
+ * `SharedDockviewLayout.handleOpenExternalFile`.
+ *
+ * Test architecture (per the repo's integration-test doctrine):
+ *   - Boots the real production server against a fresh tmp home — no
+ *     in-process React mounting, no tRPC mocking, no `page.route()`.
+ *   - A real git worktree is the workspace; the "external" files are written
+ *     OUTSIDE the worktree root so they can only be reached by absolute path.
+ *   - A `.ts` external file gives a deterministic CodeMirror content read;
+ *     the user's literal `/tmp/…​.md` example is covered separately (markdown
+ *     opens as a rendered preview, so that case asserts the tab opens rather
+ *     than editor text).
+ *   - The link-driven cases use `dispatchOpenFileEvent` — the exact
+ *     `band:open-file` window event the xterm link provider
+ *     (`terminal-file-links.ts`) and chat file links
+ *     (`ai-elements/file-link-components.tsx`) both fire. The real
+ *     terminal-click variant lives in `terminal-external-file-link.spec.ts`.
+ *   - All locators/actions go through the WorkspacePage / FileViewerPage
+ *     page objects.
+ */
+
+import { mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { expect, test } from "@playwright/test";
+import { toWorkspaceId } from "@/dashboard";
+import { gitInHome as git } from "./helpers/git";
+import {
+  cleanupTmpHome,
+  createTmpHome,
+  type ServerHandle,
+  seedSettings,
+  seedState,
+  startServer,
+} from "./helpers/server";
+import { FileViewerPage } from "./pages/FileViewerPage";
+import { WorkspacePage } from "./pages/WorkspacePage";
+
+const TOKEN = "e2e-quick-open-external-file-token";
+const PROJECT = "quick-open-external-repo";
+const DEFAULT_BRANCH = "main";
+const BRANCH = "feature";
+const WORKSPACE = toWorkspaceId(PROJECT, BRANCH);
+
+// Distinctive marker so the CodeMirror render of the `.ts` external file is
+// unambiguous.
+const TS_MARKER = "band-external-note-marker";
+
+// Desktop viewport so `useIsDesktop()` is true and `SharedDockviewLayout`
+// (which mounts QuickOpenDialog + owns the external-open wiring) renders.
+test.use({ viewport: { width: 1280, height: 800 } });
+
+let server!: ServerHandle;
+let tmpHome: string | undefined;
+let worktreePath!: string;
+// Absolute paths to files OUTSIDE the worktree — the only way to reach them
+// is by absolute path, which is exactly the external-open case under test.
+let externalTsPath!: string;
+let externalMdPath!: string;
+
+test.beforeAll(async () => {
+  tmpHome = createTmpHome();
+
+  const repoPath = join(tmpHome, PROJECT);
+  mkdirSync(repoPath, { recursive: true });
+  git(repoPath, ["init", "-b", DEFAULT_BRANCH], tmpHome);
+  // A single in-worktree file so the workspace is non-empty and Quick Open's
+  // worktree search has a corpus (the external paths must NOT match it).
+  writeFileSync(join(repoPath, "inside.ts"), "export const inside = 1;\n");
+  git(repoPath, ["add", "."], tmpHome);
+  git(repoPath, ["commit", "-m", "seed"], tmpHome);
+
+  worktreePath = join(tmpHome, `${PROJECT}-${BRANCH}`);
+  git(repoPath, ["worktree", "add", "-b", BRANCH, worktreePath], tmpHome);
+
+  // Both sit at the tmp-home root — outside the repo and the worktree, so
+  // they can only be opened by absolute path.
+  externalTsPath = join(tmpHome, "band-external-note.ts");
+  writeFileSync(externalTsPath, `export const marker = "${TS_MARKER}";\n`);
+  externalMdPath = join(tmpHome, "band-terminal-repair-task.md");
+  writeFileSync(externalMdPath, "# task\n\nrepair the terminal\n");
+
+  seedState(tmpHome, {
+    projects: [
+      {
+        name: PROJECT,
+        path: repoPath,
+        defaultBranch: DEFAULT_BRANCH,
+        worktrees: [
+          { branch: DEFAULT_BRANCH, path: repoPath },
+          { branch: BRANCH, path: worktreePath },
+        ],
+      },
+    ],
+  });
+  seedSettings(tmpHome, { tokenSecret: TOKEN });
+  server = await startServer({ tmpHome });
+});
+
+test.afterAll(async () => {
+  if (server) await server.close();
+  if (tmpHome) cleanupTmpHome(tmpHome);
+});
+
+test.describe("Quick Open — open a file outside the worktree by absolute path", () => {
+  test("typing an existing absolute path offers to open it and lands an external tab", async ({
+    page,
+  }) => {
+    const workspacePage = new WorkspacePage(page, server.url, TOKEN);
+    await workspacePage.goto(WORKSPACE);
+    await workspacePage.waitForReady();
+
+    // Nothing open before we begin — poll for settled state.
+    await expect
+      .poll(async () => await workspacePage.readOpenTabPaths(WORKSPACE), { timeout: 5_000 })
+      .not.toContain(externalTsPath);
+
+    await workspacePage.openQuickOpen();
+    await workspacePage.fillQuickOpen(externalTsPath);
+
+    // The offer appears once the probe resolves, and shows the path.
+    await expect(workspacePage.quickOpenPathItem).toBeVisible({ timeout: 15_000 });
+    await expect(workspacePage.quickOpenPathItem).toContainText(externalTsPath);
+
+    // Accept the offer.
+    await workspacePage.openQuickOpenPathItem();
+
+    // Observable outcome: the absolute path is now the active external tab,
+    // the Files panel is active, and the editor shows the file's contents.
+    await expect
+      .poll(async () => (await workspacePage.readOpenTabsState(WORKSPACE))?.active, {
+        timeout: 15_000,
+      })
+      .toBe(externalTsPath);
+    await expect(workspacePage.tabContainer("files")).toHaveClass(/\bdv-active-tab\b/, {
+      timeout: 15_000,
+    });
+    await expect(workspacePage.quickOpenDialog()).toBeHidden();
+
+    const fileViewer = new FileViewerPage(page);
+    await fileViewer.expectContent(TS_MARKER);
+  });
+
+  test("a band:open-file event with an absolute .md path auto-opens it as an external tab (link path)", async ({
+    page,
+  }) => {
+    const workspacePage = new WorkspacePage(page, server.url, TOKEN);
+    await workspacePage.goto(WORKSPACE);
+    await workspacePage.waitForReady();
+
+    // The same event a terminal or chat file link dispatches — here the
+    // user's literal example: an absolute path to a `.md` file, with a
+    // `:line` suffix that `parseFileLocation` strips off the tab path.
+    await workspacePage.dispatchOpenFileEvent({
+      filename: `${externalMdPath}:2`,
+      workspaceId: WORKSPACE,
+    });
+
+    // Single external match → opened directly, the dialog never shows. The
+    // absolute path (suffix stripped) is the active tab. Markdown renders as
+    // a preview rather than a CodeMirror buffer, so we assert the tab opened
+    // and the viewer mounted rather than editor text.
+    await expect
+      .poll(async () => (await workspacePage.readOpenTabsState(WORKSPACE))?.active, {
+        timeout: 15_000,
+      })
+      .toBe(externalMdPath);
+    await expect(workspacePage.quickOpenDialog()).toBeHidden();
+    await expect(page.getByTestId("file-viewer__root")).toBeVisible({ timeout: 15_000 });
+  });
+
+  test("a band:open-file event for a non-existent absolute path reveals the dialog with no match", async ({
+    page,
+  }) => {
+    const workspacePage = new WorkspacePage(page, server.url, TOKEN);
+    await workspacePage.goto(WORKSPACE);
+    await workspacePage.waitForReady();
+
+    const missing = join(tmpHome!, "does-not-exist.md");
+    await workspacePage.dispatchOpenFileEvent({ filename: missing, workspaceId: WORKSPACE });
+
+    // No file to auto-open → the dialog is revealed for the user, and offers
+    // no external-open row (the path isn't a real file).
+    await expect(workspacePage.quickOpenDialog()).toBeVisible({ timeout: 15_000 });
+    await expect(workspacePage.quickOpenPathItem).toBeHidden();
+    expect(await workspacePage.readOpenTabPaths(WORKSPACE)).not.toContain(missing);
+  });
+
+  test("typing an absolute path INSIDE the worktree opens it as a normal (relative) tab", async ({
+    page,
+  }) => {
+    const workspacePage = new WorkspacePage(page, server.url, TOKEN);
+    await workspacePage.goto(WORKSPACE);
+    await workspacePage.waitForReady();
+
+    // An absolute path that happens to point inside the current worktree.
+    const insideAbs = join(worktreePath, "inside.ts");
+    await workspacePage.openQuickOpen();
+    await workspacePage.fillQuickOpen(insideAbs);
+
+    // The offer resolves the path back to its workspace-relative form —
+    // NOT the absolute path — because the file lives inside the worktree.
+    await expect(workspacePage.quickOpenPathItem).toBeVisible({ timeout: 15_000 });
+    await expect(workspacePage.quickOpenPathItem).toContainText("inside.ts");
+    await workspacePage.openQuickOpenPathItem();
+
+    // Observable outcome: it opens as a NORMAL workspace tab keyed by the
+    // relative path (not an external tab keyed by the absolute path).
+    await expect
+      .poll(async () => (await workspacePage.readOpenTabsState(WORKSPACE))?.active, {
+        timeout: 15_000,
+      })
+      .toBe("inside.ts");
+    expect(await workspacePage.readOpenTabPaths(WORKSPACE)).not.toContain(insideAbs);
+    await expect(workspacePage.tabContainer("files")).toHaveClass(/\bdv-active-tab\b/, {
+      timeout: 15_000,
+    });
+
+    const fileViewer = new FileViewerPage(page);
+    await fileViewer.expectContent("export const inside");
+  });
+});

--- a/apps/web/e2e/terminal-external-file-link.spec.ts
+++ b/apps/web/e2e/terminal-external-file-link.spec.ts
@@ -1,0 +1,134 @@
+/**
+ * End-to-end coverage for clicking a terminal link that points at a file
+ * OUTSIDE the workspace worktree.
+ *
+ * Feature: a file-path reference printed in the terminal is a clickable link
+ * (see `lib/terminal-file-links.ts`). The existing `terminal-file-links.spec`
+ * covers a workspace-relative path resolving into the Files panel. This spec
+ * covers the sibling case the user asked for: an ABSOLUTE path to a file that
+ * lives outside the worktree (e.g. `/tmp/band-terminal-repair-task.md`).
+ * Clicking it dispatches the same `band:open-file` event, which Quick Open
+ * now probes against the host filesystem (`host.statFile`) and — since the
+ * file exists — opens as an external editor tab via the same pipeline the
+ * CLI's `band open <abs>` uses.
+ *
+ * Boots the production server bundle against a tmp `~/.band/`, opens a real
+ * terminal (real PTY), prints an absolute path to a file that exists outside
+ * the workspace, clicks the rendered link, and asserts the file lands open as
+ * an external tab (Files tab active + the absolute path persisted into the
+ * open-tabs localStorage entry).
+ *
+ * Renderer note: xterm paints to a `<canvas>` under WebGL, leaving no
+ * hittable DOM text. We force the DOM renderer via
+ * `seedSettings({ useWebGLTerminalRenderer: false })` so the printed path
+ * exists as locatable DOM text — same carve-out as `terminal-file-links.spec`.
+ */
+
+import { mkdtempSync, realpathSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { expect, test } from "@playwright/test";
+import { toWorkspaceId } from "@/dashboard";
+import {
+  cleanupTmpHome,
+  createTmpHome,
+  type ServerHandle,
+  seedSettings,
+  seedState,
+  startServer,
+} from "./helpers/server";
+import { WorkspacePage } from "./pages/WorkspacePage";
+
+const TOKEN = "e2e-terminal-external-file-link-token";
+const PROJECT = "alpha-terminal-external-link";
+const WORKSPACE = toWorkspaceId(PROJECT, "main");
+
+// Wide viewport so `useIsDesktop()` reports true and the shared dockview
+// (which hosts the terminal container) renders.
+test.use({ viewport: { width: 1280, height: 800 } });
+
+let server: ServerHandle;
+let tmpHome: string;
+/** The project path — the PTY spawns with cwd = the project path. */
+let workdir: string;
+/** A directory OUTSIDE the workspace holding the external file. */
+let externalDir: string;
+/** Absolute path to the external file the terminal link points at. */
+let externalPath: string;
+
+test.beforeAll(async () => {
+  tmpHome = createTmpHome();
+  workdir = realpathSync(mkdtempSync(join(tmpdir(), "band-term-ext-workdir-")));
+  // The external file — outside the worktree, reachable only by absolute
+  // path. Deliberately created under a SHORT base (`/tmp`, like the user's
+  // real `/tmp/band-terminal-repair-task.md` example) rather than the OS
+  // tmpdir: on macOS `os.tmpdir()` is a ~57-char `/private/var/folders/…`
+  // path, which pushes the printed line past the terminal's width so it
+  // wraps — and the link provider deliberately doesn't linkify a path split
+  // across rows. We do NOT canonicalize the `/tmp` symlink: the Quick Open
+  // path passes the string through verbatim, and `host.statFile` opens it
+  // fine (its O_NOFOLLOW guards only the final path component, not the
+  // intermediate `/tmp` → `/private/tmp` symlink on macOS).
+  externalDir = mkdtempSync(join("/tmp", "bext-"));
+  externalPath = join(externalDir, "n.md");
+  writeFileSync(externalPath, "# notes\n\noutside the worktree\n", "utf-8");
+
+  seedState(tmpHome, {
+    projects: [
+      {
+        name: PROJECT,
+        path: workdir,
+        defaultBranch: "main",
+        worktrees: [{ branch: "main", path: workdir }],
+      },
+    ],
+  });
+  // Force the DOM renderer so the printed path is locatable DOM text.
+  seedSettings(tmpHome, { tokenSecret: TOKEN, useWebGLTerminalRenderer: false });
+  server = await startServer({ tmpHome });
+});
+
+test.afterAll(async () => {
+  await server.close();
+  cleanupTmpHome(tmpHome);
+  rmSync(workdir, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 });
+  rmSync(externalDir, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 });
+});
+
+test.describe("Terminal links to files outside the worktree", () => {
+  test("clicking an absolute path printed in the terminal opens it as an external tab", async ({
+    page,
+  }) => {
+    // The xterm boot + PTY handshake carries the same generous budget the
+    // other terminal specs use under CI worker contention.
+    test.setTimeout(120_000);
+
+    const workspacePage = new WorkspacePage(page, server.url, TOKEN);
+    await workspacePage.goto(WORKSPACE);
+    await workspacePage.waitForReady();
+    await workspacePage.openTerminalTab();
+    await workspacePage.waitForTerminalReady(75_000);
+
+    // Positive anchor: the external file is not open before the click.
+    await expect
+      .poll(async () => await workspacePage.readOpenTabPaths(WORKSPACE), { timeout: 5_000 })
+      .not.toContain(externalPath);
+
+    // Print the absolute path on its own line; the shell echoes it as a bare
+    // output line the link provider turns into a clickable link.
+    await workspacePage.runInTerminal(`echo ${externalPath}`);
+    await workspacePage.clickTerminalFileLink(externalPath);
+
+    // Observable outcome: the click routed the absolute path through Quick
+    // Open, which opened it as an external tab (Files tab active + the
+    // absolute path persisted into the workspace's open-tabs entry).
+    await expect(workspacePage.tabContainer("files")).toHaveClass(/\bdv-active-tab\b/, {
+      timeout: 15_000,
+    });
+    await expect
+      .poll(async () => (await workspacePage.readOpenTabsState(WORKSPACE))?.active, {
+        timeout: 15_000,
+      })
+      .toBe(externalPath);
+  });
+});

--- a/apps/web/src/components/SharedDockviewLayout.tsx
+++ b/apps/web/src/components/SharedDockviewLayout.tsx
@@ -54,6 +54,7 @@ import {
 } from "../lib/dockview-edge-groups";
 import { isDesktop } from "../lib/is-desktop";
 import { parseWorkspaceFromPath } from "../lib/parse-workspace";
+import { enqueueExternalOpen } from "../lib/pending-external-open";
 import { trpc } from "../lib/trpc-client";
 import { CodeBrowserView } from "./CodeBrowserView";
 import { DockviewChatContainer } from "./DockviewChatContainer";
@@ -892,6 +893,25 @@ export function SharedDockviewLayout() {
 
   const handleFileOpened = useCallback((workspaceId: string) => {
     setPerWorkspaceState(workspaceId, { openFilePath: null });
+  }, []);
+
+  // Open a file that lives OUTSIDE the worktree by absolute path (Quick
+  // Open offers this when the query resolves to an existing file on the
+  // host filesystem — e.g. a `/tmp/notes.md` path pasted in or arriving
+  // from a terminal/chat link). We can't route through `handleOpenFile`:
+  // that path is workspace-relative and `CodeBrowserView` would join it
+  // against the worktree root. Instead reuse the same external-open queue
+  // the CLI's `band open <abs>` uses — `CodeBrowserView` drains it and
+  // mounts the path as an *external* tab (reads via `host.readFile`). The
+  // `location` may carry a `:line[:col]` suffix, which the drain parses.
+  const handleOpenExternalFile = useCallback((workspaceId: string, location: string) => {
+    enqueueExternalOpen(workspaceId, location);
+    // Reveal the Files panel only for the visible workspace, mirroring
+    // `handleOpenFile` — a cached-but-invisible workspace must not steal
+    // the active tab.
+    if (workspaceId === activeWorkspaceIdRef.current) {
+      apiRef.current?.getPanel("files")?.api.setActive();
+    }
   }, []);
 
   const handleSelectFile = useCallback(
@@ -1947,6 +1967,9 @@ export function SharedDockviewLayout() {
         }}
         onOpenFile={(filename) => {
           if (activeWorkspaceId) handleOpenFile(activeWorkspaceId, filename);
+        }}
+        onOpenExternalFile={(location) => {
+          if (activeWorkspaceId) handleOpenExternalFile(activeWorkspaceId, location);
         }}
         currentFile={activeCurrentFile}
         initialQuery={quickOpenQuery}

--- a/apps/web/src/dashboard/adapter.ts
+++ b/apps/web/src/dashboard/adapter.ts
@@ -191,8 +191,10 @@ export interface DashboardAdapter {
    * does it exist, is it a regular file, and does it live inside the
    * worktree (→ `workspaceRelativePath`) or outside it (→ `external`)? Used
    * by Quick Open to decide whether a pasted / terminal-link path opens as a
-   * normal workspace file or an external tab. Never rejects for a
-   * missing/invalid path — reports `{ exists: false }`.
+   * normal workspace file or an external tab.
+   *
+   * Resolves even when the path doesn't exist on disk (reports
+   * `{ exists: false }`); may REJECT when `workspaceId` is unknown.
    */
   resolveWorkspacePath?(
     workspaceId: string,

--- a/apps/web/src/dashboard/adapter.ts
+++ b/apps/web/src/dashboard/adapter.ts
@@ -186,6 +186,24 @@ export interface DashboardAdapter {
    */
   readExternalFile?(absolutePath: string): Promise<FileContentResult>;
 
+  /**
+   * Resolve an absolute (or workspace-relative) path against a workspace:
+   * does it exist, is it a regular file, and does it live inside the
+   * worktree (→ `workspaceRelativePath`) or outside it (→ `external`)? Used
+   * by Quick Open to decide whether a pasted / terminal-link path opens as a
+   * normal workspace file or an external tab. Never rejects for a
+   * missing/invalid path — reports `{ exists: false }`.
+   */
+  resolveWorkspacePath?(
+    workspaceId: string,
+    path: string,
+  ): Promise<{
+    exists: boolean;
+    isFile: boolean;
+    external: boolean;
+    workspaceRelativePath: string | null;
+  }>;
+
   /** Write a file by absolute filesystem path. Mirror of `saveWorkspaceFile`
    *  for external files. */
   saveExternalFile?(absolutePath: string, content: string): Promise<void>;

--- a/apps/web/src/dashboard/adapters/web.ts
+++ b/apps/web/src/dashboard/adapters/web.ts
@@ -438,6 +438,18 @@ export class WebDashboardAdapter implements DashboardAdapter {
     return (await this.trpc.host.readFile.query({ absolutePath })) as FileContentResult;
   }
 
+  async resolveWorkspacePath(
+    workspaceId: string,
+    path: string,
+  ): Promise<{
+    exists: boolean;
+    isFile: boolean;
+    external: boolean;
+    workspaceRelativePath: string | null;
+  }> {
+    return await this.trpc.workspace.resolvePath.query({ workspaceId, path });
+  }
+
   async saveExternalFile(absolutePath: string, content: string): Promise<void> {
     await this.trpc.host.saveFile.mutate({ absolutePath, content });
   }

--- a/apps/web/src/dashboard/components/QuickOpenDialog.tsx
+++ b/apps/web/src/dashboard/components/QuickOpenDialog.tsx
@@ -124,8 +124,12 @@ export function QuickOpenDialog({
   // An absolute-path query isn't a worktree-relative fuzzy match — resolve
   // it against the workspace to find out if it exists and whether it lives
   // inside the worktree (open as a normal file) or outside it (external
-  // tab). Gated on the host exposing the resolver.
-  const isAbsoluteQuery = !!adapter.resolveWorkspacePath && isAbsoluteFilePath(searchQuery);
+  // tab). Gated on the host exposing the resolver. Memoised so it's a stable
+  // dependency for the two effects and the `probeReady`/`probeHit` derivations.
+  const isAbsoluteQuery = useMemo(
+    () => !!adapter.resolveWorkspacePath && isAbsoluteFilePath(searchQuery),
+    [adapter.resolveWorkspacePath, searchQuery],
+  );
 
   // Only trust the probe result when it's for the CURRENT query (see the
   // `probe` state comment). `probeReady` gates auto-open; `probeHit` is the

--- a/apps/web/src/dashboard/components/QuickOpenDialog.tsx
+++ b/apps/web/src/dashboard/components/QuickOpenDialog.tsx
@@ -15,7 +15,7 @@ import { FileInput } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useAdapter, useCapabilities } from "../context";
 import { getFileIcon } from "../lib/file-icon";
-import { formatFileLocation, parseFileLocation } from "../lib/file-location";
+import { formatFileLocation, isAbsoluteFilePath, parseFileLocation } from "../lib/file-location";
 import { shouldBailAutoOpen } from "../lib/quick-open-bail";
 
 interface QuickOpenDialogProps {
@@ -23,6 +23,14 @@ interface QuickOpenDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   onOpenFile: (path: string) => void;
+  /**
+   * Open a file that lives OUTSIDE the workspace worktree, by absolute
+   * path (optionally with a `:line[:col]` suffix). Offered when the query
+   * is an absolute path to an existing file — e.g. a path pasted in, or a
+   * terminal/chat link to `/tmp/notes.md`. When omitted, the external
+   * "Open file" affordance is not shown.
+   */
+  onOpenExternalFile?: (path: string) => void;
   /** The currently open file path (used for ":line" go-to-line shortcut). */
   currentFile?: string;
   /** When set, the dialog opens with this query pre-filled. Cleared on close. */
@@ -43,6 +51,7 @@ export function QuickOpenDialog({
   open,
   onOpenChange,
   onOpenFile,
+  onOpenExternalFile,
   currentFile,
   initialQuery,
   autoOpen,
@@ -54,8 +63,31 @@ export function QuickOpenDialog({
   const capabilities = useCapabilities();
   const [query, setQuery] = useState("");
   const [files, setFiles] = useState<string[]>([]);
+  // Result of probing an absolute-path query against the workspace.
+  // `resolved` gates auto-open (terminal/chat links) until the probe has
+  // settled; `hit` is the file to offer (with the path to open and whether
+  // it lives outside the worktree), or null when the query isn't an absolute
+  // path / the file is missing / isn't a regular file.
+  //
+  // This is a single state object (not `hit` state + a `resolved` ref) on
+  // purpose: a NON-existent path must still fire a re-render when the probe
+  // settles so the auto-open effect re-runs and reveals the dialog. A ref
+  // wouldn't change any effect dependency (hit stays null→null), so the
+  // effect would never re-run and the dialog would hang invisible.
+  //
+  // `query` records which query this result is for. State updates are async,
+  // so a result for a PRIOR query (e.g. the transient empty query the field
+  // holds before `initialQuery` seeds) can linger into the render for the
+  // NEXT query; the auto-open effect must not trust a result whose `query`
+  // doesn't match the current one, or it would act on a stale `resolved`.
+  const [probe, setProbe] = useState<{
+    query: string;
+    resolved: boolean;
+    hit: { openPath: string; external: boolean } | null;
+  }>({ query: "", resolved: false, hit: null });
   const [loading, setLoading] = useState(false);
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const probeStatRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   // Controlled cmdk selection. We drive the highlighted item ourselves so we
   // can snap it back to the first result whenever the query changes (see the
   // reset effect near the render). The scrollable results list is scrolled to
@@ -89,6 +121,20 @@ export function QuickOpenDialog({
   const parsedQuery = useMemo(() => parseFileLocation(query), [query]);
   const searchQuery = parsedQuery.filePath;
 
+  // An absolute-path query isn't a worktree-relative fuzzy match — resolve
+  // it against the workspace to find out if it exists and whether it lives
+  // inside the worktree (open as a normal file) or outside it (external
+  // tab). Gated on the host exposing the resolver.
+  const isAbsoluteQuery = !!adapter.resolveWorkspacePath && isAbsoluteFilePath(searchQuery);
+
+  // Only trust the probe result when it's for the CURRENT query (see the
+  // `probe` state comment). `probeReady` gates auto-open; `probeHit` is the
+  // offerable file, or null. External hits are only actionable when the host
+  // provides `onOpenExternalFile`.
+  const probeReady = probe.resolved && probe.query === searchQuery;
+  const probeHit =
+    probeReady && probe.hit && (!probe.hit.external || onOpenExternalFile) ? probe.hit : null;
+
   // Whether to show recent files instead of searching
   const showRecent =
     searchQuery === "" && parsedQuery.line == null && recentFiles && recentFiles.length > 0;
@@ -108,6 +154,19 @@ export function QuickOpenDialog({
     if (showRecent) {
       setFiles([]);
       setLoading(false);
+      searchResolved.current = true;
+      return;
+    }
+
+    // Absolute path → skip the worktree fuzzy search entirely. Matching the
+    // absolute string against worktree files would surface unrelated
+    // coincidental fuzzy hits — and with autoOpen (terminal/chat links) a
+    // single such hit would open the WRONG file. The path-resolve probe
+    // effect below owns the loading flag for this case; mark the worktree
+    // search trivially resolved (no worktree match) so the autoOpen gate
+    // depends only on the probe.
+    if (isAbsoluteQuery) {
+      setFiles([]);
       searchResolved.current = true;
       return;
     }
@@ -139,7 +198,58 @@ export function QuickOpenDialog({
       cancelled = true;
       if (debounceRef.current) clearTimeout(debounceRef.current);
     };
-  }, [adapter, workspaceId, searchQuery, parsedQuery.line, open, showRecent]);
+  }, [adapter, workspaceId, searchQuery, parsedQuery.line, open, showRecent, isAbsoluteQuery]);
+
+  // Resolve an absolute-path query against the workspace so we can offer to
+  // open it — as a normal file when it lives inside the worktree, or as an
+  // external tab when outside (e.g. `/tmp/notes.md` pasted in, or a terminal
+  // link that dispatched `band:open-file`). Debounced like the worktree
+  // search; owns the `loading` flag while an absolute query is active.
+  useEffect(() => {
+    if (!open) return;
+
+    if (!isAbsoluteQuery || !adapter.resolveWorkspacePath) {
+      // Nothing to probe — mark resolved so the auto-open gate below passes.
+      setProbe({ query: searchQuery, resolved: true, hit: null });
+      return;
+    }
+
+    let cancelled = false;
+    // Mark unresolved while the debounce + probe are in flight so auto-open
+    // waits (and the empty state reads "Searching…" rather than "No files").
+    setProbe({ query: searchQuery, resolved: false, hit: null });
+    setLoading(true);
+
+    if (probeStatRef.current) clearTimeout(probeStatRef.current);
+    probeStatRef.current = setTimeout(() => {
+      adapter.resolveWorkspacePath!(workspaceId, searchQuery)
+        .then((res) => {
+          if (cancelled) return;
+          const hit =
+            res.exists && res.isFile
+              ? {
+                  // Inside the worktree → open the workspace-relative path so
+                  // it flows through the normal Files-panel / route plumbing.
+                  // Outside → open the absolute path as an external tab.
+                  openPath: res.external ? searchQuery : (res.workspaceRelativePath ?? searchQuery),
+                  external: res.external,
+                }
+              : null;
+          setProbe({ query: searchQuery, resolved: true, hit });
+        })
+        .catch(() => {
+          if (!cancelled) setProbe({ query: searchQuery, resolved: true, hit: null });
+        })
+        .finally(() => {
+          if (!cancelled) setLoading(false);
+        });
+    }, 150);
+
+    return () => {
+      cancelled = true;
+      if (probeStatRef.current) clearTimeout(probeStatRef.current);
+    };
+  }, [adapter, workspaceId, searchQuery, isAbsoluteQuery, open]);
 
   // Auto-open: wait for the initial search to resolve, then either open the
   // single result directly or reveal the dialog for the user to pick.
@@ -199,7 +309,17 @@ export function QuickOpenDialog({
 
   useEffect(() => {
     if (!open || !autoOpen || autoOpened.current) return;
-    if (!searchResolved.current) return; // search hasn't completed yet
+    // Don't decide on the transient empty-query render. `query` starts "" and
+    // is seeded to `initialQuery` in a follow-up effect, so the first render
+    // after open always has an empty query. Auto-open only ever targets a
+    // real filename (or a go-to-line ":N"), so waiting here avoids latching
+    // `autoOpened` on the empty phase — where a just-resolved worktree search
+    // would otherwise reveal the dialog before the seeded query is searched.
+    if (searchQuery === "" && parsedQuery.line == null) return;
+    if (!searchResolved.current) return; // worktree search hasn't completed yet
+    // For an absolute-path query, also wait for the path-resolve probe so we
+    // don't prematurely reveal "No files found" before it resolves.
+    if (isAbsoluteQuery && !probeReady) return;
 
     // Bail if the workspace switched while we were waiting for the
     // search. `onOpenFile` is bound to the parent's *current* workspace
@@ -217,7 +337,18 @@ export function QuickOpenDialog({
     }
 
     autoOpened.current = true;
-    if (files.length === 1) {
+    if (probeHit) {
+      // Absolute path to an existing file — open it directly, never show the
+      // dialog. Inside the worktree → normal (workspace-relative) tab;
+      // outside → external tab.
+      const location = formatFileLocation(probeHit.openPath, parsedQuery.line, {
+        lineEnd: parsedQuery.lineEnd,
+        column: parsedQuery.column,
+      });
+      if (probeHit.external) onOpenExternalFile?.(location);
+      else onOpenFile(location);
+      onOpenChange(false);
+    } else if (files.length === 1) {
       // Single result — open it directly, never show the dialog
       const location = formatFileLocation(files[0], parsedQuery.line, {
         lineEnd: parsedQuery.lineEnd,
@@ -229,7 +360,20 @@ export function QuickOpenDialog({
       // 0 or 2+ results — reveal the dialog so the user can pick
       setDialogVisible(true);
     }
-  }, [autoOpen, files, open, parsedQuery, onOpenFile, onOpenChange, workspaceId]);
+  }, [
+    autoOpen,
+    files,
+    open,
+    parsedQuery,
+    onOpenFile,
+    onOpenExternalFile,
+    onOpenChange,
+    workspaceId,
+    isAbsoluteQuery,
+    probeReady,
+    probeHit,
+    searchQuery,
+  ]);
 
   // Keep a ref to the current query so the close effect can read it without depending on it
   const queryRef = useRef(query);
@@ -244,6 +388,7 @@ export function QuickOpenDialog({
       onQueryChange?.(queryRef.current);
       setQuery("");
       setFiles([]);
+      setProbe({ query: "", resolved: false, hit: null });
       autoOpened.current = false;
       searchResolved.current = false;
       openedWorkspaceIdRef.current = null;
@@ -274,6 +419,20 @@ export function QuickOpenDialog({
     },
     [onOpenFile, onOpenChange, parsedQuery],
   );
+
+  // Open the probed absolute-path hit. Re-attaches any `:line[:col]` suffix
+  // from the query. Inside the worktree → normal tab (`onOpenFile`); outside
+  // → external tab (`onOpenExternalFile`).
+  const handleOpenProbed = useCallback(() => {
+    if (!probeHit) return;
+    const location = formatFileLocation(probeHit.openPath, parsedQuery.line, {
+      lineEnd: parsedQuery.lineEnd,
+      column: parsedQuery.column,
+    });
+    if (probeHit.external) onOpenExternalFile?.(location);
+    else onOpenFile(location);
+    onOpenChange(false);
+  }, [probeHit, onOpenFile, onOpenExternalFile, onOpenChange, parsedQuery]);
 
   // "Open File…" entry — surfaces the OS file picker so the user can
   // open a file from anywhere on the local filesystem. Only available
@@ -327,11 +486,20 @@ export function QuickOpenDialog({
     () => displayFiles.map((file) => file.split("/").pop() || file),
     [displayFiles],
   );
+  // Basename of the external candidate, split on both separators so a
+  // Windows path (`C:\Users\me\notes.md`) shows `notes.md` too.
+  const probeFileName = useMemo(
+    () => (probeHit ? probeHit.openPath.split(/[\\/]/).pop() || probeHit.openPath : ""),
+    [probeHit],
+  );
+  const ProbeFileIcon = getFileIcon(probeFileName);
   // biome-ignore lint/correctness/useExhaustiveDependencies: resultKey is an intentional trigger dependency (fires on any content change, incl. when firstFile is unchanged) — it isn't read in the body
   useEffect(() => {
-    setSelectedValue(firstFile);
+    // For an absolute-path query the probed item is the primary (only)
+    // result, so highlight it — otherwise Enter would do nothing.
+    setSelectedValue(probeHit ? probeHit.openPath : firstFile);
     if (listRef.current) listRef.current.scrollTop = 0;
-  }, [resultKey, firstFile]);
+  }, [resultKey, firstFile, probeHit]);
 
   return (
     <Dialog open={open && dialogVisible} onOpenChange={onOpenChange}>
@@ -377,6 +545,28 @@ export function QuickOpenDialog({
             ) : (
               <>
                 <CommandEmpty>{loading ? "Searching..." : "No files found."}</CommandEmpty>
+                {probeHit && (
+                  <CommandGroup heading={probeHit.external ? "Open external file" : "Open file"}>
+                    <CommandItem
+                      value={probeHit.openPath}
+                      onSelect={handleOpenProbed}
+                      data-testid="quick-open__path-result"
+                    >
+                      <ProbeFileIcon className="size-4 shrink-0 text-muted-foreground" />
+                      <div className="flex min-w-0 flex-1 items-baseline gap-2">
+                        <span className="shrink-0 text-sm font-medium">{probeFileName}</span>
+                        <span className="min-w-0 truncate text-xs text-muted-foreground">
+                          {probeHit.openPath}
+                        </span>
+                      </div>
+                      {probeHit.external && (
+                        <span className="ml-auto shrink-0 text-xs text-muted-foreground">
+                          Outside this workspace
+                        </span>
+                      )}
+                    </CommandItem>
+                  </CommandGroup>
+                )}
                 <CommandGroup heading={groupHeading}>
                   {displayFiles.map((file, index) => {
                     const fileName = fileNames[index];

--- a/apps/web/src/dashboard/components/QuickOpenDialog.tsx
+++ b/apps/web/src/dashboard/components/QuickOpenDialog.tsx
@@ -214,6 +214,10 @@ export function QuickOpenDialog({
 
     if (!isAbsoluteQuery || !adapter.resolveWorkspacePath) {
       // Nothing to probe — mark resolved so the auto-open gate below passes.
+      // Also clear `loading`: if a prior probe left it set and the worktree
+      // search effect can't clear it (an adapter without `searchWorkspaceFiles`
+      // early-returns), the "Searching…" state would otherwise stick.
+      setLoading(false);
       setProbe({ query: searchQuery, resolved: true, hit: null });
       return;
     }

--- a/apps/web/src/dashboard/lib/file-location.ts
+++ b/apps/web/src/dashboard/lib/file-location.ts
@@ -64,6 +64,20 @@ export function parseFileLocation(raw: string): FileLocation {
 }
 
 /**
+ * Whether `filePath` is an absolute filesystem path — a POSIX path
+ * (`/tmp/x`), a Windows drive path (`C:\x` or `C:/x`), or a Windows UNC
+ * path (`\\host\share`). Used by Quick Open to decide whether a query
+ * could refer to a file outside the workspace worktree.
+ *
+ * This runs in the browser where `node:path` isn't available, so it can't
+ * defer to `path.isAbsolute`; the server re-checks with the real
+ * `isAbsolute` before touching the filesystem.
+ */
+export function isAbsoluteFilePath(filePath: string): boolean {
+  return /^(\/|[A-Za-z]:[\\/]|\\\\)/.test(filePath);
+}
+
+/**
  * Formats a file path with optional line/range/column information.
  * Inverse of parseFileLocation.
  */

--- a/apps/web/src/server/api/editor/router.ts
+++ b/apps/web/src/server/api/editor/router.ts
@@ -68,9 +68,9 @@ export const editorRouter = t.router({
           path: ["lineEnd"],
         }),
     )
-    .mutation(({ input }) => {
+    .mutation(async ({ input }) => {
       try {
-        return editorService.openFile(input);
+        return await editorService.openFile(input);
       } catch (err) {
         if (err instanceof EditorOpenError) {
           throw new TRPCError({ code: err.code, message: err.message });

--- a/apps/web/src/server/api/workspace/router.ts
+++ b/apps/web/src/server/api/workspace/router.ts
@@ -395,6 +395,14 @@ export const workspaceRouter = t.router({
   // Quick Open calls this for an absolute-path query so a path that happens
   // to be inside the current workspace opens as a normal file rather than an
   // external tab. Shares `openFile`'s canonicalize + containment logic.
+  //
+  // Intentional tradeoff: this reports `exists`/`isFile` for ANY absolute
+  // path an authenticated caller supplies (not just in-worktree ones), so it
+  // is a filesystem-existence oracle. That is acceptable under Band's threat
+  // model — the same auth scope already reads arbitrary absolute paths via
+  // `host.readFile` — and the `external` flag is load-bearing, not dead code:
+  // it's how the client decides between a workspace-relative and an external
+  // tab. Do not "harden" this by dropping the out-of-worktree classification.
   resolvePath: publicProcedure
     .input(z.object({ workspaceId: z.string(), path: z.string().min(1) }))
     .query(({ input }) =>

--- a/apps/web/src/server/api/workspace/router.ts
+++ b/apps/web/src/server/api/workspace/router.ts
@@ -389,6 +389,18 @@ export const workspaceRouter = t.router({
       }),
     ),
 
+  // Resolve an absolute (or workspace-relative) path against this
+  // workspace: does it exist, is it a regular file, and does it live inside
+  // the worktree (→ workspace-relative path) or outside it (→ external tab)?
+  // Quick Open calls this for an absolute-path query so a path that happens
+  // to be inside the current workspace opens as a normal file rather than an
+  // external tab. Shares `openFile`'s canonicalize + containment logic.
+  resolvePath: publicProcedure
+    .input(z.object({ workspaceId: z.string(), path: z.string().min(1) }))
+    .query(({ input }) =>
+      editorService.resolvePath({ workspaceId: input.workspaceId, filePath: input.path }),
+    ),
+
   searchContent: publicProcedure
     .input(
       z.object({

--- a/apps/web/src/server/services/editor-service.ts
+++ b/apps/web/src/server/services/editor-service.ts
@@ -123,13 +123,101 @@ export class EditorService {
       throw new EditorOpenError("NOT_FOUND", `Workspace '${targetWorkspaceId}' not found`);
     }
 
-    const root = workspace.worktree.path;
+    const resolved = this.resolveTarget(workspace.worktree.path, input.filePath);
 
-    // Resolve the path: absolute paths are taken as-is; relative paths
-    // are resolved against the workspace root.
-    const absoluteTarget = isAbsolute(input.filePath)
-      ? resolve(input.filePath)
-      : resolve(root, input.filePath);
+    // `existsSync` is true for directories too. Without the `isFile`
+    // guard, `band open /path/to/some-dir` would pass through to the
+    // renderer as an external "file" and the editor would try to open
+    // the directory as a text buffer.
+    if (!resolved.exists) {
+      throw new EditorOpenError("NOT_FOUND", `File not found: ${input.filePath}`);
+    }
+    if (!resolved.isFile) {
+      throw new EditorOpenError("BAD_REQUEST", `Not a file: ${input.filePath}`);
+    }
+
+    // Two open modes share this procedure:
+    //   - In-workspace: emit a workspace-relative path so the renderer
+    //     opens it in the workspace's Files panel.
+    //   - External: file exists on disk but lives outside the active
+    //     workspace's root. Pass the absolute path through verbatim so
+    //     the FileViewer mounts it as an *external* tab.
+    const payloadPath = resolved.inside ? resolved.relativePath! : resolved.canonicalTarget;
+
+    const formatted = formatFileLocation(payloadPath, input.line, {
+      lineEnd: input.lineEnd,
+      column: input.column,
+    });
+
+    emit({
+      kind: "open-file",
+      workspaceId: targetWorkspaceId,
+      filePath: formatted,
+      external: !resolved.inside,
+      focus: input.focus ?? true,
+    });
+
+    return {
+      ok: true,
+      workspaceId: targetWorkspaceId,
+      filePath: formatted,
+      external: !resolved.inside,
+    };
+  }
+
+  /**
+   * Resolve a path (absolute or workspace-relative) against a workspace and
+   * report where it lands. Used by the dashboard's Quick Open to decide, for
+   * an absolute-path query, whether to open the file as a normal
+   * workspace-relative tab (when it lives *inside* the worktree) or as an
+   * external tab (outside) — and, either way, whether it exists at all.
+   *
+   * Shares the exact canonicalize + segment-aware containment logic that
+   * `openFile` uses, so an absolute path typed into Quick Open and the same
+   * path passed to `band open` resolve identically. Unlike `openFile` this
+   * neither emits an SSE event nor throws for a missing file — the caller
+   * only offers to open when `exists && isFile`.
+   */
+  resolvePath(input: { workspaceId: string; filePath: string }): {
+    exists: boolean;
+    isFile: boolean;
+    /** True when the path lies outside the workspace worktree. */
+    external: boolean;
+    /** POSIX workspace-relative path, set only when inside the worktree. */
+    workspaceRelativePath: string | null;
+  } {
+    const workspace = workspaceService.resolve(input.workspaceId);
+    if (!workspace) {
+      throw new WorkspaceNotFoundError(input.workspaceId);
+    }
+    const resolved = this.resolveTarget(workspace.worktree.path, input.filePath);
+    return {
+      exists: resolved.exists,
+      isFile: resolved.isFile,
+      external: !resolved.inside,
+      workspaceRelativePath: resolved.inside ? resolved.relativePath : null,
+    };
+  }
+
+  /**
+   * Shared resolution core for {@link openFile} and {@link resolvePath}:
+   * canonicalize the target (following the deepest existing ancestor so
+   * not-yet-created paths still classify), stat it, and run the
+   * segment-aware containment check against the canonicalized worktree root.
+   */
+  private resolveTarget(
+    root: string,
+    filePath: string,
+  ): {
+    canonicalTarget: string;
+    exists: boolean;
+    isFile: boolean;
+    inside: boolean;
+    /** POSIX workspace-relative path when `inside`, else null. */
+    relativePath: string | null;
+  } {
+    // Absolute paths are taken as-is; relative paths resolve against root.
+    const absoluteTarget = isAbsolute(filePath) ? resolve(filePath) : resolve(root, filePath);
 
     // Canonicalize the workspace root so symlinked path prefixes
     // (macOS's `/var/folders` → `/private/var/folders` in particular)
@@ -150,65 +238,34 @@ export class EditorService {
     // *create* as well.
     const canonicalTarget = canonicalizeMaybeMissing(absoluteTarget);
 
-    // `existsSync` is true for directories too. Without the `isFile`
-    // guard, `band open /path/to/some-dir` would pass through to the
-    // renderer as an external "file" and the editor would try to open
-    // the directory as a text buffer.
     let targetStat: import("node:fs").Stats | null = null;
     try {
       targetStat = statSync(canonicalTarget);
     } catch {
-      // ENOENT or another IO error — surfaced as "File not found" below.
-    }
-    if (!targetStat) {
-      throw new EditorOpenError("NOT_FOUND", `File not found: ${input.filePath}`);
-    }
-    if (!targetStat.isFile()) {
-      throw new EditorOpenError("BAD_REQUEST", `Not a file: ${input.filePath}`);
+      // ENOENT or another IO error — reported via `exists: false`.
     }
 
     // Segment-aware containment check (same invariant as the untitled
     // save flow in CodeBrowserView): a naive `startsWith` would treat
     // `/a/band-fork/x.ts` as inside `/a/band`.
     const normalizedRoot = canonicalRoot.replace(/\/+$/, "");
-    const isInside =
+    const inside =
       canonicalTarget === normalizedRoot || canonicalTarget.startsWith(`${normalizedRoot}${sep}`);
 
-    // Two open modes share this procedure:
-    //   - In-workspace: emit a workspace-relative path so the renderer
-    //     opens it in the workspace's Files panel.
-    //   - External: file exists on disk but lives outside the active
-    //     workspace's root. Pass the absolute path through verbatim so
-    //     the FileViewer mounts it as an *external* tab.
-    let payloadPath: string;
-    if (isInside) {
-      const relativePath =
-        canonicalTarget === normalizedRoot ? "" : canonicalTarget.slice(normalizedRoot.length + 1);
-      // POSIX separators on the wire — tanstack-router and
-      // `parseFileLocation` both work off `/`-separated paths.
-      payloadPath = relativePath.split(sep).join("/");
-    } else {
-      payloadPath = canonicalTarget;
-    }
-
-    const formatted = formatFileLocation(payloadPath, input.line, {
-      lineEnd: input.lineEnd,
-      column: input.column,
-    });
-
-    emit({
-      kind: "open-file",
-      workspaceId: targetWorkspaceId,
-      filePath: formatted,
-      external: !isInside,
-      focus: input.focus ?? true,
-    });
+    // POSIX separators on the wire — tanstack-router and
+    // `parseFileLocation` both work off `/`-separated paths.
+    const relativePath = inside
+      ? (canonicalTarget === normalizedRoot ? "" : canonicalTarget.slice(normalizedRoot.length + 1))
+          .split(sep)
+          .join("/")
+      : null;
 
     return {
-      ok: true,
-      workspaceId: targetWorkspaceId,
-      filePath: formatted,
-      external: !isInside,
+      canonicalTarget,
+      exists: !!targetStat,
+      isFile: !!targetStat?.isFile(),
+      inside,
+      relativePath,
     };
   }
 }

--- a/apps/web/src/server/services/editor-service.ts
+++ b/apps/web/src/server/services/editor-service.ts
@@ -1,4 +1,4 @@
-import { existsSync, realpathSync, statSync } from "node:fs";
+import { realpath, stat } from "node:fs/promises";
 import { isAbsolute, join, resolve, sep } from "node:path";
 import { formatFileLocation } from "@/dashboard";
 import { WorkspaceNotFoundError } from "../errors";
@@ -97,19 +97,19 @@ export class EditorService {
   // `band open` — resolve a CLI-supplied path and emit the SSE event
   // -------------------------------------------------------------------------
 
-  openFile(input: {
+  async openFile(input: {
     workspaceId?: string;
     filePath: string;
     line?: number;
     lineEnd?: number;
     column?: number;
     focus?: boolean;
-  }): {
+  }): Promise<{
     ok: true;
     workspaceId: string;
     filePath: string;
     external: boolean;
-  } {
+  }> {
     const targetWorkspaceId = input.workspaceId ?? this.activeWorkspaceId;
     if (!targetWorkspaceId) {
       throw new EditorOpenError(
@@ -123,9 +123,9 @@ export class EditorService {
       throw new EditorOpenError("NOT_FOUND", `Workspace '${targetWorkspaceId}' not found`);
     }
 
-    const resolved = this.resolveTarget(workspace.worktree.path, input.filePath);
+    const resolved = await this.resolveTarget(workspace.worktree.path, input.filePath);
 
-    // `existsSync` is true for directories too. Without the `isFile`
+    // `stat` follows to a directory too. Without the `isFile`
     // guard, `band open /path/to/some-dir` would pass through to the
     // renderer as an external "file" and the editor would try to open
     // the directory as a text buffer.
@@ -178,19 +178,19 @@ export class EditorService {
    * neither emits an SSE event nor throws for a missing file — the caller
    * only offers to open when `exists && isFile`.
    */
-  resolvePath(input: { workspaceId: string; filePath: string }): {
+  async resolvePath(input: { workspaceId: string; filePath: string }): Promise<{
     exists: boolean;
     isFile: boolean;
     /** True when the path lies outside the workspace worktree. */
     external: boolean;
     /** POSIX workspace-relative path, set only when inside the worktree. */
     workspaceRelativePath: string | null;
-  } {
+  }> {
     const workspace = workspaceService.resolve(input.workspaceId);
     if (!workspace) {
       throw new WorkspaceNotFoundError(input.workspaceId);
     }
-    const resolved = this.resolveTarget(workspace.worktree.path, input.filePath);
+    const resolved = await this.resolveTarget(workspace.worktree.path, input.filePath);
     return {
       exists: resolved.exists,
       isFile: resolved.isFile,
@@ -205,17 +205,17 @@ export class EditorService {
    * not-yet-created paths still classify), stat it, and run the
    * segment-aware containment check against the canonicalized worktree root.
    */
-  private resolveTarget(
+  private async resolveTarget(
     root: string,
     filePath: string,
-  ): {
+  ): Promise<{
     canonicalTarget: string;
     exists: boolean;
     isFile: boolean;
     inside: boolean;
     /** POSIX workspace-relative path when `inside`, else null. */
     relativePath: string | null;
-  } {
+  }> {
     // Absolute paths are taken as-is; relative paths resolve against root.
     const absoluteTarget = isAbsolute(filePath) ? resolve(filePath) : resolve(root, filePath);
 
@@ -223,24 +223,25 @@ export class EditorService {
     // (macOS's `/var/folders` → `/private/var/folders` in particular)
     // compare equal. The CLI canonicalizes the user's argument before
     // sending, so a stored worktree path under `/var/...` would
-    // otherwise look "outside" its real location.
+    // otherwise look "outside" its real location. Async fs (fs/promises)
+    // so the tRPC query handler never parks the event loop on sync I/O.
     let canonicalRoot = root;
     try {
-      canonicalRoot = realpathSync(root);
+      canonicalRoot = await realpath(root);
     } catch {
       // worktree may have been deleted out from under us — leave as-is
     }
 
-    // Canonicalize the user's path the same way. `realpathSync` fails on
+    // Canonicalize the user's path the same way. `realpath` fails on
     // missing files, so walk up to the deepest ancestor that does exist,
     // canonicalize that, then re-append the trailing segments. That
     // keeps the in-workspace check accurate for paths the user wants to
     // *create* as well.
-    const canonicalTarget = canonicalizeMaybeMissing(absoluteTarget);
+    const canonicalTarget = await canonicalizeMaybeMissing(absoluteTarget);
 
     let targetStat: import("node:fs").Stats | null = null;
     try {
-      targetStat = statSync(canonicalTarget);
+      targetStat = await stat(canonicalTarget);
     } catch {
       // ENOENT or another IO error — reported via `exists: false`.
     }
@@ -285,32 +286,30 @@ export class EditorOpenError extends Error {
 }
 
 /**
- * `realpathSync` resolves symlinks but throws ENOENT for paths that don't
+ * `realpath` resolves symlinks but throws ENOENT for paths that don't
  * exist. We need the symlink-resolution part for paths that may or may not
- * exist (e.g. files the user wants to *open* that don't exist yet). Walk
- * up the path until we hit an ancestor that does exist, canonicalize that,
- * then re-append the trailing segments.
+ * exist (e.g. files the user wants to *open* that don't exist yet). Try to
+ * canonicalize the whole path; on failure walk up to the deepest ancestor
+ * that does resolve, canonicalize that, then re-append the trailing
+ * segments. Async (fs/promises) so callers don't block the event loop.
  */
-function canonicalizeMaybeMissing(p: string): string {
-  if (existsSync(p)) {
-    try {
-      return realpathSync(p);
-    } catch {
-      return p;
-    }
+async function canonicalizeMaybeMissing(p: string): Promise<string> {
+  try {
+    // Succeeds iff `p` exists and every component resolves.
+    return await realpath(p);
+  } catch {
+    // Missing / unresolvable — fall through to the walk-up below.
   }
   const parts = p.split(sep);
   for (let i = parts.length - 1; i > 0; i--) {
     const prefix = parts.slice(0, i).join(sep) || sep;
-    if (existsSync(prefix)) {
-      try {
-        const canonicalPrefix = realpathSync(prefix);
-        // `path.join` collapses the duplicate separator that arises when
-        // `canonicalPrefix === "/"`.
-        return join(canonicalPrefix, ...parts.slice(i));
-      } catch {
-        return p;
-      }
+    try {
+      const canonicalPrefix = await realpath(prefix);
+      // `path.join` collapses the duplicate separator that arises when
+      // `canonicalPrefix === "/"`.
+      return join(canonicalPrefix, ...parts.slice(i));
+    } catch {
+      // keep walking up toward the root
     }
   }
   return p;

--- a/apps/web/tests/workspace-resolve-path.test.ts
+++ b/apps/web/tests/workspace-resolve-path.test.ts
@@ -1,0 +1,242 @@
+// Integration tests for the `workspace.resolvePath` tRPC query that backs
+// Quick Open's "open a file by absolute path" affordance.
+//
+// We exercise the real server pipeline: spawn the production server in a
+// child process, seed a workspace whose worktree is a real on-disk dir, then
+// call the procedure over HTTP. The assertions pin the full response shape
+// for the branches the resolver owns — a path inside the worktree (→
+// workspace-relative), a path outside it (→ external), a non-existent path, a
+// directory (not a regular file), and the unauthenticated 401 gate. No mocks;
+// the only seam is the band_token cookie the rest of the integration suite
+// uses. Mirrors the server/tRPC helpers in `host-file.test.ts`.
+
+import { spawn } from "node:child_process";
+import { mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from "node:fs";
+import { createServer } from "node:net";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { toWorkspaceId } from "@/dashboard";
+import { seedSettings, seedState } from "./helpers/seed-state";
+import { SERVER_RUNTIME, SERVER_SCRIPT } from "./helpers/server-runtime";
+
+const PROJECT_ROOT = join(import.meta.dirname, "..");
+const DEFAULT_TOKEN = "workspace-resolve-path-test-token";
+const PROJECT = "resolve-path-project";
+const BRANCH = "main";
+const WORKSPACE = toWorkspaceId(PROJECT, BRANCH);
+
+// ---------------------------------------------------------------------------
+// Server helpers (copied from host-file.test.ts to keep the file self-contained)
+// ---------------------------------------------------------------------------
+
+interface ServerHandle {
+  url: string;
+  home: string;
+  close: () => Promise<void>;
+}
+
+function createTmpHome(): string {
+  const tmp = realpathSync(mkdtempSync(join(tmpdir(), "band-resolve-path-test-")));
+  mkdirSync(join(tmp, ".band"), { recursive: true });
+  return tmp;
+}
+
+function getRandomPort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const srv = createServer();
+    srv.listen(0, "127.0.0.1", () => {
+      const { port } = srv.address() as { port: number };
+      srv.close(() => resolve(port));
+    });
+    srv.on("error", reject);
+  });
+}
+
+async function startServer(opts: { tmpHome: string }): Promise<ServerHandle> {
+  const home = opts.tmpHome;
+  const port = await getRandomPort();
+  return new Promise((resolve, reject) => {
+    const child = spawn(SERVER_RUNTIME, [SERVER_SCRIPT], {
+      cwd: PROJECT_ROOT,
+      env: { ...process.env, HOME: home, PORT: String(port), NODE_ENV: "production" },
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+
+    let stderr = "";
+    let settled = false;
+
+    child.stderr!.on("data", (chunk: Buffer) => {
+      stderr += chunk.toString();
+    });
+
+    child.stdout!.on("data", (chunk: Buffer) => {
+      if (chunk.toString().includes("listening") && !settled) {
+        settled = true;
+        resolve({
+          url: `http://127.0.0.1:${port}`,
+          home,
+          close: () =>
+            new Promise<void>((r) => {
+              child.on("exit", () => r());
+              child.kill("SIGTERM");
+            }),
+        });
+      }
+    });
+
+    child.on("error", (err) => {
+      if (!settled) {
+        settled = true;
+        reject(err);
+      }
+    });
+
+    child.on("exit", (code) => {
+      if (!settled) {
+        settled = true;
+        reject(new Error(`Server exited with code ${code} before listening.\nstderr: ${stderr}`));
+      }
+    });
+
+    setTimeout(() => {
+      if (!settled) {
+        settled = true;
+        child.kill("SIGTERM");
+        reject(new Error(`Server did not start within 15 s.\nstderr: ${stderr}`));
+      }
+    }, 15_000);
+  });
+}
+
+// ---------------------------------------------------------------------------
+// tRPC HTTP helpers
+// ---------------------------------------------------------------------------
+
+const defaultHeaders = { Cookie: `band_token=${DEFAULT_TOKEN}` };
+
+async function trpcQuery(serverUrl: string, procedure: string, input?: unknown) {
+  const url =
+    input !== undefined
+      ? `${serverUrl}/trpc/${procedure}?input=${encodeURIComponent(JSON.stringify(input))}`
+      : `${serverUrl}/trpc/${procedure}`;
+  return fetch(url, { headers: defaultHeaders });
+}
+
+interface ResolvePathResult {
+  exists: boolean;
+  isFile: boolean;
+  external: boolean;
+  workspaceRelativePath: string | null;
+}
+
+async function trpcData<T>(res: Response): Promise<T> {
+  const body = (await res.json()) as { result: { data: T } };
+  return body.result.data;
+}
+
+async function resolvePath(serverUrl: string, path: string): Promise<ResolvePathResult> {
+  const res = await trpcQuery(serverUrl, "workspace.resolvePath", { workspaceId: WORKSPACE, path });
+  expect(res.status).toBe(200);
+  return trpcData<ResolvePathResult>(res);
+}
+
+// ---------------------------------------------------------------------------
+// workspace.resolvePath
+// ---------------------------------------------------------------------------
+
+describe("tRPC — workspace.resolvePath", () => {
+  let server: ServerHandle;
+  let tmpHome: string;
+  // The worktree is a real on-disk directory so stat() sees real files.
+  let worktree: string;
+  let insideDir: string;
+  let insideFile: string;
+  // An "outside" dir next to the worktree, modelling a path no workspace
+  // would contain (e.g. a `/tmp/notes.md` a user pastes in).
+  let outsideDir: string;
+  let outsideFile: string;
+
+  beforeAll(async () => {
+    tmpHome = createTmpHome();
+
+    worktree = realpathSync(mkdtempSync(join(tmpdir(), "band-resolve-path-worktree-")));
+    insideDir = join(worktree, "src");
+    mkdirSync(insideDir, { recursive: true });
+    insideFile = join(insideDir, "inside.ts");
+    writeFileSync(insideFile, "export const inside = 1;\n", "utf-8");
+
+    outsideDir = realpathSync(mkdtempSync(join(tmpdir(), "band-resolve-path-outside-")));
+    outsideFile = join(outsideDir, "notes.md");
+    writeFileSync(outsideFile, "# notes\n", "utf-8");
+
+    seedState(tmpHome, {
+      projects: [
+        {
+          name: PROJECT,
+          path: worktree,
+          defaultBranch: BRANCH,
+          worktrees: [{ branch: BRANCH, path: worktree }],
+        },
+      ],
+    });
+    seedSettings(tmpHome, { tokenSecret: DEFAULT_TOKEN });
+    server = await startServer({ tmpHome });
+  });
+
+  afterAll(async () => {
+    await server.close();
+    rmSync(tmpHome, { recursive: true, force: true });
+    rmSync(worktree, { recursive: true, force: true });
+    rmSync(outsideDir, { recursive: true, force: true });
+  });
+
+  it("resolves an absolute path INSIDE the worktree to its workspace-relative form", async () => {
+    const data = await resolvePath(server.url, insideFile);
+    expect(data).toEqual({
+      exists: true,
+      isFile: true,
+      external: false,
+      // POSIX-separated, relative to the worktree root.
+      workspaceRelativePath: "src/inside.ts",
+    });
+  });
+
+  it("resolves an absolute path OUTSIDE the worktree as external", async () => {
+    const data = await resolvePath(server.url, outsideFile);
+    expect(data).toEqual({
+      exists: true,
+      isFile: true,
+      external: true,
+      workspaceRelativePath: null,
+    });
+  });
+
+  it("reports a non-existent absolute path as not existing", async () => {
+    const data = await resolvePath(server.url, join(outsideDir, "does-not-exist.md"));
+    expect(data.exists).toBe(false);
+    expect(data.isFile).toBe(false);
+  });
+
+  it("reports a directory as existing but not a regular file", async () => {
+    const data = await resolvePath(server.url, insideDir);
+    expect(data).toEqual({
+      exists: true,
+      isFile: false,
+      external: false,
+      workspaceRelativePath: "src",
+    });
+  });
+
+  it("rejects unauthenticated callers", async () => {
+    // resolvePath reports on arbitrary absolute paths, so the transport-layer
+    // band_token is the only gate. Pin 401 specifically (a generic non-200
+    // would also pass on a crash 500).
+    const res = await fetch(
+      `${server.url}/trpc/workspace.resolvePath?input=${encodeURIComponent(
+        JSON.stringify({ workspaceId: WORKSPACE, path: outsideFile }),
+      )}`,
+    );
+    expect(res.status).toBe(401);
+  });
+});

--- a/apps/web/tests/workspace-resolve-path.test.ts
+++ b/apps/web/tests/workspace-resolve-path.test.ts
@@ -1,127 +1,34 @@
 // Integration tests for the `workspace.resolvePath` tRPC query that backs
 // Quick Open's "open a file by absolute path" affordance.
 //
-// We exercise the real server pipeline: spawn the production server in a
-// child process, seed a workspace whose worktree is a real on-disk dir, then
-// call the procedure over HTTP. The assertions pin the full response shape
-// for the branches the resolver owns — a path inside the worktree (→
-// workspace-relative), a path outside it (→ external), a non-existent path, a
-// directory (not a regular file), and the unauthenticated 401 gate. No mocks;
-// the only seam is the band_token cookie the rest of the integration suite
-// uses. Mirrors the server/tRPC helpers in `host-file.test.ts`.
+// We exercise the real server pipeline: boot the production server in a
+// child process (shared `helpers/server.ts` harness — process-group teardown
+// so server grandchildren don't leak), seed a workspace whose worktree is a
+// real on-disk dir, then call the procedure over HTTP. The assertions pin the
+// full response shape for the branches the resolver owns — a path inside the
+// worktree (→ workspace-relative), a path outside it (→ external), a
+// non-existent path, a directory (not a regular file), and the unauthenticated
+// 401 gate. No mocks; the only seam is the band_token cookie the rest of the
+// integration suite uses.
 
-import { spawn } from "node:child_process";
 import { mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from "node:fs";
-import { createServer } from "node:net";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { toWorkspaceId } from "@/dashboard";
 import { seedSettings, seedState } from "./helpers/seed-state";
-import { SERVER_RUNTIME, SERVER_SCRIPT } from "./helpers/server-runtime";
+import {
+  createTmpHome,
+  type ServerHandle,
+  startServer,
+  trpcData,
+  trpcQuery,
+} from "./helpers/server";
 
-const PROJECT_ROOT = join(import.meta.dirname, "..");
 const DEFAULT_TOKEN = "workspace-resolve-path-test-token";
 const PROJECT = "resolve-path-project";
 const BRANCH = "main";
 const WORKSPACE = toWorkspaceId(PROJECT, BRANCH);
-
-// ---------------------------------------------------------------------------
-// Server helpers (copied from host-file.test.ts to keep the file self-contained)
-// ---------------------------------------------------------------------------
-
-interface ServerHandle {
-  url: string;
-  home: string;
-  close: () => Promise<void>;
-}
-
-function createTmpHome(): string {
-  const tmp = realpathSync(mkdtempSync(join(tmpdir(), "band-resolve-path-test-")));
-  mkdirSync(join(tmp, ".band"), { recursive: true });
-  return tmp;
-}
-
-function getRandomPort(): Promise<number> {
-  return new Promise((resolve, reject) => {
-    const srv = createServer();
-    srv.listen(0, "127.0.0.1", () => {
-      const { port } = srv.address() as { port: number };
-      srv.close(() => resolve(port));
-    });
-    srv.on("error", reject);
-  });
-}
-
-async function startServer(opts: { tmpHome: string }): Promise<ServerHandle> {
-  const home = opts.tmpHome;
-  const port = await getRandomPort();
-  return new Promise((resolve, reject) => {
-    const child = spawn(SERVER_RUNTIME, [SERVER_SCRIPT], {
-      cwd: PROJECT_ROOT,
-      env: { ...process.env, HOME: home, PORT: String(port), NODE_ENV: "production" },
-      stdio: ["pipe", "pipe", "pipe"],
-    });
-
-    let stderr = "";
-    let settled = false;
-
-    child.stderr!.on("data", (chunk: Buffer) => {
-      stderr += chunk.toString();
-    });
-
-    child.stdout!.on("data", (chunk: Buffer) => {
-      if (chunk.toString().includes("listening") && !settled) {
-        settled = true;
-        resolve({
-          url: `http://127.0.0.1:${port}`,
-          home,
-          close: () =>
-            new Promise<void>((r) => {
-              child.on("exit", () => r());
-              child.kill("SIGTERM");
-            }),
-        });
-      }
-    });
-
-    child.on("error", (err) => {
-      if (!settled) {
-        settled = true;
-        reject(err);
-      }
-    });
-
-    child.on("exit", (code) => {
-      if (!settled) {
-        settled = true;
-        reject(new Error(`Server exited with code ${code} before listening.\nstderr: ${stderr}`));
-      }
-    });
-
-    setTimeout(() => {
-      if (!settled) {
-        settled = true;
-        child.kill("SIGTERM");
-        reject(new Error(`Server did not start within 15 s.\nstderr: ${stderr}`));
-      }
-    }, 15_000);
-  });
-}
-
-// ---------------------------------------------------------------------------
-// tRPC HTTP helpers
-// ---------------------------------------------------------------------------
-
-const defaultHeaders = { Cookie: `band_token=${DEFAULT_TOKEN}` };
-
-async function trpcQuery(serverUrl: string, procedure: string, input?: unknown) {
-  const url =
-    input !== undefined
-      ? `${serverUrl}/trpc/${procedure}?input=${encodeURIComponent(JSON.stringify(input))}`
-      : `${serverUrl}/trpc/${procedure}`;
-  return fetch(url, { headers: defaultHeaders });
-}
 
 interface ResolvePathResult {
   exists: boolean;
@@ -130,20 +37,16 @@ interface ResolvePathResult {
   workspaceRelativePath: string | null;
 }
 
-async function trpcData<T>(res: Response): Promise<T> {
-  const body = (await res.json()) as { result: { data: T } };
-  return body.result.data;
-}
-
 async function resolvePath(serverUrl: string, path: string): Promise<ResolvePathResult> {
-  const res = await trpcQuery(serverUrl, "workspace.resolvePath", { workspaceId: WORKSPACE, path });
+  const res = await trpcQuery(
+    serverUrl,
+    "workspace.resolvePath",
+    { workspaceId: WORKSPACE, path },
+    DEFAULT_TOKEN,
+  );
   expect(res.status).toBe(200);
   return trpcData<ResolvePathResult>(res);
 }
-
-// ---------------------------------------------------------------------------
-// workspace.resolvePath
-// ---------------------------------------------------------------------------
 
 describe("tRPC — workspace.resolvePath", () => {
   let server: ServerHandle;
@@ -158,7 +61,7 @@ describe("tRPC — workspace.resolvePath", () => {
   let outsideFile: string;
 
   beforeAll(async () => {
-    tmpHome = createTmpHome();
+    tmpHome = createTmpHome("band-resolve-path-test-");
 
     worktree = realpathSync(mkdtempSync(join(tmpdir(), "band-resolve-path-worktree-")));
     insideDir = join(worktree, "src");
@@ -212,10 +115,14 @@ describe("tRPC — workspace.resolvePath", () => {
     });
   });
 
-  it("reports a non-existent absolute path as not existing", async () => {
+  it("reports a non-existent absolute path as not existing (and external)", async () => {
     const data = await resolvePath(server.url, join(outsideDir, "does-not-exist.md"));
-    expect(data.exists).toBe(false);
-    expect(data.isFile).toBe(false);
+    expect(data).toEqual({
+      exists: false,
+      isFile: false,
+      external: true,
+      workspaceRelativePath: null,
+    });
   });
 
   it("reports a directory as existing but not a regular file", async () => {


### PR DESCRIPTION
## What

Pasting an absolute path into Quick Open — or clicking a terminal/chat link to one — now resolves it against the workspace and offers to open it:

- **Inside the worktree** → opens as a normal workspace-relative tab (participates in the Files panel / route / history plumbing).
- **Outside the worktree** → opens as an *external* tab, read via the existing `host.readFile` — the same pipeline the CLI's `band open <abs>` uses.

Previously an absolute path yielded "No files found" (Quick Open only fuzzy-searched inside the worktree), and an early iteration always treated absolute paths as external even when they lived inside the current workspace.

## How

- **`editorService.resolvePath`** — shared canonicalize + segment-aware containment logic extracted from `openFile` (behavior-preserving), exposed via a new `workspace.resolvePath` tRPC query and `adapter.resolveWorkspacePath`.
- **`QuickOpenDialog`** probes absolute-path queries (debounced), offers an "Open file" / "Open external file" row, and auto-opens single matches for the link-driven flow. The probe result is keyed to its query to avoid stale-render mis-fires; auto-open skips the transient empty-query render.
- **`SharedDockviewLayout.handleOpenExternalFile`** routes external opens through the existing `pending-external-open` queue that `CodeBrowserView` already drains.

## Tests

- `apps/web/tests/workspace-resolve-path.test.ts` — real-server backend coverage of the endpoint's response shape (inside→relative, outside→external, non-existent, directory) and the 401 auth gate.
- `apps/web/e2e/quick-open-external-file.spec.ts` — typing an absolute path (inside, outside, non-existent) and the `band:open-file` link path.
- `apps/web/e2e/terminal-external-file-link.spec.ts` — clicking an absolute path printed in a real terminal.

Local review (`review-and-apply`): all four specialists green after fixes; `pnpm check` + `tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)